### PR TITLE
Initial implementation of declarative and type-safe wrapper

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -8,6 +8,8 @@ let package = Package(
     .target(name: "_CSwiftSyntax"),
     .target(name: "SwiftSyntax", dependencies: ["_CSwiftSyntax"]),
     .testTarget(name: "SwiftSyntaxTest", dependencies: ["SwiftSyntax"], exclude: ["Inputs"]),
+    .target(name: "SwiftSyntaxBuilder", dependencies: ["SwiftSyntax"]),
+    .testTarget(name: "SwiftSyntaxBuilderTest", dependencies: ["SwiftSyntaxBuilder"]),
     .target(name: "lit-test-helper", dependencies: ["SwiftSyntax"])
   ]
 )
@@ -20,6 +22,8 @@ import Darwin.C
 
 if getenv("SWIFT_SYNTAX_BUILD_SCRIPT") == nil {
   package.products.append(.library(name: "SwiftSyntax", targets: ["SwiftSyntax"]))
+  package.products.append(.library(name: "SwiftSyntaxBuilder", targets: ["SwiftSyntaxBuilder"]))
 } else {
   package.products.append(.library(name: "SwiftSyntax", type: .dynamic, targets: ["SwiftSyntax"]))
+  package.products.append(.library(name: "SwiftSyntaxBuilder", type: .dynamic, targets: ["SwiftSyntaxBuilder"]))
 }

