### PR TITLE
Add missing spaces between argument label and argument

### DIFF
--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -127,10 +127,10 @@ func performClassifySyntax(args: CommandLineArguments) throws {
 class NodePrinter: SyntaxVisitor {
   override func visitPre(_ node: Syntax) {
     assert(!node.isUnknown)
-    print("<\(type(of: node))>", terminator:"")
+    print("<\(type(of: node))>", terminator: "")
   }
   override func visitPost(_ node: Syntax) {
-    print("</\(type(of: node))>", terminator:"")
+    print("</\(type(of: node))>", terminator: "")
   }
   override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
     print(token, terminator:"")


### PR DESCRIPTION
Address my review comment in #46 where a space was missing between the function argument label and the respective argument to match the style of the rest of the program.