### PR TITLE
[IncrementalParseTransition] Simplify implementation of IncrementalParseTransition

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -185,6 +185,11 @@ extension _SyntaxBase {
     return totalLength.utf8Length
   }
 
+  /// The byte source range of this node including leading and trailing trivia.
+  var byteRange: ByteSourceRange {
+    return ByteSourceRange(offset: position.utf8Offset, length: byteSize)
+  }
+
   /// The length this node takes up spelled out in the source, excluding its
   /// leading or trailing trivia.
   var contentLength: SourceLength {
@@ -396,6 +401,11 @@ extension Syntax {
   /// The textual byte length of this node including leading and trailing trivia.
   public var byteSize: Int {
     return base.byteSize
+  }
+
+  /// The byte source range of this node including leading and trailing trivia.
+  public var byteRange: ByteSourceRange {
+    return base.byteRange
   }
 
   /// The length this node takes up spelled out in the source, excluding its

--- a/Sources/SwiftSyntax/Utils.swift
+++ b/Sources/SwiftSyntax/Utils.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct ByteSourceRange {
+public struct ByteSourceRange: Equatable {
   public let offset: Int
   public let length: Int
 

--- a/Tests/SwiftSyntaxTest/IncrementalParsingTests.swift
+++ b/Tests/SwiftSyntaxTest/IncrementalParsingTests.swift
@@ -5,6 +5,7 @@ public class IncrementalParsingTestCase: XCTestCase {
 
   public static let allTests = [
     ("testIncrementalInvalid", testIncrementalInvalid),
+    ("testReusedNode", testReusedNode),
   ]
 
   public func testIncrementalInvalid() {
@@ -17,5 +18,32 @@ public class IncrementalParsingTestCase: XCTestCase {
     let lookup = IncrementalParseTransition(previousTree: tree, edits: [sourceEdit])
     tree = try! SyntaxParser.parse(source: step.0, parseTransition: lookup)
     XCTAssertEqual("\(tree)", step.0)
+  }
+
+  public func testReusedNode() {
+    let original = "struct A {}\nstruct B {}\n"
+    let step: (String, (Int, Int, String)) =
+      ("struct AA {}\nstruct B {}\n", (8, 0, "A"))
+
+    let origTree = try! SyntaxParser.parse(source: original)
+    let sourceEdit = SourceEdit(range: ByteSourceRange(offset: step.1.0, length: step.1.1), replacementLength: step.1.2.utf8.count)
+    let reusedNodeCollector = IncrementalParseReusedNodeCollector()
+    let transition = IncrementalParseTransition(previousTree: origTree, edits: [sourceEdit], reusedNodeDelegate: reusedNodeCollector)
+    let newTree = try! SyntaxParser.parse(source: step.0, parseTransition: transition)
+    XCTAssertEqual("\(newTree)", step.0)
+
+    let origStructB = origTree.statements[1] as! CodeBlockItemSyntax
+    let newStructB = newTree.statements[1] as! CodeBlockItemSyntax
+    XCTAssertEqual("\(origStructB)", "\nstruct B {}")
+    XCTAssertEqual("\(newStructB)", "\nstruct B {}")
+    XCTAssertNotEqual(origStructB, newStructB)
+
+    XCTAssertEqual(reusedNodeCollector.rangeAndNodes.count, 1)
+    if reusedNodeCollector.rangeAndNodes.count != 1 { return }
+    let rangeAndNode = reusedNodeCollector.rangeAndNodes[0]
+    XCTAssertEqual("\(rangeAndNode.1)", "\nstruct B {}")
+
+    XCTAssertEqual(newStructB.byteRange, rangeAndNode.0)
+    XCTAssertEqual(origStructB, rangeAndNode.1 as! CodeBlockItemSyntax)
   }
 }


### PR DESCRIPTION
Now that getting the position offset from the node is 'cost-free' there's no need to keep track of the offset separately.