### PR TITLE
Speed-up lookups for incremental re-parsing

### DIFF
--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -997,7 +997,7 @@ extension RawSyntax {
   }
 }
 
-extension RawSyntax: TextOutputStreamable {
+extension RawSyntax: TextOutputStreamable, CustomStringConvertible {
   /// Prints the RawSyntax node, and all of its children, to the provided
   /// stream. This implementation must be source-accurate.
   /// - Parameter stream: The stream on which to output this node.
@@ -1013,6 +1013,13 @@ extension RawSyntax: TextOutputStreamable {
         self.child(at: i)?.write(to: &target)
       }
     }
+  }
+
+  /// A source-accurate description of this node.
+  var description: String {
+    var s = ""
+    self.write(to: &s)
+    return s
   }
 }
 

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
@@ -198,6 +198,24 @@ extension ${node.name}: ${traits_list} {}
 %   end
 % end
 
+extension SyntaxNode {
+  public var isUnknown: Bool { return raw.kind.isUnknown }
+  public var asUnknown: UnknownSyntax? {
+    guard isUnknown else { return nil }
+    return UnknownSyntax(asSyntaxData)
+  }
+% for node in SYNTAX_NODES:
+%   if not node.is_base():
+
+  public var is${node.syntax_kind}: Bool { return raw.kind == .${node.swift_syntax_kind} }
+  public var as${node.syntax_kind}: ${node.name}? {
+    guard is${node.syntax_kind} else { return nil }
+    return ${node.name}(asSyntaxData)
+  }
+%   end
+% end
+}
+
 /// MARK: Convenience methods
 
 extension StructDeclSyntax {

--- a/Sources/SwiftSyntax/SyntaxParser.swift
+++ b/Sources/SwiftSyntax/SyntaxParser.swift
@@ -122,10 +122,11 @@ public enum SyntaxParser {
     swiftparse_parser_set_node_handler(c_parser, nodeHandler);
 
     if let parseTransition = parseTransition {
+      var parseLookup = IncrementalParseLookup(transition: parseTransition)
       let nodeLookup = {
             (offset: Int, kind: CSyntaxKind) -> CParseLookupResult in
         guard let foundNode =
-            parseTransition.lookUp(offset, kind: .fromRawValue(kind)) else {
+            parseLookup.lookUp(offset, kind: .fromRawValue(kind)) else {
           return CParseLookupResult(length: 0, node: nil)
         }
         let lengthToSkip = foundNode.byteSize

--- a/Tests/SwiftSyntaxTest/IncrementalParsingTests.swift
+++ b/Tests/SwiftSyntaxTest/IncrementalParsingTests.swift
@@ -40,10 +40,14 @@ public class IncrementalParsingTestCase: XCTestCase {
 
     XCTAssertEqual(reusedNodeCollector.rangeAndNodes.count, 1)
     if reusedNodeCollector.rangeAndNodes.count != 1 { return }
-    let rangeAndNode = reusedNodeCollector.rangeAndNodes[0]
-    XCTAssertEqual("\(rangeAndNode.1)", "\nstruct B {}")
+    let (reusedRange, reusedNode) = reusedNodeCollector.rangeAndNodes[0]
+    XCTAssertEqual("\(reusedNode)", "\nstruct B {}")
 
-    XCTAssertEqual(newStructB.byteRange, rangeAndNode.0)
-    XCTAssertEqual(origStructB, rangeAndNode.1 as! CodeBlockItemSyntax)
+    XCTAssertEqual(newStructB.byteRange, reusedRange)
+    XCTAssertEqual(origStructB.uniqueIdentifier, reusedNode.uniqueIdentifier)
+    XCTAssertEqual(origStructB, reusedNode.asSyntax as! CodeBlockItemSyntax)
+    XCTAssertTrue(reusedNode.isCodeBlockItem)
+    XCTAssertEqual(origStructB, reusedNode.asCodeBlockItem!)
+    XCTAssertEqual(origStructB.parent!.uniqueIdentifier, reusedNode.parent!.uniqueIdentifier)
   }
 }


### PR DESCRIPTION
Previously the search for nodes to re-use was naively doing a lookup that always started from the top of the tree, every time the parser called back.
The new mechanism takes advantage of the fact that the parser continuously calls back with ascending source positions, not random ones, and keeps a "cursor" state for re-starting the lookup search from the last node position.

This commit also introduces `SyntaxNode` which is a more efficient representation for a syntax tree node, that `SyntaxParser` uses to efficiently report which syntax nodes got re-used during incremental re-parsing.

Changes result in improved performance for incremental reparsing. When using the test case from rdar://48511326, performance improves by 321x.