### PR TITLE
Modernize hashing

### DIFF
--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
@@ -145,9 +145,9 @@ public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
     return lhs._data === rhs._data
   }
 
-  /// A unique hash value for this node.
-  public var hashValue: Int {
-    return ObjectIdentifier(_data).hashValue
+  /// Feed the essential parts of this node to the supplied hasher.
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(ObjectIdentifier(_data))
   }
 }
 


### PR DESCRIPTION
(This is a followup to https://github.com/apple/swift/pull/20868.)

Change syntax nodes to implement `hash(into:)` instead of `hashValue`. The latter was deprecated as a protocol requirement in SE-0206, and implementing it may cause deprecation warnings soon. Defining `hash(into:)` also makes for slightly faster hashing.