### PR TITLE
[5.1]Remove redundant leading/trailing trivia from StringLiteralExpr

### DIFF
--- a/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -199,9 +199,7 @@ public enum SyntaxFactory {
   public static func makeStringLiteralExpr(_ text: String,
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> StringLiteralExprSyntax {
-    let string = makeStringSegment(text,
-                                   leadingTrivia: leadingTrivia,
-                                   trailingTrivia: trailingTrivia)
+    let string = makeStringSegment(text)
     let segment = makeStringSegment(content: string)
     let segments = makeStringLiteralSegments([segment])
     let openQuote = makeStringQuoteToken(leadingTrivia: leadingTrivia)

--- a/Tests/SwiftSyntaxTest/SyntaxFactory.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxFactory.swift
@@ -24,6 +24,7 @@ public class SyntaxFactoryAPITestCase: XCTestCase {
     ("testFunctionCallSyntaxBuilder", testFunctionCallSyntaxBuilder),
     ("testWithOptionalChild", testWithOptionalChild),
     ("testUnknownSyntax", testUnknownSyntax),
+    ("testMakeStringLiteralExpr", testMakeStringLiteralExpr),
   ]
 
   public func testGenerated() {
@@ -159,5 +160,17 @@ public class SyntaxFactoryAPITestCase: XCTestCase {
     XCTAssertTrue(unknown.isUnknown)
     XCTAssertNoThrow(try SyntaxVerifier.verify(expr))
     XCTAssertThrowsError(try SyntaxVerifier.verify(unknown))
+  }
+
+  public func testMakeStringLiteralExpr() {
+    let expr = SyntaxFactory.makeStringLiteralExpr(
+      "Hello, world!",
+      leadingTrivia: .init(pieces: [.lineComment("// hello"), .newlines(1)])
+    )
+    let expected = """
+// hello
+"Hello, world!"
+"""
+    XCTAssertEqual(expr.description, expected)
   }
 }


### PR DESCRIPTION
## Overview
[This PR](https://github.com/apple/swift-syntax/pull/123) introduced a bug to set leading/trailing trivia to `StringSegment` as well. This causes unexpected behavior like below

```
SyntaxFactory.makeStringLiteralExpr(
    "foo", 
    leadingTrivia: .newlines(1), 
    trailingTrivia: .newlines(1)
)
```

### Expected

```

"foo"

```

### Actual

```

"
foo
"

```
master: https://github.com/apple/swift-syntax/pull/135