### PR TITLE
Add casting methods to protocols

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -101,6 +101,15 @@ For increased performance, the modelling of the syntax node hierarchy has been s
   exprSyntax.is(IdentifierExprSyntax.self)
   ```
 
+- To retrieve the non-type erased version of a type, use the `as(_: SyntaxProtocol.self)` method
+
+  ```swift
+  let identifierExprSyntax: IdentifierExprSyntax = /* ... */
+  let node = Syntax(identifierExprSyntax)
+  node.as(SyntaxProtocol.self) // returns a IdentifierExprSyntax with static type SyntaxProtocol
+  node.as(ExprSyntaxProtocol.self) // returns a IdentifierExprSyntax with static type ExprSyntaxProtocol?
+  ```
+
 
 - Downcasting can no longer be performed using the `as` operator. For downcasting use the `as(_: SyntaxProtocol)` method on any type eraser. ([#155](https://github.com/apple/swift-syntax/pull/155))
 

--- a/Sources/SwiftSyntax/Misc.swift.gyb
+++ b/Sources/SwiftSyntax/Misc.swift.gyb
@@ -39,10 +39,16 @@ extension SyntaxNode {
 % end
 }
 
-public extension Syntax {
-  /// Retrieve the concretely typed node that this Syntax node wraps.
-  /// This property is exposed for testing purposes only.
-  var _asConcreteType: Any {
+extension Syntax {
+  /// Syntax nodes always conform to SyntaxProtocol. This API is just added
+  /// for consistency.
+  @available(*, deprecated, message: "Expression always evaluates to true")
+  public func `is`(_: SyntaxProtocol.Protocol) -> Bool {
+    return true
+  }
+
+  /// Return the non-type erased version of this syntax node.
+  public func `as`(_: SyntaxProtocol.Protocol) -> SyntaxProtocol {
     switch self.as(SyntaxEnum.self) {
     case .token(let node):
       return node

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -53,7 +53,7 @@ extension Syntax: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: self._asConcreteType)
+    return Mirror(reflecting: self.as(SyntaxProtocol.self))
   }
 }
 

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -1,4 +1,4 @@
-//===-------------------- Syntax.swift - Syntax Protocol ------------------===//
+//===--------------- Syntax.swift - Base Syntax Type eraser  --------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -13,7 +13,7 @@
 /// A Syntax node represents a tree of nodes with tokens at the leaves.
 /// Each node has accessors for its known children, and allows efficient
 /// iteration over the children through its `children` property.
-public struct Syntax: SyntaxProtocol {
+public struct Syntax: SyntaxProtocol, SyntaxHashable {
   let data: SyntaxData
 
   public var _syntaxNode: Syntax {
@@ -57,11 +57,26 @@ extension Syntax: CustomReflectable {
   }
 }
 
+/// Protocol that provides a common Hashable implementation for all syntax nodes
+public protocol SyntaxHashable: Hashable {
+  var _syntaxNode: Syntax { get }
+}
+
+public extension SyntaxHashable {
+  func hash(into hasher: inout Hasher) {
+    return _syntaxNode.data.nodeId.hash(into: &hasher)
+  }
+
+  static func ==(lhs: Self, rhs: Self) -> Bool {
+    return lhs._syntaxNode.data.nodeId == rhs._syntaxNode.data.nodeId
+  }
+}
+
 /// Provide common functionality for specialized syntax nodes. Extend this
 /// protocol to provide common functionality for all syntax nodes.
 /// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
 public protocol SyntaxProtocol: CustomStringConvertible,
-    CustomDebugStringConvertible, TextOutputStreamable, Hashable {
+    CustomDebugStringConvertible, TextOutputStreamable {
 
   /// Retrieve the generic syntax node that is represented by this node.
   /// Do not retrieve this property directly. Use `Syntax(self)` instead.
@@ -414,14 +429,6 @@ public extension SyntaxProtocol {
   func write<Target>(to target: inout Target)
     where Target: TextOutputStream {
     data.raw.write(to: &target)
-  }
-
-  func hash(into hasher: inout Hasher) {
-    return data.nodeId.hash(into: &hasher)
-  }
-
-  static func ==(lhs: Self, rhs: Self) -> Bool {
-    return lhs.data.nodeId == rhs.data.nodeId
   }
 }
 

--- a/Sources/SwiftSyntax/SyntaxBaseNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxBaseNodes.swift.gyb
@@ -29,6 +29,20 @@
 /// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
 public protocol ${node.name}Protocol: ${base_type}Protocol {}
 
+public extension Syntax {
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// ${node.name}Protocol. 
+  func `is`(_: ${node.name}Protocol.Protocol) -> Bool {
+    return self.as(${node.name}Protocol.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// ${node.name}Protocol. Otherwise return nil.
+  func `as`(_: ${node.name}Protocol.Protocol) -> ${node.name}Protocol? {
+    return self.as(SyntaxProtocol.self) as? ${node.name}Protocol
+  }
+}
+
 %     for line in dedented_lines(node.description):
 /// ${line}
 %     end
@@ -83,13 +97,25 @@ public struct ${node.name}: ${node.name}Protocol, SyntaxHashable {
   public func `as`<S: ${node.name}Protocol>(_ syntaxType: S.Type) -> S? {
     return S.init(_syntaxNode)
   }
+
+  /// Syntax nodes always conform to `${node.name}Protocol`. This API is just
+  /// added for consistency.
+  @available(*, deprecated, message: "Expression always evaluates to true")
+  public func `is`(_: ${node.name}Protocol.Protocol) -> Bool {
+    return true
+  }
+
+  /// Return the non-type erased version of this syntax node.
+  public func `as`(_: ${node.name}Protocol.Protocol) -> ${node.name}Protocol {
+    return Syntax(self).as(${node.name}Protocol.self)!
+  }
 }
 
 extension ${node.name}: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: Syntax(self)._asConcreteType)
+    return Mirror(reflecting: Syntax(self).as(SyntaxProtocol.self))
   }
 }
 

--- a/Sources/SwiftSyntax/SyntaxBaseNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxBaseNodes.swift.gyb
@@ -32,7 +32,7 @@ public protocol ${node.name}Protocol: ${base_type}Protocol {}
 %     for line in dedented_lines(node.description):
 /// ${line}
 %     end
-public struct ${node.name}: ${node.name}Protocol {
+public struct ${node.name}: ${node.name}Protocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   public init<S: ${node.name}Protocol>(_ syntax: S) {

--- a/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -31,7 +31,7 @@ public protocol SyntaxCollection: SyntaxProtocol, Sequence {
 /// `${node.collection_element_type}` nodes. ${node.name} behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct ${node.name}: SyntaxCollection {
+public struct ${node.name}: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `${node.name}` if possible. Returns 

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
@@ -162,9 +162,9 @@ extension ${node.name}: CustomReflectable {
     return Mirror(self, children: [
 %     for child in node.children:
 %       if child.is_optional:
-      "${child.swift_name}": ${child.swift_name}.map(Syntax.init)?._asConcreteType as Any,
+      "${child.swift_name}": ${child.swift_name}.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
 %       else:
-      "${child.swift_name}": Syntax(${child.swift_name})._asConcreteType,
+      "${child.swift_name}": Syntax(${child.swift_name}).as(SyntaxProtocol.self),
 %       end
 %     end
     ])

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
@@ -46,7 +46,7 @@ nodes whose base kind are that specified kind.
 %     for line in dedented_lines(node.description):
 /// ${line}
 %     end
-public struct ${node.name}: ${base_type}Protocol {
+public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
 %     # ======
 %     # Cursor
 %     # ======

--- a/Sources/SwiftSyntax/SyntaxOtherNodes.swift
+++ b/Sources/SwiftSyntax/SyntaxOtherNodes.swift
@@ -15,7 +15,7 @@
 // MARK: UnknownSyntax
 
 /// A wrapper around a raw Syntax layout.
-public struct UnknownSyntax: SyntaxProtocol {
+public struct UnknownSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Convert the given `Syntax` node to an `UnknownSyntax` if possible. Return
@@ -43,7 +43,7 @@ extension UnknownSyntax: CustomReflectable {
 // MARK: TokenSyntax
 
 /// A Syntax node representing a single token.
-public struct TokenSyntax: SyntaxProtocol {
+public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TokenSyntax` if possible. Returns

--- a/Sources/SwiftSyntax/SyntaxTraits.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxTraits.swift.gyb
@@ -20,6 +20,8 @@
 //===----------------------------------------------------------------------===//
 
 % for trait in TRAITS:
