### PR TITLE
Linux: Use a DispatchSourceRead instead of a FileHandle.readabilityHandler

### DIFF
--- a/Sources/SwiftSyntax/SwiftcInvocation.swift
+++ b/Sources/SwiftSyntax/SwiftcInvocation.swift
@@ -52,36 +52,21 @@ private func runCore(_ executable: URL, _ arguments: [String] = [])
     -> ProcessResult {
   let stdoutPipe = Pipe()
   var stdoutData = Data()
-
-#if os(macOS)
-  stdoutPipe.fileHandleForReading.readabilityHandler = { file in
-    stdoutData.append(file.availableData)
-  }
-#else
-  // Temporary fix until swift-corelibs-foundation supports .readabilityHandler
   let stdoutSource = DispatchSource.makeReadSource(
 		fileDescriptor: stdoutPipe.fileHandleForReading.fileDescriptor)
   stdoutSource.setEventHandler {
     stdoutData.append(stdoutPipe.fileHandleForReading.availableData)
   }
   stdoutSource.resume()
-#endif
 
   let stderrPipe = Pipe()
   var stderrData = Data()
-
-#if os(macOS)
-  stderrPipe.fileHandleForReading.readabilityHandler = { file in
-    stderrData.append(file.availableData)
-  }
-#else
   let stderrSource = DispatchSource.makeReadSource(
 		fileDescriptor: stderrPipe.fileHandleForReading.fileDescriptor)
   stderrSource.setEventHandler {
     stderrData.append(stderrPipe.fileHandleForReading.availableData)
   }
   stderrSource.resume()
-#endif
 
   let process = Process()
   process.launchPath = executable.path

--- a/Sources/SwiftSyntax/SwiftcInvocation.swift
+++ b/Sources/SwiftSyntax/SwiftcInvocation.swift
@@ -52,15 +52,36 @@ private func runCore(_ executable: URL, _ arguments: [String] = [])
     -> ProcessResult {
   let stdoutPipe = Pipe()
   var stdoutData = Data()
+
+#if os(macOS)
   stdoutPipe.fileHandleForReading.readabilityHandler = { file in
     stdoutData.append(file.availableData)
   }
+#else
+  // Temporary fix until swift-corelibs-foundation supports .readabilityHandler
+  let stdoutSource = DispatchSource.makeReadSource(
+		fileDescriptor: stdoutPipe.fileHandleForReading.fileDescriptor)
+  stdoutSource.setEventHandler {
+    stdoutData.append(stdoutPipe.fileHandleForReading.availableData)
+  }
+  stdoutSource.resume()
+#endif
 
   let stderrPipe = Pipe()
   var stderrData = Data()
+
+#if os(macOS)
   stderrPipe.fileHandleForReading.readabilityHandler = { file in
     stderrData.append(file.availableData)
   }
+#else
+  let stderrSource = DispatchSource.makeReadSource(
+		fileDescriptor: stderrPipe.fileHandleForReading.fileDescriptor)
+  stderrSource.setEventHandler {
+    stderrData.append(stderrPipe.fileHandleForReading.availableData)
+  }
+  stderrSource.resume()
+#endif
 
   let process = Process()
   process.launchPath = executable.path

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,14 @@
+import XCTest
+import SwiftSyntaxTest
+
+XCTMain([
+  testCase(AbsolutePositionTestCase.allTests),
+  testCase(DecodeSyntaxTestCase.allTests),
+  testCase(DiagnosticTestCase.allTests),
+  testCase(LazyCachingTestCase.allTests),
+  testCase(ParseFileTestCase.allTests),
+  testCase(SyntaxChildrenAPITestCase.allTests),
+  testCase(SyntaxCollectionsAPITestCase.allTests),
+  testCase(SyntaxFactoryAPITestCase.allTests),
+  testCase(SyntaxVisitorTestCase.allTests),
+])

--- a/Tests/SwiftSyntaxTest/AbsolutePosition.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePosition.swift
@@ -9,6 +9,18 @@ fileprivate class FuncRenamer: SyntaxRewriter {
 }
 
 public class AbsolutePositionTestCase: XCTestCase {
+
+  public static let allTests = [
+    ("testVisitor", testVisitor),
+    ("testClosure", testClosure),
+    ("testRename", testRename),
+    ("testCurrentFile", testCurrentFile),
+    ("testRecursion", testRecursion),
+    ("testTrivias", testTrivias),
+    ("testImplicit", testImplicit),
+    ("testWithoutSourceFileRoot", testWithoutSourceFileRoot),
+  ]
+
   public func testVisitor() {
     XCTAssertNoThrow(try {
       let source = try String(contentsOf: getInput("visitor.swift"))

--- a/Tests/SwiftSyntaxTest/DeserializeFile.swift
+++ b/Tests/SwiftSyntaxTest/DeserializeFile.swift
@@ -1,7 +1,12 @@
 import XCTest
 import SwiftSyntax
 
-public class DecodeSytnaxTestCase: XCTestCase {
+public class DecodeSyntaxTestCase: XCTestCase {
+
+  public static let allTests = [
+    ("testBasic", testBasic),
+  ]
+
   public func testBasic() {
     XCTAssertNoThrow(try {
       let inputFile = getInput("visitor.swift")

--- a/Tests/SwiftSyntaxTest/DiagnosticTest.swift
+++ b/Tests/SwiftSyntaxTest/DiagnosticTest.swift
@@ -28,6 +28,12 @@ fileprivate extension Diagnostic.Message {
 }
 
 public class DiagnosticTestCase: XCTestCase {
+
+  public static let allTests = [
+    ("testDiagnosticEmission", testDiagnosticEmission),
+    ("testSourceLocations", testSourceLocations),
+  ]
+
   public func testDiagnosticEmission() {
     let startLoc = loc()
     let fixLoc = loc()

--- a/Tests/SwiftSyntaxTest/LazyCaching.swift
+++ b/Tests/SwiftSyntaxTest/LazyCaching.swift
@@ -1,7 +1,13 @@
 import XCTest
 import SwiftSyntax
 
-class LazyCachingTestCase: XCTestCase {
+public class LazyCachingTestCase: XCTestCase {
+
+  public static let allTests = [
+    ("testPathological", testPathological),
+    ("testTwoAccesses", testTwoAccesses),
+  ]
+
   public func testPathological() {
     let tuple = SyntaxFactory.makeVoidTupleType()
 

--- a/Tests/SwiftSyntaxTest/ParseFile.swift
+++ b/Tests/SwiftSyntaxTest/ParseFile.swift
@@ -19,6 +19,11 @@ fileprivate class Test: NSObject {
 #endif
 
 public class ParseFileTestCase: XCTestCase {
+
+  public static let allTests = [
+    ("testParseSingleFile", testParseSingleFile)
+  ]
+
   public func testParseSingleFile() {
     let currentFile = URL(fileURLWithPath: #file)
     XCTAssertNoThrow(try {

--- a/Tests/SwiftSyntaxTest/SyntaxChildren.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxChildren.swift
@@ -2,6 +2,13 @@ import XCTest
 import SwiftSyntax
 
 public class SyntaxChildrenAPITestCase: XCTestCase {
+
+  public static let allTests = [
+    ("testIterateWithAllPresent", testIterateWithAllPresent),
+    ("testIterateWithSomeMissing", testIterateWithSomeMissing),
+    ("testIterateWithAllMissing", testIterateWithAllMissing),
+  ]
+
   public func testIterateWithAllPresent() {
     let returnStmt = SyntaxFactory.makeReturnStmt(
       returnKeyword: SyntaxFactory.makeReturnKeyword(),

--- a/Tests/SwiftSyntaxTest/SyntaxCollections.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCollections.swift
@@ -9,6 +9,17 @@ fileprivate func integerLiteralElement(_ int: Int) -> ArrayElementSyntax {
 }
 
 public class SyntaxCollectionsAPITestCase: XCTestCase {
+
+  public static let allTests = [
+    ("testAppendingElement", testAppendingElement),
+    ("testInsertingElement", testInsertingElement),
+    ("testPrependingElement", testPrependingElement),
+    ("testRemovingFirstElement", testRemovingFirstElement),
+    ("testRemovingLastElement", testRemovingLastElement),
+    ("testRemovingElement", testRemovingElement),
+    ("testReplacingElement", testReplacingElement),
+  ]
+
   public func testAppendingElement() {
       let arrayElementList = SyntaxFactory.makeArrayElementList([
           integerLiteralElement(0)

--- a/Tests/SwiftSyntaxTest/SyntaxFactory.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxFactory.swift
@@ -17,6 +17,13 @@ fileprivate func cannedStructDecl() -> StructDeclSyntax {
 }
 
 public class SyntaxFactoryAPITestCase: XCTestCase {
+
+  public static let allTests = [
+    ("testGenerated", testGenerated),
+    ("testTokenSyntax", testTokenSyntax),
+    ("testFunctionCallSyntaxBuilder", testFunctionCallSyntaxBuilder),
+  ]
+
   public func testGenerated() {
 
     let structDecl = cannedStructDecl()

--- a/Tests/SwiftSyntaxTest/VisitorTest.swift
+++ b/Tests/SwiftSyntaxTest/VisitorTest.swift
@@ -2,6 +2,14 @@ import XCTest
 import SwiftSyntax
 
 public class SyntaxVisitorTestCase: XCTestCase {
+
+  public static let allTests = [
+    ("testBasic", testBasic),
+    ("testRewritingNodeWithEmptyChild", testRewritingNodeWithEmptyChild),
+    ("testSyntaxRewriterVisitAny", testSyntaxRewriterVisitAny),
+    ("testSyntaxRewriterVisitCollection", testSyntaxRewriterVisitCollection),
+  ]
+
   public func testBasic() {
     class FuncCounter: SyntaxVisitor {
       var funcCount = 0


### PR DESCRIPTION
- swift-corelibs-foundation does not currently support FileHandle handlers
  so use DispatchSource.makeReadSource instead of
  FileHandle.readabilityHandlerForReading if not on macOS.

This is only a temporary fix and there may be other Linux issues, but it was enough to get the example in the readme working (although I had to rebase this fix on top of tag `swift-DEVELOPMENT-SNAPSHOT-2018-08-25-a` for testing).