### PR TITLE
remove .dynamic from library product

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
   name: "SwiftSyntax",
   products: [
-    .library(name: "SwiftSyntax", type: .dynamic, targets: ["SwiftSyntax"]),
+    .library(name: "SwiftSyntax", targets: ["SwiftSyntax"]),
   ],
   targets: [
     .target(name: "SwiftSyntax"),


### PR DESCRIPTION
See [SR-9038](https://bugs.swift.org/browse/SR-9038).

This flag prevents executable SPM projects from embedding `SwiftSyntax` statically.