### PR TITLE
Pretty results of dump() for Syntax

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -14,7 +14,7 @@
 /// Each node has accessors for its known children, and allows efficient
 /// iteration over the children through its `children` property.
 public protocol Syntax:
-  CustomStringConvertible, TextOutputStreamable {}
+  CustomStringConvertible, CustomDebugStringConvertible, TextOutputStreamable {}
 
 internal protocol _SyntaxBase: Syntax {
   /// The data backing this node.
@@ -273,6 +273,11 @@ extension _SyntaxBase {
   /// A source-accurate description of this node.
   public var description: String {
     return data.raw.description
+  }
+
+  /// Returns a description used by dump.
+  public var debugDescription: String {
+    return "\(type(of: self))"
   }
 
   /// Prints the raw value of this node to the provided stream.
@@ -654,6 +659,17 @@ public struct TokenSyntax: _SyntaxBase, Hashable {
   }
 }
 
+extension TokenSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "text": text,
+      "leadingTrivia": leadingTrivia,
+      "trailingTrivia": trailingTrivia,
+      "tokenKind": tokenKind,
+    ])
+  }
+}
+
 /// Sequence of tokens that are part of the provided Syntax node.
 public struct TokenSequence: Sequence {
   public struct Iterator: IteratorProtocol {
@@ -695,6 +711,13 @@ public struct TokenSequence: Sequence {
   }
 }
 
+extension TokenSequence: CustomReflectable {
+  public var customMirror: Mirror {
+    let keyAndValues = enumerated().map { (label: String($0.0) as String?, value: $0.1 as Any) }
+    return Mirror(self, children: keyAndValues)
+  }
+}
+
 /// Reverse sequence of tokens that are part of the provided Syntax node.
 public struct ReversedTokenSequence: Sequence {
   public struct Iterator: IteratorProtocol {
@@ -733,6 +756,12 @@ public struct ReversedTokenSequence: Sequence {
 
   public func reversed() -> TokenSequence {
     return TokenSequence(node)
+  }
+}
+
+extension ReversedTokenSequence: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, unlabeledChildren: self.map{ $0 })
   }
 }
 

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -713,8 +713,7 @@ public struct TokenSequence: Sequence {
 
 extension TokenSequence: CustomReflectable {
   public var customMirror: Mirror {
-    let keyAndValues = enumerated().map { (label: String($0.0) as String?, value: $0.1 as Any) }
-    return Mirror(self, children: keyAndValues)
+    return Mirror(self, unlabeledChildren: self.map{ $0 })
   }
 }
 

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -277,7 +277,7 @@ extension _SyntaxBase {
 
   /// Returns a description used by dump.
   public var debugDescription: String {
-    return "\(type(of: self))"
+    return String(reflecting: type(of: self))
   }
 
   /// Prints the raw value of this node to the provided stream.

--- a/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -230,8 +230,7 @@ extension ${node.name}: Sequence {
 %   if node.is_syntax_collection():
 extension ${node.name}: CustomReflectable {
   public var customMirror: Mirror {
-    let keyAndValues = enumerated().map { (label: String($0.0) as String?, value: $0.1 as Any) }
-    return Mirror(self, children: keyAndValues)
+    return Mirror(self, unlabeledChildren: self.map{ $0 })
   }
 }
 %   end

--- a/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -223,6 +223,16 @@ extension ${node.name}: Sequence {
     }
   }
 }
+%   end
+% end
 
+% for node in SYNTAX_NODES:
+%   if node.is_syntax_collection():
+extension ${node.name}: CustomReflectable {
+  public var customMirror: Mirror {
+    let keyAndValues = enumerated().map { (label: String($0.0) as String?, value: $0.1 as Any) }
+    return Mirror(self, children: keyAndValues)
+  }
+}
 %   end
 % end

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
@@ -58,6 +58,12 @@ public struct UnknownSyntax: _SyntaxBase, Hashable {
   }
 }
 
+extension UnknownSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [:])
+  }
+}
+
 % for node in SYNTAX_NODES:
 %   base_type = node.base_type
 %   if node.is_base():
@@ -169,7 +175,20 @@ public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
     return data.nodeId.hash(into: &hasher)
   }
 }
+%   end
+% end
 
