### PR TITLE
[Build System] Refactor build-script.py and update-toolchain.py to use more idiomatic Python.

### DIFF
--- a/build-script.py
+++ b/build-script.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 
-"""
+"""Utility script used to build, test and install SwiftSyntax.
 """
 
 
@@ -75,21 +75,21 @@ def info(*objects):
     """Prints a message to stderr and then flushes the output.
     """
 
-    _print(*objects, file=sys.stdout)
+    _print(*objects, file=sys.stdout, flush=True)
 
 
 def note(*objects):
     """Prints a note to stderr and then flushes the output.
     """
 
-    _print('NOTE:', *objects, file=sys.stdout)
+    _print('NOTE:', *objects, file=sys.stdout, flush=True)
 
 
 def error(*objects):
     """Prints an error message to stderr and then flushes the output.
     """
 
-    _print('ERROR:', *objects, file=sys.stderr)
+    _print('ERROR:', *objects, file=sys.stderr, flush=True)
 
 
 def fatal_error(*objects):
@@ -283,7 +283,7 @@ def template_gyb_files(verbose, add_source_locations):
         # `--line-directive=` (nothing following the `=`) to the generator. Our
         # flag is the reverse; we don't want them by default, only if
         # requested.
-        if add_source_locations:
+        if not add_source_locations:
             gyb_command.append('--line-directive=')
 
         try:

--- a/build-script.py
+++ b/build-script.py
@@ -351,7 +351,7 @@ def find_lit_test_helper_exec(swift_build_exec, build_dir, release=False):
     using Swift PM.
     """
 
-    product = 'list-test-helper'
+    product = 'lit-test-helper'
     command = shlex.split(swift_build_exec) + [
         '--product', product,
         '--package-path', PACKAGE_DIR,

--- a/build-script.py
+++ b/build-script.py
@@ -303,14 +303,14 @@ def template_gyb_files(verbose, add_source_locations):
 # -----------------------------------------------------------------------------
 # Build
 
-@log_section('Build SwiftSyntax')
-def build_swiftsyntax(swift_build_exec,
-                      swiftc_exec,
-                      build_dir,
-                      build_test_util,
-                      disable_sandbox=False,
-                      release=False,
-                      verbose=False):
+@log_section('Building SwiftSyntax')
+def build(swift_build_exec,
+          swiftc_exec,
+          build_dir,
+          build_test_util,
+          disable_sandbox=False,
+          release=False,
+          verbose=False):
     """Builds the SwiftSyntax dylib and optionally the lit-test-helper using
     Swift PM.
     """
@@ -662,7 +662,7 @@ def main():
         add_source_locations=args.add_source_locations,
         verbose=args.verbose)
 
