### PR TITLE
Remove redundant name space for static func call

### DIFF
--- a/Sources/SwiftSyntax/SyntaxBuilders.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxBuilders.swift.gyb
@@ -71,7 +71,7 @@ public struct ${Builder} {
 %       end
 %     end
 
-    return .forRoot(RawSyntax.createAndCalcLength(kind: .${node.swift_syntax_kind},
+    return .forRoot(.createAndCalcLength(kind: .${node.swift_syntax_kind},
       layout: layout, presence: .present))
   }
 }

--- a/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -67,16 +67,16 @@ public enum SyntaxFactory {
 %       end
 %     end
     ]
-    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.${node.swift_syntax_kind},
-      layout: layout, presence: SourcePresence.present)
+    let raw = RawSyntax.createAndCalcLength(kind: .${node.swift_syntax_kind},
+      layout: layout, presence: .present)
     let data = SyntaxData.forRoot(raw)
     return ${node.name}(data)
   }
 %   elif node.is_syntax_collection():
   public static func make${node.syntax_kind}(
     _ elements: [${node.collection_element_type}]) -> ${node.name} {
-    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.${node.swift_syntax_kind},
-      layout: elements.map { $0.raw }, presence: SourcePresence.present)
+    let raw = RawSyntax.createAndCalcLength(kind: .${node.swift_syntax_kind},
+      layout: elements.map { $0.raw }, presence: .present)
     let data = SyntaxData.forRoot(raw)
     return ${node.name}(data)
   }
@@ -84,7 +84,7 @@ public enum SyntaxFactory {
 
 %   if not node.is_base():
   public static func makeBlank${node.syntax_kind}() -> ${node.name} {
-    let data = SyntaxData.forRoot(RawSyntax.create(kind: .${node.swift_syntax_kind},
+    let data = SyntaxData.forRoot(.create(kind: .${node.swift_syntax_kind},
       layout: [
 %     for child in node.children:
 %       if child.is_optional:

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
@@ -161,7 +161,7 @@ public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
 %       if child.is_optional:
     let raw = newChild?.raw
 %       else:
-    let raw = newChild?.raw ?? ${make_missing_swift_child(child)}
+    let raw: RawSyntax = newChild?.raw ?? ${make_missing_swift_child(child)}
 %       end
     let newData = data.replacingChild(raw, at: Cursor.${child.swift_name})
     return ${node.name}(newData)


### PR DESCRIPTION
## Overview

Not sure if we have policy for gyb file, but I think that it would be less code to remove redundant name space for static func call in Swift.

## Reference

https://github.com/apple/swift/pull/26982