### PR TITLE
Change casting function to SyntaxEnum to as(SyntaxEnum.self)

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -53,7 +53,7 @@ Note: This is in reverse chronological order, so newer entries are added to the 
   ```swift
   let node: Syntax
   
-  switch node.asSyntaxEnum {
+  switch node.as(SyntaxEnum.self) {
     case .identifierExpr(let identifierExprSyntax):
     /* ... */
   }

--- a/Sources/SwiftSyntax/Misc.swift.gyb
+++ b/Sources/SwiftSyntax/Misc.swift.gyb
@@ -43,7 +43,7 @@ public extension Syntax {
   /// Retrieve the concretely typed node that this Syntax node wraps.
   /// This property is exposed for testing purposes only.
   var _asConcreteType: Any {
-    switch self.asSyntaxEnum {
+    switch self.as(SyntaxEnum.self) {
     case .token(let node):
       return node
     case .unknown(let node):

--- a/Sources/SwiftSyntax/SyntaxEnum.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxEnum.swift.gyb
@@ -34,7 +34,7 @@ public enum SyntaxEnum {
 
 public extension Syntax {
   /// Get an enum that can be used to exhaustively switch over all syntax nodes.
-  var asSyntaxEnum: SyntaxEnum {
+  func `as`(_: SyntaxEnum.Type) -> SyntaxEnum {
     switch raw.kind {
     case .token:
       return .token(TokenSyntax(self)!)

--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -1352,7 +1352,7 @@ public extension Syntax {
   /// Retrieve the concretely typed node that this Syntax node wraps.
   /// This property is exposed for testing purposes only.
   var _asConcreteType: Any {
-    switch self.asSyntaxEnum {
+    switch self.as(SyntaxEnum.self) {
     case .token(let node):
       return node
     case .unknown(let node):

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -246,7 +246,7 @@ public enum SyntaxEnum {
 
 public extension Syntax {
   /// Get an enum that can be used to exhaustively switch over all syntax nodes.
-  var asSyntaxEnum: SyntaxEnum {
+  func `as`(_: SyntaxEnum.Type) -> SyntaxEnum {
     switch raw.kind {
     case .token:
       return .token(TokenSyntax(self)!)


### PR DESCRIPTION
`SyntaxEnum` is the only place that uses the `asSyntaxEnum`-style casting.
Make the syntax more consistent with the other `as(Something.self)` casting functions.