### PR TITLE
Publish SyntaxRewriter.visitChildren

### DIFF
--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -31,7 +31,7 @@ open class SyntaxRewriter {
 %   if is_visitable(node):
   open func visit(_ node: ${node.name}) -> ${node.base_type} {
 %   cast = ('as! ' + node.base_type) if node.base_type != 'Syntax' else ''
-    return visitChildren(node) ${cast}
+    return visitChildren(of: node) ${cast}
   }
 
 %   end
@@ -74,11 +74,16 @@ open class SyntaxRewriter {
     case .${node.swift_syntax_kind}: return visit(node as! ${node.name})
 %   end
 % end
-    default: return visitChildren(node)
+    default: return visitChildren(of: node)
     }
   }
 
-  func visitChildren(_ node: Syntax) -> Syntax {
+  /// Visit the children of `node` without visiting `node` itself. Use this
+  /// method when you want `visitAny(_:)` to recurse into child nodes. If you're
+  /// using specialized vistors, `super.visit(_:)` will do the same thing.
+  ///
+  /// - Returns: A copy of `node` with its visited children rewritten.
+  public func visitChildren(of node: Syntax) -> Syntax {
     // Visit all children of this node, returning `nil` if child is not
     // present. This will ensure that there are always the same number
     // of children after transforming.


### PR DESCRIPTION
There’s currently no good way to rewrite the children of a node while using `SyntaxRewriter.visitAny(_:)`. This commit renames an existing internal method to `visitChildren(of:)` and makes it public so you can call it from a `visitAny(_:)` override.

This may not be the best way to address the issue; I'm open to alternatives. Or there might be some reason you're not supposed to do this at all, I suppose.