### PR TITLE
Fix RawSyntax's leading/trailingTrivia computation to return nil if the outermost children don't have leading/trailing trivia

### DIFF
--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -350,7 +350,7 @@ extension RawSyntax {
     case .node(_, let layout):
       for child in layout {
         guard let child = child else { continue }
-        guard let result = child.leadingTrivia else { continue }
+        guard let result = child.leadingTrivia else { break }
         return result
       }
       return nil
@@ -364,7 +364,7 @@ extension RawSyntax {
     case .node(_, let layout):
       for child in layout.reversed() {
         guard let child = child else { continue }
-        guard let result = child.trailingTrivia else { continue }
+        guard let result = child.trailingTrivia else { break }
         return result
       }
       return nil

--- a/Tests/SwiftSyntaxTest/Inputs/visitor.swift
+++ b/Tests/SwiftSyntaxTest/Inputs/visitor.swift
@@ -1,5 +1,5 @@
 func foo() {
-  func foo() {
+  public func foo() {
     func foo() {
       /*Unknown token */0xG
     }


### PR DESCRIPTION
Previously they would skip over outer children that didn't have leading/trailing trivia until they found one that did. This was causing those trivia to be included twice when computing the totalLength/byteSize of the node; once in leading/trailingTrivia and again in contentLength, which only skipped the trivia of the outermost children.