### PR TITLE
Introduce `SyntaxVisitorBase`

### DIFF
--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -221,6 +221,35 @@ public extension SyntaxAnyVisitor {
   }
 }
 
+/// A class version of the `SyntaxVisitor` protocol. This is useful if you
+/// intend to have subclasses overriding specific methods of a common base
+/// `SyntaxVisitor` class.
+///
+/// It workarounds the issue of not being able to override the default
+/// implementations of the protocol (see https://bugs.swift.org/browse/SR-103).
+open class SyntaxVisitorBase: SyntaxVisitor {
+  public init() {}
+
+% for node in SYNTAX_NODES:
+%   if is_visitable(node):
+  open func visit(_ node: ${node.name}) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+  open func visitPost(_ node: ${node.name}) {}
+%   end
+% end
+
+  open func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+  open func visitPost(_ node: TokenSyntax) {}
+
+  open func visit(_ node: UnknownSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+  open func visitPost(_ node: UnknownSyntax) {}
+}
+
 extension _SyntaxBase {
   func walk<Visitor>(_ visitor: inout Visitor) where Visitor : SyntaxVisitor {
     guard isPresent else { return }

--- a/Tests/SwiftSyntaxTest/VisitorTest.swift
+++ b/Tests/SwiftSyntaxTest/VisitorTest.swift
@@ -8,6 +8,7 @@ public class SyntaxVisitorTestCase: XCTestCase {
     ("testRewritingNodeWithEmptyChild", testRewritingNodeWithEmptyChild),
     ("testSyntaxRewriterVisitAny", testSyntaxRewriterVisitAny),
     ("testSyntaxRewriterVisitCollection", testSyntaxRewriterVisitCollection),
+    ("testVisitorClass", testVisitorClass),
   ]
 
   public func testBasic() {
@@ -81,6 +82,24 @@ public class SyntaxVisitorTestCase: XCTestCase {
       var visitor = VisitCollections()
       parsed.walk(&visitor)
       XCTAssertEqual(4, visitor.numberOfCodeBlockItems)
+    }())
+  }
+
+  public func testVisitorClass() {
+    class FuncCounter: SyntaxVisitorBase {
+      var funcCount = 0
+      override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+        funcCount += 1
+        return super.visit(node)
+      }
+    }
+    XCTAssertNoThrow(try {
+      let parsed = try SyntaxParser.parse(getInput("visitor.swift"))
+      var counter = FuncCounter()
+      let hashBefore = parsed.hashValue
+      parsed.walk(&counter)
+      XCTAssertEqual(counter.funcCount, 3)
+      XCTAssertEqual(hashBefore, parsed.hashValue)
     }())
   }
 }


### PR DESCRIPTION
This is useful if you intend to have subclasses overriding specific methods of a common base `SyntaxVisitor` class.

It workarounds the issue of not being able to override the default implementations of the protocol (see https://bugs.swift.org/browse/SR-103).