### PR TITLE
Make Diagnostic initializers public

### DIFF
--- a/Sources/SwiftSyntax/Diagnostic.swift
+++ b/Sources/SwiftSyntax/Diagnostic.swift
@@ -248,7 +248,7 @@ public struct Diagnostic: Codable, CustomDebugStringConvertible {
   ///   - location: The location the diagnostic is attached to.
   ///   - actions: A closure that's used to attach notes and highlights to
   ///              diagnostics.
-  init(message: Message, location: SourceLocation?,
+  public init(message: Message, location: SourceLocation?,
        actions: ((inout Builder) -> Void)?) {
     var builder = Builder()
     actions?(&builder)
@@ -263,7 +263,7 @@ public struct Diagnostic: Codable, CustomDebugStringConvertible {
   ///   - location: The location the diagnostic is attached to.
   ///   - highlights: An array of SourceRanges which will be highlighted when
   ///                 the diagnostic is presented.
-  init(message: Message, location: SourceLocation?, notes: [Note],
+  public init(message: Message, location: SourceLocation?, notes: [Note],
        highlights: [SourceRange], fixIts: [FixIt]) {
     self.message = message
     self.location = location


### PR DESCRIPTION
For tools that use SwiftSyntax, it's quite useful to be able to emit their own diagnostics while reusing the `Diagnostic` type from SwiftSyntax. Both `Diagnostic` and its `Builder` type are `public`, and properties of `Diagnostic` are `public` too, but initializers are implicitly `internal`. This means that instances of `Diagnostic` can't be created by tools using SwiftSyntax. I hope this can be fixed with this simple change.