### PR TITLE
Add Periphery as an example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Then, import `SwiftSyntax` in your Swift code.
 
 [**SwiftPack**](https://github.com/omochi/SwiftPack): a tool for automatically embedding Swift library source.
 
+[**Periphery**](https://github.com/peripheryapp/periphery): a tool to detect unused code.
+
 ## Contributing
 
 ### Building SwiftSyntax from `master`


### PR DESCRIPTION
Not sure if you want anymore examples in the README, but Periphery uses SwiftSyntax for unused function parameter detection.