-    build_swiftsyntax(
+    build(
         swift_build_exec=args.swift_build_exec,
         swiftc_exec=args.swiftc_exec,
         build_dir=args.build_dir,

--- a/update-toolchain.py
+++ b/update-toolchain.py
@@ -1,78 +1,135 @@
 #!/usr/bin/env python
-from __future__ import print_function
+
+
+from __future__ import absolute_import, print_function, unicode_literals
 
 import argparse
 import os
 import subprocess
 import sys
 import tempfile
-import errno
-import platform
-import shutil
 
-BUILD_SCRIPT = os.path.dirname(os.path.abspath(__file__)) + '/build-script.py'
 
-def printerr(message):
-    print(message, file=sys.stderr)
+try:
+    # Python 2
+    from pipes import quote
+except ImportError:
+    from shutil import quote
 
-def note(message):
-    print("--- %s: note: %s" % (os.path.basename(sys.argv[0]), message))
-    sys.stdout.flush()
 
-def fatal_error(message):
-    printerr(message)
-    sys.exit(1)
+# -----------------------------------------------------------------------------
+# Constants
 
-def escapeCmdArg(arg):
-    if '"' in arg or ' ' in arg:
-        return '"%s"' % arg.replace('"', '\\"')
-    else:
-        return arg
+PACKAGE_DIR = os.path.abspath(os.path.dirname(__file__))
+BUILD_SCRIPT = os.path.join(PACKAGE_DIR, 'build-script.py')
 
-def check_call(cmd, env=os.environ):
-    print(' '.join([escapeCmdArg(arg) for arg in cmd]))
-    return subprocess.check_call(cmd, env=env, stderr=subprocess.STDOUT)
-
-def build(swiftc_exec, build_dir):
-    check_call([BUILD_SCRIPT, '--release', '--swiftc-exec', swiftc_exec,
-        '--build-dir', build_dir, '-v'])
-
-def install(swiftc_exec, build_dir, dylib_dir, module_dir):
-    check_call([BUILD_SCRIPT, '--release', '--install', '--swiftc-exec',
-        swiftc_exec, '--dylib-dir', dylib_dir, '--swiftmodule-dir', module_dir,
-        '--build-dir', build_dir, '-v'])
-
-def main():
-    parser = argparse.ArgumentParser(
-        formatter_class=argparse.RawDescriptionHelpFormatter,
-        description='''
+ARGUMENT_PARSER_DESCRIPTION = """
 Build and re-install SwiftSytnax for an existing toolchain.
 
 This script calls ./build-script internally to rebuild SwiftSyntax using an
 existing toolchain and install the build artifacts back to the toolchain.
-''')
+"""
 
-    basic_group = parser.add_argument_group('Basic')
 
-    basic_group.add_argument('--toolchain-dir', default=None, help='''
-        Directory of an existing toolchain.
-        ''')
+# -----------------------------------------------------------------------------
+# Helpers
 
-    args = parser.parse_args(sys.argv[1:])
-    if not args.toolchain_dir:
-        fatal_error("Need to specify --toolchain-dir")
+def _print(*objects, **kwargs):
+    """Simple backport of the Python 3 print with flush support.
+    """
+
+    # Keyword only arguments
+    sep = kwargs.get('sep', ' ')
+    end = kwargs.get('end', '\n')
+    file = kwargs.get('file', sys.stdout)
+    flush = kwargs.get('flush', False)
+
+    file.write(sep.join(objects) + end)
+
+    if flush:
+        file.flush()
+
+
+def info(*objects):
+    _print(*objects, file=sys.stdout)
+
+
+def error(*objects):
+    _print('ERROR:', *objects, file=sys.stderr)
+
+
+def fatal_error(*objects):
+    error(*objects)
+    sys.exit(1)
+
+
+def quote_command(command):
+    return ' '.join([quote(arg) for arg in command])
+
+
+# -----------------------------------------------------------------------------
+# Build and Install
+
+def build(swiftc_exec, build_dir):
+    command = [
+        BUILD_SCRIPT, '-v',
+        '--release',
+        '--build-dir', build_dir,
+        '--swiftc-exec', swiftc_exec,
+    ]
+
+    info(quote_command(command))
+    subprocess.check_call(command)
+
+
+def install(swiftc_exec, build_dir, dylib_dir, module_dir):
+    command = [
+        BUILD_SCRIPT, '-v',
+        '--release',
+        '--install',
+        '--build-dir', build_dir,
+        '--dylib-dir', dylib_dir,
+        '--swiftc-exec', swiftc_exec,
+        '--swiftmodule-dir', module_dir,
+    ]
+
+    info(quote_command(command))
+    subprocess.check_call(command)
+
+
+# -----------------------------------------------------------------------------
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        description=ARGUMENT_PARSER_DESCRIPTION)
+
+    parser.add_argument('--toolchain-dir',
+                        required=True,
+                        help='Directory of an existing toolchain.')
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
     if not os.geteuid() == 0:
-        fatal_error("\n!!!!!!!!Run this script with root access!!!!!!!!\n")
+        fatal_error('Re-run this script with root access!')
 
     build_dir = tempfile.mkdtemp()
-    swiftc_exec = args.toolchain_dir + '/usr/bin/swiftc'
-    dylib_dir = args.toolchain_dir + '/usr/lib/swift/macosx'
-    module_dir = args.toolchain_dir + '/usr/lib/swift/macosx/x86_64'
-    print('Using swiftc: ' + swiftc_exec)
-    print('Using build directory: ' + build_dir)
-    build(swiftc_exec=swiftc_exec, build_dir=build_dir)
-    install(swiftc_exec=swiftc_exec, build_dir=build_dir, dylib_dir=dylib_dir,
-        module_dir=module_dir)
+    toolchain_usr_dir = os.path.join(args.toolchain_dir, 'usr')
+
+    swiftc_exec = os.path.join(toolchain_usr_dir, 'bin', 'swiftc')
+    dylib_dir = os.path.join(toolchain_usr_dir, 'lib', 'swift', 'macosx')
+    module_dir = os.path.join(dylib_dir, 'x86_64')
+
+    info('Using swiftc:', swiftc_exec)
+    info('Using build directory:', build_dir)
+
+    build(swiftc_exec, build_dir)
+    install(swiftc_exec, build_dir, dylib_dir, module_dir)
+
 
 if __name__ == '__main__':
     main()

--- a/update-toolchain.py
+++ b/update-toolchain.py
@@ -51,11 +51,11 @@ def _print(*objects, **kwargs):
 
 
 def info(*objects):
-    _print(*objects, file=sys.stdout)
+    _print(*objects, file=sys.stdout, flush=True)
 
 
 def error(*objects):
-    _print('ERROR:', *objects, file=sys.stderr)
+    _print('ERROR:', *objects, file=sys.stderr, flush=True)
 
 
 def fatal_error(*objects):


### PR DESCRIPTION
This PR re-factors the `build-script.py` and `update-toolchain.py` scripts to use more idiomatic Python and conform to the standard PEP8 style guide. There are no functional changes, merely a re-organization of code and addition of comments. All functionality remains unchanged, just with improvements to control flow and output organization.