### PR TITLE
Properly compute start location after leading trivia

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -239,9 +239,9 @@ extension Syntax {
     in file: URL,
     afterLeadingTrivia: Bool = true
   ) -> SourceLocation {
-    let pos = afterLeadingTrivia ? 
-      data.position :
-      data.positionAfterSkippingLeadingTrivia
+    let pos = afterLeadingTrivia ?
+      data.positionAfterSkippingLeadingTrivia :
+      data.position
     return SourceLocation(file: file.path, position: pos)
   }
 

--- a/Tests/SwiftSyntaxTest/AbsolutePosition.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePosition.swift
@@ -19,6 +19,7 @@ public class AbsolutePositionTestCase: XCTestCase {
     ("testTrivias", testTrivias),
     ("testImplicit", testImplicit),
     ("testWithoutSourceFileRoot", testWithoutSourceFileRoot),
+    ("testSourceLocation", testSourceLocation),
   ]
 
   public func testVisitor() {
@@ -137,5 +138,30 @@ public class AbsolutePositionTestCase: XCTestCase {
           expression: nil), semicolon: nil, errorTokens: nil)
      XCTAssertEqual(0, item.position.utf8Offset)
      XCTAssertEqual(1, item.positionAfterSkippingLeadingTrivia.utf8Offset)
+  }
+
+  public func testSourceLocation() {
+    let url = URL(fileURLWithPath: "/tmp/test.swift")
+    let root = self.createSourceFile(2)
+    guard let secondReturnStmt = root.child(at: 0)?.child(at: 1) else {
+      fatalError("out of sync with createSourceFile")
+    }
+    let startLoc = secondReturnStmt.startLocation(in: url)
+    XCTAssertEqual(startLoc.line, 4)
+    XCTAssertEqual(startLoc.column, 18)
+
+    let startLocBeforeTrivia =
+      secondReturnStmt.startLocation(in: url, afterLeadingTrivia: false)
+    XCTAssertEqual(startLocBeforeTrivia.line, 3)
+    XCTAssertEqual(startLocBeforeTrivia.column, 1)
+
+    let endLoc = secondReturnStmt.endLocation(in: url)
+    XCTAssertEqual(endLoc.line, 4)
+    XCTAssertEqual(endLoc.column, 24)
+
+    let endLocAfterTrivia =
+      secondReturnStmt.endLocation(in: url, afterTrailingTrivia: true)
+    XCTAssertEqual(endLocAfterTrivia.line, 5)
+    XCTAssertEqual(endLocAfterTrivia.column, 1)
   }
 }


### PR DESCRIPTION
The logic here was flipped, causing nodes at the beginning of a line to
display their start location at the end of the previous line.

Also adds tests to make sure we don't regress here.