### PR TITLE
Diagnostics: teach the parser API to listen to diagnostics emitted from the compiler(parser).

### DIFF
--- a/Sources/SwiftSyntax/Diagnostic.swift
+++ b/Sources/SwiftSyntax/Diagnostic.swift
@@ -14,7 +14,8 @@
 
 /// A FixIt represents a change to source code in order to "correct" a
 /// diagnostic.
-public enum FixIt: Codable {
+public enum FixIt: Codable, CustomDebugStringConvertible {
+
   /// Remove the characters from the source file over the provided source range.
   case remove(SourceRange)
 
@@ -30,6 +31,10 @@ public enum FixIt: Codable {
     case range
     case location
     case string
+  }
+
+  public var debugDescription: String {
+    return "Fixit: \(range.debugDescription) Text: \"\(text)\""
   }
 
   public init(from decoder: Decoder) throws {
@@ -119,8 +124,14 @@ public struct Note: Codable {
 }
 
 /// A Diagnostic message that can be emitted regarding some piece of code.
-public struct Diagnostic: Codable {
-  public struct Message: Codable {
+public struct Diagnostic: Codable, CustomDebugStringConvertible {
+
+  public struct Message: Codable, CustomDebugStringConvertible {
+
+    public var debugDescription: String {
+      return "\(severity): \(text)"
+    }
+
     /// The severity of diagnostic. This can be note, error, or warning.
     public let severity: Severity
 
@@ -156,6 +167,18 @@ public struct Diagnostic: Codable {
 
   /// An array of possible FixIts to apply to this diagnostic.
   public let fixIts: [FixIt]
+
+  public var debugDescription: String {
+    var lines: [String] = []
+    if let location = location {
+      lines.append("\(location) \(message.debugDescription)")
+    } else {
+      lines.append("\(message.debugDescription)")
+    }
+    fixIts.forEach { lines.append("\($0.debugDescription)") }
+    highlights.forEach { lines.append("Hightlight: \($0.debugDescription)") }
+    return lines.joined(separator: "\n")
+  }
 
   /// A diagnostic builder that exposes mutating operations for notes,
   /// highlights, and FixIts. When a Diagnostic is created, a builder

--- a/Sources/SwiftSyntax/Diagnostic.swift
+++ b/Sources/SwiftSyntax/Diagnostic.swift
@@ -177,6 +177,7 @@ public struct Diagnostic: Codable, CustomDebugStringConvertible {
     }
     fixIts.forEach { lines.append("\($0.debugDescription)") }
     highlights.forEach { lines.append("Hightlight: \($0.debugDescription)") }
+    lines.append(contentsOf: notes.map({$0.asDiagnostic().debugDescription}))
     return lines.joined(separator: "\n")
   }
 

--- a/Sources/SwiftSyntax/Diagnostic.swift
+++ b/Sources/SwiftSyntax/Diagnostic.swift
@@ -170,14 +170,11 @@ public struct Diagnostic: Codable, CustomDebugStringConvertible {
 
   public var debugDescription: String {
     var lines: [String] = []
-    if let location = location {
-      lines.append("\(location) \(message.debugDescription)")
-    } else {
-      lines.append("\(message.debugDescription)")
-    }
+    let loc = location == nil ? "" : "\(location!) "
+    lines.append("\(loc)\(message.debugDescription)")
     fixIts.forEach { lines.append("\($0.debugDescription)") }
-    highlights.forEach { lines.append("Hightlight: \($0.debugDescription)") }
-    lines.append(contentsOf: notes.map({$0.asDiagnostic().debugDescription}))
+    highlights.forEach { lines.append("Highlight: \($0.debugDescription)") }
+    lines.append(contentsOf: notes.map({ loc + $0.asDiagnostic().debugDescription}))
     return lines.joined(separator: "\n")
   }
 

--- a/Sources/SwiftSyntax/DiagnosticConsumer.swift
+++ b/Sources/SwiftSyntax/DiagnosticConsumer.swift
@@ -18,7 +18,7 @@ public protocol DiagnosticConsumer {
 
   /// Whether the collected diagnostics should calculate line:column pair; true
   /// by default.
-  var calculateLineColumn: Bool { get }
+  var needsLineColumn: Bool { get }
 
   /// Handle the provided diagnostic which has just been registered with the
   /// DiagnosticEngine.
@@ -29,5 +29,5 @@ public protocol DiagnosticConsumer {
 }
 
 public extension DiagnosticConsumer  {
-  var calculateLineColumn: Bool { return true }
+  var needsLineColumn: Bool { return true }
 }

--- a/Sources/SwiftSyntax/DiagnosticConsumer.swift
+++ b/Sources/SwiftSyntax/DiagnosticConsumer.swift
@@ -15,10 +15,19 @@
 /// An object that intends to receive notifications when diagnostics are
 /// emitted.
 public protocol DiagnosticConsumer {
+
+  /// Whether the collected diagnostics should calculate line:column pair; true
+  /// by default.
+  var calculateLineColumn: Bool { get }
+
   /// Handle the provided diagnostic which has just been registered with the
   /// DiagnosticEngine.
   func handle(_ diagnostic: Diagnostic)
 
   /// Finalize the consumption of diagnostics, flushing to disk if necessary.
   func finalize()
+}
+
+public extension DiagnosticConsumer  {
+  var calculateLineColumn: Bool { return true }
 }

--- a/Sources/SwiftSyntax/DiagnosticEngine.swift
+++ b/Sources/SwiftSyntax/DiagnosticEngine.swift
@@ -26,12 +26,24 @@ public class DiagnosticEngine {
 
   public private(set) var diagnostics = [Diagnostic]()
 
+  internal var needsLineColumn: Bool {
+    // Check if any consumer is interested in line and column.
+    return consumers.first { $0.needsLineColumn } != nil
+  }
+
   /// Adds the provided consumer to the consumers list.
   public func addConsumer(_ consumer: DiagnosticConsumer) {
     consumers.append(consumer)
 
     // Start the consumer with all previous diagnostics.
     for diagnostic in diagnostics {
+      consumer.handle(diagnostic)
+    }
+  }
+
+  internal func diagnose(_ diagnostic: Diagnostic) {
+    diagnostics.append(diagnostic)
+    for consumer in consumers {
       consumer.handle(diagnostic)
     }
   }
@@ -44,12 +56,7 @@ public class DiagnosticEngine {
   public func diagnose(_ message: Diagnostic.Message,
                        location: SourceLocation? = nil,
                        actions: ((inout Diagnostic.Builder) -> Void)? = nil) {
-    let diagnostic = Diagnostic(message: message, location: location,
-                                actions: actions)
-    diagnostics.append(diagnostic)
-    for consumer in consumers {
-      consumer.handle(diagnostic)
-    }
+    diagnose(Diagnostic(message: message, location: location, actions: actions))
   }
 
   /// If any of the diagnostics in this engine have the `error` severity.

--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -415,7 +415,9 @@ func printParserDiags(args: CommandLineArguments) throws {
       print("\(counter.error) error(s) \(counter.warning) warnings(s) \(counter.note) note(s)")
     }
   }
-  _ = try SyntaxParser.parse(treeURL, diagConsumer: ParserDiagPrinter())
+  let diagEngine = DiagnosticEngine()
+  diagEngine.addConsumer(ParserDiagPrinter())
+  _ = try SyntaxParser.parse(treeURL, diagnosticEngine: diagEngine)
 }
 
 do {

--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -395,19 +395,24 @@ func printSyntaxTree(args: CommandLineArguments) throws {
 func printParserDiags(args: CommandLineArguments) throws {
   let treeURL = URL(fileURLWithPath: try args.getRequired("-source-file"))
   class ParserDiagPrinter: DiagnosticConsumer {
-    var counter = [0, 0, 0]
+    var counter : (error: Int, warning: Int, note: Int) = (0, 0, 0)
     var calculateLineColumn: Bool { return true }
     func finalize() {}
     func handle(_ diag: Diagnostic) {
       switch diag.message.severity {
-      case .error: counter[0] += 1
-      case .warning: counter[1] += 1
-      case .note: counter[2] += 1
+      case .error:
+        counter.error += 1
+        counter.note += diag.notes.count
+      case .warning:
+        counter.warning += 1
+        counter.note += diag.notes.count
+      case .note:
+        counter.note += 1
       }
       print(diag.debugDescription)
     }
     deinit {
-      print("\(counter[0]) error(s) \(counter[1]) warnings(s) \(counter[2]) note(s)")
+      print("\(counter.error) error(s) \(counter.warning) warnings(s) \(counter.note) note(s)")
     }
   }
   _ = try SyntaxParser.parse(treeURL, diagConsumer: ParserDiagPrinter())

--- a/lit_tests/parser-diags.swift
+++ b/lit_tests/parser-diags.swift
@@ -8,7 +8,7 @@ let number⁚ Int
 // CHECK-NEXT: [[@LINE+2]]:3 error: invalid character in source file
 // CHECK-NEXT: Fixit: ([[@LINE+1]]:3,[[@LINE+1]]:6) Text: " "
 5 ‒ 5
-// CHECK-NEXT: [[@LINE-1]]:3 note: unicode character '‒' looks similar to '-'; did you mean to use '-'?
+// CHECK-NEXT: [[@LINE-1]]:3 [[@LINE-1]]:3 note: unicode character '‒' looks similar to '-'; did you mean to use '-'?
 // CHECK-NEXT: Fixit: ([[@LINE-2]]:3,[[@LINE-2]]:6) Text: "-"
 // CHECK-NEXT: [[@LINE-3]]:2 error: consecutive statements on a line must be separated by ';'
 // CHECK-NEXT: Fixit: ([[@LINE-4]]:2,[[@LINE-4]]:2) Text: ";"
@@ -20,7 +20,7 @@ if (true ꝸꝸꝸ false) {}
 if (5 ‒ 5) == 0 {}
 // CHECK-NEXT: [[@LINE-1]]:7 error: invalid character in source file
 // CHECK-NEXT: Fixit: ([[@LINE-2]]:7,[[@LINE-2]]:10) Text: " "
-// CHECK-NEXT: [[@LINE-3]]:7 note: unicode character '‒' looks similar to '-'; did you mean to use '-'?
+// CHECK-NEXT: [[@LINE-3]]:7 [[@LINE-3]]:7 note: unicode character '‒' looks similar to '-'; did you mean to use '-'?
 // CHECK-NEXT: Fixit: ([[@LINE-4]]:7,[[@LINE-4]]:10) Text: "-"
 // CHECK-NEXT: [[@LINE-5]]:11 error: expected ',' separator
 // CHECK-NEXT: Fixit: ([[@LINE-6]]:6,[[@LINE-6]]:6) Text: ","

--- a/lit_tests/parser-diags.swift
+++ b/lit_tests/parser-diags.swift
@@ -1,0 +1,27 @@
+// RUN: %lit-test-helper -source-file %s -dump-diags 2>&1 | %FileCheck %s
+
+// CHECK: [[@LINE+2]]:11 error: consecutive statements on a line must be separated by ';'
+// CHECK-NEXT: Fixit: ([[@LINE+1]]:11,[[@LINE+1]]:11) Text: ";"
+let number⁚ Int
+// CHECK-NEXT: [[@LINE-1]]:11 error: operator with postfix spacing cannot start a subexpression
+
+// CHECK-NEXT: [[@LINE+2]]:3 error: invalid character in source file
+// CHECK-NEXT: Fixit: ([[@LINE+1]]:3,[[@LINE+1]]:6) Text: " "
+5 ‒ 5
+// CHECK-NEXT: [[@LINE-1]]:3 note: unicode character '‒' looks similar to '-'; did you mean to use '-'?
+// CHECK-NEXT: Fixit: ([[@LINE-2]]:3,[[@LINE-2]]:6) Text: "-"
+// CHECK-NEXT: [[@LINE-3]]:2 error: consecutive statements on a line must be separated by ';'
+// CHECK-NEXT: Fixit: ([[@LINE-4]]:2,[[@LINE-4]]:2) Text: ";"
+
+// CHECK-NEXT: [[@LINE+2]]:10 error: expected ',' separator
+// CHECK-NEXT: Fixit: ([[@LINE+1]]:9,[[@LINE+1]]:9) Text: ","
+if (true ꝸꝸꝸ false) {}
+
+if (5 ‒ 5) == 0 {}
+// CHECK-NEXT: [[@LINE-1]]:7 error: invalid character in source file
+// CHECK-NEXT: Fixit: ([[@LINE-2]]:7,[[@LINE-2]]:10) Text: " "
+// CHECK-NEXT: [[@LINE-3]]:7 note: unicode character '‒' looks similar to '-'; did you mean to use '-'?
+// CHECK-NEXT: Fixit: ([[@LINE-4]]:7,[[@LINE-4]]:10) Text: "-"
+// CHECK-NEXT: [[@LINE-5]]:11 error: expected ',' separator
+// CHECK-NEXT: Fixit: ([[@LINE-6]]:6,[[@LINE-6]]:6) Text: ","
+// CHECK-NEXT: 7 error(s) 0 warnings(s) 2 note(s)


### PR DESCRIPTION
This patch adds a parameter of DiagnosticConsumer to the parser entry point
to capture any diagnostics emitted from the compiler(parser). We also convert the
c structures collected from the compiler side to an existing Diagnostic type
in SwiftSyntax to unify the API.

To avoid unnecessarily calculating line/column from a utf8 offset, a property
is added to DiagnosticConsumer to indicate whether the users want line/column;
by default they are calculated.

rdar://48439271