### PR TITLE
Use `collection_element_name` to provide better named `add<ELEMENT_NAME>` APIs

### DIFF
--- a/Sources/SwiftSyntax/SyntaxBuilders.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxBuilders.swift.gyb
@@ -37,11 +37,13 @@ public struct ${Builder} {
 %     for child in node.children:
 %       child_node = NODE_MAP.get(child.syntax_kind)
 %       if child_node and child_node.is_syntax_collection():
-%         child_elt = child_node.collection_element_name
+%         child_elt = child.collection_element_name
 %         child_elt_type = child_node.collection_element_type
-%         child_elt_name = child.name + 'Member'
+%         if not child_elt:
+%           raise Exception("'collection_element_name' should be set for '%s' of '%s'" % (child.name, node.name))
+%         end
 
-  public mutating func add${child_elt_name}(_ elt: ${child_elt_type}) {
+  public mutating func add${child_elt}(_ elt: ${child_elt_type}) {
     let idx = ${node.name}.Cursor.${child.swift_name}.rawValue
     if let list = layout[idx] {
       layout[idx] = list.appending(elt.raw)

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
@@ -127,9 +127,11 @@ public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
   }
   }
 %       if child_node and child_node.is_syntax_collection():
-%         child_elt = child_node.collection_element_name
+%         child_elt = child.collection_element_name
 %         child_elt_type = child_node.collection_element_type
-%         child_elt_name = child.name + 'Member'
+%         if not child_elt:
+%           raise Exception("'collection_element_name' should be set for '%s' of '%s'" % (child.name, node.name))
+%         end
 
   /// Adds the provided `${child_elt}` to the node's `${child.swift_name}`
   /// collection.
@@ -137,7 +139,7 @@ public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
   ///                  `${child.swift_name}` collection.
   /// - returns: A copy of the receiver with the provided `${child_elt}`
   ///            appended to its `${child.swift_name}` collection.
-  public func add${child_elt_name}(_ element: ${child_elt_type}) -> ${node.name} {
+  public func add${child_elt}(_ element: ${child_elt_type}) -> ${node.name} {
     var collection: RawSyntax
     if let col = raw[Cursor.${child.swift_name}] {
       collection = col.appending(element.raw)

--- a/Tests/SwiftSyntaxTest/ModifierTests.swift
+++ b/Tests/SwiftSyntaxTest/ModifierTests.swift
@@ -11,7 +11,7 @@ fileprivate func cannedVarDecl() -> VariableDeclSyntax {
     initializer: nil, accessor: nil, trailingComma: nil)
   return VariableDeclSyntax {
     $0.useLetOrVarKeyword(SyntaxFactory.makeLetKeyword())
-    $0.addBindingsMember(Pattern)
+    $0.addBinding(Pattern)
   }
 }
 

--- a/Tests/SwiftSyntaxTest/SyntaxFactory.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxFactory.swift
@@ -102,7 +102,7 @@ public class SyntaxFactoryAPITestCase: XCTestCase {
     let call = FunctionCallExprSyntax {
       $0.useCalledExpression(printID)
       $0.useLeftParen(SyntaxFactory.makeLeftParenToken())
-      $0.addArgumentListMember(arg)
+      $0.addArgument(arg)
       $0.useRightParen(SyntaxFactory.makeRightParenToken())
     }
     XCTAssertEqual("\(call)", "print(\"Hello, world!\")")
@@ -133,7 +133,7 @@ public class SyntaxFactoryAPITestCase: XCTestCase {
     let call1 = FunctionCallExprSyntax {
       $0.useCalledExpression(printID)
       $0.useLeftParen(SyntaxFactory.makeLeftParenToken())
-      $0.addArgumentListMember(arg)
+      $0.addArgument(arg)
       $0.useRightParen(SyntaxFactory.makeRightParenToken())
     }
     XCTAssertNotNil(call1.leftParen)
@@ -145,7 +145,7 @@ public class SyntaxFactoryAPITestCase: XCTestCase {
 
     let call3 = FunctionCallExprSyntax {
       $0.useCalledExpression(printID)
-      $0.addArgumentListMember(arg)
+      $0.addArgument(arg)
     }
     XCTAssertNil(call3.leftParen)
     XCTAssertNil(call3.rightParen)


### PR DESCRIPTION
Related to swift PR: https://github.com/apple/swift/pull/24227