### PR TITLE
Enhancements to classification mechanism

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -251,6 +251,11 @@ extension _SyntaxBase {
   }
 
   /// Sequence of `SyntaxClassifiedRange`s for this syntax node.
+  ///
+  /// The provided classified ranges are consecutive and cover the full source
+  /// text of the node. The ranges may also span multiple tokens, if multiple
+  /// consecutive tokens would have the same classification then a single classified
+  /// range is provided for all of them.
   var classifications: SyntaxClassifications {
     let fullRange = ByteSourceRange(offset: 0, length: byteSize)
     return SyntaxClassifications(self, in: fullRange)
@@ -258,6 +263,15 @@ extension _SyntaxBase {
 
   /// Sequence of `SyntaxClassifiedRange`s contained in this syntax node within
   /// a relative range.
+  ///
+  /// The provided classified ranges may extend beyond the provided `range`.
+  /// Active classifications (non-`none`) will extend the range to include the
+  /// full classified range (e.g. from the beginning of the comment block), while
+  /// `none` classified ranges will extend to the beginning or end of the token
+  /// that the `range` touches.
+  /// It is guaranteed that no classified range will be provided that doesn't
+  /// intersect the provided `range`.
+  ///
   /// - Parameters:
   ///   - in: The relative byte range to pull `SyntaxClassifiedRange`s from.
   /// - Returns: Sequence of `SyntaxClassifiedRange`s.
@@ -504,12 +518,26 @@ extension Syntax {
   }
 
   /// Sequence of `SyntaxClassifiedRange`s for this syntax node.
+  ///
+  /// The provided classification ranges are consecutive and cover the full source
+  /// text of the node. The ranges may also span multiple tokens, if multiple
+  /// consecutive tokens would have the same classification then a single classified
+  /// range is provided for all of them.
   public var classifications: SyntaxClassifications {
     return base.classifications
   }
 
   /// Sequence of `SyntaxClassifiedRange`s contained in this syntax node within
   /// a relative range.
+  ///
+  /// The provided classified ranges may extend beyond the provided `range`.
+  /// Active classifications (non-`none`) will extend the range to include the
+  /// full classified range (e.g. from the beginning of the comment block), while
+  /// `none` classified ranges will extend to the beginning or end of the token
+  /// that the `range` touches.
+  /// It is guaranteed that no classified range will be provided that doesn't
+  /// intersect the provided `range`.
+  ///
   /// - Parameters:
   ///   - in: The relative byte range to pull `SyntaxClassifiedRange`s from.
   /// - Returns: Sequence of `SyntaxClassifiedRange`s.

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -265,6 +265,27 @@ extension _SyntaxBase {
     return SyntaxClassifications(self, in: range)
   }
 
+  /// The `SyntaxClassifiedRange` for a relative byte offset.
+  /// - Parameters:
+  ///   - at: The relative to the node byte offset.
+  /// - Returns: The `SyntaxClassifiedRange` for the offset or nil if the source text
+  ///   at the given offset is unclassified.
+  func classification(at offset: Int) -> SyntaxClassifiedRange? {
+    let classifications = SyntaxClassifications(self, in: ByteSourceRange(offset: offset, length: 1))
+    var iterator = classifications.makeIterator()
+    return iterator.next()
+  }
+
+  /// The `SyntaxClassifiedRange` for an absolute position.
+  /// - Parameters:
+  ///   - at: The absolute position.
+  /// - Returns: The `SyntaxClassifiedRange` for the position or nil if the source text
+  ///   at the given position is unclassified.
+  func classification(at position: AbsolutePosition) -> SyntaxClassifiedRange? {
+    let relativeOffset = position.utf8Offset - self.position.utf8Offset
+    return self.classification(at: relativeOffset)
+  }
+
   /// Returns a value representing the unique identity of the node.
   var uniqueIdentifier: SyntaxIdentifier {
     return data.nodeId
@@ -494,6 +515,24 @@ extension Syntax {
   /// - Returns: Sequence of `SyntaxClassifiedRange`s.
   public func classifications(in range: ByteSourceRange) -> SyntaxClassifications {
     return base.classifications(in: range)
+  }
+
+  /// The `SyntaxClassifiedRange` for a relative byte offset.
+  /// - Parameters:
+  ///   - at: The relative to the node byte offset.
+  /// - Returns: The `SyntaxClassifiedRange` for the offset or nil if the source text
+  ///   at the given offset is unclassified.
+  public func classification(at offset: Int) -> SyntaxClassifiedRange? {
+    return base.classification(at: offset)
+  }
+
+  /// The `SyntaxClassifiedRange` for an absolute position.
+  /// - Parameters:
+  ///   - at: The absolute position.
+  /// - Returns: The `SyntaxClassifiedRange` for the position or nil if the source text
+  ///   at the given position is unclassified.
+  public func classification(at position: AbsolutePosition) -> SyntaxClassifiedRange? {
+    return base.classification(at: position)
   }
 
   /// Returns a value representing the unique identity of the node.

--- a/Sources/SwiftSyntax/SyntaxClassification.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxClassification.swift.gyb
@@ -55,7 +55,7 @@ extension SyntaxClassification {
   /// - Returns: A pair of classification and whether it is "forced", or nil if
   ///   no classification is attached.
   internal static func classify(
-    parentKind: SyntaxKind, indexInParent: UInt32, childKind: SyntaxKind
+    parentKind: SyntaxKind, indexInParent: Int, childKind: SyntaxKind
   ) -> (SyntaxClassification, Bool)? {
     // Separate checks for token nodes (most common checks) versus checks for layout nodes.
     if childKind == .token {

--- a/Sources/SwiftSyntax/SyntaxClassification.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxClassification.swift.gyb
@@ -83,18 +83,18 @@ extension SyntaxClassification {
 }
 
 extension RawTokenKind {
-  internal var classification: SyntaxClassification? {
+  internal var classification: SyntaxClassification {
     switch (self) {
 % for token in SYNTAX_TOKENS:
     case .${token.swift_kind()}:
-%   if token.classification and token.classification.name != 'None':
+%   if token.classification:
       return .${token.classification.swift_name}
 %   else:
-      return nil
+      return .none
 %   end
 % end
     case .eof:
-      return nil
+      return .none
     }
   }
 }

--- a/Sources/SwiftSyntax/SyntaxClassifier.swift
+++ b/Sources/SwiftSyntax/SyntaxClassifier.swift
@@ -295,7 +295,7 @@ fileprivate struct TokenClassificationIterator: IteratorProtocol {
 }
 
 /// Represents a source range that is associated with a syntax classification.
-public struct SyntaxClassifiedRange {
+public struct SyntaxClassifiedRange: Equatable {
   public let kind: SyntaxClassification
   public let range: ByteSourceRange
 }

--- a/Sources/SwiftSyntax/Utils.swift
+++ b/Sources/SwiftSyntax/Utils.swift
@@ -11,8 +11,8 @@
 //===----------------------------------------------------------------------===//
 
 public struct ByteSourceRange: Equatable {
-  public let offset: Int
-  public let length: Int
+  public var offset: Int
+  public var length: Int
 
   public init(offset: Int, length: Int) {
     self.offset = offset

--- a/Tests/SwiftSyntaxTest/ClassificationTests.swift
+++ b/Tests/SwiftSyntaxTest/ClassificationTests.swift
@@ -52,6 +52,15 @@ public class ClassificationTests: XCTestCase {
       }
       XCTAssertEqual(classif[0].kind, .blockComment)
       XCTAssertEqual(classif[0].range, ByteSourceRange(offset: 14, length: 6))
+
+      do {
+        let singleClassif = initializer.classification(at: 5)
+        XCTAssertEqual(singleClassif, classif[0])
+      }
+      do {
+        let singleClassif = initializer.classification(at: AbsolutePosition(utf8Offset: 19))
+        XCTAssertEqual(singleClassif, classif[0])
+      }
     }
   }
 }

--- a/Tests/SwiftSyntaxTest/ClassificationTests.swift
+++ b/Tests/SwiftSyntaxTest/ClassificationTests.swift
@@ -4,6 +4,7 @@ import SwiftSyntax
 public class ClassificationTests: XCTestCase {
   public static let allTests = [
     ("testClassification", testClassification),
+    ("testTokenClassification", testTokenClassification),
   ]
 
   public func testClassification() {
@@ -90,6 +91,27 @@ public class ClassificationTests: XCTestCase {
       let classif = tree.classification(at: 11)!
       XCTAssertEqual(classif.kind, .none)
       XCTAssertEqual(classif.range, ByteSourceRange(offset: 11, length: 1))
+    }
+  }
+
+  public func testTokenClassification() {
+    let source = "let x: Int"
+    let tree = try! SyntaxParser.parse(source: source)
+    do {
+      let tokens = Array(tree.tokens)
+      XCTAssertEqual(tokens.count, 4)
+      guard tokens.count == 4 else {
+        return
+      }
+      let classif = tokens.map { $0.tokenClassification }
+      XCTAssertEqual(classif[0].kind, .keyword)
+      XCTAssertEqual(classif[0].range, ByteSourceRange(offset: 0, length: 3))
+      XCTAssertEqual(classif[1].kind, .none)
+      XCTAssertEqual(classif[1].range, ByteSourceRange(offset: 4, length: 1))
+      XCTAssertEqual(classif[2].kind, .none)
+      XCTAssertEqual(classif[2].range, ByteSourceRange(offset: 5, length: 1))
+      XCTAssertEqual(classif[3].kind, .typeIdentifier)
+      XCTAssertEqual(classif[3].range, ByteSourceRange(offset: 7, length: 3))
     }
   }
 }

--- a/Tests/SwiftSyntaxTest/ClassificationTests.swift
+++ b/Tests/SwiftSyntaxTest/ClassificationTests.swift
@@ -11,47 +11,64 @@ public class ClassificationTests: XCTestCase {
     let tree = try! SyntaxParser.parse(source: source)
     do {
       let classif = Array(tree.classifications)
-      XCTAssertEqual(classif.count, 4)
-      guard classif.count == 4 else {
+      XCTAssertEqual(classif.count, 7)
+      guard classif.count == 7 else {
         return
       }
       XCTAssertEqual(classif[0].kind, .lineComment)
       XCTAssertEqual(classif[0].range, ByteSourceRange(offset: 0, length: 8))
-      XCTAssertEqual(classif[1].kind, .keyword)
-      XCTAssertEqual(classif[1].range, ByteSourceRange(offset: 9, length: 3))
-      XCTAssertEqual(classif[2].kind, .blockComment)
-      XCTAssertEqual(classif[2].range, ByteSourceRange(offset: 14, length: 6))
-      XCTAssertEqual(classif[3].kind, .integerLiteral)
-      XCTAssertEqual(classif[3].range, ByteSourceRange(offset: 23, length: 1))
+      XCTAssertEqual(classif[1].kind, .none)
+      XCTAssertEqual(classif[1].range, ByteSourceRange(offset: 8, length: 1))
+      XCTAssertEqual(classif[2].kind, .keyword)
+      XCTAssertEqual(classif[2].range, ByteSourceRange(offset: 9, length: 3))
+      XCTAssertEqual(classif[3].kind, .none)
+      XCTAssertEqual(classif[3].range, ByteSourceRange(offset: 12, length: 2))
+      XCTAssertEqual(classif[4].kind, .blockComment)
+      XCTAssertEqual(classif[4].range, ByteSourceRange(offset: 14, length: 6))
+      XCTAssertEqual(classif[5].kind, .none)
+      XCTAssertEqual(classif[5].range, ByteSourceRange(offset: 20, length: 3))
+      XCTAssertEqual(classif[6].kind, .integerLiteral)
+      XCTAssertEqual(classif[6].range, ByteSourceRange(offset: 23, length: 1))
     }
     do {
       let classif = Array(tree.classifications(in: ByteSourceRange(offset: 7, length: 8)))
-      XCTAssertEqual(classif.count, 3)
-      guard classif.count == 3 else {
+      XCTAssertEqual(classif.count, 5)
+      guard classif.count == 5 else {
         return
       }
       XCTAssertEqual(classif[0].kind, .lineComment)
       XCTAssertEqual(classif[0].range, ByteSourceRange(offset: 0, length: 8))
-      XCTAssertEqual(classif[1].kind, .keyword)
-      XCTAssertEqual(classif[1].range, ByteSourceRange(offset: 9, length: 3))
-      XCTAssertEqual(classif[2].kind, .blockComment)
-      XCTAssertEqual(classif[2].range, ByteSourceRange(offset: 14, length: 6))
+      XCTAssertEqual(classif[1].kind, .none)
+      XCTAssertEqual(classif[1].range, ByteSourceRange(offset: 8, length: 1))
+      XCTAssertEqual(classif[2].kind, .keyword)
+      XCTAssertEqual(classif[2].range, ByteSourceRange(offset: 9, length: 3))
+      XCTAssertEqual(classif[3].kind, .none)
+      XCTAssertEqual(classif[3].range, ByteSourceRange(offset: 12, length: 2))
+      XCTAssertEqual(classif[4].kind, .blockComment)
+      XCTAssertEqual(classif[4].range, ByteSourceRange(offset: 14, length: 6))
     }
     do {
       let classif = Array(tree.classifications(in: ByteSourceRange(offset: 21, length: 1)))
-      XCTAssertEqual(classif.count, 0)
+      XCTAssertEqual(classif.count, 1)
+      guard classif.count == 1 else {
+        return
+      }
+      XCTAssertEqual(classif[0].kind, .none)
+      XCTAssertEqual(classif[0].range, ByteSourceRange(offset: 20, length: 3))
     }
     do {
       let initializer = (tree.statements[0].item as! VariableDeclSyntax).bindings[0].initializer!
       XCTAssertEqual(initializer.description, "/*yo*/ = 0")
       // Classify with a relative range inside this node.
       let classif = Array(initializer.classifications(in: ByteSourceRange(offset: 5, length: 2)))
-      XCTAssertEqual(classif.count, 1)
-      guard classif.count == 1 else {
+      XCTAssertEqual(classif.count, 2)
+      guard classif.count == 2 else {
         return
       }
       XCTAssertEqual(classif[0].kind, .blockComment)
       XCTAssertEqual(classif[0].range, ByteSourceRange(offset: 14, length: 6))
+      XCTAssertEqual(classif[1].kind, .none)
+      XCTAssertEqual(classif[1].range, ByteSourceRange(offset: 20, length: 3))
 
       do {
         let singleClassif = initializer.classification(at: 5)
@@ -61,6 +78,18 @@ public class ClassificationTests: XCTestCase {
         let singleClassif = initializer.classification(at: AbsolutePosition(utf8Offset: 19))
         XCTAssertEqual(singleClassif, classif[0])
       }
+    }
+
+    do {
+      let source = "func foo() {}"
+      let tree = try! SyntaxParser.parse(source: source)
+      // For `classification(at:)` there's an initial walk to find the token that
+      // the offset is contained in and the classified ranges are processed from that
+      // token. That means that a `none` classified range would be restricted inside
+      // the token range.
+      let classif = tree.classification(at: 11)!
+      XCTAssertEqual(classif.kind, .none)
+      XCTAssertEqual(classif.range, ByteSourceRange(offset: 11, length: 1))
     }
   }
 }


### PR DESCRIPTION
* Add some convenience APIs for getting the classification at a certain offset
* Provided classification ranges that are consecutive and cover the full source text of the node, including `none` classifications.
* Add API `TokenSyntax.tokenClassification` to get the classification for a specific token