### PR TITLE
Change `endPosition` to be the end of the node's length and add `endPositionBeforeTrailingTrivia` in its place

### DIFF
--- a/Sources/SwiftSyntax/SourceLength.swift
+++ b/Sources/SwiftSyntax/SourceLength.swift
@@ -64,4 +64,15 @@ extension AbsolutePosition {
   public static func +=(lhs: inout AbsolutePosition, rhs: SourceLength) {
     lhs = lhs + rhs
   }
+
+  public static func -(
+    lhs: AbsolutePosition, rhs: SourceLength
+  ) -> AbsolutePosition {
+    let utf8Offset = lhs.utf8Offset - rhs.utf8Length
+    return AbsolutePosition(utf8Offset: utf8Offset)
+  }
+
+  public static func -=(lhs: inout AbsolutePosition, rhs: SourceLength) {
+    lhs = lhs - rhs
+  }
 }

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -170,15 +170,14 @@ extension _SyntaxBase {
     return data.positionAfterSkippingLeadingTrivia
   }
 
-  /// The absolute position where this node (excluding its trailing trivia)
-  /// ends.
-  var endPosition: AbsolutePosition {
-    return data.endPosition
+  /// The end position of this node's content, before any trailing trivia.
+  var endPositionBeforeTrailingTrivia: AbsolutePosition {
+    return data.endPositionBeforeTrailingTrivia
   }
 
-  /// The absolute position where this node's trailing trivia ends
-  var endPositionAfterTrailingTrivia: AbsolutePosition {
-    return data.endPositionAfterTrailingTrivia
+  /// The end position of this node, including its trivia.
+  var endPosition: AbsolutePosition {
+    return data.endPosition
   }
 
   /// The textual byte length of this node including leading and trailing trivia.
@@ -384,15 +383,14 @@ extension Syntax {
     return base.positionAfterSkippingLeadingTrivia
   }
 
-  /// The absolute position where this node (excluding its trailing trivia)
-  /// ends.
-  public var endPosition: AbsolutePosition {
-    return base.endPosition
+  /// The end position of this node's content.
+  public var endPositionBeforeTrailingTrivia: AbsolutePosition {
+    return base.endPositionBeforeTrailingTrivia
   }
 
-  /// The absolute position where this node's trailing trivia ends
-  public var endPositionAfterTrailingTrivia: AbsolutePosition {
-    return base.endPositionAfterTrailingTrivia
+  /// The end position of this node, including its trivia
+  public var endPosition: AbsolutePosition {
+    return base.endPosition
   }
 
   /// The textual byte length of this node including leading and trailing trivia.

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -117,14 +117,14 @@ struct SyntaxData {
     return position + raw.leadingTriviaLength
   }
 
-  /// The end position of this node's content, excluding its trivia
-  var endPosition: AbsolutePosition {
-    return positionAfterSkippingLeadingTrivia + raw.contentLength
+  /// The end position of this node's content, before any trailing trivia.
+  var endPositionBeforeTrailingTrivia: AbsolutePosition {
+    return endPosition - raw.trailingTriviaLength
   }
 
-  /// The end position of this node's trivia
-  var endPositionAfterTrailingTrivia: AbsolutePosition {
-    return endPosition + raw.trailingTriviaLength
+  /// The end position of this node, including its trivia.
+  var endPosition: AbsolutePosition {
+    return position + raw.totalLength
   }
 
   /// Creates a `SyntaxData` with the provided raw syntax and parent.

--- a/Tests/SwiftSyntaxTest/SyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTests.swift
@@ -5,6 +5,7 @@ public class SyntaxAPITestCase: XCTestCase {
 
   public static let allTests = [
     ("testSyntaxAPI", testSyntaxAPI),
+    ("testPositions", testPositions),
   ]
 
   public func testSyntaxAPI() {
@@ -62,5 +63,29 @@ public class SyntaxAPITestCase: XCTestCase {
     XCTAssertEqual(toks[3].uniqueIdentifier, rtoks[2].uniqueIdentifier)
     XCTAssertEqual(toks[4].uniqueIdentifier, rtoks[1].uniqueIdentifier)
     XCTAssertEqual(toks[5].uniqueIdentifier, rtoks[0].uniqueIdentifier)
+  }
+
+  public func testPositions() {
+    func testFuncKw(_ funcKW: TokenSyntax) {
+      XCTAssertEqual("\(funcKW)", "  func ")
+      XCTAssertEqual(funcKW.position, AbsolutePosition(utf8Offset: 0))
+      XCTAssertEqual(funcKW.positionAfterSkippingLeadingTrivia, AbsolutePosition(utf8Offset: 2))
+      XCTAssertEqual(funcKW.endPositionBeforeTrailingTrivia, AbsolutePosition(utf8Offset: 6))
+      XCTAssertEqual(funcKW.endPosition, AbsolutePosition(utf8Offset: 7))
+      XCTAssertEqual(funcKW.contentLength, SourceLength(utf8Length: 4))
+    }
+    do {
+      let source = "  func f() {}"
+      let tree = try! SyntaxParser.parse(source: source)
+      let funcKW = tree.firstToken!
+      testFuncKw(funcKW)
+    }
+    do {
+      let leading = Trivia(pieces: [ .spaces(2) ])
+      let trailing = Trivia(pieces: [ .spaces(1) ])
+      let funcKW = SyntaxFactory.makeFuncKeyword(
+        leadingTrivia: leading, trailingTrivia: trailing)
+      testFuncKw(funcKW)
+    }
   }
 }


### PR DESCRIPTION
* It is unintuitive that `position` points at the beginning of the node and `endPosition` points at the beginning of the trailing trivia. Pointing at the end of the node is more intuitive
* Now there is a symmetry for `position`/`endPosition` and `positionAfterSkippingLeadingTrivia`/`endPositionBeforeTrailingTrivia`. `position`/`endPosition` are both "cost-free" while `positionAfterSkippingLeadingTrivia`/`endPositionBeforeTrailingTrivia` requires calculating the trivia length.