### PR TITLE
Allow ByteTree deserialisation functions to throw

### DIFF
--- a/Sources/SwiftSyntax/TokenKind.swift.gyb
+++ b/Sources/SwiftSyntax/TokenKind.swift.gyb
@@ -114,10 +114,10 @@ extension TokenKind: ByteTreeObjectDecodable {
   static func read(from reader: UnsafeMutablePointer<ByteTreeObjectReader>, 
                    numFields: Int, 
                    userInfo: UnsafePointer<[ByteTreeUserInfoKey: Any]>
-  ) -> TokenKind {
+  ) throws -> TokenKind {
     // Explicitly spell out all TokenKinds to keep the serialized value stable
     // even if its members get reordered or members get removed
-    let kind = reader.pointee.readField(UInt8.self, index: 0)
+    let kind = try reader.pointee.readField(UInt8.self, index: 0)
     switch kind {
     case 0: return .eof
 % for token in SYNTAX_TOKENS:
@@ -125,7 +125,7 @@ extension TokenKind: ByteTreeObjectDecodable {
 %   if token.text: # The token does not have text associated with it
       return .${token.swift_kind()}
 %   else:
-      let text = reader.pointee.readField(String.self, index: 1)
+      let text = try reader.pointee.readField(String.self, index: 1)
       return .${token.swift_kind()}(text)
 %   end
 % end
@@ -133,12 +133,13 @@ extension TokenKind: ByteTreeObjectDecodable {
       if numFields > 1 {
         // Default to an unknown token with the passed text if we don't know 
         // its kind.
-        let text = reader.pointee.readField(String.self, index: 1)
+        let text = try reader.pointee.readField(String.self, index: 1)
         return .unknown(text)
       } else {
         // If we were not passed the token's text, we cannot recover since we 
         // would lose roundtripness.
-        fatalError("Unknown TokenKind \(kind)")
+        throw ByteTreeDecodingError.invalidEnumRawValue(type: "\(self)", 
+                                                        value: Int(kind))
       }
     }
   }

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -224,9 +224,9 @@ extension Trivia: ByteTreeObjectDecodable {
   static func read(from reader: UnsafeMutablePointer<ByteTreeObjectReader>, 
                    numFields: Int, 
                    userInfo: UnsafePointer<[ByteTreeUserInfoKey: Any]>
-  ) -> Trivia {
-    let pieces = [TriviaPiece].read(from: reader, numFields: numFields,
-                                    userInfo: userInfo)
+  ) throws -> Trivia {
+    let pieces = try [TriviaPiece].read(from: reader, numFields: numFields,
+                                        userInfo: userInfo)
     return Trivia(pieces: pieces)
   }
 }
@@ -235,21 +235,22 @@ extension TriviaPiece: ByteTreeObjectDecodable {
   static func read(from reader: UnsafeMutablePointer<ByteTreeObjectReader>, 
                    numFields: Int, 
                    userInfo: UnsafePointer<[ByteTreeUserInfoKey: Any]>
-  ) -> TriviaPiece {
-    let kind = reader.pointee.readField(UInt8.self, index: 0)
+  ) throws -> TriviaPiece {
+    let kind = try reader.pointee.readField(UInt8.self, index: 0)
     switch kind {
 % for trivia in TRIVIAS:
     case ${trivia.serialization_code}:
 %   if trivia.is_collection():
-      let count = Int(reader.pointee.readField(UInt32.self, index: 1))
+      let count = Int(try reader.pointee.readField(UInt32.self, index: 1))
       return .${trivia.lower_name}s(count)      
 %   else:
-      let text = reader.pointee.readField(String.self, index: 1)
+      let text = try reader.pointee.readField(String.self, index: 1)
       return .${trivia.lower_name}(text)      
 %   end
 % end
     default:
-      fatalError("Unknown trivia piece kind \(kind)")
+      throw ByteTreeDecodingError.invalidEnumRawValue(type: "\(self)", 
+                                                      value: Int(kind))
     }
   }
 }


### PR DESCRIPTION
At the moment we `fatalError` if an error occurs while deserialising ByteTree (e.g. because of an unexpected syntax node kind or because incremental parsing failed. With this, we will throw and the client will be able to handle the error.