### PR TITLE
Optimize creation of RawSyntax objects for parsing

### DIFF
--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -57,9 +57,9 @@ fileprivate func numberOfElements<T>(for value: T) -> Int {
 /// * For a parsed token (`TokenData.isConstructed` is false):
 ///   * List of leading `CTriviaPiece`s
 ///   * List of trailing `CTriviaPiece`s
-///   * A string buffer. If `TokenData.hasText` is false then the buffer is empty
+///   * A string buffer. If `TokenData.hasCustomText` is false then the buffer is empty
 ///     otherwise it contains the full text for the token, including the trivia.
-///     `TokenData.hasText` is true if there's any custom text in any of the trivia
+///     `TokenData.hasCustomText` is true if there's any custom text in any of the trivia
 ///     or the token kind.
 /// * For a constructed token (`TokenData.isConstructed` is true):
 ///   * A `ConstructedTokenData` value
@@ -277,7 +277,7 @@ fileprivate struct TokenData {
     }
   }
 
-  /// Prints the RawSyntax token. If self is a layout node it does nothing.
+  /// Prints the RawSyntax token.
   fileprivate func write<Target>(
     to target: inout Target, length: UInt32, extraPtr: DataElementPtr
   ) where Target: TextOutputStream {
@@ -298,6 +298,7 @@ fileprivate struct TokenData {
 }
 
 /// Convenience wrapper over the tail-allocated data for a token node.
+/// This is used only for tokens created during parsing.
 fileprivate struct UnsafeTokenData {
   let length: UInt32
   let tokenKind: CTokenKind

--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -371,7 +371,7 @@ fileprivate struct UnsafeTokenData {
   ) where Target: TextOutputStream {
     if hasText {
       // FIXME: A way to print the buffer directly and avoid the copy ?
-      target.write(String(decoding: fullTextBuffer, as: UTF8.self))
+      target.write(String.fromBuffer(fullTextBuffer))
     } else {
       func printTrivia(_ buf: UnsafeBufferPointer<CTriviaPiece>) {
         let emptyBuffer: UnsafeBufferPointer<UInt8> = .init(start: nil, count: 0)

--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -286,13 +286,7 @@ fileprivate struct TokenData {
       return data.write(to: &target)
     } else {
       let tok: ConstructedTokenData = castElementAs(extraPtr).pointee
-      for piece in tok.leadingTrivia {
-        piece.write(to: &target)
-      }
-      target.write(tok.kind.text)
-      for piece in tok.trailingTrivia {
-        piece.write(to: &target)
-      }
+      tok.write(to: &target)
     }
   }
 }
@@ -574,7 +568,7 @@ fileprivate struct ConstructedTokenData {
   let leadingTrivia: Trivia
   let trailingTrivia: Trivia
 
-  func writeToken<Target>(
+  func write<Target>(
     to target: inout Target
   ) where Target: TextOutputStream {
     for piece in leadingTrivia {

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -191,14 +191,14 @@ extension _SyntaxBase {
   /// the first token syntax contained by this node. Without such token, this
   /// property will return nil.
   var leadingTrivia: Trivia? {
-    return raw.leadingTrivia
+    return raw.formLeadingTrivia()
   }
 
   /// The trailing trivia of this syntax node. Trailing trivia is attached to
   /// the last token syntax contained by this node. Without such token, this
   /// property will return nil.
   var trailingTrivia: Trivia? {
-    return raw.trailingTrivia
+    return raw.formTrailingTrivia()
   }
 
   /// The length this node's leading trivia takes up spelled out in source.
@@ -497,7 +497,7 @@ public struct TokenSyntax: _SyntaxBase, Hashable {
       fatalError("TokenSyntax must have token as its raw")
     }
     let newRaw = RawSyntax.createAndCalcLength(kind: tokenKind,
-      leadingTrivia: raw.leadingTrivia!, trailingTrivia: raw.trailingTrivia!,
+      leadingTrivia: raw.formLeadingTrivia()!, trailingTrivia: raw.formTrailingTrivia()!,
       presence: raw.presence)
     let newData = data.replacingSelf(newRaw)
     return TokenSyntax(newData)
@@ -509,8 +509,8 @@ public struct TokenSyntax: _SyntaxBase, Hashable {
     guard raw.kind == .token else {
       fatalError("TokenSyntax must have token as its raw")
     }
-    let newRaw = RawSyntax.createAndCalcLength(kind: raw.tokenKind!,
-      leadingTrivia: leadingTrivia, trailingTrivia: raw.trailingTrivia!,
+    let newRaw = RawSyntax.createAndCalcLength(kind: raw.formTokenKind()!,
+      leadingTrivia: leadingTrivia, trailingTrivia: raw.formTrailingTrivia()!,
       presence: raw.presence)
     let newData = data.replacingSelf(newRaw)
     return TokenSyntax(newData)
@@ -522,8 +522,8 @@ public struct TokenSyntax: _SyntaxBase, Hashable {
     guard raw.kind == .token else {
       fatalError("TokenSyntax must have token as its raw")
     }
-    let newRaw = RawSyntax.createAndCalcLength(kind: raw.tokenKind!,
-                           leadingTrivia: raw.leadingTrivia!,
+    let newRaw = RawSyntax.createAndCalcLength(kind: raw.formTokenKind()!,
+                           leadingTrivia: raw.formLeadingTrivia()!,
                            trailingTrivia: trailingTrivia,
                            presence: raw.presence)
     let newData = data.replacingSelf(newRaw)
@@ -547,26 +547,17 @@ public struct TokenSyntax: _SyntaxBase, Hashable {
 
   /// The leading trivia (spaces, newlines, etc.) associated with this token.
   public var leadingTrivia: Trivia {
-    guard raw.kind == .token else {
-      fatalError("TokenSyntax must have token as its raw")
-    }
-    return raw.leadingTrivia!
+    return raw.formLeadingTrivia()!
   }
 
   /// The trailing trivia (spaces, newlines, etc.) associated with this token.
   public var trailingTrivia: Trivia {
-    guard raw.kind == .token else {
-      fatalError("TokenSyntax must have token as its raw")
-    }
-    return raw.trailingTrivia!
+    return raw.formTrailingTrivia()!
   }
 
   /// The kind of token this node represents.
   public var tokenKind: TokenKind {
-    guard raw.kind == .token else {
-      fatalError("TokenSyntax must have token as its raw")
-    }
-    return raw.tokenKind!
+    return raw.formTokenKind()!
   }
 
   /// The length this node takes up spelled out in the source, excluding its

--- a/Sources/SwiftSyntax/SyntaxBuilders.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxBuilders.swift.gyb
@@ -45,9 +45,9 @@ public struct ${Builder} {
     if let list = layout[idx] {
       layout[idx] = list.appending(elt.raw)
     } else {
-      layout[idx] = RawSyntax(kind: SyntaxKind.${child.swift_syntax_kind},
-                              layout: [elt.raw], length: elt.raw.totalLength,
-                              presence: SourcePresence.present)
+      layout[idx] = RawSyntax.create(kind: SyntaxKind.${child.swift_syntax_kind},
+        layout: [elt.raw], length: elt.raw.totalLength,
+        presence: SourcePresence.present)
     }
   }
 %       else:

--- a/Sources/SwiftSyntax/SyntaxChildren.swift
+++ b/Sources/SwiftSyntax/SyntaxChildren.swift
@@ -29,10 +29,10 @@ struct RawSyntaxChildren: Sequence {
 
     mutating func next() -> (RawSyntax?, AbsoluteSyntaxInfo)? {
       let idx = Int(nextChildInfo.indexInParent)
-      guard idx < parent.layout.endIndex else {
+      guard idx < parent.numberOfChildren else {
         return nil
       }
-      let child = parent.layout[idx]
+      let child = parent.child(at: idx)
       let thisItem = (child, nextChildInfo)
       nextChildInfo = nextChildInfo.advancedBySibling(child)
       return thisItem
@@ -115,10 +115,10 @@ struct ReversedPresentRawSyntaxChildren: Sequence {
     mutating func next() -> AbsoluteRawSyntax? {
       while true {
         let prevIdx = Int(previousChildInfo.indexInParent)
-        guard prevIdx > parent.layout.startIndex else {
+        guard prevIdx > 0 else {
           return nil
         }
-        let child = parent.layout[prevIdx-1]
+        let child = parent.child(at: prevIdx-1)
         previousChildInfo = previousChildInfo.reversedBySibling(child)
         if let n = child, n.isPresent {
           return AbsoluteRawSyntax(raw: n, info: previousChildInfo)

--- a/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -62,7 +62,7 @@ public struct ${node.name}: _SyntaxBase, Hashable, SyntaxCollection {
   /// - Returns: A new `${node.name}` with that element appended to the end.
   public func appending(
     _ syntax: ${node.collection_element_type}) -> ${node.name} {
-    var newLayout = data.raw.layout
+    var newLayout = data.raw.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
   }
@@ -88,7 +88,7 @@ public struct ${node.name}: _SyntaxBase, Hashable, SyntaxCollection {
   /// - Returns: A new `${node.name}` with that element appended to the end.
   public func inserting(_ syntax: ${node.collection_element_type},
                         at index: Int) -> ${node.name} {
-    var newLayout = data.raw.layout
+    var newLayout = data.raw.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
                  "inserting node at invalid index \(index)")
@@ -106,7 +106,7 @@ public struct ${node.name}: _SyntaxBase, Hashable, SyntaxCollection {
   /// - Returns: A new `${node.name}` with the new element at the provided index.
   public func replacing(childAt index: Int,
                         with syntax: ${node.collection_element_type}) -> ${node.name} {
-    var newLayout = data.raw.layout
+    var newLayout = data.raw.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
                  "replacing node at invalid index \(index)")
@@ -121,7 +121,7 @@ public struct ${node.name}: _SyntaxBase, Hashable, SyntaxCollection {
   /// - Returns: A new `${node.name}` with the element at the provided index
   ///            removed.
   public func removing(childAt index: Int) -> ${node.name} {
-    var newLayout = data.raw.layout
+    var newLayout = data.raw.formLayoutArray()
     newLayout.remove(at: index)
     return replacingLayout(newLayout)
   }
@@ -130,7 +130,7 @@ public struct ${node.name}: _SyntaxBase, Hashable, SyntaxCollection {
   ///
   /// - Returns: A new `${node.name}` with the first element removed.
   public func removingFirst() -> ${node.name} {
-    var newLayout = data.raw.layout
+    var newLayout = data.raw.formLayoutArray()
     newLayout.removeFirst()
     return replacingLayout(newLayout)
   }
@@ -139,7 +139,7 @@ public struct ${node.name}: _SyntaxBase, Hashable, SyntaxCollection {
   ///
   /// - Returns: A new `${node.name}` with the last element removed.
   public func removingLast() -> ${node.name} {
-    var newLayout = data.raw.layout
+    var newLayout = data.raw.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
   }

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -152,7 +152,7 @@ struct SyntaxData {
   ///             normally the Syntax node that this `SyntaxData` belongs to.
   /// - Returns: The child's data at the provided index.
   func child(at index: Int, parent: _SyntaxBase) -> SyntaxData? {
-    if raw.layout[index] == nil { return nil }
+    if !raw.hasChild(at: index) { return nil }
     var iter = RawSyntaxChildren(absoluteRaw).makeIterator()
     for _ in 0..<index { _ = iter.next() }
     let (raw, info) = iter.next()!

--- a/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -84,7 +84,7 @@ public enum SyntaxFactory {
 
 %   if not node.is_base():
   public static func makeBlank${node.syntax_kind}() -> ${node.name} {
-    let data = SyntaxData.forRoot(RawSyntax(kind: .${node.swift_syntax_kind},
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .${node.swift_syntax_kind},
       layout: [
 %     for child in node.children:
 %       if child.is_optional:

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
@@ -128,10 +128,8 @@ public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
     if let col = raw[Cursor.${child.swift_name}] {
       collection = col.appending(element.raw)
     } else {
-      collection = RawSyntax(kind: SyntaxKind.${child_node.swift_syntax_kind},
-                             layout: [element.raw],
-                             length: element.raw.totalLength,
-                             presence: .present)
+      collection = RawSyntax.create(kind: SyntaxKind.${child_node.swift_syntax_kind},
+        layout: [element.raw], length: element.raw.totalLength, presence: .present)
     }
     let newData = data.replacingChild(collection,
                                       at: Cursor.${child.swift_name})

--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -92,7 +92,7 @@ open class SyntaxRewriter {
     }
 
     // Sanity check, ensure the new children are the same length.
-    assert(newLayout.count == node.raw.layout.count)
+    assert(newLayout.count == node.raw.numberOfChildren)
 
     let newRaw = node.raw.replacingLayout(newLayout)
     let newData = node.base.data.replacingSelf(newRaw)

--- a/Sources/SwiftSyntax/TokenKind.swift.gyb
+++ b/Sources/SwiftSyntax/TokenKind.swift.gyb
@@ -106,9 +106,6 @@ extension TokenKind: Equatable {
 extension TokenKind {
   static func fromRawValue(kind: CTokenKind,
                            textBuffer: UnsafeBufferPointer<UInt8>) -> TokenKind {
-    let convertToString = { () -> String in
-      return String(decoding: textBuffer, as: UTF8.self)
-    }
     switch kind {
     case 0: return .eof
 % for token in SYNTAX_TOKENS:
@@ -116,14 +113,14 @@ extension TokenKind {
 %   if token.text: # The token does not have text associated with it
       return .${token.swift_kind()}
 %   else:
-      return .${token.swift_kind()}(convertToString())
+      return .${token.swift_kind()}(.fromBuffer(textBuffer))
 %   end
 % end
     default:
       if !textBuffer.isEmpty {
         // Default to an unknown token with the passed text if we don't know
         // its kind.
-        return .unknown(convertToString())
+        return .unknown(.fromBuffer(textBuffer))
       } else {
         // If we were not passed the token's text, we cannot recover since we
         // would lose roundtripness.

--- a/Sources/SwiftSyntax/TokenKind.swift.gyb
+++ b/Sources/SwiftSyntax/TokenKind.swift.gyb
@@ -105,7 +105,10 @@ extension TokenKind: Equatable {
 
 extension TokenKind {
   static func fromRawValue(kind: CTokenKind,
-                           text: Substring) -> TokenKind {
+                           textBuffer: UnsafeBufferPointer<UInt8>) -> TokenKind {
+    let convertToString = { () -> String in
+      return String(decoding: textBuffer, as: UTF8.self)
+    }
     switch kind {
     case 0: return .eof
 % for token in SYNTAX_TOKENS:
@@ -113,19 +116,35 @@ extension TokenKind {
 %   if token.text: # The token does not have text associated with it
       return .${token.swift_kind()}
 %   else:
-      return .${token.swift_kind()}(String(text))
+      return .${token.swift_kind()}(convertToString())
 %   end
 % end
     default:
-      if !text.isEmpty {
+      if !textBuffer.isEmpty {
         // Default to an unknown token with the passed text if we don't know
         // its kind.
-        return .unknown(String(text))
+        return .unknown(convertToString())
       } else {
         // If we were not passed the token's text, we cannot recover since we
         // would lose roundtripness.
         fatalError("unexpected token kind \(kind)")
       }
+    }
+  }
+
+  static func hasText(kind: CTokenKind) -> Bool {
+    switch kind {
+    case 0: return false
+% for token in SYNTAX_TOKENS:
+    case ${token.serialization_code}:
+%   if token.text: # The token does not have text associated with it
+      return false
+%   else:
+      return true
+%   end
+% end
+    default:
+      fatalError("unexpected token kind \(kind)")
     }
   }
 }

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -162,14 +162,29 @@ extension TriviaPiece {
 
 extension TriviaPiece {
   static func fromRawValue(kind: CTriviaKind, length: Int,
-                           text: Substring) -> TriviaPiece {
+                           textBuffer: UnsafeBufferPointer<UInt8>) -> TriviaPiece {
     switch kind {
 % for trivia in TRIVIAS:
     case ${trivia.serialization_code}:
 %   if trivia.is_collection():
       return .${trivia.lower_name}s(length/${trivia.characters_len()})
 %   else:
-      return .${trivia.lower_name}(String(text))
+      return .${trivia.lower_name}(String(decoding: textBuffer, as: UTF8.self))
+%   end
+% end
+    default:
+      fatalError("unexpected trivia piece kind \(kind)")
+    }
+  }
+
+  static func hasText(kind: CTriviaKind) -> Bool {
+    switch kind {
+% for trivia in TRIVIAS:
+    case ${trivia.serialization_code}:
+%   if trivia.is_collection():
+      return false
+%   else:
+      return true
 %   end
 % end
     default:

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -169,7 +169,7 @@ extension TriviaPiece {
 %   if trivia.is_collection():
       return .${trivia.lower_name}s(length/${trivia.characters_len()})
 %   else:
-      return .${trivia.lower_name}(String(decoding: textBuffer, as: UTF8.self))
+      return .${trivia.lower_name}(.fromBuffer(textBuffer))
 %   end
 % end
     default:

--- a/Sources/SwiftSyntax/Utils.swift
+++ b/Sources/SwiftSyntax/Utils.swift
@@ -71,8 +71,6 @@ public struct SourceEdit {
 
 extension String {
   static func fromBuffer(_ textBuffer: UnsafeBufferPointer<UInt8>) -> String {
-    // The string function crashes if the buffer is empty with nil pointer (SR-9869).
-    guard !textBuffer.isEmpty else { return String() }
     return String(decoding: textBuffer, as: UTF8.self)
   }
 

--- a/Sources/SwiftSyntax/Utils.swift
+++ b/Sources/SwiftSyntax/Utils.swift
@@ -70,6 +70,12 @@ public struct SourceEdit {
 }
 
 extension String {
+  static func fromBuffer(_ textBuffer: UnsafeBufferPointer<UInt8>) -> String {
+    // The string function crashes if the buffer is empty with nil pointer (SR-9869).
+    guard !textBuffer.isEmpty else { return String() }
+    return String(decoding: textBuffer, as: UTF8.self)
+  }
+
   var isNativeUTF8: Bool {
     return utf8.withContiguousStorageIfAvailable { _ in 0 } != nil
   }


### PR DESCRIPTION
Changes to `RawSyntax`'s underlying storage with the goal of minimizing allocations during parsing:

* Use `ManagedBuffer` and perform only a single heap allocation for `RawSyntax`. `ManagedBuffer` tail allocates additional memory as needed.
* All required data for parsed nodes are copied into the single allocated buffer, avoiding converting them to strings and arrays.
* Nodes that are synthesized from the programmatic APIs are preserved in their existing form (trivia, layout arrays, etc.)
* Adjust implementation of `RawSyntax` APIs to accomodate for the new memory buffer mechanism.

With these changes `RawSyntax` tree creation during parsing is faster by 2.6x.