### PR TITLE
API: allow SyntaxNodes to check whether they are syntax collection

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -53,7 +53,7 @@ extension _SyntaxBase {
   }
 
   /// Whether or not this node represents an SyntaxCollection.
-  var isSyntaxCollection: Bool {
+  var isCollection: Bool {
     return raw.kind.isSyntaxCollection
   }
 
@@ -305,8 +305,8 @@ extension Syntax {
   }
 
   /// Whether or not this node represents an SyntaxCollection.
-  public var isSyntaxCollection: Bool {
-    return base.isSyntaxCollection
+  public var isCollection: Bool {
+    return base.isCollection
   }
 
   /// Whether or not this node represents a Declaration.

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -52,6 +52,11 @@ extension _SyntaxBase {
     return raw.kind.isExpr
   }
 
+  /// Whether or not this node represents an SyntaxCollection.
+  var isSyntaxCollection: Bool {
+    return raw.kind.isSyntaxCollection
+  }
+
   /// Whether or not this node represents a Declaration.
   var isDecl: Bool {
     return raw.kind.isDecl
@@ -297,6 +302,11 @@ extension Syntax {
   /// Whether or not this node represents an Expression.
   public var isExpr: Bool {
     return base.isExpr
+  }
+
+  /// Whether or not this node represents an SyntaxCollection.
+  public var isSyntaxCollection: Bool {
+    return base.isSyntaxCollection
   }
 
   /// Whether or not this node represents a Declaration.

--- a/Sources/SwiftSyntax/SyntaxKind.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxKind.swift.gyb
@@ -32,7 +32,7 @@ public enum SyntaxKind: String {
 % end
 
 % for name, nodes in grouped_nodes.items():
-%   if name not in ["Syntax", "SyntaxCollection"]:
+%   if name not in ["Syntax"]:
   /// Whether the underlying kind is a sub-kind of ${name}Syntax.
   public var is${name}: Bool {
     switch self {

--- a/Tests/SwiftSyntaxTest/SyntaxCollections.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCollections.swift
@@ -27,9 +27,10 @@ public class SyntaxCollectionsAPITestCase: XCTestCase {
       ])
 
       let newArrayElementList = arrayElementList.appending(integerLiteralElement(1))
-
+      XCTAssert(newArrayElementList.isSyntaxCollection)
       XCTAssertEqual(newArrayElementList.count, 2)
       XCTAssertNotNil(newArrayElementList.child(at: 1))
+      XCTAssert(!newArrayElementList.child(at: 1)!.isSyntaxCollection)
       XCTAssertEqual("\(newArrayElementList.child(at: 1)!)", "1")
   }
 

--- a/Tests/SwiftSyntaxTest/SyntaxCollections.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCollections.swift
@@ -27,10 +27,10 @@ public class SyntaxCollectionsAPITestCase: XCTestCase {
       ])
 
       let newArrayElementList = arrayElementList.appending(integerLiteralElement(1))
-      XCTAssert(newArrayElementList.isSyntaxCollection)
+      XCTAssert(newArrayElementList.isCollection)
       XCTAssertEqual(newArrayElementList.count, 2)
       XCTAssertNotNil(newArrayElementList.child(at: 1))
-      XCTAssert(!newArrayElementList.child(at: 1)!.isSyntaxCollection)
+      XCTAssert(!newArrayElementList.child(at: 1)!.isCollection)
       XCTAssertEqual("\(newArrayElementList.child(at: 1)!)", "1")
   }
 


### PR DESCRIPTION
This is helpful for indentation because syntax collection should not
add a new indentation level.