### PR TITLE
Update tests for syntax classification of identifiers as 'Identifier' classification

### DIFF
--- a/Sources/lit-test-helper/ClassifiedSyntaxTreePrinter.swift
+++ b/Sources/lit-test-helper/ClassifiedSyntaxTreePrinter.swift
@@ -18,7 +18,7 @@ extension SyntaxClassification {
     switch self {
     case .none: return ""
     case .keyword: return "kw"
-    case .identifier: return ""
+    case .identifier: return "id"
     case .typeIdentifier: return "type"
     case .dollarIdentifier: return "dollar"
     case .integerLiteral: return "int"

--- a/Tests/SwiftSyntaxTest/ClassificationTests.swift
+++ b/Tests/SwiftSyntaxTest/ClassificationTests.swift
@@ -12,8 +12,8 @@ public class ClassificationTests: XCTestCase {
     let tree = try! SyntaxParser.parse(source: source)
     do {
       let classif = Array(tree.classifications)
-      XCTAssertEqual(classif.count, 7)
-      guard classif.count == 7 else {
+      XCTAssertEqual(classif.count, 8)
+      guard classif.count == 8 else {
         return
       }
       XCTAssertEqual(classif[0].kind, .lineComment)
@@ -23,18 +23,20 @@ public class ClassificationTests: XCTestCase {
       XCTAssertEqual(classif[2].kind, .keyword)
       XCTAssertEqual(classif[2].range, ByteSourceRange(offset: 9, length: 3))
       XCTAssertEqual(classif[3].kind, .none)
-      XCTAssertEqual(classif[3].range, ByteSourceRange(offset: 12, length: 2))
-      XCTAssertEqual(classif[4].kind, .blockComment)
-      XCTAssertEqual(classif[4].range, ByteSourceRange(offset: 14, length: 6))
-      XCTAssertEqual(classif[5].kind, .none)
-      XCTAssertEqual(classif[5].range, ByteSourceRange(offset: 20, length: 3))
-      XCTAssertEqual(classif[6].kind, .integerLiteral)
-      XCTAssertEqual(classif[6].range, ByteSourceRange(offset: 23, length: 1))
+      XCTAssertEqual(classif[3].range, ByteSourceRange(offset: 12, length: 1))
+      XCTAssertEqual(classif[4].kind, .identifier)
+      XCTAssertEqual(classif[4].range, ByteSourceRange(offset: 13, length: 1))
+      XCTAssertEqual(classif[5].kind, .blockComment)
+      XCTAssertEqual(classif[5].range, ByteSourceRange(offset: 14, length: 6))
+      XCTAssertEqual(classif[6].kind, .none)
+      XCTAssertEqual(classif[6].range, ByteSourceRange(offset: 20, length: 3))
+      XCTAssertEqual(classif[7].kind, .integerLiteral)
+      XCTAssertEqual(classif[7].range, ByteSourceRange(offset: 23, length: 1))
     }
     do {
       let classif = Array(tree.classifications(in: ByteSourceRange(offset: 7, length: 8)))
-      XCTAssertEqual(classif.count, 5)
-      guard classif.count == 5 else {
+      XCTAssertEqual(classif.count, 6)
+      guard classif.count == 6 else {
         return
       }
       XCTAssertEqual(classif[0].kind, .lineComment)
@@ -44,9 +46,11 @@ public class ClassificationTests: XCTestCase {
       XCTAssertEqual(classif[2].kind, .keyword)
       XCTAssertEqual(classif[2].range, ByteSourceRange(offset: 9, length: 3))
       XCTAssertEqual(classif[3].kind, .none)
-      XCTAssertEqual(classif[3].range, ByteSourceRange(offset: 12, length: 2))
-      XCTAssertEqual(classif[4].kind, .blockComment)
-      XCTAssertEqual(classif[4].range, ByteSourceRange(offset: 14, length: 6))
+      XCTAssertEqual(classif[3].range, ByteSourceRange(offset: 12, length: 1))
+      XCTAssertEqual(classif[4].kind, .identifier)
+      XCTAssertEqual(classif[4].range, ByteSourceRange(offset: 13, length: 1))
+      XCTAssertEqual(classif[5].kind, .blockComment)
+      XCTAssertEqual(classif[5].range, ByteSourceRange(offset: 14, length: 6))
     }
     do {
       let classif = Array(tree.classifications(in: ByteSourceRange(offset: 21, length: 1)))
@@ -106,7 +110,7 @@ public class ClassificationTests: XCTestCase {
       let classif = tokens.map { $0.tokenClassification }
       XCTAssertEqual(classif[0].kind, .keyword)
       XCTAssertEqual(classif[0].range, ByteSourceRange(offset: 0, length: 3))
-      XCTAssertEqual(classif[1].kind, .none)
+      XCTAssertEqual(classif[1].kind, .identifier)
       XCTAssertEqual(classif[1].range, ByteSourceRange(offset: 4, length: 1))
       XCTAssertEqual(classif[2].kind, .none)
       XCTAssertEqual(classif[2].range, ByteSourceRange(offset: 5, length: 1))

--- a/lit_tests/coloring.swift
+++ b/lit_tests/coloring.swift
@@ -3,123 +3,123 @@
 enum List<T> {
   case Nil
   // rdar://21927124
-  // CHECK: <attr-builtin>indirect</attr-builtin> <kw>case</kw> Cons(<type>T</type>, <type>List</type>)
+  // CHECK: <attr-builtin>indirect</attr-builtin> <kw>case</kw> <id>Cons</id>(<type>T</type>, <type>List</type>)
   indirect case Cons(T, List)
 }
 
-// CHECK: <kw>struct</kw> S {
+// CHECK: <kw>struct</kw> <id>S</id> {
 struct S {
-  // CHECK: <kw>var</kw> x : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>x</id> : <type>Int</type>
   var x : Int
-  // CHECK: <kw>var</kw> y : <type>Int</type>.<type>Int</type>
+  // CHECK: <kw>var</kw> <id>y</id> : <type>Int</type>.<type>Int</type>
   var y : Int.Int
-  // CHECK: <kw>var</kw> a, b : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>a</id>, <id>b</id> : <type>Int</type>
   var a, b : Int
 }
 
 enum EnumWithDerivedEquatableConformance : Int {
-// CHECK-LABEL: <kw>enum</kw> EnumWithDerivedEquatableConformance : {{(<type>)}}Int{{(</type>)?}} {
+// CHECK-LABEL: <kw>enum</kw> <id>EnumWithDerivedEquatableConformance</id> : {{(<type>)}}Int{{(</type>)?}} {
   case CaseA
-// CHECK-NEXT: <kw>case</kw> CaseA
+// CHECK-NEXT: <kw>case</kw> <id>CaseA</id>
   case CaseB, CaseC
-// CHECK-NEXT: <kw>case</kw> CaseB, CaseC
+// CHECK-NEXT: <kw>case</kw> <id>CaseB</id>, <id>CaseC</id>
   case CaseD = 30, CaseE
-// CHECK-NEXT: <kw>case</kw> CaseD = <int>30</int>, CaseE
+// CHECK-NEXT: <kw>case</kw> <id>CaseD</id> = <int>30</int>, <id>CaseE</id>
 }
 // CHECK-NEXT: }
 
-// CHECK: <kw>class</kw> MyCls {
+// CHECK: <kw>class</kw> <id>MyCls</id> {
 class MyCls {
-    // CHECK: <kw>var</kw> www : <type>Int</type>
+    // CHECK: <kw>var</kw> <id>www</id> : <type>Int</type>
     var www : Int
 
-    // CHECK: <kw>func</kw> foo(x: <type>Int</type>) {}
+    // CHECK: <kw>func</kw> <id>foo</id>(<id>x</id>: <type>Int</type>) {}
     func foo(x: Int) {}
-    // CHECK: <kw>var</kw> aaa : <type>Int</type> {
+    // CHECK: <kw>var</kw> <id>aaa</id> : <type>Int</type> {
     var aaa : Int {
       // CHECK: <kw>get</kw> {}
       get {}
       // CHECK: <kw>set</kw> {}
       set {}
     }
-    // CHECK: <kw>var</kw> bbb : <type>Int</type> {
+    // CHECK: <kw>var</kw> <id>bbb</id> : <type>Int</type> {
     var bbb : Int {
       // CHECK: <kw>set</kw> {
       set {
-       // CHECK: <kw>var</kw> tmp : <type>Int</type>
+       // CHECK: <kw>var</kw> <id>tmp</id> : <type>Int</type>
         var tmp : Int
       }
       // CHECK: <kw>get</kw> {
       get {
-       // CHECK: <kw>var</kw> tmp : <type>Int</type>
+       // CHECK: <kw>var</kw> <id>tmp</id> : <type>Int</type>
        var tmp : Int
       }
     }
 
-    // CHECK: <kw>subscript</kw> (i : <type>Int</type>, j : <type>Int</type>) -> <type>Int</type> {
+    // CHECK: <kw>subscript</kw> (<id>i</id> : <type>Int</type>, <id>j</id> : <type>Int</type>) -> <type>Int</type> {
     subscript (i : Int, j : Int) -> Int {
       // CHECK: <kw>get</kw> {
       get {
-        // CHECK: <kw>return</kw> i + j
+        // CHECK: <kw>return</kw> <id>i</id> + <id>j</id>
         return i + j
       }
-      // CHECK: <kw>set</kw>(v) {
+      // CHECK: <kw>set</kw>(<id>v</id>) {
       set(v) {
-        // CHECK: v + i - j
+        // CHECK: <id>v</id> + <id>i</id> - <id>j</id>
         v + i - j
       }
     }
 
-    // CHECK: <kw>func</kw> multi(<kw>_</kw> name: <type>Int</type>, otherpart x: <type>Int</type>) {}
+    // CHECK: <kw>func</kw> <id>multi</id>(<kw>_</kw> <id>name</id>: <type>Int</type>, <id>otherpart</id> <id>x</id>: <type>Int</type>) {}
     func multi(_ name: Int, otherpart x: Int) {}
 }
 
-// CHECK-LABEL: <kw>class</kw> Attributes {
+// CHECK-LABEL: <kw>class</kw> <id>Attributes</id> {
 class Attributes {
-// CHECK: <attr-builtin>@IBOutlet</attr-builtin> <kw>var</kw> v0: <type>Int</type>
+// CHECK: <attr-builtin>@IBOutlet</attr-builtin> <kw>var</kw> <id>v0</id>: <type>Int</type>
   @IBOutlet var v0: Int
 
-// CHECK: <attr-builtin>@IBOutlet</attr-builtin> <attr-builtin>@IBOutlet</attr-builtin> <kw>var</kw> v1: <type>String</type>
+// CHECK: <attr-builtin>@IBOutlet</attr-builtin> <attr-builtin>@IBOutlet</attr-builtin> <kw>var</kw> <id>v1</id>: <type>String</type>
   @IBOutlet @IBOutlet var v1: String
 
-// CHECK: <attr-builtin>@objc</attr-builtin> <attr-builtin>@IBOutlet</attr-builtin> <kw>var</kw> v2: <type>String</type>
+// CHECK: <attr-builtin>@objc</attr-builtin> <attr-builtin>@IBOutlet</attr-builtin> <kw>var</kw> <id>v2</id>: <type>String</type>
   @objc @IBOutlet var v2: String
 
-// CHECK: <attr-builtin>@IBOutlet</attr-builtin> <attr-builtin>@objc</attr-builtin> <kw>var</kw> v3: <type>String</type>
+// CHECK: <attr-builtin>@IBOutlet</attr-builtin> <attr-builtin>@objc</attr-builtin> <kw>var</kw> <id>v3</id>: <type>String</type>
   @IBOutlet @objc var v3: String
 
-// CHECK: <attr-builtin>@available</attr-builtin>(*, unavailable) <kw>func</kw> f1() {}
+// CHECK: <attr-builtin>@available</attr-builtin>(*, <id>unavailable</id>) <kw>func</kw> <id>f1</id>() {}
   @available(*, unavailable) func f1() {}
 
-// CHECK: <attr-builtin>@available</attr-builtin>(*, unavailable) <attr-builtin>@IBAction</attr-builtin> <kw>func</kw> f2() {}
+// CHECK: <attr-builtin>@available</attr-builtin>(*, <id>unavailable</id>) <attr-builtin>@IBAction</attr-builtin> <kw>func</kw> <id>f2</id>() {}
   @available(*, unavailable) @IBAction func f2() {}
 
-// CHECK: <attr-builtin>@IBAction</attr-builtin> <attr-builtin>@available</attr-builtin>(*, unavailable) <kw>func</kw> f3() {}
+// CHECK: <attr-builtin>@IBAction</attr-builtin> <attr-builtin>@available</attr-builtin>(*, <id>unavailable</id>) <kw>func</kw> <id>f3</id>() {}
   @IBAction @available(*, unavailable) func f3() {}
 
-// CHECK: <attr-builtin>mutating</attr-builtin> <kw>func</kw> func_mutating_1() {}
+// CHECK: <attr-builtin>mutating</attr-builtin> <kw>func</kw> <id>func_mutating_1</id>() {}
   mutating func func_mutating_1() {}
 
-// CHECK: <attr-builtin>nonmutating</attr-builtin> <kw>func</kw> func_mutating_2() {}
+// CHECK: <attr-builtin>nonmutating</attr-builtin> <kw>func</kw> <id>func_mutating_2</id>() {}
   nonmutating func func_mutating_2() {}
 }
 
 func stringLikeLiterals() {
-// CHECK: <kw>var</kw> us1: <type>UnicodeScalar</type> = <str>"a"</str>
+// CHECK: <kw>var</kw> <id>us1</id>: <type>UnicodeScalar</type> = <str>"a"</str>
   var us1: UnicodeScalar = "a"
-// CHECK: <kw>var</kw> us2: <type>UnicodeScalar</type> = <str>"ы"</str>
+// CHECK: <kw>var</kw> <id>us2</id>: <type>UnicodeScalar</type> = <str>"ы"</str>
   var us2: UnicodeScalar = "ы"
 
-// CHECK: <kw>var</kw> ch1: <type>Character</type> = <str>"a"</str>
+// CHECK: <kw>var</kw> <id>ch1</id>: <type>Character</type> = <str>"a"</str>
   var ch1: Character = "a"
-// CHECK: <kw>var</kw> ch2: <type>Character</type> = <str>"あ"</str>
+// CHECK: <kw>var</kw> <id>ch2</id>: <type>Character</type> = <str>"あ"</str>
   var ch2: Character = "あ"
 
-// CHECK: <kw>var</kw> s1 = <str>"abc абвгд あいうえお"</str>
+// CHECK: <kw>var</kw> <id>s1</id> = <str>"abc абвгд あいうえお"</str>
   var s1 = "abc абвгд あいうえお"
 }
 
-// CHECK: <kw>var</kw> globComp : <type>Int</type>
+// CHECK: <kw>var</kw> <id>globComp</id> : <type>Int</type>
 var globComp : Int {
   // CHECK: <kw>get</kw> {
   get {
@@ -128,75 +128,75 @@ var globComp : Int {
   }
 }
 
-// CHECK: <kw>func</kw> foo(n: <type>Float</type>) -> <type>Int</type> {
+// CHECK: <kw>func</kw> <id>foo</id>(<id>n</id>: <type>Float</type>) -> <type>Int</type> {
 func foo(n: Float) -> Int {
-    // CHECK: <kw>var</kw> fnComp : <type>Int</type>
+    // CHECK: <kw>var</kw> <id>fnComp</id> : <type>Int</type>
     var fnComp : Int {
       // CHECK: <kw>get</kw> {
       get {
-        // CHECK: <kw>var</kw> a: <type>Int</type>
+        // CHECK: <kw>var</kw> <id>a</id>: <type>Int</type>
         // CHECK: <kw>return</kw> <int>0</int>
         var a: Int
         return 0
       }
     }
-    // CHECK: <kw>var</kw> q = {{(<type>)?}}MyCls{{(</type>)?}}()
+    // CHECK: <kw>var</kw> <id>q</id> = <id>MyCls</id>()
     var q = MyCls()
-    // CHECK: <kw>var</kw> ee = <str>"yoo"</str>;
+    // CHECK: <kw>var</kw> <id>ee</id> = <str>"yoo"</str>;
     var ee = "yoo";
     // CHECK: <kw>return</kw> <int>100009</int>
     return 100009
 }
 
-// CHECK: <kw>protocol</kw> Prot
+// CHECK: <kw>protocol</kw> <id>Prot</id>
 protocol Prot {
-  // CHECK: <kw>typealias</kw> Blarg
+  // CHECK: <kw>typealias</kw> <id>Blarg</id>
   typealias Blarg
-  // CHECK: <kw>func</kw> protMeth(x: <type>Int</type>)
+  // CHECK: <kw>func</kw> <id>protMeth</id>(<id>x</id>: <type>Int</type>)
   func protMeth(x: Int)
-  // CHECK: <kw>var</kw> protocolProperty1: <type>Int</type> { <kw>get</kw> }
+  // CHECK: <kw>var</kw> <id>protocolProperty1</id>: <type>Int</type> { <kw>get</kw> }
   var protocolProperty1: Int { get }
-  // CHECK: <kw>var</kw> protocolProperty2: <type>Int</type> { <kw>get</kw> <kw>set</kw> }
+  // CHECK: <kw>var</kw> <id>protocolProperty2</id>: <type>Int</type> { <kw>get</kw> <kw>set</kw> }
   var protocolProperty2: Int { get set }
 }
 
-// CHECK: <attr-builtin>infix</attr-builtin> <kw>operator</kw> *-* : FunnyPrecedence{{$}}
+// CHECK: <attr-builtin>infix</attr-builtin> <kw>operator</kw> *-* : <id>FunnyPrecedence</id>{{$}}
 infix operator *-* : FunnyPrecedence
 
-// CHECK: <kw>precedencegroup</kw> FunnyPrecedence
-// CHECK-NEXT: <kw>associativity</kw>: left{{$}}
-// CHECK-NEXT: <kw>higherThan</kw>: MultiplicationPrecedence
+// CHECK: <kw>precedencegroup</kw> <id>FunnyPrecedence</id>
+// CHECK-NEXT: <kw>associativity</kw>: <id>left</id>{{$}}
+// CHECK-NEXT: <kw>higherThan</kw>: <id>MultiplicationPrecedence</id>
 precedencegroup FunnyPrecedence {
   associativity: left
   higherThan: MultiplicationPrecedence
 }
 
-// CHECK: <kw>func</kw> *-*(l: <type>Int</type>, r: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> l }{{$}}
+// CHECK: <kw>func</kw> *-*(<id>l</id>: <type>Int</type>, <id>r</id>: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> <id>l</id> }{{$}}
 func *-*(l: Int, r: Int) -> Int { return l }
 
-// CHECK: <attr-builtin>infix</attr-builtin> <kw>operator</kw> *-+* : FunnyPrecedence
+// CHECK: <attr-builtin>infix</attr-builtin> <kw>operator</kw> *-+* : <id>FunnyPrecedence</id>
 infix operator *-+* : FunnyPrecedence
 
-// CHECK: <kw>func</kw> *-+*(l: <type>Int</type>, r: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> l }{{$}}
+// CHECK: <kw>func</kw> *-+*(<id>l</id>: <type>Int</type>, <id>r</id>: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> <id>l</id> }{{$}}
 func *-+*(l: Int, r: Int) -> Int { return l }
 
 // CHECK: <attr-builtin>infix</attr-builtin> <kw>operator</kw> *--*{{$}}
 infix operator *--*
 
-// CHECK: <kw>func</kw> *--*(l: <type>Int</type>, r: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> l }{{$}}
+// CHECK: <kw>func</kw> *--*(<id>l</id>: <type>Int</type>, <id>r</id>: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> <id>l</id> }{{$}}
 func *--*(l: Int, r: Int) -> Int { return l }
 
-// CHECK: <kw>protocol</kw> Prot2 : <type>Prot</type> {}
+// CHECK: <kw>protocol</kw> <id>Prot2</id> : <type>Prot</type> {}
 protocol Prot2 : Prot {}
 
-// CHECK: <kw>class</kw> SubCls : <type>MyCls</type>, <type>Prot</type> {}
+// CHECK: <kw>class</kw> <id>SubCls</id> : <type>MyCls</type>, <type>Prot</type> {}
 class SubCls : MyCls, Prot {}
 
-// CHECK: <kw>func</kw> genFn<T : <type>Prot</type> <kw>where</kw> <type>T</type>.<type>Blarg</type> : <type>Prot2</type>>(<kw>_</kw>: <type>T</type>) -> <type>Int</type> {}{{$}}
+// CHECK: <kw>func</kw> <id>genFn</id><<id>T</id> : <type>Prot</type> <kw>where</kw> <type>T</type>.<type>Blarg</type> : <type>Prot2</type>>(<kw>_</kw>: <type>T</type>) -> <type>Int</type> {}{{$}}
 func genFn<T : Prot where T.Blarg : Prot2>(_: T) -> Int {}
 
 func f(x: Int) -> Int {
-  // CHECK: <str>"This is string </str>\<anchor>(</anchor>genFn({(a:<type>Int</type> -> <type>Int</type>) <kw>in</kw> a})<anchor>)</anchor><str> interpolation"</str>
+  // CHECK: <str>"This is string </str>\<anchor>(</anchor><id>genFn</id>({(<id>a</id>:<type>Int</type> -> <type>Int</type>) <kw>in</kw> <id>a</id>})<anchor>)</anchor><str> interpolation"</str>
   "This is string \(genFn({(a:Int -> Int) in a})) interpolation"
 
   // CHECK: <str>"This is unterminated</str>
@@ -236,37 +236,37 @@ func f(x: Int) -> Int {
   "\(1)\(1)"
 }
 
-// CHECK: <kw>func</kw> bar(x: <type>Int</type>) -> (<type>Int</type>, <type>Float</type>) {
+// CHECK: <kw>func</kw> <id>bar</id>(<id>x</id>: <type>Int</type>) -> (<type>Int</type>, <type>Float</type>) {
 func bar(x: Int) -> (Int, Float) {
-  // CHECK: foo({{(<type>)?}}Float{{(</type>)?}}())
+  // CHECK: <id>foo</id>(<id>Float</id>())
   foo(Float())
 }
 
 class GenC<T1,T2> {}
 
 func test() {
-  // CHECK: {{(<type>)?}}GenC{{(</type>)?}}<<type>Int</type>, <type>Float</type>>()
+  // CHECK: {{(<type>)?}}<id>GenC</id>{{(</type>)?}}<<type>Int</type>, <type>Float</type>>()
   var x = GenC<Int, Float>()
 }
 
-// CHECK: <kw>typealias</kw> MyInt = <type>Int</type>
+// CHECK: <kw>typealias</kw> <id>MyInt</id> = <type>Int</type>
 typealias MyInt = Int
 
 func test2(x: Int) {
-  // CHECK: <str>"</str>\<anchor>(</anchor>x<anchor>)</anchor><str>"</str>
+  // CHECK: <str>"</str>\<anchor>(</anchor><id>x</id><anchor>)</anchor><str>"</str>
   "\(x)"
 }
 
-// CHECK: <kw>class</kw> Observers {
+// CHECK: <kw>class</kw> <id>Observers</id> {
 class Observers {
-  // CHECK: <kw>var</kw> p1 : <type>Int</type> {
+  // CHECK: <kw>var</kw> <id>p1</id> : <type>Int</type> {
   var p1 : Int {
-    // CHECK: <kw>willSet</kw>(newValue) {}
+    // CHECK: <kw>willSet</kw>(<id>newValue</id>) {}
     willSet(newValue) {}
     // CHECK: <kw>didSet</kw> {}
     didSet {}
   }
-  // CHECK: <kw>var</kw> p2 : <type>Int</type> {
+  // CHECK: <kw>var</kw> <id>p2</id> : <type>Int</type> {
   var p2 : Int {
     // CHECK: <kw>didSet</kw> {}
     didSet {}
@@ -275,22 +275,22 @@ class Observers {
   }
 }
 
-// CHECK: <kw>func</kw> test3(o: <type>AnyObject</type>) {
+// CHECK: <kw>func</kw> <id>test3</id>(<id>o</id>: <type>AnyObject</type>) {
 func test3(o: AnyObject) {
-  // CHECK: <kw>_</kw> = o <kw>is</kw> <type>MyCls</type> ? o <kw>as</kw> <type>MyCls</type> : o <kw>as</kw>! <type>MyCls</type> <kw>as</kw> <type>MyCls</type> + <int>1</int>
+  // CHECK: <kw>_</kw> = <id>o</id> <kw>is</kw> <type>MyCls</type> ? <id>o</id> <kw>as</kw> <type>MyCls</type> : <id>o</id> <kw>as</kw>! <type>MyCls</type> <kw>as</kw> <type>MyCls</type> + <int>1</int>
   _ = o is MyCls ? o as MyCls : o as! MyCls as MyCls + 1
 }
 
-// CHECK: <kw>class</kw> MySubClass : <type>MyCls</type> {
+// CHECK: <kw>class</kw> <id>MySubClass</id> : <type>MyCls</type> {
 class MySubClass : MyCls {
-    // CHECK: <attr-builtin>override</attr-builtin> <kw>func</kw> foo(x: <type>Int</type>) {}
+    // CHECK: <attr-builtin>override</attr-builtin> <kw>func</kw> <id>foo</id>(<id>x</id>: <type>Int</type>) {}
     override func foo(x: Int) {}
 
-    // CHECK: <attr-builtin>convenience</attr-builtin> <kw>init</kw>(a: <type>Int</type>) {}
+    // CHECK: <attr-builtin>convenience</attr-builtin> <kw>init</kw>(<id>a</id>: <type>Int</type>) {}
     convenience init(a: Int) {}
 }
 
-// CHECK: <kw>var</kw> g1 = { (x: <type>Int</type>) -> <type>Int</type> <kw>in</kw> <kw>return</kw> <int>0</int> }
+// CHECK: <kw>var</kw> <id>g1</id> = { (<id>x</id>: <type>Int</type>) -> <type>Int</type> <kw>in</kw> <kw>return</kw> <int>0</int> }
 var g1 = { (x: Int) -> Int in return 0 }
 
 // CHECK: <attr-builtin>infix</attr-builtin> <kw>operator</kw> ~~ {
@@ -302,22 +302,22 @@ postfix operator ~~* {}
 
 func test_defer() {
   defer {
-    // CHECK: <kw>let</kw> x : <type>Int</type> = <int>0</int>
+    // CHECK: <kw>let</kw> <id>x</id> : <type>Int</type> = <int>0</int>
     let x : Int = 0
   }
 }
 
 func test6<T : Prot>(x: T) {}
-// CHECK: <kw>func</kw> test6<T : <type>Prot</type>>(x: <type>T</type>) {}{{$}}
+// CHECK: <kw>func</kw> <id>test6</id><<id>T</id> : <type>Prot</type>>(<id>x</id>: <type>T</type>) {}{{$}}
 
 // CHECK: <kw>func</kw> <placeholder><#test1#></placeholder> () {}
 func <#test1#> () {}
 
 func funcTakingFor(for internalName: Int) {}
-// CHECK: <kw>func</kw> funcTakingFor(for internalName: <type>Int</type>) {}
+// CHECK: <kw>func</kw> <id>funcTakingFor</id>(<id>for</id> <id>internalName</id>: <type>Int</type>) {}
 
 func funcTakingIn(in internalName: Int) {}
-// CHECK: <kw>func</kw> funcTakingIn(in internalName: <type>Int</type>) {}
+// CHECK: <kw>func</kw> <id>funcTakingIn</id>(<id>in</id> <id>internalName</id>: <type>Int</type>) {}
 
 _ = 123
 // CHECK: <int>123</int>
@@ -331,61 +331,61 @@ _ = -3.1e-5
 // CHECK: <float>3.1e-5</float>
 
 "--\"\(x) --"
-// CHECK: <str>"--\"</str>\<anchor>(</anchor>x<anchor>)</anchor><str> --"</str>
+// CHECK: <str>"--\"</str>\<anchor>(</anchor><id>x</id><anchor>)</anchor><str> --"</str>
 
 func keywordAsLabel1(in: Int) {}
-// CHECK: <kw>func</kw> keywordAsLabel1(in: <type>Int</type>) {}
+// CHECK: <kw>func</kw> <id>keywordAsLabel1</id>(<id>in</id>: <type>Int</type>) {}
 func keywordAsLabel2(for: Int) {}
-// CHECK: <kw>func</kw> keywordAsLabel2(for: <type>Int</type>) {}
+// CHECK: <kw>func</kw> <id>keywordAsLabel2</id>(<id>for</id>: <type>Int</type>) {}
 func keywordAsLabel3(if: Int, for: Int) {}
-// CHECK: <kw>func</kw> keywordAsLabel3(if: <type>Int</type>, for: <type>Int</type>) {}
+// CHECK: <kw>func</kw> <id>keywordAsLabel3</id>(<id>if</id>: <type>Int</type>, <id>for</id>: <type>Int</type>) {}
 func keywordAsLabel4(_: Int) {}
-// CHECK: <kw>func</kw> keywordAsLabel4(<kw>_</kw>: <type>Int</type>) {}
+// CHECK: <kw>func</kw> <id>keywordAsLabel4</id>(<kw>_</kw>: <type>Int</type>) {}
 func keywordAsLabel5(_: Int, for: Int) {}
-// CHECK: <kw>func</kw> keywordAsLabel5(<kw>_</kw>: <type>Int</type>, for: <type>Int</type>) {}
+// CHECK: <kw>func</kw> <id>keywordAsLabel5</id>(<kw>_</kw>: <type>Int</type>, <id>for</id>: <type>Int</type>) {}
 func keywordAsLabel6(if func: Int) {}
-// CHECK: <kw>func</kw> keywordAsLabel6(if func: <type>Int</type>) {}
+// CHECK: <kw>func</kw> <id>keywordAsLabel6</id>(<id>if</id> <id>func</id>: <type>Int</type>) {}
 
 func foo1() {
-// CHECK: <kw>func</kw> foo1() {
+// CHECK: <kw>func</kw> <id>foo1</id>() {
   keywordAsLabel1(in: 1)
-// CHECK: keywordAsLabel1(in: <int>1</int>)
+// CHECK: <id>keywordAsLabel1</id>(<id>in</id>: <int>1</int>)
   keywordAsLabel2(for: 1)
-// CHECK: keywordAsLabel2(for: <int>1</int>)
+// CHECK: <id>keywordAsLabel2</id>(<id>for</id>: <int>1</int>)
   keywordAsLabel3(if: 1, for: 2)
-// CHECK: keywordAsLabel3(if: <int>1</int>, for: <int>2</int>)
+// CHECK: <id>keywordAsLabel3</id>(<id>if</id>: <int>1</int>, <id>for</id>: <int>2</int>)
   keywordAsLabel5(1, for: 2)
-// CHECK: keywordAsLabel5(<int>1</int>, for: <int>2</int>)
+// CHECK: <id>keywordAsLabel5</id>(<int>1</int>, <id>for</id>: <int>2</int>)
 
   _ = (if: 0, for: 2)
-// CHECK: <kw>_</kw> = (if: <int>0</int>, for: <int>2</int>)
+// CHECK: <kw>_</kw> = (<id>if</id>: <int>0</int>, <id>for</id>: <int>2</int>)
   _ = (_: 0, _: 2)
 // CHECK: <kw>_</kw> = (<kw>_</kw>: <int>0</int>, <kw>_</kw>: <int>2</int>)
 }
 
 func foo2(O1 : Int?, O2: Int?, O3: Int?) {
   guard let _ = O1, var _ = O2, let _ = O3 else { }
-// CHECK:  <kw>guard</kw> <kw>let</kw> <kw>_</kw> = O1, <kw>var</kw> <kw>_</kw> = O2, <kw>let</kw> <kw>_</kw> = O3 <kw>else</kw> { }
+// CHECK:  <kw>guard</kw> <kw>let</kw> <kw>_</kw> = <id>O1</id>, <kw>var</kw> <kw>_</kw> = <id>O2</id>, <kw>let</kw> <kw>_</kw> = <id>O3</id> <kw>else</kw> { }
   if let _ = O1, var _ = O2, let _ = O3 {}
-// CHECK: <kw>if</kw> <kw>let</kw> <kw>_</kw> = O1, <kw>var</kw> <kw>_</kw> = O2, <kw>let</kw> <kw>_</kw> = O3 {}
+// CHECK: <kw>if</kw> <kw>let</kw> <kw>_</kw> = <id>O1</id>, <kw>var</kw> <kw>_</kw> = <id>O2</id>, <kw>let</kw> <kw>_</kw> = <id>O3</id> {}
 }
 
 func keywordInCaseAndLocalArgLabel(_ for: Int, for in: Int, class _: Int) {
-// CHECK:  <kw>func</kw> keywordInCaseAndLocalArgLabel(<kw>_</kw> for: <type>Int</type>, for in: <type>Int</type>, class <kw>_</kw>: <type>Int</type>) {
+// CHECK:  <kw>func</kw> <id>keywordInCaseAndLocalArgLabel</id>(<kw>_</kw> <id>for</id>: <type>Int</type>, <id>for</id> <id>in</id>: <type>Int</type>, <id>class</id> <kw>_</kw>: <type>Int</type>) {
   switch(`for`, `in`) {
   case (let x, let y):
-// CHECK: <kw>case</kw> (<kw>let</kw> x, <kw>let</kw> y):
+// CHECK: <kw>case</kw> (<kw>let</kw> <id>x</id>, <kw>let</kw> <id>y</id>):
     print(x, y)
   }
 }
 
-// CHECK: <kw>class</kw> Ownership {
+// CHECK: <kw>class</kw> <id>Ownership</id> {
 class Ownership {
-  // CHECK: <attr-builtin>weak</attr-builtin> <kw>var</kw> w
+  // CHECK: <attr-builtin>weak</attr-builtin> <kw>var</kw> <id>w</id>
   weak var w
-  // CHECK: <attr-builtin>unowned</attr-builtin> <kw>var</kw> u
+  // CHECK: <attr-builtin>unowned</attr-builtin> <kw>var</kw> <id>u</id>
   unowned var u
-  // CHECK: <attr-builtin>unowned</attr-builtin>(unsafe) <kw>var</kw> uu
+  // CHECK: <attr-builtin>unowned</attr-builtin>(<id>unsafe</id>) <kw>var</kw> <id>uu</id>
   unowned(unsafe) var uu
 }
 // FIXME: CHECK: <kw>let</kw> closure = { [weak x=bindtox, unowned y=bindtoy, unowned(unsafe) z=bindtoz] <kw>in</kw> }
@@ -393,4 +393,4 @@ let closure = { [weak x=bindtox, unowned y=bindtoy, unowned(unsafe) z=bindtoz] i
 
 protocol FakeClassRestrictedProtocol : `class` {}
 // FIXME: rdar://42801404: OLD and NEW should be the same '<type>`class`</type>'.
-// CHECK: <kw>protocol</kw> FakeClassRestrictedProtocol : `<type>class</type>` {}
+// CHECK: <kw>protocol</kw> <id>FakeClassRestrictedProtocol</id> : `<type>class</type>` {}

--- a/lit_tests/coloring_comments.swift
+++ b/lit_tests/coloring_comments.swift
@@ -16,7 +16,7 @@ func foo(n: Float) {}
 ///       - returns: single-line, more spaces
 // CHECK: <doc-comment-line>///       - returns: single-line, more spaces</doc-comment-line>
 
-// CHECK: <kw>protocol</kw> Prot
+// CHECK: <kw>protocol</kw> <id>Prot</id>
 protocol Prot {}
 
 func f(x: Int) -> Int {
@@ -57,7 +57,7 @@ func f(x: Int) -> Int {
 // CHECK: <comment-line>// TTODO: blah.</comment-line>
 // CHECK: <comment-line>// MARK: blah.</comment-line>
 
-// CHECK: <kw>func</kw> test5() -> <type>Int</type> {
+// CHECK: <kw>func</kw> <id>test5</id>() -> <type>Int</type> {
 func test5() -> Int {
   // CHECK: <comment-line>// TODO: something, something.</comment-line>
   // TODO: something, something.
@@ -121,7 +121,7 @@ func foo(x: Int, y: Int) -> Int { return x + y }
 // CHECK: <doc-comment-line>/// - seealso : nope</doc-comment-line>
 // CHECK: <doc-comment-line>/// - seealso nope</doc-comment-line>
 // CHECK: <doc-comment-line>/// - returns: `x + y`</doc-comment-line>
-// CHECK: <kw>func</kw> foo(x: <type>Int</type>, y: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> x + y }
+// CHECK: <kw>func</kw> <id>foo</id>(<id>x</id>: <type>Int</type>, <id>y</id>: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> <id>x</id> + <id>y</id> }
 
 
 /// Brief.
@@ -151,7 +151,7 @@ func bar(x: Int, y: Int) -> Int { return x + y }
 // CHECK: <doc-comment-line>/// - NOTE: NOTE2</doc-comment-line>
 // CHECK: <doc-comment-line>///   - note: Not a Note field (not at top level)</doc-comment-line>
 // CHECK: <doc-comment-line>/// - returns: `x + y`</doc-comment-line>
-// CHECK: <kw>func</kw> bar(x: <type>Int</type>, y: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> x + y }
+// CHECK: <kw>func</kw> <id>bar</id>(<id>x</id>: <type>Int</type>, <id>y</id>: <type>Int</type>) -> <type>Int</type> { <kw>return</kw> <id>x</id> + <id>y</id> }
 
 /**
   Does pretty much nothing.
@@ -174,31 +174,31 @@ func baz() {}
 // CHECK:   - $$$: Not a field.
 // CHECK:   Empty field, OK:
 // CHECK: */</doc-comment-block>
-// CHECK: <kw>func</kw> baz() {}
+// CHECK: <kw>func</kw> <id>baz</id>() {}
 
 /***/
 func emptyDocBlockComment() {}
 // CHECK: <doc-comment-block>/***/</doc-comment-block>
-// CHECK: <kw>func</kw> emptyDocBlockComment() {}
+// CHECK: <kw>func</kw> <id>emptyDocBlockComment</id>() {}
 
 /**
 */
 func emptyDocBlockComment2() {}
 // CHECK: <doc-comment-block>/**
 // CHECK: */
-// CHECK: <kw>func</kw> emptyDocBlockComment2() {}
+// CHECK: <kw>func</kw> <id>emptyDocBlockComment2</id>() {}
 
 /**          */
 func emptyDocBlockComment3() {}
 // CHECK: <doc-comment-block>/**          */
-// CHECK: <kw>func</kw> emptyDocBlockComment3() {}
+// CHECK: <kw>func</kw> <id>emptyDocBlockComment3</id>() {}
 
 
 /**/
 func malformedBlockComment(f : () throws -> ()) rethrows {}
 // CHECK: <doc-comment-block>/**/</doc-comment-block>
 
-// CHECK: <kw>func</kw> malformedBlockComment(f : () <kw>throws</kw> -> ()) <kw>rethrows</kw> {}
+// CHECK: <kw>func</kw> <id>malformedBlockComment</id>(<id>f</id> : () <kw>throws</kw> -> ()) <kw>rethrows</kw> {}
 
 //: playground doc comment line
 func playgroundCommentLine(f : () throws -> ()) rethrows {}

--- a/lit_tests/coloring_configs.swift
+++ b/lit_tests/coloring_configs.swift
@@ -1,6 +1,6 @@
 // RUN: %lit-test-helper -classify-syntax -source-file %s | %FileCheck %s
 
-// CHECK: <kw>var</kw> f : <type>Int</type>
+// CHECK: <kw>var</kw> <id>f</id> : <type>Int</type>
 var f : Int
 
 // CHECK: <#kw>#if</#kw> <#id>os</#id>(<#id>macOS</#id>)
@@ -9,323 +9,323 @@ var f : Int
 
 // CHECK: <#kw>#if</#kw> <#id>CONF</#id>
 #if CONF
-  // CHECK: <kw>var</kw> x : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>x</id> : <type>Int</type>
   var x : Int
 // CHECK: <#kw>#else</#kw>
 #else
-  // CHECK: <kw>var</kw> x : <type>Float</type>
+  // CHECK: <kw>var</kw> <id>x</id> : <type>Float</type>
   var x : Float
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> <#id>CONF</#id>
 #if CONF
-  // CHECK: <kw>var</kw> x2 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>x2</id> : <type>Int</type>
   var x2 : Int
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> !<#id>CONF</#id>
 #if !CONF
-  // CHECK: <kw>var</kw> x3 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>x3</id> : <type>Int</type>
   var x3 : Int
 // CHECK: <#kw>#else</#kw>
 #else
-  // CHECK: <kw>var</kw> x3 : <type>Float</type>
+  // CHECK: <kw>var</kw> <id>x3</id> : <type>Float</type>
   var x3 : Float
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> !<#id>CONF</#id>
 #if !CONF
-  // CHECK: <kw>var</kw> x4 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>x4</id> : <type>Int</type>
   var x4 : Int
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> <#id>CONF</#id>
 #if CONF
-  // CHECK: <kw>var</kw> y1 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>y1</id> : <type>Int</type>
   var y1 : Int
 // CHECK: <#kw>#elseif</#kw> <#id>BAZ</#id>
 #elseif BAZ
-  // CHECK: <kw>var</kw> y1 : <type>String</type>
+  // CHECK: <kw>var</kw> <id>y1</id> : <type>String</type>
   var y1 : String
 // CHECK: <#kw>#else</#kw>
 #else
-  // CHECK: <kw>var</kw> y1 : <type>Float</type>
+  // CHECK: <kw>var</kw> <id>y1</id> : <type>Float</type>
   var y1 : Float
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> !<#id>CONF</#id>
 #if !CONF
-  // CHECK: <kw>var</kw> y2 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>y2</id> : <type>Int</type>
   var y2 : Int
 // CHECK: <#kw>#elseif</#kw> <#id>BAZ</#id>
 #elseif BAZ
-  // CHECK: <kw>var</kw> y2 : <type>String</type>
+  // CHECK: <kw>var</kw> <id>y2</id> : <type>String</type>
   var y2 : String
 // CHECK: <#kw>#else</#kw>
 #else
-  // CHECK: <kw>var</kw> y2 : <type>Float</type>
+  // CHECK: <kw>var</kw> <id>y2</id> : <type>Float</type>
   var y2 : Float
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> !<#id>CONF</#id>
 #if !CONF
-  // CHECK: <kw>var</kw> y3 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>y3</id> : <type>Int</type>
   var y3 : Int
 // CHECK: <#kw>#elseif</#kw> <#id>CONF</#id>
 #elseif CONF
-  // CHECK: <kw>var</kw> y3 : <type>String</type>
+  // CHECK: <kw>var</kw> <id>y3</id> : <type>String</type>
   var y3 : String
 // CHECK: <#kw>#else</#kw>
 #else
-  // CHECK: <kw>var</kw> y3 : <type>Float</type>
+  // CHECK: <kw>var</kw> <id>y3</id> : <type>Float</type>
   var y3 : Float
 // CHECK: <#kw>#endif</#kw>
 #endif
 
-// CHECK: <kw>var</kw> l : <type>Int</type>
+// CHECK: <kw>var</kw> <id>l</id> : <type>Int</type>
 var l : Int
 
-// CHECK: <kw>class</kw> C1 {
+// CHECK: <kw>class</kw> <id>C1</id> {
 class C1 {
-  // CHECK: <kw>var</kw> f : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>f</id> : <type>Int</type>
   var f : Int
 
 // CHECK: <#kw>#if</#kw> <#id>CONF</#id>
 #if CONF
-  // CHECK: <kw>var</kw> x : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>x</id> : <type>Int</type>
   var x : Int
 // CHECK: <#kw>#else</#kw>
 #else
-  // CHECK: <kw>var</kw> x : <type>Float</type>
+  // CHECK: <kw>var</kw> <id>x</id> : <type>Float</type>
   var x : Float
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> <#id>CONF</#id>
 #if CONF
-  // CHECK: <kw>var</kw> x2 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>x2</id> : <type>Int</type>
   var x2 : Int
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> !<#id>CONF</#id>
 #if !CONF
-  // CHECK: <kw>var</kw> x3 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>x3</id> : <type>Int</type>
   var x3 : Int
 // CHECK: <#kw>#else</#kw>
 #else
-  // CHECK: <kw>var</kw> x3 : <type>Float</type>
+  // CHECK: <kw>var</kw> <id>x3</id> : <type>Float</type>
   var x3 : Float
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> !<#id>CONF</#id>
 #if !CONF
-  // CHECK: <kw>var</kw> x4 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>x4</id> : <type>Int</type>
   var x4 : Int
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> <#id>CONF</#id>
 #if CONF
-  // CHECK: <kw>var</kw> y1 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>y1</id> : <type>Int</type>
   var y1 : Int
 // CHECK: <#kw>#elseif</#kw> <#id>BAZ</#id>
 #elseif BAZ
-  // CHECK: <kw>var</kw> y1 : <type>String</type>
+  // CHECK: <kw>var</kw> <id>y1</id> : <type>String</type>
   var y1 : String
 // CHECK: <#kw>#else</#kw>
 #else
-  // CHECK: <kw>var</kw> y1 : <type>Float</type>
+  // CHECK: <kw>var</kw> <id>y1</id> : <type>Float</type>
   var y1 : Float
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> !<#id>CONF</#id>
 #if !CONF
-  // CHECK: <kw>var</kw> y2 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>y2</id> : <type>Int</type>
   var y2 : Int
 // CHECK: <#kw>#elseif</#kw> <#id>BAZ</#id>
 #elseif BAZ
-  // CHECK: <kw>var</kw> y2 : <type>String</type>
+  // CHECK: <kw>var</kw> <id>y2</id> : <type>String</type>
   var y2 : String
 // CHECK: <#kw>#else</#kw>
 #else
-  // CHECK: <kw>var</kw> y2 : <type>Float</type>
+  // CHECK: <kw>var</kw> <id>y2</id> : <type>Float</type>
   var y2 : Float
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> !<#id>CONF</#id>
 #if !CONF
-  // CHECK: <kw>var</kw> y3 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>y3</id> : <type>Int</type>
   var y3 : Int
 // CHECK: <#kw>#elseif</#kw> <#id>CONF</#id>
 #elseif CONF
-  // CHECK: <kw>var</kw> y3 : <type>String</type>
+  // CHECK: <kw>var</kw> <id>y3</id> : <type>String</type>
   var y3 : String
 // CHECK: <#kw>#else</#kw>
 #else
-  // CHECK: <kw>var</kw> y3 : <type>Float</type>
+  // CHECK: <kw>var</kw> <id>y3</id> : <type>Float</type>
   var y3 : Float
 // CHECK: <#kw>#endif</#kw>
 #endif
 
-  // CHECK: <kw>var</kw> l : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>l</id> : <type>Int</type>
   var l : Int
 }
 
-// CHECK: <kw>func</kw> test1() {
+// CHECK: <kw>func</kw> <id>test1</id>() {
 func test1() {
-  // CHECK: <kw>var</kw> f : <type>Int</type>
-  var f : Int
-
+  // CHECK: <kw>var</kw> <id>f</id> : <type>Int</type>
+  var f : Int<id>
+</id>
 // CHECK: <#kw>#if</#kw> <#id>CONF</#id>
 #if CONF
-  // CHECK: <kw>var</kw> x : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>x</id> : <type>Int</type>
   var x : Int
 // CHECK: <#kw>#else</#kw>
 #else
-  // CHECK: <kw>var</kw> x : <type>Float</type>
+  // CHECK: <kw>var</kw> <id>x</id> : <type>Float</type>
   var x : Float
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> <#id>CONF</#id>
 #if CONF
-  // CHECK: <kw>var</kw> x2 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>x2</id> : <type>Int</type>
   var x2 : Int
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> !<#id>CONF</#id>
 #if !CONF
-  // CHECK: <kw>var</kw> x3 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>x3</id> : <type>Int</type>
   var x3 : Int
 // CHECK: <#kw>#else</#kw>
 #else
-  // CHECK: <kw>var</kw> x3 : <type>Float</type>
+  // CHECK: <kw>var</kw> <id>x3</id> : <type>Float</type>
   var x3 : Float
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> !<#id>CONF</#id>
 #if !CONF
-  // CHECK: <kw>var</kw> x4 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>x4</id> : <type>Int</type>
   var x4 : Int
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> <#id>CONF</#id>
 #if CONF
-  // CHECK: <kw>var</kw> y1 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>y1</id> : <type>Int</type>
   var y1 : Int
 // CHECK: <#kw>#elseif</#kw> <#id>BAZ</#id>
 #elseif BAZ
-  // CHECK: <kw>var</kw> y1 : <type>String</type>
+  // CHECK: <kw>var</kw> <id>y1</id> : <type>String</type>
   var y1 : String
 // CHECK: <#kw>#else</#kw>
 #else
-  // CHECK: <kw>var</kw> y1 : <type>Float</type>
+  // CHECK: <kw>var</kw> <id>y1</id> : <type>Float</type>
   var y1 : Float
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> !<#id>CONF</#id>
 #if !CONF
-  // CHECK: <kw>var</kw> y2 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>y2</id> : <type>Int</type>
   var y2 : Int
 // CHECK: <#kw>#elseif</#kw> <#id>BAZ</#id>
 #elseif BAZ
-  // CHECK: <kw>var</kw> y2 : <type>String</type>
+  // CHECK: <kw>var</kw> <id>y2</id> : <type>String</type>
   var y2 : String
 // CHECK: <#kw>#else</#kw>
 #else
-  // CHECK: <kw>var</kw> y2 : <type>Float</type>
+  // CHECK: <kw>var</kw> <id>y2</id> : <type>Float</type>
   var y2 : Float
 // CHECK: <#kw>#endif</#kw>
 #endif
 
 // CHECK: <#kw>#if</#kw> !<#id>CONF</#id>
 #if !CONF
-  // CHECK: <kw>var</kw> y3 : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>y3</id> : <type>Int</type>
   var y3 : Int
 // CHECK: <#kw>#elseif</#kw> <#id>CONF</#id>
 #elseif CONF
-  // CHECK: <kw>var</kw> y3 : <type>String</type>
+  // CHECK: <kw>var</kw> <id>y3</id> : <type>String</type>
   var y3 : String
 // CHECK: <#kw>#else</#kw>
 #else
-  // CHECK: <kw>var</kw> y3 : <type>Float</type>
+  // CHECK: <kw>var</kw> <id>y3</id> : <type>Float</type>
   var y3 : Float
 // CHECK: <#kw>#endif</#kw>
 #endif
 
-  // CHECK: <kw>var</kw> l : <type>Int</type>
+  // CHECK: <kw>var</kw> <id>l</id> : <type>Int</type>
   var l : Int
 }
 
-// CHECK: <kw>class</kw> C2 {
+// CHECK: <kw>class</kw> <id>C2</id> {
 class C2 {
   // CHECK: <#kw>#if</#kw> <#id>os</#id>(<#id>iOS</#id>)
   #if os(iOS)
-  // CHECK: <kw>func</kw> foo() {}
+  // CHECK: <kw>func</kw> <id>foo</id>() {}
   func foo() {}
   #endif
 }
 
 class NestedPoundIf {
-// CHECK: <kw>class</kw> NestedPoundIf {
+// CHECK: <kw>class</kw> <id>NestedPoundIf</id> {
     func foo1() {
-// CHECK: <kw>func</kw> foo1() {
+// CHECK: <kw>func</kw> <id>foo1</id>() {
         #if os(macOS)
 // CHECK: <#kw>#if</#kw> <#id>os</#id>(<#id>macOS</#id>)
           var a = 1
-// CHECK: <kw>var</kw> a = <int>1</int>
+// CHECK: <kw>var</kw> <id>a</id> = <int>1</int>
             #if USE_METAL
 // CHECK: <#kw>#if</#kw> <#id>USE_METAL</#id>
               var b = 2
-// CHECK: <kw>var</kw> b = <int>2</int>
+// CHECK: <kw>var</kw> <id>b</id> = <int>2</int>
               #if os(iOS)
 // CHECK: <#kw>#if</#kw> <#id>os</#id>(<#id>iOS</#id>)
                 var c = 3
-// CHECK: <kw>var</kw> c = <int>3</int>
+// CHECK: <kw>var</kw> <id>c</id> = <int>3</int>
               #else
 // CHECK: <#kw>#else</#kw>
                 var c = 3
-// CHECK: <kw>var</kw> c = <int>3</int>
+// CHECK: <kw>var</kw> <id>c</id> = <int>3</int>
               #endif
 // CHECK: <#kw>#endif</#kw>
             #else
 // CHECK: <#kw>#else</#kw>
               var b = 2
-// CHECK: <kw>var</kw> b = <int>2</int>
+// CHECK: <kw>var</kw> <id>b</id> = <int>2</int>
             #endif
 // CHECK: <#kw>#endif</#kw>
            #else
 // CHECK: <#kw>#else</#kw>
             var a = 1
-// CHECK: <kw>var</kw> a = <int>1</int>
+// CHECK: <kw>var</kw> <id>a</id> = <int>1</int>
         #endif
 // CHECK: <#kw>#endif</#kw>
     }
     func foo2() {}
-// CHECK: <kw>func</kw> foo2() {}
+// CHECK: <kw>func</kw> <id>foo2</id>() {}
     func foo3() {}
-// CHECK: <kw>func</kw> foo3() {}
+// CHECK: <kw>func</kw> <id>foo3</id>() {}
 }
 
 // CHECK: <#kw>#error</#kw>(<str>"Error"</str>)
 #error("Error")
 // CHECK: <#kw>#warning</#kw>(<str>"Warning"</str>)
 #warning("Warning")
-// CHECK: <#kw>#sourceLocation</#kw>(file: <str>"x"</str>, line: <int>1</int>)
+// CHECK: <#kw>#sourceLocation</#kw>(<id>file</id>: <str>"x"</str>, <id>line</id>: <int>1</int>)
 #sourceLocation(file: "x", line: 1)
 // CHECK: <kw>#line</kw> <int>17</int> <str>"abc.swift"</str>
 #line 17 "abc.swift"
@@ -337,34 +337,34 @@ func foo() {
   if #available (OSX 10.10, iOS 8.01, *) {let _ = "iOS"}
 }
 
-// CHECK: <kw>func</kw> test4(<kw>inout</kw> a: <type>Int</type>) {{{$}}
+// CHECK: <kw>func</kw> <id>test4</id>(<kw>inout</kw> <id>a</id>: <type>Int</type>) {{{$}}
 func test4(inout a: Int) {
   // CHECK-OLD: <kw>if</kw> <kw>#available</kw> (<kw>OSX</kw> >= <float>10.10</float>, <kw>iOS</kw> >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
   // CHECK-NEW: <kw>if</kw> <kw>#available</kw> (OSX >= <float>10.10</float>, iOS >= <float>8.01</float>) {<kw>let</kw> OSX = <str>"iOS"</str>}}{{$}}
   if #available (OSX >= 10.10, iOS >= 8.01) {let OSX = "iOS"}}
 
-// CHECK: <kw>func</kw> test4b(a: <kw>inout</kw> <type>Int</type>) {{{$}}
+// CHECK: <kw>func</kw> <id>test4b</id>(<id>a</id>: <kw>inout</kw> <type>Int</type>) {{{$}}
 func test4b(a: inout Int) {
 }
 
 let filename = #file
-// CHECK: <kw>let</kw> filename = <kw>#file</kw>
+// CHECK: <kw>let</kw> <id>filename</id> = <kw>#file</kw>
 let line = #line
-// CHECK: <kw>let</kw> line = <kw>#line</kw>
+// CHECK: <kw>let</kw> <id>line</id> = <kw>#line</kw>
 let column = #column
-// CHECK: <kw>let</kw> column = <kw>#column</kw>
+// CHECK: <kw>let</kw> <id>column</id> = <kw>#column</kw>
 let function = #function
-// CHECK: <kw>let</kw> function = <kw>#function</kw>
+// CHECK: <kw>let</kw> <id>function</id> = <kw>#function</kw>
 
 let image = #imageLiteral(resourceName: "cloud.png")
-// CHECK-OLD: <kw>let</kw> image = <object-literal>#imageLiteral(resourceName: "cloud.png")</object-literal>
-// CHECK-NEW: <kw>let</kw> image = <object-literal>#imageLiteral</object-literal>(resourceName: <str>"cloud.png"</str>)
+// CHECK-OLD: <kw>let</kw> <id>image</id> = <object-literal>#imageLiteral(resourceName: "cloud.png")</object-literal>
+// CHECK-NEW: <kw>let</kw> <id>image</id> = <object-literal>#imageLiteral</object-literal>(resourceName: <str>"cloud.png"</str>)
 let file = #fileLiteral(resourceName: "cloud.png")
-// CHECK-OLD: <kw>let</kw> file = <object-literal>#fileLiteral(resourceName: "cloud.png")</object-literal>
-// CHECK-NEW: <kw>let</kw> file = <object-literal>#fileLiteral</object-literal>(resourceName: <str>"cloud.png"</str>)
+// CHECK-OLD: <kw>let</kw> <id>file</id> = <object-literal>#fileLiteral(resourceName: "cloud.png")</object-literal>
+// CHECK-NEW: <kw>let</kw> <id>file</id> = <object-literal>#fileLiteral</object-literal>(resourceName: <str>"cloud.png"</str>)
 let black = #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)
-// CHECK-OLD: <kw>let</kw> black = <object-literal>#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)</object-literal>
-// CHECK-NEW: <kw>let</kw> black = <object-literal>#colorLiteral</object-literal>(red: <int>0</int>, green: <int>0</int>, blue: <int>0</int>, alpha: <int>1</int>)
+// CHECK-OLD: <kw>let</kw> <id>black</id> = <object-literal>#colorLiteral(red: 0, green: 0, blue: 0, alpha: 1)</object-literal>
+// CHECK-NEW: <kw>let</kw> <id>black</id> = <object-literal>#colorLiteral</object-literal>(red: <int>0</int>, green: <int>0</int>, blue: <int>0</int>, alpha: <int>1</int>)
 
 let rgb = [#colorLiteral(red: 1, green: 0, blue: 0, alpha: 1),
            #colorLiteral(red: 0, green: 1, blue: 0, alpha: 1),

--- a/lit_tests/coloring_keywords.swift
+++ b/lit_tests/coloring_keywords.swift
@@ -1,6 +1,6 @@
 // RUN: %lit-test-helper -classify-syntax -source-file %s | %FileCheck %s
 
-// CHECK: <kw>return</kw> c.return
+// CHECK: <kw>return</kw> <id>c</id>.<id>return</id>
 
 class C {
   var `return` = 2

--- a/lit_tests/coloring_unclosed_hash_if.swift
+++ b/lit_tests/coloring_unclosed_hash_if.swift
@@ -1,10 +1,10 @@
 // RUN: %lit-test-helper -classify-syntax -source-file %s | %FileCheck %s
 
 // CHECK: <#kw>#if</#kw> <#id>d</#id>
-// CHECK-NEXT: <kw>func</kw> bar() {
+// CHECK-NEXT: <kw>func</kw> <id>bar</id>() {
 // CHECK-NEXT: <#kw>#if</#kw> <#id>d</#id>
 // CHECK-NEXT: }
-// CHECK-NEXT: <kw>func</kw> foo() {}
+// CHECK-NEXT: <kw>func</kw> <id>foo</id>() {}
 
 #if d
 func bar() {


### PR DESCRIPTION
Requires this change on the swift side: https://github.com/apple/swift/pull/25945