### PR TITLE
Get SwiftSyntax ready for building in a unified build with other projects

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let swiftSyntaxTarget: PackageDescription.Target
 
 /// If we are in a controlled CI environment, we can use internal compiler flags
 /// to speed up the build or improve it.
-if getenv("SWIFT_SYNTAX_CI_ENVIRONMENT") != nil {
+if getenv("SWIFT_BUILD_SCRIPT_ENVIRONMENT") != nil {
   let groupFile = URL(fileURLWithPath: #file)
     .deletingLastPathComponent()
     .appendingPathComponent("utils")
@@ -48,9 +48,9 @@ package.targets.append(swiftSyntaxTarget)
 
 let libraryType: Product.Library.LibraryType
 
-/// When we're in a CI environment, we want to build a dylib instead of a static
-/// library since we install the dylib into the toolchain.
-if getenv("SWIFT_SYNTAX_CI_ENVIRONMENT") != nil {
+/// When we're in a build-script environment, we want to build a dylib instead
+/// of a static library since we install the dylib into the toolchain.
+if getenv("SWIFT_BUILD_SCRIPT_ENVIRONMENT") != nil {
   libraryType = .dynamic
 } else {
   libraryType = .static


### PR DESCRIPTION
Avoid recompiling SwiftSyntax for every project that depends on it by building all of these projects in a unified build. 

This PR gets SwiftSyntax ready for the unified build by providing a `--multiroot-data-file` command line option with which the workspace for the unified build can be specified. Furthermore it sets environment variables that configure the builds of downstream jobs to use local dependencies.

See https://github.com/apple/swift/pull/28005