### PR TITLE
Use .exact instead of .branch in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ import PackageDescription
 let package = Package(
   name: "MyTool",
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", .branch("<#Specify Release tag#>")),
+    .package(url: "https://github.com/apple/swift-syntax.git", .exact("<#Specify Release tag#>")),
   ],
   targets: [
     .target(name: "MyTool", dependencies: ["SwiftSyntax"]),


### PR DESCRIPTION
Since the dependency is on a tag, not a branch, this changes the README example to us `.exact(...)` instead of `.branch(...)`.

The result on `Package.resolved` reflects that it's a correct change.

```diff
         "state": {
-          "branch": "0.40200.0",
+          "branch": null,
           "revision": "f20c0bcbfb4b07e107c9851350217cb2217f0cb4",
-          "version": null
+          "version": "0.40200.0"
         }
```