### PR TITLE
Extend the expected reparse range for REPLACE test case

### DIFF
--- a/lit_tests/simple.swift
+++ b/lit_tests/simple.swift
@@ -14,8 +14,8 @@ func start() {}
 func foo() {
 }
 
-_ = <<REPLACE<6|||7>>></reparse REPLACE>
-_ = <<REPLACE_BY_LONGER<6|||"Hello World">>>
+_ = <<REPLACE<6|||7>>>
+_ = <<REPLACE_BY_LONGER<6|||"Hello World">>></reparse REPLACE>
 _ = <<REPLACE_BY_SHORTER<"Hello again"|||"a">>>
 <<INSERT<|||foo()>>>
 <<REMOVE<print("abc")|||>>>


### PR DESCRIPTION
After apple/swift#19782 is merged, statements adjacent to an edit will
no longer be reused. Hence the REPLACE_BY_LONGER line is expected to be
reparsed.