### PR TITLE
Add convenience methods to read the value of float and int literals

### DIFF
--- a/Sources/SwiftSyntax/SyntaxConvenienceMethods.swift
+++ b/Sources/SwiftSyntax/SyntaxConvenienceMethods.swift
@@ -1,0 +1,25 @@
+//===- SyntaxConvenienceMethods.swift - Convenience funcs for syntax nodes ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public extension FloatLiteralExprSyntax {
+  var floatingValue: Double {
+    // Parsing a floating literal as a Double should never fail
+    return Double(self.floatingDigits.text)!
+  }
+}
+
+public extension IntegerLiteralExprSyntax {
+  var integerValue: Int {
+    // Parsing an integer literal as an Int should never fail
+    return Int(self.digits.text)!
+  }
+}

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -18,6 +18,7 @@ XCTMain({ () -> [XCTestCaseEntry] in
     testCase(SyntaxTreeModifierTests.allTests),
     testCase(TriviaTests.allTests),
     testCase(CustomReflectableTests.allTests),
+    testCase(SyntaxConvenienceMethodsTestCase.allTests)
   ]
   return testCases
 }())

--- a/Tests/SwiftSyntaxTest/SyntaxConvenienceMethodsTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxConvenienceMethodsTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+import SwiftSyntax
+
+public class SyntaxConvenienceMethodsTestCase: XCTestCase {
+
+  public static let allTests = [
+    ("testFloatingValue", testFloatingValue),
+    ("testIntegerValue", testIntegerValue),
+  ]
+
+  public func testFloatingValue() {
+    let digits = SyntaxFactory.makeFloatingLiteral("5.38")
+    let literalExpr = SyntaxFactory.makeFloatLiteralExpr(floatingDigits: digits)
+    XCTAssertEqual(literalExpr.floatingValue, 5.38)
+  }
+
+  public func testIntegerValue() {
+    let digits = SyntaxFactory.makeIntegerLiteral("42")
+    let literalExpr = SyntaxFactory.makeIntegerLiteralExpr(digits: digits)
+    XCTAssertEqual(literalExpr.integerValue, 42)
+  }
+}

--- a/utils/group.json
+++ b/utils/group.json
@@ -10,6 +10,7 @@
     "SyntaxCollections.swift",
     "SourcePresence.swift",
     "SyntaxChildren.swift",
+    "SyntaxConvenienceMethods.swift",
   ],
   "Utils": [
     "SyntaxBuilders.swift",


### PR DESCRIPTION
I was trying to get the integer/float value of integer/float literals and was surprised to find there is no method for it and you need to parse the value from the characters in the digits token yourself. I feel like there should be a convenience method for that. 

If you disagree and don't think we should increase the API surface for these kinds of methods, I‘m also happy with the decision.