### PR TITLE
Add swift-tools-version comment to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ code.
 Add this repository to the `Package.swift` manifest of your project:
 
 ```swift
+// swift-tools-version:4.2
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
Without `// swift-tools-version:4.2`, the example used verbatim gives:

```
error: argument 'targets' must precede argument 'dependencies'
  targets: [
~~^~~~~~~~~~
```