+% for node in SYNTAX_NODES:
+%   if not node.is_base() and not node.is_syntax_collection():
+extension ${node.name}: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+%     for child in node.children:
+      "${child.swift_name}": ${child.swift_name} as Any,
+%     end
+    ])
+  }
+}
 %   end
 % end
 

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -62,6 +62,13 @@ extension TriviaPiece: TextOutputStreamable {
   }
 }
 
+extension TriviaPiece: CustomDebugStringConvertible {
+  /// Returns a description used by dump.
+  public var debugDescription: String {
+    return "TriviaPiece"
+  }
+}
+
 /// A collection of leading or trailing trivia. This is the main data structure
 /// for thinking about trivia.
 public struct Trivia {

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -17,6 +17,7 @@ XCTMain({ () -> [XCTestCaseEntry] in
     testCase(TokenSyntaxTestCase.allTests),
     testCase(SyntaxTreeModifierTests.allTests),
     testCase(TriviaTests.allTests),
+    testCase(CustomRelectableTests.allTests),
   ]
   return testCases
 }())

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -17,7 +17,7 @@ XCTMain({ () -> [XCTestCaseEntry] in
     testCase(TokenSyntaxTestCase.allTests),
     testCase(SyntaxTreeModifierTests.allTests),
     testCase(TriviaTests.allTests),
-    testCase(CustomRelectableTests.allTests),
+    testCase(CustomReflectableTests.allTests),
   ]
   return testCases
 }())

