### PR TITLE
Helper methods to modify leading and trailing trivia on nodes

### DIFF
--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -915,6 +915,44 @@ final class RawSyntax: ManagedBuffer<RawSyntaxBase, RawSyntaxDataElement> {
     }
   }
 
+  func withLeadingTrivia(_ leadingTrivia: Trivia) -> RawSyntax {
+    if isToken {
+      return RawSyntax.createAndCalcLength(
+        kind: formTokenKind()!,
+        leadingTrivia: leadingTrivia,
+        trailingTrivia: formTrailingTrivia()!,
+        presence: presence)
+    } else {
+      var layout = formLayoutArray()
+      for (index, raw) in layout.enumerated() {
+        if let raw = raw {
+          layout[index] = raw.withLeadingTrivia(leadingTrivia)
+          return replacingLayout(layout)
+        }
+      }
+      return self
+    }
+  }
+
+  func withTrailingTrivia(_ trailingTrivia: Trivia) -> RawSyntax {
+    if isToken {
+      return RawSyntax.createAndCalcLength(
+        kind: formTokenKind()!,
+        leadingTrivia: formLeadingTrivia()!,
+        trailingTrivia: trailingTrivia,
+        presence: presence)
+    } else {
+      var layout = formLayoutArray()
+      for (index, raw) in layout.enumerated().reversed() {
+        if let raw = raw {
+          layout[index] = raw.withTrailingTrivia(trailingTrivia)
+          return replacingLayout(layout)
+        }
+      }
+      return self
+    }
+  }
+
   /// Creates a RawSyntax node that's marked missing in the source with the
   /// provided kind and layout.
   /// - Parameters:

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -527,11 +527,7 @@ public struct TokenSyntax: _SyntaxBase, Hashable {
     guard raw.kind == .token else {
       fatalError("TokenSyntax must have token as its raw")
     }
-    let newRaw = RawSyntax.createAndCalcLength(kind: raw.formTokenKind()!,
-      leadingTrivia: leadingTrivia, trailingTrivia: raw.formTrailingTrivia()!,
-      presence: raw.presence)
-    let newData = data.replacingSelf(newRaw)
-    return TokenSyntax(newData)
+    return TokenSyntax(data.withLeadingTrivia(leadingTrivia))
   }
 
   /// Returns a new TokenSyntax with its trailing trivia replaced
@@ -540,12 +536,7 @@ public struct TokenSyntax: _SyntaxBase, Hashable {
     guard raw.kind == .token else {
       fatalError("TokenSyntax must have token as its raw")
     }
-    let newRaw = RawSyntax.createAndCalcLength(kind: raw.formTokenKind()!,
-                           leadingTrivia: raw.formLeadingTrivia()!,
-                           trailingTrivia: trailingTrivia,
-                           presence: raw.presence)
-    let newData = data.replacingSelf(newRaw)
-    return TokenSyntax(newData)
+    return TokenSyntax(data.withTrailingTrivia(trailingTrivia))
   }
 
   /// Returns a new TokenSyntax with its leading trivia removed.

--- a/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -144,6 +144,53 @@ public struct ${node.name}: _SyntaxBase, Hashable, SyntaxCollection {
     return replacingLayout(newLayout)
   }
 
+  /// Returns a new `${node.name}` with its leading trivia replaced
+  /// by the provided trivia.
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ${node.name} {
+    return ${node.name}(data.withLeadingTrivia(leadingTrivia))
+  }
+
+  /// Returns a new `${node.name}` with its trailing trivia replaced
+  /// by the provided trivia.
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ${node.name} {
+    return ${node.name}(data.withTrailingTrivia(trailingTrivia))
+  }
+
+  /// Returns a new `${node.name}` with its leading trivia removed.
+  public func withoutLeadingTrivia() -> ${node.name} {
+    return withLeadingTrivia([])
+  }
+
+  /// Returns a new `${node.name}` with its trailing trivia removed.
+  public func withoutTrailingTrivia() -> ${node.name} {
+    return withTrailingTrivia([])
+  }
+
+  /// Returns a new `${node.name}` with all trivia removed.
+  public func withoutTrivia() -> ${node.name} {
+    return withoutLeadingTrivia().withoutTrailingTrivia()
+  }
+
+  /// The leading trivia (spaces, newlines, etc.) associated with this `${node.name}`.
+  public var leadingTrivia: Trivia? {
+    get {
+      return raw.formLeadingTrivia()
+    }
+    set {
+      self = withLeadingTrivia(newValue ?? [])
+    }
+  }
+
+  /// The trailing trivia (spaces, newlines, etc.) associated with this `${node.name}`.
+  public var trailingTrivia: Trivia? {
+    get {
+      return raw.formTrailingTrivia()
+    }
+    set {
+      self = withTrailingTrivia(newValue ?? [])
+    }
+  }
+
   /// Determines if two `${node.name}` nodes are equal to each other.
   public static func ==(lhs: ${node.name}, rhs: ${node.name}) -> Bool {
     return lhs.data.nodeId == rhs.data.nodeId

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -255,4 +255,12 @@ struct SyntaxData {
     where CursorType.RawValue == Int {
     return replacingChild(child, at: cursor.rawValue)
   }
+
+  func withLeadingTrivia(_ leadingTrivia: Trivia) -> SyntaxData {
+    return replacingSelf(raw.withLeadingTrivia(leadingTrivia))
+  }
+
+  func withTrailingTrivia(_ trailingTrivia: Trivia) -> SyntaxData {
+    return replacingSelf(raw.withTrailingTrivia(trailingTrivia))
+  }
 }

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
@@ -159,6 +159,53 @@ public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
   }
 %     end
 
+  /// Returns a new `${node.name}` with its leading trivia replaced
+  /// by the provided trivia.
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> ${node.name} {
+    return ${node.name}(data.withLeadingTrivia(leadingTrivia))
+  }
+
+  /// Returns a new `${node.name}` with its trailing trivia replaced
+  /// by the provided trivia.
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> ${node.name} {
+    return ${node.name}(data.withTrailingTrivia(trailingTrivia))
+  }
+
+  /// Returns a new `${node.name}` with its leading trivia removed.
+  public func withoutLeadingTrivia() -> ${node.name} {
+    return withLeadingTrivia([])
+  }
+
+  /// Returns a new `${node.name}` with its trailing trivia removed.
+  public func withoutTrailingTrivia() -> ${node.name} {
+    return withTrailingTrivia([])
+  }
+
+  /// Returns a new `${node.name}` with all trivia removed.
+  public func withoutTrivia() -> ${node.name} {
+    return withoutLeadingTrivia().withoutTrailingTrivia()
+  }
+
+  /// The leading trivia (spaces, newlines, etc.) associated with this `${node.name}`.
+  public var leadingTrivia: Trivia? {
+    get {
+      return raw.formLeadingTrivia()
+    }
+    set {
+      self = withLeadingTrivia(newValue ?? [])
+    }
+  }
+
+  /// The trailing trivia (spaces, newlines, etc.) associated with this `${node.name}`.
+  public var trailingTrivia: Trivia? {
+    get {
+      return raw.formTrailingTrivia()
+    }
+    set {
+      self = withTrailingTrivia(newValue ?? [])
+    }
+  }
+
   /// Determines if two `${node.name}` nodes are equal to each other.
   public static func ==(lhs: ${node.name}, rhs: ${node.name}) -> Bool {
     return lhs.data.nodeId == rhs.data.nodeId


### PR DESCRIPTION
This is implemented recursively on `RawSyntax` and through `SyntaxData` and appropriate public methods were made available on all syntax nodes and collections.