### PR TITLE
[Syntax] Rename the `as` conversion functions that incur existential conversions to `asProtocol`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -88,7 +88,7 @@ For increased performance, the modelling of the syntax node hierarchy has been s
   
   stays the same. `ExprSyntax` is now a struct and not a protocol. See below on how to create an `ExprSyntax`.
 
-  **Extening a type**
+  **Extending a type**
   
   ```swift
   // Before
@@ -118,8 +118,8 @@ For increased performance, the modelling of the syntax node hierarchy has been s
   ```swift
   let identifierExprSyntax: IdentifierExprSyntax = /* ... */
   let node = Syntax(identifierExprSyntax)
-  node.as(SyntaxProtocol.self) // returns a IdentifierExprSyntax with static type SyntaxProtocol
-  node.as(ExprSyntaxProtocol.self) // returns a IdentifierExprSyntax with static type ExprSyntaxProtocol?
+  node.asProtocol(SyntaxProtocol.self) // returns a IdentifierExprSyntax with static type SyntaxProtocol
+  node.asProtocol(ExprSyntaxProtocol.self) // returns a IdentifierExprSyntax with static type ExprSyntaxProtocol?
   ```
 
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ SwiftSyntax is a set of Swift bindings for the
 allows for Swift tools to parse, inspect, generate, and transform Swift source
 code.
 
+Its API is designed for performance critical applications. It uses value types almost exclusively and aims to avoid existential conversions where possible.
+
 > Note: SwiftSyntax is still in development, and the API is not guaranteed to
 > be stable. It's subject to change without warning.
 

--- a/Sources/SwiftSyntax/Misc.swift.gyb
+++ b/Sources/SwiftSyntax/Misc.swift.gyb
@@ -42,13 +42,15 @@ extension SyntaxNode {
 extension Syntax {
   /// Syntax nodes always conform to SyntaxProtocol. This API is just added
   /// for consistency.
+  /// Note that this will incur an existential conversion.
   @available(*, deprecated, message: "Expression always evaluates to true")
-  public func `is`(_: SyntaxProtocol.Protocol) -> Bool {
+  public func isProtocol(_: SyntaxProtocol.Protocol) -> Bool {
     return true
   }
 
   /// Return the non-type erased version of this syntax node.
-  public func `as`(_: SyntaxProtocol.Protocol) -> SyntaxProtocol {
+  /// Note that this will incur an existential conversion.
+  public func asProtocol(_: SyntaxProtocol.Protocol) -> SyntaxProtocol {
     switch self.as(SyntaxEnum.self) {
     case .token(let node):
       return node

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -26,7 +26,7 @@ public struct Syntax: SyntaxProtocol, SyntaxHashable {
 
   public func _validateLayout() {
     // Check the layout of the concrete type
-    return self.as(SyntaxProtocol.self)._validateLayout()
+    return self.asProtocol(SyntaxProtocol.self)._validateLayout()
   }
 
   /// Create a `Syntax` node from a specialized syntax node.
@@ -64,7 +64,7 @@ extension Syntax: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: self.as(SyntaxProtocol.self))
+    return Mirror(reflecting: self.asProtocol(SyntaxProtocol.self))
   }
 }
 

--- a/Sources/SwiftSyntax/SyntaxBaseNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxBaseNodes.swift.gyb
@@ -32,14 +32,16 @@ public protocol ${node.name}Protocol: ${base_type}Protocol {}
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to 
   /// ${node.name}Protocol. 
-  func `is`(_: ${node.name}Protocol.Protocol) -> Bool {
-    return self.as(${node.name}Protocol.self) != nil
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: ${node.name}Protocol.Protocol) -> Bool {
+    return self.asProtocol(${node.name}Protocol.self) != nil
   }
 
   /// Return the non-type erased version of this syntax node if it conforms to 
   /// ${node.name}Protocol. Otherwise return nil.
-  func `as`(_: ${node.name}Protocol.Protocol) -> ${node.name}Protocol? {
-    return self.as(SyntaxProtocol.self) as? ${node.name}Protocol
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: ${node.name}Protocol.Protocol) -> ${node.name}Protocol? {
+    return self.asProtocol(SyntaxProtocol.self) as? ${node.name}Protocol
   }
 }
 
@@ -105,14 +107,16 @@ public struct ${node.name}: ${node.name}Protocol, SyntaxHashable {
 
   /// Syntax nodes always conform to `${node.name}Protocol`. This API is just
   /// added for consistency.
+  /// Note that this will incur an existential conversion.
   @available(*, deprecated, message: "Expression always evaluates to true")
-  public func `is`(_: ${node.name}Protocol.Protocol) -> Bool {
+  public func isProtocol(_: ${node.name}Protocol.Protocol) -> Bool {
     return true
   }
 
   /// Return the non-type erased version of this syntax node.
-  public func `as`(_: ${node.name}Protocol.Protocol) -> ${node.name}Protocol {
-    return Syntax(self).as(${node.name}Protocol.self)!
+  /// Note that this will incur an existential conversion.
+  public func asProtocol(_: ${node.name}Protocol.Protocol) -> ${node.name}Protocol {
+    return Syntax(self).asProtocol(${node.name}Protocol.self)!
   }
 }
 
@@ -120,7 +124,7 @@ extension ${node.name}: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: Syntax(self).as(SyntaxProtocol.self))
+    return Mirror(reflecting: Syntax(self).asProtocol(SyntaxProtocol.self))
   }
 }
 

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
@@ -189,9 +189,9 @@ extension ${node.name}: CustomReflectable {
     return Mirror(self, children: [
 %     for child in node.children:
 %       if child.is_optional:
-      "${child.swift_name}": ${child.swift_name}.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "${child.swift_name}": ${child.swift_name}.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
 %       else:
-      "${child.swift_name}": Syntax(${child.swift_name}).as(SyntaxProtocol.self),
+      "${child.swift_name}": Syntax(${child.swift_name}).asProtocol(SyntaxProtocol.self),
 %       end
 %     end
     ])

--- a/Sources/SwiftSyntax/SyntaxTraits.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxTraits.swift.gyb
@@ -36,14 +36,16 @@ public protocol ${trait.trait_name}Syntax: SyntaxProtocol {
 public extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to 
   /// `${trait.trait_name}Syntax`. 
-  func `is`(_: ${trait.trait_name}Syntax.Protocol) -> Bool {
-    return self.as(${trait.trait_name}Syntax.self) != nil
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: ${trait.trait_name}Syntax.Protocol) -> Bool {
+    return self.asProtocol(${trait.trait_name}Syntax.self) != nil
   }
 
   /// Return the non-type erased version of this syntax node if it conforms to 
   /// `${trait.trait_name}Syntax`. Otherwise return `nil`.
-  func `as`(_: ${trait.trait_name}Syntax.Protocol) -> ${trait.trait_name}Syntax? {
-    return Syntax(self).as(SyntaxProtocol.self) as? ${trait.trait_name}Syntax
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: ${trait.trait_name}Syntax.Protocol) -> ${trait.trait_name}Syntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? ${trait.trait_name}Syntax
   }
 }
 

--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -1393,13 +1393,15 @@ extension SyntaxNode {
 extension Syntax {
   /// Syntax nodes always conform to SyntaxProtocol. This API is just added
   /// for consistency.
+  /// Note that this will incur an existential conversion.
   @available(*, deprecated, message: "Expression always evaluates to true")
-  public func `is`(_: SyntaxProtocol.Protocol) -> Bool {
+  public func isProtocol(_: SyntaxProtocol.Protocol) -> Bool {
     return true
   }
 
   /// Return the non-type erased version of this syntax node.
-  public func `as`(_: SyntaxProtocol.Protocol) -> SyntaxProtocol {
+  /// Note that this will incur an existential conversion.
+  public func asProtocol(_: SyntaxProtocol.Protocol) -> SyntaxProtocol {
     switch self.as(SyntaxEnum.self) {
     case .token(let node):
       return node

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
@@ -22,14 +22,16 @@ public protocol DeclSyntaxProtocol: SyntaxProtocol {}
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to 
   /// DeclSyntaxProtocol. 
-  func `is`(_: DeclSyntaxProtocol.Protocol) -> Bool {
-    return self.as(DeclSyntaxProtocol.self) != nil
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: DeclSyntaxProtocol.Protocol) -> Bool {
+    return self.asProtocol(DeclSyntaxProtocol.self) != nil
   }
 
   /// Return the non-type erased version of this syntax node if it conforms to 
   /// DeclSyntaxProtocol. Otherwise return nil.
-  func `as`(_: DeclSyntaxProtocol.Protocol) -> DeclSyntaxProtocol? {
-    return self.as(SyntaxProtocol.self) as? DeclSyntaxProtocol
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: DeclSyntaxProtocol.Protocol) -> DeclSyntaxProtocol? {
+    return self.asProtocol(SyntaxProtocol.self) as? DeclSyntaxProtocol
   }
 }
 
@@ -86,14 +88,16 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   /// Syntax nodes always conform to `DeclSyntaxProtocol`. This API is just
   /// added for consistency.
+  /// Note that this will incur an existential conversion.
   @available(*, deprecated, message: "Expression always evaluates to true")
-  public func `is`(_: DeclSyntaxProtocol.Protocol) -> Bool {
+  public func isProtocol(_: DeclSyntaxProtocol.Protocol) -> Bool {
     return true
   }
 
   /// Return the non-type erased version of this syntax node.
-  public func `as`(_: DeclSyntaxProtocol.Protocol) -> DeclSyntaxProtocol {
-    return Syntax(self).as(DeclSyntaxProtocol.self)!
+  /// Note that this will incur an existential conversion.
+  public func asProtocol(_: DeclSyntaxProtocol.Protocol) -> DeclSyntaxProtocol {
+    return Syntax(self).asProtocol(DeclSyntaxProtocol.self)!
   }
 }
 
@@ -101,7 +105,7 @@ extension DeclSyntax: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: Syntax(self).as(SyntaxProtocol.self))
+    return Mirror(reflecting: Syntax(self).asProtocol(SyntaxProtocol.self))
   }
 }
 
@@ -115,14 +119,16 @@ public protocol ExprSyntaxProtocol: SyntaxProtocol {}
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to 
   /// ExprSyntaxProtocol. 
-  func `is`(_: ExprSyntaxProtocol.Protocol) -> Bool {
-    return self.as(ExprSyntaxProtocol.self) != nil
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: ExprSyntaxProtocol.Protocol) -> Bool {
+    return self.asProtocol(ExprSyntaxProtocol.self) != nil
   }
 
   /// Return the non-type erased version of this syntax node if it conforms to 
   /// ExprSyntaxProtocol. Otherwise return nil.
-  func `as`(_: ExprSyntaxProtocol.Protocol) -> ExprSyntaxProtocol? {
-    return self.as(SyntaxProtocol.self) as? ExprSyntaxProtocol
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: ExprSyntaxProtocol.Protocol) -> ExprSyntaxProtocol? {
+    return self.asProtocol(SyntaxProtocol.self) as? ExprSyntaxProtocol
   }
 }
 
@@ -179,14 +185,16 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   /// Syntax nodes always conform to `ExprSyntaxProtocol`. This API is just
   /// added for consistency.
+  /// Note that this will incur an existential conversion.
   @available(*, deprecated, message: "Expression always evaluates to true")
-  public func `is`(_: ExprSyntaxProtocol.Protocol) -> Bool {
+  public func isProtocol(_: ExprSyntaxProtocol.Protocol) -> Bool {
     return true
   }
 
   /// Return the non-type erased version of this syntax node.
-  public func `as`(_: ExprSyntaxProtocol.Protocol) -> ExprSyntaxProtocol {
-    return Syntax(self).as(ExprSyntaxProtocol.self)!
+  /// Note that this will incur an existential conversion.
+  public func asProtocol(_: ExprSyntaxProtocol.Protocol) -> ExprSyntaxProtocol {
+    return Syntax(self).asProtocol(ExprSyntaxProtocol.self)!
   }
 }
 
@@ -194,7 +202,7 @@ extension ExprSyntax: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: Syntax(self).as(SyntaxProtocol.self))
+    return Mirror(reflecting: Syntax(self).asProtocol(SyntaxProtocol.self))
   }
 }
 
@@ -208,14 +216,16 @@ public protocol StmtSyntaxProtocol: SyntaxProtocol {}
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to 
   /// StmtSyntaxProtocol. 
-  func `is`(_: StmtSyntaxProtocol.Protocol) -> Bool {
-    return self.as(StmtSyntaxProtocol.self) != nil
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: StmtSyntaxProtocol.Protocol) -> Bool {
+    return self.asProtocol(StmtSyntaxProtocol.self) != nil
   }
 
   /// Return the non-type erased version of this syntax node if it conforms to 
   /// StmtSyntaxProtocol. Otherwise return nil.
-  func `as`(_: StmtSyntaxProtocol.Protocol) -> StmtSyntaxProtocol? {
-    return self.as(SyntaxProtocol.self) as? StmtSyntaxProtocol
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: StmtSyntaxProtocol.Protocol) -> StmtSyntaxProtocol? {
+    return self.asProtocol(SyntaxProtocol.self) as? StmtSyntaxProtocol
   }
 }
 
@@ -272,14 +282,16 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   /// Syntax nodes always conform to `StmtSyntaxProtocol`. This API is just
   /// added for consistency.
+  /// Note that this will incur an existential conversion.
   @available(*, deprecated, message: "Expression always evaluates to true")
-  public func `is`(_: StmtSyntaxProtocol.Protocol) -> Bool {
+  public func isProtocol(_: StmtSyntaxProtocol.Protocol) -> Bool {
     return true
   }
 
   /// Return the non-type erased version of this syntax node.
-  public func `as`(_: StmtSyntaxProtocol.Protocol) -> StmtSyntaxProtocol {
-    return Syntax(self).as(StmtSyntaxProtocol.self)!
+  /// Note that this will incur an existential conversion.
+  public func asProtocol(_: StmtSyntaxProtocol.Protocol) -> StmtSyntaxProtocol {
+    return Syntax(self).asProtocol(StmtSyntaxProtocol.self)!
   }
 }
 
@@ -287,7 +299,7 @@ extension StmtSyntax: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: Syntax(self).as(SyntaxProtocol.self))
+    return Mirror(reflecting: Syntax(self).asProtocol(SyntaxProtocol.self))
   }
 }
 
@@ -301,14 +313,16 @@ public protocol TypeSyntaxProtocol: SyntaxProtocol {}
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to 
   /// TypeSyntaxProtocol. 
-  func `is`(_: TypeSyntaxProtocol.Protocol) -> Bool {
-    return self.as(TypeSyntaxProtocol.self) != nil
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: TypeSyntaxProtocol.Protocol) -> Bool {
+    return self.asProtocol(TypeSyntaxProtocol.self) != nil
   }
 
   /// Return the non-type erased version of this syntax node if it conforms to 
   /// TypeSyntaxProtocol. Otherwise return nil.
-  func `as`(_: TypeSyntaxProtocol.Protocol) -> TypeSyntaxProtocol? {
-    return self.as(SyntaxProtocol.self) as? TypeSyntaxProtocol
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: TypeSyntaxProtocol.Protocol) -> TypeSyntaxProtocol? {
+    return self.asProtocol(SyntaxProtocol.self) as? TypeSyntaxProtocol
   }
 }
 
@@ -365,14 +379,16 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   /// Syntax nodes always conform to `TypeSyntaxProtocol`. This API is just
   /// added for consistency.
+  /// Note that this will incur an existential conversion.
   @available(*, deprecated, message: "Expression always evaluates to true")
-  public func `is`(_: TypeSyntaxProtocol.Protocol) -> Bool {
+  public func isProtocol(_: TypeSyntaxProtocol.Protocol) -> Bool {
     return true
   }
 
   /// Return the non-type erased version of this syntax node.
-  public func `as`(_: TypeSyntaxProtocol.Protocol) -> TypeSyntaxProtocol {
-    return Syntax(self).as(TypeSyntaxProtocol.self)!
+  /// Note that this will incur an existential conversion.
+  public func asProtocol(_: TypeSyntaxProtocol.Protocol) -> TypeSyntaxProtocol {
+    return Syntax(self).asProtocol(TypeSyntaxProtocol.self)!
   }
 }
 
@@ -380,7 +396,7 @@ extension TypeSyntax: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: Syntax(self).as(SyntaxProtocol.self))
+    return Mirror(reflecting: Syntax(self).asProtocol(SyntaxProtocol.self))
   }
 }
 
@@ -394,14 +410,16 @@ public protocol PatternSyntaxProtocol: SyntaxProtocol {}
 public extension Syntax {
   /// Check whether the non-type erased version of this syntax node conforms to 
   /// PatternSyntaxProtocol. 
-  func `is`(_: PatternSyntaxProtocol.Protocol) -> Bool {
-    return self.as(PatternSyntaxProtocol.self) != nil
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: PatternSyntaxProtocol.Protocol) -> Bool {
+    return self.asProtocol(PatternSyntaxProtocol.self) != nil
   }
 
   /// Return the non-type erased version of this syntax node if it conforms to 
   /// PatternSyntaxProtocol. Otherwise return nil.
-  func `as`(_: PatternSyntaxProtocol.Protocol) -> PatternSyntaxProtocol? {
-    return self.as(SyntaxProtocol.self) as? PatternSyntaxProtocol
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: PatternSyntaxProtocol.Protocol) -> PatternSyntaxProtocol? {
+    return self.asProtocol(SyntaxProtocol.self) as? PatternSyntaxProtocol
   }
 }
 
@@ -458,14 +476,16 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
   /// Syntax nodes always conform to `PatternSyntaxProtocol`. This API is just
   /// added for consistency.
+  /// Note that this will incur an existential conversion.
   @available(*, deprecated, message: "Expression always evaluates to true")
-  public func `is`(_: PatternSyntaxProtocol.Protocol) -> Bool {
+  public func isProtocol(_: PatternSyntaxProtocol.Protocol) -> Bool {
     return true
   }
 
   /// Return the non-type erased version of this syntax node.
-  public func `as`(_: PatternSyntaxProtocol.Protocol) -> PatternSyntaxProtocol {
-    return Syntax(self).as(PatternSyntaxProtocol.self)!
+  /// Note that this will incur an existential conversion.
+  public func asProtocol(_: PatternSyntaxProtocol.Protocol) -> PatternSyntaxProtocol {
+    return Syntax(self).asProtocol(PatternSyntaxProtocol.self)!
   }
 }
 
@@ -473,7 +493,7 @@ extension PatternSyntax: CustomReflectable {
   /// Reconstructs the real syntax type for this type from the node's kind and
   /// provides a mirror that reflects this type.
   public var customMirror: Mirror {
-    return Mirror(reflecting: Syntax(self).as(SyntaxProtocol.self))
+    return Mirror(reflecting: Syntax(self).asProtocol(SyntaxProtocol.self))
   }
 }
 

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxTraits.swift
@@ -26,14 +26,16 @@ public protocol DeclGroupSyntax: SyntaxProtocol {
 public extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to 
   /// `DeclGroupSyntax`. 
-  func `is`(_: DeclGroupSyntax.Protocol) -> Bool {
-    return self.as(DeclGroupSyntax.self) != nil
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: DeclGroupSyntax.Protocol) -> Bool {
+    return self.asProtocol(DeclGroupSyntax.self) != nil
   }
 
   /// Return the non-type erased version of this syntax node if it conforms to 
   /// `DeclGroupSyntax`. Otherwise return `nil`.
-  func `as`(_: DeclGroupSyntax.Protocol) -> DeclGroupSyntax? {
-    return Syntax(self).as(SyntaxProtocol.self) as? DeclGroupSyntax
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: DeclGroupSyntax.Protocol) -> DeclGroupSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? DeclGroupSyntax
   }
 }
 
@@ -49,14 +51,16 @@ public protocol BracedSyntax: SyntaxProtocol {
 public extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to 
   /// `BracedSyntax`. 
-  func `is`(_: BracedSyntax.Protocol) -> Bool {
-    return self.as(BracedSyntax.self) != nil
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: BracedSyntax.Protocol) -> Bool {
+    return self.asProtocol(BracedSyntax.self) != nil
   }
 
   /// Return the non-type erased version of this syntax node if it conforms to 
   /// `BracedSyntax`. Otherwise return `nil`.
-  func `as`(_: BracedSyntax.Protocol) -> BracedSyntax? {
-    return Syntax(self).as(SyntaxProtocol.self) as? BracedSyntax
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: BracedSyntax.Protocol) -> BracedSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? BracedSyntax
   }
 }
 
@@ -70,14 +74,16 @@ public protocol IdentifiedDeclSyntax: SyntaxProtocol {
 public extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to 
   /// `IdentifiedDeclSyntax`. 
-  func `is`(_: IdentifiedDeclSyntax.Protocol) -> Bool {
-    return self.as(IdentifiedDeclSyntax.self) != nil
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: IdentifiedDeclSyntax.Protocol) -> Bool {
+    return self.asProtocol(IdentifiedDeclSyntax.self) != nil
   }
 
   /// Return the non-type erased version of this syntax node if it conforms to 
   /// `IdentifiedDeclSyntax`. Otherwise return `nil`.
-  func `as`(_: IdentifiedDeclSyntax.Protocol) -> IdentifiedDeclSyntax? {
-    return Syntax(self).as(SyntaxProtocol.self) as? IdentifiedDeclSyntax
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: IdentifiedDeclSyntax.Protocol) -> IdentifiedDeclSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? IdentifiedDeclSyntax
   }
 }
 
@@ -91,14 +97,16 @@ public protocol WithCodeBlockSyntax: SyntaxProtocol {
 public extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to 
   /// `WithCodeBlockSyntax`. 
-  func `is`(_: WithCodeBlockSyntax.Protocol) -> Bool {
-    return self.as(WithCodeBlockSyntax.self) != nil
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: WithCodeBlockSyntax.Protocol) -> Bool {
+    return self.asProtocol(WithCodeBlockSyntax.self) != nil
   }
 
   /// Return the non-type erased version of this syntax node if it conforms to 
   /// `WithCodeBlockSyntax`. Otherwise return `nil`.
-  func `as`(_: WithCodeBlockSyntax.Protocol) -> WithCodeBlockSyntax? {
-    return Syntax(self).as(SyntaxProtocol.self) as? WithCodeBlockSyntax
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: WithCodeBlockSyntax.Protocol) -> WithCodeBlockSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? WithCodeBlockSyntax
   }
 }
 
@@ -114,14 +122,16 @@ public protocol ParenthesizedSyntax: SyntaxProtocol {
 public extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to 
   /// `ParenthesizedSyntax`. 
-  func `is`(_: ParenthesizedSyntax.Protocol) -> Bool {
-    return self.as(ParenthesizedSyntax.self) != nil
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: ParenthesizedSyntax.Protocol) -> Bool {
+    return self.asProtocol(ParenthesizedSyntax.self) != nil
   }
 
   /// Return the non-type erased version of this syntax node if it conforms to 
   /// `ParenthesizedSyntax`. Otherwise return `nil`.
-  func `as`(_: ParenthesizedSyntax.Protocol) -> ParenthesizedSyntax? {
-    return Syntax(self).as(SyntaxProtocol.self) as? ParenthesizedSyntax
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: ParenthesizedSyntax.Protocol) -> ParenthesizedSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? ParenthesizedSyntax
   }
 }
 
@@ -135,14 +145,16 @@ public protocol WithTrailingCommaSyntax: SyntaxProtocol {
 public extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to 
   /// `WithTrailingCommaSyntax`. 
-  func `is`(_: WithTrailingCommaSyntax.Protocol) -> Bool {
-    return self.as(WithTrailingCommaSyntax.self) != nil
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: WithTrailingCommaSyntax.Protocol) -> Bool {
+    return self.asProtocol(WithTrailingCommaSyntax.self) != nil
   }
 
   /// Return the non-type erased version of this syntax node if it conforms to 
   /// `WithTrailingCommaSyntax`. Otherwise return `nil`.
-  func `as`(_: WithTrailingCommaSyntax.Protocol) -> WithTrailingCommaSyntax? {
-    return Syntax(self).as(SyntaxProtocol.self) as? WithTrailingCommaSyntax
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: WithTrailingCommaSyntax.Protocol) -> WithTrailingCommaSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? WithTrailingCommaSyntax
   }
 }
 
@@ -158,14 +170,16 @@ public protocol LabeledSyntax: SyntaxProtocol {
 public extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to 
   /// `LabeledSyntax`. 
-  func `is`(_: LabeledSyntax.Protocol) -> Bool {
-    return self.as(LabeledSyntax.self) != nil
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: LabeledSyntax.Protocol) -> Bool {
+    return self.asProtocol(LabeledSyntax.self) != nil
   }
 
   /// Return the non-type erased version of this syntax node if it conforms to 
   /// `LabeledSyntax`. Otherwise return `nil`.
-  func `as`(_: LabeledSyntax.Protocol) -> LabeledSyntax? {
-    return Syntax(self).as(SyntaxProtocol.self) as? LabeledSyntax
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: LabeledSyntax.Protocol) -> LabeledSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? LabeledSyntax
   }
 }
 
@@ -179,14 +193,16 @@ public protocol WithStatementsSyntax: SyntaxProtocol {
 public extension SyntaxProtocol {
   /// Check whether the non-type erased version of this syntax node conforms to 
   /// `WithStatementsSyntax`. 
-  func `is`(_: WithStatementsSyntax.Protocol) -> Bool {
-    return self.as(WithStatementsSyntax.self) != nil
+  /// Note that this will incur an existential conversion.
+  func isProtocol(_: WithStatementsSyntax.Protocol) -> Bool {
+    return self.asProtocol(WithStatementsSyntax.self) != nil
   }
 
   /// Return the non-type erased version of this syntax node if it conforms to 
   /// `WithStatementsSyntax`. Otherwise return `nil`.
-  func `as`(_: WithStatementsSyntax.Protocol) -> WithStatementsSyntax? {
-    return Syntax(self).as(SyntaxProtocol.self) as? WithStatementsSyntax
+  /// Note that this will incur an existential conversion.
+  func asProtocol(_: WithStatementsSyntax.Protocol) -> WithStatementsSyntax? {
+    return Syntax(self).asProtocol(SyntaxProtocol.self) as? WithStatementsSyntax
   }
 }
 

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -336,13 +336,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension TypealiasDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "typealiasKeyword": Syntax(typealiasKeyword).as(SyntaxProtocol.self),
-      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
-      "genericParameterClause": genericParameterClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "initializer": initializer.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "typealiasKeyword": Syntax(typealiasKeyword).asProtocol(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "genericParameterClause": genericParameterClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "initializer": initializer.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -635,13 +635,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension AssociatedtypeDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "associatedtypeKeyword": Syntax(associatedtypeKeyword).as(SyntaxProtocol.self),
-      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
-      "inheritanceClause": inheritanceClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "initializer": initializer.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "associatedtypeKeyword": Syntax(associatedtypeKeyword).asProtocol(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "inheritanceClause": inheritanceClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "initializer": initializer.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -760,8 +760,8 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension IfConfigDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "clauses": Syntax(clauses).as(SyntaxProtocol.self),
-      "poundEndif": Syntax(poundEndif).as(SyntaxProtocol.self),
+      "clauses": Syntax(clauses).asProtocol(SyntaxProtocol.self),
+      "poundEndif": Syntax(poundEndif).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -923,10 +923,10 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension PoundErrorDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundError": Syntax(poundError).as(SyntaxProtocol.self),
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "message": Syntax(message).as(SyntaxProtocol.self),
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "poundError": Syntax(poundError).asProtocol(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "message": Syntax(message).asProtocol(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1088,10 +1088,10 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension PoundWarningDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundWarning": Syntax(poundWarning).as(SyntaxProtocol.self),
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "message": Syntax(message).as(SyntaxProtocol.self),
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "poundWarning": Syntax(poundWarning).asProtocol(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "message": Syntax(message).asProtocol(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1253,10 +1253,10 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension PoundSourceLocationSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundSourceLocation": Syntax(poundSourceLocation).as(SyntaxProtocol.self),
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "args": args.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "poundSourceLocation": Syntax(poundSourceLocation).asProtocol(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "args": args.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1580,14 +1580,14 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension ClassDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "classKeyword": Syntax(classKeyword).as(SyntaxProtocol.self),
-      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
-      "genericParameterClause": genericParameterClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "inheritanceClause": inheritanceClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "members": Syntax(members).as(SyntaxProtocol.self),
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "classKeyword": Syntax(classKeyword).asProtocol(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "genericParameterClause": genericParameterClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "inheritanceClause": inheritanceClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "members": Syntax(members).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1911,14 +1911,14 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension StructDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "structKeyword": Syntax(structKeyword).as(SyntaxProtocol.self),
-      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
-      "genericParameterClause": genericParameterClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "inheritanceClause": inheritanceClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "members": Syntax(members).as(SyntaxProtocol.self),
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "structKeyword": Syntax(structKeyword).asProtocol(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "genericParameterClause": genericParameterClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "inheritanceClause": inheritanceClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "members": Syntax(members).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2211,13 +2211,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension ProtocolDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "protocolKeyword": Syntax(protocolKeyword).as(SyntaxProtocol.self),
-      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
-      "inheritanceClause": inheritanceClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "members": Syntax(members).as(SyntaxProtocol.self),
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "protocolKeyword": Syntax(protocolKeyword).asProtocol(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "inheritanceClause": inheritanceClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "members": Syntax(members).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2510,13 +2510,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension ExtensionDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "extensionKeyword": Syntax(extensionKeyword).as(SyntaxProtocol.self),
-      "extendedType": Syntax(extendedType).as(SyntaxProtocol.self),
-      "inheritanceClause": inheritanceClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "members": Syntax(members).as(SyntaxProtocol.self),
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "extensionKeyword": Syntax(extensionKeyword).asProtocol(SyntaxProtocol.self),
+      "extendedType": Syntax(extendedType).asProtocol(SyntaxProtocol.self),
+      "inheritanceClause": inheritanceClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "members": Syntax(members).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2840,14 +2840,14 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension FunctionDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "funcKeyword": Syntax(funcKeyword).as(SyntaxProtocol.self),
-      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
-      "genericParameterClause": genericParameterClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "signature": Syntax(signature).as(SyntaxProtocol.self),
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "body": body.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "funcKeyword": Syntax(funcKeyword).asProtocol(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "genericParameterClause": genericParameterClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "signature": Syntax(signature).asProtocol(SyntaxProtocol.self),
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "body": body.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3202,15 +3202,15 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension InitializerDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "initKeyword": Syntax(initKeyword).as(SyntaxProtocol.self),
-      "optionalMark": optionalMark.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "genericParameterClause": genericParameterClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "parameters": Syntax(parameters).as(SyntaxProtocol.self),
-      "throwsOrRethrowsKeyword": throwsOrRethrowsKeyword.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "body": body.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "initKeyword": Syntax(initKeyword).asProtocol(SyntaxProtocol.self),
+      "optionalMark": optionalMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "genericParameterClause": genericParameterClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "parameters": Syntax(parameters).asProtocol(SyntaxProtocol.self),
+      "throwsOrRethrowsKeyword": throwsOrRethrowsKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "body": body.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3410,10 +3410,10 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension DeinitializerDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "deinitKeyword": Syntax(deinitKeyword).as(SyntaxProtocol.self),
-      "body": Syntax(body).as(SyntaxProtocol.self),
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "deinitKeyword": Syntax(deinitKeyword).asProtocol(SyntaxProtocol.self),
+      "body": Syntax(body).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -3737,14 +3737,14 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension SubscriptDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "subscriptKeyword": Syntax(subscriptKeyword).as(SyntaxProtocol.self),
-      "genericParameterClause": genericParameterClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "indices": Syntax(indices).as(SyntaxProtocol.self),
-      "result": Syntax(result).as(SyntaxProtocol.self),
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "accessor": accessor.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "subscriptKeyword": Syntax(subscriptKeyword).asProtocol(SyntaxProtocol.self),
+      "genericParameterClause": genericParameterClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "indices": Syntax(indices).asProtocol(SyntaxProtocol.self),
+      "result": Syntax(result).asProtocol(SyntaxProtocol.self),
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "accessor": accessor.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3994,11 +3994,11 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension ImportDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "importTok": Syntax(importTok).as(SyntaxProtocol.self),
-      "importKind": importKind.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "path": Syntax(path).as(SyntaxProtocol.self),
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "importTok": Syntax(importTok).asProtocol(SyntaxProtocol.self),
+      "importKind": importKind.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "path": Syntax(path).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -4210,11 +4210,11 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension AccessorDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifier": modifier.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "accessorKind": Syntax(accessorKind).as(SyntaxProtocol.self),
-      "parameter": parameter.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "body": body.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifier": modifier.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "accessorKind": Syntax(accessorKind).asProtocol(SyntaxProtocol.self),
+      "parameter": parameter.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "body": body.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4433,10 +4433,10 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension VariableDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "letOrVarKeyword": Syntax(letOrVarKeyword).as(SyntaxProtocol.self),
-      "bindings": Syntax(bindings).as(SyntaxProtocol.self),
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "letOrVarKeyword": Syntax(letOrVarKeyword).asProtocol(SyntaxProtocol.self),
+      "bindings": Syntax(bindings).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -4668,10 +4668,10 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension EnumCaseDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "caseKeyword": Syntax(caseKeyword).as(SyntaxProtocol.self),
-      "elements": Syntax(elements).as(SyntaxProtocol.self),
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "caseKeyword": Syntax(caseKeyword).asProtocol(SyntaxProtocol.self),
+      "elements": Syntax(elements).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -5022,14 +5022,14 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension EnumDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "enumKeyword": Syntax(enumKeyword).as(SyntaxProtocol.self),
-      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
-      "genericParameters": genericParameters.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "inheritanceClause": inheritanceClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "genericWhereClause": genericWhereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "members": Syntax(members).as(SyntaxProtocol.self),
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "enumKeyword": Syntax(enumKeyword).asProtocol(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "genericParameters": genericParameters.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "inheritanceClause": inheritanceClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "members": Syntax(members).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -5271,11 +5271,11 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension OperatorDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "operatorKeyword": Syntax(operatorKeyword).as(SyntaxProtocol.self),
-      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
-      "operatorPrecedenceAndTypes": operatorPrecedenceAndTypes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "operatorKeyword": Syntax(operatorKeyword).asProtocol(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "operatorPrecedenceAndTypes": operatorPrecedenceAndTypes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5601,13 +5601,13 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 extension PrecedenceGroupDeclSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifiers": modifiers.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "precedencegroupKeyword": Syntax(precedencegroupKeyword).as(SyntaxProtocol.self),
-      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
-      "leftBrace": Syntax(leftBrace).as(SyntaxProtocol.self),
-      "groupAttributes": Syntax(groupAttributes).as(SyntaxProtocol.self),
-      "rightBrace": Syntax(rightBrace).as(SyntaxProtocol.self),
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "precedencegroupKeyword": Syntax(precedencegroupKeyword).asProtocol(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "leftBrace": Syntax(leftBrace).asProtocol(SyntaxProtocol.self),
+      "groupAttributes": Syntax(groupAttributes).asProtocol(SyntaxProtocol.self),
+      "rightBrace": Syntax(rightBrace).asProtocol(SyntaxProtocol.self),
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -143,8 +143,8 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension InOutExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "ampersand": Syntax(ampersand).as(SyntaxProtocol.self),
-      "expression": Syntax(expression).as(SyntaxProtocol.self),
+      "ampersand": Syntax(ampersand).asProtocol(SyntaxProtocol.self),
+      "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -213,7 +213,7 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension PoundColumnExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundColumn": Syntax(poundColumn).as(SyntaxProtocol.self),
+      "poundColumn": Syntax(poundColumn).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -344,9 +344,9 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension TryExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "tryKeyword": Syntax(tryKeyword).as(SyntaxProtocol.self),
-      "questionOrExclamationMark": questionOrExclamationMark.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "expression": Syntax(expression).as(SyntaxProtocol.self),
+      "tryKeyword": Syntax(tryKeyword).asProtocol(SyntaxProtocol.self),
+      "questionOrExclamationMark": questionOrExclamationMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -446,8 +446,8 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension IdentifierExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
-      "declNameArguments": declNameArguments.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "declNameArguments": declNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -516,7 +516,7 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension SuperRefExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "superKeyword": Syntax(superKeyword).as(SyntaxProtocol.self),
+      "superKeyword": Syntax(superKeyword).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -585,7 +585,7 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension NilLiteralExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "nilKeyword": Syntax(nilKeyword).as(SyntaxProtocol.self),
+      "nilKeyword": Syntax(nilKeyword).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -654,7 +654,7 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension DiscardAssignmentExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "wildcard": Syntax(wildcard).as(SyntaxProtocol.self),
+      "wildcard": Syntax(wildcard).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -723,7 +723,7 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension AssignmentExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "assignToken": Syntax(assignToken).as(SyntaxProtocol.self),
+      "assignToken": Syntax(assignToken).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -811,7 +811,7 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension SequenceExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "elements": Syntax(elements).as(SyntaxProtocol.self),
+      "elements": Syntax(elements).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -880,7 +880,7 @@ public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension PoundLineExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundLine": Syntax(poundLine).as(SyntaxProtocol.self),
+      "poundLine": Syntax(poundLine).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -949,7 +949,7 @@ public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension PoundFileExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundFile": Syntax(poundFile).as(SyntaxProtocol.self),
+      "poundFile": Syntax(poundFile).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1018,7 +1018,7 @@ public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension PoundFunctionExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundFunction": Syntax(poundFunction).as(SyntaxProtocol.self),
+      "poundFunction": Syntax(poundFunction).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1087,7 +1087,7 @@ public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension PoundDsohandleExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundDsohandle": Syntax(poundDsohandle).as(SyntaxProtocol.self),
+      "poundDsohandle": Syntax(poundDsohandle).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1187,8 +1187,8 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension SymbolicReferenceExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
-      "genericArgumentClause": genericArgumentClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "genericArgumentClause": genericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1288,8 +1288,8 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension PrefixOperatorExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "operatorToken": operatorToken.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "postfixExpression": Syntax(postfixExpression).as(SyntaxProtocol.self),
+      "operatorToken": operatorToken.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "postfixExpression": Syntax(postfixExpression).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1358,7 +1358,7 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension BinaryOperatorExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "operatorToken": Syntax(operatorToken).as(SyntaxProtocol.self),
+      "operatorToken": Syntax(operatorToken).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1458,8 +1458,8 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension ArrowExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "throwsToken": throwsToken.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "arrowToken": Syntax(arrowToken).as(SyntaxProtocol.self),
+      "throwsToken": throwsToken.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "arrowToken": Syntax(arrowToken).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1528,7 +1528,7 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension FloatLiteralExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "floatingDigits": Syntax(floatingDigits).as(SyntaxProtocol.self),
+      "floatingDigits": Syntax(floatingDigits).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1678,9 +1678,9 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension TupleExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "elementList": Syntax(elementList).as(SyntaxProtocol.self),
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "elementList": Syntax(elementList).asProtocol(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1830,9 +1830,9 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension ArrayExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftSquare": Syntax(leftSquare).as(SyntaxProtocol.self),
-      "elements": Syntax(elements).as(SyntaxProtocol.self),
-      "rightSquare": Syntax(rightSquare).as(SyntaxProtocol.self),
+      "leftSquare": Syntax(leftSquare).asProtocol(SyntaxProtocol.self),
+      "elements": Syntax(elements).asProtocol(SyntaxProtocol.self),
+      "rightSquare": Syntax(rightSquare).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1963,9 +1963,9 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension DictionaryExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftSquare": Syntax(leftSquare).as(SyntaxProtocol.self),
-      "content": Syntax(content).as(SyntaxProtocol.self),
-      "rightSquare": Syntax(rightSquare).as(SyntaxProtocol.self),
+      "leftSquare": Syntax(leftSquare).asProtocol(SyntaxProtocol.self),
+      "content": Syntax(content).asProtocol(SyntaxProtocol.self),
+      "rightSquare": Syntax(rightSquare).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2034,7 +2034,7 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension IntegerLiteralExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "digits": Syntax(digits).as(SyntaxProtocol.self),
+      "digits": Syntax(digits).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2103,7 +2103,7 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension BooleanLiteralExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "booleanLiteral": Syntax(booleanLiteral).as(SyntaxProtocol.self),
+      "booleanLiteral": Syntax(booleanLiteral).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2296,11 +2296,11 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension TernaryExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "conditionExpression": Syntax(conditionExpression).as(SyntaxProtocol.self),
-      "questionMark": Syntax(questionMark).as(SyntaxProtocol.self),
-      "firstChoice": Syntax(firstChoice).as(SyntaxProtocol.self),
-      "colonMark": Syntax(colonMark).as(SyntaxProtocol.self),
-      "secondChoice": Syntax(secondChoice).as(SyntaxProtocol.self),
+      "conditionExpression": Syntax(conditionExpression).asProtocol(SyntaxProtocol.self),
+      "questionMark": Syntax(questionMark).asProtocol(SyntaxProtocol.self),
+      "firstChoice": Syntax(firstChoice).asProtocol(SyntaxProtocol.self),
+      "colonMark": Syntax(colonMark).asProtocol(SyntaxProtocol.self),
+      "secondChoice": Syntax(secondChoice).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2462,10 +2462,10 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension MemberAccessExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "base": base.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "dot": Syntax(dot).as(SyntaxProtocol.self),
-      "name": Syntax(name).as(SyntaxProtocol.self),
-      "declNameArguments": declNameArguments.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "base": base.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "dot": Syntax(dot).asProtocol(SyntaxProtocol.self),
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "declNameArguments": declNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2565,8 +2565,8 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension IsExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "isTok": Syntax(isTok).as(SyntaxProtocol.self),
-      "typeName": Syntax(typeName).as(SyntaxProtocol.self),
+      "isTok": Syntax(isTok).asProtocol(SyntaxProtocol.self),
+      "typeName": Syntax(typeName).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2697,9 +2697,9 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension AsExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "asTok": Syntax(asTok).as(SyntaxProtocol.self),
-      "questionOrExclamationMark": questionOrExclamationMark.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "typeName": Syntax(typeName).as(SyntaxProtocol.self),
+      "asTok": Syntax(asTok).asProtocol(SyntaxProtocol.self),
+      "questionOrExclamationMark": questionOrExclamationMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "typeName": Syntax(typeName).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2768,7 +2768,7 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension TypeExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "type": Syntax(type).as(SyntaxProtocol.self),
+      "type": Syntax(type).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2949,10 +2949,10 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension ClosureExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftBrace": Syntax(leftBrace).as(SyntaxProtocol.self),
-      "signature": signature.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "statements": Syntax(statements).as(SyntaxProtocol.self),
-      "rightBrace": Syntax(rightBrace).as(SyntaxProtocol.self),
+      "leftBrace": Syntax(leftBrace).asProtocol(SyntaxProtocol.self),
+      "signature": signature.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "statements": Syntax(statements).asProtocol(SyntaxProtocol.self),
+      "rightBrace": Syntax(rightBrace).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -3021,7 +3021,7 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension UnresolvedPatternExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
+      "pattern": Syntax(pattern).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -3233,11 +3233,11 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension FunctionCallExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "calledExpression": Syntax(calledExpression).as(SyntaxProtocol.self),
-      "leftParen": leftParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "argumentList": Syntax(argumentList).as(SyntaxProtocol.self),
-      "rightParen": rightParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "trailingClosure": trailingClosure.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "calledExpression": Syntax(calledExpression).asProtocol(SyntaxProtocol.self),
+      "leftParen": leftParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "argumentList": Syntax(argumentList).asProtocol(SyntaxProtocol.self),
+      "rightParen": rightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "trailingClosure": trailingClosure.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3449,11 +3449,11 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension SubscriptExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "calledExpression": Syntax(calledExpression).as(SyntaxProtocol.self),
-      "leftBracket": Syntax(leftBracket).as(SyntaxProtocol.self),
-      "argumentList": Syntax(argumentList).as(SyntaxProtocol.self),
-      "rightBracket": Syntax(rightBracket).as(SyntaxProtocol.self),
-      "trailingClosure": trailingClosure.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "calledExpression": Syntax(calledExpression).asProtocol(SyntaxProtocol.self),
+      "leftBracket": Syntax(leftBracket).asProtocol(SyntaxProtocol.self),
+      "argumentList": Syntax(argumentList).asProtocol(SyntaxProtocol.self),
+      "rightBracket": Syntax(rightBracket).asProtocol(SyntaxProtocol.self),
+      "trailingClosure": trailingClosure.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3553,8 +3553,8 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension OptionalChainingExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "expression": Syntax(expression).as(SyntaxProtocol.self),
-      "questionMark": Syntax(questionMark).as(SyntaxProtocol.self),
+      "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "questionMark": Syntax(questionMark).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -3654,8 +3654,8 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension ForcedValueExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "expression": Syntax(expression).as(SyntaxProtocol.self),
-      "exclamationMark": Syntax(exclamationMark).as(SyntaxProtocol.self),
+      "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "exclamationMark": Syntax(exclamationMark).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -3755,8 +3755,8 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension PostfixUnaryExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "expression": Syntax(expression).as(SyntaxProtocol.self),
-      "operatorToken": Syntax(operatorToken).as(SyntaxProtocol.self),
+      "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "operatorToken": Syntax(operatorToken).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -3856,8 +3856,8 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension SpecializeExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "expression": Syntax(expression).as(SyntaxProtocol.self),
-      "genericArgumentClause": Syntax(genericArgumentClause).as(SyntaxProtocol.self),
+      "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "genericArgumentClause": Syntax(genericArgumentClause).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -4069,11 +4069,11 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension StringLiteralExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "openDelimiter": openDelimiter.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "openQuote": Syntax(openQuote).as(SyntaxProtocol.self),
-      "segments": Syntax(segments).as(SyntaxProtocol.self),
-      "closeQuote": Syntax(closeQuote).as(SyntaxProtocol.self),
-      "closeDelimiter": closeDelimiter.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "openDelimiter": openDelimiter.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "openQuote": Syntax(openQuote).asProtocol(SyntaxProtocol.self),
+      "segments": Syntax(segments).asProtocol(SyntaxProtocol.self),
+      "closeQuote": Syntax(closeQuote).asProtocol(SyntaxProtocol.self),
+      "closeDelimiter": closeDelimiter.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4204,9 +4204,9 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension KeyPathExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "backslash": Syntax(backslash).as(SyntaxProtocol.self),
-      "rootExpr": rootExpr.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "expression": Syntax(expression).as(SyntaxProtocol.self),
+      "backslash": Syntax(backslash).asProtocol(SyntaxProtocol.self),
+      "rootExpr": rootExpr.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -4275,7 +4275,7 @@ public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension KeyPathBaseExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "period": Syntax(period).as(SyntaxProtocol.self),
+      "period": Syntax(period).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -4456,10 +4456,10 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension ObjcKeyPathExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "keyPath": Syntax(keyPath).as(SyntaxProtocol.self),
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "name": Syntax(name).as(SyntaxProtocol.self),
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "keyPath": Syntax(keyPath).asProtocol(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -4683,12 +4683,12 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension ObjcSelectorExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundSelector": Syntax(poundSelector).as(SyntaxProtocol.self),
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "kind": kind.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "colon": colon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "name": Syntax(name).as(SyntaxProtocol.self),
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "poundSelector": Syntax(poundSelector).asProtocol(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "kind": kind.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "colon": colon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -4757,7 +4757,7 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension EditorPlaceholderExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -4938,10 +4938,10 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 extension ObjectLiteralExprSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "arguments": Syntax(arguments).as(SyntaxProtocol.self),
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "arguments": Syntax(arguments).asProtocol(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -147,9 +147,9 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
 extension CodeBlockItemSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "item": Syntax(item).as(SyntaxProtocol.self),
-      "semicolon": semicolon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "errorTokens": errorTokens.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "item": Syntax(item).asProtocol(SyntaxProtocol.self),
+      "semicolon": semicolon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "errorTokens": errorTokens.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -299,9 +299,9 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
 extension CodeBlockSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftBrace": Syntax(leftBrace).as(SyntaxProtocol.self),
-      "statements": Syntax(statements).as(SyntaxProtocol.self),
-      "rightBrace": Syntax(rightBrace).as(SyntaxProtocol.self),
+      "leftBrace": Syntax(leftBrace).asProtocol(SyntaxProtocol.self),
+      "statements": Syntax(statements).asProtocol(SyntaxProtocol.self),
+      "rightBrace": Syntax(rightBrace).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -401,8 +401,8 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 extension DeclNameArgumentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name).as(SyntaxProtocol.self),
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -552,9 +552,9 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 extension DeclNameArgumentsSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "arguments": Syntax(arguments).as(SyntaxProtocol.self),
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "arguments": Syntax(arguments).asProtocol(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -716,10 +716,10 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension TupleExprElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "label": label.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "colon": colon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "expression": Syntax(expression).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "label": label.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "colon": colon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -819,8 +819,8 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension ArrayElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "expression": Syntax(expression).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -982,10 +982,10 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension DictionaryElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "keyExpression": Syntax(keyExpression).as(SyntaxProtocol.self),
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
-      "valueExpression": Syntax(valueExpression).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "keyExpression": Syntax(keyExpression).asProtocol(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "valueExpression": Syntax(valueExpression).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1197,11 +1197,11 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
 extension ClosureCaptureItemSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "specifier": specifier.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "name": name.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "assignToken": assignToken.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "expression": Syntax(expression).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "specifier": specifier.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "name": name.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "assignToken": assignToken.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1351,9 +1351,9 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 extension ClosureCaptureSignatureSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftSquare": Syntax(leftSquare).as(SyntaxProtocol.self),
-      "items": items.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "rightSquare": Syntax(rightSquare).as(SyntaxProtocol.self),
+      "leftSquare": Syntax(leftSquare).asProtocol(SyntaxProtocol.self),
+      "items": items.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "rightSquare": Syntax(rightSquare).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1453,8 +1453,8 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
 extension ClosureParamSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1647,11 +1647,11 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 extension ClosureSignatureSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "capture": capture.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "input": input.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "throwsTok": throwsTok.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "output": output.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "inTok": Syntax(inTok).as(SyntaxProtocol.self),
+      "capture": capture.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "input": input.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "throwsTok": throwsTok.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "output": output.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "inTok": Syntax(inTok).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1720,7 +1720,7 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 extension StringSegmentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "content": Syntax(content).as(SyntaxProtocol.self),
+      "content": Syntax(content).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1932,11 +1932,11 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 extension ExpressionSegmentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "backslash": Syntax(backslash).as(SyntaxProtocol.self),
-      "delimiter": delimiter.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "expressions": Syntax(expressions).as(SyntaxProtocol.self),
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "backslash": Syntax(backslash).asProtocol(SyntaxProtocol.self),
+      "delimiter": delimiter.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "expressions": Syntax(expressions).asProtocol(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2036,8 +2036,8 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
 extension ObjcNamePieceSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name).as(SyntaxProtocol.self),
-      "dot": dot.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "dot": dot.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2137,8 +2137,8 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension TypeInitializerClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "equal": Syntax(equal).as(SyntaxProtocol.self),
-      "value": Syntax(value).as(SyntaxProtocol.self),
+      "equal": Syntax(equal).asProtocol(SyntaxProtocol.self),
+      "value": Syntax(value).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2288,9 +2288,9 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension ParameterClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "parameterList": Syntax(parameterList).as(SyntaxProtocol.self),
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "parameterList": Syntax(parameterList).asProtocol(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2390,8 +2390,8 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension ReturnClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "arrow": Syntax(arrow).as(SyntaxProtocol.self),
-      "returnType": Syntax(returnType).as(SyntaxProtocol.self),
+      "arrow": Syntax(arrow).asProtocol(SyntaxProtocol.self),
+      "returnType": Syntax(returnType).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2522,9 +2522,9 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 extension FunctionSignatureSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "input": Syntax(input).as(SyntaxProtocol.self),
-      "throwsOrRethrowsKeyword": throwsOrRethrowsKeyword.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "output": output.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "input": Syntax(input).asProtocol(SyntaxProtocol.self),
+      "throwsOrRethrowsKeyword": throwsOrRethrowsKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "output": output.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2655,9 +2655,9 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension IfConfigClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundKeyword": Syntax(poundKeyword).as(SyntaxProtocol.self),
-      "condition": condition.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "elements": Syntax(elements).as(SyntaxProtocol.self),
+      "poundKeyword": Syntax(poundKeyword).asProtocol(SyntaxProtocol.self),
+      "condition": condition.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "elements": Syntax(elements).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2912,13 +2912,13 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
 extension PoundSourceLocationArgsSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "fileArgLabel": Syntax(fileArgLabel).as(SyntaxProtocol.self),
-      "fileArgColon": Syntax(fileArgColon).as(SyntaxProtocol.self),
-      "fileName": Syntax(fileName).as(SyntaxProtocol.self),
-      "comma": Syntax(comma).as(SyntaxProtocol.self),
-      "lineArgLabel": Syntax(lineArgLabel).as(SyntaxProtocol.self),
-      "lineArgColon": Syntax(lineArgColon).as(SyntaxProtocol.self),
-      "lineNumber": Syntax(lineNumber).as(SyntaxProtocol.self),
+      "fileArgLabel": Syntax(fileArgLabel).asProtocol(SyntaxProtocol.self),
+      "fileArgColon": Syntax(fileArgColon).asProtocol(SyntaxProtocol.self),
+      "fileName": Syntax(fileName).asProtocol(SyntaxProtocol.self),
+      "comma": Syntax(comma).asProtocol(SyntaxProtocol.self),
+      "lineArgLabel": Syntax(lineArgLabel).asProtocol(SyntaxProtocol.self),
+      "lineArgColon": Syntax(lineArgColon).asProtocol(SyntaxProtocol.self),
+      "lineNumber": Syntax(lineNumber).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -3080,10 +3080,10 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
 extension DeclModifierSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name).as(SyntaxProtocol.self),
-      "detailLeftParen": detailLeftParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "detail": detail.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "detailRightParen": detailRightParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "detailLeftParen": detailLeftParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "detail": detail.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "detailRightParen": detailRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3183,8 +3183,8 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 extension InheritedTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "typeName": Syntax(typeName).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "typeName": Syntax(typeName).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3303,8 +3303,8 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension TypeInheritanceClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
-      "inheritedTypeCollection": Syntax(inheritedTypeCollection).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "inheritedTypeCollection": Syntax(inheritedTypeCollection).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -3454,9 +3454,9 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
 extension MemberDeclBlockSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftBrace": Syntax(leftBrace).as(SyntaxProtocol.self),
-      "members": Syntax(members).as(SyntaxProtocol.self),
-      "rightBrace": Syntax(rightBrace).as(SyntaxProtocol.self),
+      "leftBrace": Syntax(leftBrace).asProtocol(SyntaxProtocol.self),
+      "members": Syntax(members).asProtocol(SyntaxProtocol.self),
+      "rightBrace": Syntax(rightBrace).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -3562,8 +3562,8 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
 extension MemberDeclListItemSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "decl": Syntax(decl).as(SyntaxProtocol.self),
-      "semicolon": semicolon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "decl": Syntax(decl).asProtocol(SyntaxProtocol.self),
+      "semicolon": semicolon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3682,8 +3682,8 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
 extension SourceFileSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "statements": Syntax(statements).as(SyntaxProtocol.self),
-      "eofToken": Syntax(eofToken).as(SyntaxProtocol.self),
+      "statements": Syntax(statements).asProtocol(SyntaxProtocol.self),
+      "eofToken": Syntax(eofToken).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -3783,8 +3783,8 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension InitializerClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "equal": Syntax(equal).as(SyntaxProtocol.self),
-      "value": Syntax(value).as(SyntaxProtocol.self),
+      "equal": Syntax(equal).asProtocol(SyntaxProtocol.self),
+      "value": Syntax(value).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -4089,14 +4089,14 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
 extension FunctionParameterSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "firstName": firstName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "secondName": secondName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "colon": colon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "type": type.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "ellipsis": ellipsis.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "defaultArgument": defaultArgument.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "firstName": firstName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "secondName": secondName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "colon": colon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "type": type.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "ellipsis": ellipsis.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "defaultArgument": defaultArgument.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4258,10 +4258,10 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
 extension AccessLevelModifierSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name).as(SyntaxProtocol.self),
-      "leftParen": leftParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "modifier": modifier.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "rightParen": rightParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "leftParen": leftParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "modifier": modifier.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "rightParen": rightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4361,8 +4361,8 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 extension AccessPathComponentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name).as(SyntaxProtocol.self),
-      "trailingDot": trailingDot.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "trailingDot": trailingDot.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4493,9 +4493,9 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
 extension AccessorParameterSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "name": Syntax(name).as(SyntaxProtocol.self),
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -4645,9 +4645,9 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
 extension AccessorBlockSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftBrace": Syntax(leftBrace).as(SyntaxProtocol.self),
-      "accessors": Syntax(accessors).as(SyntaxProtocol.self),
-      "rightBrace": Syntax(rightBrace).as(SyntaxProtocol.self),
+      "leftBrace": Syntax(leftBrace).asProtocol(SyntaxProtocol.self),
+      "accessors": Syntax(accessors).asProtocol(SyntaxProtocol.self),
+      "rightBrace": Syntax(rightBrace).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -4840,11 +4840,11 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
 extension PatternBindingSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
-      "typeAnnotation": typeAnnotation.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "initializer": initializer.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "accessor": accessor.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "pattern": Syntax(pattern).asProtocol(SyntaxProtocol.self),
+      "typeAnnotation": typeAnnotation.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "initializer": initializer.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "accessor": accessor.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5019,10 +5019,10 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension EnumCaseElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
-      "associatedValue": associatedValue.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "rawValue": rawValue.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "associatedValue": associatedValue.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "rawValue": rawValue.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5147,8 +5147,8 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
 extension OperatorPrecedenceAndTypesSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
-      "precedenceGroupAndDesignatedTypes": Syntax(precedenceGroupAndDesignatedTypes).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "precedenceGroupAndDesignatedTypes": Syntax(precedenceGroupAndDesignatedTypes).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -5309,9 +5309,9 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
 extension PrecedenceGroupRelationSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "higherThanOrLowerThan": Syntax(higherThanOrLowerThan).as(SyntaxProtocol.self),
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
-      "otherNames": Syntax(otherNames).as(SyntaxProtocol.self),
+      "higherThanOrLowerThan": Syntax(higherThanOrLowerThan).asProtocol(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "otherNames": Syntax(otherNames).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -5411,8 +5411,8 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension PrecedenceGroupNameElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5554,9 +5554,9 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
 extension PrecedenceGroupAssignmentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "assignmentKeyword": Syntax(assignmentKeyword).as(SyntaxProtocol.self),
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
-      "flag": Syntax(flag).as(SyntaxProtocol.self),
+      "assignmentKeyword": Syntax(assignmentKeyword).asProtocol(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "flag": Syntax(flag).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -5697,9 +5697,9 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
 extension PrecedenceGroupAssociativitySyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "associativityKeyword": Syntax(associativityKeyword).as(SyntaxProtocol.self),
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
-      "value": Syntax(value).as(SyntaxProtocol.self),
+      "associativityKeyword": Syntax(associativityKeyword).asProtocol(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "value": Syntax(value).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -5916,11 +5916,11 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
 extension CustomAttributeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "atSignToken": Syntax(atSignToken).as(SyntaxProtocol.self),
-      "attributeName": Syntax(attributeName).as(SyntaxProtocol.self),
-      "leftParen": leftParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "argumentList": argumentList.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "rightParen": rightParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "atSignToken": Syntax(atSignToken).asProtocol(SyntaxProtocol.self),
+      "attributeName": Syntax(attributeName).asProtocol(SyntaxProtocol.self),
+      "leftParen": leftParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "argumentList": argumentList.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "rightParen": rightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6179,12 +6179,12 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
 extension AttributeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "atSignToken": Syntax(atSignToken).as(SyntaxProtocol.self),
-      "attributeName": Syntax(attributeName).as(SyntaxProtocol.self),
-      "leftParen": leftParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "argument": argument.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "rightParen": rightParen.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "tokenList": tokenList.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "atSignToken": Syntax(atSignToken).asProtocol(SyntaxProtocol.self),
+      "attributeName": Syntax(attributeName).asProtocol(SyntaxProtocol.self),
+      "leftParen": leftParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "argument": argument.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "rightParen": rightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "tokenList": tokenList.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6356,10 +6356,10 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
 extension LabeledSpecializeEntrySyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "label": Syntax(label).as(SyntaxProtocol.self),
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
-      "value": Syntax(value).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "label": Syntax(label).asProtocol(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "value": Syntax(value).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6497,9 +6497,9 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
 extension NamedAttributeStringArgumentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "nameTok": Syntax(nameTok).as(SyntaxProtocol.self),
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
-      "stringOrDeclname": Syntax(stringOrDeclname).as(SyntaxProtocol.self),
+      "nameTok": Syntax(nameTok).asProtocol(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "stringOrDeclname": Syntax(stringOrDeclname).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -6606,8 +6606,8 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 extension DeclNameSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "declBaseName": Syntax(declBaseName).as(SyntaxProtocol.self),
-      "declNameArguments": declNameArguments.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "declBaseName": Syntax(declBaseName).asProtocol(SyntaxProtocol.self),
+      "declNameArguments": declNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6787,10 +6787,10 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 extension ImplementsAttributeArgumentsSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "type": Syntax(type).as(SyntaxProtocol.self),
-      "comma": Syntax(comma).as(SyntaxProtocol.self),
-      "declBaseName": Syntax(declBaseName).as(SyntaxProtocol.self),
-      "declNameArguments": declNameArguments.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "type": Syntax(type).asProtocol(SyntaxProtocol.self),
+      "comma": Syntax(comma).asProtocol(SyntaxProtocol.self),
+      "declBaseName": Syntax(declBaseName).asProtocol(SyntaxProtocol.self),
+      "declNameArguments": declNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6895,8 +6895,8 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
 extension ObjCSelectorPieceSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": name.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "colon": colon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "name": name.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "colon": colon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7097,11 +7097,11 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
 extension DifferentiableAttributeArgumentsSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "diffParams": diffParams.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "diffParamsComma": diffParamsComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "maybeJVP": maybeJVP.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "maybeVJP": maybeVJP.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "whereClause": whereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "diffParams": diffParams.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "diffParamsComma": diffParamsComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "maybeJVP": maybeJVP.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "maybeVJP": maybeVJP.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "whereClause": whereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7237,9 +7237,9 @@ public struct DifferentiationParamsClauseSyntax: SyntaxProtocol, SyntaxHashable 
 extension DifferentiationParamsClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "wrtLabel": Syntax(wrtLabel).as(SyntaxProtocol.self),
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
-      "parameters": Syntax(parameters).as(SyntaxProtocol.self),
+      "wrtLabel": Syntax(wrtLabel).asProtocol(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "parameters": Syntax(parameters).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -7391,9 +7391,9 @@ public struct DifferentiationParamsSyntax: SyntaxProtocol, SyntaxHashable {
 extension DifferentiationParamsSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "diffParams": Syntax(diffParams).as(SyntaxProtocol.self),
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "diffParams": Syntax(diffParams).asProtocol(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -7497,8 +7497,8 @@ public struct DifferentiationParamSyntax: SyntaxProtocol, SyntaxHashable {
 extension DifferentiationParamSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "parameter": Syntax(parameter).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "parameter": Syntax(parameter).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7665,10 +7665,10 @@ public struct DifferentiableAttributeFuncSpecifierSyntax: SyntaxProtocol, Syntax
 extension DifferentiableAttributeFuncSpecifierSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "label": Syntax(label).as(SyntaxProtocol.self),
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
-      "functionDeclName": Syntax(functionDeclName).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "label": Syntax(label).asProtocol(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "functionDeclName": Syntax(functionDeclName).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7776,8 +7776,8 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 extension FunctionDeclNameSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name).as(SyntaxProtocol.self),
-      "arguments": arguments.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "arguments": arguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7877,8 +7877,8 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension WhereClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "whereKeyword": Syntax(whereKeyword).as(SyntaxProtocol.self),
-      "guardResult": Syntax(guardResult).as(SyntaxProtocol.self),
+      "whereKeyword": Syntax(whereKeyword).asProtocol(SyntaxProtocol.self),
+      "guardResult": Syntax(guardResult).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -8059,10 +8059,10 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
 extension YieldListSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "elementList": Syntax(elementList).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "elementList": Syntax(elementList).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -8162,8 +8162,8 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension ConditionElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "condition": Syntax(condition).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "condition": Syntax(condition).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -8344,10 +8344,10 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
 extension AvailabilityConditionSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundAvailableKeyword": Syntax(poundAvailableKeyword).as(SyntaxProtocol.self),
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "availabilitySpec": Syntax(availabilitySpec).as(SyntaxProtocol.self),
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "poundAvailableKeyword": Syntax(poundAvailableKeyword).asProtocol(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "availabilitySpec": Syntax(availabilitySpec).asProtocol(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -8509,10 +8509,10 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
 extension MatchingPatternConditionSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "caseKeyword": Syntax(caseKeyword).as(SyntaxProtocol.self),
-      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
-      "typeAnnotation": typeAnnotation.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "initializer": Syntax(initializer).as(SyntaxProtocol.self),
+      "caseKeyword": Syntax(caseKeyword).asProtocol(SyntaxProtocol.self),
+      "pattern": Syntax(pattern).asProtocol(SyntaxProtocol.self),
+      "typeAnnotation": typeAnnotation.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "initializer": Syntax(initializer).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -8674,10 +8674,10 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
 extension OptionalBindingConditionSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "letOrVarKeyword": Syntax(letOrVarKeyword).as(SyntaxProtocol.self),
-      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
-      "typeAnnotation": typeAnnotation.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "initializer": Syntax(initializer).as(SyntaxProtocol.self),
+      "letOrVarKeyword": Syntax(letOrVarKeyword).asProtocol(SyntaxProtocol.self),
+      "pattern": Syntax(pattern).asProtocol(SyntaxProtocol.self),
+      "typeAnnotation": typeAnnotation.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "initializer": Syntax(initializer).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -8746,7 +8746,7 @@ public struct ElseIfContinuationSyntax: SyntaxProtocol, SyntaxHashable {
 extension ElseIfContinuationSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "ifStatement": Syntax(ifStatement).as(SyntaxProtocol.self),
+      "ifStatement": Syntax(ifStatement).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -8846,8 +8846,8 @@ public struct ElseBlockSyntax: SyntaxProtocol, SyntaxHashable {
 extension ElseBlockSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "elseKeyword": Syntax(elseKeyword).as(SyntaxProtocol.self),
-      "body": Syntax(body).as(SyntaxProtocol.self),
+      "elseKeyword": Syntax(elseKeyword).asProtocol(SyntaxProtocol.self),
+      "body": Syntax(body).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -8997,9 +8997,9 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
 extension SwitchCaseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "unknownAttr": unknownAttr.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "label": Syntax(label).as(SyntaxProtocol.self),
-      "statements": Syntax(statements).as(SyntaxProtocol.self),
+      "unknownAttr": unknownAttr.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "label": Syntax(label).asProtocol(SyntaxProtocol.self),
+      "statements": Syntax(statements).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -9099,8 +9099,8 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
 extension SwitchDefaultLabelSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "defaultKeyword": Syntax(defaultKeyword).as(SyntaxProtocol.self),
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "defaultKeyword": Syntax(defaultKeyword).asProtocol(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -9231,9 +9231,9 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
 extension CaseItemSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
-      "whereClause": whereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "pattern": Syntax(pattern).asProtocol(SyntaxProtocol.self),
+      "whereClause": whereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -9383,9 +9383,9 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
 extension SwitchCaseLabelSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "caseKeyword": Syntax(caseKeyword).as(SyntaxProtocol.self),
-      "caseItems": Syntax(caseItems).as(SyntaxProtocol.self),
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
+      "caseKeyword": Syntax(caseKeyword).asProtocol(SyntaxProtocol.self),
+      "caseItems": Syntax(caseItems).asProtocol(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -9547,10 +9547,10 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension CatchClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "catchKeyword": Syntax(catchKeyword).as(SyntaxProtocol.self),
-      "pattern": pattern.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "whereClause": whereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "body": Syntax(body).as(SyntaxProtocol.self),
+      "catchKeyword": Syntax(catchKeyword).asProtocol(SyntaxProtocol.self),
+      "pattern": pattern.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "whereClause": whereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "body": Syntax(body).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -9669,8 +9669,8 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension GenericWhereClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "whereKeyword": Syntax(whereKeyword).as(SyntaxProtocol.self),
-      "requirementList": Syntax(requirementList).as(SyntaxProtocol.self),
+      "whereKeyword": Syntax(whereKeyword).asProtocol(SyntaxProtocol.self),
+      "requirementList": Syntax(requirementList).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -9770,8 +9770,8 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 extension GenericRequirementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "body": Syntax(body).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "body": Syntax(body).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -9902,9 +9902,9 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 extension SameTypeRequirementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftTypeIdentifier": Syntax(leftTypeIdentifier).as(SyntaxProtocol.self),
-      "equalityToken": Syntax(equalityToken).as(SyntaxProtocol.self),
-      "rightTypeIdentifier": Syntax(rightTypeIdentifier).as(SyntaxProtocol.self),
+      "leftTypeIdentifier": Syntax(leftTypeIdentifier).asProtocol(SyntaxProtocol.self),
+      "equalityToken": Syntax(equalityToken).asProtocol(SyntaxProtocol.self),
+      "rightTypeIdentifier": Syntax(rightTypeIdentifier).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -10116,11 +10116,11 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
 extension GenericParameterSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "name": Syntax(name).as(SyntaxProtocol.self),
-      "colon": colon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "inheritedType": inheritedType.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "colon": colon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "inheritedType": inheritedType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -10270,9 +10270,9 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension GenericParameterClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftAngleBracket": Syntax(leftAngleBracket).as(SyntaxProtocol.self),
-      "genericParameterList": Syntax(genericParameterList).as(SyntaxProtocol.self),
-      "rightAngleBracket": Syntax(rightAngleBracket).as(SyntaxProtocol.self),
+      "leftAngleBracket": Syntax(leftAngleBracket).asProtocol(SyntaxProtocol.self),
+      "genericParameterList": Syntax(genericParameterList).asProtocol(SyntaxProtocol.self),
+      "rightAngleBracket": Syntax(rightAngleBracket).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -10403,9 +10403,9 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 extension ConformanceRequirementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftTypeIdentifier": Syntax(leftTypeIdentifier).as(SyntaxProtocol.self),
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
-      "rightTypeIdentifier": Syntax(rightTypeIdentifier).as(SyntaxProtocol.self),
+      "leftTypeIdentifier": Syntax(leftTypeIdentifier).asProtocol(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "rightTypeIdentifier": Syntax(rightTypeIdentifier).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -10505,8 +10505,8 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension CompositionTypeElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "type": Syntax(type).as(SyntaxProtocol.self),
-      "ampersand": ampersand.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "type": Syntax(type).asProtocol(SyntaxProtocol.self),
+      "ampersand": ampersand.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -10792,14 +10792,14 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension TupleTypeElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "inOut": inOut.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "name": name.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "secondName": secondName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "colon": colon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "type": Syntax(type).as(SyntaxProtocol.self),
-      "ellipsis": ellipsis.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "initializer": initializer.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "inOut": inOut.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "name": name.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "secondName": secondName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "colon": colon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "type": Syntax(type).asProtocol(SyntaxProtocol.self),
+      "ellipsis": ellipsis.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "initializer": initializer.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -10899,8 +10899,8 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 extension GenericArgumentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "argumentType": Syntax(argumentType).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "argumentType": Syntax(argumentType).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -11050,9 +11050,9 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
 extension GenericArgumentClauseSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftAngleBracket": Syntax(leftAngleBracket).as(SyntaxProtocol.self),
-      "arguments": Syntax(arguments).as(SyntaxProtocol.self),
-      "rightAngleBracket": Syntax(rightAngleBracket).as(SyntaxProtocol.self),
+      "leftAngleBracket": Syntax(leftAngleBracket).asProtocol(SyntaxProtocol.self),
+      "arguments": Syntax(arguments).asProtocol(SyntaxProtocol.self),
+      "rightAngleBracket": Syntax(rightAngleBracket).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -11152,8 +11152,8 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
 extension TypeAnnotationSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
-      "type": Syntax(type).as(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "type": Syntax(type).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -11315,10 +11315,10 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
 extension TuplePatternElementSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "labelName": labelName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "labelColon": labelColon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "labelName": labelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "labelColon": labelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "pattern": Syntax(pattern).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -11427,8 +11427,8 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 extension AvailabilityArgumentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "entry": Syntax(entry).as(SyntaxProtocol.self),
-      "trailingComma": trailingComma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "entry": Syntax(entry).asProtocol(SyntaxProtocol.self),
+      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -11566,9 +11566,9 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
 extension AvailabilityLabeledArgumentSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "label": Syntax(label).as(SyntaxProtocol.self),
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
-      "value": Syntax(value).as(SyntaxProtocol.self),
+      "label": Syntax(label).asProtocol(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "value": Syntax(value).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -11677,8 +11677,8 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
 extension AvailabilityVersionRestrictionSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "platform": Syntax(platform).as(SyntaxProtocol.self),
-      "version": Syntax(version).as(SyntaxProtocol.self),
+      "platform": Syntax(platform).asProtocol(SyntaxProtocol.self),
+      "version": Syntax(version).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -11827,9 +11827,9 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
 extension VersionTupleSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "majorMinor": Syntax(majorMinor).as(SyntaxProtocol.self),
-      "patchPeriod": patchPeriod.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "patchVersion": patchVersion.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "majorMinor": Syntax(majorMinor).asProtocol(SyntaxProtocol.self),
+      "patchPeriod": patchPeriod.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "patchVersion": patchVersion.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
@@ -205,10 +205,10 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension EnumCasePatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "type": type.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "period": Syntax(period).as(SyntaxProtocol.self),
-      "caseName": Syntax(caseName).as(SyntaxProtocol.self),
-      "associatedTuple": associatedTuple.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "type": type.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "period": Syntax(period).asProtocol(SyntaxProtocol.self),
+      "caseName": Syntax(caseName).asProtocol(SyntaxProtocol.self),
+      "associatedTuple": associatedTuple.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -308,8 +308,8 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension IsTypePatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "isKeyword": Syntax(isKeyword).as(SyntaxProtocol.self),
-      "type": Syntax(type).as(SyntaxProtocol.self),
+      "isKeyword": Syntax(isKeyword).asProtocol(SyntaxProtocol.self),
+      "type": Syntax(type).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -409,8 +409,8 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension OptionalPatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "subPattern": Syntax(subPattern).as(SyntaxProtocol.self),
-      "questionMark": Syntax(questionMark).as(SyntaxProtocol.self),
+      "subPattern": Syntax(subPattern).asProtocol(SyntaxProtocol.self),
+      "questionMark": Syntax(questionMark).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -479,7 +479,7 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension IdentifierPatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "identifier": Syntax(identifier).as(SyntaxProtocol.self),
+      "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -610,9 +610,9 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension AsTypePatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
-      "asKeyword": Syntax(asKeyword).as(SyntaxProtocol.self),
-      "type": Syntax(type).as(SyntaxProtocol.self),
+      "pattern": Syntax(pattern).asProtocol(SyntaxProtocol.self),
+      "asKeyword": Syntax(asKeyword).asProtocol(SyntaxProtocol.self),
+      "type": Syntax(type).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -762,9 +762,9 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension TuplePatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "elements": Syntax(elements).as(SyntaxProtocol.self),
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "elements": Syntax(elements).asProtocol(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -864,8 +864,8 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension WildcardPatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "wildcard": Syntax(wildcard).as(SyntaxProtocol.self),
-      "typeAnnotation": typeAnnotation.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "wildcard": Syntax(wildcard).asProtocol(SyntaxProtocol.self),
+      "typeAnnotation": typeAnnotation.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -934,7 +934,7 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension ExpressionPatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "expression": Syntax(expression).as(SyntaxProtocol.self),
+      "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1034,8 +1034,8 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 extension ValueBindingPatternSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "letOrVarKeyword": Syntax(letOrVarKeyword).as(SyntaxProtocol.self),
-      "valuePattern": Syntax(valuePattern).as(SyntaxProtocol.self),
+      "letOrVarKeyword": Syntax(letOrVarKeyword).asProtocol(SyntaxProtocol.self),
+      "valuePattern": Syntax(valuePattern).asProtocol(SyntaxProtocol.self),
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -143,8 +143,8 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension ContinueStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "continueKeyword": Syntax(continueKeyword).as(SyntaxProtocol.self),
-      "label": label.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "continueKeyword": Syntax(continueKeyword).asProtocol(SyntaxProtocol.self),
+      "label": label.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -356,11 +356,11 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension WhileStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "labelName": labelName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "labelColon": labelColon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "whileKeyword": Syntax(whileKeyword).as(SyntaxProtocol.self),
-      "conditions": Syntax(conditions).as(SyntaxProtocol.self),
-      "body": Syntax(body).as(SyntaxProtocol.self),
+      "labelName": labelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "labelColon": labelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "whileKeyword": Syntax(whileKeyword).asProtocol(SyntaxProtocol.self),
+      "conditions": Syntax(conditions).asProtocol(SyntaxProtocol.self),
+      "body": Syntax(body).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -460,8 +460,8 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension DeferStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "deferKeyword": Syntax(deferKeyword).as(SyntaxProtocol.self),
-      "body": Syntax(body).as(SyntaxProtocol.self),
+      "deferKeyword": Syntax(deferKeyword).asProtocol(SyntaxProtocol.self),
+      "body": Syntax(body).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -530,7 +530,7 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension ExpressionStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "expression": Syntax(expression).as(SyntaxProtocol.self),
+      "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -754,12 +754,12 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension RepeatWhileStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "labelName": labelName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "labelColon": labelColon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "repeatKeyword": Syntax(repeatKeyword).as(SyntaxProtocol.self),
-      "body": Syntax(body).as(SyntaxProtocol.self),
-      "whileKeyword": Syntax(whileKeyword).as(SyntaxProtocol.self),
-      "condition": Syntax(condition).as(SyntaxProtocol.self),
+      "labelName": labelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "labelColon": labelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "repeatKeyword": Syntax(repeatKeyword).asProtocol(SyntaxProtocol.self),
+      "body": Syntax(body).asProtocol(SyntaxProtocol.self),
+      "whileKeyword": Syntax(whileKeyword).asProtocol(SyntaxProtocol.self),
+      "condition": Syntax(condition).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -940,10 +940,10 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension GuardStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "guardKeyword": Syntax(guardKeyword).as(SyntaxProtocol.self),
-      "conditions": Syntax(conditions).as(SyntaxProtocol.self),
-      "elseKeyword": Syntax(elseKeyword).as(SyntaxProtocol.self),
-      "body": Syntax(body).as(SyntaxProtocol.self),
+      "guardKeyword": Syntax(guardKeyword).asProtocol(SyntaxProtocol.self),
+      "conditions": Syntax(conditions).asProtocol(SyntaxProtocol.self),
+      "elseKeyword": Syntax(elseKeyword).asProtocol(SyntaxProtocol.self),
+      "body": Syntax(body).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1291,16 +1291,16 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension ForInStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "labelName": labelName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "labelColon": labelColon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "forKeyword": Syntax(forKeyword).as(SyntaxProtocol.self),
-      "caseKeyword": caseKeyword.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "pattern": Syntax(pattern).as(SyntaxProtocol.self),
-      "typeAnnotation": typeAnnotation.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "inKeyword": Syntax(inKeyword).as(SyntaxProtocol.self),
-      "sequenceExpr": Syntax(sequenceExpr).as(SyntaxProtocol.self),
-      "whereClause": whereClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "body": Syntax(body).as(SyntaxProtocol.self),
+      "labelName": labelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "labelColon": labelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "forKeyword": Syntax(forKeyword).asProtocol(SyntaxProtocol.self),
+      "caseKeyword": caseKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "pattern": Syntax(pattern).asProtocol(SyntaxProtocol.self),
+      "typeAnnotation": typeAnnotation.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "inKeyword": Syntax(inKeyword).asProtocol(SyntaxProtocol.self),
+      "sequenceExpr": Syntax(sequenceExpr).asProtocol(SyntaxProtocol.self),
+      "whereClause": whereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "body": Syntax(body).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1574,13 +1574,13 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension SwitchStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "labelName": labelName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "labelColon": labelColon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "switchKeyword": Syntax(switchKeyword).as(SyntaxProtocol.self),
-      "expression": Syntax(expression).as(SyntaxProtocol.self),
-      "leftBrace": Syntax(leftBrace).as(SyntaxProtocol.self),
-      "cases": Syntax(cases).as(SyntaxProtocol.self),
-      "rightBrace": Syntax(rightBrace).as(SyntaxProtocol.self),
+      "labelName": labelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "labelColon": labelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "switchKeyword": Syntax(switchKeyword).asProtocol(SyntaxProtocol.self),
+      "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "leftBrace": Syntax(leftBrace).asProtocol(SyntaxProtocol.self),
+      "cases": Syntax(cases).asProtocol(SyntaxProtocol.self),
+      "rightBrace": Syntax(rightBrace).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1792,11 +1792,11 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension DoStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "labelName": labelName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "labelColon": labelColon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "doKeyword": Syntax(doKeyword).as(SyntaxProtocol.self),
-      "body": Syntax(body).as(SyntaxProtocol.self),
-      "catchClauses": catchClauses.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "labelName": labelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "labelColon": labelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "doKeyword": Syntax(doKeyword).asProtocol(SyntaxProtocol.self),
+      "body": Syntax(body).asProtocol(SyntaxProtocol.self),
+      "catchClauses": catchClauses.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1896,8 +1896,8 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension ReturnStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "returnKeyword": Syntax(returnKeyword).as(SyntaxProtocol.self),
-      "expression": expression.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "returnKeyword": Syntax(returnKeyword).asProtocol(SyntaxProtocol.self),
+      "expression": expression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1997,8 +1997,8 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension YieldStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "yieldKeyword": Syntax(yieldKeyword).as(SyntaxProtocol.self),
-      "yields": Syntax(yields).as(SyntaxProtocol.self),
+      "yieldKeyword": Syntax(yieldKeyword).asProtocol(SyntaxProtocol.self),
+      "yields": Syntax(yields).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2067,7 +2067,7 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension FallthroughStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "fallthroughKeyword": Syntax(fallthroughKeyword).as(SyntaxProtocol.self),
+      "fallthroughKeyword": Syntax(fallthroughKeyword).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2167,8 +2167,8 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension BreakStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "breakKeyword": Syntax(breakKeyword).as(SyntaxProtocol.self),
-      "label": label.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "breakKeyword": Syntax(breakKeyword).asProtocol(SyntaxProtocol.self),
+      "label": label.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2237,7 +2237,7 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension DeclarationStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "declaration": Syntax(declaration).as(SyntaxProtocol.self),
+      "declaration": Syntax(declaration).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2337,8 +2337,8 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension ThrowStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "throwKeyword": Syntax(throwKeyword).as(SyntaxProtocol.self),
-      "expression": Syntax(expression).as(SyntaxProtocol.self),
+      "throwKeyword": Syntax(throwKeyword).asProtocol(SyntaxProtocol.self),
+      "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -2612,13 +2612,13 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension IfStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "labelName": labelName.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "labelColon": labelColon.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "ifKeyword": Syntax(ifKeyword).as(SyntaxProtocol.self),
-      "conditions": Syntax(conditions).as(SyntaxProtocol.self),
-      "body": Syntax(body).as(SyntaxProtocol.self),
-      "elseKeyword": elseKeyword.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "elseBody": elseBody.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "labelName": labelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "labelColon": labelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "ifKeyword": Syntax(ifKeyword).asProtocol(SyntaxProtocol.self),
+      "conditions": Syntax(conditions).asProtocol(SyntaxProtocol.self),
+      "body": Syntax(body).asProtocol(SyntaxProtocol.self),
+      "elseKeyword": elseKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "elseBody": elseBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2845,12 +2845,12 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension PoundAssertStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "poundAssert": Syntax(poundAssert).as(SyntaxProtocol.self),
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "condition": Syntax(condition).as(SyntaxProtocol.self),
-      "comma": comma.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "message": message.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "poundAssert": Syntax(poundAssert).asProtocol(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "condition": Syntax(condition).asProtocol(SyntaxProtocol.self),
+      "comma": comma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "message": message.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -143,8 +143,8 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension SimpleTypeIdentifierSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "name": Syntax(name).as(SyntaxProtocol.self),
-      "genericArgumentClause": genericArgumentClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "genericArgumentClause": genericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -306,10 +306,10 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension MemberTypeIdentifierSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "baseType": Syntax(baseType).as(SyntaxProtocol.self),
-      "period": Syntax(period).as(SyntaxProtocol.self),
-      "name": Syntax(name).as(SyntaxProtocol.self),
-      "genericArgumentClause": genericArgumentClause.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
+      "baseType": Syntax(baseType).asProtocol(SyntaxProtocol.self),
+      "period": Syntax(period).asProtocol(SyntaxProtocol.self),
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "genericArgumentClause": genericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -378,7 +378,7 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension ClassRestrictionTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "classKeyword": Syntax(classKeyword).as(SyntaxProtocol.self),
+      "classKeyword": Syntax(classKeyword).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -509,9 +509,9 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension ArrayTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftSquareBracket": Syntax(leftSquareBracket).as(SyntaxProtocol.self),
-      "elementType": Syntax(elementType).as(SyntaxProtocol.self),
-      "rightSquareBracket": Syntax(rightSquareBracket).as(SyntaxProtocol.self),
+      "leftSquareBracket": Syntax(leftSquareBracket).asProtocol(SyntaxProtocol.self),
+      "elementType": Syntax(elementType).asProtocol(SyntaxProtocol.self),
+      "rightSquareBracket": Syntax(rightSquareBracket).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -704,11 +704,11 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension DictionaryTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftSquareBracket": Syntax(leftSquareBracket).as(SyntaxProtocol.self),
-      "keyType": Syntax(keyType).as(SyntaxProtocol.self),
-      "colon": Syntax(colon).as(SyntaxProtocol.self),
-      "valueType": Syntax(valueType).as(SyntaxProtocol.self),
-      "rightSquareBracket": Syntax(rightSquareBracket).as(SyntaxProtocol.self),
+      "leftSquareBracket": Syntax(leftSquareBracket).asProtocol(SyntaxProtocol.self),
+      "keyType": Syntax(keyType).asProtocol(SyntaxProtocol.self),
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "valueType": Syntax(valueType).asProtocol(SyntaxProtocol.self),
+      "rightSquareBracket": Syntax(rightSquareBracket).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -839,9 +839,9 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension MetatypeTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "baseType": Syntax(baseType).as(SyntaxProtocol.self),
-      "period": Syntax(period).as(SyntaxProtocol.self),
-      "typeOrProtocol": Syntax(typeOrProtocol).as(SyntaxProtocol.self),
+      "baseType": Syntax(baseType).asProtocol(SyntaxProtocol.self),
+      "period": Syntax(period).asProtocol(SyntaxProtocol.self),
+      "typeOrProtocol": Syntax(typeOrProtocol).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -941,8 +941,8 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension OptionalTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "wrappedType": Syntax(wrappedType).as(SyntaxProtocol.self),
-      "questionMark": Syntax(questionMark).as(SyntaxProtocol.self),
+      "wrappedType": Syntax(wrappedType).asProtocol(SyntaxProtocol.self),
+      "questionMark": Syntax(questionMark).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1042,8 +1042,8 @@ public struct SomeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension SomeTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "someSpecifier": Syntax(someSpecifier).as(SyntaxProtocol.self),
-      "baseType": Syntax(baseType).as(SyntaxProtocol.self),
+      "someSpecifier": Syntax(someSpecifier).asProtocol(SyntaxProtocol.self),
+      "baseType": Syntax(baseType).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1143,8 +1143,8 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
 extension ImplicitlyUnwrappedOptionalTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "wrappedType": Syntax(wrappedType).as(SyntaxProtocol.self),
-      "exclamationMark": Syntax(exclamationMark).as(SyntaxProtocol.self),
+      "wrappedType": Syntax(wrappedType).asProtocol(SyntaxProtocol.self),
+      "exclamationMark": Syntax(exclamationMark).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1232,7 +1232,7 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension CompositionTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "elements": Syntax(elements).as(SyntaxProtocol.self),
+      "elements": Syntax(elements).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1382,9 +1382,9 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension TupleTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "elements": Syntax(elements).as(SyntaxProtocol.self),
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "elements": Syntax(elements).asProtocol(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1627,12 +1627,12 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension FunctionTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "leftParen": Syntax(leftParen).as(SyntaxProtocol.self),
-      "arguments": Syntax(arguments).as(SyntaxProtocol.self),
-      "rightParen": Syntax(rightParen).as(SyntaxProtocol.self),
-      "throwsOrRethrowsKeyword": throwsOrRethrowsKeyword.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "arrow": Syntax(arrow).as(SyntaxProtocol.self),
-      "returnType": Syntax(returnType).as(SyntaxProtocol.self),
+      "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
+      "arguments": Syntax(arguments).asProtocol(SyntaxProtocol.self),
+      "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "throwsOrRethrowsKeyword": throwsOrRethrowsKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "arrow": Syntax(arrow).asProtocol(SyntaxProtocol.self),
+      "returnType": Syntax(returnType).asProtocol(SyntaxProtocol.self),
     ])
   }
 }
@@ -1782,9 +1782,9 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 extension AttributedTypeSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "specifier": specifier.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "attributes": attributes.map(Syntax.init)?.as(SyntaxProtocol.self) as Any,
-      "baseType": Syntax(baseType).as(SyntaxProtocol.self),
+      "specifier": specifier.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "baseType": Syntax(baseType).asProtocol(SyntaxProtocol.self),
     ])
   }
 }

--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -399,11 +399,11 @@ func performRoundtrip(args: CommandLineArguments) throws {
 class NodePrinter: SyntaxAnyVisitor {
   override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
     assert(!node.isUnknown)
-    print("<\(type(of: node.as(SyntaxProtocol.self)))>", terminator: "")
+    print("<\(type(of: node.asProtocol(SyntaxProtocol.self)))>", terminator: "")
     return .visitChildren
   }
   override func visitAnyPost(_ node: Syntax) {
-    print("</\(type(of: node.as(SyntaxProtocol.self)))>", terminator: "")
+    print("</\(type(of: node.asProtocol(SyntaxProtocol.self)))>", terminator: "")
   }
   override func visit(_ token: TokenSyntax) -> SyntaxVisitorContinueKind {
     print("<\(type(of: token))>", terminator: "")

--- a/Tests/SwiftSyntaxTest/SyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTests.swift
@@ -95,15 +95,15 @@ public class SyntaxTests: XCTestCase {
     XCTAssertTrue(node.is(IntegerLiteralExprSyntax.self))
     XCTAssertTrue(node.as(ExprSyntax.self)!.is(IntegerLiteralExprSyntax.self))
 
-    XCTAssertTrue(node.is(ExprSyntaxProtocol.self))
-    XCTAssertTrue(node.as(ExprSyntaxProtocol.self) is IntegerLiteralExprSyntax)
-    XCTAssertTrue(expr.as(ExprSyntaxProtocol.self) is IntegerLiteralExprSyntax)
-    XCTAssertTrue(expr.as(ExprSyntaxProtocol.self) as? IntegerLiteralExprSyntax == integerExpr)
+    XCTAssertTrue(node.isProtocol(ExprSyntaxProtocol.self))
+    XCTAssertTrue(node.asProtocol(ExprSyntaxProtocol.self) is IntegerLiteralExprSyntax)
+    XCTAssertTrue(expr.asProtocol(ExprSyntaxProtocol.self) is IntegerLiteralExprSyntax)
+    XCTAssertTrue(expr.asProtocol(ExprSyntaxProtocol.self) as? IntegerLiteralExprSyntax == integerExpr)
 
-    XCTAssertFalse(node.is(BracedSyntax.self))
-    XCTAssertNil(node.as(BracedSyntax.self))
-    XCTAssertFalse(expr.is(BracedSyntax.self))
-    XCTAssertNil(expr.as(BracedSyntax.self))
+    XCTAssertFalse(node.isProtocol(BracedSyntax.self))
+    XCTAssertNil(node.asProtocol(BracedSyntax.self))
+    XCTAssertFalse(expr.isProtocol(BracedSyntax.self))
+    XCTAssertNil(expr.asProtocol(BracedSyntax.self))
 
     let classDecl = SyntaxFactory.makeCodeBlock(
       leftBrace: SyntaxFactory.makeToken(.leftBrace, presence: .present),
@@ -111,8 +111,8 @@ public class SyntaxTests: XCTestCase {
       rightBrace: SyntaxFactory.makeToken(.rightBrace, presence: .present)
     )
 
-    XCTAssertTrue(classDecl.is(BracedSyntax.self))
-    XCTAssertNotNil(classDecl.as(BracedSyntax.self))
+    XCTAssertTrue(classDecl.isProtocol(BracedSyntax.self))
+    XCTAssertNotNil(classDecl.asProtocol(BracedSyntax.self))
 
     let optNode: Syntax? = node
     switch optNode?.as(SyntaxEnum.self) {


### PR DESCRIPTION
The intention is to make it clear in the API usage where existential conversion overhead exists,
allowing performance critical clients to eliminate use of existentials where possible.

Also add a note in README file to clarify that the API is designed with performance in mind.