### PR TITLE
[README] Add section on how to report issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ the Swift compiler source because we always push gyb-generated files to a tag.
 
 [**Muter**](https://github.com/SeanROlszewski/muter): Automated mutation testing for Swift
 
+### Reporting Issues
+
+If you should hit any issues while using SwiftSyntax, we appreciate bug reports on [bugs.swift.org](https://bugs.swift.org) in the [SwiftSyntax component](https://bugs.swift.org/issues/?jql=component%20%3D%20SwiftSyntax).
+
 ## Contributing
 
 ### Building SwiftSyntax from `master`


### PR DESCRIPTION
I just had a hard time figuring out how I can ask a question on the usage or report issues with the documentation/implementation of SwiftSyntax. Neither does this repo have the issues activated, nor could I find a category for that on the Swift Forums. Luckily though, I could find [this post](https://forums.swift.org/t/swiftsyntax-is-now-a-swiftpm-project/15691?u=dschee) where there's a hint on where to report issues.

I simply copy & pasted the hint from there to the README of this repo and also updated the table listing the released Swift versions.