--- a/Tests/SwiftSyntaxTest/CustomReflecatbleTests.swift
+++ b/Tests/SwiftSyntaxTest/CustomReflecatbleTests.swift
@@ -4,8 +4,216 @@ import SwiftSyntax
 
 public class CustomReflectableTests: XCTestCase {
   public static let allTests = [
+    ("testDump", testDump),
     ("testConformanceToCustomReflectable", testConformanceToCustomReflectable),
   ]
+
+
+  public func testDump() {
+    struct TestCase {
+      let syntax: Any
+      let expectedDumped: String
+    }
+
+    let testCases: [UInt: TestCase] = [
+      #line: .init(syntax: SyntaxFactory.makeUnknownSyntax(tokens: []),
+                   expectedDumped: """
+                                   - UnknownSyntax
+
+                                   """),
+      #line: .init(syntax: SyntaxFactory.makeToken(.associatedtypeKeyword,
+                                                   presence: .present,
+                                                   leadingTrivia: [],
+                                                   trailingTrivia: []),
+                   expectedDumped: """
+                                   ▿ TokenSyntax
+                                     - text: "associatedtype"
+                                     ▿ leadingTrivia: SwiftSyntax.Trivia
+                                       - pieces: 0 elements
+                                     ▿ trailingTrivia: SwiftSyntax.Trivia
+                                       - pieces: 0 elements
+                                     - tokenKind: SwiftSyntax.TokenKind.associatedtypeKeyword
+
+                                   """),
+      #line: {
+        let leftToken = SyntaxFactory.makeToken(.leftSquareBracket,
+                                                presence: .present,
+                                                leadingTrivia: [],
+                                                trailingTrivia: [])
+        let elements = SyntaxFactory.makeBlankArrayElementList()
+        let rightToken = SyntaxFactory.makeToken(.rightSquareBracket,
+                                                 presence: .present,
+                                                 leadingTrivia: [],
+                                                 trailingTrivia: [])
+        let expr = SyntaxFactory.makeArrayExpr(leftSquare: leftToken,
+                                               elements: elements,
+                                               rightSquare: rightToken)
+        return .init(syntax: expr.tokens,
+                     expectedDumped: """
+                                     ▿ SwiftSyntax.TokenSequence
+                                       ▿ TokenSyntax
+                                         - text: "["
+                                         ▿ leadingTrivia: SwiftSyntax.Trivia
+                                           - pieces: 0 elements
+                                         ▿ trailingTrivia: SwiftSyntax.Trivia
+                                           - pieces: 0 elements
+                                         - tokenKind: SwiftSyntax.TokenKind.leftSquareBracket
+                                       ▿ TokenSyntax
+                                         - text: "]"
+                                         ▿ leadingTrivia: SwiftSyntax.Trivia
+                                           - pieces: 0 elements
+                                         ▿ trailingTrivia: SwiftSyntax.Trivia
+                                           - pieces: 0 elements
+                                         - tokenKind: SwiftSyntax.TokenKind.rightSquareBracket
+
+                                     """)
+      }(),
+      #line: {
+        let leftToken = SyntaxFactory.makeToken(.leftSquareBracket,
+                                                presence: .present,
+                                                leadingTrivia: [],
+                                                trailingTrivia: [])
+        let elements = SyntaxFactory.makeBlankArrayElementList()
+        let rightToken = SyntaxFactory.makeToken(.rightSquareBracket,
+                                                 presence: .present,
+                                                 leadingTrivia: [],
+                                                 trailingTrivia: [])
+        let expr = SyntaxFactory.makeArrayExpr(leftSquare: leftToken,
+                                               elements: elements,
+                                               rightSquare: rightToken)
+        return .init(syntax: expr.tokens.reversed(),
+                     expectedDumped: """
+                                     ▿ SwiftSyntax.ReversedTokenSequence
+                                       ▿ TokenSyntax
+                                         - text: "]"
+                                         ▿ leadingTrivia: SwiftSyntax.Trivia
+                                           - pieces: 0 elements
+                                         ▿ trailingTrivia: SwiftSyntax.Trivia
+                                           - pieces: 0 elements
+                                         - tokenKind: SwiftSyntax.TokenKind.rightSquareBracket
+                                       ▿ TokenSyntax
+                                         - text: "["
+                                         ▿ leadingTrivia: SwiftSyntax.Trivia
+                                           - pieces: 0 elements
+                                         ▿ trailingTrivia: SwiftSyntax.Trivia
+                                           - pieces: 0 elements
+                                         - tokenKind: SwiftSyntax.TokenKind.leftSquareBracket
+
+                                     """)
+      }(),
+      #line: {
+        let token1 = SyntaxFactory.makeToken(.integerLiteral("1"),
+                                             presence: .present,
+                                             leadingTrivia: [],
+                                             trailingTrivia: [])
+        let expr1 = SyntaxFactory.makeIntegerLiteralExpr(digits: token1)
+        let token2 = SyntaxFactory.makeToken(.integerLiteral("2"),
+                                             presence: .present,
+                                             leadingTrivia: [],
+                                             trailingTrivia: [])
+        let expr2 = SyntaxFactory.makeIntegerLiteralExpr(digits: token2)
+        let elements = [SyntaxFactory.makeTupleElement(label: nil,
+                                                       colon: nil,
+                                                       expression: expr1,
+                                                       trailingComma: nil),
+                        SyntaxFactory.makeTupleElement(label: nil,
+                                                       colon: nil,
+                                                       expression: expr2,
+                                                       trailingComma: nil)]
+        let tuples = SyntaxFactory.makeTupleElementList(elements)
+        return .init(syntax: tuples,
+                     expectedDumped: """
+                                     ▿ TupleElementListSyntax
+                                       ▿ TupleElementSyntax
+                                         - label: nil
+                                         - colon: nil
+                                         ▿ expression: IntegerLiteralExprSyntax
+                                           ▿ digits: TokenSyntax
+                                             - text: "1"
+                                             ▿ leadingTrivia: SwiftSyntax.Trivia
+                                               - pieces: 0 elements
+                                             ▿ trailingTrivia: SwiftSyntax.Trivia
+                                               - pieces: 0 elements
+                                             ▿ tokenKind: SwiftSyntax.TokenKind.integerLiteral
+                                               - integerLiteral: "1"
+                                         - trailingComma: nil
+                                       ▿ TupleElementSyntax
+                                         - label: nil
+                                         - colon: nil
+                                         ▿ expression: IntegerLiteralExprSyntax
+                                           ▿ digits: TokenSyntax
+                                             - text: "2"
+                                             ▿ leadingTrivia: SwiftSyntax.Trivia
+                                               - pieces: 0 elements
+                                             ▿ trailingTrivia: SwiftSyntax.Trivia
+                                               - pieces: 0 elements
+                                             ▿ tokenKind: SwiftSyntax.TokenKind.integerLiteral
+                                               - integerLiteral: "2"
+                                         - trailingComma: nil
+
+                                     """)
+      }(),
+      #line: {
+        let token1 = SyntaxFactory.makeToken(.integerLiteral("1"),
+                                             presence: .present,
+                                             leadingTrivia: [],
+                                             trailingTrivia: [])
+        let expr1 = SyntaxFactory.makeIntegerLiteralExpr(digits: token1)
+        let token2 = SyntaxFactory.makeToken(.integerLiteral("2"),
+                                             presence: .present,
+                                             leadingTrivia: [],
+                                             trailingTrivia: [])
+        let expr2 = SyntaxFactory.makeIntegerLiteralExpr(digits: token2)
+        let elements = [SyntaxFactory.makeTupleElement(label: nil,
+                                                       colon: nil,
+                                                       expression: expr1,
+                                                       trailingComma: nil),
+          SyntaxFactory.makeTupleElement(label: nil,
+                                         colon: nil,
+                                         expression: expr2,
+                                         trailingComma: nil)]
+        let tuples = SyntaxFactory.makeTupleElementList(elements)
+        return .init(syntax: tuples.reversed(),
+                     expectedDumped: """
+                                     ▿ SwiftSyntax.TupleElementListSyntax.Reversed
+                                       ▿ collection: TupleElementListSyntax
+                                         ▿ TupleElementSyntax
+                                           - label: nil
+                                           - colon: nil
+                                           ▿ expression: IntegerLiteralExprSyntax
+                                             ▿ digits: TokenSyntax
+                                               - text: "1"
+                                               ▿ leadingTrivia: SwiftSyntax.Trivia
+                                                 - pieces: 0 elements
+                                               ▿ trailingTrivia: SwiftSyntax.Trivia
+                                                 - pieces: 0 elements
+                                               ▿ tokenKind: SwiftSyntax.TokenKind.integerLiteral
+                                                 - integerLiteral: "1"
+                                           - trailingComma: nil
+                                         ▿ TupleElementSyntax
+                                           - label: nil
+                                           - colon: nil
+                                           ▿ expression: IntegerLiteralExprSyntax
+                                             ▿ digits: TokenSyntax
+                                               - text: "2"
+                                               ▿ leadingTrivia: SwiftSyntax.Trivia
+                                                 - pieces: 0 elements
+                                               ▿ trailingTrivia: SwiftSyntax.Trivia
+                                                 - pieces: 0 elements
+                                               ▿ tokenKind: SwiftSyntax.TokenKind.integerLiteral
+                                                 - integerLiteral: "2"
+                                           - trailingComma: nil
+
+                                     """)
+      }(),
+    ]
+
+    testCases.forEach { keyAndValue in
+      let (key: line, value: testCase) = keyAndValue
+      let actualDumped = dumped(testCase.syntax)
+      XCTAssertEqual(testCase.expectedDumped, actualDumped, line: line)
+    }
+  }
 
 
   public func testConformanceToCustomReflectable() {
@@ -48,5 +256,12 @@ public class CustomReflectableTests: XCTestCase {
 
       collectSyntaxNotConformedCustomReflectable(from: value, ancestors: currentPathComponents, foundPaths: &foundPaths)
     }
+  }
+
+
+  public func dumped(_ syntax: Any) -> String {
+    var result = ""
+    dump(syntax, to: &result)
+    return result
   }
 }

