### PR TITLE
SourceLocation: refactor user-facing part of SourceLocation out and allow it to be computed on demand.

### DIFF
--- a/Sources/SwiftSyntax/PrintingDiagnosticConsumer.swift
+++ b/Sources/SwiftSyntax/PrintingDiagnosticConsumer.swift
@@ -38,7 +38,7 @@ public class PrintingDiagnosticConsumer: DiagnosticConsumer {
   /// Prints each of the fields in a diagnositic to stderr.
   public func write(_ diagnostic: Diagnostic) {
     if let loc = diagnostic.location {
-      write("\(loc.file):\(loc.line):\(loc.column): ")
+      write("\(loc.file!):\(loc.line!):\(loc.column!): ")
     } else {
       write("<unknown>:0:0: ")
     }

--- a/Tests/SwiftSyntaxTest/AbsolutePosition.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePosition.swift
@@ -149,7 +149,7 @@ public class AbsolutePositionTestCase: XCTestCase {
     let startLoc = secondReturnStmt.startLocation(converter: converter)
     XCTAssertEqual(startLoc.line, 8)
     XCTAssertEqual(startLoc.column, 1)
-    XCTAssertEqual(converter.position(ofLine: startLoc.line, column: startLoc.column),
+    XCTAssertEqual(converter.position(ofLine: startLoc.line!, column: startLoc.column!),
       secondReturnStmt.positionAfterSkippingLeadingTrivia)
 
     let startLocBeforeTrivia =
@@ -157,7 +157,7 @@ public class AbsolutePositionTestCase: XCTestCase {
         afterLeadingTrivia: false)
     XCTAssertEqual(startLocBeforeTrivia.line, 6)
     XCTAssertEqual(startLocBeforeTrivia.column, 1)
-    XCTAssertEqual(converter.position(ofLine: startLocBeforeTrivia.line, column: startLocBeforeTrivia.column),
+    XCTAssertEqual(converter.position(ofLine: startLocBeforeTrivia.line!, column: startLocBeforeTrivia.column!),
       secondReturnStmt.position)
 
     let endLoc = secondReturnStmt.endLocation(converter: converter)
@@ -170,9 +170,9 @@ public class AbsolutePositionTestCase: XCTestCase {
     XCTAssertEqual(endLocAfterTrivia.line, 11)
     XCTAssertEqual(endLocAfterTrivia.column, 1)
 
-    XCTAssertTrue(converter.isValid(line: startLoc.line, column: startLoc.column))
-    XCTAssertFalse(converter.isValid(line: startLoc.line, column: startLoc.column+50))
-    XCTAssertFalse(converter.isValid(line: 0, column: startLoc.column))
+    XCTAssertTrue(converter.isValid(line: startLoc.line!, column: startLoc.column!))
+    XCTAssertFalse(converter.isValid(line: startLoc.line!, column: startLoc.column!+50))
+    XCTAssertFalse(converter.isValid(line: 0, column: startLoc.column!))
     XCTAssertTrue(converter.isValid(position: secondReturnStmt.position))
     XCTAssertFalse(converter.isValid(position: secondReturnStmt.position+SourceLength(utf8Length: 100)))
   }


### PR DESCRIPTION
Always computing the user-facing part of source location (line/column) can be
inefficient and unnecessary. This patch refactors the user-facing
part of SourceLocation to a separate data structure and allows it to
be computed on demand.