### PR TITLE
Optimize `SyntaxVisitor` and make it a protocol

### DIFF
--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -1116,39 +1116,3 @@ extension RawSyntax {
       trailingTrivia: trailingTrivia, length: length, presence: presence)
   }
 }
-
-extension RawSyntax {
-  func accept(_ visitor: RawSyntaxVisitor) {
-    // FIXME: Simplify visitation, this deferred 'shouldVisit` visitation
-    // mechanism is unnecessary now.
-    defer { visitor.moveUp() }
-    guard isPresent else { return }
-    if let tokKind = self.formTokenKind() {
-      if visitor.shouldVisit(tokKind) {
-        visitor.visitPre()
-        _ = visitor.visit()
-        visitor.visitPost()
-      }
-    } else {
-      let shouldVisit = visitor.shouldVisit(kind)
-      var visitChildren = true
-      if shouldVisit {
-        // Visit this node realizes a syntax node.
-        visitor.visitPre()
-        visitChildren = visitor.visit() == .visitChildren
-      }
-      if visitChildren {
-        for offset in 0..<numberOfChildren {
-          let child = self.child(at: offset)
-          guard let element = child else { continue }
-          // Teach the visitor to navigate to this child.
-          visitor.addChildIdx(offset)
-          element.accept(visitor)
-        }
-      }
-      if shouldVisit {
-        visitor.visitPost()
-      }
-    }
-  }
-}

--- a/Sources/SwiftSyntax/SyntaxClassifier.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxClassifier.swift.gyb
@@ -28,7 +28,7 @@ public enum SyntaxClassification {
 % end
 }
 
