### PR TITLE
Suppress FileManager.createFile warning on Linux

### DIFF
--- a/Sources/SwiftSyntax/JSONDiagnosticConsumer.swift
+++ b/Sources/SwiftSyntax/JSONDiagnosticConsumer.swift
@@ -60,7 +60,7 @@ public final class JSONDiagnosticConsumer: DiagnosticConsumer {
         if FileManager.default.fileExists(atPath: url.path) {
           try FileManager.default.removeItem(at: url)
         }
-        FileManager.default.createFile(atPath: url.path, contents: data)
+        _ = FileManager.default.createFile(atPath: url.path, contents: data)
       case .stdout:
         FileHandle.standardOutput.write(data)
       }


### PR DESCRIPTION
Works around https://bugs.swift.org/browse/SR-1638

The real fix is here https://github.com/apple/swift-corelibs-foundation/pull/1742 but we might want to merge this in the meantime.

Either way I thought this would be a good place to discuss enabling `-warnings-as-errors` on CI to catch future issues like this sooner. Thoughts?