### PR TITLE
[RawSyntax] For the `RawSyntax.contentLength` calculation make sure to ignore `missing` tokens

### DIFF
--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -41,6 +41,9 @@ final class RawSyntax {
   /// The length of this node excluding its leading and trailing trivia
   var contentLength: SourceLength {
     return _contentLength.value({
+      if isMissing {
+        return Box(SourceLength.zero)
+      }
       switch data {
       case .node(kind: _, layout: let layout):
         let firstElementIndex = layout.firstIndex(where: { $0 != nil })

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -5,6 +5,7 @@ XCTMain({ () -> [XCTestCaseEntry] in
   var testCases: [XCTestCaseEntry] = [
     testCase(AbsolutePositionTestCase.allTests),
     testCase(DiagnosticTestCase.allTests),
+    testCase(IncrementalParsingTestCase.allTests),
     // We need to make syntax node thread safe to enable these tests
     // testCase(LazyCachingTestCase.allTests),
     testCase(ParseFileTestCase.allTests),

--- a/Tests/SwiftSyntaxTest/IncrementalParsingTests.swift
+++ b/Tests/SwiftSyntaxTest/IncrementalParsingTests.swift
@@ -1,0 +1,21 @@
+import XCTest
+import SwiftSyntax
+
+public class IncrementalParsingTestCase: XCTestCase {
+
+  public static let allTests = [
+    ("testIncrementalInvalid", testIncrementalInvalid),
+  ]
+
+  public func testIncrementalInvalid() {
+    let original = "struct A { func f() {"
+    let step: (String, (Int, Int, String)) =
+      ("struct AA { func f() {", (8, 0, "A"))
+
+    var tree = try! SyntaxParser.parse(source: original)
+    let sourceEdit = SourceEdit(range: ByteSourceRange(offset: step.1.0, length: step.1.1), replacementLength: step.1.2.utf8.count)
+    let lookup = IncrementalEditTransition(previousTree: tree, edits: [sourceEdit])
+    tree = try! SyntaxParser.parse(source: step.0, parseLookup: lookup)
+    XCTAssertEqual("\(tree)", step.0)
+  }
+}


### PR DESCRIPTION
It was previously counting missing tokens, resulting in an incorrect `contentLength`.
rdar://47371307