### PR TITLE
Make `SyntaxKind` internal

### DIFF
--- a/Sources/SwiftSyntax/SyntaxKind.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxKind.swift.gyb
@@ -21,14 +21,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
-
 /// Enumerates the known kinds of Syntax represented in the Syntax tree.
-public enum SyntaxKind: String {
-  case token = "Token"
-  case unknown = "Unknown"
+internal enum SyntaxKind: CSyntaxKind {
+  case token = 0
+  case unknown = 1
 % for node in SYNTAX_NODES:
-  case ${node.swift_syntax_kind} = "${node.syntax_kind}"
+  case ${node.swift_syntax_kind} = ${SYNTAX_NODE_SERIALIZATION_CODES[node.syntax_kind]}
 % end
 
 % for name, nodes in grouped_nodes.items():
@@ -56,11 +54,11 @@ public enum SyntaxKind: String {
     default: return false
     }
   }
+}
 
-  public init(from decoder: Decoder) throws {
-    let container = try decoder.singleValueContainer()
-    let kind = try container.decode(String.self)
-    self = SyntaxKind(rawValue: kind) ?? .unknown
+extension SyntaxKind {
+  static func fromRawValue(_ rawValue: CSyntaxKind) -> SyntaxKind {
+    return SyntaxKind(rawValue: rawValue)!
   }
 }
 
@@ -81,27 +79,5 @@ internal func makeSyntax(_ data: SyntaxData) -> _SyntaxBase {
     return ${node.name}(data)
 %   end
 % end
-  }
-}
-
-
-extension SyntaxKind {
-  static func fromRawValue(_ rawValue: CSyntaxKind) -> SyntaxKind {
-    // Explicitly spell out all SyntaxKinds to keep the serialized value stable
-    // even if its members get reordered or members get removed
-    switch rawValue {
-    case 0:
-      return .token
-    case 1:
-      return .unknown
-% for name, nodes in grouped_nodes.items():
-%   for node in nodes:
-    case ${SYNTAX_NODE_SERIALIZATION_CODES[node.syntax_kind]}:
-      return .${node.swift_syntax_kind}
-%   end
-% end
-    default:
-      return .unknown
-    }
   }
 }

--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -272,12 +272,12 @@ func performParseIncremental(args: CommandLineArguments) throws {
   let preEditTree = try SyntaxParser.parse(preEditURL)
   let edits = try parseIncrementalEditArguments(args: args)
   let regionCollector = IncrementalParseReusedNodeCollector()
-  let editTransition = IncrementalEditTransition(previousTree: preEditTree,
+  let editTransition = IncrementalParseTransition(previousTree: preEditTree,
     edits: edits, reusedNodeDelegate: regionCollector)
 
   let postEditText = try String(contentsOf: postEditURL)
   let postEditTree =
-    try SyntaxParser.parse(source: postEditText, parseLookup: editTransition)
+    try SyntaxParser.parse(source: postEditText, parseTransition: editTransition)
 
   let postTreeDump = postEditTree.description
 

--- a/Tests/SwiftSyntaxTest/IncrementalParsingTests.swift
+++ b/Tests/SwiftSyntaxTest/IncrementalParsingTests.swift
@@ -14,8 +14,8 @@ public class IncrementalParsingTestCase: XCTestCase {
 
     var tree = try! SyntaxParser.parse(source: original)
     let sourceEdit = SourceEdit(range: ByteSourceRange(offset: step.1.0, length: step.1.1), replacementLength: step.1.2.utf8.count)
-    let lookup = IncrementalEditTransition(previousTree: tree, edits: [sourceEdit])
-    tree = try! SyntaxParser.parse(source: step.0, parseLookup: lookup)
+    let lookup = IncrementalParseTransition(previousTree: tree, edits: [sourceEdit])
+    tree = try! SyntaxParser.parse(source: step.0, parseTransition: lookup)
     XCTAssertEqual("\(tree)", step.0)
   }
 }


### PR DESCRIPTION
`SyntaxKind` was made public in order to provide a visitation check for clients. Since the visitation check has been removed there's no need for `SyntaxKind` to be public.
Additional changes:

* Make `SyntaxKind` have CSyntaxKind as raw type. Avoids having to convert between them.
* Remove protocol `IncrementalParseLookup`. It can't be public since `SyntaxKind` is internal, and it's not much use to external clients anyway.
* Rename `IncrementalEditTransition` -> `IncrementalParseTransition`.