### PR TITLE
Diagnostics: simplify the source locations associated with Diagnostics

### DIFF
--- a/Sources/SwiftSyntax/DiagnosticEngine.swift
+++ b/Sources/SwiftSyntax/DiagnosticEngine.swift
@@ -42,9 +42,9 @@ public class DiagnosticEngine {
   ///              a severity and text that will be conveyed when the diagnostic
   ///              is serialized.
   public func diagnose(_ message: Diagnostic.Message,
-                       location: SourceLocation? = nil,
+                       utf8Offset: Int? = nil,
                        actions: ((inout Diagnostic.Builder) -> Void)? = nil) {
-    let diagnostic = Diagnostic(message: message, location: location,
+    let diagnostic = Diagnostic(message: message, utf8Offset: utf8Offset,
                                 actions: actions)
     diagnostics.append(diagnostic)
     for consumer in consumers {

--- a/Sources/SwiftSyntax/PrintingDiagnosticConsumer.swift
+++ b/Sources/SwiftSyntax/PrintingDiagnosticConsumer.swift
@@ -37,8 +37,8 @@ public class PrintingDiagnosticConsumer: DiagnosticConsumer {
 
   /// Prints each of the fields in a diagnositic to stderr.
   public func write(_ diagnostic: Diagnostic) {
-    if let loc = diagnostic.location {
-      write("\(loc.file):\(loc.line):\(loc.column): ")
+    if let loc = diagnostic.utf8Offset {
+      write("\(loc): ")
     } else {
       write("<unknown>:0:0: ")
     }

--- a/Sources/SwiftSyntax/Utils.swift
+++ b/Sources/SwiftSyntax/Utils.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct ByteSourceRange: Equatable {
+public struct ByteSourceRange: Equatable, Codable {
   public let offset: Int
   public let length: Int
 


### PR DESCRIPTION
We used to include Line/Col/Offset for diagnostics in SwiftSyntax. This patch
teaches diagnostics to use only utf8 offset for positions. Two advantages are:

1) This aligns with SyntaxNode's absolute position API where we can conveniently
provide byte offset.

2) Diagnostics retrieved from the parser library can be easily converted the Diagnostic
type in the SwiftSyntax side.

Line and column can be calculated as a separate step by using SourceLocationConverter.