--- a/Tests/SwiftSyntaxTest/CustomReflecatbleTests.swift
+++ b/Tests/SwiftSyntaxTest/CustomReflecatbleTests.swift
@@ -18,7 +18,7 @@ public class CustomReflectableTests: XCTestCase {
     let testCases: [UInt: TestCase] = [
       #line: .init(syntax: SyntaxFactory.makeUnknownSyntax(tokens: []),
                    expectedDumped: """
-                                   - UnknownSyntax
+                                   - SwiftSyntax.UnknownSyntax
 
                                    """),
       #line: .init(syntax: SyntaxFactory.makeToken(.associatedtypeKeyword,
@@ -26,7 +26,7 @@ public class CustomReflectableTests: XCTestCase {
                                                    leadingTrivia: [],
                                                    trailingTrivia: []),
                    expectedDumped: """
-                                   ▿ TokenSyntax
+                                   ▿ SwiftSyntax.TokenSyntax
                                      - text: "associatedtype"
                                      ▿ leadingTrivia: SwiftSyntax.Trivia
                                        - pieces: 0 elements
@@ -51,14 +51,14 @@ public class CustomReflectableTests: XCTestCase {
         return .init(syntax: expr.tokens,
                      expectedDumped: """
                                      ▿ SwiftSyntax.TokenSequence
-                                       ▿ TokenSyntax
+                                       ▿ SwiftSyntax.TokenSyntax
                                          - text: "["
                                          ▿ leadingTrivia: SwiftSyntax.Trivia
                                            - pieces: 0 elements
                                          ▿ trailingTrivia: SwiftSyntax.Trivia
                                            - pieces: 0 elements
                                          - tokenKind: SwiftSyntax.TokenKind.leftSquareBracket
-                                       ▿ TokenSyntax
+                                       ▿ SwiftSyntax.TokenSyntax
                                          - text: "]"
                                          ▿ leadingTrivia: SwiftSyntax.Trivia
                                            - pieces: 0 elements
@@ -84,14 +84,14 @@ public class CustomReflectableTests: XCTestCase {
         return .init(syntax: expr.tokens.reversed(),
                      expectedDumped: """
                                      ▿ SwiftSyntax.ReversedTokenSequence
-                                       ▿ TokenSyntax
+                                       ▿ SwiftSyntax.TokenSyntax
                                          - text: "]"
                                          ▿ leadingTrivia: SwiftSyntax.Trivia
                                            - pieces: 0 elements
                                          ▿ trailingTrivia: SwiftSyntax.Trivia
                                            - pieces: 0 elements
                                          - tokenKind: SwiftSyntax.TokenKind.rightSquareBracket
-                                       ▿ TokenSyntax
+                                       ▿ SwiftSyntax.TokenSyntax
                                          - text: "["
                                          ▿ leadingTrivia: SwiftSyntax.Trivia
                                            - pieces: 0 elements
@@ -123,12 +123,12 @@ public class CustomReflectableTests: XCTestCase {
         let tuples = SyntaxFactory.makeTupleElementList(elements)
         return .init(syntax: tuples,
                      expectedDumped: """
-                                     ▿ TupleElementListSyntax
-                                       ▿ TupleElementSyntax
+                                     ▿ SwiftSyntax.TupleElementListSyntax
+                                       ▿ SwiftSyntax.TupleElementSyntax
                                          - label: nil
                                          - colon: nil
-                                         ▿ expression: IntegerLiteralExprSyntax
-                                           ▿ digits: TokenSyntax
+                                         ▿ expression: SwiftSyntax.IntegerLiteralExprSyntax
+                                           ▿ digits: SwiftSyntax.TokenSyntax
                                              - text: "1"
                                              ▿ leadingTrivia: SwiftSyntax.Trivia
                                                - pieces: 0 elements
@@ -137,11 +137,11 @@ public class CustomReflectableTests: XCTestCase {
                                              ▿ tokenKind: SwiftSyntax.TokenKind.integerLiteral
                                                - integerLiteral: "1"
                                          - trailingComma: nil
-                                       ▿ TupleElementSyntax
+                                       ▿ SwiftSyntax.TupleElementSyntax
                                          - label: nil
                                          - colon: nil
-                                         ▿ expression: IntegerLiteralExprSyntax
-                                           ▿ digits: TokenSyntax
+                                         ▿ expression: SwiftSyntax.IntegerLiteralExprSyntax
+                                           ▿ digits: SwiftSyntax.TokenSyntax
                                              - text: "2"
                                              ▿ leadingTrivia: SwiftSyntax.Trivia
                                                - pieces: 0 elements
@@ -176,12 +176,12 @@ public class CustomReflectableTests: XCTestCase {
         return .init(syntax: tuples.reversed(),
                      expectedDumped: """
                                      ▿ SwiftSyntax.TupleElementListSyntax.Reversed
-                                       ▿ collection: TupleElementListSyntax
-                                         ▿ TupleElementSyntax
+                                       ▿ collection: SwiftSyntax.TupleElementListSyntax
+                                         ▿ SwiftSyntax.TupleElementSyntax
                                            - label: nil
                                            - colon: nil
-                                           ▿ expression: IntegerLiteralExprSyntax
-                                             ▿ digits: TokenSyntax
+                                           ▿ expression: SwiftSyntax.IntegerLiteralExprSyntax
+                                             ▿ digits: SwiftSyntax.TokenSyntax
                                                - text: "1"
                                                ▿ leadingTrivia: SwiftSyntax.Trivia
                                                  - pieces: 0 elements
@@ -190,11 +190,11 @@ public class CustomReflectableTests: XCTestCase {
                                                ▿ tokenKind: SwiftSyntax.TokenKind.integerLiteral
                                                  - integerLiteral: "1"
                                            - trailingComma: nil
-                                         ▿ TupleElementSyntax
+                                         ▿ SwiftSyntax.TupleElementSyntax
                                            - label: nil
                                            - colon: nil
-                                           ▿ expression: IntegerLiteralExprSyntax
-                                             ▿ digits: TokenSyntax
+                                           ▿ expression: SwiftSyntax.IntegerLiteralExprSyntax
+                                             ▿ digits: SwiftSyntax.TokenSyntax
                                                - text: "2"
                                                ▿ leadingTrivia: SwiftSyntax.Trivia
                                                  - pieces: 0 elements

--- a/Tests/SwiftSyntaxTest/CustomReflecatbleTests.swift
+++ b/Tests/SwiftSyntaxTest/CustomReflecatbleTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+import SwiftSyntax
+
+
+public class CustomReflectableTests: XCTestCase {
+    public static let allTests = [
+        ("testConformanceToCustomReflectable", testConformanceToCustomReflectable),
+    ]
+
+
+    public func testConformanceToCustomReflectable() {
+        XCTAssertNoThrow(try {
+            let parsed = try SyntaxParser.parse(getInput("near-empty.swift"))
+            XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
+        }())
+        XCTAssertNoThrow(try {
+            let parsed = try SyntaxParser.parse(getInput("closure.swift"))
+            XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
+        }())
+        XCTAssertNoThrow(try {
+            let parsed = try SyntaxParser.parse(getInput("nested-blocks.swift"))
+            XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
+        }())
+        XCTAssertNoThrow(try {
+            let parsed = try SyntaxParser.parse(getInput("visitor.swift"))
+            XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
+        }())
+    }
+
+
+    public func collectSyntaxNotConformedCustomReflectable<S: Any>(from object: S) -> [String] {
+        var paths = [String]()
+        collectSyntaxNotConformedCustomReflectable(from: object, ancestors: ["root"], foundPaths: &paths)
+        return paths
+    }
+
+
+    public func collectSyntaxNotConformedCustomReflectable<S: Any>(from object: S, ancestors: [String], foundPaths: inout [String]) {
+        Mirror(reflecting: object).children.forEach { child in
+            let (label: label, value: value) = child
+
+            var currentPathComponents = ancestors
+            currentPathComponents.append(label ?? "(nil)")
+
+            if let syntax = value as? Syntax, !(syntax is CustomReflectable) {
+                foundPaths.append("\(currentPathComponents.joined(separator: ".")): \(type(of: value as Any))")
+            }
+
+            collectSyntaxNotConformedCustomReflectable(from: value, ancestors: currentPathComponents, foundPaths: &foundPaths)
+        }
+    }
+}

--- a/Tests/SwiftSyntaxTest/CustomReflecatbleTests.swift
+++ b/Tests/SwiftSyntaxTest/CustomReflecatbleTests.swift
@@ -3,50 +3,50 @@ import SwiftSyntax
 
 
 public class CustomReflectableTests: XCTestCase {
-    public static let allTests = [
-        ("testConformanceToCustomReflectable", testConformanceToCustomReflectable),
-    ]
+  public static let allTests = [
+    ("testConformanceToCustomReflectable", testConformanceToCustomReflectable),
+  ]
 
 
-    public func testConformanceToCustomReflectable() {
-        XCTAssertNoThrow(try {
-            let parsed = try SyntaxParser.parse(getInput("near-empty.swift"))
-            XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
-        }())
-        XCTAssertNoThrow(try {
-            let parsed = try SyntaxParser.parse(getInput("closure.swift"))
-            XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
-        }())
-        XCTAssertNoThrow(try {
-            let parsed = try SyntaxParser.parse(getInput("nested-blocks.swift"))
-            XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
-        }())
-        XCTAssertNoThrow(try {
-            let parsed = try SyntaxParser.parse(getInput("visitor.swift"))
-            XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
-        }())
+  public func testConformanceToCustomReflectable() {
+    XCTAssertNoThrow(try {
+      let parsed = try SyntaxParser.parse(getInput("near-empty.swift"))
+      XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
+    }())
+    XCTAssertNoThrow(try {
+      let parsed = try SyntaxParser.parse(getInput("closure.swift"))
+      XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
+    }())
+    XCTAssertNoThrow(try {
+      let parsed = try SyntaxParser.parse(getInput("nested-blocks.swift"))
+      XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
+    }())
+    XCTAssertNoThrow(try {
+      let parsed = try SyntaxParser.parse(getInput("visitor.swift"))
+      XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
+    }())
+  }
+
+
+  public func collectSyntaxNotConformedCustomReflectable<S: Any>(from object: S) -> [String] {
+    var paths = [String]()
+    collectSyntaxNotConformedCustomReflectable(from: object, ancestors: ["root"], foundPaths: &paths)
+    return paths
+  }
+
+
+  public func collectSyntaxNotConformedCustomReflectable<S: Any>(from object: S, ancestors: [String], foundPaths: inout [String]) {
+    Mirror(reflecting: object).children.forEach { child in
+      let (label: label, value: value) = child
+
+      var currentPathComponents = ancestors
+      currentPathComponents.append(label ?? "(nil)")
+
+      if let syntax = value as? Syntax, !(syntax is CustomReflectable) {
+        foundPaths.append("\(currentPathComponents.joined(separator: ".")): \(type(of: value as Any))")
+      }
+
+      collectSyntaxNotConformedCustomReflectable(from: value, ancestors: currentPathComponents, foundPaths: &foundPaths)
     }
-
-
-    public func collectSyntaxNotConformedCustomReflectable<S: Any>(from object: S) -> [String] {
-        var paths = [String]()
-        collectSyntaxNotConformedCustomReflectable(from: object, ancestors: ["root"], foundPaths: &paths)
-        return paths
-    }
-
-
-    public func collectSyntaxNotConformedCustomReflectable<S: Any>(from object: S, ancestors: [String], foundPaths: inout [String]) {
-        Mirror(reflecting: object).children.forEach { child in
-            let (label: label, value: value) = child
-
-            var currentPathComponents = ancestors
-            currentPathComponents.append(label ?? "(nil)")
-
-            if let syntax = value as? Syntax, !(syntax is CustomReflectable) {
-                foundPaths.append("\(currentPathComponents.joined(separator: ".")): \(type(of: value as Any))")
-            }
-
-            collectSyntaxNotConformedCustomReflectable(from: value, ancestors: currentPathComponents, foundPaths: &foundPaths)
-        }
-    }
+  }
 }


### PR DESCRIPTION
The result of dump() with Syntax is not useful. For example,
the dumped result of `Tests/SwiftSyntaxTest/Inputs/closure.swift` is the following:

```
▿ // A closure without a signature. The test will ensure it stays the same after
// applying a rewriting pass.
let x: () -> Void = {}
  ▿ data: SwiftSyntax.SyntaxData
    - parent: nil
    ▿ absoluteRaw: SwiftSyntax.AbsoluteRawSyntax
      - raw: // A closure without a signature. The test will ensure it stays the same after
// applying a rewriting pass.
let x: () -> Void = {} #0
        ▿ super: Swift.ManagedBuffer<SwiftSyntax.RawSyntaxBase, Swift.UInt64>
          ▿ header: SwiftSyntax.RawSyntaxBase
	  ...
```

This patch improves this result to the following:

```
▿ SwiftSyntax.SourceFileSyntax
  ▿ statements: SwiftSyntax.CodeBlockItemListSyntax
    ▿ SwiftSyntax.CodeBlockItemSyntax
      ▿ item: SwiftSyntax.VariableDeclSyntax
        - attributes: nil
        - modifiers: nil
        ▿ letOrVarKeyword: SwiftSyntax.TokenSyntax
          - text: "let"
          ▿ leadingTrivia: SwiftSyntax.Trivia
            ▿ pieces: 4 elements
              ▿ TriviaPiece
                - lineComment: "// A closure without a signature. The test will ensure it stays the same after"
                ...
```