### PR TITLE
[Trivia] Add @available attribute to deprecated trivia kind

### DIFF
--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -406,8 +406,7 @@ fileprivate extension TriviaPiece {
     case let .spaces(count),
          let .tabs(count),
          let .verticalTabs(count),
-         let .formfeeds(count),
-         let .backticks(count):
+         let .formfeeds(count):
       lineLength += SourceLength(utf8Length: count)
     case let .newlines(count),
          let .carriageReturns(count):

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -30,6 +30,9 @@ import Foundation
 public enum TriviaPiece {
 % for trivia in TRIVIAS:
     /// ${trivia.comment}
+%   if trivia.deprecated is not None:
+    @available(*, deprecated, message: "${trivia.deprecated}")
+%   end
 %   if trivia.is_collection():
     case ${trivia.lower_name}s(Int)
 %   else:
@@ -101,6 +104,9 @@ public struct Trivia {
   }
 
 % for trivia in TRIVIAS:
+%   if trivia.deprecated is not None:
+    @available(*, deprecated, message: "${trivia.deprecated}")
+%   end
 %   if trivia.is_collection():
 %   joined = ''.join(trivia.swift_characters)
     /// Return a piece of trivia for some number of '${joined}' characters.
@@ -208,6 +214,9 @@ extension TriviaPiece {
 internal enum TriviaPieceKind: CTriviaKind {
 % for trivia in TRIVIAS:
     /// ${trivia.comment}
+%   if trivia.deprecated is not None:
+    @available(*, deprecated, message: "${trivia.deprecated}")
+%   end
 %   if trivia.is_collection():
     case ${trivia.lower_name}s = ${trivia.serialization_code}
 %   else:

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -30,9 +30,6 @@ import Foundation
 public enum TriviaPiece {
 % for trivia in TRIVIAS:
     /// ${trivia.comment}
-%   if trivia.deprecated is not None:
-    @available(*, deprecated, message: "${trivia.deprecated}")
-%   end
 %   if trivia.is_collection():
     case ${trivia.lower_name}s(Int)
 %   else:
@@ -104,9 +101,6 @@ public struct Trivia {
   }
 
 % for trivia in TRIVIAS:
-%   if trivia.deprecated is not None:
-    @available(*, deprecated, message: "${trivia.deprecated}")
-%   end
 %   if trivia.is_collection():
 %   joined = ''.join(trivia.swift_characters)
     /// Return a piece of trivia for some number of '${joined}' characters.
@@ -214,9 +208,6 @@ extension TriviaPiece {
 internal enum TriviaPieceKind: CTriviaKind {
 % for trivia in TRIVIAS:
     /// ${trivia.comment}
-%   if trivia.deprecated is not None:
-    @available(*, deprecated, message: "${trivia.deprecated}")
-%   end
 %   if trivia.is_collection():
     case ${trivia.lower_name}s = ${trivia.serialization_code}
 %   else:

--- a/Tests/SwiftSyntaxTest/AbsolutePosition.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePosition.swift
@@ -90,7 +90,6 @@ public class AbsolutePositionTestCase: XCTestCase {
 
   static let leadingTrivia = Trivia(pieces: [
     .newlines(1),
-    .backticks(1),
     .docLineComment("/// some comment"),
     .carriageReturns(1),
   ])
@@ -117,10 +116,10 @@ public class AbsolutePositionTestCase: XCTestCase {
   public func testTrivias() {
     let idx = 5
     let root = self.createSourceFile(idx + 1)
-    XCTAssertEqual(4, root.leadingTrivia!.count)
+    XCTAssertEqual(3, root.leadingTrivia!.count)
     XCTAssertEqual(0, root.trailingTrivia!.count)
     let state = root.statements[idx]
-    XCTAssertEqual(4, state.leadingTrivia!.count)
+    XCTAssertEqual(3, state.leadingTrivia!.count)
     XCTAssertEqual(2, state.trailingTrivia!.count)
     XCTAssertEqual(state.byteSize,
       state.leadingTrivia!.byteSize + state.trailingTrivia!.byteSize
@@ -138,8 +137,8 @@ public class AbsolutePositionTestCase: XCTestCase {
     modifiedRoot1.leadingTrivia = [.blockComment("/* this is a comment */")]
     XCTAssertEqual([.blockComment("/* this is a comment */")], modifiedRoot1.leadingTrivia)
 
-    var modifiedRoot2 = root.withTrailingTrivia([.backticks(2)])
-    XCTAssertEqual([.backticks(2)], modifiedRoot2.trailingTrivia)
+    var modifiedRoot2 = root.withTrailingTrivia([.tabs(2)])
+    XCTAssertEqual([.tabs(2)], modifiedRoot2.trailingTrivia)
     XCTAssertEqual([], root.trailingTrivia)
     modifiedRoot2.trailingTrivia = [.carriageReturns(1), .newlines(2)]
     XCTAssertEqual([.carriageReturns(1), .newlines(2)], modifiedRoot2.trailingTrivia)

--- a/Tests/SwiftSyntaxTest/SyntaxFactory.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxFactory.swift
@@ -38,10 +38,10 @@ public class SyntaxFactoryAPITestCase: XCTestCase {
                    }
                    """)
 
-    let forType = SyntaxFactory.makeIdentifier("for",
-                                               leadingTrivia: .backticks(1),
+    let forType = SyntaxFactory.makeIdentifier("`for`",
+                                               leadingTrivia: [],
                                                trailingTrivia: [
-                                                 .backticks(1), .spaces(1)
+                                                 .spaces(1)
                                                ])
     let newBrace = SyntaxFactory.makeRightBraceToken(leadingTrivia: .newlines(2))
 

--- a/Tests/SwiftSyntaxTest/TriviaTests.swift
+++ b/Tests/SwiftSyntaxTest/TriviaTests.swift
@@ -42,10 +42,6 @@ public class TriviaTestCase: XCTestCase {
     XCTAssertEqual(TriviaPiece.carriageReturnLineFeeds(3), .carriageReturnLineFeeds(3))
     XCTAssertNotEqual(TriviaPiece.carriageReturnLineFeeds(4), .carriageReturnLineFeeds(2))
 
-    XCTAssertEqual(TriviaPiece.backticks(2), .backticks(2))
-    XCTAssertNotEqual(TriviaPiece.backticks(3), .backticks(4))
-    XCTAssertNotEqual(TriviaPiece.backticks(3), .spaces(3))
-
     XCTAssertEqual(TriviaPiece.lineComment("a"), .lineComment("a"))
     XCTAssertNotEqual(TriviaPiece.lineComment("a"), .lineComment("b"))
     XCTAssertNotEqual(TriviaPiece.lineComment("a"), .blockComment("a"))

--- a/lit_tests/coloring.swift
+++ b/lit_tests/coloring.swift
@@ -392,8 +392,7 @@ class Ownership {
 let closure = { [weak x=bindtox, unowned y=bindtoy, unowned(unsafe) z=bindtoz] in }
 
 protocol FakeClassRestrictedProtocol : `class` {}
-// FIXME: rdar://42801404: OLD and NEW should be the same '<type>`class`</type>'.
-// CHECK: <kw>protocol</kw> <id>FakeClassRestrictedProtocol</id> : `<type>class</type>` {}
+// CHECK: <kw>protocol</kw> <id>FakeClassRestrictedProtocol</id> : <type>`class`</type> {}
 
 // CHECK: <kw>func</kw> <id>foo</id>() -> <kw>some</kw> <type>P</type> {}
 func foo() -> some P {}


### PR DESCRIPTION
Update for https://github.com/apple/swift/pull/27090

'Backtick' trivia is now removed.
Adjust syntax test not to use 'backticks' trivia.

rdar://problem/54810608