### PR TITLE
Emit description for SyntaxCollections as doc comments

### DIFF
--- a/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -27,10 +27,16 @@ public protocol SyntaxCollection: SyntaxProtocol, Sequence {
 %   if node.collection_element:
 %     element_node = NODE_MAP.get(node.collection_element)
 
+% if node.description:
+%   for line in dedented_lines(node.description):
+/// ${line}
+%   end
+% else:
 /// `${node.name}` represents a collection of one or more
 /// `${node.collection_element_type}` nodes. ${node.name} behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
+% end
 public struct ${node.name}: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
@@ -1488,10 +1488,10 @@ extension DeclNameArgumentListSyntax: BidirectionalCollection {
   }
 }
 
-/// `ExprListSyntax` represents a collection of one or more
-/// `ExprSyntax` nodes. ExprListSyntax behaves
-/// as a regular Swift collection, and has accessors that return new
-/// versions of the collection with different children.
+/// 
+/// A list of expressions connected by operators. This list is contained
+/// by a `SequenceExprSyntax`.
+/// 
 public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
@@ -4428,10 +4428,7 @@ extension PatternBindingListSyntax: BidirectionalCollection {
   }
 }
 
-/// `EnumCaseElementListSyntax` represents a collection of one or more
-/// `EnumCaseElementSyntax` nodes. EnumCaseElementListSyntax behaves
-/// as a regular Swift collection, and has accessors that return new
-/// versions of the collection with different children.
+/// A collection of 0 or more `EnumCaseElement`s.
 public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
@@ -6143,10 +6140,9 @@ extension AttributeListSyntax: BidirectionalCollection {
   }
 }
 
-/// `SpecializeAttributeSpecListSyntax` represents a collection of one or more
-/// `Syntax` nodes. SpecializeAttributeSpecListSyntax behaves
-/// as a regular Swift collection, and has accessors that return new
-/// versions of the collection with different children.
+/// 
+/// A collection of arguments for the `@_specialize` attribute
+/// 
 public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 


### PR DESCRIPTION
At the moment we are not emitting the description for `SyntaxCollection` nodes, even if there is one.

This also adds the description added in https://github.com/apple/swift/pull/28162.