-fileprivate class _SyntaxClassifier: SyntaxVisitor {
+fileprivate struct _SyntaxClassifier: SyntaxVisitor {
 
   /// The top of the `contextStack` determines the classification for all tokens
   /// encountered that do not have a native classification. If `force` is `true`
@@ -41,13 +41,13 @@ fileprivate class _SyntaxClassifier: SyntaxVisitor {
   /// array.
   var classifications: [(TokenSyntax, SyntaxClassification)] = []
 
-  private func visit(
+  mutating private func visit(
     _ node: Syntax, 
     classification: SyntaxClassification, 
     force: Bool = false
   ) {
     contextStack.append((classification: classification, force: force))
-    node.walk(self)
+    node.walk(&self)
     contextStack.removeLast()
   }
 
@@ -67,7 +67,7 @@ fileprivate class _SyntaxClassifier: SyntaxVisitor {
     }
   }
 
-  override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
+  mutating func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
     assert(token.isPresent)
     // FIXME: We need to come up with some way in which the SyntaxClassifier can
     // classify trivia (i.e. comments). In particular we need to be able to
@@ -91,7 +91,7 @@ fileprivate class _SyntaxClassifier: SyntaxVisitor {
 
 % for node in SYNTAX_NODES:
 %   if is_visitable(node):
-  override func visit(_ node: ${node.name}) -> SyntaxVisitorContinueKind {
+  mutating func visit(_ node: ${node.name}) -> SyntaxVisitorContinueKind {
 %     if node.is_unknown() or node.is_syntax_collection():
     return .visitChildren
 %     else:
@@ -103,7 +103,7 @@ fileprivate class _SyntaxClassifier: SyntaxVisitor {
             classification: .${child.classification.swift_name}, 
             force: ${"true" if child.force_classification else "false"})
 %           else:
-      ${child.swift_name}.walk(self)
+      ${child.swift_name}.walk(&self)
 %           end
     }
 %         else:
@@ -112,7 +112,7 @@ fileprivate class _SyntaxClassifier: SyntaxVisitor {
           classification: .${child.classification.swift_name}, 
           force: ${"true" if child.force_classification else "false"})
 %           else:
-    node.${child.swift_name}.walk(self)
+    node.${child.swift_name}.walk(&self)
 %           end
 %         end
 %       end
@@ -130,8 +130,8 @@ public enum SyntaxClassifier {
   public static func classifyTokensInTree(
     _ syntaxTree: SourceFileSyntax
   ) -> [(TokenSyntax, SyntaxClassification)] {
-    let classifier = _SyntaxClassifier()
-    syntaxTree.walk(classifier)
+    var classifier = _SyntaxClassifier()
+    syntaxTree.walk(&classifier)
     return classifier.classifications
   }
 }

--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -54,7 +54,7 @@ open class SyntaxRewriter {
     return nil
   }
 
-  /// The function called after visting the node and its descendents.
+  /// The function called after visiting the node and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: Syntax) {}
 
@@ -111,198 +111,177 @@ public enum SyntaxVisitorContinueKind {
   case skipChildren
 }
 
-open class SyntaxVisitor {
-    public init() {}
+public protocol SyntaxVisitor {
 % for node in SYNTAX_NODES:
 %   if is_visitable(node):
-  /// Visting ${node.name} specifically.
+  /// Visiting `${node.name}` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
-  open func visit(_ node: ${node.name}) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-%   end
-% end
+  mutating func visit(_ node: ${node.name}) -> SyntaxVisitorContinueKind
 
-  /// Visting UnknownSyntax specifically.
-  ///   - Parameter node: the node we are visiting.
-  ///   - Returns: how should we continue visiting.
-  open func visit(_ node: UnknownSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-
-  /// Whether we should ever visit a given syntax kind.
-  ///   - Parameter kind: the input kind we're checking.
-  ///   - Returns: whether we should visit syntax nodes of this kind.
-  open func shouldVisit(_ kind: SyntaxKind) -> Bool {
-    return true
-  }
-
-  /// Whether we should ever visit a given token kind.
-  ///   - Parameter kind: the input token kind we're checking.
-  ///   - Returns: whether we should visit tokens of this kind.
-  open func shouldVisit(_ kind: TokenKind) -> Bool {
-    return true
-  }
-
-  open func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
-    return .skipChildren
-  }
-
-  /// The function called before visiting the node and its descendents.
-  ///   - node: the node we are about to visit.
-  open func visitPre(_ node: Syntax) {}
-
-  /// The function called after visting the node and its descendents.
+  /// The function called after visiting `${node.name}` and its descendents.
   ///   - node: the node we just finished visiting.
-  open func visitPost(_ node: Syntax) {}
-
-  public func visit(_ node: Syntax) -> SyntaxVisitorContinueKind {
-    switch node.raw.kind {
-    case .token: return visit(node as! TokenSyntax)
-% for node in SYNTAX_NODES:
-%   if is_visitable(node):
-    case .${node.swift_syntax_kind}: return visit(node as! ${node.name})
+  mutating func visitPost(_ node: ${node.name})
 %   end
 % end
-    case .unknown: return visit(node as! UnknownSyntax)
-    default: return .skipChildren
-    }
+
+  /// Visiting `TokenSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  mutating func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind
+
+  /// The function called after visiting the node and its descendents.
+  ///   - node: the node we just finished visiting.
+  mutating func visitPost(_ node: TokenSyntax)
+
+  /// Visiting `UnknownSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  mutating func visit(_ node: UnknownSyntax) -> SyntaxVisitorContinueKind
+
+  /// The function called after visiting the node and its descendents.
+  ///   - node: the node we just finished visiting.
+  mutating func visitPost(_ node: UnknownSyntax)
+}
+
+public extension SyntaxVisitor {
+% for node in SYNTAX_NODES:
+%   if is_visitable(node):
+  mutating func visit(_ node: ${node.name}) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+  mutating func visitPost(_ node: ${node.name}) {}
+%   end
+% end
+
+  mutating func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+  mutating func visitPost(_ node: TokenSyntax) {}
+
+  mutating func visit(_ node: UnknownSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+  mutating func visitPost(_ node: UnknownSyntax) {}
+}
+
+/// A `SyntaxVisitor` that can visit the nodes as generic `Syntax` values.
+///
+/// This is a separate protocol because this kind of visitation is slower than
+/// the type-specific visitation of `SyntaxVisitor`. Use `SyntaxAnyVisitor` if
+/// the `visitAny(_)` function would be useful to have, otherwise use
+/// `SyntaxVisitor`.
+///
+/// This works by introducing default implementations of the type-specific
+/// visit function that delegate to `visitAny(_)`. A conformant type that
+/// provides a custom type-specific visit function, should also call
+/// `visitAny(_)` in its implementation, if calling `visitAny` is needed:
+///
+///     struct MyVisitor: SyntaxAnyVisitor {
+///       func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
+///         <code>
+///       }
+///
+///       func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
+///         <code>
+///         // Call this to pass tokens to `visitAny(_)` as well if needed
+///         visitAny(token)
+///       }
+///
+public protocol SyntaxAnyVisitor: SyntaxVisitor {
+  mutating func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind
+  mutating func visitAnyPost(_ node: Syntax)
+}
+
+public extension SyntaxAnyVisitor {
+  mutating func visitAnyPost(_ node: Syntax) {}
+
+% for node in SYNTAX_NODES:
+%   if is_visitable(node):
+  mutating func visit(_ node: ${node.name}) -> SyntaxVisitorContinueKind {
+    return visitAny(node)
+  }
+  mutating func visitPost(_ node: ${node.name}) {
+    return visitAnyPost(node)
+  }
+%   end
+% end
+
+  mutating func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(token)
+  }
+  mutating func visitPost(_ node: TokenSyntax) {
+    return visitAnyPost(node)
+  }
+
+  mutating func visit(_ node: UnknownSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node)
+  }
+  mutating func visitPost(_ node: UnknownSyntax) {
+    return visitAnyPost(node)
   }
 }
 
-
-/// A wrapper over Syntax. A syntax node is only realized when explicitly asked;
-/// otherwise the node is represented as a child index list from a realized
-/// ancestor.
-class PendingSyntaxNode {
-  let parent: PendingSyntaxNode!
-  private var kind: PendingSyntaxNodeKind
-
-  private enum PendingSyntaxNodeKind {
-    /// We already have a `Syntax` node realised for this node
-    case realized(node: Syntax)
-    /// This node does not have a `Syntax` node instantiated yet. If needed, we
-    /// need to compute it from its parent RawSyntax node
-    case virtual(index: Int)
-  }
-
-  var node: Syntax {
-    switch kind {
-    case .realized(let node):
-      return node
-    case .virtual(let index):
-      let base = parent.node.base
-      let data = base.data.child(at: index, parent: base)!
-      let _node = makeSyntax(data)
-      kind = .realized(node: _node)
-      return _node
-    }
-  }
-
-  init(_ root: Syntax) {
-    self.parent = nil
-    self.kind = .realized(node: root)
-  }
-
-  init(_ parent: PendingSyntaxNode, _ idx: Int) {
-    self.parent = parent
-    self.kind = .virtual(index: idx)
-  }
-}
-
-
-/// The raw syntax walker traverses the raw syntax tree to find
-/// node kinds the SyntaxVisitor is interested and feed these syntax nodes to
-/// SyntaxVisitor.
-/// By traversing the raw syntax tree, we avoid realizing syntax nodes that're
-/// not interesting to users' SyntaxVisitor.
-class RawSyntaxVisitor {
-  private let visitor: SyntaxVisitor
-  private var currentNode: PendingSyntaxNode!
-
-  required init(_ visitor: SyntaxVisitor, _ root: Syntax) {
-    self.visitor = visitor
-    self.currentNode = PendingSyntaxNode(root)
-  }
-
-  func shouldVisit(_ kind: SyntaxKind) -> Bool {
-    return visitor.shouldVisit(kind)
-  }
-
-  func shouldVisit(_ kind: TokenKind) -> Bool {
-    return visitor.shouldVisit(kind)
-  }
-
-  func addChildIdx(_ idx: Int) {
-    currentNode = PendingSyntaxNode(currentNode, idx)
-  }
-
-  func moveUp() {
-    currentNode = currentNode.parent
-  }
-
-  func visitPre() {
-    visitor.visitPre(currentNode.node)
-  }
-
-  func visitPost() {
-    visitor.visitPost(currentNode.node)
-  }
-
-  // The current raw syntax node is interesting for the user, so realize a
-  // correponding syntax node and feed it into the visitor.
-  func visit() -> SyntaxVisitorContinueKind {
-    return visitor.visit(currentNode.node)
+extension _SyntaxBase {
+  func walk<Visitor>(_ visitor: inout Visitor) where Visitor : SyntaxVisitor {
+    guard isPresent else { return }
+    return doVisit(data, &visitor)
   }
 }
 
 extension Syntax {
-  public func walk(_ visitor: SyntaxVisitor) {
-
-    // Traverse the raw syntax tree by using the current syntax node as root.
-    raw.accept(RawSyntaxVisitor(visitor, self))
+  public func walk<Visitor>(_ visitor: inout Visitor) where Visitor : SyntaxVisitor {
+    return base.walk(&visitor)
   }
 }
 
-public enum SyntaxVerifierError: Error, CustomStringConvertible {
-  case unknownSyntaxFound(node: Syntax)
-
-  public var description: String {
-    switch self {
-      case .unknownSyntaxFound(let node):
-        return "unknown syntax node for \"\(node)\""
+fileprivate func doVisit<Visitor>(
+  _ data: SyntaxData, _ visitor: inout Visitor
+) where Visitor : SyntaxVisitor {
+  // Create the node types directly instead of going through `makeSyntax()`
+  // which has additional cost for casting back and forth from `_SyntaxBase`.
+  switch data.raw.kind {
+  case .token:
+    let node = TokenSyntax(data)
+    _ = visitor.visit(node)
+    // No children to visit.
+    visitor.visitPost(node)
+  case .unknown:
+    let node = UnknownSyntax(data)
+    let needsChildren = visitor.visit(node) == .visitChildren
+    // Avoid casting to `_SyntaxBase` if we don't need to visit children.
+    if needsChildren && data.raw.numberOfChildren > 0 {
+      visitChildren(data, parent: node, &visitor)
     }
+    visitor.visitPost(node)
+% for node in SYNTAX_NODES:
+  case .${node.swift_syntax_kind}:
+%   if node.is_base():
+    let node = Unknown${node.name}(data)
+    let needsChildren = visitor.visit(node) == .visitChildren
+    // Avoid casting to `_SyntaxBase` if we don't need to visit children.
+    if needsChildren && data.raw.numberOfChildren > 0 {
+      visitChildren(data, parent: node, &visitor)
+    }
+    visitor.visitPost(node)
+%   else:
+    let node = ${node.name}(data)
+    let needsChildren = visitor.visit(node) == .visitChildren
+    // Avoid casting to `_SyntaxBase` if we don't need to visit children.
+    if needsChildren && data.raw.numberOfChildren > 0 {
+      visitChildren(data, parent: node, &visitor)
+    }
+    visitor.visitPost(node)
+%   end
+% end
   }
 }
 
-public class SyntaxVerifier: SyntaxVisitor {
-
-  var unknownNodes: [Syntax] = []
-
-  override public func shouldVisit(_ node: SyntaxKind) -> Bool {
-    return node.isUnknown
-  }
-
-  override public func shouldVisit(_ node: TokenKind) -> Bool {
-    return false
-  }
-
-  override public func visitPre(_ node: Syntax) {
-    assert(node.isUnknown)
-    unknownNodes.append(node)
-  }
-
-  private func verify(_ node: Syntax) throws {
-    node.walk(self)
-    if let unknownNode = unknownNodes.first {
-      throw SyntaxVerifierError.unknownSyntaxFound(node: unknownNode)
-    }
-  }
-
-  private override init() {}
-
-  public static func verify(_ node: Syntax) throws {
-    try SyntaxVerifier().verify(node)
+fileprivate func visitChildren<Visitor>(
+  _ data: SyntaxData, parent: _SyntaxBase, _ visitor: inout Visitor
+) where Visitor : SyntaxVisitor {
+  for childRaw in PresentRawSyntaxChildren(data.absoluteRaw) {
+    let childData = SyntaxData(childRaw, parent: parent)
+    doVisit(childData, &visitor)
   }
 }

--- a/Sources/SwiftSyntax/SyntaxVerifier.swift
+++ b/Sources/SwiftSyntax/SyntaxVerifier.swift
@@ -1,0 +1,51 @@
+//===------ SyntaxVerifier.swift - Syntax Verifier ------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// Verifier to check that there are no unknown syntax nodes in the tree.
+//
+//===----------------------------------------------------------------------===//
+
+public enum SyntaxVerifierError: Error, CustomStringConvertible {
+  case unknownSyntaxFound(node: Syntax)
+
+  public var description: String {
+    switch self {
+      case .unknownSyntaxFound(let node):
+        return "unknown syntax node for \"\(node)\""
+    }
+  }
+}
+
+/// Verifier to check that there are no unknown syntax nodes in the tree.
+public struct SyntaxVerifier: SyntaxAnyVisitor {
+
+  var unknownNodes: [Syntax] = []
+
+  public mutating func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
+    if node.isUnknown {
+      unknownNodes.append(node)
+    }
+    return .visitChildren
+  }
+
+  private mutating func verify(_ node: Syntax) throws {
+    node.walk(&self)
+    if let unknownNode = unknownNodes.first {
+      throw SyntaxVerifierError.unknownSyntaxFound(node: unknownNode)
+    }
+  }
+
+  public static func verify(_ node: Syntax) throws {
+    var verifier = SyntaxVerifier()
+    try verifier.verify(node)
+  }
+}

--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -371,15 +371,16 @@ func performRoundtrip(args: CommandLineArguments) throws {
   }
 }
 
-class NodePrinter: SyntaxVisitor {
-  override func visitPre(_ node: Syntax) {
+struct NodePrinter: SyntaxAnyVisitor {
+  func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
     assert(!node.isUnknown)
     print("<\(type(of: node))>", terminator: "")
+    return .visitChildren
   }
-  override func visitPost(_ node: Syntax) {
+  func visitAnyPost(_ node: Syntax) {
     print("</\(type(of: node))>", terminator: "")
   }
-  override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
+  func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
     print(token, terminator:"")
     return .visitChildren
   }
@@ -388,7 +389,8 @@ class NodePrinter: SyntaxVisitor {
 func printSyntaxTree(args: CommandLineArguments) throws {
   let treeURL = URL(fileURLWithPath: try args.getRequired("-source-file"))
   let tree = try SyntaxParser.parse(treeURL)
-  tree.walk(NodePrinter())
+  var printer = NodePrinter()
+  tree.walk(&printer)
 }
 
 do {

--- a/Tests/SwiftSyntaxTest/AbsolutePosition.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePosition.swift
@@ -59,19 +59,15 @@ public class AbsolutePositionTestCase: XCTestCase {
   public func testCurrentFile() {
     XCTAssertNoThrow(try {
       let parsed = try SyntaxParser.parse(URL(fileURLWithPath: #file))
-      class Visitor: SyntaxVisitor {
-        override func visitPre(_ node: Syntax) {
-          _ = node.position
-          _ = node.byteSize
-          _ = node.positionAfterSkippingLeadingTrivia
-        }
-        override func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
+      struct Visitor: SyntaxVisitor {
+        func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
           XCTAssertEqual(node.positionAfterSkippingLeadingTrivia.utf8Offset,
             node.position.utf8Offset + node.leadingTrivia.byteSize)
           return .skipChildren
         }
       }
-      parsed.walk(Visitor())
+      var visitor = Visitor()
+      parsed.walk(&visitor)
     }())
   }
 

--- a/Tests/SwiftSyntaxTest/DiagnosticTest.swift
+++ b/Tests/SwiftSyntaxTest/DiagnosticTest.swift
@@ -69,14 +69,14 @@ public class DiagnosticTestCase: XCTestCase {
     // engine.addConsumer(PrintingDiagnosticConsumer())
     let url = getInput("diagnostics.swift")
 
-    class Visitor: SyntaxVisitor {
+    struct Visitor: SyntaxVisitor {
       let converter: SourceLocationConverter
       let engine: DiagnosticEngine
       init(converter: SourceLocationConverter, engine: DiagnosticEngine) {
         self.converter = converter
         self.engine = engine
       }
-      override func visit(_ function: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+      func visit(_ function: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
         let startLoc = function.identifier.startLocation(converter: converter)
         let endLoc = function.endLocation(converter: converter)
         engine.diagnose(.badFunction(function.identifier), location: startLoc) {
@@ -90,7 +90,8 @@ public class DiagnosticTestCase: XCTestCase {
     XCTAssertNoThrow(try {
       let file = try SyntaxParser.parse(url)
       let converter = SourceLocationConverter(file: url.path, tree: file)
-      file.walk(Visitor(converter: converter, engine: engine))
+      var visitor = Visitor(converter: converter, engine: engine)
+      file.walk(&visitor)
     }())
 
      XCTAssertEqual(6, engine.diagnostics.count)

--- a/Tests/SwiftSyntaxTest/VisitorTest.swift
+++ b/Tests/SwiftSyntaxTest/VisitorTest.swift
@@ -11,18 +11,18 @@ public class SyntaxVisitorTestCase: XCTestCase {
   ]
 
   public func testBasic() {
-    class FuncCounter: SyntaxVisitor {
+    struct FuncCounter: SyntaxVisitor {
       var funcCount = 0
-      override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+      mutating func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
         funcCount += 1
         return .visitChildren
       }
     }
     XCTAssertNoThrow(try {
       let parsed = try SyntaxParser.parse(getInput("visitor.swift"))
-      let counter = FuncCounter()
+      var counter = FuncCounter()
       let hashBefore = parsed.hashValue
-      parsed.walk(counter)
+      parsed.walk(&counter)
       XCTAssertEqual(counter.funcCount, 3)
       XCTAssertEqual(hashBefore, parsed.hashValue)
     }())
@@ -67,10 +67,10 @@ public class SyntaxVisitorTestCase: XCTestCase {
   }
 
   public func testSyntaxRewriterVisitCollection() {
-    class VisitCollections: SyntaxVisitor {
+    struct VisitCollections: SyntaxVisitor {
       var numberOfCodeBlockItems = 0
 
-      override func visit(_ items: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
+      mutating func visit(_ items: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
         numberOfCodeBlockItems += items.count
         return .visitChildren
       }
@@ -78,8 +78,8 @@ public class SyntaxVisitorTestCase: XCTestCase {
 
     XCTAssertNoThrow(try {
       let parsed = try SyntaxParser.parse(getInput("nested-blocks.swift"))
-      let visitor = VisitCollections()
-      parsed.walk(visitor)
+      var visitor = VisitCollections()
+      parsed.walk(&visitor)
       XCTAssertEqual(4, visitor.numberOfCodeBlockItems)
     }())
   }


### PR DESCRIPTION
* Remove the deferred visitation `shouldVisit` checks. They are unnecessary now.
* Change `SyntaxVisitor` to a protocol. `SyntaxVisitor` was a pure abstract class, a protocol is more appropriate for it.
* Minimize casts to `Syntax`/`_SyntaxBase` during visitation to improve performance
* Introduce `SyntaxAnyVisitor` as separate protocol for clients that want to use a `visitAny(_:Syntax)` function. It is a separate protocol because this kind of visitation is 1.6x slower.
* Removed `SyntaxVisitor.visitPre()` because it doesn't seem useful, a client can put related code into `visit()` instead.
* Move `SyntaxVerifier` to a separate source file

After these changes, performance of visition has improved significantly. Depending on whether the `SyntaxVisitor` client was visiting only token nodes or all nodes, the speed-up is 5x or 6x respectively.