+// MARK: - ${trait.trait_name}Syntax
+
 public protocol ${trait.trait_name}Syntax: SyntaxProtocol {
 % for child in trait.children:
 %   ret_type = child.type_name
@@ -30,6 +32,21 @@ public protocol ${trait.trait_name}Syntax: SyntaxProtocol {
   func with${child.name}(_ newChild: ${child.type_name}?) -> Self
 % end
 }
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// `${trait.trait_name}Syntax`. 
+  func `is`(_: ${trait.trait_name}Syntax.Protocol) -> Bool {
+    return self.as(${trait.trait_name}Syntax.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// `${trait.trait_name}Syntax`. Otherwise return `nil`.
+  func `as`(_: ${trait.trait_name}Syntax.Protocol) -> ${trait.trait_name}Syntax? {
+    return Syntax(self).as(SyntaxProtocol.self) as? ${trait.trait_name}Syntax
+  }
+}
+
 % end
 
 % for node in SYNTAX_NODES:

--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -1348,10 +1348,16 @@ extension SyntaxNode {
   }
 }
 
-public extension Syntax {
-  /// Retrieve the concretely typed node that this Syntax node wraps.
-  /// This property is exposed for testing purposes only.
-  var _asConcreteType: Any {
+extension Syntax {
+  /// Syntax nodes always conform to SyntaxProtocol. This API is just added
+  /// for consistency.
+  @available(*, deprecated, message: "Expression always evaluates to true")
+  public func `is`(_: SyntaxProtocol.Protocol) -> Bool {
+    return true
+  }
+
+  /// Return the non-type erased version of this syntax node.
+  public func `as`(_: SyntaxProtocol.Protocol) -> SyntaxProtocol {
     switch self.as(SyntaxEnum.self) {
     case .token(let node):
       return node

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
@@ -19,7 +19,7 @@
 /// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
 public protocol DeclSyntaxProtocol: SyntaxProtocol {}
 
-public struct DeclSyntax: DeclSyntaxProtocol {
+public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   public init<S: DeclSyntaxProtocol>(_ syntax: S) {
@@ -81,7 +81,7 @@ extension DeclSyntax: CustomReflectable {
 /// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
 public protocol ExprSyntaxProtocol: SyntaxProtocol {}
 
-public struct ExprSyntax: ExprSyntaxProtocol {
+public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   public init<S: ExprSyntaxProtocol>(_ syntax: S) {
@@ -143,7 +143,7 @@ extension ExprSyntax: CustomReflectable {
 /// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
 public protocol StmtSyntaxProtocol: SyntaxProtocol {}
 
-public struct StmtSyntax: StmtSyntaxProtocol {
+public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   public init<S: StmtSyntaxProtocol>(_ syntax: S) {
@@ -205,7 +205,7 @@ extension StmtSyntax: CustomReflectable {
 /// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
 public protocol TypeSyntaxProtocol: SyntaxProtocol {}
 
-public struct TypeSyntax: TypeSyntaxProtocol {
+public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   public init<S: TypeSyntaxProtocol>(_ syntax: S) {
@@ -267,7 +267,7 @@ extension TypeSyntax: CustomReflectable {
 /// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
 public protocol PatternSyntaxProtocol: SyntaxProtocol {}
 
-public struct PatternSyntax: PatternSyntaxProtocol {
+public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   public init<S: PatternSyntaxProtocol>(_ syntax: S) {

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
@@ -19,6 +19,20 @@
 /// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
 public protocol DeclSyntaxProtocol: SyntaxProtocol {}
 
+public extension Syntax {
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// DeclSyntaxProtocol. 
+  func `is`(_: DeclSyntaxProtocol.Protocol) -> Bool {
+    return self.as(DeclSyntaxProtocol.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// DeclSyntaxProtocol. Otherwise return nil.
+  func `as`(_: DeclSyntaxProtocol.Protocol) -> DeclSyntaxProtocol? {
+    return self.as(SyntaxProtocol.self) as? DeclSyntaxProtocol
+  }
+}
+
 public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
 
@@ -64,13 +78,25 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func `as`<S: DeclSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return S.init(_syntaxNode)
   }
+
+  /// Syntax nodes always conform to `DeclSyntaxProtocol`. This API is just
+  /// added for consistency.
+  @available(*, deprecated, message: "Expression always evaluates to true")
+  public func `is`(_: DeclSyntaxProtocol.Protocol) -> Bool {
+    return true
+  }
+
+  /// Return the non-type erased version of this syntax node.
+  public func `as`(_: DeclSyntaxProtocol.Protocol) -> DeclSyntaxProtocol {
+    return Syntax(self).as(DeclSyntaxProtocol.self)!
+  }
 }
 
 extension DeclSyntax: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: Syntax(self)._asConcreteType)
+    return Mirror(reflecting: Syntax(self).as(SyntaxProtocol.self))
   }
 }
 
@@ -80,6 +106,20 @@ extension DeclSyntax: CustomReflectable {
 /// common methods to all `ExprSyntax` nodes.
 /// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
 public protocol ExprSyntaxProtocol: SyntaxProtocol {}
+
+public extension Syntax {
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// ExprSyntaxProtocol. 
+  func `is`(_: ExprSyntaxProtocol.Protocol) -> Bool {
+    return self.as(ExprSyntaxProtocol.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// ExprSyntaxProtocol. Otherwise return nil.
+  func `as`(_: ExprSyntaxProtocol.Protocol) -> ExprSyntaxProtocol? {
+    return self.as(SyntaxProtocol.self) as? ExprSyntaxProtocol
+  }
+}
 
 public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
@@ -126,13 +166,25 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func `as`<S: ExprSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return S.init(_syntaxNode)
   }
+
+  /// Syntax nodes always conform to `ExprSyntaxProtocol`. This API is just
+  /// added for consistency.
+  @available(*, deprecated, message: "Expression always evaluates to true")
+  public func `is`(_: ExprSyntaxProtocol.Protocol) -> Bool {
+    return true
+  }
+
+  /// Return the non-type erased version of this syntax node.
+  public func `as`(_: ExprSyntaxProtocol.Protocol) -> ExprSyntaxProtocol {
+    return Syntax(self).as(ExprSyntaxProtocol.self)!
+  }
 }
 
 extension ExprSyntax: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: Syntax(self)._asConcreteType)
+    return Mirror(reflecting: Syntax(self).as(SyntaxProtocol.self))
   }
 }
 
@@ -142,6 +194,20 @@ extension ExprSyntax: CustomReflectable {
 /// common methods to all `StmtSyntax` nodes.
 /// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
 public protocol StmtSyntaxProtocol: SyntaxProtocol {}
+
+public extension Syntax {
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// StmtSyntaxProtocol. 
+  func `is`(_: StmtSyntaxProtocol.Protocol) -> Bool {
+    return self.as(StmtSyntaxProtocol.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// StmtSyntaxProtocol. Otherwise return nil.
+  func `as`(_: StmtSyntaxProtocol.Protocol) -> StmtSyntaxProtocol? {
+    return self.as(SyntaxProtocol.self) as? StmtSyntaxProtocol
+  }
+}
 
 public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
@@ -188,13 +254,25 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func `as`<S: StmtSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return S.init(_syntaxNode)
   }
+
+  /// Syntax nodes always conform to `StmtSyntaxProtocol`. This API is just
+  /// added for consistency.
+  @available(*, deprecated, message: "Expression always evaluates to true")
+  public func `is`(_: StmtSyntaxProtocol.Protocol) -> Bool {
+    return true
+  }
+
+  /// Return the non-type erased version of this syntax node.
+  public func `as`(_: StmtSyntaxProtocol.Protocol) -> StmtSyntaxProtocol {
+    return Syntax(self).as(StmtSyntaxProtocol.self)!
+  }
 }
 
 extension StmtSyntax: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: Syntax(self)._asConcreteType)
+    return Mirror(reflecting: Syntax(self).as(SyntaxProtocol.self))
   }
 }
 
@@ -204,6 +282,20 @@ extension StmtSyntax: CustomReflectable {
 /// common methods to all `TypeSyntax` nodes.
 /// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
 public protocol TypeSyntaxProtocol: SyntaxProtocol {}
+
+public extension Syntax {
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// TypeSyntaxProtocol. 
+  func `is`(_: TypeSyntaxProtocol.Protocol) -> Bool {
+    return self.as(TypeSyntaxProtocol.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// TypeSyntaxProtocol. Otherwise return nil.
+  func `as`(_: TypeSyntaxProtocol.Protocol) -> TypeSyntaxProtocol? {
+    return self.as(SyntaxProtocol.self) as? TypeSyntaxProtocol
+  }
+}
 
 public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
@@ -250,13 +342,25 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func `as`<S: TypeSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return S.init(_syntaxNode)
   }
+
+  /// Syntax nodes always conform to `TypeSyntaxProtocol`. This API is just
+  /// added for consistency.
+  @available(*, deprecated, message: "Expression always evaluates to true")
+  public func `is`(_: TypeSyntaxProtocol.Protocol) -> Bool {
+    return true
+  }
+
+  /// Return the non-type erased version of this syntax node.
+  public func `as`(_: TypeSyntaxProtocol.Protocol) -> TypeSyntaxProtocol {
+    return Syntax(self).as(TypeSyntaxProtocol.self)!
+  }
 }
 
 extension TypeSyntax: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: Syntax(self)._asConcreteType)
+    return Mirror(reflecting: Syntax(self).as(SyntaxProtocol.self))
   }
 }
 
@@ -266,6 +370,20 @@ extension TypeSyntax: CustomReflectable {
 /// common methods to all `PatternSyntax` nodes.
 /// DO NOT CONFORM TO THIS PROTOCOL YOURSELF!
 public protocol PatternSyntaxProtocol: SyntaxProtocol {}
+
+public extension Syntax {
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// PatternSyntaxProtocol. 
+  func `is`(_: PatternSyntaxProtocol.Protocol) -> Bool {
+    return self.as(PatternSyntaxProtocol.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// PatternSyntaxProtocol. Otherwise return nil.
+  func `as`(_: PatternSyntaxProtocol.Protocol) -> PatternSyntaxProtocol? {
+    return self.as(SyntaxProtocol.self) as? PatternSyntaxProtocol
+  }
+}
 
 public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public let _syntaxNode: Syntax
@@ -312,13 +430,25 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func `as`<S: PatternSyntaxProtocol>(_ syntaxType: S.Type) -> S? {
     return S.init(_syntaxNode)
   }
+
+  /// Syntax nodes always conform to `PatternSyntaxProtocol`. This API is just
+  /// added for consistency.
+  @available(*, deprecated, message: "Expression always evaluates to true")
+  public func `is`(_: PatternSyntaxProtocol.Protocol) -> Bool {
+    return true
+  }
+
+  /// Return the non-type erased version of this syntax node.
+  public func `as`(_: PatternSyntaxProtocol.Protocol) -> PatternSyntaxProtocol {
+    return Syntax(self).as(PatternSyntaxProtocol.self)!
+  }
 }
 
 extension PatternSyntax: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: Syntax(self)._asConcreteType)
+    return Mirror(reflecting: Syntax(self).as(SyntaxProtocol.self))
   }
 }
 

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
@@ -22,7 +22,7 @@ public protocol SyntaxCollection: SyntaxProtocol, Sequence {
 /// `CodeBlockItemSyntax` nodes. CodeBlockItemListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct CodeBlockItemListSyntax: SyntaxCollection {
+public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `CodeBlockItemListSyntax` if possible. Returns 
@@ -258,7 +258,7 @@ extension CodeBlockItemListSyntax: Sequence {
 /// `TupleExprElementSyntax` nodes. TupleExprElementListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct TupleExprElementListSyntax: SyntaxCollection {
+public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TupleExprElementListSyntax` if possible. Returns 
@@ -494,7 +494,7 @@ extension TupleExprElementListSyntax: Sequence {
 /// `ArrayElementSyntax` nodes. ArrayElementListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct ArrayElementListSyntax: SyntaxCollection {
+public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ArrayElementListSyntax` if possible. Returns 
@@ -730,7 +730,7 @@ extension ArrayElementListSyntax: Sequence {
 /// `DictionaryElementSyntax` nodes. DictionaryElementListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct DictionaryElementListSyntax: SyntaxCollection {
+public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DictionaryElementListSyntax` if possible. Returns 
@@ -966,7 +966,7 @@ extension DictionaryElementListSyntax: Sequence {
 /// `Syntax` nodes. StringLiteralSegmentsSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct StringLiteralSegmentsSyntax: SyntaxCollection {
+public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `StringLiteralSegmentsSyntax` if possible. Returns 
@@ -1202,7 +1202,7 @@ extension StringLiteralSegmentsSyntax: Sequence {
 /// `DeclNameArgumentSyntax` nodes. DeclNameArgumentListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct DeclNameArgumentListSyntax: SyntaxCollection {
+public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DeclNameArgumentListSyntax` if possible. Returns 
@@ -1438,7 +1438,7 @@ extension DeclNameArgumentListSyntax: Sequence {
 /// `ExprSyntax` nodes. ExprListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct ExprListSyntax: SyntaxCollection {
+public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ExprListSyntax` if possible. Returns 
@@ -1674,7 +1674,7 @@ extension ExprListSyntax: Sequence {
 /// `ClosureCaptureItemSyntax` nodes. ClosureCaptureItemListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct ClosureCaptureItemListSyntax: SyntaxCollection {
+public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ClosureCaptureItemListSyntax` if possible. Returns 
@@ -1910,7 +1910,7 @@ extension ClosureCaptureItemListSyntax: Sequence {
 /// `ClosureParamSyntax` nodes. ClosureParamListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct ClosureParamListSyntax: SyntaxCollection {
+public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ClosureParamListSyntax` if possible. Returns 
@@ -2146,7 +2146,7 @@ extension ClosureParamListSyntax: Sequence {
 /// `ObjcNamePieceSyntax` nodes. ObjcNameSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct ObjcNameSyntax: SyntaxCollection {
+public struct ObjcNameSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ObjcNameSyntax` if possible. Returns 
@@ -2382,7 +2382,7 @@ extension ObjcNameSyntax: Sequence {
 /// `FunctionParameterSyntax` nodes. FunctionParameterListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct FunctionParameterListSyntax: SyntaxCollection {
+public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `FunctionParameterListSyntax` if possible. Returns 
@@ -2618,7 +2618,7 @@ extension FunctionParameterListSyntax: Sequence {
 /// `IfConfigClauseSyntax` nodes. IfConfigClauseListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct IfConfigClauseListSyntax: SyntaxCollection {
+public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `IfConfigClauseListSyntax` if possible. Returns 
@@ -2854,7 +2854,7 @@ extension IfConfigClauseListSyntax: Sequence {
 /// `InheritedTypeSyntax` nodes. InheritedTypeListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct InheritedTypeListSyntax: SyntaxCollection {
+public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `InheritedTypeListSyntax` if possible. Returns 
@@ -3090,7 +3090,7 @@ extension InheritedTypeListSyntax: Sequence {
 /// `MemberDeclListItemSyntax` nodes. MemberDeclListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct MemberDeclListSyntax: SyntaxCollection {
+public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `MemberDeclListSyntax` if possible. Returns 
@@ -3326,7 +3326,7 @@ extension MemberDeclListSyntax: Sequence {
 /// `DeclModifierSyntax` nodes. ModifierListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct ModifierListSyntax: SyntaxCollection {
+public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ModifierListSyntax` if possible. Returns 
@@ -3562,7 +3562,7 @@ extension ModifierListSyntax: Sequence {
 /// `AccessPathComponentSyntax` nodes. AccessPathSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct AccessPathSyntax: SyntaxCollection {
+public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AccessPathSyntax` if possible. Returns 
@@ -3798,7 +3798,7 @@ extension AccessPathSyntax: Sequence {
 /// `AccessorDeclSyntax` nodes. AccessorListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct AccessorListSyntax: SyntaxCollection {
+public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AccessorListSyntax` if possible. Returns 
@@ -4034,7 +4034,7 @@ extension AccessorListSyntax: Sequence {
 /// `PatternBindingSyntax` nodes. PatternBindingListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct PatternBindingListSyntax: SyntaxCollection {
+public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PatternBindingListSyntax` if possible. Returns 
@@ -4270,7 +4270,7 @@ extension PatternBindingListSyntax: Sequence {
 /// `EnumCaseElementSyntax` nodes. EnumCaseElementListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct EnumCaseElementListSyntax: SyntaxCollection {
+public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `EnumCaseElementListSyntax` if possible. Returns 
@@ -4506,7 +4506,7 @@ extension EnumCaseElementListSyntax: Sequence {
 /// `TokenSyntax` nodes. IdentifierListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct IdentifierListSyntax: SyntaxCollection {
+public struct IdentifierListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `IdentifierListSyntax` if possible. Returns 
@@ -4742,7 +4742,7 @@ extension IdentifierListSyntax: Sequence {
 /// `Syntax` nodes. PrecedenceGroupAttributeListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection {
+public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PrecedenceGroupAttributeListSyntax` if possible. Returns 
@@ -4978,7 +4978,7 @@ extension PrecedenceGroupAttributeListSyntax: Sequence {
 /// `PrecedenceGroupNameElementSyntax` nodes. PrecedenceGroupNameListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct PrecedenceGroupNameListSyntax: SyntaxCollection {
+public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PrecedenceGroupNameListSyntax` if possible. Returns 
@@ -5214,7 +5214,7 @@ extension PrecedenceGroupNameListSyntax: Sequence {
 /// `TokenSyntax` nodes. TokenListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct TokenListSyntax: SyntaxCollection {
+public struct TokenListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TokenListSyntax` if possible. Returns 
@@ -5450,7 +5450,7 @@ extension TokenListSyntax: Sequence {
 /// `TokenSyntax` nodes. NonEmptyTokenListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct NonEmptyTokenListSyntax: SyntaxCollection {
+public struct NonEmptyTokenListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `NonEmptyTokenListSyntax` if possible. Returns 
@@ -5686,7 +5686,7 @@ extension NonEmptyTokenListSyntax: Sequence {
 /// `Syntax` nodes. AttributeListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct AttributeListSyntax: SyntaxCollection {
+public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AttributeListSyntax` if possible. Returns 
@@ -5922,7 +5922,7 @@ extension AttributeListSyntax: Sequence {
 /// `Syntax` nodes. SpecializeAttributeSpecListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct SpecializeAttributeSpecListSyntax: SyntaxCollection {
+public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SpecializeAttributeSpecListSyntax` if possible. Returns 
@@ -6158,7 +6158,7 @@ extension SpecializeAttributeSpecListSyntax: Sequence {
 /// `ObjCSelectorPieceSyntax` nodes. ObjCSelectorSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct ObjCSelectorSyntax: SyntaxCollection {
+public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ObjCSelectorSyntax` if possible. Returns 
@@ -6394,7 +6394,7 @@ extension ObjCSelectorSyntax: Sequence {
 /// `Syntax` nodes. SwitchCaseListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct SwitchCaseListSyntax: SyntaxCollection {
+public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SwitchCaseListSyntax` if possible. Returns 
@@ -6630,7 +6630,7 @@ extension SwitchCaseListSyntax: Sequence {
 /// `CatchClauseSyntax` nodes. CatchClauseListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct CatchClauseListSyntax: SyntaxCollection {
+public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `CatchClauseListSyntax` if possible. Returns 
@@ -6866,7 +6866,7 @@ extension CatchClauseListSyntax: Sequence {
 /// `CaseItemSyntax` nodes. CaseItemListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct CaseItemListSyntax: SyntaxCollection {
+public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `CaseItemListSyntax` if possible. Returns 
@@ -7102,7 +7102,7 @@ extension CaseItemListSyntax: Sequence {
 /// `ConditionElementSyntax` nodes. ConditionElementListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct ConditionElementListSyntax: SyntaxCollection {
+public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ConditionElementListSyntax` if possible. Returns 
@@ -7338,7 +7338,7 @@ extension ConditionElementListSyntax: Sequence {
 /// `GenericRequirementSyntax` nodes. GenericRequirementListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct GenericRequirementListSyntax: SyntaxCollection {
+public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `GenericRequirementListSyntax` if possible. Returns 
@@ -7574,7 +7574,7 @@ extension GenericRequirementListSyntax: Sequence {
 /// `GenericParameterSyntax` nodes. GenericParameterListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct GenericParameterListSyntax: SyntaxCollection {
+public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `GenericParameterListSyntax` if possible. Returns 
@@ -7810,7 +7810,7 @@ extension GenericParameterListSyntax: Sequence {
 /// `CompositionTypeElementSyntax` nodes. CompositionTypeElementListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct CompositionTypeElementListSyntax: SyntaxCollection {
+public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `CompositionTypeElementListSyntax` if possible. Returns 
@@ -8046,7 +8046,7 @@ extension CompositionTypeElementListSyntax: Sequence {
 /// `TupleTypeElementSyntax` nodes. TupleTypeElementListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct TupleTypeElementListSyntax: SyntaxCollection {
+public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TupleTypeElementListSyntax` if possible. Returns 
@@ -8282,7 +8282,7 @@ extension TupleTypeElementListSyntax: Sequence {
 /// `GenericArgumentSyntax` nodes. GenericArgumentListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct GenericArgumentListSyntax: SyntaxCollection {
+public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `GenericArgumentListSyntax` if possible. Returns 
@@ -8518,7 +8518,7 @@ extension GenericArgumentListSyntax: Sequence {
 /// `TuplePatternElementSyntax` nodes. TuplePatternElementListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct TuplePatternElementListSyntax: SyntaxCollection {
+public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TuplePatternElementListSyntax` if possible. Returns 
@@ -8754,7 +8754,7 @@ extension TuplePatternElementListSyntax: Sequence {
 /// `AvailabilityArgumentSyntax` nodes. AvailabilitySpecListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct AvailabilitySpecListSyntax: SyntaxCollection {
+public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AvailabilitySpecListSyntax` if possible. Returns 

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxTraits.swift
@@ -12,6 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// MARK: - DeclGroupSyntax
+
 public protocol DeclGroupSyntax: SyntaxProtocol {
   var attributes: AttributeListSyntax? { get }
   func withAttributes(_ newChild: AttributeListSyntax?) -> Self
@@ -20,40 +22,174 @@ public protocol DeclGroupSyntax: SyntaxProtocol {
   var members: MemberDeclBlockSyntax { get }
   func withMembers(_ newChild: MemberDeclBlockSyntax?) -> Self
 }
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// `DeclGroupSyntax`. 
+  func `is`(_: DeclGroupSyntax.Protocol) -> Bool {
+    return self.as(DeclGroupSyntax.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// `DeclGroupSyntax`. Otherwise return `nil`.
+  func `as`(_: DeclGroupSyntax.Protocol) -> DeclGroupSyntax? {
+    return Syntax(self).as(SyntaxProtocol.self) as? DeclGroupSyntax
+  }
+}
+
+// MARK: - BracedSyntax
+
 public protocol BracedSyntax: SyntaxProtocol {
   var leftBrace: TokenSyntax { get }
   func withLeftBrace(_ newChild: TokenSyntax?) -> Self
   var rightBrace: TokenSyntax { get }
   func withRightBrace(_ newChild: TokenSyntax?) -> Self
 }
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// `BracedSyntax`. 
+  func `is`(_: BracedSyntax.Protocol) -> Bool {
+    return self.as(BracedSyntax.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// `BracedSyntax`. Otherwise return `nil`.
+  func `as`(_: BracedSyntax.Protocol) -> BracedSyntax? {
+    return Syntax(self).as(SyntaxProtocol.self) as? BracedSyntax
+  }
+}
+
+// MARK: - IdentifiedDeclSyntax
+
 public protocol IdentifiedDeclSyntax: SyntaxProtocol {
   var identifier: TokenSyntax { get }
   func withIdentifier(_ newChild: TokenSyntax?) -> Self
 }
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// `IdentifiedDeclSyntax`. 
+  func `is`(_: IdentifiedDeclSyntax.Protocol) -> Bool {
+    return self.as(IdentifiedDeclSyntax.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// `IdentifiedDeclSyntax`. Otherwise return `nil`.
+  func `as`(_: IdentifiedDeclSyntax.Protocol) -> IdentifiedDeclSyntax? {
+    return Syntax(self).as(SyntaxProtocol.self) as? IdentifiedDeclSyntax
+  }
+}
+
+// MARK: - WithCodeBlockSyntax
+
 public protocol WithCodeBlockSyntax: SyntaxProtocol {
   var body: CodeBlockSyntax { get }
   func withBody(_ newChild: CodeBlockSyntax?) -> Self
 }
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// `WithCodeBlockSyntax`. 
+  func `is`(_: WithCodeBlockSyntax.Protocol) -> Bool {
+    return self.as(WithCodeBlockSyntax.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// `WithCodeBlockSyntax`. Otherwise return `nil`.
+  func `as`(_: WithCodeBlockSyntax.Protocol) -> WithCodeBlockSyntax? {
+    return Syntax(self).as(SyntaxProtocol.self) as? WithCodeBlockSyntax
+  }
+}
+
+// MARK: - ParenthesizedSyntax
+
 public protocol ParenthesizedSyntax: SyntaxProtocol {
   var leftParen: TokenSyntax { get }
   func withLeftParen(_ newChild: TokenSyntax?) -> Self
   var rightParen: TokenSyntax { get }
   func withRightParen(_ newChild: TokenSyntax?) -> Self
 }
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// `ParenthesizedSyntax`. 
+  func `is`(_: ParenthesizedSyntax.Protocol) -> Bool {
+    return self.as(ParenthesizedSyntax.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// `ParenthesizedSyntax`. Otherwise return `nil`.
+  func `as`(_: ParenthesizedSyntax.Protocol) -> ParenthesizedSyntax? {
+    return Syntax(self).as(SyntaxProtocol.self) as? ParenthesizedSyntax
+  }
+}
+
+// MARK: - WithTrailingCommaSyntax
+
 public protocol WithTrailingCommaSyntax: SyntaxProtocol {
   var trailingComma: TokenSyntax? { get }
   func withTrailingComma(_ newChild: TokenSyntax?) -> Self
 }
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// `WithTrailingCommaSyntax`. 
+  func `is`(_: WithTrailingCommaSyntax.Protocol) -> Bool {
+    return self.as(WithTrailingCommaSyntax.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// `WithTrailingCommaSyntax`. Otherwise return `nil`.
+  func `as`(_: WithTrailingCommaSyntax.Protocol) -> WithTrailingCommaSyntax? {
+    return Syntax(self).as(SyntaxProtocol.self) as? WithTrailingCommaSyntax
+  }
+}
+
+// MARK: - LabeledSyntax
+
 public protocol LabeledSyntax: SyntaxProtocol {
   var labelName: TokenSyntax? { get }
   func withLabelName(_ newChild: TokenSyntax?) -> Self
   var labelColon: TokenSyntax? { get }
   func withLabelColon(_ newChild: TokenSyntax?) -> Self
 }
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// `LabeledSyntax`. 
+  func `is`(_: LabeledSyntax.Protocol) -> Bool {
+    return self.as(LabeledSyntax.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// `LabeledSyntax`. Otherwise return `nil`.
+  func `as`(_: LabeledSyntax.Protocol) -> LabeledSyntax? {
+    return Syntax(self).as(SyntaxProtocol.self) as? LabeledSyntax
+  }
+}
+
+// MARK: - WithStatementsSyntax
+
 public protocol WithStatementsSyntax: SyntaxProtocol {
   var statements: CodeBlockItemListSyntax { get }
   func withStatements(_ newChild: CodeBlockItemListSyntax?) -> Self
 }
+
+public extension SyntaxProtocol {
+  /// Check whether the non-type erased version of this syntax node conforms to 
+  /// `WithStatementsSyntax`. 
+  func `is`(_: WithStatementsSyntax.Protocol) -> Bool {
+    return self.as(WithStatementsSyntax.self) != nil
+  }
+
+  /// Return the non-type erased version of this syntax node if it conforms to 
+  /// `WithStatementsSyntax`. Otherwise return `nil`.
+  func `as`(_: WithStatementsSyntax.Protocol) -> WithStatementsSyntax? {
+    return Syntax(self).as(SyntaxProtocol.self) as? WithStatementsSyntax
+  }
+}
+
 
 extension CodeBlockSyntax: BracedSyntax, WithStatementsSyntax {}
 extension DeclNameArgumentsSyntax: ParenthesizedSyntax {}

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -15,7 +15,7 @@
 
 // MARK: - UnknownDeclSyntax
 
-public struct UnknownDeclSyntax: DeclSyntaxProtocol {
+public struct UnknownDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
@@ -44,7 +44,7 @@ extension UnknownDeclSyntax: CustomReflectable {
 
 // MARK: - TypealiasDeclSyntax
 
-public struct TypealiasDeclSyntax: DeclSyntaxProtocol {
+public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
@@ -279,7 +279,7 @@ extension TypealiasDeclSyntax: CustomReflectable {
 
 // MARK: - AssociatedtypeDeclSyntax
 
-public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol {
+public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
@@ -514,7 +514,7 @@ extension AssociatedtypeDeclSyntax: CustomReflectable {
 
 // MARK: - IfConfigDeclSyntax
 
-public struct IfConfigDeclSyntax: DeclSyntaxProtocol {
+public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case clauses
     case poundEndif
@@ -610,7 +610,7 @@ extension IfConfigDeclSyntax: CustomReflectable {
 
 // MARK: - PoundErrorDeclSyntax
 
-public struct PoundErrorDeclSyntax: DeclSyntaxProtocol {
+public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case poundError
     case leftParen
@@ -733,7 +733,7 @@ extension PoundErrorDeclSyntax: CustomReflectable {
 
 // MARK: - PoundWarningDeclSyntax
 
-public struct PoundWarningDeclSyntax: DeclSyntaxProtocol {
+public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case poundWarning
     case leftParen
@@ -856,7 +856,7 @@ extension PoundWarningDeclSyntax: CustomReflectable {
 
 // MARK: - PoundSourceLocationSyntax
 
-public struct PoundSourceLocationSyntax: DeclSyntaxProtocol {
+public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case poundSourceLocation
     case leftParen
@@ -980,7 +980,7 @@ extension PoundSourceLocationSyntax: CustomReflectable {
 
 // MARK: - ClassDeclSyntax
 
-public struct ClassDeclSyntax: DeclSyntaxProtocol {
+public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
@@ -1238,7 +1238,7 @@ extension ClassDeclSyntax: CustomReflectable {
 
 // MARK: - StructDeclSyntax
 
-public struct StructDeclSyntax: DeclSyntaxProtocol {
+public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
@@ -1496,7 +1496,7 @@ extension StructDeclSyntax: CustomReflectable {
 
 // MARK: - ProtocolDeclSyntax
 
-public struct ProtocolDeclSyntax: DeclSyntaxProtocol {
+public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
@@ -1730,7 +1730,7 @@ extension ProtocolDeclSyntax: CustomReflectable {
 
 // MARK: - ExtensionDeclSyntax
 
-public struct ExtensionDeclSyntax: DeclSyntaxProtocol {
+public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
@@ -1964,7 +1964,7 @@ extension ExtensionDeclSyntax: CustomReflectable {
 
 // MARK: - FunctionDeclSyntax
 
-public struct FunctionDeclSyntax: DeclSyntaxProtocol {
+public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
@@ -2222,7 +2222,7 @@ extension FunctionDeclSyntax: CustomReflectable {
 
 // MARK: - InitializerDeclSyntax
 
-public struct InitializerDeclSyntax: DeclSyntaxProtocol {
+public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
@@ -2505,7 +2505,7 @@ extension InitializerDeclSyntax: CustomReflectable {
 
 // MARK: - DeinitializerDeclSyntax
 
-public struct DeinitializerDeclSyntax: DeclSyntaxProtocol {
+public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
@@ -2668,7 +2668,7 @@ extension DeinitializerDeclSyntax: CustomReflectable {
 
 // MARK: - SubscriptDeclSyntax
 
-public struct SubscriptDeclSyntax: DeclSyntaxProtocol {
+public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
@@ -2926,7 +2926,7 @@ extension SubscriptDeclSyntax: CustomReflectable {
 
 // MARK: - ImportDeclSyntax
 
-public struct ImportDeclSyntax: DeclSyntaxProtocol {
+public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
@@ -3132,7 +3132,7 @@ extension ImportDeclSyntax: CustomReflectable {
 
 // MARK: - AccessorDeclSyntax
 
-public struct AccessorDeclSyntax: DeclSyntaxProtocol {
+public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifier
@@ -3301,7 +3301,7 @@ extension AccessorDeclSyntax: CustomReflectable {
 
 // MARK: - VariableDeclSyntax
 
-public struct VariableDeclSyntax: DeclSyntaxProtocol {
+public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
@@ -3484,11 +3484,10 @@ extension VariableDeclSyntax: CustomReflectable {
 // MARK: - EnumCaseDeclSyntax
 
 /// 
-/// A `case` declaration of a Swift `enum`. It can have 1 or more
-/// `EnumCaseElement`s inside, each declaring a different case of the
+/// A `case` declaration of a Swift `enum`. It can have 1 or more          `EnumCaseElement`s inside, each declaring a different case of the
 /// enum.
 /// 
-public struct EnumCaseDeclSyntax: DeclSyntaxProtocol {
+public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
@@ -3679,7 +3678,7 @@ extension EnumCaseDeclSyntax: CustomReflectable {
 // MARK: - EnumDeclSyntax
 
 /// A Swift `enum` declaration.
-public struct EnumDeclSyntax: DeclSyntaxProtocol {
+public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
@@ -3870,8 +3869,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol {
   }
 
   /// 
-  /// The inheritance clause describing conformances or raw
-  /// values for this enum.
+  /// The inheritance clause describing conformances or raw                    values for this enum.
   /// 
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
     get {
@@ -3896,8 +3894,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol {
   }
 
   /// 
-  /// The `where` clause that applies to the generic parameters of
-  /// this enum.
+  /// The `where` clause that applies to the generic parameters of                    this enum.
   /// 
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
@@ -3964,7 +3961,7 @@ extension EnumDeclSyntax: CustomReflectable {
 // MARK: - OperatorDeclSyntax
 
 /// A Swift `operator` declaration.
-public struct OperatorDeclSyntax: DeclSyntaxProtocol {
+public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
@@ -4162,7 +4159,7 @@ extension OperatorDeclSyntax: CustomReflectable {
 // MARK: - PrecedenceGroupDeclSyntax
 
 /// A Swift `precedencegroup` declaration.
-public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol {
+public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -266,13 +266,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension TypealiasDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "typealiasKeyword": Syntax(typealiasKeyword)._asConcreteType,
-      "identifier": Syntax(identifier)._asConcreteType,
-      "genericParameterClause": genericParameterClause.map(Syntax.init)?._asConcreteType as Any,
-      "initializer": initializer.map(Syntax.init)?._asConcreteType as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?._asConcreteType as Any,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "typealiasKeyword": Syntax(typealiasKeyword).as(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
+      "genericParameterClause": genericParameterClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "initializer": initializer.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -501,13 +501,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension AssociatedtypeDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "associatedtypeKeyword": Syntax(associatedtypeKeyword)._asConcreteType,
-      "identifier": Syntax(identifier)._asConcreteType,
-      "inheritanceClause": inheritanceClause.map(Syntax.init)?._asConcreteType as Any,
-      "initializer": initializer.map(Syntax.init)?._asConcreteType as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?._asConcreteType as Any,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "associatedtypeKeyword": Syntax(associatedtypeKeyword).as(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
+      "inheritanceClause": inheritanceClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "initializer": initializer.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -602,8 +602,8 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension IfConfigDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "clauses": Syntax(clauses)._asConcreteType,
-      "poundEndif": Syntax(poundEndif)._asConcreteType,
+      "clauses": Syntax(clauses).as(SyntaxProtocol.self),
+      "poundEndif": Syntax(poundEndif).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -723,10 +723,10 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension PoundErrorDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundError": Syntax(poundError)._asConcreteType,
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "message": Syntax(message)._asConcreteType,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "poundError": Syntax(poundError).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "message": Syntax(message).as(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -846,10 +846,10 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension PoundWarningDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundWarning": Syntax(poundWarning)._asConcreteType,
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "message": Syntax(message)._asConcreteType,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "poundWarning": Syntax(poundWarning).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "message": Syntax(message).as(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -970,10 +970,10 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension PoundSourceLocationSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundSourceLocation": Syntax(poundSourceLocation)._asConcreteType,
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "args": args.map(Syntax.init)?._asConcreteType as Any,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "poundSourceLocation": Syntax(poundSourceLocation).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "args": args.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1224,14 +1224,14 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension ClassDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "classKeyword": Syntax(classKeyword)._asConcreteType,
-      "identifier": Syntax(identifier)._asConcreteType,
-      "genericParameterClause": genericParameterClause.map(Syntax.init)?._asConcreteType as Any,
-      "inheritanceClause": inheritanceClause.map(Syntax.init)?._asConcreteType as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?._asConcreteType as Any,
-      "members": Syntax(members)._asConcreteType,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "classKeyword": Syntax(classKeyword).as(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
+      "genericParameterClause": genericParameterClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "inheritanceClause": inheritanceClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "members": Syntax(members).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1482,14 +1482,14 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension StructDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "structKeyword": Syntax(structKeyword)._asConcreteType,
-      "identifier": Syntax(identifier)._asConcreteType,
-      "genericParameterClause": genericParameterClause.map(Syntax.init)?._asConcreteType as Any,
-      "inheritanceClause": inheritanceClause.map(Syntax.init)?._asConcreteType as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?._asConcreteType as Any,
-      "members": Syntax(members)._asConcreteType,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "structKeyword": Syntax(structKeyword).as(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
+      "genericParameterClause": genericParameterClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "inheritanceClause": inheritanceClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "members": Syntax(members).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1717,13 +1717,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension ProtocolDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "protocolKeyword": Syntax(protocolKeyword)._asConcreteType,
-      "identifier": Syntax(identifier)._asConcreteType,
-      "inheritanceClause": inheritanceClause.map(Syntax.init)?._asConcreteType as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?._asConcreteType as Any,
-      "members": Syntax(members)._asConcreteType,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "protocolKeyword": Syntax(protocolKeyword).as(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
+      "inheritanceClause": inheritanceClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "members": Syntax(members).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1951,13 +1951,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension ExtensionDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "extensionKeyword": Syntax(extensionKeyword)._asConcreteType,
-      "extendedType": Syntax(extendedType)._asConcreteType,
-      "inheritanceClause": inheritanceClause.map(Syntax.init)?._asConcreteType as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?._asConcreteType as Any,
-      "members": Syntax(members)._asConcreteType,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "extensionKeyword": Syntax(extensionKeyword).as(SyntaxProtocol.self),
+      "extendedType": Syntax(extendedType).as(SyntaxProtocol.self),
+      "inheritanceClause": inheritanceClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "members": Syntax(members).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2208,14 +2208,14 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension FunctionDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "funcKeyword": Syntax(funcKeyword)._asConcreteType,
-      "identifier": Syntax(identifier)._asConcreteType,
-      "genericParameterClause": genericParameterClause.map(Syntax.init)?._asConcreteType as Any,
-      "signature": Syntax(signature)._asConcreteType,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?._asConcreteType as Any,
-      "body": body.map(Syntax.init)?._asConcreteType as Any,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "funcKeyword": Syntax(funcKeyword).as(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
+      "genericParameterClause": genericParameterClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "signature": Syntax(signature).as(SyntaxProtocol.self),
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "body": body.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2490,15 +2490,15 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension InitializerDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "initKeyword": Syntax(initKeyword)._asConcreteType,
-      "optionalMark": optionalMark.map(Syntax.init)?._asConcreteType as Any,
-      "genericParameterClause": genericParameterClause.map(Syntax.init)?._asConcreteType as Any,
-      "parameters": Syntax(parameters)._asConcreteType,
-      "throwsOrRethrowsKeyword": throwsOrRethrowsKeyword.map(Syntax.init)?._asConcreteType as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?._asConcreteType as Any,
-      "body": body.map(Syntax.init)?._asConcreteType as Any,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "initKeyword": Syntax(initKeyword).as(SyntaxProtocol.self),
+      "optionalMark": optionalMark.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "genericParameterClause": genericParameterClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "parameters": Syntax(parameters).as(SyntaxProtocol.self),
+      "throwsOrRethrowsKeyword": throwsOrRethrowsKeyword.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "body": body.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2658,10 +2658,10 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension DeinitializerDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "deinitKeyword": Syntax(deinitKeyword)._asConcreteType,
-      "body": Syntax(body)._asConcreteType,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "deinitKeyword": Syntax(deinitKeyword).as(SyntaxProtocol.self),
+      "body": Syntax(body).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2912,14 +2912,14 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension SubscriptDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "subscriptKeyword": Syntax(subscriptKeyword)._asConcreteType,
-      "genericParameterClause": genericParameterClause.map(Syntax.init)?._asConcreteType as Any,
-      "indices": Syntax(indices)._asConcreteType,
-      "result": Syntax(result)._asConcreteType,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?._asConcreteType as Any,
-      "accessor": accessor.map(Syntax.init)?._asConcreteType as Any,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "subscriptKeyword": Syntax(subscriptKeyword).as(SyntaxProtocol.self),
+      "genericParameterClause": genericParameterClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "indices": Syntax(indices).as(SyntaxProtocol.self),
+      "result": Syntax(result).as(SyntaxProtocol.self),
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "accessor": accessor.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3121,11 +3121,11 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension ImportDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "importTok": Syntax(importTok)._asConcreteType,
-      "importKind": importKind.map(Syntax.init)?._asConcreteType as Any,
-      "path": Syntax(path)._asConcreteType,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "importTok": Syntax(importTok).as(SyntaxProtocol.self),
+      "importKind": importKind.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "path": Syntax(path).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -3290,11 +3290,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension AccessorDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifier": modifier.map(Syntax.init)?._asConcreteType as Any,
-      "accessorKind": Syntax(accessorKind)._asConcreteType,
-      "parameter": parameter.map(Syntax.init)?._asConcreteType as Any,
-      "body": body.map(Syntax.init)?._asConcreteType as Any,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifier": modifier.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "accessorKind": Syntax(accessorKind).as(SyntaxProtocol.self),
+      "parameter": parameter.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "body": body.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3473,10 +3473,10 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension VariableDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "letOrVarKeyword": Syntax(letOrVarKeyword)._asConcreteType,
-      "bindings": Syntax(bindings)._asConcreteType,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "letOrVarKeyword": Syntax(letOrVarKeyword).as(SyntaxProtocol.self),
+      "bindings": Syntax(bindings).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -3484,7 +3484,8 @@ extension VariableDeclSyntax: CustomReflectable {
 // MARK: - EnumCaseDeclSyntax
 
 /// 
-/// A `case` declaration of a Swift `enum`. It can have 1 or more          `EnumCaseElement`s inside, each declaring a different case of the
+/// A `case` declaration of a Swift `enum`. It can have 1 or more
+/// `EnumCaseElement`s inside, each declaring a different case of the
 /// enum.
 /// 
 public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
@@ -3667,10 +3668,10 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension EnumCaseDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "caseKeyword": Syntax(caseKeyword)._asConcreteType,
-      "elements": Syntax(elements)._asConcreteType,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "caseKeyword": Syntax(caseKeyword).as(SyntaxProtocol.self),
+      "elements": Syntax(elements).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -3869,7 +3870,8 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   /// 
-  /// The inheritance clause describing conformances or raw                    values for this enum.
+  /// The inheritance clause describing conformances or raw
+  /// values for this enum.
   /// 
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
     get {
@@ -3894,7 +3896,8 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   /// 
-  /// The `where` clause that applies to the generic parameters of                    this enum.
+  /// The `where` clause that applies to the generic parameters of
+  /// this enum.
   /// 
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
@@ -3946,14 +3949,14 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension EnumDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "enumKeyword": Syntax(enumKeyword)._asConcreteType,
-      "identifier": Syntax(identifier)._asConcreteType,
-      "genericParameters": genericParameters.map(Syntax.init)?._asConcreteType as Any,
-      "inheritanceClause": inheritanceClause.map(Syntax.init)?._asConcreteType as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?._asConcreteType as Any,
-      "members": Syntax(members)._asConcreteType,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "enumKeyword": Syntax(enumKeyword).as(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
+      "genericParameters": genericParameters.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "inheritanceClause": inheritanceClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "members": Syntax(members).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -4147,11 +4150,11 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension OperatorDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "operatorKeyword": Syntax(operatorKeyword)._asConcreteType,
-      "identifier": Syntax(identifier)._asConcreteType,
-      "operatorPrecedenceAndTypes": operatorPrecedenceAndTypes.map(Syntax.init)?._asConcreteType as Any,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "operatorKeyword": Syntax(operatorKeyword).as(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
+      "operatorPrecedenceAndTypes": operatorPrecedenceAndTypes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4410,13 +4413,13 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension PrecedenceGroupDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "modifiers": modifiers.map(Syntax.init)?._asConcreteType as Any,
-      "precedencegroupKeyword": Syntax(precedencegroupKeyword)._asConcreteType,
-      "identifier": Syntax(identifier)._asConcreteType,
-      "leftBrace": Syntax(leftBrace)._asConcreteType,
-      "groupAttributes": Syntax(groupAttributes)._asConcreteType,
-      "rightBrace": Syntax(rightBrace)._asConcreteType,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "precedencegroupKeyword": Syntax(precedencegroupKeyword).as(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
+      "leftBrace": Syntax(leftBrace).as(SyntaxProtocol.self),
+      "groupAttributes": Syntax(groupAttributes).as(SyntaxProtocol.self),
+      "rightBrace": Syntax(rightBrace).as(SyntaxProtocol.self),
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -113,8 +113,8 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension InOutExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "ampersand": Syntax(ampersand)._asConcreteType,
-      "expression": Syntax(expression)._asConcreteType,
+      "ampersand": Syntax(ampersand).as(SyntaxProtocol.self),
+      "expression": Syntax(expression).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -168,7 +168,7 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension PoundColumnExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundColumn": Syntax(poundColumn)._asConcreteType,
+      "poundColumn": Syntax(poundColumn).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -267,9 +267,9 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension TryExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "tryKeyword": Syntax(tryKeyword)._asConcreteType,
-      "questionOrExclamationMark": questionOrExclamationMark.map(Syntax.init)?._asConcreteType as Any,
-      "expression": Syntax(expression)._asConcreteType,
+      "tryKeyword": Syntax(tryKeyword).as(SyntaxProtocol.self),
+      "questionOrExclamationMark": questionOrExclamationMark.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "expression": Syntax(expression).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -346,8 +346,8 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension IdentifierExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "identifier": Syntax(identifier)._asConcreteType,
-      "declNameArguments": declNameArguments.map(Syntax.init)?._asConcreteType as Any,
+      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
+      "declNameArguments": declNameArguments.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -401,7 +401,7 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension SuperRefExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "superKeyword": Syntax(superKeyword)._asConcreteType,
+      "superKeyword": Syntax(superKeyword).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -455,7 +455,7 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension NilLiteralExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "nilKeyword": Syntax(nilKeyword)._asConcreteType,
+      "nilKeyword": Syntax(nilKeyword).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -509,7 +509,7 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension DiscardAssignmentExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "wildcard": Syntax(wildcard)._asConcreteType,
+      "wildcard": Syntax(wildcard).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -563,7 +563,7 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension AssignmentExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "assignToken": Syntax(assignToken)._asConcreteType,
+      "assignToken": Syntax(assignToken).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -636,7 +636,7 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension SequenceExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "elements": Syntax(elements)._asConcreteType,
+      "elements": Syntax(elements).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -690,7 +690,7 @@ public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension PoundLineExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundLine": Syntax(poundLine)._asConcreteType,
+      "poundLine": Syntax(poundLine).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -744,7 +744,7 @@ public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension PoundFileExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundFile": Syntax(poundFile)._asConcreteType,
+      "poundFile": Syntax(poundFile).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -798,7 +798,7 @@ public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension PoundFunctionExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundFunction": Syntax(poundFunction)._asConcreteType,
+      "poundFunction": Syntax(poundFunction).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -852,7 +852,7 @@ public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension PoundDsohandleExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundDsohandle": Syntax(poundDsohandle)._asConcreteType,
+      "poundDsohandle": Syntax(poundDsohandle).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -929,8 +929,8 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension SymbolicReferenceExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "identifier": Syntax(identifier)._asConcreteType,
-      "genericArgumentClause": genericArgumentClause.map(Syntax.init)?._asConcreteType as Any,
+      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
+      "genericArgumentClause": genericArgumentClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1007,8 +1007,8 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension PrefixOperatorExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "operatorToken": operatorToken.map(Syntax.init)?._asConcreteType as Any,
-      "postfixExpression": Syntax(postfixExpression)._asConcreteType,
+      "operatorToken": operatorToken.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "postfixExpression": Syntax(postfixExpression).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1062,7 +1062,7 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension BinaryOperatorExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "operatorToken": Syntax(operatorToken)._asConcreteType,
+      "operatorToken": Syntax(operatorToken).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1139,8 +1139,8 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension ArrowExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "throwsToken": throwsToken.map(Syntax.init)?._asConcreteType as Any,
-      "arrowToken": Syntax(arrowToken)._asConcreteType,
+      "throwsToken": throwsToken.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "arrowToken": Syntax(arrowToken).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1194,7 +1194,7 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension FloatLiteralExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "floatingDigits": Syntax(floatingDigits)._asConcreteType,
+      "floatingDigits": Syntax(floatingDigits).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1311,9 +1311,9 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension TupleExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "elementList": Syntax(elementList)._asConcreteType,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "elementList": Syntax(elementList).as(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1430,9 +1430,9 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension ArrayExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftSquare": Syntax(leftSquare)._asConcreteType,
-      "elements": Syntax(elements)._asConcreteType,
-      "rightSquare": Syntax(rightSquare)._asConcreteType,
+      "leftSquare": Syntax(leftSquare).as(SyntaxProtocol.self),
+      "elements": Syntax(elements).as(SyntaxProtocol.self),
+      "rightSquare": Syntax(rightSquare).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1530,9 +1530,9 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension DictionaryExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftSquare": Syntax(leftSquare)._asConcreteType,
-      "content": Syntax(content)._asConcreteType,
-      "rightSquare": Syntax(rightSquare)._asConcreteType,
+      "leftSquare": Syntax(leftSquare).as(SyntaxProtocol.self),
+      "content": Syntax(content).as(SyntaxProtocol.self),
+      "rightSquare": Syntax(rightSquare).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1586,7 +1586,7 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension IntegerLiteralExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "digits": Syntax(digits)._asConcreteType,
+      "digits": Syntax(digits).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1640,7 +1640,7 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension BooleanLiteralExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "booleanLiteral": Syntax(booleanLiteral)._asConcreteType,
+      "booleanLiteral": Syntax(booleanLiteral).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1782,11 +1782,11 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension TernaryExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "conditionExpression": Syntax(conditionExpression)._asConcreteType,
-      "questionMark": Syntax(questionMark)._asConcreteType,
-      "firstChoice": Syntax(firstChoice)._asConcreteType,
-      "colonMark": Syntax(colonMark)._asConcreteType,
-      "secondChoice": Syntax(secondChoice)._asConcreteType,
+      "conditionExpression": Syntax(conditionExpression).as(SyntaxProtocol.self),
+      "questionMark": Syntax(questionMark).as(SyntaxProtocol.self),
+      "firstChoice": Syntax(firstChoice).as(SyntaxProtocol.self),
+      "colonMark": Syntax(colonMark).as(SyntaxProtocol.self),
+      "secondChoice": Syntax(secondChoice).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1908,10 +1908,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension MemberAccessExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "base": base.map(Syntax.init)?._asConcreteType as Any,
-      "dot": Syntax(dot)._asConcreteType,
-      "name": Syntax(name)._asConcreteType,
-      "declNameArguments": declNameArguments.map(Syntax.init)?._asConcreteType as Any,
+      "base": base.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "dot": Syntax(dot).as(SyntaxProtocol.self),
+      "name": Syntax(name).as(SyntaxProtocol.self),
+      "declNameArguments": declNameArguments.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1987,8 +1987,8 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension IsExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "isTok": Syntax(isTok)._asConcreteType,
-      "typeName": Syntax(typeName)._asConcreteType,
+      "isTok": Syntax(isTok).as(SyntaxProtocol.self),
+      "typeName": Syntax(typeName).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2087,9 +2087,9 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension AsExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "asTok": Syntax(asTok)._asConcreteType,
-      "questionOrExclamationMark": questionOrExclamationMark.map(Syntax.init)?._asConcreteType as Any,
-      "typeName": Syntax(typeName)._asConcreteType,
+      "asTok": Syntax(asTok).as(SyntaxProtocol.self),
+      "questionOrExclamationMark": questionOrExclamationMark.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "typeName": Syntax(typeName).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2143,7 +2143,7 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension TypeExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "type": Syntax(type)._asConcreteType,
+      "type": Syntax(type).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2283,10 +2283,10 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension ClosureExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftBrace": Syntax(leftBrace)._asConcreteType,
-      "signature": signature.map(Syntax.init)?._asConcreteType as Any,
-      "statements": Syntax(statements)._asConcreteType,
-      "rightBrace": Syntax(rightBrace)._asConcreteType,
+      "leftBrace": Syntax(leftBrace).as(SyntaxProtocol.self),
+      "signature": signature.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "statements": Syntax(statements).as(SyntaxProtocol.self),
+      "rightBrace": Syntax(rightBrace).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2340,7 +2340,7 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension UnresolvedPatternExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "pattern": Syntax(pattern)._asConcreteType,
+      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2504,11 +2504,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension FunctionCallExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "calledExpression": Syntax(calledExpression)._asConcreteType,
-      "leftParen": leftParen.map(Syntax.init)?._asConcreteType as Any,
-      "argumentList": Syntax(argumentList)._asConcreteType,
-      "rightParen": rightParen.map(Syntax.init)?._asConcreteType as Any,
-      "trailingClosure": trailingClosure.map(Syntax.init)?._asConcreteType as Any,
+      "calledExpression": Syntax(calledExpression).as(SyntaxProtocol.self),
+      "leftParen": leftParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "argumentList": Syntax(argumentList).as(SyntaxProtocol.self),
+      "rightParen": rightParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "trailingClosure": trailingClosure.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2670,11 +2670,11 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension SubscriptExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "calledExpression": Syntax(calledExpression)._asConcreteType,
-      "leftBracket": Syntax(leftBracket)._asConcreteType,
-      "argumentList": Syntax(argumentList)._asConcreteType,
-      "rightBracket": Syntax(rightBracket)._asConcreteType,
-      "trailingClosure": trailingClosure.map(Syntax.init)?._asConcreteType as Any,
+      "calledExpression": Syntax(calledExpression).as(SyntaxProtocol.self),
+      "leftBracket": Syntax(leftBracket).as(SyntaxProtocol.self),
+      "argumentList": Syntax(argumentList).as(SyntaxProtocol.self),
+      "rightBracket": Syntax(rightBracket).as(SyntaxProtocol.self),
+      "trailingClosure": trailingClosure.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2750,8 +2750,8 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension OptionalChainingExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "expression": Syntax(expression)._asConcreteType,
-      "questionMark": Syntax(questionMark)._asConcreteType,
+      "expression": Syntax(expression).as(SyntaxProtocol.self),
+      "questionMark": Syntax(questionMark).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2827,8 +2827,8 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension ForcedValueExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "expression": Syntax(expression)._asConcreteType,
-      "exclamationMark": Syntax(exclamationMark)._asConcreteType,
+      "expression": Syntax(expression).as(SyntaxProtocol.self),
+      "exclamationMark": Syntax(exclamationMark).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2904,8 +2904,8 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension PostfixUnaryExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "expression": Syntax(expression)._asConcreteType,
-      "operatorToken": Syntax(operatorToken)._asConcreteType,
+      "expression": Syntax(expression).as(SyntaxProtocol.self),
+      "operatorToken": Syntax(operatorToken).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2981,8 +2981,8 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension SpecializeExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "expression": Syntax(expression)._asConcreteType,
-      "genericArgumentClause": Syntax(genericArgumentClause)._asConcreteType,
+      "expression": Syntax(expression).as(SyntaxProtocol.self),
+      "genericArgumentClause": Syntax(genericArgumentClause).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -3145,11 +3145,11 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension StringLiteralExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "openDelimiter": openDelimiter.map(Syntax.init)?._asConcreteType as Any,
-      "openQuote": Syntax(openQuote)._asConcreteType,
-      "segments": Syntax(segments)._asConcreteType,
-      "closeQuote": Syntax(closeQuote)._asConcreteType,
-      "closeDelimiter": closeDelimiter.map(Syntax.init)?._asConcreteType as Any,
+      "openDelimiter": openDelimiter.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "openQuote": Syntax(openQuote).as(SyntaxProtocol.self),
+      "segments": Syntax(segments).as(SyntaxProtocol.self),
+      "closeQuote": Syntax(closeQuote).as(SyntaxProtocol.self),
+      "closeDelimiter": closeDelimiter.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3248,9 +3248,9 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension KeyPathExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "backslash": Syntax(backslash)._asConcreteType,
-      "rootExpr": rootExpr.map(Syntax.init)?._asConcreteType as Any,
-      "expression": Syntax(expression)._asConcreteType,
+      "backslash": Syntax(backslash).as(SyntaxProtocol.self),
+      "rootExpr": rootExpr.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "expression": Syntax(expression).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -3304,7 +3304,7 @@ public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension KeyPathBaseExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "period": Syntax(period)._asConcreteType,
+      "period": Syntax(period).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -3443,10 +3443,10 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension ObjcKeyPathExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "keyPath": Syntax(keyPath)._asConcreteType,
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "name": Syntax(name)._asConcreteType,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "keyPath": Syntax(keyPath).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "name": Syntax(name).as(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -3612,12 +3612,12 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension ObjcSelectorExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundSelector": Syntax(poundSelector)._asConcreteType,
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "kind": kind.map(Syntax.init)?._asConcreteType as Any,
-      "colon": colon.map(Syntax.init)?._asConcreteType as Any,
-      "name": Syntax(name)._asConcreteType,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "poundSelector": Syntax(poundSelector).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "kind": kind.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "colon": colon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "name": Syntax(name).as(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -3671,7 +3671,7 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension EditorPlaceholderExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "identifier": Syntax(identifier)._asConcreteType,
+      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -3810,10 +3810,10 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension ObjectLiteralExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "identifier": Syntax(identifier)._asConcreteType,
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "arguments": Syntax(arguments)._asConcreteType,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "arguments": Syntax(arguments).as(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -15,7 +15,7 @@
 
 // MARK: - UnknownExprSyntax
 
-public struct UnknownExprSyntax: ExprSyntaxProtocol {
+public struct UnknownExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
@@ -44,7 +44,7 @@ extension UnknownExprSyntax: CustomReflectable {
 
 // MARK: - InOutExprSyntax
 
-public struct InOutExprSyntax: ExprSyntaxProtocol {
+public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case ampersand
     case expression
@@ -121,7 +121,7 @@ extension InOutExprSyntax: CustomReflectable {
 
 // MARK: - PoundColumnExprSyntax
 
-public struct PoundColumnExprSyntax: ExprSyntaxProtocol {
+public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case poundColumn
   }
@@ -175,7 +175,7 @@ extension PoundColumnExprSyntax: CustomReflectable {
 
 // MARK: - TryExprSyntax
 
-public struct TryExprSyntax: ExprSyntaxProtocol {
+public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case tryKeyword
     case questionOrExclamationMark
@@ -276,7 +276,7 @@ extension TryExprSyntax: CustomReflectable {
 
 // MARK: - IdentifierExprSyntax
 
-public struct IdentifierExprSyntax: ExprSyntaxProtocol {
+public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case identifier
     case declNameArguments
@@ -354,7 +354,7 @@ extension IdentifierExprSyntax: CustomReflectable {
 
 // MARK: - SuperRefExprSyntax
 
-public struct SuperRefExprSyntax: ExprSyntaxProtocol {
+public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case superKeyword
   }
@@ -408,7 +408,7 @@ extension SuperRefExprSyntax: CustomReflectable {
 
 // MARK: - NilLiteralExprSyntax
 
-public struct NilLiteralExprSyntax: ExprSyntaxProtocol {
+public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case nilKeyword
   }
@@ -462,7 +462,7 @@ extension NilLiteralExprSyntax: CustomReflectable {
 
 // MARK: - DiscardAssignmentExprSyntax
 
-public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol {
+public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case wildcard
   }
@@ -516,7 +516,7 @@ extension DiscardAssignmentExprSyntax: CustomReflectable {
 
 // MARK: - AssignmentExprSyntax
 
-public struct AssignmentExprSyntax: ExprSyntaxProtocol {
+public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case assignToken
   }
@@ -570,7 +570,7 @@ extension AssignmentExprSyntax: CustomReflectable {
 
 // MARK: - SequenceExprSyntax
 
-public struct SequenceExprSyntax: ExprSyntaxProtocol {
+public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case elements
   }
@@ -643,7 +643,7 @@ extension SequenceExprSyntax: CustomReflectable {
 
 // MARK: - PoundLineExprSyntax
 
-public struct PoundLineExprSyntax: ExprSyntaxProtocol {
+public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case poundLine
   }
@@ -697,7 +697,7 @@ extension PoundLineExprSyntax: CustomReflectable {
 
 // MARK: - PoundFileExprSyntax
 
-public struct PoundFileExprSyntax: ExprSyntaxProtocol {
+public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case poundFile
   }
@@ -751,7 +751,7 @@ extension PoundFileExprSyntax: CustomReflectable {
 
 // MARK: - PoundFunctionExprSyntax
 
-public struct PoundFunctionExprSyntax: ExprSyntaxProtocol {
+public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case poundFunction
   }
@@ -805,7 +805,7 @@ extension PoundFunctionExprSyntax: CustomReflectable {
 
 // MARK: - PoundDsohandleExprSyntax
 
-public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol {
+public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case poundDsohandle
   }
@@ -859,7 +859,7 @@ extension PoundDsohandleExprSyntax: CustomReflectable {
 
 // MARK: - SymbolicReferenceExprSyntax
 
-public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol {
+public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case identifier
     case genericArgumentClause
@@ -937,7 +937,7 @@ extension SymbolicReferenceExprSyntax: CustomReflectable {
 
 // MARK: - PrefixOperatorExprSyntax
 
-public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol {
+public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case operatorToken
     case postfixExpression
@@ -1015,7 +1015,7 @@ extension PrefixOperatorExprSyntax: CustomReflectable {
 
 // MARK: - BinaryOperatorExprSyntax
 
-public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol {
+public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case operatorToken
   }
@@ -1069,7 +1069,7 @@ extension BinaryOperatorExprSyntax: CustomReflectable {
 
 // MARK: - ArrowExprSyntax
 
-public struct ArrowExprSyntax: ExprSyntaxProtocol {
+public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case throwsToken
     case arrowToken
@@ -1147,7 +1147,7 @@ extension ArrowExprSyntax: CustomReflectable {
 
 // MARK: - FloatLiteralExprSyntax
 
-public struct FloatLiteralExprSyntax: ExprSyntaxProtocol {
+public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case floatingDigits
   }
@@ -1201,7 +1201,7 @@ extension FloatLiteralExprSyntax: CustomReflectable {
 
 // MARK: - TupleExprSyntax
 
-public struct TupleExprSyntax: ExprSyntaxProtocol {
+public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftParen
     case elementList
@@ -1320,7 +1320,7 @@ extension TupleExprSyntax: CustomReflectable {
 
 // MARK: - ArrayExprSyntax
 
-public struct ArrayExprSyntax: ExprSyntaxProtocol {
+public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftSquare
     case elements
@@ -1439,7 +1439,7 @@ extension ArrayExprSyntax: CustomReflectable {
 
 // MARK: - DictionaryExprSyntax
 
-public struct DictionaryExprSyntax: ExprSyntaxProtocol {
+public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftSquare
     case content
@@ -1539,7 +1539,7 @@ extension DictionaryExprSyntax: CustomReflectable {
 
 // MARK: - IntegerLiteralExprSyntax
 
-public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol {
+public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case digits
   }
@@ -1593,7 +1593,7 @@ extension IntegerLiteralExprSyntax: CustomReflectable {
 
 // MARK: - BooleanLiteralExprSyntax
 
-public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol {
+public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case booleanLiteral
   }
@@ -1647,7 +1647,7 @@ extension BooleanLiteralExprSyntax: CustomReflectable {
 
 // MARK: - TernaryExprSyntax
 
-public struct TernaryExprSyntax: ExprSyntaxProtocol {
+public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case conditionExpression
     case questionMark
@@ -1793,7 +1793,7 @@ extension TernaryExprSyntax: CustomReflectable {
 
 // MARK: - MemberAccessExprSyntax
 
-public struct MemberAccessExprSyntax: ExprSyntaxProtocol {
+public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case base
     case dot
@@ -1918,7 +1918,7 @@ extension MemberAccessExprSyntax: CustomReflectable {
 
 // MARK: - IsExprSyntax
 
-public struct IsExprSyntax: ExprSyntaxProtocol {
+public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case isTok
     case typeName
@@ -1995,7 +1995,7 @@ extension IsExprSyntax: CustomReflectable {
 
 // MARK: - AsExprSyntax
 
-public struct AsExprSyntax: ExprSyntaxProtocol {
+public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case asTok
     case questionOrExclamationMark
@@ -2096,7 +2096,7 @@ extension AsExprSyntax: CustomReflectable {
 
 // MARK: - TypeExprSyntax
 
-public struct TypeExprSyntax: ExprSyntaxProtocol {
+public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case type
   }
@@ -2150,7 +2150,7 @@ extension TypeExprSyntax: CustomReflectable {
 
 // MARK: - ClosureExprSyntax
 
-public struct ClosureExprSyntax: ExprSyntaxProtocol {
+public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftBrace
     case signature
@@ -2293,7 +2293,7 @@ extension ClosureExprSyntax: CustomReflectable {
 
 // MARK: - UnresolvedPatternExprSyntax
 
-public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol {
+public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case pattern
   }
@@ -2347,7 +2347,7 @@ extension UnresolvedPatternExprSyntax: CustomReflectable {
 
 // MARK: - FunctionCallExprSyntax
 
-public struct FunctionCallExprSyntax: ExprSyntaxProtocol {
+public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case calledExpression
     case leftParen
@@ -2515,7 +2515,7 @@ extension FunctionCallExprSyntax: CustomReflectable {
 
 // MARK: - SubscriptExprSyntax
 
-public struct SubscriptExprSyntax: ExprSyntaxProtocol {
+public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case calledExpression
     case leftBracket
@@ -2681,7 +2681,7 @@ extension SubscriptExprSyntax: CustomReflectable {
 
 // MARK: - OptionalChainingExprSyntax
 
-public struct OptionalChainingExprSyntax: ExprSyntaxProtocol {
+public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case expression
     case questionMark
@@ -2758,7 +2758,7 @@ extension OptionalChainingExprSyntax: CustomReflectable {
 
 // MARK: - ForcedValueExprSyntax
 
-public struct ForcedValueExprSyntax: ExprSyntaxProtocol {
+public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case expression
     case exclamationMark
@@ -2835,7 +2835,7 @@ extension ForcedValueExprSyntax: CustomReflectable {
 
 // MARK: - PostfixUnaryExprSyntax
 
-public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol {
+public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case expression
     case operatorToken
@@ -2912,7 +2912,7 @@ extension PostfixUnaryExprSyntax: CustomReflectable {
 
 // MARK: - SpecializeExprSyntax
 
-public struct SpecializeExprSyntax: ExprSyntaxProtocol {
+public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case expression
     case genericArgumentClause
@@ -2989,7 +2989,7 @@ extension SpecializeExprSyntax: CustomReflectable {
 
 // MARK: - StringLiteralExprSyntax
 
-public struct StringLiteralExprSyntax: ExprSyntaxProtocol {
+public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case openDelimiter
     case openQuote
@@ -3156,7 +3156,7 @@ extension StringLiteralExprSyntax: CustomReflectable {
 
 // MARK: - KeyPathExprSyntax
 
-public struct KeyPathExprSyntax: ExprSyntaxProtocol {
+public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case backslash
     case rootExpr
@@ -3257,7 +3257,7 @@ extension KeyPathExprSyntax: CustomReflectable {
 
 // MARK: - KeyPathBaseExprSyntax
 
-public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol {
+public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case period
   }
@@ -3311,7 +3311,7 @@ extension KeyPathBaseExprSyntax: CustomReflectable {
 
 // MARK: - ObjcKeyPathExprSyntax
 
-public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol {
+public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case keyPath
     case leftParen
@@ -3453,7 +3453,7 @@ extension ObjcKeyPathExprSyntax: CustomReflectable {
 
 // MARK: - ObjcSelectorExprSyntax
 
-public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol {
+public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case poundSelector
     case leftParen
@@ -3624,7 +3624,7 @@ extension ObjcSelectorExprSyntax: CustomReflectable {
 
 // MARK: - EditorPlaceholderExprSyntax
 
-public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol {
+public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case identifier
   }
@@ -3678,7 +3678,7 @@ extension EditorPlaceholderExprSyntax: CustomReflectable {
 
 // MARK: - ObjectLiteralExprSyntax
 
-public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol {
+public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case identifier
     case leftParen

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -116,9 +116,9 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
 extension CodeBlockItemSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "item": Syntax(item)._asConcreteType,
-      "semicolon": semicolon.map(Syntax.init)?._asConcreteType as Any,
-      "errorTokens": errorTokens.map(Syntax.init)?._asConcreteType as Any,
+      "item": Syntax(item).as(SyntaxProtocol.self),
+      "semicolon": semicolon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "errorTokens": errorTokens.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -235,9 +235,9 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
 extension CodeBlockSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftBrace": Syntax(leftBrace)._asConcreteType,
-      "statements": Syntax(statements)._asConcreteType,
-      "rightBrace": Syntax(rightBrace)._asConcreteType,
+      "leftBrace": Syntax(leftBrace).as(SyntaxProtocol.self),
+      "statements": Syntax(statements).as(SyntaxProtocol.self),
+      "rightBrace": Syntax(rightBrace).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -313,8 +313,8 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 extension DeclNameArgumentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name)._asConcreteType,
-      "colon": Syntax(colon)._asConcreteType,
+      "name": Syntax(name).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -431,9 +431,9 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 extension DeclNameArgumentsSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "arguments": Syntax(arguments)._asConcreteType,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "arguments": Syntax(arguments).as(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -556,10 +556,10 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension TupleExprElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "label": label.map(Syntax.init)?._asConcreteType as Any,
-      "colon": colon.map(Syntax.init)?._asConcreteType as Any,
-      "expression": Syntax(expression)._asConcreteType,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "label": label.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "colon": colon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "expression": Syntax(expression).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -636,8 +636,8 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension ArrayElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "expression": Syntax(expression)._asConcreteType,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "expression": Syntax(expression).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -758,10 +758,10 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension DictionaryElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "keyExpression": Syntax(keyExpression)._asConcreteType,
-      "colon": Syntax(colon)._asConcreteType,
-      "valueExpression": Syntax(valueExpression)._asConcreteType,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "keyExpression": Syntax(keyExpression).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "valueExpression": Syntax(valueExpression).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -926,11 +926,11 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
 extension ClosureCaptureItemSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "specifier": specifier.map(Syntax.init)?._asConcreteType as Any,
-      "name": name.map(Syntax.init)?._asConcreteType as Any,
-      "assignToken": assignToken.map(Syntax.init)?._asConcreteType as Any,
-      "expression": Syntax(expression)._asConcreteType,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "specifier": specifier.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "name": name.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "assignToken": assignToken.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "expression": Syntax(expression).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1048,9 +1048,9 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 extension ClosureCaptureSignatureSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftSquare": Syntax(leftSquare)._asConcreteType,
-      "items": items.map(Syntax.init)?._asConcreteType as Any,
-      "rightSquare": Syntax(rightSquare)._asConcreteType,
+      "leftSquare": Syntax(leftSquare).as(SyntaxProtocol.self),
+      "items": items.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "rightSquare": Syntax(rightSquare).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1127,8 +1127,8 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
 extension ClosureParamSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name)._asConcreteType,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "name": Syntax(name).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1274,11 +1274,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 extension ClosureSignatureSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "capture": capture.map(Syntax.init)?._asConcreteType as Any,
-      "input": input.map(Syntax.init)?._asConcreteType as Any,
-      "throwsTok": throwsTok.map(Syntax.init)?._asConcreteType as Any,
-      "output": output.map(Syntax.init)?._asConcreteType as Any,
-      "inTok": Syntax(inTok)._asConcreteType,
+      "capture": capture.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "input": input.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "throwsTok": throwsTok.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "output": output.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "inTok": Syntax(inTok).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1332,7 +1332,7 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 extension StringSegmentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "content": Syntax(content)._asConcreteType,
+      "content": Syntax(content).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1494,11 +1494,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 extension ExpressionSegmentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "backslash": Syntax(backslash)._asConcreteType,
-      "delimiter": delimiter.map(Syntax.init)?._asConcreteType as Any,
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "expressions": Syntax(expressions)._asConcreteType,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "backslash": Syntax(backslash).as(SyntaxProtocol.self),
+      "delimiter": delimiter.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "expressions": Syntax(expressions).as(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1575,8 +1575,8 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
 extension ObjcNamePieceSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name)._asConcreteType,
-      "dot": dot.map(Syntax.init)?._asConcreteType as Any,
+      "name": Syntax(name).as(SyntaxProtocol.self),
+      "dot": dot.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1652,8 +1652,8 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension TypeInitializerClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "equal": Syntax(equal)._asConcreteType,
-      "value": Syntax(value)._asConcreteType,
+      "equal": Syntax(equal).as(SyntaxProtocol.self),
+      "value": Syntax(value).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1770,9 +1770,9 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension ParameterClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "parameterList": Syntax(parameterList)._asConcreteType,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "parameterList": Syntax(parameterList).as(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1848,8 +1848,8 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension ReturnClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "arrow": Syntax(arrow)._asConcreteType,
-      "returnType": Syntax(returnType)._asConcreteType,
+      "arrow": Syntax(arrow).as(SyntaxProtocol.self),
+      "returnType": Syntax(returnType).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1949,9 +1949,9 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 extension FunctionSignatureSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "input": Syntax(input)._asConcreteType,
-      "throwsOrRethrowsKeyword": throwsOrRethrowsKeyword.map(Syntax.init)?._asConcreteType as Any,
-      "output": output.map(Syntax.init)?._asConcreteType as Any,
+      "input": Syntax(input).as(SyntaxProtocol.self),
+      "throwsOrRethrowsKeyword": throwsOrRethrowsKeyword.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "output": output.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2050,9 +2050,9 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension IfConfigClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundKeyword": Syntax(poundKeyword)._asConcreteType,
-      "condition": condition.map(Syntax.init)?._asConcreteType as Any,
-      "elements": Syntax(elements)._asConcreteType,
+      "poundKeyword": Syntax(poundKeyword).as(SyntaxProtocol.self),
+      "condition": condition.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "elements": Syntax(elements).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2238,13 +2238,13 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
 extension PoundSourceLocationArgsSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "fileArgLabel": Syntax(fileArgLabel)._asConcreteType,
-      "fileArgColon": Syntax(fileArgColon)._asConcreteType,
-      "fileName": Syntax(fileName)._asConcreteType,
-      "comma": Syntax(comma)._asConcreteType,
-      "lineArgLabel": Syntax(lineArgLabel)._asConcreteType,
-      "lineArgColon": Syntax(lineArgColon)._asConcreteType,
-      "lineNumber": Syntax(lineNumber)._asConcreteType,
+      "fileArgLabel": Syntax(fileArgLabel).as(SyntaxProtocol.self),
+      "fileArgColon": Syntax(fileArgColon).as(SyntaxProtocol.self),
+      "fileName": Syntax(fileName).as(SyntaxProtocol.self),
+      "comma": Syntax(comma).as(SyntaxProtocol.self),
+      "lineArgLabel": Syntax(lineArgLabel).as(SyntaxProtocol.self),
+      "lineArgColon": Syntax(lineArgColon).as(SyntaxProtocol.self),
+      "lineNumber": Syntax(lineNumber).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2367,10 +2367,10 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
 extension DeclModifierSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name)._asConcreteType,
-      "detailLeftParen": detailLeftParen.map(Syntax.init)?._asConcreteType as Any,
-      "detail": detail.map(Syntax.init)?._asConcreteType as Any,
-      "detailRightParen": detailRightParen.map(Syntax.init)?._asConcreteType as Any,
+      "name": Syntax(name).as(SyntaxProtocol.self),
+      "detailLeftParen": detailLeftParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "detail": detail.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "detailRightParen": detailRightParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2447,8 +2447,8 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 extension InheritedTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "typeName": Syntax(typeName)._asConcreteType,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "typeName": Syntax(typeName).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2543,8 +2543,8 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension TypeInheritanceClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "colon": Syntax(colon)._asConcreteType,
-      "inheritedTypeCollection": Syntax(inheritedTypeCollection)._asConcreteType,
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "inheritedTypeCollection": Syntax(inheritedTypeCollection).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2661,9 +2661,9 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
 extension MemberDeclBlockSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftBrace": Syntax(leftBrace)._asConcreteType,
-      "members": Syntax(members)._asConcreteType,
-      "rightBrace": Syntax(rightBrace)._asConcreteType,
+      "leftBrace": Syntax(leftBrace).as(SyntaxProtocol.self),
+      "members": Syntax(members).as(SyntaxProtocol.self),
+      "rightBrace": Syntax(rightBrace).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2671,7 +2671,8 @@ extension MemberDeclBlockSyntax: CustomReflectable {
 // MARK: - MemberDeclListItemSyntax
 
 /// 
-/// A member declaration of a type consisting of a declaration and an          optional semicolon;
+/// A member declaration of a type consisting of a declaration and an
+/// optional semicolon;
 /// 
 public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
@@ -2745,8 +2746,8 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
 extension MemberDeclListItemSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "decl": Syntax(decl)._asConcreteType,
-      "semicolon": semicolon.map(Syntax.init)?._asConcreteType as Any,
+      "decl": Syntax(decl).as(SyntaxProtocol.self),
+      "semicolon": semicolon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2841,8 +2842,8 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
 extension SourceFileSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "statements": Syntax(statements)._asConcreteType,
-      "eofToken": Syntax(eofToken)._asConcreteType,
+      "statements": Syntax(statements).as(SyntaxProtocol.self),
+      "eofToken": Syntax(eofToken).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2918,8 +2919,8 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension InitializerClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "equal": Syntax(equal)._asConcreteType,
-      "value": Syntax(value)._asConcreteType,
+      "equal": Syntax(equal).as(SyntaxProtocol.self),
+      "value": Syntax(value).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -3154,14 +3155,14 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
 extension FunctionParameterSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "firstName": firstName.map(Syntax.init)?._asConcreteType as Any,
-      "secondName": secondName.map(Syntax.init)?._asConcreteType as Any,
-      "colon": colon.map(Syntax.init)?._asConcreteType as Any,
-      "type": type.map(Syntax.init)?._asConcreteType as Any,
-      "ellipsis": ellipsis.map(Syntax.init)?._asConcreteType as Any,
-      "defaultArgument": defaultArgument.map(Syntax.init)?._asConcreteType as Any,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "firstName": firstName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "secondName": secondName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "colon": colon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "type": type.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "ellipsis": ellipsis.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "defaultArgument": defaultArgument.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3284,10 +3285,10 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
 extension AccessLevelModifierSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name)._asConcreteType,
-      "leftParen": leftParen.map(Syntax.init)?._asConcreteType as Any,
-      "modifier": modifier.map(Syntax.init)?._asConcreteType as Any,
-      "rightParen": rightParen.map(Syntax.init)?._asConcreteType as Any,
+      "name": Syntax(name).as(SyntaxProtocol.self),
+      "leftParen": leftParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "modifier": modifier.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "rightParen": rightParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3364,8 +3365,8 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 extension AccessPathComponentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name)._asConcreteType,
-      "trailingDot": trailingDot.map(Syntax.init)?._asConcreteType as Any,
+      "name": Syntax(name).as(SyntaxProtocol.self),
+      "trailingDot": trailingDot.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3463,9 +3464,9 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
 extension AccessorParameterSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "name": Syntax(name)._asConcreteType,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "name": Syntax(name).as(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -3582,9 +3583,9 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
 extension AccessorBlockSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftBrace": Syntax(leftBrace)._asConcreteType,
-      "accessors": Syntax(accessors)._asConcreteType,
-      "rightBrace": Syntax(rightBrace)._asConcreteType,
+      "leftBrace": Syntax(leftBrace).as(SyntaxProtocol.self),
+      "accessors": Syntax(accessors).as(SyntaxProtocol.self),
+      "rightBrace": Syntax(rightBrace).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -3730,11 +3731,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
 extension PatternBindingSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "pattern": Syntax(pattern)._asConcreteType,
-      "typeAnnotation": typeAnnotation.map(Syntax.init)?._asConcreteType as Any,
-      "initializer": initializer.map(Syntax.init)?._asConcreteType as Any,
-      "accessor": accessor.map(Syntax.init)?._asConcreteType as Any,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
+      "typeAnnotation": typeAnnotation.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "initializer": initializer.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "accessor": accessor.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3742,7 +3743,8 @@ extension PatternBindingSyntax: CustomReflectable {
 // MARK: - EnumCaseElementSyntax
 
 /// 
-/// An element of an enum case, containing the name of the case and,          optionally, either associated values or an assignment to a raw value.
+/// An element of an enum case, containing the name of the case and,
+/// optionally, either associated values or an assignment to a raw value.
 /// 
 public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
@@ -3840,7 +3842,8 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   }
 
   /// 
-  /// The trailing comma of this element, if the case has                    multiple elements.
+  /// The trailing comma of this element, if the case has
+  /// multiple elements.
   /// 
   public var trailingComma: TokenSyntax? {
     get {
@@ -3868,10 +3871,10 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension EnumCaseElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "identifier": Syntax(identifier)._asConcreteType,
-      "associatedValue": associatedValue.map(Syntax.init)?._asConcreteType as Any,
-      "rawValue": rawValue.map(Syntax.init)?._asConcreteType as Any,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
+      "associatedValue": associatedValue.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "rawValue": rawValue.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3972,8 +3975,8 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
 extension OperatorPrecedenceAndTypesSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "colon": Syntax(colon)._asConcreteType,
-      "precedenceGroupAndDesignatedTypes": Syntax(precedenceGroupAndDesignatedTypes)._asConcreteType,
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "precedenceGroupAndDesignatedTypes": Syntax(precedenceGroupAndDesignatedTypes).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -4101,9 +4104,9 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
 extension PrecedenceGroupRelationSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "higherThanOrLowerThan": Syntax(higherThanOrLowerThan)._asConcreteType,
-      "colon": Syntax(colon)._asConcreteType,
-      "otherNames": Syntax(otherNames)._asConcreteType,
+      "higherThanOrLowerThan": Syntax(higherThanOrLowerThan).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "otherNames": Syntax(otherNames).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -4180,8 +4183,8 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension PrecedenceGroupNameElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name)._asConcreteType,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "name": Syntax(name).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4290,9 +4293,9 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
 extension PrecedenceGroupAssignmentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "assignmentKeyword": Syntax(assignmentKeyword)._asConcreteType,
-      "colon": Syntax(colon)._asConcreteType,
-      "flag": Syntax(flag)._asConcreteType,
+      "assignmentKeyword": Syntax(assignmentKeyword).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "flag": Syntax(flag).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -4400,9 +4403,9 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
 extension PrecedenceGroupAssociativitySyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "associativityKeyword": Syntax(associativityKeyword)._asConcreteType,
-      "colon": Syntax(colon)._asConcreteType,
-      "value": Syntax(value)._asConcreteType,
+      "associativityKeyword": Syntax(associativityKeyword).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "value": Syntax(value).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -4571,11 +4574,11 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
 extension CustomAttributeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "atSignToken": Syntax(atSignToken)._asConcreteType,
-      "attributeName": Syntax(attributeName)._asConcreteType,
-      "leftParen": leftParen.map(Syntax.init)?._asConcreteType as Any,
-      "argumentList": argumentList.map(Syntax.init)?._asConcreteType as Any,
-      "rightParen": rightParen.map(Syntax.init)?._asConcreteType as Any,
+      "atSignToken": Syntax(atSignToken).as(SyntaxProtocol.self),
+      "attributeName": Syntax(attributeName).as(SyntaxProtocol.self),
+      "leftParen": leftParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "argumentList": argumentList.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "rightParen": rightParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4682,7 +4685,9 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   }
 
   /// 
-  /// The arguments of the attribute. In case the attribute                     takes multiple arguments, they are gather in the                    appropriate takes first.
+  /// The arguments of the attribute. In case the attribute
+  /// takes multiple arguments, they are gather in the
+  /// appropriate takes first.
   /// 
   public var argument: Syntax? {
     get {
@@ -4776,12 +4781,12 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
 extension AttributeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "atSignToken": Syntax(atSignToken)._asConcreteType,
-      "attributeName": Syntax(attributeName)._asConcreteType,
-      "leftParen": leftParen.map(Syntax.init)?._asConcreteType as Any,
-      "argument": argument.map(Syntax.init)?._asConcreteType as Any,
-      "rightParen": rightParen.map(Syntax.init)?._asConcreteType as Any,
-      "tokenList": tokenList.map(Syntax.init)?._asConcreteType as Any,
+      "atSignToken": Syntax(atSignToken).as(SyntaxProtocol.self),
+      "attributeName": Syntax(attributeName).as(SyntaxProtocol.self),
+      "leftParen": leftParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "argument": argument.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "rightParen": rightParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "tokenList": tokenList.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4789,7 +4794,8 @@ extension AttributeSyntax: CustomReflectable {
 // MARK: - LabeledSpecializeEntrySyntax
 
 /// 
-/// A labeled argument for the `@_specialize` attribute like          `exported: true`
+/// A labeled argument for the `@_specialize` attribute like
+/// `exported: true`
 /// 
 public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
@@ -4911,10 +4917,10 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
 extension LabeledSpecializeEntrySyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "label": Syntax(label)._asConcreteType,
-      "colon": Syntax(colon)._asConcreteType,
-      "value": Syntax(value)._asConcreteType,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "label": Syntax(label).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "value": Syntax(value).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4922,7 +4928,9 @@ extension LabeledSpecializeEntrySyntax: CustomReflectable {
 // MARK: - NamedAttributeStringArgumentSyntax
 
 /// 
-/// The argument for the `@_dynamic_replacement` or `@_private`          attribute of the form `for: "function()"` or `sourceFile:          "Src.swift"`
+/// The argument for the `@_dynamic_replacement` or `@_private`
+/// attribute of the form `for: "function()"` or `sourceFile:
+/// "Src.swift"`
 /// 
 public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
@@ -5017,9 +5025,9 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
 extension NamedAttributeStringArgumentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "nameTok": Syntax(nameTok)._asConcreteType,
-      "colon": Syntax(colon)._asConcreteType,
-      "stringOrDeclname": Syntax(stringOrDeclname)._asConcreteType,
+      "nameTok": Syntax(nameTok).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "stringOrDeclname": Syntax(stringOrDeclname).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -5074,7 +5082,8 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   }
 
   /// 
-  /// The argument labels of the protocol's requirement if it                is a function requirement.
+  /// The argument labels of the protocol's requirement if it
+  /// is a function requirement.
   /// 
   public var declNameArguments: DeclNameArgumentsSyntax? {
     get {
@@ -5102,8 +5111,8 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 extension DeclNameSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "declBaseName": Syntax(declBaseName)._asConcreteType,
-      "declNameArguments": declNameArguments.map(Syntax.init)?._asConcreteType as Any,
+      "declBaseName": Syntax(declBaseName).as(SyntaxProtocol.self),
+      "declNameArguments": declNameArguments.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5111,7 +5120,8 @@ extension DeclNameSyntax: CustomReflectable {
 // MARK: - ImplementsAttributeArgumentsSyntax
 
 /// 
-/// The arguments for the `@_implements` attribute of the form          `Type, methodName(arg1Label:arg2Label:)`
+/// The arguments for the `@_implements` attribute of the form
+/// `Type, methodName(arg1Label:arg2Label:)`
 /// 
 public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
@@ -5139,7 +5149,8 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   }
 
   /// 
-  /// The type for which the method with this attribute                    implements a requirement.
+  /// The type for which the method with this attribute
+  /// implements a requirement.
   /// 
   public var type: SimpleTypeIdentifierSyntax {
     get {
@@ -5211,7 +5222,8 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   }
 
   /// 
-  /// The argument labels of the protocol's requirement if it                    is a function requirement.
+  /// The argument labels of the protocol's requirement if it
+  /// is a function requirement.
   /// 
   public var declNameArguments: DeclNameArgumentsSyntax? {
     get {
@@ -5239,10 +5251,10 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 extension ImplementsAttributeArgumentsSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "type": Syntax(type)._asConcreteType,
-      "comma": Syntax(comma)._asConcreteType,
-      "declBaseName": Syntax(declBaseName)._asConcreteType,
-      "declNameArguments": declNameArguments.map(Syntax.init)?._asConcreteType as Any,
+      "type": Syntax(type).as(SyntaxProtocol.self),
+      "comma": Syntax(comma).as(SyntaxProtocol.self),
+      "declBaseName": Syntax(declBaseName).as(SyntaxProtocol.self),
+      "declNameArguments": declNameArguments.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5250,7 +5262,9 @@ extension ImplementsAttributeArgumentsSyntax: CustomReflectable {
 // MARK: - ObjCSelectorPieceSyntax
 
 /// 
-/// A piece of an Objective-C selector. Either consisiting of just an          identifier for a nullary selector, an identifier and a colon for a          labeled argument or just a colon for an unlabeled argument
+/// A piece of an Objective-C selector. Either consisiting of just an
+/// identifier for a nullary selector, an identifier and a colon for a
+/// labeled argument or just a colon for an unlabeled argument
 /// 
 public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
@@ -5323,8 +5337,8 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
 extension ObjCSelectorPieceSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": name.map(Syntax.init)?._asConcreteType as Any,
-      "colon": colon.map(Syntax.init)?._asConcreteType as Any,
+      "name": name.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "colon": colon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5400,8 +5414,8 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension WhereClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "whereKeyword": Syntax(whereKeyword)._asConcreteType,
-      "guardResult": Syntax(guardResult)._asConcreteType,
+      "whereKeyword": Syntax(whereKeyword).as(SyntaxProtocol.self),
+      "guardResult": Syntax(guardResult).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -5541,10 +5555,10 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
 extension YieldListSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "elementList": Syntax(elementList)._asConcreteType,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "elementList": Syntax(elementList).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -5621,8 +5635,8 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension ConditionElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "condition": Syntax(condition)._asConcreteType,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "condition": Syntax(condition).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5761,10 +5775,10 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
 extension AvailabilityConditionSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundAvailableKeyword": Syntax(poundAvailableKeyword)._asConcreteType,
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "availabilitySpec": Syntax(availabilitySpec)._asConcreteType,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "poundAvailableKeyword": Syntax(poundAvailableKeyword).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "availabilitySpec": Syntax(availabilitySpec).as(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -5885,10 +5899,10 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
 extension MatchingPatternConditionSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "caseKeyword": Syntax(caseKeyword)._asConcreteType,
-      "pattern": Syntax(pattern)._asConcreteType,
-      "typeAnnotation": typeAnnotation.map(Syntax.init)?._asConcreteType as Any,
-      "initializer": Syntax(initializer)._asConcreteType,
+      "caseKeyword": Syntax(caseKeyword).as(SyntaxProtocol.self),
+      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
+      "typeAnnotation": typeAnnotation.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "initializer": Syntax(initializer).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -6009,10 +6023,10 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
 extension OptionalBindingConditionSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "letOrVarKeyword": Syntax(letOrVarKeyword)._asConcreteType,
-      "pattern": Syntax(pattern)._asConcreteType,
-      "typeAnnotation": typeAnnotation.map(Syntax.init)?._asConcreteType as Any,
-      "initializer": Syntax(initializer)._asConcreteType,
+      "letOrVarKeyword": Syntax(letOrVarKeyword).as(SyntaxProtocol.self),
+      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
+      "typeAnnotation": typeAnnotation.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "initializer": Syntax(initializer).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -6066,7 +6080,7 @@ public struct ElseIfContinuationSyntax: SyntaxProtocol, SyntaxHashable {
 extension ElseIfContinuationSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "ifStatement": Syntax(ifStatement)._asConcreteType,
+      "ifStatement": Syntax(ifStatement).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -6142,8 +6156,8 @@ public struct ElseBlockSyntax: SyntaxProtocol, SyntaxHashable {
 extension ElseBlockSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "elseKeyword": Syntax(elseKeyword)._asConcreteType,
-      "body": Syntax(body)._asConcreteType,
+      "elseKeyword": Syntax(elseKeyword).as(SyntaxProtocol.self),
+      "body": Syntax(body).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -6261,9 +6275,9 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
 extension SwitchCaseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "unknownAttr": unknownAttr.map(Syntax.init)?._asConcreteType as Any,
-      "label": Syntax(label)._asConcreteType,
-      "statements": Syntax(statements)._asConcreteType,
+      "unknownAttr": unknownAttr.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "label": Syntax(label).as(SyntaxProtocol.self),
+      "statements": Syntax(statements).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -6339,8 +6353,8 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
 extension SwitchDefaultLabelSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "defaultKeyword": Syntax(defaultKeyword)._asConcreteType,
-      "colon": Syntax(colon)._asConcreteType,
+      "defaultKeyword": Syntax(defaultKeyword).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -6440,9 +6454,9 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
 extension CaseItemSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "pattern": Syntax(pattern)._asConcreteType,
-      "whereClause": whereClause.map(Syntax.init)?._asConcreteType as Any,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
+      "whereClause": whereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6559,9 +6573,9 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
 extension SwitchCaseLabelSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "caseKeyword": Syntax(caseKeyword)._asConcreteType,
-      "caseItems": Syntax(caseItems)._asConcreteType,
-      "colon": Syntax(colon)._asConcreteType,
+      "caseKeyword": Syntax(caseKeyword).as(SyntaxProtocol.self),
+      "caseItems": Syntax(caseItems).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -6683,10 +6697,10 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension CatchClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "catchKeyword": Syntax(catchKeyword)._asConcreteType,
-      "pattern": pattern.map(Syntax.init)?._asConcreteType as Any,
-      "whereClause": whereClause.map(Syntax.init)?._asConcreteType as Any,
-      "body": Syntax(body)._asConcreteType,
+      "catchKeyword": Syntax(catchKeyword).as(SyntaxProtocol.self),
+      "pattern": pattern.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "whereClause": whereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "body": Syntax(body).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -6781,8 +6795,8 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension GenericWhereClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "whereKeyword": Syntax(whereKeyword)._asConcreteType,
-      "requirementList": Syntax(requirementList)._asConcreteType,
+      "whereKeyword": Syntax(whereKeyword).as(SyntaxProtocol.self),
+      "requirementList": Syntax(requirementList).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -6859,8 +6873,8 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 extension GenericRequirementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "body": Syntax(body)._asConcreteType,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "body": Syntax(body).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6958,9 +6972,9 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 extension SameTypeRequirementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftTypeIdentifier": Syntax(leftTypeIdentifier)._asConcreteType,
-      "equalityToken": Syntax(equalityToken)._asConcreteType,
-      "rightTypeIdentifier": Syntax(rightTypeIdentifier)._asConcreteType,
+      "leftTypeIdentifier": Syntax(leftTypeIdentifier).as(SyntaxProtocol.self),
+      "equalityToken": Syntax(equalityToken).as(SyntaxProtocol.self),
+      "rightTypeIdentifier": Syntax(rightTypeIdentifier).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -7125,11 +7139,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
 extension GenericParameterSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "name": Syntax(name)._asConcreteType,
-      "colon": colon.map(Syntax.init)?._asConcreteType as Any,
-      "inheritedType": inheritedType.map(Syntax.init)?._asConcreteType as Any,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "name": Syntax(name).as(SyntaxProtocol.self),
+      "colon": colon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "inheritedType": inheritedType.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7246,9 +7260,9 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension GenericParameterClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftAngleBracket": Syntax(leftAngleBracket)._asConcreteType,
-      "genericParameterList": Syntax(genericParameterList)._asConcreteType,
-      "rightAngleBracket": Syntax(rightAngleBracket)._asConcreteType,
+      "leftAngleBracket": Syntax(leftAngleBracket).as(SyntaxProtocol.self),
+      "genericParameterList": Syntax(genericParameterList).as(SyntaxProtocol.self),
+      "rightAngleBracket": Syntax(rightAngleBracket).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -7346,9 +7360,9 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 extension ConformanceRequirementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftTypeIdentifier": Syntax(leftTypeIdentifier)._asConcreteType,
-      "colon": Syntax(colon)._asConcreteType,
-      "rightTypeIdentifier": Syntax(rightTypeIdentifier)._asConcreteType,
+      "leftTypeIdentifier": Syntax(leftTypeIdentifier).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "rightTypeIdentifier": Syntax(rightTypeIdentifier).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -7425,8 +7439,8 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension CompositionTypeElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "type": Syntax(type)._asConcreteType,
-      "ampersand": ampersand.map(Syntax.init)?._asConcreteType as Any,
+      "type": Syntax(type).as(SyntaxProtocol.self),
+      "ampersand": ampersand.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7641,14 +7655,14 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension TupleTypeElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "inOut": inOut.map(Syntax.init)?._asConcreteType as Any,
-      "name": name.map(Syntax.init)?._asConcreteType as Any,
-      "secondName": secondName.map(Syntax.init)?._asConcreteType as Any,
-      "colon": colon.map(Syntax.init)?._asConcreteType as Any,
-      "type": Syntax(type)._asConcreteType,
-      "ellipsis": ellipsis.map(Syntax.init)?._asConcreteType as Any,
-      "initializer": initializer.map(Syntax.init)?._asConcreteType as Any,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "inOut": inOut.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "name": name.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "secondName": secondName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "colon": colon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "type": Syntax(type).as(SyntaxProtocol.self),
+      "ellipsis": ellipsis.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "initializer": initializer.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7725,8 +7739,8 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 extension GenericArgumentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "argumentType": Syntax(argumentType)._asConcreteType,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "argumentType": Syntax(argumentType).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7843,9 +7857,9 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension GenericArgumentClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftAngleBracket": Syntax(leftAngleBracket)._asConcreteType,
-      "arguments": Syntax(arguments)._asConcreteType,
-      "rightAngleBracket": Syntax(rightAngleBracket)._asConcreteType,
+      "leftAngleBracket": Syntax(leftAngleBracket).as(SyntaxProtocol.self),
+      "arguments": Syntax(arguments).as(SyntaxProtocol.self),
+      "rightAngleBracket": Syntax(rightAngleBracket).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -7921,8 +7935,8 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
 extension TypeAnnotationSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "colon": Syntax(colon)._asConcreteType,
-      "type": Syntax(type)._asConcreteType,
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "type": Syntax(type).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -8045,10 +8059,10 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension TuplePatternElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "labelName": labelName.map(Syntax.init)?._asConcreteType as Any,
-      "labelColon": labelColon.map(Syntax.init)?._asConcreteType as Any,
-      "pattern": Syntax(pattern)._asConcreteType,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "labelName": labelName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "labelColon": labelColon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -8056,7 +8070,8 @@ extension TuplePatternElementSyntax: CustomReflectable {
 // MARK: - AvailabilityArgumentSyntax
 
 /// 
-/// A single argument to an `@available` argument like `*`, `iOS 10.1`,          or `message: "This has been deprecated"`.
+/// A single argument to an `@available` argument like `*`, `iOS 10.1`,
+/// or `message: "This has been deprecated"`.
 /// 
 public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
@@ -8104,7 +8119,8 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   }
 
   /// 
-  /// A trailing comma if the argument is followed by another                    argument
+  /// A trailing comma if the argument is followed by another
+  /// argument
   /// 
   public var trailingComma: TokenSyntax? {
     get {
@@ -8132,8 +8148,8 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 extension AvailabilityArgumentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "entry": Syntax(entry)._asConcreteType,
-      "trailingComma": trailingComma.map(Syntax.init)?._asConcreteType as Any,
+      "entry": Syntax(entry).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -8141,7 +8157,8 @@ extension AvailabilityArgumentSyntax: CustomReflectable {
 // MARK: - AvailabilityLabeledArgumentSyntax
 
 /// 
-/// A argument to an `@available` attribute that consists of a label and          a value, e.g. `message: "This has been deprecated"`.
+/// A argument to an `@available` attribute that consists of a label and
+/// a value, e.g. `message: "This has been deprecated"`.
 /// 
 public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
@@ -8237,9 +8254,9 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
 extension AvailabilityLabeledArgumentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "label": Syntax(label)._asConcreteType,
-      "colon": Syntax(colon)._asConcreteType,
-      "value": Syntax(value)._asConcreteType,
+      "label": Syntax(label).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "value": Syntax(value).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -8247,7 +8264,8 @@ extension AvailabilityLabeledArgumentSyntax: CustomReflectable {
 // MARK: - AvailabilityVersionRestrictionSyntax
 
 /// 
-/// An argument to `@available` that restricts the availability on a          certain platform to a version, e.g. `iOS 10` or `swift 3.4`.
+/// An argument to `@available` that restricts the availability on a
+/// certain platform to a version, e.g. `iOS 10` or `swift 3.4`.
 /// 
 public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
@@ -8273,7 +8291,9 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
   }
 
   /// 
-  /// The name of the OS on which the availability should be                    restricted or 'swift' if the availability should be                    restricted based on a Swift version.
+  /// The name of the OS on which the availability should be
+  /// restricted or 'swift' if the availability should be
+  /// restricted based on a Swift version.
   /// 
   public var platform: TokenSyntax {
     get {
@@ -8321,8 +8341,8 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
 extension AvailabilityVersionRestrictionSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "platform": Syntax(platform)._asConcreteType,
-      "version": Syntax(version)._asConcreteType,
+      "platform": Syntax(platform).as(SyntaxProtocol.self),
+      "version": Syntax(version).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -8330,7 +8350,8 @@ extension AvailabilityVersionRestrictionSyntax: CustomReflectable {
 // MARK: - VersionTupleSyntax
 
 /// 
-/// A version number of the form major.minor.patch in which the minor          and patch part may be ommited.
+/// A version number of the form major.minor.patch in which the minor
+/// and patch part may be ommited.
 /// 
 public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
@@ -8357,7 +8378,11 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   }
 
   /// 
-  /// In case the version consists only of the major version, an                    integer literal that specifies the major version. In case                    the version consists of major and minor version number, a                    floating literal in which the decimal part is interpreted                    as the minor version.
+  /// In case the version consists only of the major version, an
+  /// integer literal that specifies the major version. In case
+  /// the version consists of major and minor version number, a
+  /// floating literal in which the decimal part is interpreted
+  /// as the minor version.
   /// 
   public var majorMinor: Syntax {
     get {
@@ -8381,7 +8406,8 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   }
 
   /// 
-  /// If the version contains a patch number, the period                    separating the minor from the patch number.
+  /// If the version contains a patch number, the period
+  /// separating the minor from the patch number.
   /// 
   public var patchPeriod: TokenSyntax? {
     get {
@@ -8434,9 +8460,9 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
 extension VersionTupleSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "majorMinor": Syntax(majorMinor)._asConcreteType,
-      "patchPeriod": patchPeriod.map(Syntax.init)?._asConcreteType as Any,
-      "patchVersion": patchVersion.map(Syntax.init)?._asConcreteType as Any,
+      "majorMinor": Syntax(majorMinor).as(SyntaxProtocol.self),
+      "patchPeriod": patchPeriod.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "patchVersion": patchVersion.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -19,7 +19,7 @@
 /// A CodeBlockItem is any Syntax node that appears on its own line inside
 /// a CodeBlock.
 /// 
-public struct CodeBlockItemSyntax: SyntaxProtocol {
+public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case item
     case semicolon
@@ -125,7 +125,7 @@ extension CodeBlockItemSyntax: CustomReflectable {
 
 // MARK: - CodeBlockSyntax
 
-public struct CodeBlockSyntax: SyntaxProtocol {
+public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftBrace
     case statements
@@ -244,7 +244,7 @@ extension CodeBlockSyntax: CustomReflectable {
 
 // MARK: - DeclNameArgumentSyntax
 
-public struct DeclNameArgumentSyntax: SyntaxProtocol {
+public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case name
     case colon
@@ -321,7 +321,7 @@ extension DeclNameArgumentSyntax: CustomReflectable {
 
 // MARK: - DeclNameArgumentsSyntax
 
-public struct DeclNameArgumentsSyntax: SyntaxProtocol {
+public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftParen
     case arguments
@@ -440,7 +440,7 @@ extension DeclNameArgumentsSyntax: CustomReflectable {
 
 // MARK: - TupleExprElementSyntax
 
-public struct TupleExprElementSyntax: SyntaxProtocol {
+public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case label
     case colon
@@ -566,7 +566,7 @@ extension TupleExprElementSyntax: CustomReflectable {
 
 // MARK: - ArrayElementSyntax
 
-public struct ArrayElementSyntax: SyntaxProtocol {
+public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case expression
     case trailingComma
@@ -644,7 +644,7 @@ extension ArrayElementSyntax: CustomReflectable {
 
 // MARK: - DictionaryElementSyntax
 
-public struct DictionaryElementSyntax: SyntaxProtocol {
+public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case keyExpression
     case colon
@@ -768,7 +768,7 @@ extension DictionaryElementSyntax: CustomReflectable {
 
 // MARK: - ClosureCaptureItemSyntax
 
-public struct ClosureCaptureItemSyntax: SyntaxProtocol {
+public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case specifier
     case name
@@ -937,7 +937,7 @@ extension ClosureCaptureItemSyntax: CustomReflectable {
 
 // MARK: - ClosureCaptureSignatureSyntax
 
-public struct ClosureCaptureSignatureSyntax: SyntaxProtocol {
+public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftSquare
     case items
@@ -1057,7 +1057,7 @@ extension ClosureCaptureSignatureSyntax: CustomReflectable {
 
 // MARK: - ClosureParamSyntax
 
-public struct ClosureParamSyntax: SyntaxProtocol {
+public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case name
     case trailingComma
@@ -1135,7 +1135,7 @@ extension ClosureParamSyntax: CustomReflectable {
 
 // MARK: - ClosureSignatureSyntax
 
-public struct ClosureSignatureSyntax: SyntaxProtocol {
+public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case capture
     case input
@@ -1285,7 +1285,7 @@ extension ClosureSignatureSyntax: CustomReflectable {
 
 // MARK: - StringSegmentSyntax
 
-public struct StringSegmentSyntax: SyntaxProtocol {
+public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case content
   }
@@ -1339,7 +1339,7 @@ extension StringSegmentSyntax: CustomReflectable {
 
 // MARK: - ExpressionSegmentSyntax
 
-public struct ExpressionSegmentSyntax: SyntaxProtocol {
+public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case backslash
     case delimiter
@@ -1505,7 +1505,7 @@ extension ExpressionSegmentSyntax: CustomReflectable {
 
 // MARK: - ObjcNamePieceSyntax
 
-public struct ObjcNamePieceSyntax: SyntaxProtocol {
+public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case name
     case dot
@@ -1583,7 +1583,7 @@ extension ObjcNamePieceSyntax: CustomReflectable {
 
 // MARK: - TypeInitializerClauseSyntax
 
-public struct TypeInitializerClauseSyntax: SyntaxProtocol {
+public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case equal
     case value
@@ -1660,7 +1660,7 @@ extension TypeInitializerClauseSyntax: CustomReflectable {
 
 // MARK: - ParameterClauseSyntax
 
-public struct ParameterClauseSyntax: SyntaxProtocol {
+public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftParen
     case parameterList
@@ -1779,7 +1779,7 @@ extension ParameterClauseSyntax: CustomReflectable {
 
 // MARK: - ReturnClauseSyntax
 
-public struct ReturnClauseSyntax: SyntaxProtocol {
+public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case arrow
     case returnType
@@ -1856,7 +1856,7 @@ extension ReturnClauseSyntax: CustomReflectable {
 
 // MARK: - FunctionSignatureSyntax
 
-public struct FunctionSignatureSyntax: SyntaxProtocol {
+public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case input
     case throwsOrRethrowsKeyword
@@ -1958,7 +1958,7 @@ extension FunctionSignatureSyntax: CustomReflectable {
 
 // MARK: - IfConfigClauseSyntax
 
-public struct IfConfigClauseSyntax: SyntaxProtocol {
+public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case poundKeyword
     case condition
@@ -2059,7 +2059,7 @@ extension IfConfigClauseSyntax: CustomReflectable {
 
 // MARK: - PoundSourceLocationArgsSyntax
 
-public struct PoundSourceLocationArgsSyntax: SyntaxProtocol {
+public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case fileArgLabel
     case fileArgColon
@@ -2251,7 +2251,7 @@ extension PoundSourceLocationArgsSyntax: CustomReflectable {
 
 // MARK: - DeclModifierSyntax
 
-public struct DeclModifierSyntax: SyntaxProtocol {
+public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case name
     case detailLeftParen
@@ -2377,7 +2377,7 @@ extension DeclModifierSyntax: CustomReflectable {
 
 // MARK: - InheritedTypeSyntax
 
-public struct InheritedTypeSyntax: SyntaxProtocol {
+public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case typeName
     case trailingComma
@@ -2455,7 +2455,7 @@ extension InheritedTypeSyntax: CustomReflectable {
 
 // MARK: - TypeInheritanceClauseSyntax
 
-public struct TypeInheritanceClauseSyntax: SyntaxProtocol {
+public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case colon
     case inheritedTypeCollection
@@ -2551,7 +2551,7 @@ extension TypeInheritanceClauseSyntax: CustomReflectable {
 
 // MARK: - MemberDeclBlockSyntax
 
-public struct MemberDeclBlockSyntax: SyntaxProtocol {
+public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftBrace
     case members
@@ -2671,10 +2671,9 @@ extension MemberDeclBlockSyntax: CustomReflectable {
 // MARK: - MemberDeclListItemSyntax
 
 /// 
-/// A member declaration of a type consisting of a declaration and an
-/// optional semicolon;
+/// A member declaration of a type consisting of a declaration and an          optional semicolon;
 /// 
-public struct MemberDeclListItemSyntax: SyntaxProtocol {
+public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case decl
     case semicolon
@@ -2754,7 +2753,7 @@ extension MemberDeclListItemSyntax: CustomReflectable {
 
 // MARK: - SourceFileSyntax
 
-public struct SourceFileSyntax: SyntaxProtocol {
+public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case statements
     case eofToken
@@ -2850,7 +2849,7 @@ extension SourceFileSyntax: CustomReflectable {
 
 // MARK: - InitializerClauseSyntax
 
-public struct InitializerClauseSyntax: SyntaxProtocol {
+public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case equal
     case value
@@ -2927,7 +2926,7 @@ extension InitializerClauseSyntax: CustomReflectable {
 
 // MARK: - FunctionParameterSyntax
 
-public struct FunctionParameterSyntax: SyntaxProtocol {
+public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case firstName
@@ -3169,7 +3168,7 @@ extension FunctionParameterSyntax: CustomReflectable {
 
 // MARK: - AccessLevelModifierSyntax
 
-public struct AccessLevelModifierSyntax: SyntaxProtocol {
+public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case name
     case leftParen
@@ -3295,7 +3294,7 @@ extension AccessLevelModifierSyntax: CustomReflectable {
 
 // MARK: - AccessPathComponentSyntax
 
-public struct AccessPathComponentSyntax: SyntaxProtocol {
+public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case name
     case trailingDot
@@ -3373,7 +3372,7 @@ extension AccessPathComponentSyntax: CustomReflectable {
 
 // MARK: - AccessorParameterSyntax
 
-public struct AccessorParameterSyntax: SyntaxProtocol {
+public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftParen
     case name
@@ -3473,7 +3472,7 @@ extension AccessorParameterSyntax: CustomReflectable {
 
 // MARK: - AccessorBlockSyntax
 
-public struct AccessorBlockSyntax: SyntaxProtocol {
+public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftBrace
     case accessors
@@ -3592,7 +3591,7 @@ extension AccessorBlockSyntax: CustomReflectable {
 
 // MARK: - PatternBindingSyntax
 
-public struct PatternBindingSyntax: SyntaxProtocol {
+public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case pattern
     case typeAnnotation
@@ -3743,10 +3742,9 @@ extension PatternBindingSyntax: CustomReflectable {
 // MARK: - EnumCaseElementSyntax
 
 /// 
-/// An element of an enum case, containing the name of the case and,
-/// optionally, either associated values or an assignment to a raw value.
+/// An element of an enum case, containing the name of the case and,          optionally, either associated values or an assignment to a raw value.
 /// 
-public struct EnumCaseElementSyntax: SyntaxProtocol {
+public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case identifier
     case associatedValue
@@ -3842,8 +3840,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol {
   }
 
   /// 
-  /// The trailing comma of this element, if the case has
-  /// multiple elements.
+  /// The trailing comma of this element, if the case has                    multiple elements.
   /// 
   public var trailingComma: TokenSyntax? {
     get {
@@ -3884,7 +3881,7 @@ extension EnumCaseElementSyntax: CustomReflectable {
 /// 
 /// A clause to specify precedence group in infix operator declarations, and designated types in any operator declaration.
 /// 
-public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol {
+public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case colon
     case precedenceGroupAndDesignatedTypes
@@ -3987,7 +3984,7 @@ extension OperatorPrecedenceAndTypesSyntax: CustomReflectable {
 /// Specify the new precedence group's relation to existing precedence
 /// groups.
 /// 
-public struct PrecedenceGroupRelationSyntax: SyntaxProtocol {
+public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case higherThanOrLowerThan
     case colon
@@ -4113,7 +4110,7 @@ extension PrecedenceGroupRelationSyntax: CustomReflectable {
 
 // MARK: - PrecedenceGroupNameElementSyntax
 
-public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol {
+public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case name
     case trailingComma
@@ -4195,7 +4192,7 @@ extension PrecedenceGroupNameElementSyntax: CustomReflectable {
 /// Specifies the precedence of an operator when used in an operation
 /// that includes optional chaining.
 /// 
-public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol {
+public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case assignmentKeyword
     case colon
@@ -4306,7 +4303,7 @@ extension PrecedenceGroupAssignmentSyntax: CustomReflectable {
 /// Specifies how a sequence of operators with the same precedence level
 /// are grouped together in the absence of grouping parentheses.
 /// 
-public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol {
+public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case associativityKeyword
     case colon
@@ -4415,7 +4412,7 @@ extension PrecedenceGroupAssociativitySyntax: CustomReflectable {
 /// 
 /// A custom `@` attribute.
 /// 
-public struct CustomAttributeSyntax: SyntaxProtocol {
+public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case atSignToken
     case attributeName
@@ -4588,7 +4585,7 @@ extension CustomAttributeSyntax: CustomReflectable {
 /// 
 /// An `@` attribute.
 /// 
-public struct AttributeSyntax: SyntaxProtocol {
+public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case atSignToken
     case attributeName
@@ -4685,9 +4682,7 @@ public struct AttributeSyntax: SyntaxProtocol {
   }
 
   /// 
-  /// The arguments of the attribute. In case the attribute
-  /// takes multiple arguments, they are gather in the
-  /// appropriate takes first.
+  /// The arguments of the attribute. In case the attribute                     takes multiple arguments, they are gather in the                    appropriate takes first.
   /// 
   public var argument: Syntax? {
     get {
@@ -4794,10 +4789,9 @@ extension AttributeSyntax: CustomReflectable {
 // MARK: - LabeledSpecializeEntrySyntax
 
 /// 
-/// A labeled argument for the `@_specialize` attribute like
-/// `exported: true`
+/// A labeled argument for the `@_specialize` attribute like          `exported: true`
 /// 
-public struct LabeledSpecializeEntrySyntax: SyntaxProtocol {
+public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case label
     case colon
@@ -4928,11 +4922,9 @@ extension LabeledSpecializeEntrySyntax: CustomReflectable {
 // MARK: - NamedAttributeStringArgumentSyntax
 
 /// 
-/// The argument for the `@_dynamic_replacement` or `@_private`
-/// attribute of the form `for: "function()"` or `sourceFile:
-/// "Src.swift"`
+/// The argument for the `@_dynamic_replacement` or `@_private`          attribute of the form `for: "function()"` or `sourceFile:          "Src.swift"`
 /// 
-public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol {
+public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case nameTok
     case colon
@@ -5034,7 +5026,7 @@ extension NamedAttributeStringArgumentSyntax: CustomReflectable {
 
 // MARK: - DeclNameSyntax
 
-public struct DeclNameSyntax: SyntaxProtocol {
+public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case declBaseName
     case declNameArguments
@@ -5082,8 +5074,7 @@ public struct DeclNameSyntax: SyntaxProtocol {
   }
 
   /// 
-  /// The argument labels of the protocol's requirement if it
-  /// is a function requirement.
+  /// The argument labels of the protocol's requirement if it                is a function requirement.
   /// 
   public var declNameArguments: DeclNameArgumentsSyntax? {
     get {
@@ -5120,10 +5111,9 @@ extension DeclNameSyntax: CustomReflectable {
 // MARK: - ImplementsAttributeArgumentsSyntax
 
 /// 
-/// The arguments for the `@_implements` attribute of the form
-/// `Type, methodName(arg1Label:arg2Label:)`
+/// The arguments for the `@_implements` attribute of the form          `Type, methodName(arg1Label:arg2Label:)`
 /// 
-public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol {
+public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case type
     case comma
@@ -5149,8 +5139,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol {
   }
 
   /// 
-  /// The type for which the method with this attribute
-  /// implements a requirement.
+  /// The type for which the method with this attribute                    implements a requirement.
   /// 
   public var type: SimpleTypeIdentifierSyntax {
     get {
@@ -5222,8 +5211,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol {
   }
 
   /// 
-  /// The argument labels of the protocol's requirement if it
-  /// is a function requirement.
+  /// The argument labels of the protocol's requirement if it                    is a function requirement.
   /// 
   public var declNameArguments: DeclNameArgumentsSyntax? {
     get {
@@ -5262,11 +5250,9 @@ extension ImplementsAttributeArgumentsSyntax: CustomReflectable {
 // MARK: - ObjCSelectorPieceSyntax
 
 /// 
-/// A piece of an Objective-C selector. Either consisiting of just an
-/// identifier for a nullary selector, an identifier and a colon for a
-/// labeled argument or just a colon for an unlabeled argument
+/// A piece of an Objective-C selector. Either consisiting of just an          identifier for a nullary selector, an identifier and a colon for a          labeled argument or just a colon for an unlabeled argument
 /// 
-public struct ObjCSelectorPieceSyntax: SyntaxProtocol {
+public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case name
     case colon
@@ -5345,7 +5331,7 @@ extension ObjCSelectorPieceSyntax: CustomReflectable {
 
 // MARK: - WhereClauseSyntax
 
-public struct WhereClauseSyntax: SyntaxProtocol {
+public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case whereKeyword
     case guardResult
@@ -5422,7 +5408,7 @@ extension WhereClauseSyntax: CustomReflectable {
 
 // MARK: - YieldListSyntax
 
-public struct YieldListSyntax: SyntaxProtocol {
+public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftParen
     case elementList
@@ -5565,7 +5551,7 @@ extension YieldListSyntax: CustomReflectable {
 
 // MARK: - ConditionElementSyntax
 
-public struct ConditionElementSyntax: SyntaxProtocol {
+public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case condition
     case trailingComma
@@ -5643,7 +5629,7 @@ extension ConditionElementSyntax: CustomReflectable {
 
 // MARK: - AvailabilityConditionSyntax
 
-public struct AvailabilityConditionSyntax: SyntaxProtocol {
+public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case poundAvailableKeyword
     case leftParen
@@ -5785,7 +5771,7 @@ extension AvailabilityConditionSyntax: CustomReflectable {
 
 // MARK: - MatchingPatternConditionSyntax
 
-public struct MatchingPatternConditionSyntax: SyntaxProtocol {
+public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case caseKeyword
     case pattern
@@ -5909,7 +5895,7 @@ extension MatchingPatternConditionSyntax: CustomReflectable {
 
 // MARK: - OptionalBindingConditionSyntax
 
-public struct OptionalBindingConditionSyntax: SyntaxProtocol {
+public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case letOrVarKeyword
     case pattern
@@ -6033,7 +6019,7 @@ extension OptionalBindingConditionSyntax: CustomReflectable {
 
 // MARK: - ElseIfContinuationSyntax
 
-public struct ElseIfContinuationSyntax: SyntaxProtocol {
+public struct ElseIfContinuationSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case ifStatement
   }
@@ -6087,7 +6073,7 @@ extension ElseIfContinuationSyntax: CustomReflectable {
 
 // MARK: - ElseBlockSyntax
 
-public struct ElseBlockSyntax: SyntaxProtocol {
+public struct ElseBlockSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case elseKeyword
     case body
@@ -6164,7 +6150,7 @@ extension ElseBlockSyntax: CustomReflectable {
 
 // MARK: - SwitchCaseSyntax
 
-public struct SwitchCaseSyntax: SyntaxProtocol {
+public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case unknownAttr
     case label
@@ -6284,7 +6270,7 @@ extension SwitchCaseSyntax: CustomReflectable {
 
 // MARK: - SwitchDefaultLabelSyntax
 
-public struct SwitchDefaultLabelSyntax: SyntaxProtocol {
+public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case defaultKeyword
     case colon
@@ -6361,7 +6347,7 @@ extension SwitchDefaultLabelSyntax: CustomReflectable {
 
 // MARK: - CaseItemSyntax
 
-public struct CaseItemSyntax: SyntaxProtocol {
+public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case pattern
     case whereClause
@@ -6463,7 +6449,7 @@ extension CaseItemSyntax: CustomReflectable {
 
 // MARK: - SwitchCaseLabelSyntax
 
-public struct SwitchCaseLabelSyntax: SyntaxProtocol {
+public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case caseKeyword
     case caseItems
@@ -6582,7 +6568,7 @@ extension SwitchCaseLabelSyntax: CustomReflectable {
 
 // MARK: - CatchClauseSyntax
 
-public struct CatchClauseSyntax: SyntaxProtocol {
+public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case catchKeyword
     case pattern
@@ -6707,7 +6693,7 @@ extension CatchClauseSyntax: CustomReflectable {
 
 // MARK: - GenericWhereClauseSyntax
 
-public struct GenericWhereClauseSyntax: SyntaxProtocol {
+public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case whereKeyword
     case requirementList
@@ -6803,7 +6789,7 @@ extension GenericWhereClauseSyntax: CustomReflectable {
 
 // MARK: - GenericRequirementSyntax
 
-public struct GenericRequirementSyntax: SyntaxProtocol {
+public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case body
     case trailingComma
@@ -6881,7 +6867,7 @@ extension GenericRequirementSyntax: CustomReflectable {
 
 // MARK: - SameTypeRequirementSyntax
 
-public struct SameTypeRequirementSyntax: SyntaxProtocol {
+public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftTypeIdentifier
     case equalityToken
@@ -6981,7 +6967,7 @@ extension SameTypeRequirementSyntax: CustomReflectable {
 
 // MARK: - GenericParameterSyntax
 
-public struct GenericParameterSyntax: SyntaxProtocol {
+public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case name
@@ -7150,7 +7136,7 @@ extension GenericParameterSyntax: CustomReflectable {
 
 // MARK: - GenericParameterClauseSyntax
 
-public struct GenericParameterClauseSyntax: SyntaxProtocol {
+public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftAngleBracket
     case genericParameterList
@@ -7269,7 +7255,7 @@ extension GenericParameterClauseSyntax: CustomReflectable {
 
 // MARK: - ConformanceRequirementSyntax
 
-public struct ConformanceRequirementSyntax: SyntaxProtocol {
+public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftTypeIdentifier
     case colon
@@ -7369,7 +7355,7 @@ extension ConformanceRequirementSyntax: CustomReflectable {
 
 // MARK: - CompositionTypeElementSyntax
 
-public struct CompositionTypeElementSyntax: SyntaxProtocol {
+public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case type
     case ampersand
@@ -7447,7 +7433,7 @@ extension CompositionTypeElementSyntax: CustomReflectable {
 
 // MARK: - TupleTypeElementSyntax
 
-public struct TupleTypeElementSyntax: SyntaxProtocol {
+public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case inOut
     case name
@@ -7669,7 +7655,7 @@ extension TupleTypeElementSyntax: CustomReflectable {
 
 // MARK: - GenericArgumentSyntax
 
-public struct GenericArgumentSyntax: SyntaxProtocol {
+public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case argumentType
     case trailingComma
@@ -7747,7 +7733,7 @@ extension GenericArgumentSyntax: CustomReflectable {
 
 // MARK: - GenericArgumentClauseSyntax
 
-public struct GenericArgumentClauseSyntax: SyntaxProtocol {
+public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftAngleBracket
     case arguments
@@ -7866,7 +7852,7 @@ extension GenericArgumentClauseSyntax: CustomReflectable {
 
 // MARK: - TypeAnnotationSyntax
 
-public struct TypeAnnotationSyntax: SyntaxProtocol {
+public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case colon
     case type
@@ -7943,7 +7929,7 @@ extension TypeAnnotationSyntax: CustomReflectable {
 
 // MARK: - TuplePatternElementSyntax
 
-public struct TuplePatternElementSyntax: SyntaxProtocol {
+public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case labelName
     case labelColon
@@ -8070,10 +8056,9 @@ extension TuplePatternElementSyntax: CustomReflectable {
 // MARK: - AvailabilityArgumentSyntax
 
 /// 
-/// A single argument to an `@available` argument like `*`, `iOS 10.1`,
-/// or `message: "This has been deprecated"`.
+/// A single argument to an `@available` argument like `*`, `iOS 10.1`,          or `message: "This has been deprecated"`.
 /// 
-public struct AvailabilityArgumentSyntax: SyntaxProtocol {
+public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case entry
     case trailingComma
@@ -8119,8 +8104,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol {
   }
 
   /// 
-  /// A trailing comma if the argument is followed by another
-  /// argument
+  /// A trailing comma if the argument is followed by another                    argument
   /// 
   public var trailingComma: TokenSyntax? {
     get {
@@ -8157,10 +8141,9 @@ extension AvailabilityArgumentSyntax: CustomReflectable {
 // MARK: - AvailabilityLabeledArgumentSyntax
 
 /// 
-/// A argument to an `@available` attribute that consists of a label and
-/// a value, e.g. `message: "This has been deprecated"`.
+/// A argument to an `@available` attribute that consists of a label and          a value, e.g. `message: "This has been deprecated"`.
 /// 
-public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol {
+public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case label
     case colon
@@ -8264,10 +8247,9 @@ extension AvailabilityLabeledArgumentSyntax: CustomReflectable {
 // MARK: - AvailabilityVersionRestrictionSyntax
 
 /// 
-/// An argument to `@available` that restricts the availability on a
-/// certain platform to a version, e.g. `iOS 10` or `swift 3.4`.
+/// An argument to `@available` that restricts the availability on a          certain platform to a version, e.g. `iOS 10` or `swift 3.4`.
 /// 
-public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol {
+public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case platform
     case version
@@ -8291,9 +8273,7 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol {
   }
 
   /// 
-  /// The name of the OS on which the availability should be
-  /// restricted or 'swift' if the availability should be
-  /// restricted based on a Swift version.
+  /// The name of the OS on which the availability should be                    restricted or 'swift' if the availability should be                    restricted based on a Swift version.
   /// 
   public var platform: TokenSyntax {
     get {
@@ -8350,10 +8330,9 @@ extension AvailabilityVersionRestrictionSyntax: CustomReflectable {
 // MARK: - VersionTupleSyntax
 
 /// 
-/// A version number of the form major.minor.patch in which the minor
-/// and patch part may be ommited.
+/// A version number of the form major.minor.patch in which the minor          and patch part may be ommited.
 /// 
-public struct VersionTupleSyntax: SyntaxProtocol {
+public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case majorMinor
     case patchPeriod
@@ -8378,11 +8357,7 @@ public struct VersionTupleSyntax: SyntaxProtocol {
   }
 
   /// 
-  /// In case the version consists only of the major version, an
-  /// integer literal that specifies the major version. In case
-  /// the version consists of major and minor version number, a
-  /// floating literal in which the decimal part is interpreted
-  /// as the minor version.
+  /// In case the version consists only of the major version, an                    integer literal that specifies the major version. In case                    the version consists of major and minor version number, a                    floating literal in which the decimal part is interpreted                    as the minor version.
   /// 
   public var majorMinor: Syntax {
     get {
@@ -8406,8 +8381,7 @@ public struct VersionTupleSyntax: SyntaxProtocol {
   }
 
   /// 
-  /// If the version contains a patch number, the period
-  /// separating the minor from the patch number.
+  /// If the version contains a patch number, the period                    separating the minor from the patch number.
   /// 
   public var patchPeriod: TokenSyntax? {
     get {

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
@@ -15,7 +15,7 @@
 
 // MARK: - UnknownPatternSyntax
 
-public struct UnknownPatternSyntax: PatternSyntaxProtocol {
+public struct UnknownPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
@@ -44,7 +44,7 @@ extension UnknownPatternSyntax: CustomReflectable {
 
 // MARK: - EnumCasePatternSyntax
 
-public struct EnumCasePatternSyntax: PatternSyntaxProtocol {
+public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case type
     case period
@@ -169,7 +169,7 @@ extension EnumCasePatternSyntax: CustomReflectable {
 
 // MARK: - IsTypePatternSyntax
 
-public struct IsTypePatternSyntax: PatternSyntaxProtocol {
+public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case isKeyword
     case type
@@ -246,7 +246,7 @@ extension IsTypePatternSyntax: CustomReflectable {
 
 // MARK: - OptionalPatternSyntax
 
-public struct OptionalPatternSyntax: PatternSyntaxProtocol {
+public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case subPattern
     case questionMark
@@ -323,7 +323,7 @@ extension OptionalPatternSyntax: CustomReflectable {
 
 // MARK: - IdentifierPatternSyntax
 
-public struct IdentifierPatternSyntax: PatternSyntaxProtocol {
+public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case identifier
   }
@@ -377,7 +377,7 @@ extension IdentifierPatternSyntax: CustomReflectable {
 
 // MARK: - AsTypePatternSyntax
 
-public struct AsTypePatternSyntax: PatternSyntaxProtocol {
+public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case pattern
     case asKeyword
@@ -477,7 +477,7 @@ extension AsTypePatternSyntax: CustomReflectable {
 
 // MARK: - TuplePatternSyntax
 
-public struct TuplePatternSyntax: PatternSyntaxProtocol {
+public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftParen
     case elements
@@ -596,7 +596,7 @@ extension TuplePatternSyntax: CustomReflectable {
 
 // MARK: - WildcardPatternSyntax
 
-public struct WildcardPatternSyntax: PatternSyntaxProtocol {
+public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case wildcard
     case typeAnnotation
@@ -674,7 +674,7 @@ extension WildcardPatternSyntax: CustomReflectable {
 
 // MARK: - ExpressionPatternSyntax
 
-public struct ExpressionPatternSyntax: PatternSyntaxProtocol {
+public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case expression
   }
@@ -728,7 +728,7 @@ extension ExpressionPatternSyntax: CustomReflectable {
 
 // MARK: - ValueBindingPatternSyntax
 
-public struct ValueBindingPatternSyntax: PatternSyntaxProtocol {
+public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case letOrVarKeyword
     case valuePattern

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
@@ -159,10 +159,10 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension EnumCasePatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "type": type.map(Syntax.init)?._asConcreteType as Any,
-      "period": Syntax(period)._asConcreteType,
-      "caseName": Syntax(caseName)._asConcreteType,
-      "associatedTuple": associatedTuple.map(Syntax.init)?._asConcreteType as Any,
+      "type": type.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "period": Syntax(period).as(SyntaxProtocol.self),
+      "caseName": Syntax(caseName).as(SyntaxProtocol.self),
+      "associatedTuple": associatedTuple.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -238,8 +238,8 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension IsTypePatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "isKeyword": Syntax(isKeyword)._asConcreteType,
-      "type": Syntax(type)._asConcreteType,
+      "isKeyword": Syntax(isKeyword).as(SyntaxProtocol.self),
+      "type": Syntax(type).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -315,8 +315,8 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension OptionalPatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "subPattern": Syntax(subPattern)._asConcreteType,
-      "questionMark": Syntax(questionMark)._asConcreteType,
+      "subPattern": Syntax(subPattern).as(SyntaxProtocol.self),
+      "questionMark": Syntax(questionMark).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -370,7 +370,7 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension IdentifierPatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "identifier": Syntax(identifier)._asConcreteType,
+      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -468,9 +468,9 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension AsTypePatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "pattern": Syntax(pattern)._asConcreteType,
-      "asKeyword": Syntax(asKeyword)._asConcreteType,
-      "type": Syntax(type)._asConcreteType,
+      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
+      "asKeyword": Syntax(asKeyword).as(SyntaxProtocol.self),
+      "type": Syntax(type).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -587,9 +587,9 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension TuplePatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "elements": Syntax(elements)._asConcreteType,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "elements": Syntax(elements).as(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -666,8 +666,8 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension WildcardPatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "wildcard": Syntax(wildcard)._asConcreteType,
-      "typeAnnotation": typeAnnotation.map(Syntax.init)?._asConcreteType as Any,
+      "wildcard": Syntax(wildcard).as(SyntaxProtocol.self),
+      "typeAnnotation": typeAnnotation.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -721,7 +721,7 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension ExpressionPatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "expression": Syntax(expression)._asConcreteType,
+      "expression": Syntax(expression).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -797,8 +797,8 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension ValueBindingPatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "letOrVarKeyword": Syntax(letOrVarKeyword)._asConcreteType,
-      "valuePattern": Syntax(valuePattern)._asConcreteType,
+      "letOrVarKeyword": Syntax(letOrVarKeyword).as(SyntaxProtocol.self),
+      "valuePattern": Syntax(valuePattern).as(SyntaxProtocol.self),
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -114,8 +114,8 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension ContinueStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "continueKeyword": Syntax(continueKeyword)._asConcreteType,
-      "label": label.map(Syntax.init)?._asConcreteType as Any,
+      "continueKeyword": Syntax(continueKeyword).as(SyntaxProtocol.self),
+      "label": label.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -278,11 +278,11 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension WhileStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "labelName": labelName.map(Syntax.init)?._asConcreteType as Any,
-      "labelColon": labelColon.map(Syntax.init)?._asConcreteType as Any,
-      "whileKeyword": Syntax(whileKeyword)._asConcreteType,
-      "conditions": Syntax(conditions)._asConcreteType,
-      "body": Syntax(body)._asConcreteType,
+      "labelName": labelName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "labelColon": labelColon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "whileKeyword": Syntax(whileKeyword).as(SyntaxProtocol.self),
+      "conditions": Syntax(conditions).as(SyntaxProtocol.self),
+      "body": Syntax(body).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -358,8 +358,8 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension DeferStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "deferKeyword": Syntax(deferKeyword)._asConcreteType,
-      "body": Syntax(body)._asConcreteType,
+      "deferKeyword": Syntax(deferKeyword).as(SyntaxProtocol.self),
+      "body": Syntax(body).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -413,7 +413,7 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension ExpressionStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "expression": Syntax(expression)._asConcreteType,
+      "expression": Syntax(expression).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -579,12 +579,12 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension RepeatWhileStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "labelName": labelName.map(Syntax.init)?._asConcreteType as Any,
-      "labelColon": labelColon.map(Syntax.init)?._asConcreteType as Any,
-      "repeatKeyword": Syntax(repeatKeyword)._asConcreteType,
-      "body": Syntax(body)._asConcreteType,
-      "whileKeyword": Syntax(whileKeyword)._asConcreteType,
-      "condition": Syntax(condition)._asConcreteType,
+      "labelName": labelName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "labelColon": labelColon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "repeatKeyword": Syntax(repeatKeyword).as(SyntaxProtocol.self),
+      "body": Syntax(body).as(SyntaxProtocol.self),
+      "whileKeyword": Syntax(whileKeyword).as(SyntaxProtocol.self),
+      "condition": Syntax(condition).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -723,10 +723,10 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension GuardStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "guardKeyword": Syntax(guardKeyword)._asConcreteType,
-      "conditions": Syntax(conditions)._asConcreteType,
-      "elseKeyword": Syntax(elseKeyword)._asConcreteType,
-      "body": Syntax(body)._asConcreteType,
+      "guardKeyword": Syntax(guardKeyword).as(SyntaxProtocol.self),
+      "conditions": Syntax(conditions).as(SyntaxProtocol.self),
+      "elseKeyword": Syntax(elseKeyword).as(SyntaxProtocol.self),
+      "body": Syntax(body).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -983,16 +983,16 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension ForInStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "labelName": labelName.map(Syntax.init)?._asConcreteType as Any,
-      "labelColon": labelColon.map(Syntax.init)?._asConcreteType as Any,
-      "forKeyword": Syntax(forKeyword)._asConcreteType,
-      "caseKeyword": caseKeyword.map(Syntax.init)?._asConcreteType as Any,
-      "pattern": Syntax(pattern)._asConcreteType,
-      "typeAnnotation": typeAnnotation.map(Syntax.init)?._asConcreteType as Any,
-      "inKeyword": Syntax(inKeyword)._asConcreteType,
-      "sequenceExpr": Syntax(sequenceExpr)._asConcreteType,
-      "whereClause": whereClause.map(Syntax.init)?._asConcreteType as Any,
-      "body": Syntax(body)._asConcreteType,
+      "labelName": labelName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "labelColon": labelColon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "forKeyword": Syntax(forKeyword).as(SyntaxProtocol.self),
+      "caseKeyword": caseKeyword.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
+      "typeAnnotation": typeAnnotation.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "inKeyword": Syntax(inKeyword).as(SyntaxProtocol.self),
+      "sequenceExpr": Syntax(sequenceExpr).as(SyntaxProtocol.self),
+      "whereClause": whereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "body": Syntax(body).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1199,13 +1199,13 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension SwitchStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "labelName": labelName.map(Syntax.init)?._asConcreteType as Any,
-      "labelColon": labelColon.map(Syntax.init)?._asConcreteType as Any,
-      "switchKeyword": Syntax(switchKeyword)._asConcreteType,
-      "expression": Syntax(expression)._asConcreteType,
-      "leftBrace": Syntax(leftBrace)._asConcreteType,
-      "cases": Syntax(cases)._asConcreteType,
-      "rightBrace": Syntax(rightBrace)._asConcreteType,
+      "labelName": labelName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "labelColon": labelColon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "switchKeyword": Syntax(switchKeyword).as(SyntaxProtocol.self),
+      "expression": Syntax(expression).as(SyntaxProtocol.self),
+      "leftBrace": Syntax(leftBrace).as(SyntaxProtocol.self),
+      "cases": Syntax(cases).as(SyntaxProtocol.self),
+      "rightBrace": Syntax(rightBrace).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1369,11 +1369,11 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension DoStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "labelName": labelName.map(Syntax.init)?._asConcreteType as Any,
-      "labelColon": labelColon.map(Syntax.init)?._asConcreteType as Any,
-      "doKeyword": Syntax(doKeyword)._asConcreteType,
-      "body": Syntax(body)._asConcreteType,
-      "catchClauses": catchClauses.map(Syntax.init)?._asConcreteType as Any,
+      "labelName": labelName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "labelColon": labelColon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "doKeyword": Syntax(doKeyword).as(SyntaxProtocol.self),
+      "body": Syntax(body).as(SyntaxProtocol.self),
+      "catchClauses": catchClauses.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1450,8 +1450,8 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension ReturnStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "returnKeyword": Syntax(returnKeyword)._asConcreteType,
-      "expression": expression.map(Syntax.init)?._asConcreteType as Any,
+      "returnKeyword": Syntax(returnKeyword).as(SyntaxProtocol.self),
+      "expression": expression.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1527,8 +1527,8 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension YieldStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "yieldKeyword": Syntax(yieldKeyword)._asConcreteType,
-      "yields": Syntax(yields)._asConcreteType,
+      "yieldKeyword": Syntax(yieldKeyword).as(SyntaxProtocol.self),
+      "yields": Syntax(yields).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1582,7 +1582,7 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension FallthroughStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "fallthroughKeyword": Syntax(fallthroughKeyword)._asConcreteType,
+      "fallthroughKeyword": Syntax(fallthroughKeyword).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1659,8 +1659,8 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension BreakStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "breakKeyword": Syntax(breakKeyword)._asConcreteType,
-      "label": label.map(Syntax.init)?._asConcreteType as Any,
+      "breakKeyword": Syntax(breakKeyword).as(SyntaxProtocol.self),
+      "label": label.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1714,7 +1714,7 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension DeclarationStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "declaration": Syntax(declaration)._asConcreteType,
+      "declaration": Syntax(declaration).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1790,8 +1790,8 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension ThrowStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "throwKeyword": Syntax(throwKeyword)._asConcreteType,
-      "expression": Syntax(expression)._asConcreteType,
+      "throwKeyword": Syntax(throwKeyword).as(SyntaxProtocol.self),
+      "expression": Syntax(expression).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -2000,13 +2000,13 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension IfStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "labelName": labelName.map(Syntax.init)?._asConcreteType as Any,
-      "labelColon": labelColon.map(Syntax.init)?._asConcreteType as Any,
-      "ifKeyword": Syntax(ifKeyword)._asConcreteType,
-      "conditions": Syntax(conditions)._asConcreteType,
-      "body": Syntax(body)._asConcreteType,
-      "elseKeyword": elseKeyword.map(Syntax.init)?._asConcreteType as Any,
-      "elseBody": elseBody.map(Syntax.init)?._asConcreteType as Any,
+      "labelName": labelName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "labelColon": labelColon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "ifKeyword": Syntax(ifKeyword).as(SyntaxProtocol.self),
+      "conditions": Syntax(conditions).as(SyntaxProtocol.self),
+      "body": Syntax(body).as(SyntaxProtocol.self),
+      "elseKeyword": elseKeyword.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "elseBody": elseBody.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2175,12 +2175,12 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension PoundAssertStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundAssert": Syntax(poundAssert)._asConcreteType,
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "condition": Syntax(condition)._asConcreteType,
-      "comma": comma.map(Syntax.init)?._asConcreteType as Any,
-      "message": message.map(Syntax.init)?._asConcreteType as Any,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "poundAssert": Syntax(poundAssert).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "condition": Syntax(condition).as(SyntaxProtocol.self),
+      "comma": comma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "message": message.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -15,7 +15,7 @@
 
 // MARK: - UnknownStmtSyntax
 
-public struct UnknownStmtSyntax: StmtSyntaxProtocol {
+public struct UnknownStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
@@ -44,7 +44,7 @@ extension UnknownStmtSyntax: CustomReflectable {
 
 // MARK: - ContinueStmtSyntax
 
-public struct ContinueStmtSyntax: StmtSyntaxProtocol {
+public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case continueKeyword
     case label
@@ -122,7 +122,7 @@ extension ContinueStmtSyntax: CustomReflectable {
 
 // MARK: - WhileStmtSyntax
 
-public struct WhileStmtSyntax: StmtSyntaxProtocol {
+public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case labelName
     case labelColon
@@ -289,7 +289,7 @@ extension WhileStmtSyntax: CustomReflectable {
 
 // MARK: - DeferStmtSyntax
 
-public struct DeferStmtSyntax: StmtSyntaxProtocol {
+public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case deferKeyword
     case body
@@ -366,7 +366,7 @@ extension DeferStmtSyntax: CustomReflectable {
 
 // MARK: - ExpressionStmtSyntax
 
-public struct ExpressionStmtSyntax: StmtSyntaxProtocol {
+public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case expression
   }
@@ -420,7 +420,7 @@ extension ExpressionStmtSyntax: CustomReflectable {
 
 // MARK: - RepeatWhileStmtSyntax
 
-public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol {
+public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case labelName
     case labelColon
@@ -591,7 +591,7 @@ extension RepeatWhileStmtSyntax: CustomReflectable {
 
 // MARK: - GuardStmtSyntax
 
-public struct GuardStmtSyntax: StmtSyntaxProtocol {
+public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case guardKeyword
     case conditions
@@ -733,7 +733,7 @@ extension GuardStmtSyntax: CustomReflectable {
 
 // MARK: - ForInStmtSyntax
 
-public struct ForInStmtSyntax: StmtSyntaxProtocol {
+public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case labelName
     case labelColon
@@ -999,7 +999,7 @@ extension ForInStmtSyntax: CustomReflectable {
 
 // MARK: - SwitchStmtSyntax
 
-public struct SwitchStmtSyntax: StmtSyntaxProtocol {
+public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case labelName
     case labelColon
@@ -1212,7 +1212,7 @@ extension SwitchStmtSyntax: CustomReflectable {
 
 // MARK: - DoStmtSyntax
 
-public struct DoStmtSyntax: StmtSyntaxProtocol {
+public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case labelName
     case labelColon
@@ -1380,7 +1380,7 @@ extension DoStmtSyntax: CustomReflectable {
 
 // MARK: - ReturnStmtSyntax
 
-public struct ReturnStmtSyntax: StmtSyntaxProtocol {
+public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case returnKeyword
     case expression
@@ -1458,7 +1458,7 @@ extension ReturnStmtSyntax: CustomReflectable {
 
 // MARK: - YieldStmtSyntax
 
-public struct YieldStmtSyntax: StmtSyntaxProtocol {
+public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case yieldKeyword
     case yields
@@ -1535,7 +1535,7 @@ extension YieldStmtSyntax: CustomReflectable {
 
 // MARK: - FallthroughStmtSyntax
 
-public struct FallthroughStmtSyntax: StmtSyntaxProtocol {
+public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case fallthroughKeyword
   }
@@ -1589,7 +1589,7 @@ extension FallthroughStmtSyntax: CustomReflectable {
 
 // MARK: - BreakStmtSyntax
 
-public struct BreakStmtSyntax: StmtSyntaxProtocol {
+public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case breakKeyword
     case label
@@ -1667,7 +1667,7 @@ extension BreakStmtSyntax: CustomReflectable {
 
 // MARK: - DeclarationStmtSyntax
 
-public struct DeclarationStmtSyntax: StmtSyntaxProtocol {
+public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case declaration
   }
@@ -1721,7 +1721,7 @@ extension DeclarationStmtSyntax: CustomReflectable {
 
 // MARK: - ThrowStmtSyntax
 
-public struct ThrowStmtSyntax: StmtSyntaxProtocol {
+public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case throwKeyword
     case expression
@@ -1798,7 +1798,7 @@ extension ThrowStmtSyntax: CustomReflectable {
 
 // MARK: - IfStmtSyntax
 
-public struct IfStmtSyntax: StmtSyntaxProtocol {
+public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case labelName
     case labelColon
@@ -2013,7 +2013,7 @@ extension IfStmtSyntax: CustomReflectable {
 
 // MARK: - PoundAssertStmtSyntax
 
-public struct PoundAssertStmtSyntax: StmtSyntaxProtocol {
+public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case poundAssert
     case leftParen

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -15,7 +15,7 @@
 
 // MARK: - UnknownTypeSyntax
 
-public struct UnknownTypeSyntax: TypeSyntaxProtocol {
+public struct UnknownTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public let _syntaxNode: Syntax
 
@@ -44,7 +44,7 @@ extension UnknownTypeSyntax: CustomReflectable {
 
 // MARK: - SimpleTypeIdentifierSyntax
 
-public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol {
+public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case name
     case genericArgumentClause
@@ -122,7 +122,7 @@ extension SimpleTypeIdentifierSyntax: CustomReflectable {
 
 // MARK: - MemberTypeIdentifierSyntax
 
-public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol {
+public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case baseType
     case period
@@ -246,7 +246,7 @@ extension MemberTypeIdentifierSyntax: CustomReflectable {
 
 // MARK: - ClassRestrictionTypeSyntax
 
-public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol {
+public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case classKeyword
   }
@@ -300,7 +300,7 @@ extension ClassRestrictionTypeSyntax: CustomReflectable {
 
 // MARK: - ArrayTypeSyntax
 
-public struct ArrayTypeSyntax: TypeSyntaxProtocol {
+public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftSquareBracket
     case elementType
@@ -400,7 +400,7 @@ extension ArrayTypeSyntax: CustomReflectable {
 
 // MARK: - DictionaryTypeSyntax
 
-public struct DictionaryTypeSyntax: TypeSyntaxProtocol {
+public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftSquareBracket
     case keyType
@@ -546,7 +546,7 @@ extension DictionaryTypeSyntax: CustomReflectable {
 
 // MARK: - MetatypeTypeSyntax
 
-public struct MetatypeTypeSyntax: TypeSyntaxProtocol {
+public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case baseType
     case period
@@ -646,7 +646,7 @@ extension MetatypeTypeSyntax: CustomReflectable {
 
 // MARK: - OptionalTypeSyntax
 
-public struct OptionalTypeSyntax: TypeSyntaxProtocol {
+public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case wrappedType
     case questionMark
@@ -723,7 +723,7 @@ extension OptionalTypeSyntax: CustomReflectable {
 
 // MARK: - SomeTypeSyntax
 
-public struct SomeTypeSyntax: TypeSyntaxProtocol {
+public struct SomeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case someSpecifier
     case baseType
@@ -800,7 +800,7 @@ extension SomeTypeSyntax: CustomReflectable {
 
 // MARK: - ImplicitlyUnwrappedOptionalTypeSyntax
 
-public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol {
+public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case wrappedType
     case exclamationMark
@@ -877,7 +877,7 @@ extension ImplicitlyUnwrappedOptionalTypeSyntax: CustomReflectable {
 
 // MARK: - CompositionTypeSyntax
 
-public struct CompositionTypeSyntax: TypeSyntaxProtocol {
+public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case elements
   }
@@ -950,7 +950,7 @@ extension CompositionTypeSyntax: CustomReflectable {
 
 // MARK: - TupleTypeSyntax
 
-public struct TupleTypeSyntax: TypeSyntaxProtocol {
+public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftParen
     case elements
@@ -1069,7 +1069,7 @@ extension TupleTypeSyntax: CustomReflectable {
 
 // MARK: - FunctionTypeSyntax
 
-public struct FunctionTypeSyntax: TypeSyntaxProtocol {
+public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case leftParen
     case arguments
@@ -1258,7 +1258,7 @@ extension FunctionTypeSyntax: CustomReflectable {
 
 // MARK: - AttributedTypeSyntax
 
-public struct AttributedTypeSyntax: TypeSyntaxProtocol {
+public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case specifier
     case attributes

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -114,8 +114,8 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension SimpleTypeIdentifierSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name)._asConcreteType,
-      "genericArgumentClause": genericArgumentClause.map(Syntax.init)?._asConcreteType as Any,
+      "name": Syntax(name).as(SyntaxProtocol.self),
+      "genericArgumentClause": genericArgumentClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -236,10 +236,10 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension MemberTypeIdentifierSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "baseType": Syntax(baseType)._asConcreteType,
-      "period": Syntax(period)._asConcreteType,
-      "name": Syntax(name)._asConcreteType,
-      "genericArgumentClause": genericArgumentClause.map(Syntax.init)?._asConcreteType as Any,
+      "baseType": Syntax(baseType).as(SyntaxProtocol.self),
+      "period": Syntax(period).as(SyntaxProtocol.self),
+      "name": Syntax(name).as(SyntaxProtocol.self),
+      "genericArgumentClause": genericArgumentClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -293,7 +293,7 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension ClassRestrictionTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "classKeyword": Syntax(classKeyword)._asConcreteType,
+      "classKeyword": Syntax(classKeyword).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -391,9 +391,9 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension ArrayTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftSquareBracket": Syntax(leftSquareBracket)._asConcreteType,
-      "elementType": Syntax(elementType)._asConcreteType,
-      "rightSquareBracket": Syntax(rightSquareBracket)._asConcreteType,
+      "leftSquareBracket": Syntax(leftSquareBracket).as(SyntaxProtocol.self),
+      "elementType": Syntax(elementType).as(SyntaxProtocol.self),
+      "rightSquareBracket": Syntax(rightSquareBracket).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -535,11 +535,11 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension DictionaryTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftSquareBracket": Syntax(leftSquareBracket)._asConcreteType,
-      "keyType": Syntax(keyType)._asConcreteType,
-      "colon": Syntax(colon)._asConcreteType,
-      "valueType": Syntax(valueType)._asConcreteType,
-      "rightSquareBracket": Syntax(rightSquareBracket)._asConcreteType,
+      "leftSquareBracket": Syntax(leftSquareBracket).as(SyntaxProtocol.self),
+      "keyType": Syntax(keyType).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "valueType": Syntax(valueType).as(SyntaxProtocol.self),
+      "rightSquareBracket": Syntax(rightSquareBracket).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -637,9 +637,9 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension MetatypeTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "baseType": Syntax(baseType)._asConcreteType,
-      "period": Syntax(period)._asConcreteType,
-      "typeOrProtocol": Syntax(typeOrProtocol)._asConcreteType,
+      "baseType": Syntax(baseType).as(SyntaxProtocol.self),
+      "period": Syntax(period).as(SyntaxProtocol.self),
+      "typeOrProtocol": Syntax(typeOrProtocol).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -715,8 +715,8 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension OptionalTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "wrappedType": Syntax(wrappedType)._asConcreteType,
-      "questionMark": Syntax(questionMark)._asConcreteType,
+      "wrappedType": Syntax(wrappedType).as(SyntaxProtocol.self),
+      "questionMark": Syntax(questionMark).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -792,8 +792,8 @@ public struct SomeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension SomeTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "someSpecifier": Syntax(someSpecifier)._asConcreteType,
-      "baseType": Syntax(baseType)._asConcreteType,
+      "someSpecifier": Syntax(someSpecifier).as(SyntaxProtocol.self),
+      "baseType": Syntax(baseType).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -869,8 +869,8 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
 extension ImplicitlyUnwrappedOptionalTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "wrappedType": Syntax(wrappedType)._asConcreteType,
-      "exclamationMark": Syntax(exclamationMark)._asConcreteType,
+      "wrappedType": Syntax(wrappedType).as(SyntaxProtocol.self),
+      "exclamationMark": Syntax(exclamationMark).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -943,7 +943,7 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension CompositionTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "elements": Syntax(elements)._asConcreteType,
+      "elements": Syntax(elements).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1060,9 +1060,9 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension TupleTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "elements": Syntax(elements)._asConcreteType,
-      "rightParen": Syntax(rightParen)._asConcreteType,
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "elements": Syntax(elements).as(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1246,12 +1246,12 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension FunctionTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen)._asConcreteType,
-      "arguments": Syntax(arguments)._asConcreteType,
-      "rightParen": Syntax(rightParen)._asConcreteType,
-      "throwsOrRethrowsKeyword": throwsOrRethrowsKeyword.map(Syntax.init)?._asConcreteType as Any,
-      "arrow": Syntax(arrow)._asConcreteType,
-      "returnType": Syntax(returnType)._asConcreteType,
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "arguments": Syntax(arguments).as(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "throwsOrRethrowsKeyword": throwsOrRethrowsKeyword.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "arrow": Syntax(arrow).as(SyntaxProtocol.self),
+      "returnType": Syntax(returnType).as(SyntaxProtocol.self),
     ])
   }
 }
@@ -1370,9 +1370,9 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension AttributedTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "specifier": specifier.map(Syntax.init)?._asConcreteType as Any,
-      "attributes": attributes.map(Syntax.init)?._asConcreteType as Any,
-      "baseType": Syntax(baseType)._asConcreteType,
+      "specifier": specifier.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "baseType": Syntax(baseType).as(SyntaxProtocol.self),
     ])
   }
 }

--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -399,11 +399,11 @@ func performRoundtrip(args: CommandLineArguments) throws {
 class NodePrinter: SyntaxAnyVisitor {
   override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
     assert(!node.isUnknown)
-    print("<\(type(of: node._asConcreteType))>", terminator: "")
+    print("<\(type(of: node.as(SyntaxProtocol.self)))>", terminator: "")
     return .visitChildren
   }
   override func visitAnyPost(_ node: Syntax) {
-    print("</\(type(of: node._asConcreteType))>", terminator: "")
+    print("</\(type(of: node.as(SyntaxProtocol.self)))>", terminator: "")
   }
   override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
     print("<\(type(of: token))>", terminator: "")

--- a/Tests/SwiftSyntaxTest/SyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTests.swift
@@ -83,4 +83,35 @@ public class SyntaxTests: XCTestCase {
       testFuncKw(funcKW)
     }
   }
+
+  public func testCasting() {
+    let integerExpr = IntegerLiteralExprSyntax {
+      $0.useDigits(SyntaxFactory.makeIntegerLiteral("1", trailingTrivia: .spaces(1)))
+    }
+
+    let expr = ExprSyntax(integerExpr)
+    let node = Syntax(expr)
+    XCTAssertTrue(expr.is(IntegerLiteralExprSyntax.self))
+    XCTAssertTrue(node.is(IntegerLiteralExprSyntax.self))
+    XCTAssertTrue(node.as(ExprSyntax.self)!.is(IntegerLiteralExprSyntax.self))
+
+    XCTAssertTrue(node.is(ExprSyntaxProtocol.self))
+    XCTAssertTrue(node.as(ExprSyntaxProtocol.self) is IntegerLiteralExprSyntax)
+    XCTAssertTrue(expr.as(ExprSyntaxProtocol.self) is IntegerLiteralExprSyntax)
+    XCTAssertTrue(expr.as(ExprSyntaxProtocol.self) as? IntegerLiteralExprSyntax == integerExpr)
+
+    XCTAssertFalse(node.is(BracedSyntax.self))
+    XCTAssertNil(node.as(BracedSyntax.self))
+    XCTAssertFalse(expr.is(BracedSyntax.self))
+    XCTAssertNil(expr.as(BracedSyntax.self))
+
+    let classDecl = SyntaxFactory.makeCodeBlock(
+      leftBrace: SyntaxFactory.makeToken(.leftBrace, presence: .present),
+      statements: SyntaxFactory.makeCodeBlockItemList([]),
+      rightBrace: SyntaxFactory.makeToken(.rightBrace, presence: .present)
+    )
+
+    XCTAssertTrue(classDecl.is(BracedSyntax.self))
+    XCTAssertNotNil(classDecl.as(BracedSyntax.self))
+  }
 }


### PR DESCRIPTION
These return the non type-erased types of a node if it conforms to the given protocol and `nil` otherwise.

```swift
let identifierExprSyntax: IdentifierExprSyntax = /* ... */
let node = Syntax(identifierExprSyntax)
node.as(SyntaxProtocol.self) // returns a IdentifierExprSyntax with static type SyntaxProtocol
node.as(ExprSyntaxProtocol.self) // returns a IdentifierExprSyntax with static type ExprSyntaxProtocol?
```

With these methods returning the non type-erased type we can get rid of `_asConcreteType`. The new way to get the concrete type of a `Syntax` node is to call `as(SyntaxProtocol.self)` which will return a non-type-erased type that conforms to `SyntaxProtocol`.