### PR TITLE
Model SyntaxVisitor as a class

### DIFF
--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -227,7 +227,13 @@ public final class SourceLocationConverter {
   }
 }
 
-extension _SyntaxBase {
+public extension Syntax {
+  /// The starting location, in the provided file, of this Syntax node.
+  /// - Parameters:
+  ///   - converter: The `SourceLocationConverter` that was previously
+  ///     initialized using the root tree of this node.
+  ///   - afterLeadingTrivia: Whether to skip leading trivia when getting
+  ///                         the node's location. Defaults to `true`.
   func startLocation(
     converter: SourceLocationConverter,
     afterLeadingTrivia: Bool = true
@@ -238,6 +244,12 @@ extension _SyntaxBase {
     return converter.location(for: pos)
   }
 
+  /// The ending location, in the provided file, of this Syntax node.
+  /// - Parameters:
+  ///   - converter: The `SourceLocationConverter` that was previously
+  ///     initialized using the root tree of this node.
+  ///   - afterTrailingTrivia: Whether to skip trailing trivia when getting
+  ///                          the node's location. Defaults to `false`.
   func endLocation(
     converter: SourceLocationConverter,
     afterTrailingTrivia: Bool = false
@@ -251,30 +263,40 @@ extension _SyntaxBase {
     return converter.location(for: pos)
   }
 
+  /// The source range, in the provided file, of this Syntax node.
+  /// - Parameters:
+  ///   - converter: The `SourceLocationConverter` that was previously
+  ///     initialized using the root tree of this node.
+  ///   - afterLeadingTrivia: Whether to skip leading trivia when getting
+  ///                          the node's start location. Defaults to `true`.
+  ///   - afterTrailingTrivia: Whether to skip trailing trivia when getting
+  ///                          the node's end location. Defaults to `false`.
   func sourceRange(
     converter: SourceLocationConverter,
     afterLeadingTrivia: Bool = true,
     afterTrailingTrivia: Bool = false
   ) -> SourceRange {
-    let start = startLocation(converter: converter, afterLeadingTrivia: afterLeadingTrivia)
-    let end = endLocation(converter: converter, afterTrailingTrivia: afterTrailingTrivia)
+    let start = startLocation(converter: converter, 
+                              afterLeadingTrivia: afterLeadingTrivia)
+    let end = endLocation(converter: converter, 
+                          afterTrailingTrivia: afterTrailingTrivia)
     return SourceRange(start: start, end: end)
   }
 }
 
-extension Syntax {
+public extension SyntaxProtocol {
   /// The starting location, in the provided file, of this Syntax node.
   /// - Parameters:
   ///   - converter: The `SourceLocationConverter` that was previously
   ///     initialized using the root tree of this node.
   ///   - afterLeadingTrivia: Whether to skip leading trivia when getting
   ///                         the node's location. Defaults to `true`.
-  public func startLocation(
+  func startLocation(
     converter: SourceLocationConverter,
     afterLeadingTrivia: Bool = true
   ) -> SourceLocation {
-    return base.startLocation(converter: converter,
-      afterLeadingTrivia: afterLeadingTrivia)
+    return _syntaxNode.startLocation(converter: converter, 
+                                    afterLeadingTrivia: afterLeadingTrivia)
   }
 
   /// The ending location, in the provided file, of this Syntax node.
@@ -283,12 +305,12 @@ extension Syntax {
   ///     initialized using the root tree of this node.
   ///   - afterTrailingTrivia: Whether to skip trailing trivia when getting
   ///                          the node's location. Defaults to `false`.
-  public func endLocation(
+  func endLocation(
     converter: SourceLocationConverter,
     afterTrailingTrivia: Bool = false
   ) -> SourceLocation {
-    return base.endLocation(converter: converter,
-      afterTrailingTrivia: afterTrailingTrivia)
+    return _syntaxNode.endLocation(converter: converter, 
+                                  afterTrailingTrivia: afterTrailingTrivia)
   }
 
   /// The source range, in the provided file, of this Syntax node.
@@ -299,14 +321,14 @@ extension Syntax {
   ///                          the node's start location. Defaults to `true`.
   ///   - afterTrailingTrivia: Whether to skip trailing trivia when getting
   ///                          the node's end location. Defaults to `false`.
-  public func sourceRange(
+  func sourceRange(
     converter: SourceLocationConverter,
     afterLeadingTrivia: Bool = true,
     afterTrailingTrivia: Bool = false
   ) -> SourceRange {
-    return base.sourceRange(converter: converter,
-      afterLeadingTrivia: afterLeadingTrivia,
-      afterTrailingTrivia: afterTrailingTrivia)
+    return _syntaxNode.sourceRange(converter: converter, 
+                                  afterLeadingTrivia: afterLeadingTrivia,
+                                  afterTrailingTrivia: afterTrailingTrivia)
   }
 }
 

--- a/Sources/SwiftSyntax/SyntaxChildren.swift
+++ b/Sources/SwiftSyntax/SyntaxChildren.swift
@@ -45,7 +45,7 @@ struct RawSyntaxChildren: Sequence {
     self.node = absoluteRaw
   }
 
-  init(_ base: _SyntaxBase) {
+  init(_ base: Syntax) {
     self.init(base.data.absoluteRaw)
   }
 
@@ -91,7 +91,7 @@ struct PresentRawSyntaxChildren: Sequence {
     self.node = absoluteRaw
   }
 
-  init(_ base: _SyntaxBase) {
+  init(_ base: Syntax) {
     self.init(base.data.absoluteRaw)
   }
 
@@ -137,7 +137,7 @@ struct ReversedPresentRawSyntaxChildren: Sequence {
     self.node = absoluteRaw
   }
 
-  init(_ base: _SyntaxBase) {
+  init(_ base: Syntax) {
     self.init(base.data.absoluteRaw)
   }
 
@@ -150,9 +150,9 @@ struct ReversedPresentRawSyntaxChildren: Sequence {
 struct PresentRawSyntaxNextSiblings: Sequence {
   typealias Iterator = PresentRawSyntaxChildren.Iterator
 
-  private let node: _SyntaxBase
+  private let node: Syntax
 
-  init(_ node: _SyntaxBase) {
+  init(_ node: Syntax) {
     self.node = node
   }
 
@@ -168,9 +168,9 @@ struct PresentRawSyntaxNextSiblings: Sequence {
 struct PresentRawSyntaxPreviousSiblings: Sequence {
   typealias Iterator = ReversedPresentRawSyntaxChildren.Iterator
 
-  private let node: _SyntaxBase
+  private let node: Syntax
 
-  init(_ node: _SyntaxBase) {
+  init(_ node: Syntax) {
     self.node = node
   }
 
@@ -181,94 +181,28 @@ struct PresentRawSyntaxPreviousSiblings: Sequence {
   }
 }
 
-/// Sequence of present children nodes of the provided `_SyntaxBase` node.
-struct SyntaxBaseChildren: Sequence {
-  struct Iterator: IteratorProtocol {
-    let parent: _SyntaxBase
-    var iterator: PresentRawSyntaxChildren.Iterator
-
-    init(node: _SyntaxBase) {
-      self.iterator = .init(parent: node.data.absoluteRaw)
-      self.parent = node
-    }
-
-    mutating func next() -> _SyntaxBase? {
-      guard let absoluteRaw = iterator.next() else { return nil }
-      let data = SyntaxData(absoluteRaw, parent: self.parent)
-      return makeSyntax(data)
-    }
-  }
-
-  let node: _SyntaxBase
-
-  init(_ node: _SyntaxBase) {
-    self.node = node
-  }
-
-  func makeIterator() -> Iterator {
-    return Iterator(node: node)
-  }
-
-  func reversed() -> ReversedSyntaxBaseChildren {
-    return ReversedSyntaxBaseChildren(node)
-  }
-}
-
-/// Reversed Sequence of `SyntaxBaseChildren`.
-struct ReversedSyntaxBaseChildren: Sequence {
-  struct Iterator: IteratorProtocol {
-    let parent: _SyntaxBase
-    var iterator: ReversedPresentRawSyntaxChildren.Iterator
-
-    init(node: _SyntaxBase) {
-      self.iterator = .init(parent: node.data.absoluteRaw)
-      self.parent = node
-    }
-
-    mutating func next() -> _SyntaxBase? {
-      guard let absoluteRaw = iterator.next() else { return nil }
-      let data = SyntaxData(absoluteRaw, parent: self.parent)
-      return makeSyntax(data)
-    }
-  }
-
-  let node: _SyntaxBase
-
-  init(_ node: _SyntaxBase) {
-    self.node = node
-  }
-
-  func makeIterator() -> Iterator {
-    return Iterator(node: node)
-  }
-
-  func reversed() -> SyntaxBaseChildren {
-    return SyntaxBaseChildren(node)
-  }
-}
-
 /// Sequence of present children nodes of the provided `Syntax` node.
 public struct SyntaxChildren: Sequence {
   public struct Iterator: IteratorProtocol {
-    var iterator: SyntaxBaseChildren.Iterator
+    let parent: Syntax
+    var iterator: PresentRawSyntaxChildren.Iterator
 
-    init(node: _SyntaxBase) {
-      self.iterator = .init(node: node)
+    init(node: Syntax) {
+      self.iterator = .init(parent: node.data.absoluteRaw)
+      self.parent = node
     }
 
     public mutating func next() -> Syntax? {
-      return iterator.next()
+      guard let absoluteRaw = iterator.next() else { return nil }
+      let data = SyntaxData(absoluteRaw, parent: self.parent)
+      return Syntax(data)
     }
   }
 
-  let node: _SyntaxBase
-
-  init(_ node: _SyntaxBase) {
-    self.node = node
-  }
+  let node: Syntax
 
   public init(_ node: Syntax) {
-    self.node = node.base
+    self.node = node
   }
 
   public func makeIterator() -> Iterator {
@@ -283,25 +217,25 @@ public struct SyntaxChildren: Sequence {
 /// Reversed Sequence of `SyntaxChildren`.
 public struct ReversedSyntaxChildren: Sequence {
   public struct Iterator: IteratorProtocol {
-    var iterator: ReversedSyntaxBaseChildren.Iterator
+    let parent: Syntax
+    var iterator: ReversedPresentRawSyntaxChildren.Iterator
 
-    init(node: _SyntaxBase) {
-      self.iterator = .init(node: node)
+    init(node: Syntax) {
+      self.iterator = .init(parent: node.data.absoluteRaw)
+      self.parent = node
     }
 
     public mutating func next() -> Syntax? {
-      return iterator.next()
+      guard let absoluteRaw = iterator.next() else { return nil }
+      let data = SyntaxData(absoluteRaw, parent: self.parent)
+      return Syntax(data)
     }
   }
 
-  let node: _SyntaxBase
-
-  init(_ node: _SyntaxBase) {
-    self.node = node
-  }
+  let node: Syntax
 
   public init(_ node: Syntax) {
-    self.node = node.base
+    self.node = node
   }
 
   public func makeIterator() -> Iterator {

--- a/Sources/SwiftSyntax/SyntaxClassifier.swift
+++ b/Sources/SwiftSyntax/SyntaxClassifier.swift
@@ -224,8 +224,8 @@ fileprivate struct SyntaxCursor {
   }
 }
 
-/// Sequence of tokens of a syntax node. This is more efficient than `TokenSequence`
-/// because it avoids casts to `Syntax`/`_SyntaxBase` protocols.
+/// Sequence of tokens of a syntax node. This is more efficient than 
+/// `TokenSequence` because it avoids casts to `Syntax` protocols.
 fileprivate struct FastTokenSequence: Sequence {
   struct Iterator: IteratorProtocol {
     var cursor: SyntaxCursor
@@ -449,16 +449,11 @@ public struct SyntaxClassifications: Sequence {
     }
   }
 
-  let node: _SyntaxBase
+  let node: Syntax
   let relRange: ByteSourceRange
 
-  init(_ node: _SyntaxBase, in relRange: ByteSourceRange) {
-    self.node = node
-    self.relRange = relRange
-  }
-
   public init(_ node: Syntax, in relRange: ByteSourceRange) {
-    self.node = node.base
+    self.node = node
     self.relRange = relRange
   }
 

--- a/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -18,7 +18,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public protocol SyntaxCollection: Syntax, Sequence {
+public protocol SyntaxCollection: SyntaxProtocol, Sequence {
   /// The number of elements, `present` or `missing`, in this collection.
   var count: Int { get }
 }
@@ -31,12 +31,22 @@ public protocol SyntaxCollection: Syntax, Sequence {
 /// `${node.collection_element_type}` nodes. ${node.name} behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct ${node.name}: _SyntaxBase, Hashable, SyntaxCollection {
-  let data: SyntaxData
+public struct ${node.name}: SyntaxCollection {
+  public let _syntaxNode: Syntax
 
-  /// Creates a Syntax node from the provided root and data.
+  /// Converts the given `Syntax` node to a `${node.name}` if possible. Returns 
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .${node.swift_syntax_kind} else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a Syntax node from the provided root and data. This assumes 
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
   internal init(_ data: SyntaxData) {
-    self.data = data
+    assert(data.raw.kind == .${node.swift_syntax_kind})
+    self._syntaxNode = Syntax(data)
   }
 
   /// The number of elements, `present` or `missing`, in this collection.
@@ -190,43 +200,25 @@ public struct ${node.name}: _SyntaxBase, Hashable, SyntaxCollection {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
-
-  /// Determines if two `${node.name}` nodes are equal to each other.
-  public static func ==(lhs: ${node.name}, rhs: ${node.name}) -> Bool {
-    return lhs.data.nodeId == rhs.data.nodeId
-  }
-
-  /// Feed the essential parts of this node to the supplied hasher.
-  public func hash(into hasher: inout Hasher) {
-    return data.nodeId.hash(into: &hasher)
-  }
 }
 
 /// Conformance for `${node.name}`` to the Sequence protocol.
 extension ${node.name}: Sequence {
   fileprivate static func nextElement<Iter>(
-    _ iterator: inout Iter, parent: _SyntaxBase
+    _ iterator: inout Iter, parent: Syntax
   ) -> ${node.collection_element_type}? where Iter: AbsoluteRawSyntaxIteratorProtocol {
     guard let absoluteRaw = iterator.next() else { return nil }
     let data = SyntaxData(absoluteRaw, parent: parent)
-%   is_constructable = node.collection_element_type != 'Syntax' and \
-%       not (element_node and element_node.is_base())
-%   if is_constructable:
     return ${node.collection_element_type}(data)
-%   else:
-%     cast = '' if node.collection_element_type == 'Syntax' \
-%         else 'as! ' + node.collection_element_type
-    return (makeSyntax(data) ${cast})
-%   end
   }
 
   public struct Iterator: IteratorProtocol {
-    private let parent: _SyntaxBase
+    private let parent: Syntax
     private var iterator: PresentRawSyntaxChildren.Iterator
 
     public init(collection node: ${node.name}) {
       self.iterator = .init(parent: node.data.absoluteRaw)
-      self.parent = node
+      self.parent = Syntax(node)
     }
 
     public mutating func next() -> ${node.collection_element_type}? {
@@ -245,12 +237,12 @@ extension ${node.name}: Sequence {
 
   public struct Reversed: Sequence {
     public struct Iterator: IteratorProtocol {
-      private let parent: _SyntaxBase
+      private let parent: Syntax
       private var iterator: ReversedPresentRawSyntaxChildren.Iterator
 
       public init(collection node: ${node.name}) {
         self.iterator = .init(parent: node.data.absoluteRaw)
-        self.parent = node
+        self.parent = Syntax(node)
       }
 
       public mutating func next() -> ${node.collection_element_type}? {

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -162,7 +162,7 @@ struct AbsoluteRawSyntax {
 
 /// Indirect wrapper for a `Syntax` node to avoid cyclic inclusion of the 
 /// `Syntax` struct in `SyntaxData`
-fileprivate class SyntaxBox: CustomStringConvertible, 
+class SyntaxBox: CustomStringConvertible, 
     CustomDebugStringConvertible, TextOutputStreamable {
   let value: Syntax
 
@@ -173,18 +173,18 @@ fileprivate class SyntaxBox: CustomStringConvertible,
   // SyntaxBox should be transparent in all descriptions
 
   /// A source-accurate description of this node.
-  public var description: String {
+  var description: String {
     return value.description
   }
 
   /// Returns a description used by dump.
-  public var debugDescription: String {
+  var debugDescription: String {
     return value.debugDescription
   }
 
   /// Prints the raw value of this node to the provided stream.
   /// - Parameter stream: The stream to which to print the raw tree.
-  public func write<Target>(to target: inout Target)
+  func write<Target>(to target: inout Target)
     where Target: TextOutputStream {
     return value.write(to: &target)
   }
@@ -234,6 +234,16 @@ struct SyntaxData {
   init(_ absoluteRaw: AbsoluteRawSyntax, parent: Syntax?) {
     self.absoluteRaw = absoluteRaw
     self.parentBox = parent.map(SyntaxBox.init)
+  }
+
+  /// Creates a `SyntaxData` with the provided raw syntax and parent.
+  /// - Parameters:
+  ///   - absoluteRaw: The underlying `AbsoluteRawSyntax` of this node.
+  ///   - parentBox: The boxed parent of this node, or `nil` if this node is the 
+  ///                root.
+  init(_ absoluteRaw: AbsoluteRawSyntax, parentBox: SyntaxBox?) {
+    self.absoluteRaw = absoluteRaw
+    self.parentBox = parentBox
   }
 
   /// Creates a `SyntaxData` for a root raw node.

--- a/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -37,7 +37,7 @@ public enum SyntaxFactory {
     return TokenSyntax(data)
   }
 
-  public static func makeUnknownSyntax(tokens: [TokenSyntax]) -> Syntax {
+  public static func makeUnknownSyntax(tokens: [TokenSyntax]) -> UnknownSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: .unknown,
       layout: tokens.map { $0.raw }, presence: .present)
     let data = SyntaxData.forRoot(raw)
@@ -160,8 +160,9 @@ public enum SyntaxFactory {
     trailingTrivia: Trivia = []) -> TypeSyntax {
     let identifier = makeIdentifier(name, leadingTrivia: leadingTrivia, 
                                     trailingTrivia: trailingTrivia)
-    return makeSimpleTypeIdentifier(name: identifier,
-                                    genericArgumentClause: nil)
+    let typeIdentifier = makeSimpleTypeIdentifier(name: identifier,
+                                                  genericArgumentClause: nil)
+    return TypeSyntax(typeIdentifier)
   }
 
   public static func makeAnyTypeIdentifier(leadingTrivia: Trivia = [],
@@ -202,7 +203,7 @@ public enum SyntaxFactory {
     trailingTrivia: Trivia = []) -> StringLiteralExprSyntax {
     let string = makeStringSegment(text)
     let segment = makeStringSegment(content: string)
-    let segments = makeStringLiteralSegments([segment])
+    let segments = makeStringLiteralSegments([Syntax(segment)])
     let openQuote = makeStringQuoteToken(leadingTrivia: leadingTrivia)
     let closeQuote = makeStringQuoteToken(trailingTrivia: trailingTrivia)
     return makeStringLiteralExpr(openDelimiter: nil,

--- a/Sources/SwiftSyntax/SyntaxKind.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxKind.swift.gyb
@@ -32,7 +32,7 @@ internal enum SyntaxKind: CSyntaxKind {
 % for name, nodes in grouped_nodes.items():
 %   if name not in ["Syntax"]:
   /// Whether the underlying kind is a sub-kind of ${name}Syntax.
-  public var is${name}: Bool {
+  var is${name}: Bool {
     switch self {
 %     for node in nodes:
     case .${node.swift_syntax_kind}: return true
@@ -43,7 +43,7 @@ internal enum SyntaxKind: CSyntaxKind {
 %   end
 % end
 
-  public var isUnknown: Bool {
+  var isUnknown: Bool {
     switch self {
 % for name, nodes in grouped_nodes.items():
 %   if name not in ["Syntax", "SyntaxCollection"]:
@@ -59,25 +59,5 @@ internal enum SyntaxKind: CSyntaxKind {
 extension SyntaxKind {
   static func fromRawValue(_ rawValue: CSyntaxKind) -> SyntaxKind {
     return SyntaxKind(rawValue: rawValue)!
-  }
-}
-
-/// Creates a Syntax node from the provided SyntaxData using the appropriate
-/// Syntax type, as specified by its kind.
-/// - Parameters:
-///   - root: The root of this tree, or `nil` if the new node is the root.
-///   - data: The data for this new node.
-internal func makeSyntax(_ data: SyntaxData) -> _SyntaxBase {
-  switch data.raw.kind {
-  case .token: return TokenSyntax(data)
-  case .unknown: return UnknownSyntax(data)
-% for node in SYNTAX_NODES:
-  case .${node.swift_syntax_kind}:
-%   if node.is_base():
-    return Unknown${node.name}(data)
-%   else:
-    return ${node.name}(data)
-%   end
-% end
   }
 }

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
@@ -53,7 +53,7 @@ extension Syntax {
 public struct UnknownSyntax: SyntaxProtocol {
   public let _syntaxNode: Syntax
 
-  /// Convert the given `Syntax` node to a `UnknownSyntax` if possible. Return 
+  /// Convert the given `Syntax` node to an `UnknownSyntax` if possible. Return 
   /// `nil` if the conversion is not possible.
   public init?(_ syntax: Syntax) {
     guard syntax.raw.kind == .unknown else { return nil }

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
@@ -317,13 +317,28 @@ public extension Syntax {
 % end
     }
   }
+
+  /// Retrieve the concretely typed node that this Syntax node wraps.
+  /// This property is exposed for testing purposes only.
+  var _asConcreteType: Any {
+    switch self.asSyntaxEnum {
+    case .token(let node):
+      return node
+    case .unknown(let node):
+      return node
+% for node in SYNTAX_NODES:
+    case .${node.swift_syntax_kind}(let node):
+      return node
+% end
+    }
+  }
 }
 
 extension Syntax: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and 
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: self.asConcreteType)
+    return Mirror(reflecting: self._asConcreteType)
   }
 }
 
@@ -333,7 +348,7 @@ extension ${node.name}: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and 
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: Syntax(self).asConcreteType)
+    return Mirror(reflecting: Syntax(self)._asConcreteType)
   }
 }
 %   elif node.is_syntax_collection():
@@ -344,9 +359,9 @@ extension ${node.name}: CustomReflectable {
     return Mirror(self, children: [
 %     for child in node.children:
 %       if child.is_optional:
-      "${child.swift_name}": ${child.swift_name}.map(Syntax.init)?.asConcreteType as Any,
+      "${child.swift_name}": ${child.swift_name}.map(Syntax.init)?._asConcreteType as Any,
 %       else:
-      "${child.swift_name}": Syntax(${child.swift_name}).asConcreteType,
+      "${child.swift_name}": Syntax(${child.swift_name})._asConcreteType,
 %       end
 %     end
     ])

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb
@@ -38,23 +38,34 @@ Each node will have:
 """
 }%
 
+/// Provide all the cusotmised casting functions for Syntax nodes
+extension Syntax {
+  public func `is`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> Bool {
+    return self.as(syntaxType) != nil
+  }
+
+  public func `as`<S: SyntaxProtocol>(_ syntaxType: S.Type) -> S? {
+    return S.init(self)
+  }
+}
+
 /// A wrapper around a raw Syntax layout.
-public struct UnknownSyntax: _SyntaxBase, Hashable {
-  let data: SyntaxData
+public struct UnknownSyntax: SyntaxProtocol {
+  public let _syntaxNode: Syntax
 
-  /// Creates an `UnknownSyntax` node from the provided root and data.
+  /// Convert the given `Syntax` node to a `UnknownSyntax` if possible. Return 
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .unknown else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates an `UnknownSyntax` node from the given `SyntaxData`. This assumes 
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
   internal init(_ data: SyntaxData) {
-    self.data = data
-  }
-
-  /// Determines if two `UnknownSyntax` nodes are equal to each other.
-  public static func ==(lhs: UnknownSyntax, rhs: UnknownSyntax) -> Bool {
-    return lhs.data.nodeId == rhs.data.nodeId
-  }
-
-  /// Feed the essential parts of this node to the supplied hasher.
-  public func hash(into hasher: inout Hasher) {
-    return data.nodeId.hash(into: &hasher)
+    assert(data.raw.kind == .unknown)
+    self._syntaxNode = Syntax(data)
   }
 }
 
@@ -66,11 +77,67 @@ extension UnknownSyntax: CustomReflectable {
 
 % for node in SYNTAX_NODES:
 %   base_type = node.base_type
+/// Protocol to which all `${node.name}` nodes conform. Extension point to add
+/// common methods to all `${node.name}` nodes. 
+/// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
+public protocol ${node.name}Protocol: ${base_type}Protocol {}
+
 %   if node.is_base():
 %     for line in dedented_lines(node.description):
 /// ${line}
 %     end
-public protocol ${node.name}: Syntax {}
+public struct ${node.name}: ${node.name}Protocol {
+  public let _syntaxNode: Syntax
+
+  public init<S: ${node.name}Protocol>(_ syntax: S) {
+    // We know this cast is going to succeed. Go through init(_: SyntaxData)
+    // to do a sanity check and verify the kind matches in debug builds and get
+    // maximum performance in release builds.
+    self.init(syntax._syntaxNode.data)
+  }
+
+  /// Converts the given `Syntax` node to a `${node.name}` if possible. Returns 
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    switch syntax.raw.kind {
+%     castable_kinds = ['.' + child_node.swift_syntax_kind for child_node \
+%                       in SYNTAX_NODES \
+%                       if child_node.base_kind == node.syntax_kind]
+    case ${', '.join(castable_kinds)}:
+      self._syntaxNode = syntax
+    default:
+      return nil
+    }
+  }
+
+  /// Creates a `${node.name}` node from the given `SyntaxData`. This assumes 
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    // Assert that the kind of the given data matches in debug builds.
+#if DEBUG
+    switch data.raw.kind {
+%     castable_kinds = ['.' + child_node.swift_syntax_kind for child_node \
+%                       in SYNTAX_NODES \
+%                       if child_node.base_kind == node.syntax_kind]
+    case ${', '.join(castable_kinds)}:
+      break
+    default:
+      fatalError("Unable to create ${node.name} from \(data.raw.kind)")
+    }
+#endif
+
+    self._syntaxNode = Syntax(data)
+  }
+
+  public func `is`<S: ${node.name}Protocol>(_ syntaxType: S.Type) -> Bool {
+    return self.as(syntaxType) != nil
+  }
+
+  public func `as`<S: ${node.name}Protocol>(_ syntaxType: S.Type) -> S? {
+    return S.init(_syntaxNode)
+  }
+}
 
 %   elif node.collection_element:
 %     pass
@@ -79,7 +146,7 @@ public protocol ${node.name}: Syntax {}
 %     for line in dedented_lines(node.description):
 /// ${line}
 %     end
-public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
+public struct ${node.name}: ${base_type}Protocol {
 %     if node.children:
   enum Cursor: Int {
 %       for child in node.children:
@@ -88,43 +155,44 @@ public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
   }
 %     end
 
-  let data: SyntaxData
+  public let _syntaxNode: Syntax
 
-  /// Creates a `${node.name}` node from the provided root and data.
+  /// Converts the given `Syntax` node to a `${node.name}` if possible. Returns 
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .${node.swift_syntax_kind} else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `${node.name}` node from the given `SyntaxData`. This assumes 
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
   internal init(_ data: SyntaxData) {
-    self.data = data
+    assert(data.raw.kind == .${node.swift_syntax_kind})
+    self._syntaxNode = Syntax(data)
   }
 
 %     for child in node.children:
 %       child_node = NODE_MAP.get(child.syntax_kind)
 %       ret_type = child.type_name
-%       cast_symbol = 'as!'
 %       if child.is_optional:
 %         ret_type += '?'
-%         cast_symbol = 'as?'
 %       end
 %       for line in dedented_lines(child.description):
   /// ${line}
 %       end
   public var ${child.swift_name}: ${ret_type} {
-  get {
-    let child = data.child(at: Cursor.${child.swift_name}, parent: self)
+    get {
+      let childData = data.child(at: Cursor.${child.swift_name}, 
+                                 parent: Syntax(self))
 %       if child.is_optional:
-    if child == nil { return nil }
+      if childData == nil { return nil }
 %       end
-%       child_is_constructable = child.type_name != 'Syntax' and \
-%         not (child_node and child_node.is_base())
-%       if child_is_constructable:
-    return ${child.type_name}(child!)
-%       else:
-%         cast = '' if child.type_name == 'Syntax' \
-%                   else '%s %s' % (cast_symbol, child.type_name)
-    return makeSyntax(child!) ${cast}
-%       end
-  }
-  set(value) {
-    self = with${child.name}(value)
-  }
+      return ${child.type_name}(childData!)
+    }
+    set(value) {
+      self = with${child.name}(value)
+    }
   }
 %       if child_node and child_node.is_syntax_collection():
 %         child_elt = child.collection_element_name
@@ -214,27 +282,72 @@ public struct ${node.name}: ${base_type}, _SyntaxBase, Hashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
-
-  /// Determines if two `${node.name}` nodes are equal to each other.
-  public static func ==(lhs: ${node.name}, rhs: ${node.name}) -> Bool {
-    return lhs.data.nodeId == rhs.data.nodeId
-  }
-
-  /// Feed the essential parts of this node to the supplied hasher.
-  public func hash(into hasher: inout Hasher) {
-    return data.nodeId.hash(into: &hasher)
-  }
 }
 %   end
 % end
 
+/// Enum to exhaustively switch over all different syntax nodes.
+public enum SyntaxEnum {
+  case unknown(UnknownSyntax)
+  case token(TokenSyntax)
 % for node in SYNTAX_NODES:
-%   if not node.is_base() and not node.is_syntax_collection():
+%   if node.is_base():
+  case ${node.swift_syntax_kind}(Unknown${node.name})
+%   else:
+  case ${node.swift_syntax_kind}(${node.name})
+%   end
+% end
+}
+
+public extension Syntax {
+  /// Get an enum that can be used to exhaustively switch over all syntax nodes.
+  var asSyntaxEnum: SyntaxEnum {
+    switch raw.kind {
+    case .token:
+      return .token(TokenSyntax(self)!)
+    case .unknown:
+      return .unknown(UnknownSyntax(self)!)
+% for node in SYNTAX_NODES:
+    case .${node.swift_syntax_kind}:
+%   if node.is_base():
+      return .${node.swift_syntax_kind}(Unknown${node.name}(self)!)
+%   else:
+      return .${node.swift_syntax_kind}(${node.name}(self)!)
+%   end
+% end
+    }
+  }
+}
+
+extension Syntax: CustomReflectable {
+  /// Reconstructs the real syntax type for this type from the node's kind and 
+  /// provides a mirror that reflects this type.
+  public var customMirror: Mirror {
+    return Mirror(reflecting: self.asConcreteType)
+  }
+}
+
+% for node in SYNTAX_NODES:
+%   if node.is_base():
+extension ${node.name}: CustomReflectable {
+  /// Reconstructs the real syntax type for this type from the node's kind and 
+  /// provides a mirror that reflects this type.
+  public var customMirror: Mirror {
+    return Mirror(reflecting: Syntax(self).asConcreteType)
+  }
+}
+%   elif node.is_syntax_collection():
+%     pass
+%   else:
 extension ${node.name}: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
 %     for child in node.children:
-      "${child.swift_name}": ${child.swift_name} as Any,
+%       if child.is_optional:
+      "${child.swift_name}": ${child.swift_name}.map(Syntax.init)?.asConcreteType as Any,
+%       else:
+      "${child.swift_name}": Syntax(${child.swift_name}).asConcreteType,
+%       end
 %     end
     ])
   }
@@ -243,7 +356,7 @@ extension ${node.name}: CustomReflectable {
 % end
 
 % for trait in TRAITS:
-public protocol ${trait.trait_name}Syntax: Syntax {
+public protocol ${trait.trait_name}Syntax: SyntaxProtocol {
 % for child in trait.children:
 %   ret_type = child.type_name
 %   if child.is_optional:

--- a/Sources/SwiftSyntax/SyntaxParser.swift
+++ b/Sources/SwiftSyntax/SyntaxParser.swift
@@ -88,7 +88,8 @@ public enum SyntaxParser {
     let rawSyntax = parseRaw(utf8Source, parseTransition, filenameForDiagnostics,
                              diagnosticEngine)
 
-    guard let file = makeSyntax(.forRoot(rawSyntax)) as? SourceFileSyntax else {
+    let base = Syntax(SyntaxData.forRoot(rawSyntax))
+    guard let file = base.as(SourceFileSyntax.self) else {
       throw ParserError.invalidSyntaxData
     }
     return file

--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -106,7 +106,7 @@ open class SyntaxRewriter {
 
 % end
 
-  final func visit(_ data: SyntaxData) -> Syntax {
+  private func visit(_ data: SyntaxData) -> Syntax {
     switch data.raw.kind {
     case .token:
       let node = TokenSyntax(data)
@@ -133,8 +133,9 @@ open class SyntaxRewriter {
     }
   }
 
-  final func visitChildren<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) 
-      -> SyntaxType {
+  private func visitChildren<SyntaxType: SyntaxProtocol>(
+    _ node: SyntaxType
+  ) -> SyntaxType {
     // Walk over all children of this node and rewrite them. Don't store any 
     // rewritten nodes until the first non-`nil` value is encountered. When this 
     // happens, retrieve all previous syntax nodes from the parent node to 
@@ -222,71 +223,122 @@ public enum SyntaxVisitorContinueKind {
   case skipChildren
 }
 
-public protocol SyntaxVisitor {
+open class SyntaxVisitor {
+  public init() {}
+
+  /// Walk all nodes of the given syntax tree, calling the corresponding `visit` 
+  /// function for every node that is being visited.
+  public func walk<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) {
+    visit(node.data)
+  }
+
 % for node in SYNTAX_NODES:
 %   if is_visitable(node):
   /// Visiting `${node.name}` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
-  mutating func visit(_ node: ${node.name}) -> SyntaxVisitorContinueKind
+  open func visit(_ node: ${node.name}) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
 
   /// The function called after visiting `${node.name}` and its descendents.
   ///   - node: the node we just finished visiting.
-  mutating func visitPost(_ node: ${node.name})
+  open func visitPost(_ node: ${node.name}) {}
 %   end
 % end
 
   /// Visiting `TokenSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
-  mutating func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind
+  open func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
 
   /// The function called after visiting the node and its descendents.
   ///   - node: the node we just finished visiting.
-  mutating func visitPost(_ node: TokenSyntax)
+  open func visitPost(_ node: TokenSyntax) {}
 
   /// Visiting `UnknownSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
-  mutating func visit(_ node: UnknownSyntax) -> SyntaxVisitorContinueKind
+  open func visit(_ node: UnknownSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
 
   /// The function called after visiting the node and its descendents.
   ///   - node: the node we just finished visiting.
-  mutating func visitPost(_ node: UnknownSyntax)
-}
+  open func visitPost(_ node: UnknownSyntax) {}
 
-public extension SyntaxVisitor {
 % for node in SYNTAX_NODES:
-%   if is_visitable(node):
-  mutating func visit(_ node: ${node.name}) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-  mutating func visitPost(_ node: ${node.name}) {}
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImpl${node.name}(_ data: SyntaxData) {
+%   if node.is_base():
+      let node = Unknown${node.name}(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+%   else:
+      let node = ${node.name}(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
 %   end
+  }
+
 % end
 
-  mutating func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
+  private func visit(_ data: SyntaxData) {
+    switch data.raw.kind {
+    case .token:
+      let node = TokenSyntax(data)
+      _ = visit(node)
+      // No children to visit.
+      visitPost(node)
+    case .unknown:
+      let node = UnknownSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+    // The implementation of every generated case goes into its own function. This
+    // circumvents an issue where the compiler allocates stack space for every
+    // case statement next to each other in debug builds, causing it to allocate
+    // ~50KB per call to this function. rdar://55929175
+  % for node in SYNTAX_NODES:
+    case .${node.swift_syntax_kind}:
+      visitImpl${node.name}(data)
+  % end
+    }
   }
-  mutating func visitPost(_ node: TokenSyntax) {}
 
-  mutating func visit(_ node: UnknownSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
+  private func visitChildren<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) {
+    let syntaxNode = Syntax(node)
+    let parentBox = SyntaxBox(syntaxNode)
+    for childRaw in PresentRawSyntaxChildren(syntaxNode) {
+      let childData = SyntaxData(childRaw, parentBox: parentBox)
+      visit(childData)
+    }
   }
-  mutating func visitPost(_ node: UnknownSyntax) {}
 }
 
 /// A `SyntaxVisitor` that can visit the nodes as generic `Syntax` values.
 ///
-/// This is a separate protocol because this kind of visitation is slower than
-/// the type-specific visitation of `SyntaxVisitor`. Use `SyntaxAnyVisitor` if
-/// the `visitAny(_)` function would be useful to have, otherwise use
-/// `SyntaxVisitor`.
+/// This subclass of `SyntaxVisitor` is slower than the type-specific visitation 
+/// of `SyntaxVisitor`. Use `SyntaxAnyVisitor` if the `visitAny(_)` function 
+/// would be useful to have, otherwise inherit from `SyntaxVisitor`.
 ///
-/// This works by introducing default implementations of the type-specific
-/// visit function that delegate to `visitAny(_)`. A conformant type that
-/// provides a custom type-specific visit function, should also call
-/// `visitAny(_)` in its implementation, if calling `visitAny` is needed:
+/// This works by overriding the type-specific visit function that delegate to 
+/// `visitAny(_)`. A subclass that provides a custom type-specific visit 
+/// function, should also call `visitAny(_)` in its implementation, if calling 
+/// `visitAny` is needed:
 ///
 ///     struct MyVisitor: SyntaxAnyVisitor {
 ///       func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
@@ -299,143 +351,46 @@ public extension SyntaxVisitor {
 ///         visitAny(token)
 ///       }
 ///
-public protocol SyntaxAnyVisitor: SyntaxVisitor {
-  mutating func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind
-  mutating func visitAnyPost(_ node: Syntax)
-}
-
-public extension SyntaxAnyVisitor {
-  mutating func visitAnyPost(_ node: Syntax) {}
-
-% for node in SYNTAX_NODES:
-%   if is_visitable(node):
-  mutating func visit(_ node: ${node.name}) -> SyntaxVisitorContinueKind {
-    return visitAny(node._syntaxNode)
+open class SyntaxAnyVisitor: SyntaxVisitor {
+  /// Visiting `UnknownSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
   }
-  mutating func visitPost(_ node: ${node.name}) {
-    return visitAnyPost(node._syntaxNode)
-  }
-%   end
-% end
 
-  mutating func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
+  /// The function called after visiting the node and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitAnyPost(_ node: Syntax) {}
+
+  // MARK: Override type specific visit methods
+
+  override open func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(token._syntaxNode)
   }
-  mutating func visitPost(_ node: TokenSyntax) {
-    return visitAnyPost(node._syntaxNode)
+
+  override open func visitPost(_ node: TokenSyntax) {
+    visitAnyPost(node._syntaxNode)
   }
 
-  mutating func visit(_ node: UnknownSyntax) -> SyntaxVisitorContinueKind {
+  override open func visit(_ node: UnknownSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
-  mutating func visitPost(_ node: UnknownSyntax) {
-    return visitAnyPost(node._syntaxNode)
+
+  override open func visitPost(_ node: UnknownSyntax) {
+    visitAnyPost(node._syntaxNode)
   }
-}
-
-/// A class version of the `SyntaxVisitor` protocol. This is useful if you
-/// intend to have subclasses overriding specific methods of a common base
-/// `SyntaxVisitor` class.
-///
-/// It workarounds the issue of not being able to override the default
-/// implementations of the protocol (see https://bugs.swift.org/browse/SR-103).
-open class SyntaxVisitorBase: SyntaxVisitor {
-  public init() {}
-
+  
 % for node in SYNTAX_NODES:
 %   if is_visitable(node):
-  open func visit(_ node: ${node.name}) -> SyntaxVisitorContinueKind {
-    return .visitChildren
+  override open func visit(_ node: ${node.name}) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
   }
-  open func visitPost(_ node: ${node.name}) {}
+
+  override open func visitPost(_ node: ${node.name}) {
+    visitAnyPost(node._syntaxNode)
+  }
 %   end
 % end
 
-  open func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-  open func visitPost(_ node: TokenSyntax) {}
-
-  open func visit(_ node: UnknownSyntax) -> SyntaxVisitorContinueKind {
-    return .visitChildren
-  }
-  open func visitPost(_ node: UnknownSyntax) {}
-}
-
-public extension Syntax {
-  func walk<Visitor>(_ visitor: inout Visitor) where Visitor : SyntaxVisitor {
-    guard isPresent else { return }
-    return doVisit(data, &visitor)
-  }
-}
-
-public extension SyntaxProtocol {
-  func walk<Visitor>(_ visitor: inout Visitor) where Visitor : SyntaxVisitor {
-    return _syntaxNode.walk(&visitor)
-  }
-}
-
-% for node in SYNTAX_NODES:
-/// Implementation detail of doVisit(_:_:). Do not call directly.
-private func _doVisitImpl${node.name}<Visitor>(
-  _ data: SyntaxData, _ visitor: inout Visitor
-) where Visitor : SyntaxVisitor  {
-%   if node.is_base():
-    let node = Unknown${node.name}(data)
-    let needsChildren = (visitor.visit(node) == .visitChildren)
-    // Avoid calling into visitChildren if possible.
-    if needsChildren && node.raw.numberOfChildren > 0 {
-      visitChildren(node, &visitor)
-    }
-    visitor.visitPost(node)
-%   else:
-    let node = ${node.name}(data)
-    let needsChildren = (visitor.visit(node) == .visitChildren)
-    // Avoid calling into visitChildren if possible.
-    if needsChildren && node.raw.numberOfChildren > 0 {
-      visitChildren(node, &visitor)
-    }
-    visitor.visitPost(node)
-%   end
-}
-
-% end
-
-fileprivate func doVisit<Visitor>(
-  _ data: SyntaxData, _ visitor: inout Visitor
-) where Visitor : SyntaxVisitor {
-  switch data.raw.kind {
-  case .token:
-    let node = TokenSyntax(data)
-    _ = visitor.visit(node)
-    // No children to visit.
-    visitor.visitPost(node)
-  case .unknown:
-    let node = UnknownSyntax(data)
-    let needsChildren = (visitor.visit(node) == .visitChildren)
-    // Avoid calling into visitChildren if possible.
-    if needsChildren && node.raw.numberOfChildren > 0 {
-      visitChildren(node, &visitor)
-    }
-    visitor.visitPost(node)
-  // The implementation of every generated case goes into its own function. This
-  // circumvents an issue where the compiler allocates stack space for every
-  // case statement next to each other in debug builds, causing it to allocate
-  // ~50KB per call to this function. rdar://55929175
-% for node in SYNTAX_NODES:
-  case .${node.swift_syntax_kind}:
-    _doVisitImpl${node.name}(data, &visitor)
-% end
-  }
-}
-
-fileprivate func visitChildren<SyntaxType: SyntaxProtocol, Visitor>(
-  _ syntax: SyntaxType, _ visitor: inout Visitor
-) where Visitor : SyntaxVisitor {
-  let syntaxNode = Syntax(syntax)
-  let parentBox = SyntaxBox(syntaxNode)
-  for childRaw in PresentRawSyntaxChildren(syntaxNode) {
-    let childData = SyntaxData(childRaw, parentBox: parentBox)
-    doVisit(childData, &visitor)
-  }
 }

--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -47,7 +47,7 @@ open class SyntaxRewriter {
     return Syntax(token)
   }
   
-  /// Visit a `UnknownSyntax`.
+  /// Visit an `UnknownSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: UnknownSyntax) -> Syntax {

--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -85,15 +85,17 @@ open class SyntaxRewriter {
   private func visitImpl${node.name}(_ data: SyntaxData) -> Syntax {
 %   if node.is_base():
       let node = Unknown${node.name}(data)
-      visitPre(Syntax(node))
-      defer { visitPost(Syntax(node)) }
-      if let newNode = visitAny(Syntax(node)) { return newNode }
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
       return Syntax(visit(node))
 %   else:
       let node = ${node.name}(data)
-      visitPre(Syntax(node))
-      defer { visitPost(Syntax(node)) }
-      if let newNode = visitAny(Syntax(node)) { return newNode }
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
 %     if node.base_type == 'Syntax':
       return visit(node)
 %     else:
@@ -108,15 +110,17 @@ open class SyntaxRewriter {
     switch data.raw.kind {
     case .token:
       let node = TokenSyntax(data)
-      visitPre(Syntax(node))
-      defer { visitPost(Syntax(node)) }
-      if let newNode = visitAny(Syntax(node)) { return newNode }
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
       return visit(node)
     case .unknown:
       let node = UnknownSyntax(data)
-      visitPre(Syntax(node))
-      defer { visitPost(Syntax(node)) }
-      if let newNode = visitAny(Syntax(node)) { return newNode }
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
       return visit(node)
     // The implementation of every generated case goes into its own function. This
     // circumvents an issue where the compiler allocates stack space for every
@@ -142,7 +146,13 @@ open class SyntaxRewriter {
     // nodes are being collected.
     var newLayout: ContiguousArray<RawSyntax?>?
 
-    for (i, (raw, info)) in RawSyntaxChildren(Syntax(node)).enumerated() {
+    let syntaxNode = node._syntaxNode
+    let parentBox = SyntaxBox(syntaxNode)
+
+    // Incrementing i manually is faster than using .enumerated()
+    var childIndex = 0
+    for (raw, info) in RawSyntaxChildren(Syntax(node)) {
+      defer { childIndex += 1 }
       guard let child = raw else {
         // Node does not exist. If we are collecting rewritten nodes, we need to 
         // collect this one as well, otherwise we can ignore it.
@@ -154,7 +164,7 @@ open class SyntaxRewriter {
 
       // Build the Syntax node to rewrite
       let absoluteRaw = AbsoluteRawSyntax(raw: child, info: info)
-      let data = SyntaxData(absoluteRaw, parent: Syntax(node))
+      let data = SyntaxData(absoluteRaw, parentBox: parentBox)
       
       let rewritten = visit(data)
       if rewritten.data.nodeId != info.nodeId {
@@ -168,7 +178,7 @@ open class SyntaxRewriter {
           // reserves enough capacity for the entire layout.
           newLayout = ContiguousArray<RawSyntax?>()
           newLayout!.reserveCapacity(node.raw.numberOfChildren)
-          for j in 0..<i {
+          for j in 0..<childIndex {
             newLayout!.append(node.raw.child(at: j))
           }
         }

--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -30,12 +30,11 @@ open class SyntaxRewriter {
 
 % for node in SYNTAX_NODES:
 %   if is_visitable(node):
-  /// Visit a `${node.name}`. 
+  /// Visit a `${node.name}`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: ${node.name}) -> ${node.base_type} {
-%   cast = ('as! ' + node.base_type) if node.base_type != 'Syntax' else ''
-    return visitChildren(node) ${cast}
+    return ${node.base_type}(visitChildren(node))
   }
 
 %   end
@@ -45,14 +44,14 @@ open class SyntaxRewriter {
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ token: TokenSyntax) -> Syntax {
-    return token
+    return Syntax(token)
   }
   
-  /// Visit a `UnknownSyntax`. 
+  /// Visit a `UnknownSyntax`.
   ///   - Parameter node: the node that is being visited
-  ///   - Returns: the rewritten node or `nil`.
+  ///   - Returns: the rewritten node
   open func visit(_ node: UnknownSyntax) -> Syntax {
-    return visitChildren(node)
+    return Syntax(visitChildren(node))
   }
 
   /// The function called before visiting the node and its descendents.
@@ -78,7 +77,7 @@ open class SyntaxRewriter {
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   public func visit(_ node: Syntax) -> Syntax {
-    return visit(node.base.data)
+    return visit(node.data)
   }
 
 % for node in SYNTAX_NODES:
@@ -86,36 +85,38 @@ open class SyntaxRewriter {
   private func visitImpl${node.name}(_ data: SyntaxData) -> Syntax {
 %   if node.is_base():
       let node = Unknown${node.name}(data)
-      visitPre(node)
-      defer { visitPost(node) }
-      if let newNode = visitAny(node) { return newNode }
-      return visit(node)
+      visitPre(Syntax(node))
+      defer { visitPost(Syntax(node)) }
+      if let newNode = visitAny(Syntax(node)) { return newNode }
+      return Syntax(visit(node))
 %   else:
       let node = ${node.name}(data)
-      visitPre(node)
-      defer { visitPost(node) }
-      if let newNode = visitAny(node) { return newNode }
+      visitPre(Syntax(node))
+      defer { visitPost(Syntax(node)) }
+      if let newNode = visitAny(Syntax(node)) { return newNode }
+%     if node.base_type == 'Syntax':
       return visit(node)
+%     else:
+      return Syntax(visit(node))
+%     end
 %   end
   }
 
 % end
 
   final func visit(_ data: SyntaxData) -> Syntax {
-    // Create the node types directly instead of going through `makeSyntax()`
-    // which has additional cost for casting back and forth from `_SyntaxBase`.
     switch data.raw.kind {
     case .token:
       let node = TokenSyntax(data)
-      visitPre(node)
-      defer { visitPost(node) }
-      if let newNode = visitAny(node) { return newNode }
+      visitPre(Syntax(node))
+      defer { visitPost(Syntax(node)) }
+      if let newNode = visitAny(Syntax(node)) { return newNode }
       return visit(node)
     case .unknown:
       let node = UnknownSyntax(data)
-      visitPre(node)
-      defer { visitPost(node) }
-      if let newNode = visitAny(node) { return newNode }
+      visitPre(Syntax(node))
+      defer { visitPost(Syntax(node)) }
+      if let newNode = visitAny(Syntax(node)) { return newNode }
       return visit(node)
     // The implementation of every generated case goes into its own function. This
     // circumvents an issue where the compiler allocates stack space for every
@@ -128,9 +129,8 @@ open class SyntaxRewriter {
     }
   }
 
-  final func visitChildren(_ nodeS: Syntax) -> Syntax {
-    let node = nodeS.base
-
+  final func visitChildren<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) 
+      -> SyntaxType {
     // Walk over all children of this node and rewrite them. Don't store any 
     // rewritten nodes until the first non-`nil` value is encountered. When this 
     // happens, retrieve all previous syntax nodes from the parent node to 
@@ -142,7 +142,7 @@ open class SyntaxRewriter {
     // nodes are being collected.
     var newLayout: ContiguousArray<RawSyntax?>?
 
-    for (i, (raw, info)) in RawSyntaxChildren(node).enumerated() {
+    for (i, (raw, info)) in RawSyntaxChildren(Syntax(node)).enumerated() {
       guard let child = raw else {
         // Node does not exist. If we are collecting rewritten nodes, we need to 
         // collect this one as well, otherwise we can ignore it.
@@ -154,10 +154,10 @@ open class SyntaxRewriter {
 
       // Build the Syntax node to rewrite
       let absoluteRaw = AbsoluteRawSyntax(raw: child, info: info)
-      let data = SyntaxData(absoluteRaw, parent: node)
+      let data = SyntaxData(absoluteRaw, parent: Syntax(node))
       
       let rewritten = visit(data)
-      if rewritten.base.data.absoluteRaw.info.nodeId != info.nodeId {
+      if rewritten.data.nodeId != info.nodeId {
         // The node was rewritten, let's handle it
         if newLayout == nil {
           // We have not yet collected any previous rewritten nodes. Initialize
@@ -192,10 +192,10 @@ open class SyntaxRewriter {
       assert(newLayout.count == node.raw.numberOfChildren)
       
       let newRaw = node.raw.replacingLayout(Array(newLayout))
-      return makeSyntax(.forRoot(newRaw))
+      return SyntaxType(Syntax(SyntaxData.forRoot(newRaw)))!
     } else {
       // No child node was rewritten. So no need to change this node as well.
-      return nodeS
+      return node
     }
 
   }
@@ -300,26 +300,26 @@ public extension SyntaxAnyVisitor {
 % for node in SYNTAX_NODES:
 %   if is_visitable(node):
   mutating func visit(_ node: ${node.name}) -> SyntaxVisitorContinueKind {
-    return visitAny(node)
+    return visitAny(Syntax(node))
   }
   mutating func visitPost(_ node: ${node.name}) {
-    return visitAnyPost(node)
+    return visitAnyPost(Syntax(node))
   }
 %   end
 % end
 
   mutating func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
-    return visitAny(token)
+    return visitAny(Syntax(token))
   }
   mutating func visitPost(_ node: TokenSyntax) {
-    return visitAnyPost(node)
+    return visitAnyPost(Syntax(node))
   }
 
   mutating func visit(_ node: UnknownSyntax) -> SyntaxVisitorContinueKind {
-    return visitAny(node)
+    return visitAny(Syntax(node))
   }
   mutating func visitPost(_ node: UnknownSyntax) {
-    return visitAnyPost(node)
+    return visitAnyPost(Syntax(node))
   }
 }
 
@@ -352,16 +352,16 @@ open class SyntaxVisitorBase: SyntaxVisitor {
   open func visitPost(_ node: UnknownSyntax) {}
 }
 
-extension _SyntaxBase {
+public extension Syntax {
   func walk<Visitor>(_ visitor: inout Visitor) where Visitor : SyntaxVisitor {
     guard isPresent else { return }
     return doVisit(data, &visitor)
   }
 }
 
-extension Syntax {
-  public func walk<Visitor>(_ visitor: inout Visitor) where Visitor : SyntaxVisitor {
-    return base.walk(&visitor)
+public extension SyntaxProtocol {
+  func walk<Visitor>(_ visitor: inout Visitor) where Visitor : SyntaxVisitor {
+    return _syntaxNode.walk(&visitor)
   }
 }
 
@@ -373,17 +373,17 @@ private func _doVisitImpl${node.name}<Visitor>(
 %   if node.is_base():
     let node = Unknown${node.name}(data)
     let needsChildren = (visitor.visit(node) == .visitChildren)
-    // Avoid casting to `_SyntaxBase` if we don't need to visit children.
+    // Avoid calling into visitChildren if possible.
     if needsChildren && data.raw.numberOfChildren > 0 {
-      visitChildren(data, parent: node, &visitor)
+      visitChildren(data, parent: Syntax(node), &visitor)
     }
     visitor.visitPost(node)
 %   else:
     let node = ${node.name}(data)
     let needsChildren = (visitor.visit(node) == .visitChildren)
-    // Avoid casting to `_SyntaxBase` if we don't need to visit children.
+    // Avoid calling into visitChildren if possible.
     if needsChildren && data.raw.numberOfChildren > 0 {
-      visitChildren(data, parent: node, &visitor)
+      visitChildren(data, parent: Syntax(node), &visitor)
     }
     visitor.visitPost(node)
 %   end
@@ -394,8 +394,6 @@ private func _doVisitImpl${node.name}<Visitor>(
 fileprivate func doVisit<Visitor>(
   _ data: SyntaxData, _ visitor: inout Visitor
 ) where Visitor : SyntaxVisitor {
-  // Create the node types directly instead of going through `makeSyntax()`
-  // which has additional cost for casting back and forth from `_SyntaxBase`.
   switch data.raw.kind {
   case .token:
     let node = TokenSyntax(data)
@@ -405,9 +403,9 @@ fileprivate func doVisit<Visitor>(
   case .unknown:
     let node = UnknownSyntax(data)
     let needsChildren = (visitor.visit(node) == .visitChildren)
-    // Avoid casting to `_SyntaxBase` if we don't need to visit children.
+    // Avoid calling into visitChildren if possible.
     if needsChildren && data.raw.numberOfChildren > 0 {
-      visitChildren(data, parent: node, &visitor)
+      visitChildren(data, parent: Syntax(node), &visitor)
     }
     visitor.visitPost(node)
   // The implementation of every generated case goes into its own function. This
@@ -422,7 +420,7 @@ fileprivate func doVisit<Visitor>(
 }
 
 fileprivate func visitChildren<Visitor>(
-  _ data: SyntaxData, parent: _SyntaxBase, _ visitor: inout Visitor
+  _ data: SyntaxData, parent: Syntax, _ visitor: inout Visitor
 ) where Visitor : SyntaxVisitor {
   for childRaw in PresentRawSyntaxChildren(data.absoluteRaw) {
     let childData = SyntaxData(childRaw, parent: parent)

--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -151,7 +151,7 @@ open class SyntaxRewriter {
 
     // Incrementing i manually is faster than using .enumerated()
     var childIndex = 0
-    for (raw, info) in RawSyntaxChildren(Syntax(node)) {
+    for (raw, info) in RawSyntaxChildren(syntaxNode) {
       defer { childIndex += 1 }
       guard let child = raw else {
         // Node does not exist. If we are collecting rewritten nodes, we need to 
@@ -310,26 +310,26 @@ public extension SyntaxAnyVisitor {
 % for node in SYNTAX_NODES:
 %   if is_visitable(node):
   mutating func visit(_ node: ${node.name}) -> SyntaxVisitorContinueKind {
-    return visitAny(Syntax(node))
+    return visitAny(node._syntaxNode)
   }
   mutating func visitPost(_ node: ${node.name}) {
-    return visitAnyPost(Syntax(node))
+    return visitAnyPost(node._syntaxNode)
   }
 %   end
 % end
 
   mutating func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
-    return visitAny(Syntax(token))
+    return visitAny(token._syntaxNode)
   }
   mutating func visitPost(_ node: TokenSyntax) {
-    return visitAnyPost(Syntax(node))
+    return visitAnyPost(node._syntaxNode)
   }
 
   mutating func visit(_ node: UnknownSyntax) -> SyntaxVisitorContinueKind {
-    return visitAny(Syntax(node))
+    return visitAny(node._syntaxNode)
   }
   mutating func visitPost(_ node: UnknownSyntax) {
-    return visitAnyPost(Syntax(node))
+    return visitAnyPost(node._syntaxNode)
   }
 }
 
@@ -384,16 +384,16 @@ private func _doVisitImpl${node.name}<Visitor>(
     let node = Unknown${node.name}(data)
     let needsChildren = (visitor.visit(node) == .visitChildren)
     // Avoid calling into visitChildren if possible.
-    if needsChildren && data.raw.numberOfChildren > 0 {
-      visitChildren(data, parent: Syntax(node), &visitor)
+    if needsChildren && node.raw.numberOfChildren > 0 {
+      visitChildren(node, &visitor)
     }
     visitor.visitPost(node)
 %   else:
     let node = ${node.name}(data)
     let needsChildren = (visitor.visit(node) == .visitChildren)
     // Avoid calling into visitChildren if possible.
-    if needsChildren && data.raw.numberOfChildren > 0 {
-      visitChildren(data, parent: Syntax(node), &visitor)
+    if needsChildren && node.raw.numberOfChildren > 0 {
+      visitChildren(node, &visitor)
     }
     visitor.visitPost(node)
 %   end
@@ -414,8 +414,8 @@ fileprivate func doVisit<Visitor>(
     let node = UnknownSyntax(data)
     let needsChildren = (visitor.visit(node) == .visitChildren)
     // Avoid calling into visitChildren if possible.
-    if needsChildren && data.raw.numberOfChildren > 0 {
-      visitChildren(data, parent: Syntax(node), &visitor)
+    if needsChildren && node.raw.numberOfChildren > 0 {
+      visitChildren(node, &visitor)
     }
     visitor.visitPost(node)
   // The implementation of every generated case goes into its own function. This
@@ -429,11 +429,13 @@ fileprivate func doVisit<Visitor>(
   }
 }
 
-fileprivate func visitChildren<Visitor>(
-  _ data: SyntaxData, parent: Syntax, _ visitor: inout Visitor
+fileprivate func visitChildren<SyntaxType: SyntaxProtocol, Visitor>(
+  _ syntax: SyntaxType, _ visitor: inout Visitor
 ) where Visitor : SyntaxVisitor {
-  for childRaw in PresentRawSyntaxChildren(data.absoluteRaw) {
-    let childData = SyntaxData(childRaw, parent: parent)
+  let syntaxNode = Syntax(syntax)
+  let parentBox = SyntaxBox(syntaxNode)
+  for childRaw in PresentRawSyntaxChildren(syntaxNode) {
+    let childData = SyntaxData(childRaw, parentBox: parentBox)
     doVisit(childData, &visitor)
   }
 }

--- a/Sources/SwiftSyntax/SyntaxVerifier.swift
+++ b/Sources/SwiftSyntax/SyntaxVerifier.swift
@@ -26,26 +26,26 @@ public enum SyntaxVerifierError: Error, CustomStringConvertible {
 }
 
 /// Verifier to check that there are no unknown syntax nodes in the tree.
-public struct SyntaxVerifier: SyntaxAnyVisitor {
+public class SyntaxVerifier: SyntaxAnyVisitor {
 
   var unknownNodes: [Syntax] = []
 
-  public mutating func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
+  public override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
     if node.isUnknown {
       unknownNodes.append(node)
     }
     return .visitChildren
   }
 
-  private mutating func verify(_ node: Syntax) throws {
-    node.walk(&self)
+  private func verify(_ node: Syntax) throws {
+    self.walk(node)
     if let unknownNode = unknownNodes.first {
       throw SyntaxVerifierError.unknownSyntaxFound(node: unknownNode)
     }
   }
 
   public static func verify(_ node: Syntax) throws {
-    var verifier = SyntaxVerifier()
+    let verifier = SyntaxVerifier()
     try verifier.verify(node)
   }
 }

--- a/Sources/SwiftSyntaxBuilder/DeclBuildables.swift
+++ b/Sources/SwiftSyntaxBuilder/DeclBuildables.swift
@@ -24,7 +24,7 @@ public protocol DeclBuildable: SyntaxBuildable, DeclListBuildable {
 
 extension DeclBuildable {
   public func buildSyntax(format: Format, leadingTrivia: Trivia) -> Syntax {
-    buildDecl(format: format, leadingTrivia: leadingTrivia)
+    Syntax(buildDecl(format: format, leadingTrivia: leadingTrivia))
   }
 
   public func buildDeclList(format: Format, leadingTrivia: Trivia) -> [DeclSyntax] {
@@ -51,7 +51,7 @@ public struct DeclList: DeclListBuildable {
   }
 
   public func buildSyntaxList(format: Format, leadingTrivia: Trivia) -> [Syntax] {
-    buildDeclList(format: format, leadingTrivia: leadingTrivia)
+    buildDeclList(format: format, leadingTrivia: leadingTrivia).map { Syntax($0) }
   }
 }
 
@@ -74,12 +74,13 @@ public struct Import: DeclBuildable {
     let importToken = Tokens.import.withLeadingTrivia(leadingTrivia)
     let moduleNameToken = SyntaxFactory.makeIdentifier(moduleName)
 
-    return ImportDeclSyntax {
+    let importDecl = ImportDeclSyntax {
       $0.useImportTok(importToken)
       $0.addPathComponent(AccessPathComponentSyntax {
         $0.useName(moduleNameToken)
       })
     }
+    return DeclSyntax(importDecl)
   }
 }
 
@@ -128,10 +129,10 @@ public struct Variable<Mutability: VariableMutability>: DeclBuildable {
       return SyntaxFactory.makeInitializerClause(equal: Tokens.equal, value: expr)
     }
 
-    return VariableDeclSyntax {
+    let variableDecl = VariableDeclSyntax {
       $0.useLetOrVarKeyword(mutabilityKeyword)
       $0.addBinding(PatternBindingSyntax {
-        $0.usePattern(namePattern)
+        $0.usePattern(PatternSyntax(namePattern))
         $0.useTypeAnnotation(typeAnnotation)
 
         if let initClause = initClause {
@@ -139,6 +140,7 @@ public struct Variable<Mutability: VariableMutability>: DeclBuildable {
         }
       })
     }
+    return DeclSyntax(variableDecl)
   }
 }
 
@@ -164,7 +166,7 @@ public struct Struct: DeclBuildable {
       leadingTrivia: .zero
     )
 
-    return StructDeclSyntax {
+    let structDecl = StructDeclSyntax {
       $0.useStructKeyword(structKeyword)
       $0.useIdentifier(SyntaxFactory.makeIdentifier(name))
       $0.useMembers(MemberDeclBlockSyntax {
@@ -180,5 +182,6 @@ public struct Struct: DeclBuildable {
         }
       })
     }
+    return DeclSyntax(structDecl)
   }
 }

--- a/Sources/SwiftSyntaxBuilder/ExprBuildables.swift
+++ b/Sources/SwiftSyntaxBuilder/ExprBuildables.swift
@@ -24,7 +24,7 @@ public protocol ExprBuildable: SyntaxBuildable, ExprListBuildable {
 
 extension ExprBuildable {
   public func buildSyntax(format: Format, leadingTrivia: Trivia) -> Syntax {
-    buildExpr(format: format, leadingTrivia: leadingTrivia)
+    Syntax(buildExpr(format: format, leadingTrivia: leadingTrivia))
   }
 
   public func buildExprList(format: Format, leadingTrivia: Trivia) -> [ExprSyntax] {
@@ -44,9 +44,10 @@ public struct IntegerLiteral: ExprBuildable {
     }
 
     public func buildExpr(format: Format, leadingTrivia: Trivia) -> ExprSyntax {
-        SyntaxFactory.makeIntegerLiteralExpr(
+        let integerLiteral = SyntaxFactory.makeIntegerLiteralExpr(
             digits: SyntaxFactory.makeIntegerLiteral(String(value))
         ).withLeadingTrivia(leadingTrivia)
+        return ExprSyntax(integerLiteral)
     }
 }
 
@@ -66,8 +67,9 @@ public struct StringLiteral: ExprBuildable {
     }
 
     public func buildExpr(format: Format, leadingTrivia: Trivia) -> ExprSyntax {
-        SyntaxFactory.makeStringLiteralExpr(value)
-          .withLeadingTrivia(leadingTrivia)
+        let stringLiteral = SyntaxFactory.makeStringLiteralExpr(value)
+            .withLeadingTrivia(leadingTrivia)
+        return ExprSyntax(stringLiteral)
     }
 }
 

--- a/Sources/SwiftSyntaxBuilder/SyntaxBuildables.swift
+++ b/Sources/SwiftSyntaxBuilder/SyntaxBuildables.swift
@@ -67,7 +67,7 @@ public struct SourceFile: SyntaxBuildable {
   public func buildSyntax(format: Format, leadingTrivia: Trivia) -> Syntax {
     let syntaxList = builder.buildSyntaxList(format: format, leadingTrivia: leadingTrivia)
 
-    return SourceFileSyntax {
+    let sourceFile = SourceFileSyntax {
       for (index, syntax) in syntaxList.enumerated() {
         let trivia: Trivia =
           index == syntaxList.startIndex
@@ -79,5 +79,7 @@ public struct SourceFile: SyntaxBuildable {
         }.withLeadingTrivia(trivia))
       }
     }.withLeadingTrivia(leadingTrivia)
+
+    return Syntax(sourceFile)
   }
 }

--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -197,9 +197,10 @@ struct IncrementalEdit {
 /// Rewrites a parsed tree with all constructed nodes.
 class TreeReconstructor : SyntaxRewriter {
   override func visit(_ token: TokenSyntax) -> Syntax {
-    return SyntaxFactory.makeToken(token.tokenKind, presence: token.presence,
-                     leadingTrivia: token.leadingTrivia,
-                     trailingTrivia: token.trailingTrivia)
+    let token = SyntaxFactory.makeToken(token.tokenKind, presence: token.presence,
+                                        leadingTrivia: token.leadingTrivia,
+                                        trailingTrivia: token.trailingTrivia)
+    return Syntax(token)
   }
 }
 
@@ -207,10 +208,11 @@ func performClassifySyntax(args: CommandLineArguments) throws {
   let treeURL = URL(fileURLWithPath: try args.getRequired("-source-file"))
 
   let tree = try SyntaxParser.parse(treeURL)
-  let result = ClassifiedSyntaxTreePrinter.print(tree)
+  let result = ClassifiedSyntaxTreePrinter.print(Syntax(tree))
   do {
     // Sanity check that we get the same result if the tree has constructed nodes.
-    let ctorTree = TreeReconstructor().visit(tree) as! SourceFileSyntax
+    let ctorTree = TreeReconstructor().visit(tree)
+    assert(ctorTree.is(SourceFileSyntax.self))
     let ctorResult = ClassifiedSyntaxTreePrinter.print(ctorTree)
     if ctorResult != result {
       throw TestingError.classificationVerificationFailed(result, ctorResult)

--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -399,11 +399,11 @@ func performRoundtrip(args: CommandLineArguments) throws {
 struct NodePrinter: SyntaxAnyVisitor {
   func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
     assert(!node.isUnknown)
-    print("<\(type(of: node))>", terminator: "")
+    print("<\(type(of: node._asConcreteType))>", terminator: "")
     return .visitChildren
   }
   func visitAnyPost(_ node: Syntax) {
-    print("</\(type(of: node))>", terminator: "")
+    print("</\(type(of: node._asConcreteType))>", terminator: "")
   }
   func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
     print("<\(type(of: token))>", terminator: "")

--- a/Tests/SwiftSyntaxTest/AbsolutePosition.swift
+++ b/Tests/SwiftSyntaxTest/AbsolutePosition.swift
@@ -61,15 +61,15 @@ public class AbsolutePositionTestCase: XCTestCase {
   public func testCurrentFile() {
     XCTAssertNoThrow(try {
       let parsed = try SyntaxParser.parse(URL(fileURLWithPath: #file))
-      struct Visitor: SyntaxVisitor {
-        func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
+      class Visitor: SyntaxVisitor {
+        override func visit(_ node: TokenSyntax) -> SyntaxVisitorContinueKind {
           XCTAssertEqual(node.positionAfterSkippingLeadingTrivia.utf8Offset,
             node.position.utf8Offset + node.leadingTrivia.byteSize)
           return .skipChildren
         }
       }
-      var visitor = Visitor()
-      parsed.walk(&visitor)
+      let visitor = Visitor()
+      visitor.walk(parsed)
     }())
   }
 

--- a/Tests/SwiftSyntaxTest/ClassificationTests.swift
+++ b/Tests/SwiftSyntaxTest/ClassificationTests.swift
@@ -62,7 +62,7 @@ public class ClassificationTests: XCTestCase {
       XCTAssertEqual(classif[0].range, ByteSourceRange(offset: 20, length: 3))
     }
     do {
-      let initializer = (tree.statements[0].item as! VariableDeclSyntax).bindings[0].initializer!
+      let initializer = (tree.statements[0].item.as(VariableDeclSyntax.self)!).bindings[0].initializer!
       XCTAssertEqual(initializer.description, "/*yo*/ = 0")
       // Classify with a relative range inside this node.
       let classif = Array(initializer.classifications(in: ByteSourceRange(offset: 5, length: 2)))

--- a/Tests/SwiftSyntaxTest/CustomReflecatbleTests.swift
+++ b/Tests/SwiftSyntaxTest/CustomReflecatbleTests.swift
@@ -5,7 +5,6 @@ import SwiftSyntax
 public class CustomReflectableTests: XCTestCase {
   public static let allTests = [
     ("testDump", testDump),
-    ("testConformanceToCustomReflectable", testConformanceToCustomReflectable),
   ]
 
 
@@ -114,11 +113,11 @@ public class CustomReflectableTests: XCTestCase {
         let expr2 = SyntaxFactory.makeIntegerLiteralExpr(digits: token2)
         let elements = [SyntaxFactory.makeTupleExprElement(label: nil,
                                                        colon: nil,
-                                                       expression: expr1,
+                                                       expression: ExprSyntax(expr1),
                                                        trailingComma: nil),
                         SyntaxFactory.makeTupleExprElement(label: nil,
                                                        colon: nil,
-                                                       expression: expr2,
+                                                       expression: ExprSyntax(expr2),
                                                        trailingComma: nil)]
         let tuples = SyntaxFactory.makeTupleExprElementList(elements)
         return .init(syntax: tuples,
@@ -166,11 +165,11 @@ public class CustomReflectableTests: XCTestCase {
         let expr2 = SyntaxFactory.makeIntegerLiteralExpr(digits: token2)
         let elements = [SyntaxFactory.makeTupleExprElement(label: nil,
                                                        colon: nil,
-                                                       expression: expr1,
+                                                       expression: ExprSyntax(expr1),
                                                        trailingComma: nil),
           SyntaxFactory.makeTupleExprElement(label: nil,
                                          colon: nil,
-                                         expression: expr2,
+                                         expression: ExprSyntax(expr2),
                                          trailingComma: nil)]
         let tuples = SyntaxFactory.makeTupleExprElementList(elements)
         return .init(syntax: tuples.reversed(),
@@ -212,49 +211,6 @@ public class CustomReflectableTests: XCTestCase {
       let (key: line, value: testCase) = keyAndValue
       let actualDumped = dumped(testCase.syntax)
       XCTAssertEqual(testCase.expectedDumped, actualDumped, line: line)
-    }
-  }
-
-
-  public func testConformanceToCustomReflectable() {
-    XCTAssertNoThrow(try {
-      let parsed = try SyntaxParser.parse(getInput("near-empty.swift"))
-      XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
-    }())
-    XCTAssertNoThrow(try {
-      let parsed = try SyntaxParser.parse(getInput("closure.swift"))
-      XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
-    }())
-    XCTAssertNoThrow(try {
-      let parsed = try SyntaxParser.parse(getInput("nested-blocks.swift"))
-      XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
-    }())
-    XCTAssertNoThrow(try {
-      let parsed = try SyntaxParser.parse(getInput("visitor.swift"))
-      XCTAssertEqual(collectSyntaxNotConformedCustomReflectable(from: parsed), [])
-    }())
-  }
-
-
-  public func collectSyntaxNotConformedCustomReflectable<S: Any>(from object: S) -> [String] {
-    var paths = [String]()
-    collectSyntaxNotConformedCustomReflectable(from: object, ancestors: ["root"], foundPaths: &paths)
-    return paths
-  }
-
-
-  public func collectSyntaxNotConformedCustomReflectable<S: Any>(from object: S, ancestors: [String], foundPaths: inout [String]) {
-    Mirror(reflecting: object).children.forEach { child in
-      let (label: label, value: value) = child
-
-      var currentPathComponents = ancestors
-      currentPathComponents.append(label ?? "(nil)")
-
-      if let syntax = value as? Syntax, !(syntax is CustomReflectable) {
-        foundPaths.append("\(currentPathComponents.joined(separator: ".")): \(type(of: value as Any))")
-      }
-
-      collectSyntaxNotConformedCustomReflectable(from: value, ancestors: currentPathComponents, foundPaths: &foundPaths)
     }
   }
 

--- a/Tests/SwiftSyntaxTest/DiagnosticTest.swift
+++ b/Tests/SwiftSyntaxTest/DiagnosticTest.swift
@@ -69,14 +69,14 @@ public class DiagnosticTestCase: XCTestCase {
     // engine.addConsumer(PrintingDiagnosticConsumer())
     let url = getInput("diagnostics.swift")
 
-    struct Visitor: SyntaxVisitor {
+    class Visitor: SyntaxVisitor {
       let converter: SourceLocationConverter
       let engine: DiagnosticEngine
       init(converter: SourceLocationConverter, engine: DiagnosticEngine) {
         self.converter = converter
         self.engine = engine
       }
-      func visit(_ function: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+      override func visit(_ function: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
         let startLoc = function.identifier.startLocation(converter: converter)
         let endLoc = function.endLocation(converter: converter)
         engine.diagnose(.badFunction(function.identifier), location: startLoc) {
@@ -90,8 +90,8 @@ public class DiagnosticTestCase: XCTestCase {
     XCTAssertNoThrow(try {
       let file = try SyntaxParser.parse(url)
       let converter = SourceLocationConverter(file: url.path, tree: file)
-      var visitor = Visitor(converter: converter, engine: engine)
-      file.walk(&visitor)
+      let visitor = Visitor(converter: converter, engine: engine)
+      visitor.walk(file)
     }())
 
      XCTAssertEqual(6, engine.diagnostics.count)

--- a/Tests/SwiftSyntaxTest/IncrementalParsingTests.swift
+++ b/Tests/SwiftSyntaxTest/IncrementalParsingTests.swift
@@ -45,7 +45,7 @@ public class IncrementalParsingTestCase: XCTestCase {
 
     XCTAssertEqual(newStructB.byteRange, reusedRange)
     XCTAssertEqual(origStructB.uniqueIdentifier, reusedNode.uniqueIdentifier)
-    XCTAssertEqual(origStructB, reusedNode.asSyntax as! CodeBlockItemSyntax)
+    XCTAssertEqual(origStructB, reusedNode.asCodeBlockItem)
     XCTAssertTrue(reusedNode.isCodeBlockItem)
     XCTAssertEqual(origStructB, reusedNode.asCodeBlockItem!)
     XCTAssertEqual(origStructB.parent!.uniqueIdentifier, reusedNode.parent!.uniqueIdentifier)

--- a/Tests/SwiftSyntaxTest/ModifierTests.swift
+++ b/Tests/SwiftSyntaxTest/ModifierTests.swift
@@ -2,9 +2,12 @@ import XCTest
 import SwiftSyntax
 
 fileprivate func cannedVarDecl() -> VariableDeclSyntax {
+  let identifierPattern = SyntaxFactory.makeIdentifierPattern(
+    identifier: SyntaxFactory.makeIdentifier("a")
+                .withLeadingTrivia(.spaces(1))
+  )
   let Pattern = SyntaxFactory.makePatternBinding(
-    pattern: SyntaxFactory.makeIdentifierPattern(
-      identifier: SyntaxFactory.makeIdentifier("a").withLeadingTrivia(.spaces(1))),
+    pattern: PatternSyntax(identifierPattern),
     typeAnnotation: SyntaxFactory.makeTypeAnnotation(
       colon: SyntaxFactory.makeColonToken().withTrailingTrivia(.spaces(1)),
       type: SyntaxFactory.makeTypeIdentifier("Int")),

--- a/Tests/SwiftSyntaxTest/ParseFile.swift
+++ b/Tests/SwiftSyntaxTest/ParseFile.swift
@@ -43,17 +43,17 @@ public class ParseFileTestCase: XCTestCase {
   public func testEnumCaseStructure() {
     class Visitor: SyntaxVisitor {
       var cases: [EnumCaseDeclSyntax] = []
-      func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
+      override func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
         cases.append(contentsOf: node.members.members.compactMap {
           $0.decl.as(EnumCaseDeclSyntax.self)
         })
         return .skipChildren
       }
     }
-    var v = Visitor()
+    let v = Visitor()
     let currentFile = URL(fileURLWithPath: #file)
     let parsed = try! SyntaxParser.parse(currentFile)
-    parsed.walk(&v)
+    v.walk(parsed)
     XCTAssertEqual(v.cases.count, 2)
   }
 }

--- a/Tests/SwiftSyntaxTest/ParseFile.swift
+++ b/Tests/SwiftSyntaxTest/ParseFile.swift
@@ -36,7 +36,7 @@ public class ParseFileTestCase: XCTestCase {
       let fileContents = try String(contentsOf: currentFile)
       let parsed = try SyntaxParser.parse(currentFile)
       XCTAssertEqual("\(parsed)", fileContents)
-      try SyntaxVerifier.verify(parsed)
+      try SyntaxVerifier.verify(Syntax(parsed))
     }())
   }
 
@@ -45,7 +45,7 @@ public class ParseFileTestCase: XCTestCase {
       var cases: [EnumCaseDeclSyntax] = []
       func visit(_ node: EnumDeclSyntax) -> SyntaxVisitorContinueKind {
         cases.append(contentsOf: node.members.members.compactMap {
-          ($0 as MemberDeclListItemSyntax).decl as? EnumCaseDeclSyntax
+          $0.decl.as(EnumCaseDeclSyntax.self)
         })
         return .skipChildren
       }

--- a/Tests/SwiftSyntaxTest/SyntaxChildren.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxChildren.swift
@@ -12,11 +12,11 @@ public class SyntaxChildrenAPITestCase: XCTestCase {
   public func testIterateWithAllPresent() {
     let returnStmt = SyntaxFactory.makeReturnStmt(
       returnKeyword: SyntaxFactory.makeReturnKeyword(),
-      expression: SyntaxFactory.makeBlankUnknownExpr())
+      expression: ExprSyntax(SyntaxFactory.makeBlankUnknownExpr()))
 
     var iterator = returnStmt.children.makeIterator()
-    XCTAssertNext(&iterator) { ($0 as? TokenSyntax)?.tokenKind == .returnKeyword }
-    XCTAssertNext(&iterator) { $0 is ExprSyntax }
+    XCTAssertNext(&iterator) { $0.as(TokenSyntax.self)?.tokenKind == .returnKeyword }
+    XCTAssertNext(&iterator) { $0.is(ExprSyntax.self) }
     XCTAssertNextIsNil(&iterator)
   }
 
@@ -26,7 +26,7 @@ public class SyntaxChildrenAPITestCase: XCTestCase {
       expression: nil)
 
     var iterator = returnStmt.children.makeIterator()
-    XCTAssertNext(&iterator) { ($0 as? TokenSyntax)?.tokenKind == .returnKeyword }
+    XCTAssertNext(&iterator) { $0.as(TokenSyntax.self)?.tokenKind == .returnKeyword }
     XCTAssertNextIsNil(&iterator)
   }
 

--- a/Tests/SwiftSyntaxTest/SyntaxCollections.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCollections.swift
@@ -4,7 +4,7 @@ import SwiftSyntax
 fileprivate func integerLiteralElement(_ int: Int) -> ArrayElementSyntax {
     let literal = SyntaxFactory.makeIntegerLiteral("\(int)")
     return SyntaxFactory.makeArrayElement(
-        expression: SyntaxFactory.makeIntegerLiteralExpr(digits: literal),
+        expression: ExprSyntax(SyntaxFactory.makeIntegerLiteralExpr(digits: literal)),
         trailingComma: nil)
 }
 

--- a/Tests/SwiftSyntaxTest/SyntaxFactory.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxFactory.swift
@@ -57,10 +57,10 @@ public class SyntaxFactoryAPITestCase: XCTestCase {
                    """)
 
     XCTAssertNotEqual(structDecl.members, renamed.members)
-    XCTAssertEqual(structDecl, structDecl.root as? StructDeclSyntax)
+    XCTAssertEqual(structDecl, StructDeclSyntax(structDecl.root))
     XCTAssertNil(structDecl.parent)
     XCTAssertNotNil(structDecl.members.parent)
-    XCTAssertEqual(structDecl.members.parent as? StructDeclSyntax, structDecl)
+    XCTAssertEqual(structDecl.members.parent.map(StructDeclSyntax.init), structDecl)
 
     XCTAssertEqual("\(structDecl.members.rightBrace)",
                    """
@@ -99,10 +99,10 @@ public class SyntaxFactoryAPITestCase: XCTestCase {
     let string = SyntaxFactory.makeStringLiteralExpr("Hello, world!")
     let printID = SyntaxFactory.makeVariableExpr("print")
     let arg = TupleExprElementSyntax {
-      $0.useExpression(string)
+      $0.useExpression(ExprSyntax(string))
     }
     let call = FunctionCallExprSyntax {
-      $0.useCalledExpression(printID)
+      $0.useCalledExpression(ExprSyntax(printID))
       $0.useLeftParen(SyntaxFactory.makeLeftParenToken())
       $0.addArgument(arg)
       $0.useRightParen(SyntaxFactory.makeRightParenToken())
@@ -112,7 +112,7 @@ public class SyntaxFactoryAPITestCase: XCTestCase {
     let terminatorArg = TupleExprElementSyntax {
       $0.useLabel(SyntaxFactory.makeIdentifier("terminator"))
       $0.useColon(SyntaxFactory.makeColonToken(trailingTrivia: .spaces(1)))
-      $0.useExpression(SyntaxFactory.makeStringLiteralExpr(" "))
+      $0.useExpression(ExprSyntax(SyntaxFactory.makeStringLiteralExpr(" ")))
     }
     let callWithTerminator = call.withArgumentList(
       SyntaxFactory.makeTupleExprElementList([
@@ -130,10 +130,10 @@ public class SyntaxFactoryAPITestCase: XCTestCase {
     let string = SyntaxFactory.makeStringLiteralExpr("Hello, world!")
     let printID = SyntaxFactory.makeVariableExpr("print")
     let arg = TupleExprElementSyntax {
-      $0.useExpression(string)
+      $0.useExpression(ExprSyntax(string))
     }
     let call1 = FunctionCallExprSyntax {
-      $0.useCalledExpression(printID)
+      $0.useCalledExpression(ExprSyntax(printID))
       $0.useLeftParen(SyntaxFactory.makeLeftParenToken())
       $0.addArgument(arg)
       $0.useRightParen(SyntaxFactory.makeRightParenToken())
@@ -146,7 +146,7 @@ public class SyntaxFactoryAPITestCase: XCTestCase {
     XCTAssertNil(call2.rightParen)
 
     let call3 = FunctionCallExprSyntax {
-      $0.useCalledExpression(printID)
+      $0.useCalledExpression(ExprSyntax(printID))
       $0.addArgument(arg)
     }
     XCTAssertNil(call3.leftParen)
@@ -159,8 +159,8 @@ public class SyntaxFactoryAPITestCase: XCTestCase {
     let unknown = SyntaxFactory.makeUnknownSyntax(
       tokens: [SyntaxFactory.makeLeftBraceToken()])
     XCTAssertTrue(unknown.isUnknown)
-    XCTAssertNoThrow(try SyntaxVerifier.verify(expr))
-    XCTAssertThrowsError(try SyntaxVerifier.verify(unknown))
+    XCTAssertNoThrow(try SyntaxVerifier.verify(Syntax(expr)))
+    XCTAssertThrowsError(try SyntaxVerifier.verify(Syntax(unknown)))
   }
 
   public func testMakeStringLiteralExpr() {
@@ -188,7 +188,9 @@ public class SyntaxFactoryAPITestCase: XCTestCase {
       let operatorExpr = BinaryOperatorExprSyntax {
         $0.useOperatorToken(operatorToken)
       }
-      let exprList = SyntaxFactory.makeExprList([first, operatorExpr, second])
+      let exprList = SyntaxFactory.makeExprList([ExprSyntax(first),
+                                                 ExprSyntax(operatorExpr),
+                                                 ExprSyntax(second)])
 
       XCTAssertEqual("\(exprList)", "1 \(operatorName) 1")
     }

--- a/Tests/SwiftSyntaxTest/VisitorTest.swift
+++ b/Tests/SwiftSyntaxTest/VisitorTest.swift
@@ -12,18 +12,18 @@ public class SyntaxVisitorTestCase: XCTestCase {
   ]
 
   public func testBasic() {
-    struct FuncCounter: SyntaxVisitor {
+    class FuncCounter: SyntaxVisitor {
       var funcCount = 0
-      mutating func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
+      override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
         funcCount += 1
         return .visitChildren
       }
     }
     XCTAssertNoThrow(try {
       let parsed = try SyntaxParser.parse(getInput("visitor.swift"))
-      var counter = FuncCounter()
+      let counter = FuncCounter()
       let hashBefore = parsed.hashValue
-      parsed.walk(&counter)
+      counter.walk(parsed)
       XCTAssertEqual(counter.funcCount, 3)
       XCTAssertEqual(hashBefore, parsed.hashValue)
     }())
@@ -68,10 +68,10 @@ public class SyntaxVisitorTestCase: XCTestCase {
   }
 
   public func testSyntaxRewriterVisitCollection() {
-    struct VisitCollections: SyntaxVisitor {
+    class VisitCollections: SyntaxVisitor {
       var numberOfCodeBlockItems = 0
 
-      mutating func visit(_ items: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
+      override func visit(_ items: CodeBlockItemListSyntax) -> SyntaxVisitorContinueKind {
         numberOfCodeBlockItems += items.count
         return .visitChildren
       }
@@ -79,14 +79,14 @@ public class SyntaxVisitorTestCase: XCTestCase {
 
     XCTAssertNoThrow(try {
       let parsed = try SyntaxParser.parse(getInput("nested-blocks.swift"))
-      var visitor = VisitCollections()
-      parsed.walk(&visitor)
+      let visitor = VisitCollections()
+      visitor.walk(parsed)
       XCTAssertEqual(4, visitor.numberOfCodeBlockItems)
     }())
   }
 
   public func testVisitorClass() {
-    class FuncCounter: SyntaxVisitorBase {
+    class FuncCounter: SyntaxVisitor {
       var funcCount = 0
       override func visit(_ node: FunctionDeclSyntax) -> SyntaxVisitorContinueKind {
         funcCount += 1
@@ -95,9 +95,9 @@ public class SyntaxVisitorTestCase: XCTestCase {
     }
     XCTAssertNoThrow(try {
       let parsed = try SyntaxParser.parse(getInput("visitor.swift"))
-      var counter = FuncCounter()
+      let counter = FuncCounter()
       let hashBefore = parsed.hashValue
-      parsed.walk(&counter)
+      counter.walk(parsed)
       XCTAssertEqual(counter.funcCount, 3)
       XCTAssertEqual(hashBefore, parsed.hashValue)
     }())

--- a/Tests/SwiftSyntaxTest/VisitorTest.swift
+++ b/Tests/SwiftSyntaxTest/VisitorTest.swift
@@ -33,7 +33,7 @@ public class SyntaxVisitorTestCase: XCTestCase {
     class ClosureRewriter: SyntaxRewriter {
       override func visit(_ node: ClosureExprSyntax) -> ExprSyntax {
         // Perform a no-op transform that requires rebuilding the node.
-        return node.withSignature(node.signature)
+        return ExprSyntax(node.withSignature(node.signature))
       }
     }
     XCTAssertNoThrow(try {
@@ -51,8 +51,8 @@ public class SyntaxVisitorTestCase: XCTestCase {
         self.transform = transform
       }
       override func visitAny(_ node: Syntax) -> Syntax? {
-        if let tok = node as? TokenSyntax {
-          return transform(tok)
+        if let tok = node.as(TokenSyntax.self) {
+          return Syntax(transform(tok))
         }
         return nil
       }


### PR DESCRIPTION
Since all the methods on the SyntaxVisitor were mutating, it makes more sense to model the SyntaxVisitor as a class. This also increases visitation performance.

## API Change

### `SyntaxVisitor`

* Structs that conformed to `SyntaxVisitor` need to become classes
* Otherwise, the change should be source compatible

### `SyntaxAnyVisitor`

* Structs that conformed to `SyntaxAnyVisitor` need to become classes
* Since `SyntaxAnyVisitor` no longer specializes `SyntaxVisitor` the methods were renamed from `visitAny` to the more generic name `visit(_ syntax: Syntax)`. The corresponding renaming needs to be done in the codebase.

## Performance improvements

Performance measurements were done by running an empty `SyntaxRewriter` / `SyntaxVisitor` on a Swift file with ~5000 lines of code. The baseline is the current performance of SwiftSyntax before #155 is merged.

### Empty `SyntaxVisitor`

|               | Before | After #155      | After this PR    |
|---------|--------|----------------|----------------|
| Debug   | 92.9ms | 112.1ms (+21%) | 107.9ms (+16%) |
| Release | 12.3ms | 12.6ms (+3%)   | 10.9ms (-12%)  |

### Empty `SyntaxAnyVisitor`

|         | Before  | After #155          | After this PR   |
|---------|---------|----------------|---------------|
| Debug   | 106.2ms | 136.2ms (+28%) | 115.3 (+9%) |
| Release | 24.8ms  | 15.5ms (-38%)  | 11.4ms (-54%)  |