### PR TITLE
For the with* and SyntaxFactory APIs allow using a nil value for an optional child

### DIFF
--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -176,7 +176,7 @@ final class RawSyntax {
   ///   - index: The index of the child to replace.
   ///   - newChild: The new child that should occupy that index in the node.
   func replacingChild(_ index: Int,
-                      with newChild: RawSyntax) -> RawSyntax {
+                      with newChild: RawSyntax?) -> RawSyntax {
     precondition(index < layout.count, "Cursor \(index) reached past layout")
     var newLayout = layout
     newLayout[index] = newChild

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -170,7 +170,7 @@ final class SyntaxData: Equatable {
   /// - Returns: The new root node created by this operation, and the new child
   ///            syntax data.
   /// - SeeAlso: replacingSelf(_:)
-  func replacingChild(_ child: RawSyntax, 
+  func replacingChild(_ child: RawSyntax?,
     at index: Int) -> (root: SyntaxData, newValue: SyntaxData) {
     let newRaw = raw.replacingChild(index, with: child)
     return replacingSelf(newRaw)
@@ -186,7 +186,7 @@ final class SyntaxData: Equatable {
   /// - Returns: The new root node created by this operation, and the new child
   ///            syntax data.
   /// - SeeAlso: replacingSelf(_:)
-  func replacingChild<CursorType: RawRepresentable>(_ child: RawSyntax, 
+  func replacingChild<CursorType: RawRepresentable>(_ child: RawSyntax?,
     at cursor: CursorType) -> (root: SyntaxData, newValue: SyntaxData)
     where CursorType.RawValue == Int {
     return replacingChild(child, at: cursor.rawValue)

--- a/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -61,7 +61,7 @@ public enum SyntaxFactory {
     let layout: [RawSyntax?] = [
 %     for child in node.children:
 %       if child.is_optional:
-      ${child.swift_name}?.data.raw ?? ${make_missing_swift_child(child)},
+      ${child.swift_name}?.data.raw,
 %       else:
       ${child.swift_name}.data.raw,
 %       end
@@ -88,7 +88,11 @@ public enum SyntaxFactory {
     let data = SyntaxData(raw: RawSyntax(kind: .${node.swift_syntax_kind},
                                          layout: [
 %     for child in node.children:
+%       if child.is_optional:
+      nil,
+%       else:
       ${make_missing_swift_child(child)},
+%       end
 %     end
     ], presence: .present))
     return ${node.name}(root: data, data: data)

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
@@ -134,7 +134,11 @@ public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
   ///                   current `${child.swift_name}`, if present.
   public func with${child.name}(
     _ newChild: ${child.type_name}?) -> ${node.name} {
+%       if child.is_optional:
+    let raw = newChild?.raw
+%       else:
     let raw = newChild?.raw ?? ${make_missing_swift_child(child)}
+%       end
     let (root, newData) = data.replacingChild(raw,
                                               at: Cursor.${child.swift_name})
     return ${node.name}(root: root, data: newData)

--- a/Tests/SwiftSyntaxTest/SyntaxFactory.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxFactory.swift
@@ -22,6 +22,7 @@ public class SyntaxFactoryAPITestCase: XCTestCase {
     ("testGenerated", testGenerated),
     ("testTokenSyntax", testTokenSyntax),
     ("testFunctionCallSyntaxBuilder", testFunctionCallSyntaxBuilder),
+    ("testWithOptionalChild", testWithOptionalChild),
     ("testUnknownSyntax", testUnknownSyntax),
   ]
 
@@ -115,6 +116,33 @@ public class SyntaxFactoryAPITestCase: XCTestCase {
 
     XCTAssertEqual("\(callWithTerminator)",
                    "print(\"Hello, world!\", terminator: \" \")")
+  }
+
+  public func testWithOptionalChild() {
+    let string = SyntaxFactory.makeStringLiteralExpr("Hello, world!")
+    let printID = SyntaxFactory.makeVariableExpr("print")
+    let arg = FunctionCallArgumentSyntax {
+      $0.useExpression(string)
+    }
+    let call1 = FunctionCallExprSyntax {
+      $0.useCalledExpression(printID)
+      $0.useLeftParen(SyntaxFactory.makeLeftParenToken())
+      $0.addFunctionCallArgument(arg)
+      $0.useRightParen(SyntaxFactory.makeRightParenToken())
+    }
+    XCTAssertNotNil(call1.leftParen)
+    XCTAssertNotNil(call1.rightParen)
+
+    let call2 = call1.withLeftParen(nil).withRightParen(nil)
+    XCTAssertNil(call2.leftParen)
+    XCTAssertNil(call2.rightParen)
+
+    let call3 = FunctionCallExprSyntax {
+      $0.useCalledExpression(printID)
+      $0.addFunctionCallArgument(arg)
+    }
+    XCTAssertNil(call3.leftParen)
+    XCTAssertNil(call3.rightParen)
   }
 
   public func testUnknownSyntax() {


### PR DESCRIPTION
The with* APIs in particular were always creating a RawSyntax node (`missing`) even if the child is optional.
If the child is optional it is more correct to just use the nil value in the parent's layout array.