### PR TITLE
Add a dynamic and static library product of SwiftSyntax to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,21 +4,13 @@ import PackageDescription
 
 let package = Package(
   name: "SwiftSyntax",
+  products: [
+    .library(name: "SwiftSyntax", targets: ["SwiftSyntax"]),
+    .library(name: "SwiftSyntax-dynamic", type: .dynamic, targets: ["SwiftSyntax"]),
+  ],
   targets: [
     .target(name: "SwiftSyntax"),
     .testTarget(name: "SwiftSyntaxTest", dependencies: ["SwiftSyntax"], exclude: ["Inputs"]),
     .target(name: "lit-test-helper", dependencies: ["SwiftSyntax"])
   ]
 )
-
-#if os(Linux)
-import Glibc
-#else
-import Darwin.C
-#endif
-
-if getenv("SWIFT_SYNTAX_BUILD_SCRIPT") == nil {
-  package.products.append(.library(name: "SwiftSyntax", targets: ["SwiftSyntax"]))
-} else {
-  package.products.append(.library(name: "SwiftSyntax", type: .dynamic, targets: ["SwiftSyntax"]))
-}

--- a/build-script.py
+++ b/build-script.py
@@ -153,7 +153,7 @@ def build_swiftsyntax(swift_build_exec, swiftc_exec, build_dir, build_test_util,
     swiftpm_call = get_swiftpm_invocation(spm_exec=swift_build_exec,
                                           build_dir=build_dir,
                                           release=release)
-    swiftpm_call.extend(['--product', 'SwiftSyntax'])
+    swiftpm_call.extend(['--product', 'SwiftSyntax-dynamic'])
 
     # Only build lit-test-helper if we are planning to run tests
     if build_test_util:
@@ -163,7 +163,6 @@ def build_swiftsyntax(swift_build_exec, swiftc_exec, build_dir, build_test_util,
         swiftpm_call.extend(['--verbose'])
     _environ = dict(os.environ)
     _environ['SWIFT_EXEC'] = swiftc_exec
-    _environ['SWIFT_SYNTAX_BUILD_SCRIPT'] = ''
     check_call(swiftpm_call, env=_environ, verbose=verbose)
 
 


### PR DESCRIPTION
Address https://github.com/apple/swift-syntax/pull/25#issuecomment-435566501.

We should not specify the type of the library product via an environment variable. Instead a cleaner approach is to have both a static and a dynamic library product in the package and just build the type of the library that is needed.