### PR TITLE
[AutoDiff upstream] Update gyb-generated files.

### DIFF
--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -873,6 +873,48 @@ extension SyntaxNode {
     return ObjCSelectorSyntax(asSyntaxData)
   }
 
+  public var isDifferentiableAttributeArguments: Bool { return raw.kind == .differentiableAttributeArguments }
+  public var asDifferentiableAttributeArguments: DifferentiableAttributeArgumentsSyntax? {
+    guard isDifferentiableAttributeArguments else { return nil }
+    return DifferentiableAttributeArgumentsSyntax(asSyntaxData)
+  }
+
+  public var isDifferentiationParamsClause: Bool { return raw.kind == .differentiationParamsClause }
+  public var asDifferentiationParamsClause: DifferentiationParamsClauseSyntax? {
+    guard isDifferentiationParamsClause else { return nil }
+    return DifferentiationParamsClauseSyntax(asSyntaxData)
+  }
+
+  public var isDifferentiationParams: Bool { return raw.kind == .differentiationParams }
+  public var asDifferentiationParams: DifferentiationParamsSyntax? {
+    guard isDifferentiationParams else { return nil }
+    return DifferentiationParamsSyntax(asSyntaxData)
+  }
+
+  public var isDifferentiationParamList: Bool { return raw.kind == .differentiationParamList }
+  public var asDifferentiationParamList: DifferentiationParamListSyntax? {
+    guard isDifferentiationParamList else { return nil }
+    return DifferentiationParamListSyntax(asSyntaxData)
+  }
+
+  public var isDifferentiationParam: Bool { return raw.kind == .differentiationParam }
+  public var asDifferentiationParam: DifferentiationParamSyntax? {
+    guard isDifferentiationParam else { return nil }
+    return DifferentiationParamSyntax(asSyntaxData)
+  }
+
+  public var isDifferentiableAttributeFuncSpecifier: Bool { return raw.kind == .differentiableAttributeFuncSpecifier }
+  public var asDifferentiableAttributeFuncSpecifier: DifferentiableAttributeFuncSpecifierSyntax? {
+    guard isDifferentiableAttributeFuncSpecifier else { return nil }
+    return DifferentiableAttributeFuncSpecifierSyntax(asSyntaxData)
+  }
+
+  public var isFunctionDeclName: Bool { return raw.kind == .functionDeclName }
+  public var asFunctionDeclName: FunctionDeclNameSyntax? {
+    guard isFunctionDeclName else { return nil }
+    return FunctionDeclNameSyntax(asSyntaxData)
+  }
+
   public var isContinueStmt: Bool { return raw.kind == .continueStmt }
   public var asContinueStmt: ContinueStmtSyntax? {
     guard isContinueStmt else { return nil }
@@ -1657,6 +1699,20 @@ extension Syntax {
       return node
     case .objCSelector(let node):
       return node
+    case .differentiableAttributeArguments(let node):
+      return node
+    case .differentiationParamsClause(let node):
+      return node
+    case .differentiationParams(let node):
+      return node
+    case .differentiationParamList(let node):
+      return node
+    case .differentiationParam(let node):
+      return node
+    case .differentiableAttributeFuncSpecifier(let node):
+      return node
+    case .functionDeclName(let node):
+      return node
     case .continueStmt(let node):
       return node
     case .whileStmt(let node):
@@ -1822,6 +1878,6 @@ extension Syntax {
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "1232070026209439384"
+      "274521544372836110"
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
@@ -1058,6 +1058,55 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   override open func visitPost(_ node: ObjCSelectorSyntax) {
     visitAnyPost(node._syntaxNode)
   }
+  override open func visit(_ node: DifferentiableAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: DifferentiableAttributeArgumentsSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: DifferentiationParamsClauseSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: DifferentiationParamsClauseSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: DifferentiationParamsSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: DifferentiationParamsSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: DifferentiationParamListSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: DifferentiationParamListSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: DifferentiationParamSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: DifferentiationParamSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: DifferentiableAttributeFuncSpecifierSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: DifferentiableAttributeFuncSpecifierSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: FunctionDeclNameSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: FunctionDeclNameSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
   override open func visit(_ node: ContinueStmtSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
@@ -6223,6 +6223,330 @@ extension ObjCSelectorPieceSyntax {
   }
 }
 
+public struct DifferentiableAttributeArgumentsSyntaxBuilder {
+  private var layout =
+    Array<RawSyntax?>(repeating: nil, count: 7)
+
+  internal init() {}
+
+  public mutating func useDiffParams(_ node: DifferentiationParamsClauseSyntax) {
+    let idx = DifferentiableAttributeArgumentsSyntax.Cursor.diffParams.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func useDiffParamsComma(_ node: TokenSyntax) {
+    let idx = DifferentiableAttributeArgumentsSyntax.Cursor.diffParamsComma.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func useMaybePrimal(_ node: DifferentiableAttributeFuncSpecifierSyntax) {
+    let idx = DifferentiableAttributeArgumentsSyntax.Cursor.maybePrimal.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func useMaybeAdjoint(_ node: DifferentiableAttributeFuncSpecifierSyntax) {
+    let idx = DifferentiableAttributeArgumentsSyntax.Cursor.maybeAdjoint.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func useMaybeJVP(_ node: DifferentiableAttributeFuncSpecifierSyntax) {
+    let idx = DifferentiableAttributeArgumentsSyntax.Cursor.maybeJVP.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func useMaybeVJP(_ node: DifferentiableAttributeFuncSpecifierSyntax) {
+    let idx = DifferentiableAttributeArgumentsSyntax.Cursor.maybeVJP.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func useWhereClause(_ node: GenericWhereClauseSyntax) {
+    let idx = DifferentiableAttributeArgumentsSyntax.Cursor.whereClause.rawValue
+    layout[idx] = node.raw
+  }
+
+  internal mutating func buildData() -> SyntaxData {
+
+    return .forRoot(RawSyntax.createAndCalcLength(kind: .differentiableAttributeArguments,
+      layout: layout, presence: .present))
+  }
+}
+
+extension DifferentiableAttributeArgumentsSyntax {
+  /// Creates a `DifferentiableAttributeArgumentsSyntax` using the provided build function.
+  /// - Parameter:
+  ///   - build: A closure that wil be invoked in order to initialize
+  ///            the fields of the syntax node.
+  ///            This closure is passed a `DifferentiableAttributeArgumentsSyntaxBuilder` which you can use to
+  ///            incrementally build the structure of the node.
+  /// - Returns: A `DifferentiableAttributeArgumentsSyntax` with all the fields populated in the builder
+  ///            closure.
+  public init(_ build: (inout DifferentiableAttributeArgumentsSyntaxBuilder) -> Void) {
+    var builder = DifferentiableAttributeArgumentsSyntaxBuilder()
+    build(&builder)
+    let data = builder.buildData()
+    self.init(data)
+  }
+}
+
+public struct DifferentiationParamsClauseSyntaxBuilder {
+  private var layout =
+    Array<RawSyntax?>(repeating: nil, count: 3)
+
+  internal init() {}
+
+  public mutating func useWrtLabel(_ node: TokenSyntax) {
+    let idx = DifferentiationParamsClauseSyntax.Cursor.wrtLabel.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func useColon(_ node: TokenSyntax) {
+    let idx = DifferentiationParamsClauseSyntax.Cursor.colon.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func useParameters(_ node: Syntax) {
+    let idx = DifferentiationParamsClauseSyntax.Cursor.parameters.rawValue
+    layout[idx] = node.raw
+  }
+
+  internal mutating func buildData() -> SyntaxData {
+    if (layout[0] == nil) {
+      layout[0] = RawSyntax.missingToken(TokenKind.identifier(""))
+    }
+    if (layout[1] == nil) {
+      layout[1] = RawSyntax.missingToken(TokenKind.colon)
+    }
+    if (layout[2] == nil) {
+      layout[2] = RawSyntax.missing(SyntaxKind.unknown)
+    }
+
+    return .forRoot(RawSyntax.createAndCalcLength(kind: .differentiationParamsClause,
+      layout: layout, presence: .present))
+  }
+}
+
+extension DifferentiationParamsClauseSyntax {
+  /// Creates a `DifferentiationParamsClauseSyntax` using the provided build function.
+  /// - Parameter:
+  ///   - build: A closure that wil be invoked in order to initialize
+  ///            the fields of the syntax node.
+  ///            This closure is passed a `DifferentiationParamsClauseSyntaxBuilder` which you can use to
+  ///            incrementally build the structure of the node.
+  /// - Returns: A `DifferentiationParamsClauseSyntax` with all the fields populated in the builder
+  ///            closure.
+  public init(_ build: (inout DifferentiationParamsClauseSyntaxBuilder) -> Void) {
+    var builder = DifferentiationParamsClauseSyntaxBuilder()
+    build(&builder)
+    let data = builder.buildData()
+    self.init(data)
+  }
+}
+
+public struct DifferentiationParamsSyntaxBuilder {
+  private var layout =
+    Array<RawSyntax?>(repeating: nil, count: 3)
+
+  internal init() {}
+
+  public mutating func useLeftParen(_ node: TokenSyntax) {
+    let idx = DifferentiationParamsSyntax.Cursor.leftParen.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func addDifferentiationParam(_ elt: DifferentiationParamSyntax) {
+    let idx = DifferentiationParamsSyntax.Cursor.diffParams.rawValue
+    if let list = layout[idx] {
+      layout[idx] = list.appending(elt.raw)
+    } else {
+      layout[idx] = RawSyntax.create(kind: SyntaxKind.differentiationParamList,
+        layout: [elt.raw], length: elt.raw.totalLength,
+        presence: SourcePresence.present)
+    }
+  }
+
+  public mutating func useRightParen(_ node: TokenSyntax) {
+    let idx = DifferentiationParamsSyntax.Cursor.rightParen.rawValue
+    layout[idx] = node.raw
+  }
+
+  internal mutating func buildData() -> SyntaxData {
+    if (layout[0] == nil) {
+      layout[0] = RawSyntax.missingToken(TokenKind.leftParen)
+    }
+    if (layout[1] == nil) {
+      layout[1] = RawSyntax.missing(SyntaxKind.differentiationParamList)
+    }
+    if (layout[2] == nil) {
+      layout[2] = RawSyntax.missingToken(TokenKind.rightParen)
+    }
+
+    return .forRoot(RawSyntax.createAndCalcLength(kind: .differentiationParams,
+      layout: layout, presence: .present))
+  }
+}
+
+extension DifferentiationParamsSyntax {
+  /// Creates a `DifferentiationParamsSyntax` using the provided build function.
+  /// - Parameter:
+  ///   - build: A closure that wil be invoked in order to initialize
+  ///            the fields of the syntax node.
+  ///            This closure is passed a `DifferentiationParamsSyntaxBuilder` which you can use to
+  ///            incrementally build the structure of the node.
+  /// - Returns: A `DifferentiationParamsSyntax` with all the fields populated in the builder
+  ///            closure.
+  public init(_ build: (inout DifferentiationParamsSyntaxBuilder) -> Void) {
+    var builder = DifferentiationParamsSyntaxBuilder()
+    build(&builder)
+    let data = builder.buildData()
+    self.init(data)
+  }
+}
+
+public struct DifferentiationParamSyntaxBuilder {
+  private var layout =
+    Array<RawSyntax?>(repeating: nil, count: 2)
+
+  internal init() {}
+
+  public mutating func useParameter(_ node: Syntax) {
+    let idx = DifferentiationParamSyntax.Cursor.parameter.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func useTrailingComma(_ node: TokenSyntax) {
+    let idx = DifferentiationParamSyntax.Cursor.trailingComma.rawValue
+    layout[idx] = node.raw
+  }
+
+  internal mutating func buildData() -> SyntaxData {
+    if (layout[0] == nil) {
+      layout[0] = RawSyntax.missing(SyntaxKind.unknown)
+    }
+
+    return .forRoot(RawSyntax.createAndCalcLength(kind: .differentiationParam,
+      layout: layout, presence: .present))
+  }
+}
+
+extension DifferentiationParamSyntax {
+  /// Creates a `DifferentiationParamSyntax` using the provided build function.
+  /// - Parameter:
+  ///   - build: A closure that wil be invoked in order to initialize
+  ///            the fields of the syntax node.
+  ///            This closure is passed a `DifferentiationParamSyntaxBuilder` which you can use to
+  ///            incrementally build the structure of the node.
+  /// - Returns: A `DifferentiationParamSyntax` with all the fields populated in the builder
+  ///            closure.
+  public init(_ build: (inout DifferentiationParamSyntaxBuilder) -> Void) {
+    var builder = DifferentiationParamSyntaxBuilder()
+    build(&builder)
+    let data = builder.buildData()
+    self.init(data)
+  }
+}
+
+public struct DifferentiableAttributeFuncSpecifierSyntaxBuilder {
+  private var layout =
+    Array<RawSyntax?>(repeating: nil, count: 4)
+
+  internal init() {}
+
+  public mutating func useLabel(_ node: TokenSyntax) {
+    let idx = DifferentiableAttributeFuncSpecifierSyntax.Cursor.label.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func useColon(_ node: TokenSyntax) {
+    let idx = DifferentiableAttributeFuncSpecifierSyntax.Cursor.colon.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func useFunctionDeclName(_ node: FunctionDeclNameSyntax) {
+    let idx = DifferentiableAttributeFuncSpecifierSyntax.Cursor.functionDeclName.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func useTrailingComma(_ node: TokenSyntax) {
+    let idx = DifferentiableAttributeFuncSpecifierSyntax.Cursor.trailingComma.rawValue
+    layout[idx] = node.raw
+  }
+
+  internal mutating func buildData() -> SyntaxData {
+    if (layout[0] == nil) {
+      layout[0] = RawSyntax.missingToken(TokenKind.identifier(""))
+    }
+    if (layout[1] == nil) {
+      layout[1] = RawSyntax.missingToken(TokenKind.colon)
+    }
+    if (layout[2] == nil) {
+      layout[2] = RawSyntax.missing(SyntaxKind.functionDeclName)
+    }
+
+    return .forRoot(RawSyntax.createAndCalcLength(kind: .differentiableAttributeFuncSpecifier,
+      layout: layout, presence: .present))
+  }
+}
+
+extension DifferentiableAttributeFuncSpecifierSyntax {
+  /// Creates a `DifferentiableAttributeFuncSpecifierSyntax` using the provided build function.
+  /// - Parameter:
+  ///   - build: A closure that wil be invoked in order to initialize
+  ///            the fields of the syntax node.
+  ///            This closure is passed a `DifferentiableAttributeFuncSpecifierSyntaxBuilder` which you can use to
+  ///            incrementally build the structure of the node.
+  /// - Returns: A `DifferentiableAttributeFuncSpecifierSyntax` with all the fields populated in the builder
+  ///            closure.
+  public init(_ build: (inout DifferentiableAttributeFuncSpecifierSyntaxBuilder) -> Void) {
+    var builder = DifferentiableAttributeFuncSpecifierSyntaxBuilder()
+    build(&builder)
+    let data = builder.buildData()
+    self.init(data)
+  }
+}
+
+public struct FunctionDeclNameSyntaxBuilder {
+  private var layout =
+    Array<RawSyntax?>(repeating: nil, count: 2)
+
+  internal init() {}
+
+  public mutating func useName(_ node: Syntax) {
+    let idx = FunctionDeclNameSyntax.Cursor.name.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func useArguments(_ node: DeclNameArgumentsSyntax) {
+    let idx = FunctionDeclNameSyntax.Cursor.arguments.rawValue
+    layout[idx] = node.raw
+  }
+
+  internal mutating func buildData() -> SyntaxData {
+    if (layout[0] == nil) {
+      layout[0] = RawSyntax.missing(SyntaxKind.unknown)
+    }
+
+    return .forRoot(RawSyntax.createAndCalcLength(kind: .functionDeclName,
+      layout: layout, presence: .present))
+  }
+}
+
+extension FunctionDeclNameSyntax {
+  /// Creates a `FunctionDeclNameSyntax` using the provided build function.
+  /// - Parameter:
+  ///   - build: A closure that wil be invoked in order to initialize
+  ///            the fields of the syntax node.
+  ///            This closure is passed a `FunctionDeclNameSyntaxBuilder` which you can use to
+  ///            incrementally build the structure of the node.
+  /// - Returns: A `FunctionDeclNameSyntax` with all the fields populated in the builder
+  ///            closure.
+  public init(_ build: (inout FunctionDeclNameSyntaxBuilder) -> Void) {
+    var builder = FunctionDeclNameSyntaxBuilder()
+    build(&builder)
+    let data = builder.buildData()
+    self.init(data)
+  }
+}
+
 public struct ContinueStmtSyntaxBuilder {
   private var layout =
     Array<RawSyntax?>(repeating: nil, count: 2)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
@@ -6633,6 +6633,251 @@ extension ObjCSelectorSyntax: BidirectionalCollection {
   }
 }
 
+/// `DifferentiationParamListSyntax` represents a collection of one or more
+/// `DifferentiationParamSyntax` nodes. DifferentiationParamListSyntax behaves
+/// as a regular Swift collection, and has accessors that return new
+/// versions of the collection with different children.
+public struct DifferentiationParamListSyntax: SyntaxCollection, SyntaxHashable {
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `DifferentiationParamListSyntax` if possible. Returns 
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .differentiationParamList else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a Syntax node from the provided root and data. This assumes 
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .differentiationParamList)
+    self._syntaxNode = Syntax(data)
+  }
+
+  /// The number of elements, `present` or `missing`, in this collection.
+  public var count: Int { return raw.numberOfChildren }
+
+  /// Creates a new `DifferentiationParamListSyntax` by replacing the underlying layout with
+  /// a different set of raw syntax nodes.
+  ///
+  /// - Parameter layout: The new list of raw syntax nodes underlying this
+  ///                     collection.
+  /// - Returns: A new `DifferentiationParamListSyntax` with the new layout underlying it.
+  internal func replacingLayout(
+    _ layout: [RawSyntax?]) -> DifferentiationParamListSyntax {
+    let newRaw = data.raw.replacingLayout(layout)
+    let newData = data.replacingSelf(newRaw)
+    return DifferentiationParamListSyntax(newData)
+  }
+
+  /// Creates a new `DifferentiationParamListSyntax` by appending the provided syntax element
+  /// to the children.
+  ///
+  /// - Parameter syntax: The element to append.
+  /// - Returns: A new `DifferentiationParamListSyntax` with that element appended to the end.
+  public func appending(
+    _ syntax: DifferentiationParamSyntax) -> DifferentiationParamListSyntax {
+    var newLayout = data.raw.formLayoutArray()
+    newLayout.append(syntax.raw)
+    return replacingLayout(newLayout)
+  }
+
+  /// Creates a new `DifferentiationParamListSyntax` by prepending the provided syntax element
+  /// to the children.
+  ///
+  /// - Parameter syntax: The element to prepend.
+  /// - Returns: A new `DifferentiationParamListSyntax` with that element prepended to the
+  ///            beginning.
+  public func prepending(
+    _ syntax: DifferentiationParamSyntax) -> DifferentiationParamListSyntax {
+    return inserting(syntax, at: 0)
+  }
+
+  /// Creates a new `DifferentiationParamListSyntax` by inserting the provided syntax element
+  /// at the provided index in the children.
+  ///
+  /// - Parameters:
+  ///   - syntax: The element to insert.
+  ///   - index: The index at which to insert the element in the collection.
+  ///
+  /// - Returns: A new `DifferentiationParamListSyntax` with that element appended to the end.
+  public func inserting(_ syntax: DifferentiationParamSyntax,
+                        at index: Int) -> DifferentiationParamListSyntax {
+    var newLayout = data.raw.formLayoutArray()
+    /// Make sure the index is a valid insertion index (0 to 1 past the end)
+    precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
+                 "inserting node at invalid index \(index)")
+    newLayout.insert(syntax.raw, at: index)
+    return replacingLayout(newLayout)
+  }
+
+  /// Creates a new `DifferentiationParamListSyntax` by replacing the syntax element
+  /// at the provided index.
+  ///
+  /// - Parameters:
+  ///   - index: The index at which to replace the element in the collection.
+  ///   - syntax: The element to replace with.
+  ///
+  /// - Returns: A new `DifferentiationParamListSyntax` with the new element at the provided index.
+  public func replacing(childAt index: Int,
+                        with syntax: DifferentiationParamSyntax) -> DifferentiationParamListSyntax {
+    var newLayout = data.raw.formLayoutArray()
+    /// Make sure the index is a valid index for replacing
+    precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
+                 "replacing node at invalid index \(index)")
+    newLayout[index] = syntax.raw
+    return replacingLayout(newLayout)
+  }
+
+  /// Creates a new `DifferentiationParamListSyntax` by removing the syntax element at the
+  /// provided index.
+  ///
+  /// - Parameter index: The index of the element to remove from the collection.
+  /// - Returns: A new `DifferentiationParamListSyntax` with the element at the provided index
+  ///            removed.
+  public func removing(childAt index: Int) -> DifferentiationParamListSyntax {
+    var newLayout = data.raw.formLayoutArray()
+    newLayout.remove(at: index)
+    return replacingLayout(newLayout)
+  }
+
+  /// Creates a new `DifferentiationParamListSyntax` by removing the first element.
+  ///
+  /// - Returns: A new `DifferentiationParamListSyntax` with the first element removed.
+  public func removingFirst() -> DifferentiationParamListSyntax {
+    var newLayout = data.raw.formLayoutArray()
+    newLayout.removeFirst()
+    return replacingLayout(newLayout)
+  }
+
+  /// Creates a new `DifferentiationParamListSyntax` by removing the last element.
+  ///
+  /// - Returns: A new `DifferentiationParamListSyntax` with the last element removed.
+  public func removingLast() -> DifferentiationParamListSyntax {
+    var newLayout = data.raw.formLayoutArray()
+    newLayout.removeLast()
+    return replacingLayout(newLayout)
+  }
+
+  /// Returns a new `DifferentiationParamListSyntax` with its leading trivia replaced
+  /// by the provided trivia.
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> DifferentiationParamListSyntax {
+    return DifferentiationParamListSyntax(data.withLeadingTrivia(leadingTrivia))
+  }
+
+  /// Returns a new `DifferentiationParamListSyntax` with its trailing trivia replaced
+  /// by the provided trivia.
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> DifferentiationParamListSyntax {
+    return DifferentiationParamListSyntax(data.withTrailingTrivia(trailingTrivia))
+  }
+
+  /// Returns a new `DifferentiationParamListSyntax` with its leading trivia removed.
+  public func withoutLeadingTrivia() -> DifferentiationParamListSyntax {
+    return withLeadingTrivia([])
+  }
+
+  /// Returns a new `DifferentiationParamListSyntax` with its trailing trivia removed.
+  public func withoutTrailingTrivia() -> DifferentiationParamListSyntax {
+    return withTrailingTrivia([])
+  }
+
+  /// Returns a new `DifferentiationParamListSyntax` with all trivia removed.
+  public func withoutTrivia() -> DifferentiationParamListSyntax {
+    return withoutLeadingTrivia().withoutTrailingTrivia()
+  }
+
+  /// The leading trivia (spaces, newlines, etc.) associated with this `DifferentiationParamListSyntax`.
+  public var leadingTrivia: Trivia? {
+    get {
+      return raw.formLeadingTrivia()
+    }
+    set {
+      self = withLeadingTrivia(newValue ?? [])
+    }
+  }
+
+  /// The trailing trivia (spaces, newlines, etc.) associated with this `DifferentiationParamListSyntax`.
+  public var trailingTrivia: Trivia? {
+    get {
+      return raw.formTrailingTrivia()
+    }
+    set {
+      self = withTrailingTrivia(newValue ?? [])
+    }
+  }
+
+  public func _validateLayout() {
+    // Check that all children match the expected element type
+    assert(self.allSatisfy { node in
+      return Syntax(node).is(DifferentiationParamSyntax.self)
+    })
+  }
+}
+
+/// Conformance for `DifferentiationParamListSyntax` to the `BidirectionalCollection` protocol.
+extension DifferentiationParamListSyntax: BidirectionalCollection {
+  public typealias Element = DifferentiationParamSyntax
+  public typealias Index = SyntaxChildrenIndex
+
+  public struct Iterator: IteratorProtocol {
+    private let parent: Syntax
+    private var iterator: RawSyntaxChildren.Iterator
+
+    init(parent: Syntax, rawChildren: RawSyntaxChildren) {
+      self.parent = parent
+      self.iterator = rawChildren.makeIterator()
+    }
+
+    public mutating func next() -> DifferentiationParamSyntax? {
+      guard let (raw, info) = self.iterator.next() else {
+        return nil
+      }
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
+      let data = SyntaxData(absoluteRaw, parent: parent)
+      return DifferentiationParamSyntax(data)
+    }
+  }
+
+  public func makeIterator() -> Iterator {
+    return Iterator(parent: Syntax(self), rawChildren: rawChildren)
+  }
+
+  private var rawChildren: RawSyntaxChildren {
+    // We know children in a syntax collection cannot be missing. So we can 
+    // use the low-level and faster RawSyntaxChildren collection instead of
+    // PresentRawSyntaxChildren.
+    return RawSyntaxChildren(self.data.absoluteRaw)
+  }
+
+  public var startIndex: SyntaxChildrenIndex {
+    return rawChildren.startIndex
+  }
+  public var endIndex: SyntaxChildrenIndex {
+    return rawChildren.endIndex
+  }
+
+  public func index(after index: SyntaxChildrenIndex) -> SyntaxChildrenIndex {
+    return rawChildren.index(after: index)
+  }
+
+  public func index(before index: SyntaxChildrenIndex) -> SyntaxChildrenIndex {
+    return rawChildren.index(before: index)
+  }
+
+  public func distance(from start: SyntaxChildrenIndex, to end: SyntaxChildrenIndex)
+      -> Int {
+    return rawChildren.distance(from: start, to: end)
+  }
+
+  public subscript(position: SyntaxChildrenIndex) -> DifferentiationParamSyntax {
+    let (raw, info) = rawChildren[position]
+    let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
+    let data = SyntaxData(absoluteRaw, parent: Syntax(self))
+    return DifferentiationParamSyntax(data)
+  }
+}
+
 /// `SwitchCaseListSyntax` represents a collection of one or more
 /// `Syntax` nodes. SwitchCaseListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
@@ -9459,6 +9704,11 @@ extension SpecializeAttributeSpecListSyntax: CustomReflectable {
   }
 }
 extension ObjCSelectorSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, unlabeledChildren: self.map{ $0 })
+  }
+}
+extension DifferentiationParamListSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, unlabeledChildren: self.map{ $0 })
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -163,6 +163,13 @@ public enum SyntaxEnum {
   case implementsAttributeArguments(ImplementsAttributeArgumentsSyntax)
   case objCSelectorPiece(ObjCSelectorPieceSyntax)
   case objCSelector(ObjCSelectorSyntax)
+  case differentiableAttributeArguments(DifferentiableAttributeArgumentsSyntax)
+  case differentiationParamsClause(DifferentiationParamsClauseSyntax)
+  case differentiationParams(DifferentiationParamsSyntax)
+  case differentiationParamList(DifferentiationParamListSyntax)
+  case differentiationParam(DifferentiationParamSyntax)
+  case differentiableAttributeFuncSpecifier(DifferentiableAttributeFuncSpecifierSyntax)
+  case functionDeclName(FunctionDeclNameSyntax)
   case continueStmt(ContinueStmtSyntax)
   case whileStmt(WhileStmtSyntax)
   case deferStmt(DeferStmtSyntax)
@@ -546,6 +553,20 @@ public extension Syntax {
       return .objCSelectorPiece(ObjCSelectorPieceSyntax(self)!)
     case .objCSelector:
       return .objCSelector(ObjCSelectorSyntax(self)!)
+    case .differentiableAttributeArguments:
+      return .differentiableAttributeArguments(DifferentiableAttributeArgumentsSyntax(self)!)
+    case .differentiationParamsClause:
+      return .differentiationParamsClause(DifferentiationParamsClauseSyntax(self)!)
+    case .differentiationParams:
+      return .differentiationParams(DifferentiationParamsSyntax(self)!)
+    case .differentiationParamList:
+      return .differentiationParamList(DifferentiationParamListSyntax(self)!)
+    case .differentiationParam:
+      return .differentiationParam(DifferentiationParamSyntax(self)!)
+    case .differentiableAttributeFuncSpecifier:
+      return .differentiableAttributeFuncSpecifier(DifferentiableAttributeFuncSpecifierSyntax(self)!)
+    case .functionDeclName:
+      return .functionDeclName(FunctionDeclNameSyntax(self)!)
     case .continueStmt:
       return .continueStmt(ContinueStmtSyntax(self)!)
     case .whileStmt:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -2853,6 +2853,152 @@ public enum SyntaxFactory {
     ], length: .zero, presence: .present))
     return ObjCSelectorSyntax(data)
   }
+  public static func makeDifferentiableAttributeArguments(diffParams: DifferentiationParamsClauseSyntax?, diffParamsComma: TokenSyntax?, maybePrimal: DifferentiableAttributeFuncSpecifierSyntax?, maybeAdjoint: DifferentiableAttributeFuncSpecifierSyntax?, maybeJVP: DifferentiableAttributeFuncSpecifierSyntax?, maybeVJP: DifferentiableAttributeFuncSpecifierSyntax?, whereClause: GenericWhereClauseSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let layout: [RawSyntax?] = [
+      diffParams?.raw,
+      diffParamsComma?.raw,
+      maybePrimal?.raw,
+      maybeAdjoint?.raw,
+      maybeJVP?.raw,
+      maybeVJP?.raw,
+      whereClause?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.differentiableAttributeArguments,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    return DifferentiableAttributeArgumentsSyntax(data)
+  }
+
+  public static func makeBlankDifferentiableAttributeArguments() -> DifferentiableAttributeArgumentsSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .differentiableAttributeArguments,
+      layout: [
+      nil,
+      nil,
+      nil,
+      nil,
+      nil,
+      nil,
+      nil,
+    ], length: .zero, presence: .present))
+    return DifferentiableAttributeArgumentsSyntax(data)
+  }
+  public static func makeDifferentiationParamsClause(wrtLabel: TokenSyntax, colon: TokenSyntax, parameters: Syntax) -> DifferentiationParamsClauseSyntax {
+    let layout: [RawSyntax?] = [
+      wrtLabel.raw,
+      colon.raw,
+      parameters.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.differentiationParamsClause,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    return DifferentiationParamsClauseSyntax(data)
+  }
+
+  public static func makeBlankDifferentiationParamsClause() -> DifferentiationParamsClauseSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .differentiationParamsClause,
+      layout: [
+      RawSyntax.missingToken(TokenKind.identifier("")),
+      RawSyntax.missingToken(TokenKind.colon),
+      RawSyntax.missing(SyntaxKind.unknown),
+    ], length: .zero, presence: .present))
+    return DifferentiationParamsClauseSyntax(data)
+  }
+  public static func makeDifferentiationParams(leftParen: TokenSyntax, diffParams: DifferentiationParamListSyntax, rightParen: TokenSyntax) -> DifferentiationParamsSyntax {
+    let layout: [RawSyntax?] = [
+      leftParen.raw,
+      diffParams.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.differentiationParams,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    return DifferentiationParamsSyntax(data)
+  }
+
+  public static func makeBlankDifferentiationParams() -> DifferentiationParamsSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .differentiationParams,
+      layout: [
+      RawSyntax.missingToken(TokenKind.leftParen),
+      RawSyntax.missing(SyntaxKind.differentiationParamList),
+      RawSyntax.missingToken(TokenKind.rightParen),
+    ], length: .zero, presence: .present))
+    return DifferentiationParamsSyntax(data)
+  }
+  public static func makeDifferentiationParamList(
+    _ elements: [DifferentiationParamSyntax]) -> DifferentiationParamListSyntax {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.differentiationParamList,
+      layout: elements.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    return DifferentiationParamListSyntax(data)
+  }
+
+  public static func makeBlankDifferentiationParamList() -> DifferentiationParamListSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .differentiationParamList,
+      layout: [
+    ], length: .zero, presence: .present))
+    return DifferentiationParamListSyntax(data)
+  }
+  public static func makeDifferentiationParam(parameter: Syntax, trailingComma: TokenSyntax?) -> DifferentiationParamSyntax {
+    let layout: [RawSyntax?] = [
+      parameter.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.differentiationParam,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    return DifferentiationParamSyntax(data)
+  }
+
+  public static func makeBlankDifferentiationParam() -> DifferentiationParamSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .differentiationParam,
+      layout: [
+      RawSyntax.missing(SyntaxKind.unknown),
+      nil,
+    ], length: .zero, presence: .present))
+    return DifferentiationParamSyntax(data)
+  }
+  public static func makeDifferentiableAttributeFuncSpecifier(label: TokenSyntax, colon: TokenSyntax, functionDeclName: FunctionDeclNameSyntax, trailingComma: TokenSyntax?) -> DifferentiableAttributeFuncSpecifierSyntax {
+    let layout: [RawSyntax?] = [
+      label.raw,
+      colon.raw,
+      functionDeclName.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.differentiableAttributeFuncSpecifier,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    return DifferentiableAttributeFuncSpecifierSyntax(data)
+  }
+
+  public static func makeBlankDifferentiableAttributeFuncSpecifier() -> DifferentiableAttributeFuncSpecifierSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .differentiableAttributeFuncSpecifier,
+      layout: [
+      RawSyntax.missingToken(TokenKind.identifier("")),
+      RawSyntax.missingToken(TokenKind.colon),
+      RawSyntax.missing(SyntaxKind.functionDeclName),
+      nil,
+    ], length: .zero, presence: .present))
+    return DifferentiableAttributeFuncSpecifierSyntax(data)
+  }
+  public static func makeFunctionDeclName(name: Syntax, arguments: DeclNameArgumentsSyntax?) -> FunctionDeclNameSyntax {
+    let layout: [RawSyntax?] = [
+      name.raw,
+      arguments?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.functionDeclName,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    return FunctionDeclNameSyntax(data)
+  }
+
+  public static func makeBlankFunctionDeclName() -> FunctionDeclNameSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .functionDeclName,
+      layout: [
+      RawSyntax.missing(SyntaxKind.unknown),
+      nil,
+    ], length: .zero, presence: .present))
+    return FunctionDeclNameSyntax(data)
+  }
   public static func makeContinueStmt(continueKeyword: TokenSyntax, label: TokenSyntax?) -> ContinueStmtSyntax {
     let layout: [RawSyntax?] = [
       continueKeyword.raw,

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
@@ -163,6 +163,13 @@ internal enum SyntaxKind: CSyntaxKind {
   case implementsAttributeArguments = 134
   case objCSelectorPiece = 135
   case objCSelector = 189
+  case differentiableAttributeArguments = 233
+  case differentiationParamsClause = 234
+  case differentiationParams = 235
+  case differentiationParamList = 236
+  case differentiationParam = 237
+  case differentiableAttributeFuncSpecifier = 238
+  case functionDeclName = 239
   case continueStmt = 72
   case whileStmt = 73
   case deferStmt = 74
@@ -272,6 +279,7 @@ internal enum SyntaxKind: CSyntaxKind {
     case .attributeList: return true
     case .specializeAttributeSpecList: return true
     case .objCSelector: return true
+    case .differentiationParamList: return true
     case .switchCaseList: return true
     case .catchClauseList: return true
     case .caseItemList: return true

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -1017,6 +1017,55 @@ open class SyntaxRewriter {
     return Syntax(visitChildren(node))
   }
 
+  /// Visit a `DifferentiableAttributeArgumentsSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: DifferentiableAttributeArgumentsSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
+  /// Visit a `DifferentiationParamsClauseSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: DifferentiationParamsClauseSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
+  /// Visit a `DifferentiationParamsSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: DifferentiationParamsSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
+  /// Visit a `DifferentiationParamListSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: DifferentiationParamListSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
+  /// Visit a `DifferentiationParamSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: DifferentiationParamSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
+  /// Visit a `DifferentiableAttributeFuncSpecifierSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: DifferentiableAttributeFuncSpecifierSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
+  /// Visit a `FunctionDeclNameSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: FunctionDeclNameSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
   /// Visit a `ContinueStmtSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -3082,6 +3131,76 @@ open class SyntaxRewriter {
   }
 
   /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplDifferentiableAttributeArgumentsSyntax(_ data: SyntaxData) -> Syntax {
+      let node = DifferentiableAttributeArgumentsSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplDifferentiationParamsClauseSyntax(_ data: SyntaxData) -> Syntax {
+      let node = DifferentiationParamsClauseSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplDifferentiationParamsSyntax(_ data: SyntaxData) -> Syntax {
+      let node = DifferentiationParamsSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplDifferentiationParamListSyntax(_ data: SyntaxData) -> Syntax {
+      let node = DifferentiationParamListSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplDifferentiationParamSyntax(_ data: SyntaxData) -> Syntax {
+      let node = DifferentiationParamSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplDifferentiableAttributeFuncSpecifierSyntax(_ data: SyntaxData) -> Syntax {
+      let node = DifferentiableAttributeFuncSpecifierSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplFunctionDeclNameSyntax(_ data: SyntaxData) -> Syntax {
+      let node = FunctionDeclNameSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplContinueStmtSyntax(_ data: SyntaxData) -> Syntax {
       let node = ContinueStmtSyntax(data)
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
@@ -4186,6 +4305,20 @@ open class SyntaxRewriter {
       return visitImplObjCSelectorPieceSyntax(data)
     case .objCSelector:
       return visitImplObjCSelectorSyntax(data)
+    case .differentiableAttributeArguments:
+      return visitImplDifferentiableAttributeArgumentsSyntax(data)
+    case .differentiationParamsClause:
+      return visitImplDifferentiationParamsClauseSyntax(data)
+    case .differentiationParams:
+      return visitImplDifferentiationParamsSyntax(data)
+    case .differentiationParamList:
+      return visitImplDifferentiationParamListSyntax(data)
+    case .differentiationParam:
+      return visitImplDifferentiationParamSyntax(data)
+    case .differentiableAttributeFuncSpecifier:
+      return visitImplDifferentiableAttributeFuncSpecifierSyntax(data)
+    case .functionDeclName:
+      return visitImplFunctionDeclNameSyntax(data)
     case .continueStmt:
       return visitImplContinueStmtSyntax(data)
     case .whileStmt:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxTraits.swift
@@ -227,6 +227,8 @@ extension EnumDeclSyntax: IdentifiedDeclSyntax {}
 extension OperatorDeclSyntax: IdentifiedDeclSyntax {}
 extension PrecedenceGroupDeclSyntax: IdentifiedDeclSyntax {}
 extension LabeledSpecializeEntrySyntax: WithTrailingCommaSyntax {}
+extension DifferentiationParamSyntax: WithTrailingCommaSyntax {}
+extension DifferentiableAttributeFuncSpecifierSyntax: WithTrailingCommaSyntax {}
 extension WhileStmtSyntax: WithCodeBlockSyntax, LabeledSyntax {}
 extension DeferStmtSyntax: WithCodeBlockSyntax {}
 extension RepeatWhileStmtSyntax: WithCodeBlockSyntax, LabeledSyntax {}

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -1452,6 +1452,76 @@ open class SyntaxVisitor {
   /// The function called after visiting `ObjCSelectorSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: ObjCSelectorSyntax) {}
+  /// Visiting `DifferentiableAttributeArgumentsSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: DifferentiableAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `DifferentiableAttributeArgumentsSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: DifferentiableAttributeArgumentsSyntax) {}
+  /// Visiting `DifferentiationParamsClauseSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: DifferentiationParamsClauseSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `DifferentiationParamsClauseSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: DifferentiationParamsClauseSyntax) {}
+  /// Visiting `DifferentiationParamsSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: DifferentiationParamsSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `DifferentiationParamsSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: DifferentiationParamsSyntax) {}
+  /// Visiting `DifferentiationParamListSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: DifferentiationParamListSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `DifferentiationParamListSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: DifferentiationParamListSyntax) {}
+  /// Visiting `DifferentiationParamSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: DifferentiationParamSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `DifferentiationParamSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: DifferentiationParamSyntax) {}
+  /// Visiting `DifferentiableAttributeFuncSpecifierSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: DifferentiableAttributeFuncSpecifierSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `DifferentiableAttributeFuncSpecifierSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: DifferentiableAttributeFuncSpecifierSyntax) {}
+  /// Visiting `FunctionDeclNameSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: FunctionDeclNameSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `FunctionDeclNameSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: FunctionDeclNameSyntax) {}
   /// Visiting `ContinueStmtSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -3883,6 +3953,83 @@ open class SyntaxVisitor {
   }
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplDifferentiableAttributeArgumentsSyntax(_ data: SyntaxData) {
+      let node = DifferentiableAttributeArgumentsSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplDifferentiationParamsClauseSyntax(_ data: SyntaxData) {
+      let node = DifferentiationParamsClauseSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplDifferentiationParamsSyntax(_ data: SyntaxData) {
+      let node = DifferentiationParamsSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplDifferentiationParamListSyntax(_ data: SyntaxData) {
+      let node = DifferentiationParamListSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplDifferentiationParamSyntax(_ data: SyntaxData) {
+      let node = DifferentiationParamSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplDifferentiableAttributeFuncSpecifierSyntax(_ data: SyntaxData) {
+      let node = DifferentiableAttributeFuncSpecifierSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplFunctionDeclNameSyntax(_ data: SyntaxData) {
+      let node = FunctionDeclNameSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplContinueStmtSyntax(_ data: SyntaxData) {
       let node = ContinueStmtSyntax(data)
       let needsChildren = (visit(node) == .visitChildren)
@@ -5065,6 +5212,20 @@ open class SyntaxVisitor {
       visitImplObjCSelectorPieceSyntax(data)
     case .objCSelector:
       visitImplObjCSelectorSyntax(data)
+    case .differentiableAttributeArguments:
+      visitImplDifferentiableAttributeArgumentsSyntax(data)
+    case .differentiationParamsClause:
+      visitImplDifferentiationParamsClauseSyntax(data)
+    case .differentiationParams:
+      visitImplDifferentiationParamsSyntax(data)
+    case .differentiationParamList:
+      visitImplDifferentiationParamListSyntax(data)
+    case .differentiationParam:
+      visitImplDifferentiationParamSyntax(data)
+    case .differentiableAttributeFuncSpecifier:
+      visitImplDifferentiableAttributeFuncSpecifierSyntax(data)
+    case .functionDeclName:
+      visitImplFunctionDeclNameSyntax(data)
     case .continueStmt:
       visitImplContinueStmtSyntax(data)
     case .whileStmt:

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -6901,6 +6901,947 @@ extension ObjCSelectorPieceSyntax: CustomReflectable {
   }
 }
 
+// MARK: - DifferentiableAttributeArgumentsSyntax
+
+/// 
+/// The arguments for the `@differentiable` attribute: an optional          differentiation parameter list and associated functions.
+/// 
+public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+  enum Cursor: Int {
+    case diffParams
+    case diffParamsComma
+    case maybePrimal
+    case maybeAdjoint
+    case maybeJVP
+    case maybeVJP
+    case whereClause
+  }
+
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `DifferentiableAttributeArgumentsSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .differentiableAttributeArguments else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `DifferentiableAttributeArgumentsSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .differentiableAttributeArguments)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public var diffParams: DifferentiationParamsClauseSyntax? {
+    get {
+      let childData = data.child(at: Cursor.diffParams,
+                                 parent: Syntax(self))
+      if childData == nil { return nil }
+      return DifferentiationParamsClauseSyntax(childData!)
+    }
+    set(value) {
+      self = withDiffParams(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `diffParams` replaced.
+  /// - param newChild: The new `diffParams` to replace the node's
+  ///                   current `diffParams`, if present.
+  public func withDiffParams(
+    _ newChild: DifferentiationParamsClauseSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: Cursor.diffParams)
+    return DifferentiableAttributeArgumentsSyntax(newData)
+  }
+
+  /// 
+  /// The comma following the differentiation parameters clause,
+  /// if it exists.
+  /// 
+  public var diffParamsComma: TokenSyntax? {
+    get {
+      let childData = data.child(at: Cursor.diffParamsComma,
+                                 parent: Syntax(self))
+      if childData == nil { return nil }
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withDiffParamsComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `diffParamsComma` replaced.
+  /// - param newChild: The new `diffParamsComma` to replace the node's
+  ///                   current `diffParamsComma`, if present.
+  public func withDiffParamsComma(
+    _ newChild: TokenSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: Cursor.diffParamsComma)
+    return DifferentiableAttributeArgumentsSyntax(newData)
+  }
+
+  public var maybePrimal: DifferentiableAttributeFuncSpecifierSyntax? {
+    get {
+      let childData = data.child(at: Cursor.maybePrimal,
+                                 parent: Syntax(self))
+      if childData == nil { return nil }
+      return DifferentiableAttributeFuncSpecifierSyntax(childData!)
+    }
+    set(value) {
+      self = withMaybePrimal(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `maybePrimal` replaced.
+  /// - param newChild: The new `maybePrimal` to replace the node's
+  ///                   current `maybePrimal`, if present.
+  public func withMaybePrimal(
+    _ newChild: DifferentiableAttributeFuncSpecifierSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: Cursor.maybePrimal)
+    return DifferentiableAttributeArgumentsSyntax(newData)
+  }
+
+  public var maybeAdjoint: DifferentiableAttributeFuncSpecifierSyntax? {
+    get {
+      let childData = data.child(at: Cursor.maybeAdjoint,
+                                 parent: Syntax(self))
+      if childData == nil { return nil }
+      return DifferentiableAttributeFuncSpecifierSyntax(childData!)
+    }
+    set(value) {
+      self = withMaybeAdjoint(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `maybeAdjoint` replaced.
+  /// - param newChild: The new `maybeAdjoint` to replace the node's
+  ///                   current `maybeAdjoint`, if present.
+  public func withMaybeAdjoint(
+    _ newChild: DifferentiableAttributeFuncSpecifierSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: Cursor.maybeAdjoint)
+    return DifferentiableAttributeArgumentsSyntax(newData)
+  }
+
+  public var maybeJVP: DifferentiableAttributeFuncSpecifierSyntax? {
+    get {
+      let childData = data.child(at: Cursor.maybeJVP,
+                                 parent: Syntax(self))
+      if childData == nil { return nil }
+      return DifferentiableAttributeFuncSpecifierSyntax(childData!)
+    }
+    set(value) {
+      self = withMaybeJVP(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `maybeJVP` replaced.
+  /// - param newChild: The new `maybeJVP` to replace the node's
+  ///                   current `maybeJVP`, if present.
+  public func withMaybeJVP(
+    _ newChild: DifferentiableAttributeFuncSpecifierSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: Cursor.maybeJVP)
+    return DifferentiableAttributeArgumentsSyntax(newData)
+  }
+
+  public var maybeVJP: DifferentiableAttributeFuncSpecifierSyntax? {
+    get {
+      let childData = data.child(at: Cursor.maybeVJP,
+                                 parent: Syntax(self))
+      if childData == nil { return nil }
+      return DifferentiableAttributeFuncSpecifierSyntax(childData!)
+    }
+    set(value) {
+      self = withMaybeVJP(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `maybeVJP` replaced.
+  /// - param newChild: The new `maybeVJP` to replace the node's
+  ///                   current `maybeVJP`, if present.
+  public func withMaybeVJP(
+    _ newChild: DifferentiableAttributeFuncSpecifierSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: Cursor.maybeVJP)
+    return DifferentiableAttributeArgumentsSyntax(newData)
+  }
+
+  public var whereClause: GenericWhereClauseSyntax? {
+    get {
+      let childData = data.child(at: Cursor.whereClause,
+                                 parent: Syntax(self))
+      if childData == nil { return nil }
+      return GenericWhereClauseSyntax(childData!)
+    }
+    set(value) {
+      self = withWhereClause(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `whereClause` replaced.
+  /// - param newChild: The new `whereClause` to replace the node's
+  ///                   current `whereClause`, if present.
+  public func withWhereClause(
+    _ newChild: GenericWhereClauseSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: Cursor.whereClause)
+    return DifferentiableAttributeArgumentsSyntax(newData)
+  }
+
+
+  public func _validateLayout() {
+    let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
+    assert(rawChildren.count == 7)
+    // Check child #0 child is DifferentiationParamsClauseSyntax or missing
+    if let raw = rawChildren[0].raw {
+      let info = rawChildren[0].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(DifferentiationParamsClauseSyntax.self))
+    }
+    // Check child #1 child is TokenSyntax or missing
+    if let raw = rawChildren[1].raw {
+      let info = rawChildren[1].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(TokenSyntax.self))
+    }
+    // Check child #2 child is DifferentiableAttributeFuncSpecifierSyntax or missing
+    if let raw = rawChildren[2].raw {
+      let info = rawChildren[2].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(DifferentiableAttributeFuncSpecifierSyntax.self))
+    }
+    // Check child #3 child is DifferentiableAttributeFuncSpecifierSyntax or missing
+    if let raw = rawChildren[3].raw {
+      let info = rawChildren[3].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(DifferentiableAttributeFuncSpecifierSyntax.self))
+    }
+    // Check child #4 child is DifferentiableAttributeFuncSpecifierSyntax or missing
+    if let raw = rawChildren[4].raw {
+      let info = rawChildren[4].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(DifferentiableAttributeFuncSpecifierSyntax.self))
+    }
+    // Check child #5 child is DifferentiableAttributeFuncSpecifierSyntax or missing
+    if let raw = rawChildren[5].raw {
+      let info = rawChildren[5].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(DifferentiableAttributeFuncSpecifierSyntax.self))
+    }
+    // Check child #6 child is GenericWhereClauseSyntax or missing
+    if let raw = rawChildren[6].raw {
+      let info = rawChildren[6].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(GenericWhereClauseSyntax.self))
+    }
+  }
+}
+
+extension DifferentiableAttributeArgumentsSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "diffParams": diffParams.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "diffParamsComma": diffParamsComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "maybePrimal": maybePrimal.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "maybeAdjoint": maybeAdjoint.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "maybeJVP": maybeJVP.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "maybeVJP": maybeVJP.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "whereClause": whereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+    ])
+  }
+}
+
+// MARK: - DifferentiationParamsClauseSyntax
+
+/// A clause containing differentiation parameters.
+public struct DifferentiationParamsClauseSyntax: SyntaxProtocol, SyntaxHashable {
+  enum Cursor: Int {
+    case wrtLabel
+    case colon
+    case parameters
+  }
+
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `DifferentiationParamsClauseSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .differentiationParamsClause else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `DifferentiationParamsClauseSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .differentiationParamsClause)
+    self._syntaxNode = Syntax(data)
+  }
+
+  /// The "wrt" label.
+  public var wrtLabel: TokenSyntax {
+    get {
+      let childData = data.child(at: Cursor.wrtLabel,
+                                 parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withWrtLabel(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `wrtLabel` replaced.
+  /// - param newChild: The new `wrtLabel` to replace the node's
+  ///                   current `wrtLabel`, if present.
+  public func withWrtLabel(
+    _ newChild: TokenSyntax?) -> DifferentiationParamsClauseSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.identifier(""))
+    let newData = data.replacingChild(raw, at: Cursor.wrtLabel)
+    return DifferentiationParamsClauseSyntax(newData)
+  }
+
+  /// 
+  /// The colon separating "wrt" and the parameter list.
+  /// 
+  public var colon: TokenSyntax {
+    get {
+      let childData = data.child(at: Cursor.colon,
+                                 parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withColon(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `colon` replaced.
+  /// - param newChild: The new `colon` to replace the node's
+  ///                   current `colon`, if present.
+  public func withColon(
+    _ newChild: TokenSyntax?) -> DifferentiationParamsClauseSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.colon)
+    let newData = data.replacingChild(raw, at: Cursor.colon)
+    return DifferentiationParamsClauseSyntax(newData)
+  }
+
+  public var parameters: Syntax {
+    get {
+      let childData = data.child(at: Cursor.parameters,
+                                 parent: Syntax(self))
+      return Syntax(childData!)
+    }
+    set(value) {
+      self = withParameters(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `parameters` replaced.
+  /// - param newChild: The new `parameters` to replace the node's
+  ///                   current `parameters`, if present.
+  public func withParameters(
+    _ newChild: Syntax?) -> DifferentiationParamsClauseSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.unknown)
+    let newData = data.replacingChild(raw, at: Cursor.parameters)
+    return DifferentiationParamsClauseSyntax(newData)
+  }
+
+
+  public func _validateLayout() {
+    let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
+    assert(rawChildren.count == 3)
+    // Check child #0 child is TokenSyntax 
+    assert(rawChildren[0].raw != nil)
+    if let raw = rawChildren[0].raw {
+      let info = rawChildren[0].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(TokenSyntax.self))
+    }
+    // Check child #1 child is TokenSyntax 
+    assert(rawChildren[1].raw != nil)
+    if let raw = rawChildren[1].raw {
+      let info = rawChildren[1].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(TokenSyntax.self))
+    }
+    // Check child #2 child is Syntax 
+    assert(rawChildren[2].raw != nil)
+    if let raw = rawChildren[2].raw {
+      let info = rawChildren[2].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(Syntax.self))
+    }
+  }
+}
+
+extension DifferentiationParamsClauseSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "wrtLabel": Syntax(wrtLabel).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "parameters": Syntax(parameters).as(SyntaxProtocol.self),
+    ])
+  }
+}
+
+// MARK: - DifferentiationParamsSyntax
+
+/// The differentiation parameters.
+public struct DifferentiationParamsSyntax: SyntaxProtocol, SyntaxHashable {
+  enum Cursor: Int {
+    case leftParen
+    case diffParams
+    case rightParen
+  }
+
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `DifferentiationParamsSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .differentiationParams else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `DifferentiationParamsSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .differentiationParams)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public var leftParen: TokenSyntax {
+    get {
+      let childData = data.child(at: Cursor.leftParen,
+                                 parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withLeftParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `leftParen` replaced.
+  /// - param newChild: The new `leftParen` to replace the node's
+  ///                   current `leftParen`, if present.
+  public func withLeftParen(
+    _ newChild: TokenSyntax?) -> DifferentiationParamsSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.leftParen)
+    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    return DifferentiationParamsSyntax(newData)
+  }
+
+  /// The parameters for differentiation.
+  public var diffParams: DifferentiationParamListSyntax {
+    get {
+      let childData = data.child(at: Cursor.diffParams,
+                                 parent: Syntax(self))
+      return DifferentiationParamListSyntax(childData!)
+    }
+    set(value) {
+      self = withDiffParams(value)
+    }
+  }
+
+  /// Adds the provided `DifferentiationParam` to the node's `diffParams`
+  /// collection.
+  /// - param element: The new `DifferentiationParam` to add to the node's
+  ///                  `diffParams` collection.
+  /// - returns: A copy of the receiver with the provided `DifferentiationParam`
+  ///            appended to its `diffParams` collection.
+  public func addDifferentiationParam(_ element: DifferentiationParamSyntax) -> DifferentiationParamsSyntax {
+    var collection: RawSyntax
+    if let col = raw[Cursor.diffParams] {
+      collection = col.appending(element.raw)
+    } else {
+      collection = RawSyntax.create(kind: SyntaxKind.differentiationParamList,
+        layout: [element.raw], length: element.raw.totalLength, presence: .present)
+    }
+    let newData = data.replacingChild(collection,
+                                      at: Cursor.diffParams)
+    return DifferentiationParamsSyntax(newData)
+  }
+
+  /// Returns a copy of the receiver with its `diffParams` replaced.
+  /// - param newChild: The new `diffParams` to replace the node's
+  ///                   current `diffParams`, if present.
+  public func withDiffParams(
+    _ newChild: DifferentiationParamListSyntax?) -> DifferentiationParamsSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.differentiationParamList)
+    let newData = data.replacingChild(raw, at: Cursor.diffParams)
+    return DifferentiationParamsSyntax(newData)
+  }
+
+  public var rightParen: TokenSyntax {
+    get {
+      let childData = data.child(at: Cursor.rightParen,
+                                 parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `rightParen` replaced.
+  /// - param newChild: The new `rightParen` to replace the node's
+  ///                   current `rightParen`, if present.
+  public func withRightParen(
+    _ newChild: TokenSyntax?) -> DifferentiationParamsSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.rightParen)
+    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    return DifferentiationParamsSyntax(newData)
+  }
+
+
+  public func _validateLayout() {
+    let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
+    assert(rawChildren.count == 3)
+    // Check child #0 child is TokenSyntax 
+    assert(rawChildren[0].raw != nil)
+    if let raw = rawChildren[0].raw {
+      let info = rawChildren[0].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(TokenSyntax.self))
+    }
+    // Check child #1 child is DifferentiationParamListSyntax 
+    assert(rawChildren[1].raw != nil)
+    if let raw = rawChildren[1].raw {
+      let info = rawChildren[1].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(DifferentiationParamListSyntax.self))
+    }
+    // Check child #2 child is TokenSyntax 
+    assert(rawChildren[2].raw != nil)
+    if let raw = rawChildren[2].raw {
+      let info = rawChildren[2].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(TokenSyntax.self))
+    }
+  }
+}
+
+extension DifferentiationParamsSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
+      "diffParams": Syntax(diffParams).as(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+    ])
+  }
+}
+
+// MARK: - DifferentiationParamSyntax
+
+/// 
+/// A differentiation parameter: either the "self" identifier or a          function parameter name.
+/// 
+public struct DifferentiationParamSyntax: SyntaxProtocol, SyntaxHashable {
+  enum Cursor: Int {
+    case parameter
+    case trailingComma
+  }
+
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `DifferentiationParamSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .differentiationParam else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `DifferentiationParamSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .differentiationParam)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public var parameter: Syntax {
+    get {
+      let childData = data.child(at: Cursor.parameter,
+                                 parent: Syntax(self))
+      return Syntax(childData!)
+    }
+    set(value) {
+      self = withParameter(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `parameter` replaced.
+  /// - param newChild: The new `parameter` to replace the node's
+  ///                   current `parameter`, if present.
+  public func withParameter(
+    _ newChild: Syntax?) -> DifferentiationParamSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.unknown)
+    let newData = data.replacingChild(raw, at: Cursor.parameter)
+    return DifferentiationParamSyntax(newData)
+  }
+
+  public var trailingComma: TokenSyntax? {
+    get {
+      let childData = data.child(at: Cursor.trailingComma,
+                                 parent: Syntax(self))
+      if childData == nil { return nil }
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `trailingComma` replaced.
+  /// - param newChild: The new `trailingComma` to replace the node's
+  ///                   current `trailingComma`, if present.
+  public func withTrailingComma(
+    _ newChild: TokenSyntax?) -> DifferentiationParamSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    return DifferentiationParamSyntax(newData)
+  }
+
+
+  public func _validateLayout() {
+    let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
+    assert(rawChildren.count == 2)
+    // Check child #0 child is Syntax 
+    assert(rawChildren[0].raw != nil)
+    if let raw = rawChildren[0].raw {
+      let info = rawChildren[0].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(Syntax.self))
+    }
+    // Check child #1 child is TokenSyntax or missing
+    if let raw = rawChildren[1].raw {
+      let info = rawChildren[1].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(TokenSyntax.self))
+    }
+  }
+}
+
+extension DifferentiationParamSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "parameter": Syntax(parameter).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+    ])
+  }
+}
+
+// MARK: - DifferentiableAttributeFuncSpecifierSyntax
+
+/// 
+/// A function specifier, consisting of an identifier, colon, and a          function declaration name (e.g. `vjp: foo(_:_:)`).
+/// 
+public struct DifferentiableAttributeFuncSpecifierSyntax: SyntaxProtocol, SyntaxHashable {
+  enum Cursor: Int {
+    case label
+    case colon
+    case functionDeclName
+    case trailingComma
+  }
+
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `DifferentiableAttributeFuncSpecifierSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .differentiableAttributeFuncSpecifier else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `DifferentiableAttributeFuncSpecifierSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .differentiableAttributeFuncSpecifier)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public var label: TokenSyntax {
+    get {
+      let childData = data.child(at: Cursor.label,
+                                 parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withLabel(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `label` replaced.
+  /// - param newChild: The new `label` to replace the node's
+  ///                   current `label`, if present.
+  public func withLabel(
+    _ newChild: TokenSyntax?) -> DifferentiableAttributeFuncSpecifierSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.identifier(""))
+    let newData = data.replacingChild(raw, at: Cursor.label)
+    return DifferentiableAttributeFuncSpecifierSyntax(newData)
+  }
+
+  public var colon: TokenSyntax {
+    get {
+      let childData = data.child(at: Cursor.colon,
+                                 parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withColon(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `colon` replaced.
+  /// - param newChild: The new `colon` to replace the node's
+  ///                   current `colon`, if present.
+  public func withColon(
+    _ newChild: TokenSyntax?) -> DifferentiableAttributeFuncSpecifierSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.colon)
+    let newData = data.replacingChild(raw, at: Cursor.colon)
+    return DifferentiableAttributeFuncSpecifierSyntax(newData)
+  }
+
+  /// The referenced function name.
+  public var functionDeclName: FunctionDeclNameSyntax {
+    get {
+      let childData = data.child(at: Cursor.functionDeclName,
+                                 parent: Syntax(self))
+      return FunctionDeclNameSyntax(childData!)
+    }
+    set(value) {
+      self = withFunctionDeclName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `functionDeclName` replaced.
+  /// - param newChild: The new `functionDeclName` to replace the node's
+  ///                   current `functionDeclName`, if present.
+  public func withFunctionDeclName(
+    _ newChild: FunctionDeclNameSyntax?) -> DifferentiableAttributeFuncSpecifierSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.functionDeclName)
+    let newData = data.replacingChild(raw, at: Cursor.functionDeclName)
+    return DifferentiableAttributeFuncSpecifierSyntax(newData)
+  }
+
+  public var trailingComma: TokenSyntax? {
+    get {
+      let childData = data.child(at: Cursor.trailingComma,
+                                 parent: Syntax(self))
+      if childData == nil { return nil }
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `trailingComma` replaced.
+  /// - param newChild: The new `trailingComma` to replace the node's
+  ///                   current `trailingComma`, if present.
+  public func withTrailingComma(
+    _ newChild: TokenSyntax?) -> DifferentiableAttributeFuncSpecifierSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    return DifferentiableAttributeFuncSpecifierSyntax(newData)
+  }
+
+
+  public func _validateLayout() {
+    let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
+    assert(rawChildren.count == 4)
+    // Check child #0 child is TokenSyntax 
+    assert(rawChildren[0].raw != nil)
+    if let raw = rawChildren[0].raw {
+      let info = rawChildren[0].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(TokenSyntax.self))
+    }
+    // Check child #1 child is TokenSyntax 
+    assert(rawChildren[1].raw != nil)
+    if let raw = rawChildren[1].raw {
+      let info = rawChildren[1].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(TokenSyntax.self))
+    }
+    // Check child #2 child is FunctionDeclNameSyntax 
+    assert(rawChildren[2].raw != nil)
+    if let raw = rawChildren[2].raw {
+      let info = rawChildren[2].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(FunctionDeclNameSyntax.self))
+    }
+    // Check child #3 child is TokenSyntax or missing
+    if let raw = rawChildren[3].raw {
+      let info = rawChildren[3].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(TokenSyntax.self))
+    }
+  }
+}
+
+extension DifferentiableAttributeFuncSpecifierSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "label": Syntax(label).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "functionDeclName": Syntax(functionDeclName).as(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+    ])
+  }
+}
+
+// MARK: - FunctionDeclNameSyntax
+
+/// A function declaration name (e.g. `foo(_:_:)`).
+public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
+  enum Cursor: Int {
+    case name
+    case arguments
+  }
+
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `FunctionDeclNameSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .functionDeclName else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `FunctionDeclNameSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .functionDeclName)
+    self._syntaxNode = Syntax(data)
+  }
+
+  /// 
+  /// The base name of the referenced function.
+  /// 
+  public var name: Syntax {
+    get {
+      let childData = data.child(at: Cursor.name,
+                                 parent: Syntax(self))
+      return Syntax(childData!)
+    }
+    set(value) {
+      self = withName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `name` replaced.
+  /// - param newChild: The new `name` to replace the node's
+  ///                   current `name`, if present.
+  public func withName(
+    _ newChild: Syntax?) -> FunctionDeclNameSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.unknown)
+    let newData = data.replacingChild(raw, at: Cursor.name)
+    return FunctionDeclNameSyntax(newData)
+  }
+
+  /// 
+  /// The argument labels of the referenced function, optionally                    specified.
+  /// 
+  public var arguments: DeclNameArgumentsSyntax? {
+    get {
+      let childData = data.child(at: Cursor.arguments,
+                                 parent: Syntax(self))
+      if childData == nil { return nil }
+      return DeclNameArgumentsSyntax(childData!)
+    }
+    set(value) {
+      self = withArguments(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `arguments` replaced.
+  /// - param newChild: The new `arguments` to replace the node's
+  ///                   current `arguments`, if present.
+  public func withArguments(
+    _ newChild: DeclNameArgumentsSyntax?) -> FunctionDeclNameSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: Cursor.arguments)
+    return FunctionDeclNameSyntax(newData)
+  }
+
+
+  public func _validateLayout() {
+    let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
+    assert(rawChildren.count == 2)
+    // Check child #0 child is Syntax 
+    assert(rawChildren[0].raw != nil)
+    if let raw = rawChildren[0].raw {
+      let info = rawChildren[0].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(Syntax.self))
+    }
+    // Check child #1 child is DeclNameArgumentsSyntax or missing
+    if let raw = rawChildren[1].raw {
+      let info = rawChildren[1].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(DeclNameArgumentsSyntax.self))
+    }
+  }
+}
+
+extension FunctionDeclNameSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "name": Syntax(name).as(SyntaxProtocol.self),
+      "arguments": arguments.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+    ])
+  }
+}
+
 // MARK: - WhereClauseSyntax
 
 public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {


### PR DESCRIPTION
Update gyb-generated files for `@differentiable` attribute.
Friend PR: https://github.com/apple/swift/pull/27506

---

This fixes CI breakages after merging https://github.com/apple/swift/pull/27506: https://ci.swift.org/job/swift-PR-osx/16810/console.

We'll be sure to run `@swift-ci Please test` to catch such errors (`--swiftsyntax-verify-generated-files` in this case) on future PRs.