### PR TITLE
[classification] Make sure to inherit the contextual classification for classifications of sub-nodes

### DIFF
--- a/Tests/SwiftSyntaxTest/ClassificationTests.swift
+++ b/Tests/SwiftSyntaxTest/ClassificationTests.swift
@@ -113,5 +113,11 @@ public class ClassificationTests: XCTestCase {
       XCTAssertEqual(classif[3].kind, .typeIdentifier)
       XCTAssertEqual(classif[3].range, ByteSourceRange(offset: 7, length: 3))
     }
+    do {
+      let tok = tree.lastToken!.previousToken!
+      XCTAssertEqual("\(tok)", "Int")
+      let classif = Array(tok.classifications).first!
+      XCTAssertEqual(classif.kind, .typeIdentifier)
+    }
   }
 }


### PR DESCRIPTION
Fixes https://bugs.swift.org/browse/SR-10074