### PR TITLE
[4.2] Merge pull request #8 from nathawes/fix-rawsyntax-totallength-when-la…

### DIFF
--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -338,7 +338,7 @@ extension RawSyntax {
     case .node(_, let layout):
       for child in layout {
         guard let child = child else { continue }
-        guard let result = child.leadingTrivia else { continue }
+        guard let result = child.leadingTrivia else { break }
         return result
       }
       return nil
@@ -352,7 +352,7 @@ extension RawSyntax {
     case .node(_, let layout):
       for child in layout.reversed() {
         guard let child = child else { continue }
-        guard let result = child.trailingTrivia else { continue }
+        guard let result = child.trailingTrivia else { break }
         return result
       }
       return nil

--- a/Tests/SwiftSyntaxTest/Inputs/visitor.swift
+++ b/Tests/SwiftSyntaxTest/Inputs/visitor.swift
@@ -1,5 +1,5 @@
 func foo() {
-  func foo() {
+  public func foo() {
     func foo() {
       /*Unknown token */0xG
     }


### PR DESCRIPTION
…st-child-has-no-trailing-trivia

Fix RawSyntax's leading/trailingTrivia computation to return nil if the outermost children don't have leading/trailing trivia