### PR TITLE
build-script: build SwiftSyntax dynamic library when building from the script.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,12 +4,21 @@ import PackageDescription
 
 let package = Package(
   name: "SwiftSyntax",
-  products: [
-    .library(name: "SwiftSyntax", targets: ["SwiftSyntax"]),
-  ],
   targets: [
     .target(name: "SwiftSyntax"),
     .testTarget(name: "SwiftSyntaxTest", dependencies: ["SwiftSyntax"], exclude: ["Inputs"]),
     .target(name: "lit-test-helper", dependencies: ["SwiftSyntax"])
   ]
 )
+
+#if os(Linux)
+import Glibc
+#else
+import Darwin.C
+#endif
+
+if getenv("SWIFT_SYNTAX_BUILD_SCRIPT") == nil {
+  package.products.append(.library(name: "SwiftSyntax", targets: ["SwiftSyntax"]))
+} else {
+  package.products.append(.library(name: "SwiftSyntax", type: .dynamic, targets: ["SwiftSyntax"]))
+}

--- a/build-script.py
+++ b/build-script.py
@@ -163,6 +163,7 @@ def build_swiftsyntax(swift_build_exec, swiftc_exec, build_dir, build_test_util,
         swiftpm_call.extend(['--verbose'])
     _environ = dict(os.environ)
     _environ['SWIFT_EXEC'] = swiftc_exec
+    _environ['SWIFT_SYNTAX_BUILD_SCRIPT'] = ''
     check_call(swiftpm_call, env=_environ, verbose=verbose)
 
 


### PR DESCRIPTION
We need the .dylib artifact while building SwiftSyntax as a part of the
Swift compiler.