--- a/Sources/SwiftSyntaxBuilder/DeclBuildables.swift
+++ b/Sources/SwiftSyntaxBuilder/DeclBuildables.swift
@@ -1,0 +1,184 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+// MARK: - Protocols
+
+public protocol DeclListBuildable: SyntaxListBuildable {
+  func buildDeclList(format: Format, leadingTrivia: Trivia) -> [DeclSyntax]
+}
+
+public protocol DeclBuildable: SyntaxBuildable, DeclListBuildable {
+  func buildDecl(format: Format, leadingTrivia: Trivia) -> DeclSyntax
+}
+
+extension DeclBuildable {
+  public func buildSyntax(format: Format, leadingTrivia: Trivia) -> Syntax {
+    buildDecl(format: format, leadingTrivia: leadingTrivia)
+  }
+
+  public func buildDeclList(format: Format, leadingTrivia: Trivia) -> [DeclSyntax] {
+    [buildDecl(format: format, leadingTrivia: leadingTrivia)]
+  }
+}
+
+// MARK: - Function Builder
+
+@_functionBuilder
+public struct DeclListBuilder {
+  public static func buildBlock(_ builders: DeclListBuildable...) -> DeclListBuildable {
+    DeclList(builders: builders)
+  }
+}
+
+// MARK: - List
+
+public struct DeclList: DeclListBuildable {
+  let builders: [DeclListBuildable]
+
+  public func buildDeclList(format: Format, leadingTrivia: Trivia) -> [DeclSyntax] {
+    builders.flatMap { $0.buildDeclList(format: format, leadingTrivia: leadingTrivia) }
+  }
+
+  public func buildSyntaxList(format: Format, leadingTrivia: Trivia) -> [Syntax] {
+    buildDeclList(format: format, leadingTrivia: leadingTrivia)
+  }
+}
+
+extension DeclList {
+  public static let empty: DeclList = DeclList(builders: [])
+}
+
+// MARK: - Buildables
+
+// MARK: Import
+
+public struct Import: DeclBuildable {
+  let moduleName: String
+
+  public init(_ moduleName: String) {
+    self.moduleName = moduleName
+  }
+
+  public func buildDecl(format: Format, leadingTrivia: Trivia) -> DeclSyntax {
+    let importToken = Tokens.import.withLeadingTrivia(leadingTrivia)
+    let moduleNameToken = SyntaxFactory.makeIdentifier(moduleName)
+
+    return ImportDeclSyntax {
+      $0.useImportTok(importToken)
+      $0.addPathComponent(AccessPathComponentSyntax {
+        $0.useName(moduleNameToken)
+      })
+    }
+  }
+}
+
+// MARK: Variables
+
+public protocol VariableMutability {
+  static var token: TokenSyntax { get }
+}
+
+public enum VariableLetMutability: VariableMutability {
+  public static let token = Tokens.let
+}
+
+public enum VariableVarMutability: VariableMutability {
+  public static let token = Tokens.var
+}
+
+public typealias Let = Variable<VariableLetMutability>
+public typealias Var = Variable<VariableVarMutability>
+
+public struct Variable<Mutability: VariableMutability>: DeclBuildable {
+  let name: String
+  let type: String
+  let initializer: ExprBuildable?
+
+  public init(_ name: String, of type: String, value: ExprBuildable? = nil) {
+    self.name = name
+    self.type = type
+    self.initializer = value
+  }
+
+  public func buildDecl(format: Format, leadingTrivia: Trivia) -> DeclSyntax {
+    let mutabilityKeyword = Mutability.token.withLeadingTrivia(leadingTrivia)
+
+    let nameIdentifier = SyntaxFactory.makeIdentifier(name)
+    let namePattern = SyntaxFactory.makeIdentifierPattern(identifier: nameIdentifier)
+
+    let typeIdentifier = SyntaxFactory.makeTypeIdentifier(type)
+    let typeAnnotation = SyntaxFactory.makeTypeAnnotation(
+      colon: Tokens.colon,
+      type: typeIdentifier
+    )
+
+    let initClause = initializer.flatMap { builder -> InitializerClauseSyntax in
+      let expr = builder.buildExpr(format: format, leadingTrivia: .zero)
+      return SyntaxFactory.makeInitializerClause(equal: Tokens.equal, value: expr)
+    }
+
+    return VariableDeclSyntax {
+      $0.useLetOrVarKeyword(mutabilityKeyword)
+      $0.addBinding(PatternBindingSyntax {
+        $0.usePattern(namePattern)
+        $0.useTypeAnnotation(typeAnnotation)
+
+        if let initClause = initClause {
+          $0.useInitializer(initClause)
+        }
+      })
+    }
+  }
+}
+
+// MARK: Struct
+
+public struct Struct: DeclBuildable {
+  let name: String
+  let memberList: DeclListBuildable
+
+  public init(
+    _ name: String,
+    @DeclListBuilder buildMemberList: () -> DeclListBuildable = { DeclList.empty }
+  ) {
+    self.name = name
+    self.memberList = buildMemberList()
+  }
+
+  public func buildDecl(format: Format, leadingTrivia: Trivia) -> DeclSyntax {
+    let structKeyword = Tokens.struct.withLeadingTrivia(leadingTrivia)
+
+    let declList = memberList.buildDeclList(
+      format: format._indented(),
+      leadingTrivia: .zero
+    )
+
+    return StructDeclSyntax {
+      $0.useStructKeyword(structKeyword)
+      $0.useIdentifier(SyntaxFactory.makeIdentifier(name))
+      $0.useMembers(MemberDeclBlockSyntax {
+        $0.useLeftBrace(Tokens.leftBrace.withLeadingTrivia(.spaces(1)))
+        $0.useRightBrace(Tokens.rightBrace.withLeadingTrivia(.newlines(1) + format._makeIndent()))
+
+        let format = format._indented()
+        for decl in declList {
+          let member = SyntaxFactory
+            .makeMemberDeclListItem(decl: decl, semicolon: nil)
+            .withLeadingTrivia(.newlines(1) + format._makeIndent())
+          $0.addMember(member)
+        }
+      })
+    }
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/ExprBuildables.swift
+++ b/Sources/SwiftSyntaxBuilder/ExprBuildables.swift
@@ -1,0 +1,78 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+// MARK: - Protocols
+
+public protocol ExprListBuildable: SyntaxListBuildable {
+  func buildExprList(format: Format, leadingTrivia: Trivia) -> [ExprSyntax]
+}
+
+public protocol ExprBuildable: SyntaxBuildable, ExprListBuildable {
+  func buildExpr(format: Format, leadingTrivia: Trivia) -> ExprSyntax
+}
+
+extension ExprBuildable {
+  public func buildSyntax(format: Format, leadingTrivia: Trivia) -> Syntax {
+    buildExpr(format: format, leadingTrivia: leadingTrivia)
+  }
+
+  public func buildExprList(format: Format, leadingTrivia: Trivia) -> [ExprSyntax] {
+    [buildExpr(format: format, leadingTrivia: leadingTrivia)]
+  }
+}
+
+// MARK: - Buildables
+
+// MARK: Integer Literal
+
+public struct IntegerLiteral: ExprBuildable {
+    let value: Int
+
+    public init(_ value: Int) {
+        self.value = value
+    }
+
+    public func buildExpr(format: Format, leadingTrivia: Trivia) -> ExprSyntax {
+        SyntaxFactory.makeIntegerLiteralExpr(
+            digits: SyntaxFactory.makeIntegerLiteral(String(value))
+        ).withLeadingTrivia(leadingTrivia)
+    }
+}
+
+extension IntegerLiteral: ExpressibleByIntegerLiteral {
+    public init(integerLiteral value: Int) {
+        self.init(value)
+    }
+}
+
+// MARK: String Literal
+
+public struct StringLiteral: ExprBuildable {
+    let value: String
+
+    public init(_ value: String) {
+        self.value = value
+    }
+
+    public func buildExpr(format: Format, leadingTrivia: Trivia) -> ExprSyntax {
+        SyntaxFactory.makeStringLiteralExpr(value)
+          .withLeadingTrivia(leadingTrivia)
+    }
+}
+
+extension StringLiteral: ExpressibleByStringLiteral {
+    public init(stringLiteral value: String) {
+        self.init(value)
+    }
+}

--- a/Sources/SwiftSyntaxBuilder/Format.swift
+++ b/Sources/SwiftSyntaxBuilder/Format.swift
@@ -1,0 +1,35 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public struct Format {
+  public let indentWidth: Int
+
+  private var indents: Int = 0
+
+  public init(indentWidth: Int = 4) {
+    self.indentWidth = indentWidth
+  }
+}
+
+extension Format {
+  public func _indented() -> Format {
+    var copy = self
+    copy.indents += 1
+    return copy
+  }
+
+  public func _makeIndent() -> Trivia {
+    return indents == 0 ? .zero : Trivia.spaces(indents * indentWidth)
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/README.md
+++ b/Sources/SwiftSyntaxBuilder/README.md
@@ -1,0 +1,30 @@
+# SwiftSyntaxBuilder
+
+Declarative and type-safe wrapper around SwiftSyntax.
+
+## Example Usage
+
+```swift
+let sourceFile = SourceFile {
+  Import("SwiftSyntax")
+
+  Struct("ExampleStruct") {
+    Let("syntax", of: "Syntax")
+  }
+}
+
+let syntax = sourceFile.buildSyntax(format: format, leadingTrivia: .zero)
+
+var text = ""
+syntax.write(to: &text)
+print(text)
+```
+
+prints:
+
+```swift
+import SwiftSyntax
+struct ExampleStruct {
+  let syntax: Syntax
+}
+```

--- a/Sources/SwiftSyntaxBuilder/SyntaxBuildables.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxBuildables.swift
@@ -1,0 +1,83 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+// MARK: - Protocols
+
+public protocol SyntaxListBuildable {
+  func buildSyntaxList(format: Format, leadingTrivia: Trivia) -> [Syntax]
+}
+
+public protocol SyntaxBuildable: SyntaxListBuildable {
+  func buildSyntax(format: Format, leadingTrivia: Trivia) -> Syntax
+}
+
+extension SyntaxBuildable {
+  public func buildSyntaxList(format: Format, leadingTrivia: Trivia) -> [Syntax] {
+    [buildSyntax(format: format, leadingTrivia: leadingTrivia)]
+  }
+}
+
+// MARK: - Function Builder
+
+@_functionBuilder
+public struct SyntaxListBuilder {
+  public static func buildBlock(_ builders: SyntaxListBuildable...) -> SyntaxListBuildable {
+    SyntaxList(builders: builders)
+  }
+}
+
+// MARK: - List
+
+public struct SyntaxList: SyntaxListBuildable {
+  let builders: [SyntaxListBuildable]
+
+  public func buildSyntaxList(format: Format, leadingTrivia: Trivia) -> [Syntax] {
+    builders.flatMap {
+      $0.buildSyntaxList(format: format, leadingTrivia: leadingTrivia)
+    }
+  }
+}
+
+extension SyntaxList {
+  public static let empty = SyntaxList(builders: [])
+}
+
+// MARK: - Buildables
+
+// MARK: Source File
+
+public struct SourceFile: SyntaxBuildable {
+  let builder: SyntaxListBuildable
+
+  public init(@SyntaxListBuilder makeBuilder: () -> SyntaxListBuildable) {
+    self.builder = makeBuilder()
+  }
+
+  public func buildSyntax(format: Format, leadingTrivia: Trivia) -> Syntax {
+    let syntaxList = builder.buildSyntaxList(format: format, leadingTrivia: leadingTrivia)
+
+    return SourceFileSyntax {
+      for (index, syntax) in syntaxList.enumerated() {
+        let trivia: Trivia =
+          index == syntaxList.startIndex
+            ? format._makeIndent()
+            : .newlines(1) + format._makeIndent()
+
+        $0.addStatement(CodeBlockItemSyntax {
+          $0.useItem(syntax)
+        }.withLeadingTrivia(trivia))
+      }
+    }.withLeadingTrivia(leadingTrivia)
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/Tokens.swift
+++ b/Sources/SwiftSyntaxBuilder/Tokens.swift
@@ -1,0 +1,45 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// Namespace for commonly used tokens with default trivia.
+enum Tokens {
+  // MARK: Keywords
+
+  /// `"let "`
+  static let `let` = SyntaxFactory.makeLetKeyword().withTrailingTrivia(.spaces(1))
+
+  /// `"var "`
+  static let `var` = SyntaxFactory.makeVarKeyword().withTrailingTrivia(.spaces(1))
+
+  /// `"import "`
+  static let `import` = SyntaxFactory.makeImportKeyword().withTrailingTrivia(.spaces(1))
+
+  /// `"struct "`
+  static let `struct` = SyntaxFactory.makeStructKeyword().withTrailingTrivia(.spaces(1))
+
+  // MARK: Punctuations and Signs
+
+  /// `":"`
+  static let colon = SyntaxFactory.makeColonToken().withTrailingTrivia(.spaces(1))
+
+  /// `" = "`
+  static let equal = SyntaxFactory.makeEqualToken().withLeadingTrivia(.spaces(1))
+                                                   .withTrailingTrivia(.spaces(1))
+
+  /// `"{"`
+  static let leftBrace = SyntaxFactory.makeLeftBraceToken()
+
+  /// `"}"`
+  static let rightBrace = SyntaxFactory.makeRightBraceToken()
+}

--- a/Tests/SwiftSyntaxBuilderTest/FormatTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FormatTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+import SwiftSyntax
+
+import SwiftSyntaxBuilder
+
+final class FormatTests: XCTestCase {
+  func test_makeIndented() {
+    for width in 1 ... 4 {
+      let format = Format(indentWidth: width)
+
+      XCTAssertEqual(format._makeIndent(), .zero)
+      XCTAssertEqual(format._indented()._makeIndent(), .spaces(width))
+      XCTAssertEqual(format._indented()._indented()._makeIndent(), .spaces(width * 2))
+    }
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/ImportTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ImportTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+import SwiftSyntax
+
+import SwiftSyntaxBuilder
+
+final class ImportTests: XCTestCase {
+  func testImport() {
+    let leadingTrivia = Trivia.garbageText("␣")
+
+    let testCases: [UInt: (Import, String)] = [
+      #line: (Import("SwiftSyntax"),
+              "␣import SwiftSyntax"),
+    ]
+
+    for (line, testCase) in testCases {
+      let (builder, expected) = testCase
+      let syntax = builder.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
+
+      var text = ""
+      syntax.write(to: &text)
+
+      XCTAssertEqual(text, expected, line: line)
+    }
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/IntegerLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/IntegerLiteralTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+import SwiftSyntax
+
+import SwiftSyntaxBuilder
+
+final class IntegerLiteralTests: XCTestCase {
+  func testIntegerLiteral() {
+    let leadingTrivia = Trivia.garbageText("␣")
+
+    let testCases: [UInt: (IntegerLiteral, String)] = [
+      #line: (IntegerLiteral(123), "␣123"),
+      #line: (IntegerLiteral(-123), "␣-123"),
+      #line: (123, "␣123"),
+      #line: (-123, "␣-123"),
+    ]
+
+    for (line, testCase) in testCases {
+      let (builder, expected) = testCase
+      let syntax = builder.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
+
+      var text = ""
+      syntax.write(to: &text)
+
+      XCTAssertEqual(text, expected, line: line)
+    }
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/SourceFileTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/SourceFileTests.swift
@@ -1,0 +1,29 @@
+import XCTest
+import SwiftSyntax
+
+import SwiftSyntaxBuilder
+
+final class SourceFileTests: XCTestCase {
+  func testSourceFile() {
+    let leadingTrivia = Trivia.garbageText("␣")
+
+    let sourceFile = SourceFile {
+      Import("SwiftSyntax")
+
+      Struct("ExampleStruct") {
+        Let("syntax", of: "Syntax")
+      }
+    }
+
+    let syntax = sourceFile.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
+
+    var text = ""
+    syntax.write(to: &text)
+    XCTAssertEqual(text, """
+    ␣import SwiftSyntax
+    struct ExampleStruct {
+        let syntax: Syntax
+    }
+    """)
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+import SwiftSyntax
+
+import SwiftSyntaxBuilder
+
+final class StringLiteralTests: XCTestCase {
+  func testStringLiteral() {
+    let leadingTrivia = Trivia.garbageText("␣")
+
+    let testCases: [UInt: (StringLiteral, String)] = [
+      #line: (StringLiteral(""), #"␣"""#),
+      #line: (StringLiteral("asdf"), #"␣"asdf""#),
+      #line: ("", #"␣"""#),
+      #line: ("asdf", #"␣"asdf""#),
+    ]
+
+    for (line, testCase) in testCases {
+      let (builder, expected) = testCase
+      let syntax = builder.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
+
+      var text = ""
+      syntax.write(to: &text)
+
+      XCTAssertEqual(text, expected, line: line)
+    }
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/StructTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StructTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+import SwiftSyntax
+
+import SwiftSyntaxBuilder
+
+final class StructTests: XCTestCase {
+  func testEmptyStruct() {
+    let leadingTrivia = Trivia.garbageText("␣")
+
+    let buildable = Struct("TestStruct")
+    let syntax = buildable.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
+
+    var text = ""
+    syntax.write(to: &text)
+
+    XCTAssertEqual(text, """
+    ␣struct TestStruct {
+    }
+    """)
+  }
+
+  func testStructWithMember() {
+    let leadingTrivia = Trivia.garbageText("␣")
+
+    let buildable = Struct("TestStruct") {
+      Let("member", of: "String")
+    }
+    let syntax = buildable.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
+
+    var text = ""
+    syntax.write(to: &text)
+
+    XCTAssertEqual(text, """
+    ␣struct TestStruct {
+        let member: String
+    }
+    """)
+  }
+
+  func testNestedStruct() {
+    let leadingTrivia = Trivia.garbageText("␣")
+
+    let buildable = Struct("TestStruct") {
+      Struct("NestedStruct") {
+          Let("member", of: "String")
+      }
+    }
+    let syntax = buildable.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
+
+    var text = ""
+    syntax.write(to: &text)
+
+    XCTAssertEqual(text, """
+    ␣struct TestStruct {
+        struct NestedStruct {
+            let member: String
+        }
+    }
+    """)
+  }
+
+  func testStructWithIndent() {
+    let format = Format()._indented()
+
+    let buildable = Struct("TestStruct") {
+      Let("member", of: "String")
+    }
+    let syntax = buildable.buildSyntax(format: format, leadingTrivia: format._makeIndent())
+
+    var text = ""
+    syntax.write(to: &text)
+
+    XCTAssertEqual(text, """
+        struct TestStruct {
+            let member: String
+        }
+    """)
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -1,0 +1,52 @@
+import XCTest
+import SwiftSyntax
+
+import SwiftSyntaxBuilder
+
+final class VariableTests: XCTestCase {
+  func testLet() {
+    let leadingTrivia = Trivia.garbageText("␣")
+
+    let testCases: [UInt: (Let, String)] = [
+      #line: (Let("str", of: "String"),
+              #"␣let str: String"#),
+      #line: (Let("str", of: "String", value: StringLiteral("asdf")),
+              #"␣let str: String = "asdf""#),
+      #line: (Let("num", of: "Int", value: IntegerLiteral(123)),
+              #"␣let num: Int = 123"#),
+    ]
+
+    for (line, testCase) in testCases {
+      let (builder, expected) = testCase
+      let syntax = builder.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
+
+      var text = ""
+      syntax.write(to: &text)
+
+      XCTAssertEqual(text, expected, line: line)
+    }
+  }
+
+  func testVar() {
+    let leadingTrivia = Trivia.garbageText("␣")
+
+    let testCases: [UInt: (Var, String)] = [
+      #line: (Var("str", of: "String"),
+              #"␣var str: String"#),
+      #line: (Var("str", of: "String", value: StringLiteral("asdf")),
+              #"␣var str: String = "asdf""#),
+      #line: (Var("num", of: "Int", value: IntegerLiteral(123)),
+              #"␣var num: Int = 123"#),
+    ]
+
+    for (line, testCase) in testCases {
+      let (builder, expected) = testCase
+      let syntax = builder.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
+
+      var text = ""
+      syntax.write(to: &text)
+
+      XCTAssertEqual(text, expected, line: line)
+    }
+  }
+}


### PR DESCRIPTION
Implemented declarative and type-safe wrappers around SwiftSyntax, using [`@_functionBuilder`](https://github.com/apple/swift-evolution/pull/1046).

(@akyrtzi thank you for encouraging me to upstream it!)

## Example Usage

```swift
let format = Format(indentWidth: 2)

let sourceFile = SourceFile {
  Import("SwiftSyntax")

  Struct("ExampleStruct") {
    Let("syntax", of: "Syntax")
  }
}

let syntax = sourceFile.buildSyntax(format: format, leadingTrivia: .zero)

var text = ""
syntax.write(to: &text)
print(text)
```

emits:

```swift
import SwiftSyntax
struct ExampleStruct {
  let syntax: Syntax
}
```

## Currently implemented
- Integer and string literals (w/o interpolation) (3781538)
- `let` and `var` with optional initializer (edad18d)
- `struct` with member definition (w/o attributions, access control, generics etc.)  (e8f2d02)
- `import` (w/o importing individual declarations) (1687304)
- Source file (4495871)
- Changing indent width (using tabs is not yet)

## Considarations

- Since they are built on top of `@_functionBuilder`, calling them "SyntaxBuilders" sounds natural to me. But we already have [SyntaxBuilders](https://github.com/apple/swift-syntax/blob/1c2feb708bbf0586ece4c2139c1e9faf8381e89a/Sources/SwiftSyntax/SyntaxBuilders.swift.gyb); can this conflict be a problem? I'm welcome to change my code if we have a good way to call them.
- I think they can provide some syntactic safety, not semantic safety. But how do we validate the input, or should not? Should we accept something like `Import("")` or `Let("===", of: "@@@")`?
- I consider strict formatting to be also out of scope, and the output of my "SyntaxBuilders" can have an opinionated format. We can provide some basic options such as changing indent width, and further formatting will be done by piping the output to [swift-format](https://github.com/apple/swift-format) or other formatters which supports SwiftSyntax.
- I implemented them *by hand* because I think the structure and parameters of each builder don't have to exactly match the syntax tree of SwiftSyntax for better developer ergonomics. Do you have any idea to gyb-generate any part of (or, possibly, entire) the implementation?

And I'm a complete newbie here. Let me know if I have to change anything!