### PR TITLE
Optimize determination of a RawSyntax's SourceLength

### DIFF
--- a/Sources/SwiftSyntax/AbsolutePosition.swift
+++ b/Sources/SwiftSyntax/AbsolutePosition.swift
@@ -11,17 +11,17 @@
 //===----------------------------------------------------------------------===//
 
 /// An absolute position in a source file as text - the absolute utf8Offset from
-/// the start, line, and column.
-public struct AbsolutePosition {
+/// the start of the file.
+public struct AbsolutePosition: Comparable {
   public let utf8Offset: Int
-  public let line: Int
-  public let column: Int
 
-  static let startOfFile = AbsolutePosition(line: 1, column: 1, utf8Offset: 0)
+  static let startOfFile = AbsolutePosition(utf8Offset: 0)
 
-  public init(line: Int, column: Int, utf8Offset: Int) {
-    self.line = line
-    self.column = column
+  public init(utf8Offset: Int) {
     self.utf8Offset = utf8Offset
+  }
+
+  public static func <(lhs: AbsolutePosition, rhs: AbsolutePosition) -> Bool {
+    return lhs.utf8Offset < rhs.utf8Offset
   }
 }

--- a/Sources/SwiftSyntax/Diagnostic.swift
+++ b/Sources/SwiftSyntax/Diagnostic.swift
@@ -12,50 +12,6 @@
 // This file provides the Diagnostic, Note, and FixIt types.
 //===----------------------------------------------------------------------===//
 
-import Foundation
-
-/// Represents a source location in a Swift file.
-public struct SourceLocation: Codable {
-  /// The line in the file where this location resides.
-  public let line: Int
-
-  /// The UTF-8 byte offset from the beginning of the line where this location
-  /// resides.
-  public let column: Int
-
-  /// The UTF-8 byte offset into the file where this location resides.
-  public let offset: Int
-
-  /// The file in which this location resides.
-  public let file: String
-
-  public init(file: String, position: AbsolutePosition) {
-    self.init(line: position.line, column: position.column,
-              offset: position.utf8Offset, file: file)
-  }
-
-  public init(line: Int, column: Int, offset: Int, file: String) {
-    self.line = line
-    self.column = column
-    self.offset = offset
-    self.file = file
-  }
-}
-
-/// Represents a start and end location in a Swift file.
-public struct SourceRange: Codable {
-  /// The beginning location in the source range.
-  public let start: SourceLocation
-
-  /// The beginning location in the source range.
-  public let end: SourceLocation
-
-  public init(start: SourceLocation, end: SourceLocation) {
-    self.start = start
-    self.end = end
-  }
-}
-
 /// A FixIt represents a change to source code in order to "correct" a
 /// diagnostic.
 public enum FixIt: Codable {

--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -239,7 +239,11 @@ extension RawSyntax {
     if case .missing = presence {
       length = SourceLength.zero
     } else {
-      length = layout.compactMap({ $0?.totalLength }).reduce(.zero, +)
+      var totalen = SourceLength.zero
+      for child in layout {
+        totalen += child?.totalLength ?? .zero
+      }
+      length = totalen
     }
     return .init(kind: kind, layout: layout, length: length, presence: presence)
   }

--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -223,7 +223,7 @@ extension RawSyntax {
 
   /// The length of this node excluding its leading and trailing trivia.
   var contentLength: SourceLength {
-    return totalLength - leadingTriviaLength - trailingTriviaLength
+    return totalLength - (leadingTriviaLength + trailingTriviaLength)
   }
 
   /// Convenience function to create a RawSyntax when its byte length is not

--- a/Sources/SwiftSyntax/SourceLength.swift
+++ b/Sources/SwiftSyntax/SourceLength.swift
@@ -11,63 +11,45 @@
 //===----------------------------------------------------------------------===//
 
 /// The length a syntax node spans in the source code. From any AbsolutePosition
-/// you reach a node's end location by either adding its UTF-8 length or by
-/// inserting `lines` newlines and then moving `columns` columns to the right.
-public struct SourceLength {
-  public let newlines: Int
-  public let columnsAtLastLine: Int
+/// you reach a node's end location by adding its UTF-8 length.
+public struct SourceLength: Comparable {
   public let utf8Length: Int
 
   /// Construct the source length of a given text
   public init(of text: String) {
-    var newlines = 0
-    var columnsAtLastLine = 0
-    var utf8Length = 0
-    for char in text {
-      let charLength = String(char).utf8.count
-      utf8Length += charLength
-      switch char {
-      case "\n", "\r\n", "\r":
-        newlines += 1
-        columnsAtLastLine = 0
-      default:
-        columnsAtLastLine += charLength
-      }
-    }
-    self.newlines = newlines
-    self.columnsAtLastLine = columnsAtLastLine
-    self.utf8Length = utf8Length
+    self.utf8Length = text.utf8.count
   }
 
-  public init(newlines: Int, columnsAtLastLine: Int, utf8Length: Int) {
-    self.newlines = newlines
-    self.columnsAtLastLine = columnsAtLastLine
+  public init(utf8Length: Int) {
     self.utf8Length = utf8Length
   }
 
   /// A zero-length source length
   public static let zero: SourceLength = 
-      SourceLength(newlines: 0, columnsAtLastLine: 0, utf8Length: 0)
+      SourceLength(utf8Length: 0)
 
-  /// Combine the length of two source length. Note that the addition is *not*
-  /// commutative (3 columns + 1 line = 1 line but 1 line + 3 columns = 1 line
-  /// and 3 columns)
+  public static func <(lhs: SourceLength, rhs: SourceLength) -> Bool {
+    return lhs.utf8Length < rhs.utf8Length
+  }
+
+  /// Combine the length of two source length.
   public static func +(lhs: SourceLength, rhs: SourceLength) -> SourceLength {
+    _ = lhs == rhs
     let utf8Length = lhs.utf8Length + rhs.utf8Length
-    let newlines = lhs.newlines + rhs.newlines
-    let columnsAtLastLine: Int
-    if rhs.newlines == 0 {
-      columnsAtLastLine = lhs.columnsAtLastLine + rhs.columnsAtLastLine
-    } else {
-      columnsAtLastLine = rhs.columnsAtLastLine
-    }
-    return SourceLength(newlines: newlines, 
-                        columnsAtLastLine: columnsAtLastLine, 
-                        utf8Length: utf8Length)
+    return SourceLength(utf8Length: utf8Length)
   }
 
   public static func +=(lhs: inout SourceLength, rhs: SourceLength) {
     lhs = lhs + rhs
+  }
+
+  public static func -(lhs: SourceLength, rhs: SourceLength) -> SourceLength {
+    let utf8Length = lhs.utf8Length - rhs.utf8Length
+    return SourceLength(utf8Length: utf8Length)
+  }
+
+  public static func -=(lhs: inout SourceLength, rhs: SourceLength) {
+    lhs = lhs - rhs
   }
 }
 
@@ -77,14 +59,7 @@ extension AbsolutePosition {
   public static func +(lhs: AbsolutePosition, rhs: SourceLength) 
       -> AbsolutePosition {
     let utf8Offset = lhs.utf8Offset + rhs.utf8Length
-    let line = lhs.line + rhs.newlines
-    let column: Int
-    if rhs.newlines == 0 {
-      column = lhs.column + rhs.columnsAtLastLine
-    } else {
-      column = rhs.columnsAtLastLine + 1 // AbsolutePosition has 1-based columns
-    }
-    return AbsolutePosition(line: line, column: column, utf8Offset: utf8Offset)
+    return AbsolutePosition(utf8Offset: utf8Offset)
   }
 
   public static func +=(lhs: inout AbsolutePosition, rhs: SourceLength) {

--- a/Sources/SwiftSyntax/SourceLength.swift
+++ b/Sources/SwiftSyntax/SourceLength.swift
@@ -34,7 +34,6 @@ public struct SourceLength: Comparable {
 
   /// Combine the length of two source length.
   public static func +(lhs: SourceLength, rhs: SourceLength) -> SourceLength {
-    _ = lhs == rhs
     let utf8Length = lhs.utf8Length + rhs.utf8Length
     return SourceLength(utf8Length: utf8Length)
   }

--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -114,7 +114,7 @@ public final class SourceLocationConverter {
   /// - Parameters:
   ///   - line: A 1-based line number.
   ///   - column: A 1-based, UTF8 offset from the start of line.
-  public func positionFor(line: Int, column: Int) -> AbsolutePosition {
+  public func position(ofLine line: Int, column: Int) -> AbsolutePosition {
     let lineIdx = line-1
     guard lineIdx >= lines.startIndex else {
       return .startOfFile

--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -1,0 +1,344 @@
+//===--------------- SourceLocation.swift - Source Locations --------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Represents a source location in a Swift file.
+public struct SourceLocation: Codable {
+  /// The line in the file where this location resides. 1-based.
+  public let line: Int
+
+  /// The UTF-8 byte offset from the beginning of the line where this location
+  /// resides. 1-based.
+  public let column: Int
+
+  /// The UTF-8 byte offset into the file where this location resides.
+  public let offset: Int
+
+  /// The file in which this location resides.
+  public let file: String
+
+  public init(line: Int, column: Int, offset: Int, file: String) {
+    self.line = line
+    self.column = column
+    self.offset = offset
+    self.file = file
+  }
+}
+
+/// Represents a start and end location in a Swift file.
+public struct SourceRange: Codable {
+  /// The beginning location in the source range.
+  public let start: SourceLocation
+
+  /// The beginning location in the source range.
+  public let end: SourceLocation
+
+  public init(start: SourceLocation, end: SourceLocation) {
+    self.start = start
+    self.end = end
+  }
+}
+
+/// Converts `AbsolutePosition`s of syntax nodes to `SourceLocation`s, and
+/// vice-versa. The `AbsolutePosition`s must be originating from nodes that are
+/// part of the same tree that was used to initialize this class.
+public final class SourceLocationConverter {
+  let file: String
+  /// Array of lines and the position at the start of the line.
+  let lines: [AbsolutePosition]
+  /// Position at end of file.
+  let endOfFile: AbsolutePosition
+
+  /// - Parameters:
+  ///   - file: The file path associated with the syntax tree.
+  ///   - tree: The syntax tree to convert positions to line/columns for.
+  public init(file: String, tree: SourceFileSyntax) {
+    self.file = file
+    (self.lines, endOfFile) = computeLines(tree: tree)
+    assert(tree.byteSize == endOfFile.utf8Offset)
+  }
+
+  /// Convert a `AbsolutePosition` to a `SourceLocation`. If the position is
+  /// exceeding the file length then the `SourceLocation` for the end of file
+  /// is returned. If position is negative the location for start of file is
+  /// returned.
+  public func location(for origpos: AbsolutePosition) -> SourceLocation {
+    // Clamp the given position to the end of file if needed.
+    let pos = min(origpos, endOfFile)
+    if pos.utf8Offset < 0 {
+      return SourceLocation(line: 1, column: 1, offset: 0, file: self.file)
+    }
+
+    assert(!lines.isEmpty)
+    var first = lines.startIndex
+    var i: Int
+    var step: Int
+    var count = lines.endIndex - first
+    // Do an upper bound search, first element that is > value. This provides
+    // the line index coming after the one where the position belongs to.
+    while count > 0 {
+      step = count / 2
+      i = first + step
+      if !(pos < lines[i]) {
+        first = i + 1
+        count -= step + 1
+      } else {
+        count = step
+      }
+    }
+
+    assert(first > 0)
+    let lineIdx = first-1
+    let lineStartOffset = lines[lineIdx].utf8Offset
+    let colOffset = pos.utf8Offset - lineStartOffset
+
+    let line = lineIdx+1
+    let column = colOffset+1
+
+    return SourceLocation(line: line, column: column,
+      offset: pos.utf8Offset, file: self.file)
+  }
+
+  /// Convert a line/column to a `SourceLocation`. If the line/column exceeds
+  /// the boundaries of the file or the line, the position returned is one
+  /// adjusted to the closest boundary (beginning/end of file or line).
+  ///
+  /// - Parameters:
+  ///   - line: A 1-based line number.
+  ///   - column: A 1-based, UTF8 offset from the start of line.
+  public func positionFor(line: Int, column: Int) -> AbsolutePosition {
+    let lineIdx = line-1
+    guard lineIdx >= lines.startIndex else {
+      return .startOfFile
+    }
+    guard lineIdx < lines.endIndex else {
+      return self.endOfFile
+    }
+    let lineStart = lines[lineIdx]
+    let lineEnd = lineIdx+1 < lines.endIndex ? lines[lineIdx+1] : self.endOfFile
+    let colOffset = column-1
+    guard colOffset >= 0 else {
+      return lineStart
+    }
+    return min(lineStart+SourceLength(utf8Length: colOffset), lineEnd)
+  }
+
+  /// Returns false if the `position` is out-of-bounds for the file.
+  public func isValid(position pos: AbsolutePosition) -> Bool {
+    return pos >= .startOfFile && pos <= self.endOfFile
+  }
+
+  /// Returns false if the `line`/`column` pair is out-of-bounds for the file or
+  /// that specific line.
+  public func isValid(line: Int, column: Int) -> Bool {
+    let lineIdx = line-1
+    guard lineIdx >= lines.startIndex else {
+      return false
+    }
+    guard lineIdx < lines.endIndex else {
+      return false
+    }
+    let lineStart = lines[lineIdx]
+    let lineEnd = lineIdx+1 < lines.endIndex ? lines[lineIdx+1] : self.endOfFile
+    let colOffset = column-1
+    guard colOffset >= 0 else {
+      return false
+    }
+    return lineStart+SourceLength(utf8Length: colOffset) <= lineEnd
+  }
+}
+
+extension Syntax {
+  /// The starting location, in the provided file, of this Syntax node.
+  /// - Parameters:
+  ///   - converter: The `SourceLocationConverter` that was previously
+  ///     initialized using the root tree of this node.
+  ///   - afterLeadingTrivia: Whether to skip leading trivia when getting
+  ///                         the node's location. Defaults to `true`.
+  public func startLocation(
+    converter: SourceLocationConverter,
+    afterLeadingTrivia: Bool = true
+  ) -> SourceLocation {
+    let pos = afterLeadingTrivia ?
+      data.positionAfterSkippingLeadingTrivia :
+      data.position
+    return converter.location(for: pos)
+  }
+
+  /// The ending location, in the provided file, of this Syntax node.
+  /// - Parameters:
+  ///   - converter: The `SourceLocationConverter` that was previously
+  ///     initialized using the root tree of this node.
+  ///   - afterTrailingTrivia: Whether to skip trailing trivia when getting
+  ///                          the node's location. Defaults to `false`.
+  public func endLocation(
+    converter: SourceLocationConverter,
+    afterTrailingTrivia: Bool = false
+  ) -> SourceLocation {
+    var pos = data.position
+    pos += raw.leadingTriviaLength
+    pos += raw.contentLength
+    if afterTrailingTrivia {
+      pos += raw.trailingTriviaLength
+    }
+    return converter.location(for: pos)
+  }
+
+  /// The source range, in the provided file, of this Syntax node.
+  /// - Parameters:
+  ///   - converter: The `SourceLocationConverter` that was previously
+  ///     initialized using the root tree of this node.
+  ///   - afterLeadingTrivia: Whether to skip leading trivia when getting
+  ///                          the node's start location. Defaults to `true`.
+  ///   - afterTrailingTrivia: Whether to skip trailing trivia when getting
+  ///                          the node's end location. Defaults to `false`.
+  public func sourceRange(
+    converter: SourceLocationConverter,
+    afterLeadingTrivia: Bool = true,
+    afterTrailingTrivia: Bool = false
+  ) -> SourceRange {
+    let start = startLocation(converter: converter, afterLeadingTrivia: afterLeadingTrivia)
+    let end = endLocation(converter: converter, afterTrailingTrivia: afterTrailingTrivia)
+    return SourceRange(start: start, end: end)
+  }
+}
+
+/// Returns array of lines with the position at the start of the line and
+/// the end-of-file position.
+fileprivate func computeLines(
+  tree: SourceFileSyntax
+) -> ([AbsolutePosition], AbsolutePosition) {
+  var lines: [AbsolutePosition] = []
+  // First line starts from the beginning.
+  lines.append(.startOfFile)
+  var position: AbsolutePosition = .startOfFile
+  let addLine = { (lineLength: SourceLength) in
+    position += lineLength
+    lines.append(position)
+  }
+  var curPrefix: SourceLength = .zero
+  tree.forEachToken {
+    curPrefix = $0.forEachLineLength(prefix: curPrefix, body: addLine)
+  }
+  position += curPrefix
+  return (lines, position)
+}
+
+fileprivate extension String {
+  /// Walks and passes to `body` the `SourceLength` for every detected line,
+  /// with the newline character included.
+  /// - Returns: The leftover `SourceLength` at the end of the walk.
+  func forEachLineLength(
+    prefix: SourceLength = .zero, body: (SourceLength) -> ()
+  ) -> SourceLength {
+    var lineLength = prefix
+    for char in self {
+      lineLength += SourceLength(utf8Length: String(char).utf8.count)
+      if char.isNewline {
+        body(lineLength)
+        lineLength = .zero
+      }
+    }
+    return lineLength
+  }
+}
+
+fileprivate extension TriviaPiece {
+  /// Walks and passes to `body` the `SourceLength` for every detected line,
+  /// with the newline character included.
+  /// - Returns: The leftover `SourceLength` at the end of the walk.
+  func forEachLineLength(
+    prefix: SourceLength = .zero, body: (SourceLength) -> ()
+  ) -> SourceLength {
+    var lineLength = prefix
+    switch self {
+    case let .spaces(count),
+         let .tabs(count),
+         let .verticalTabs(count),
+         let .formfeeds(count),
+         let .backticks(count),
+         let .carriageReturns(count):
+      lineLength += SourceLength(utf8Length: count)
+    case let .newlines(count):
+      let newLineLength = SourceLength(utf8Length: 1)
+      body(lineLength + newLineLength)
+      for _ in 1..<count {
+        body(newLineLength)
+      }
+      lineLength = .zero
+    case let .carriageReturnLineFeeds(count):
+      let carriageReturnLineLength = SourceLength(utf8Length: 2)
+      body(lineLength + carriageReturnLineLength)
+      for _ in 1..<count {
+        body(carriageReturnLineLength)
+      }
+      lineLength = .zero
+    case let .lineComment(text),
+         let .docLineComment(text):
+      // Line comments are not supposed to contain newlines.
+      assert(!text.contains{ $0.isNewline }, "line comment created that contained a new-line character")
+      lineLength += SourceLength(utf8Length: text.utf8.count)
+    case let .blockComment(text),
+         let .docBlockComment(text),
+         let .garbageText(text):
+      lineLength = text.forEachLineLength(prefix: lineLength, body: body)
+    }
+    return lineLength
+  }
+}
+
+fileprivate extension Trivia {
+  /// Walks and passes to `body` the `SourceLength` for every detected line,
+  /// with the newline character included.
+  /// - Returns: The leftover `SourceLength` at the end of the walk.
+  func forEachLineLength(
+    prefix: SourceLength = .zero, body: (SourceLength) -> ()
+  ) -> SourceLength {
+    var curPrefix = prefix
+    for piece in self {
+      curPrefix = piece.forEachLineLength(prefix: curPrefix, body: body)
+    }
+    return curPrefix
+  }
+}
+
+fileprivate extension TokenKind {
+  /// Walks and passes to `body` the `SourceLength` for every detected line,
+  /// with the newline character included.
+  /// - Returns: The leftover `SourceLength` at the end of the walk.
+  func forEachLineLength(
+    prefix: SourceLength = .zero, body: (SourceLength) -> ()
+  ) -> SourceLength {
+    switch self {
+      case let .stringLiteral(text),
+           let .unknown(text),
+           let .stringSegment(text):
+        return text.forEachLineLength(prefix: prefix, body: body)
+      default:
+        return prefix + self.sourceLength
+    }
+  }
+}
+
+fileprivate extension TokenSyntax {
+  /// Walks and passes to `body` the `SourceLength` for every detected line,
+  /// with the newline character included.
+  /// - Returns: The leftover `SourceLength` at the end of the walk.
+  func forEachLineLength(
+    prefix: SourceLength = .zero, body: (SourceLength) -> ()
+  ) -> SourceLength {
+    var curPrefix = prefix
+    curPrefix = self.leadingTrivia.forEachLineLength(prefix: curPrefix, body: body)
+    curPrefix = self.tokenKind.forEachLineLength(prefix: curPrefix, body: body)
+    curPrefix = self.trailingTrivia.forEachLineLength(prefix: curPrefix, body: body)
+    return curPrefix
+  }
+}

--- a/Sources/SwiftSyntax/SyntaxBuilders.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxBuilders.swift.gyb
@@ -46,7 +46,7 @@ public struct ${Builder} {
       layout[idx] = list.appending(elt.raw)
     } else {
       layout[idx] = RawSyntax(kind: SyntaxKind.${child.swift_syntax_kind},
-                              layout: [elt.raw],
+                              layout: [elt.raw], length: elt.raw.totalLength,
                               presence: SourcePresence.present)
     }
   }
@@ -68,7 +68,7 @@ public struct ${Builder} {
 %       end
 %     end
 
-    return SyntaxData(raw: RawSyntax(kind: .${node.swift_syntax_kind},
+    return SyntaxData(raw: RawSyntax.createAndCalcLength(kind: .${node.swift_syntax_kind},
                                      layout: layout, presence: .present))
   }
 }

--- a/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -29,17 +29,17 @@
 
 public enum SyntaxFactory {
   public static func makeToken(_ kind: TokenKind, presence: SourcePresence,
-                 leadingTrivia: Trivia = [],
-                 trailingTrivia: Trivia = []) -> TokenSyntax {
+                               leadingTrivia: Trivia = [],
+                               trailingTrivia: Trivia = []) -> TokenSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: kind, leadingTrivia: leadingTrivia,
-                        trailingTrivia: trailingTrivia, presence: presence)
+      trailingTrivia: trailingTrivia, presence: presence)
     let data = SyntaxData(raw: raw)
     return TokenSyntax(root: data, data: data)
   }
 
   public static func makeUnknownSyntax(tokens: [TokenSyntax]) -> Syntax {
-    let raw = RawSyntax.createAndCalcLength(kind: .unknown, layout: tokens.map { $0.data.raw },
-                        presence: .present)
+    let raw = RawSyntax.createAndCalcLength(kind: .unknown,
+      layout: tokens.map { $0.data.raw }, presence: .present)
     let data = SyntaxData(raw: raw)
     return UnknownSyntax(root: data, data: data)
   }
@@ -68,7 +68,7 @@ public enum SyntaxFactory {
 %     end
     ]
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.${node.swift_syntax_kind},
-                        layout: layout, presence: SourcePresence.present)
+      layout: layout, presence: SourcePresence.present)
     let data = SyntaxData(raw: raw)
     return ${node.name}(root: data, data: data)
   }
@@ -76,8 +76,7 @@ public enum SyntaxFactory {
   public static func make${node.syntax_kind}(
     _ elements: [${node.collection_element_type}]) -> ${node.name} {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.${node.swift_syntax_kind},
-                        layout: elements.map { $0.data.raw },
-                        presence: SourcePresence.present)
+      layout: elements.map { $0.data.raw }, presence: SourcePresence.present)
     let data = SyntaxData(raw: raw)
     return ${node.name}(root: data, data: data)
   }

--- a/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -31,14 +31,14 @@ public enum SyntaxFactory {
   public static func makeToken(_ kind: TokenKind, presence: SourcePresence,
                  leadingTrivia: Trivia = [],
                  trailingTrivia: Trivia = []) -> TokenSyntax {
-    let raw = RawSyntax(kind: kind, leadingTrivia: leadingTrivia,
+    let raw = RawSyntax.createAndCalcLength(kind: kind, leadingTrivia: leadingTrivia,
                         trailingTrivia: trailingTrivia, presence: presence)
     let data = SyntaxData(raw: raw)
     return TokenSyntax(root: data, data: data)
   }
 
   public static func makeUnknownSyntax(tokens: [TokenSyntax]) -> Syntax {
-    let raw = RawSyntax(kind: .unknown, layout: tokens.map { $0.data.raw },
+    let raw = RawSyntax.createAndCalcLength(kind: .unknown, layout: tokens.map { $0.data.raw },
                         presence: .present)
     let data = SyntaxData(raw: raw)
     return UnknownSyntax(root: data, data: data)
@@ -67,7 +67,7 @@ public enum SyntaxFactory {
 %       end
 %     end
     ]
-    let raw = RawSyntax(kind: SyntaxKind.${node.swift_syntax_kind},
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.${node.swift_syntax_kind},
                         layout: layout, presence: SourcePresence.present)
     let data = SyntaxData(raw: raw)
     return ${node.name}(root: data, data: data)
@@ -75,7 +75,7 @@ public enum SyntaxFactory {
 %   elif node.is_syntax_collection():
   public static func make${node.syntax_kind}(
     _ elements: [${node.collection_element_type}]) -> ${node.name} {
-    let raw = RawSyntax(kind: SyntaxKind.${node.swift_syntax_kind},
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.${node.swift_syntax_kind},
                         layout: elements.map { $0.data.raw },
                         presence: SourcePresence.present)
     let data = SyntaxData(raw: raw)
@@ -94,7 +94,7 @@ public enum SyntaxFactory {
       ${make_missing_swift_child(child)},
 %       end
 %     end
-    ], presence: .present))
+    ], length: .zero, presence: .present))
     return ${node.name}(root: data, data: data)
   }
 %   end

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
@@ -121,7 +121,9 @@ public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
       collection = col.appending(element.raw)
     } else {
       collection = RawSyntax(kind: SyntaxKind.${child_node.swift_syntax_kind},
-                             layout: [element.raw], presence: .present)
+                             layout: [element.raw],
+                             length: element.raw.totalLength,
+                             presence: .present)
     }
     let (root, newData) = data.replacingChild(collection,
                                               at: Cursor.${child.swift_name})

--- a/Sources/SwiftSyntax/SyntaxParser.swift
+++ b/Sources/SwiftSyntax/SyntaxParser.swift
@@ -160,7 +160,7 @@ func makeRawToken(_ c_node: CSyntaxNode, source: String) -> RawSyntax {
   let offset = Int(c_node.range.offset)
   let totalLen = Int(c_node.range.length)
   let tokOffset = offset + leadingTriviaLen
-  let tokLen = totalLen - leadingTriviaLen - trailingTriviaLen
+  let tokLen = totalLen - (leadingTriviaLen + trailingTriviaLen)
 
   let text = source.utf8Slice(offset: tokOffset, length: tokLen)
   let tokKind = TokenKind.fromRawValue(kind: kind, text: text)

--- a/Sources/SwiftSyntax/SyntaxParser.swift
+++ b/Sources/SwiftSyntax/SyntaxParser.swift
@@ -158,8 +158,9 @@ func makeRawToken(_ c_node: CSyntaxNode, source: String) -> RawSyntax {
   }
 
   let offset = Int(c_node.range.offset)
+  let totalLen = Int(c_node.range.length)
   let tokOffset = offset + leadingTriviaLen
-  let tokLen = Int(c_node.range.length) - leadingTriviaLen - trailingTriviaLen
+  let tokLen = totalLen - leadingTriviaLen - trailingTriviaLen
 
   let text = source.utf8Slice(offset: tokOffset, length: tokLen)
   let tokKind = TokenKind.fromRawValue(kind: kind, text: text)
@@ -171,7 +172,9 @@ func makeRawToken(_ c_node: CSyntaxNode, source: String) -> RawSyntax {
                                 offset: tokOffset+tokLen, source: source)
   let presence: SourcePresence = c_node.present ? .present : .missing
   return RawSyntax(kind: tokKind, leadingTrivia: leadingTrivia,
-                   trailingTrivia: trailingTrivia, presence: presence)
+                   trailingTrivia: trailingTrivia,
+                   length: SourceLength(utf8Length: totalLen),
+                   presence: presence)
 }
 
 fileprivate
@@ -192,8 +195,10 @@ func makeRawNode(_ cnodeptr: CSyntaxNodePtr, source: String) -> RawSyntax {
       let subnode = moveFromCRawNode(cnode.layout_data.nodes![i])
       layout.append(subnode)
     }
+    let totalLen = Int(cnode.range.length)
     let presence: SourcePresence = cnode.present ? .present : .missing
-    return RawSyntax(kind: kind, layout: layout, presence: presence)
+    return RawSyntax(kind: kind, layout: layout,
+      length: SourceLength(utf8Length: totalLen), presence: presence)
   }
 }
 

--- a/Sources/SwiftSyntax/TokenKind.swift.gyb
+++ b/Sources/SwiftSyntax/TokenKind.swift.gyb
@@ -70,6 +70,19 @@ public enum TokenKind {
 % end
     }
   }
+
+  var sourceLength: SourceLength {
+    switch self {
+    case .eof: return .zero
+% for token in SYNTAX_TOKENS:
+%   if token.text:
+    case .${token.swift_kind()}: return SourceLength(utf8Length: ${len(token.text.decode('string_escape'))})
+%   else:
+    case .${token.swift_kind()}(let text): return SourceLength(of: text)
+%   end
+% end
+    }
+  }
 }
 
 extension TokenKind: Equatable {

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -147,12 +147,10 @@ extension TriviaPiece {
 % for trivia in TRIVIAS:
 %   if trivia.is_new_line:
     case let .${trivia.lower_name}s(count):
-      return SourceLength(newlines: count, columnsAtLastLine: 0, 
-                          utf8Length: count * ${trivia.characters_len()})
+      return SourceLength(utf8Length: count * ${trivia.characters_len()})
 %   elif trivia.is_collection():
     case let .${trivia.lower_name}s(count):
-      return SourceLength(newlines: 0, columnsAtLastLine: count, 
-                          utf8Length: count)
+      return SourceLength(utf8Length: count)
 %   else:
     case let .${trivia.lower_name}(text):
       return SourceLength(of: text)

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -14,6 +14,7 @@ XCTMain({ () -> [XCTestCaseEntry] in
     testCase(SyntaxFactoryAPITestCase.allTests),
     testCase(SyntaxAPITestCase.allTests),
     testCase(SyntaxVisitorTestCase.allTests),
+    testCase(TokenSyntaxTestCase.allTests),
   ]
   return testCases
 }())

--- a/Tests/SwiftSyntaxTest/AbsolutePosition.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePosition.swift
@@ -155,7 +155,7 @@ public class AbsolutePositionTestCase: XCTestCase {
     let startLoc = secondReturnStmt.startLocation(converter: converter)
     XCTAssertEqual(startLoc.line, 6)
     XCTAssertEqual(startLoc.column, 1)
-    XCTAssertEqual(converter.positionFor(line: startLoc.line, column: startLoc.column),
+    XCTAssertEqual(converter.position(ofLine: startLoc.line, column: startLoc.column),
       secondReturnStmt.positionAfterSkippingLeadingTrivia)
 
     let startLocBeforeTrivia =
@@ -163,7 +163,7 @@ public class AbsolutePositionTestCase: XCTestCase {
         afterLeadingTrivia: false)
     XCTAssertEqual(startLocBeforeTrivia.line, 4)
     XCTAssertEqual(startLocBeforeTrivia.column, 1)
-    XCTAssertEqual(converter.positionFor(line: startLocBeforeTrivia.line, column: startLocBeforeTrivia.column),
+    XCTAssertEqual(converter.position(ofLine: startLocBeforeTrivia.line, column: startLocBeforeTrivia.column),
       secondReturnStmt.position)
 
     let endLoc = secondReturnStmt.endLocation(converter: converter)

--- a/Tests/SwiftSyntaxTest/AbsolutePosition.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePosition.swift
@@ -97,11 +97,11 @@ public class AbsolutePositionTestCase: XCTestCase {
         .newlines(1),
         .backticks(1),
         .docLineComment("/// some comment"),
-        .newlines(1),
+        .carriageReturns(1),
         ])
     let trailing = Trivia(pieces: [
-        .docLineComment("/// This is comment"),
-        .newlines(1),
+        .blockComment("/* This is comment \r\r\n */"),
+        .carriageReturnLineFeeds(1),
         ])
     let items : [CodeBlockItemSyntax] =
       [CodeBlockItemSyntax](repeating: CodeBlockItemSyntax {
@@ -153,7 +153,7 @@ public class AbsolutePositionTestCase: XCTestCase {
       fatalError("out of sync with createSourceFile")
     }
     let startLoc = secondReturnStmt.startLocation(converter: converter)
-    XCTAssertEqual(startLoc.line, 6)
+    XCTAssertEqual(startLoc.line, 8)
     XCTAssertEqual(startLoc.column, 1)
     XCTAssertEqual(converter.position(ofLine: startLoc.line, column: startLoc.column),
       secondReturnStmt.positionAfterSkippingLeadingTrivia)
@@ -161,19 +161,19 @@ public class AbsolutePositionTestCase: XCTestCase {
     let startLocBeforeTrivia =
       secondReturnStmt.startLocation(converter: converter,
         afterLeadingTrivia: false)
-    XCTAssertEqual(startLocBeforeTrivia.line, 4)
+    XCTAssertEqual(startLocBeforeTrivia.line, 6)
     XCTAssertEqual(startLocBeforeTrivia.column, 1)
     XCTAssertEqual(converter.position(ofLine: startLocBeforeTrivia.line, column: startLocBeforeTrivia.column),
       secondReturnStmt.position)
 
     let endLoc = secondReturnStmt.endLocation(converter: converter)
-    XCTAssertEqual(endLoc.line, 6)
+    XCTAssertEqual(endLoc.line, 8)
     XCTAssertEqual(endLoc.column, 7)
 
     let endLocAfterTrivia =
       secondReturnStmt.endLocation(converter: converter,
         afterTrailingTrivia: true)
-    XCTAssertEqual(endLocAfterTrivia.line, 7)
+    XCTAssertEqual(endLocAfterTrivia.line, 11)
     XCTAssertEqual(endLocAfterTrivia.column, 1)
 
     XCTAssertTrue(converter.isValid(line: startLoc.line, column: startLoc.column))

--- a/Tests/SwiftSyntaxTest/AbsolutePosition.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePosition.swift
@@ -96,9 +96,13 @@ public class AbsolutePositionTestCase: XCTestCase {
     let leading = Trivia(pieces: [
         .newlines(1),
         .backticks(1),
-        .docLineComment("/// some comment")
+        .docLineComment("/// some comment"),
+        .newlines(1),
         ])
-    let trailing = Trivia.docLineComment("/// This is comment\n")
+    let trailing = Trivia(pieces: [
+        .docLineComment("/// This is comment"),
+        .newlines(1),
+        ])
     let items : [CodeBlockItemSyntax] =
       [CodeBlockItemSyntax](repeating: CodeBlockItemSyntax {
         $0.useItem(ReturnStmtSyntax {
@@ -115,11 +119,11 @@ public class AbsolutePositionTestCase: XCTestCase {
   public func testTrivias() {
     let idx = 5
     let root = self.createSourceFile(idx + 1)
-    XCTAssertEqual(3, root.leadingTrivia!.count)
+    XCTAssertEqual(4, root.leadingTrivia!.count)
     XCTAssertEqual(0, root.trailingTrivia!.count)
     let state = root.statements[idx]
-    XCTAssertEqual(3, state.leadingTrivia!.count)
-    XCTAssertEqual(1, state.trailingTrivia!.count)
+    XCTAssertEqual(4, state.leadingTrivia!.count)
+    XCTAssertEqual(2, state.trailingTrivia!.count)
     XCTAssertEqual(state.byteSize,
       state.leadingTrivia!.byteSize + state.trailingTrivia!.byteSize
         + state.byteSizeAfterTrimmingTrivia)
@@ -142,27 +146,40 @@ public class AbsolutePositionTestCase: XCTestCase {
   }
 
   public func testSourceLocation() {
-    let url = URL(fileURLWithPath: "/tmp/test.swift")
+    let filePath = "/tmp/test.swift"
     let root = self.createSourceFile(2)
+    let converter = SourceLocationConverter(file: filePath, tree: root)
     guard let secondReturnStmt = root.child(at: 0)?.child(at: 1) else {
       fatalError("out of sync with createSourceFile")
     }
-    let startLoc = secondReturnStmt.startLocation(in: url)
-    XCTAssertEqual(startLoc.line, 4)
-    XCTAssertEqual(startLoc.column, 18)
+    let startLoc = secondReturnStmt.startLocation(converter: converter)
+    XCTAssertEqual(startLoc.line, 6)
+    XCTAssertEqual(startLoc.column, 1)
+    XCTAssertEqual(converter.positionFor(line: startLoc.line, column: startLoc.column),
+      secondReturnStmt.positionAfterSkippingLeadingTrivia)
 
     let startLocBeforeTrivia =
-      secondReturnStmt.startLocation(in: url, afterLeadingTrivia: false)
-    XCTAssertEqual(startLocBeforeTrivia.line, 3)
+      secondReturnStmt.startLocation(converter: converter,
+        afterLeadingTrivia: false)
+    XCTAssertEqual(startLocBeforeTrivia.line, 4)
     XCTAssertEqual(startLocBeforeTrivia.column, 1)
+    XCTAssertEqual(converter.positionFor(line: startLocBeforeTrivia.line, column: startLocBeforeTrivia.column),
+      secondReturnStmt.position)
 
-    let endLoc = secondReturnStmt.endLocation(in: url)
-    XCTAssertEqual(endLoc.line, 4)
-    XCTAssertEqual(endLoc.column, 24)
+    let endLoc = secondReturnStmt.endLocation(converter: converter)
+    XCTAssertEqual(endLoc.line, 6)
+    XCTAssertEqual(endLoc.column, 7)
 
     let endLocAfterTrivia =
-      secondReturnStmt.endLocation(in: url, afterTrailingTrivia: true)
-    XCTAssertEqual(endLocAfterTrivia.line, 5)
+      secondReturnStmt.endLocation(converter: converter,
+        afterTrailingTrivia: true)
+    XCTAssertEqual(endLocAfterTrivia.line, 7)
     XCTAssertEqual(endLocAfterTrivia.column, 1)
+
+    XCTAssertTrue(converter.isValid(line: startLoc.line, column: startLoc.column))
+    XCTAssertFalse(converter.isValid(line: startLoc.line, column: startLoc.column+50))
+    XCTAssertFalse(converter.isValid(line: 0, column: startLoc.column))
+    XCTAssertTrue(converter.isValid(position: secondReturnStmt.position))
+    XCTAssertFalse(converter.isValid(position: secondReturnStmt.position+SourceLength(utf8Length: 100)))
   }
 }

--- a/Tests/SwiftSyntaxTest/TokenTest.swift
+++ b/Tests/SwiftSyntaxTest/TokenTest.swift
@@ -2,10 +2,27 @@ import XCTest
 import SwiftSyntax
 
 public class TokenSyntaxTestCase: XCTestCase {
+
+  public static let allTests = [
+    ("testKeywordKinds", testKeywordKinds),
+  ]
+
   public func testKeywordKinds() {
     XCTAssertTrue(TokenKind.operatorKeyword.isKeyword)
     XCTAssertTrue(TokenKind.funcKeyword.isKeyword)
     XCTAssertFalse(TokenKind.leftAngle.isKeyword)
     XCTAssertFalse(TokenKind.rightAngle.isKeyword)
+  }
+
+  public func testTokenLgnth() {
+    let source = "\"\"\"\n\\(a)\n\"\"\""
+    let tree = try! SyntaxParser.parse(source: source)
+    let tok = tree.firstToken!
+    XCTAssertTrue(tok.tokenKind == .multilineStringQuote)
+    XCTAssertEqual(tok.contentLength.utf8Length, 3)
+
+    let tok2 = SyntaxFactory.makeMultilineStringQuoteToken()
+    XCTAssertTrue(tok2.tokenKind == .multilineStringQuote)
+    XCTAssertEqual(tok2.contentLength.utf8Length, 3)
   }
 }


### PR DESCRIPTION
* Make `SourceLength` and `AbsolutePosition` simple utf8 byte offsets to avoid the overhead of calculating lines and columns as part of walking the tree
* Eagerly determine and store `SourceLength` (either provided by the parser or calculating it for constructed nodes) to avoid `LazyNonThreadSafeCache`, making `RawSyntax` efficient and thread-safe
* Introduce `SourceLocationConverter` to provide a way for clients to convert absolute offsets to line/column `SourceLocation`s and vice-versa.