### PR TITLE
Make Syntax nodes conform to Identifiable

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -339,7 +339,7 @@ public extension SyntaxProtocol {
   }
 
   /// Returns a value representing the unique identity of the node.
-  var uniqueIdentifier: SyntaxIdentifier {
+  var id: SyntaxIdentifier {
     return data.nodeId
   }
 
@@ -600,7 +600,7 @@ extension ReversedTokenSequence: CustomReflectable {
 /// This is a more efficient representation than `Syntax` because it avoids casts
 /// to `Syntax` for representing the parent hierarchy.
 /// It provides generic information, like the node's position, range, and
-/// `uniqueIdentifier`, while still allowing getting the associated `Syntax`
+/// a unique `id`, while still allowing getting the associated `Syntax`
 /// object if necessary.
 ///
 /// `SyntaxParser` uses `SyntaxNode` to efficiently report which syntax nodes
@@ -668,7 +668,7 @@ public struct SyntaxNode {
   }
 
   /// Returns a value representing the unique identity of the node.
-  public var uniqueIdentifier: SyntaxIdentifier {
+  public var id: SyntaxIdentifier {
     return absoluteRaw.info.nodeId
   }
 }

--- a/Tests/SwiftSyntaxTest/IncrementalParsingTests.swift
+++ b/Tests/SwiftSyntaxTest/IncrementalParsingTests.swift
@@ -44,10 +44,10 @@ public class IncrementalParsingTestCase: XCTestCase {
     XCTAssertEqual("\(reusedNode)", "\nstruct B {}")
 
     XCTAssertEqual(newStructB.byteRange, reusedRange)
-    XCTAssertEqual(origStructB.uniqueIdentifier, reusedNode.uniqueIdentifier)
+    XCTAssertEqual(origStructB.id, reusedNode.id)
     XCTAssertEqual(origStructB, reusedNode.asCodeBlockItem)
     XCTAssertTrue(reusedNode.isCodeBlockItem)
     XCTAssertEqual(origStructB, reusedNode.asCodeBlockItem!)
-    XCTAssertEqual(origStructB.parent!.uniqueIdentifier, reusedNode.parent!.uniqueIdentifier)
+    XCTAssertEqual(origStructB.parent!.id, reusedNode.parent!.id)
   }
 }

--- a/Tests/SwiftSyntaxTest/SyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTests.swift
@@ -57,12 +57,12 @@ public class SyntaxAPITestCase: XCTestCase {
     let tokset = Set(toks+rtoks)
     XCTAssertEqual(tokset.count, 6)
 
-    XCTAssertEqual(toks[0].uniqueIdentifier, rtoks[5].uniqueIdentifier)
-    XCTAssertEqual(toks[1].uniqueIdentifier, rtoks[4].uniqueIdentifier)
-    XCTAssertEqual(toks[2].uniqueIdentifier, rtoks[3].uniqueIdentifier)
-    XCTAssertEqual(toks[3].uniqueIdentifier, rtoks[2].uniqueIdentifier)
-    XCTAssertEqual(toks[4].uniqueIdentifier, rtoks[1].uniqueIdentifier)
-    XCTAssertEqual(toks[5].uniqueIdentifier, rtoks[0].uniqueIdentifier)
+    XCTAssertEqual(toks[0].id, rtoks[5].id)
+    XCTAssertEqual(toks[1].id, rtoks[4].id)
+    XCTAssertEqual(toks[2].id, rtoks[3].id)
+    XCTAssertEqual(toks[3].id, rtoks[2].id)
+    XCTAssertEqual(toks[4].id, rtoks[1].id)
+    XCTAssertEqual(toks[5].id, rtoks[0].id)
   }
 
   public func testPositions() {


### PR DESCRIPTION
Since we already have a stable ID (`SyntaxIdentifier`), we can make the syntax nodes conform to Identifiable. Since `Identifiable` requires an `id` property, that property will become the canonical way of accessing the `SyntaxIdentifier`.