### PR TITLE
Ignore any files Xcode generates when the package is opened directly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .build/
 # Ignore generated Xcode projects
 *.xcodeproj
+# Ignore Data Xcode stores when opening the project directly
+/.swiftpm/xcode
 
 # We always build swiftSyntax of master dependencies. Ignore any fixed 
 # dependency versions.


### PR DESCRIPTION
When opening the package using Xcode, `.swiftpm/xcode` is created to store IDE state (breakpoints etc.). We should not commit those.