### PR TITLE
[Syntax] Provide a `Syntax` constructor that can accept an optional parameter

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -34,6 +34,12 @@ public struct Syntax: SyntaxProtocol, SyntaxHashable {
     self = syntax._syntaxNode
   }
 
+  /// Create a `Syntax` node from a specialized optional syntax node.
+  public init?<S: SyntaxProtocol>(_ syntax: S?) {
+    guard let syntax = syntax else { return nil }
+    self = syntax._syntaxNode
+  }
+
   public func hash(into hasher: inout Hasher) {
     return data.nodeId.hash(into: &hasher)
   }

--- a/Tests/SwiftSyntaxTest/SyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTests.swift
@@ -113,5 +113,11 @@ public class SyntaxTests: XCTestCase {
 
     XCTAssertTrue(classDecl.is(BracedSyntax.self))
     XCTAssertNotNil(classDecl.as(BracedSyntax.self))
+
+    let optNode: Syntax? = node
+    switch optNode?.as(SyntaxEnum.self) {
+    case .integerLiteralExpr: break
+    default: XCTFail("failed to convert to SyntaxEnum")
+    }
   }
 }


### PR DESCRIPTION
Also add test to ensure the casting to `SyntaxEnum` via optional chaining works as expected.