### PR TITLE
Move additional swift compiler flags from build-script to Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,18 +1,7 @@
-// swift-tools-version:4.2
+// swift-tools-version:5.1
 
 import PackageDescription
-
-let package = Package(
-  name: "SwiftSyntax",
-  targets: [
-    .target(name: "_CSwiftSyntax"),
-    .target(name: "SwiftSyntax", dependencies: ["_CSwiftSyntax"]),
-    .testTarget(name: "SwiftSyntaxTest", dependencies: ["SwiftSyntax"], exclude: ["Inputs"]),
-    .target(name: "SwiftSyntaxBuilder", dependencies: ["SwiftSyntax"]),
-    .testTarget(name: "SwiftSyntaxBuilderTest", dependencies: ["SwiftSyntaxBuilder"]),
-    .target(name: "lit-test-helper", dependencies: ["SwiftSyntax"])
-  ]
-)
+import Foundation
 
 #if os(Linux)
 import Glibc
@@ -20,10 +9,52 @@ import Glibc
 import Darwin.C
 #endif
 
-if getenv("SWIFT_SYNTAX_BUILD_SCRIPT") == nil {
-  package.products.append(.library(name: "SwiftSyntax", targets: ["SwiftSyntax"]))
-  package.products.append(.library(name: "SwiftSyntaxBuilder", targets: ["SwiftSyntaxBuilder"]))
+let package = Package(
+  name: "SwiftSyntax",
+  targets: [
+    .target(name: "_CSwiftSyntax"),
+    .testTarget(name: "SwiftSyntaxTest", dependencies: ["SwiftSyntax"], exclude: ["Inputs"]),
+    .target(name: "SwiftSyntaxBuilder", dependencies: ["SwiftSyntax"]),
+    .testTarget(name: "SwiftSyntaxBuilderTest", dependencies: ["SwiftSyntaxBuilder"]),
+    .target(name: "lit-test-helper", dependencies: ["SwiftSyntax"])
+    // Also see targets added below
+  ]
+)
+
+let swiftSyntaxTarget: PackageDescription.Target
+
+/// If we are in a controlled CI environment, we can use internal compiler flags
+/// to speed up the build or improve it.
+if getenv("SWIFT_SYNTAX_CI_ENVIRONMENT") != nil {
+  let groupFile = URL(fileURLWithPath: #file)
+    .deletingLastPathComponent()
+    .appendingPathComponent("utils")
+    .appendingPathComponent("group.json")
+
+  var swiftSyntaxUnsafeFlags = ["-Xfrontend", "-group-info-path",
+                                "-Xfrontend", groupFile.path]
+  // Enforcing exclusivity increases compile time of release builds by 2 minutes.
+  // Disable it when we're in a controlled CI environment.
+  swiftSyntaxUnsafeFlags += ["-enforce-exclusivity=unchecked"]
+
+  swiftSyntaxTarget = .target(name: "SwiftSyntax", dependencies: ["_CSwiftSyntax"],
+                              swiftSettings: [.unsafeFlags(swiftSyntaxUnsafeFlags)]
+  )
 } else {
-  package.products.append(.library(name: "SwiftSyntax", type: .dynamic, targets: ["SwiftSyntax"]))
-  package.products.append(.library(name: "SwiftSyntaxBuilder", type: .dynamic, targets: ["SwiftSyntaxBuilder"]))
+  swiftSyntaxTarget = .target(name: "SwiftSyntax", dependencies: ["_CSwiftSyntax"])
 }
+
+package.targets.append(swiftSyntaxTarget)
+
+let libraryType: Product.Library.LibraryType
+
+/// When we're in a CI environment, we want to build a dylib instead of a static
+/// library since we install the dylib into the toolchain.
+if getenv("SWIFT_SYNTAX_CI_ENVIRONMENT") != nil {
+  libraryType = .dynamic
+} else {
+  libraryType = .static
+}
+
+package.products.append(.library(name: "SwiftSyntax", type: libraryType, targets: ["SwiftSyntax"]))
+package.products.append(.library(name: "SwiftSyntaxBuilder", type: libraryType, targets: ["SwiftSyntaxBuilder"]))


### PR DESCRIPTION
Moving all additional Swift compiler flags from `build-script.py` to `Package.swift` allows for a more consistent build, independent of whether build-script was used or not. 

This will allow us to use a unified build directory for all packages depending on Swift later on.