### PR TITLE
Update gyb generated files for multi-pattern catch clauses (SE-0276)

### DIFF
--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -1041,6 +1041,12 @@ extension SyntaxNode {
     return CaseItemListSyntax(asSyntaxData)
   }
 
+  public var isCatchItemList: Bool { return raw.kind == .catchItemList }
+  public var asCatchItemList: CatchItemListSyntax? {
+    guard isCatchItemList else { return nil }
+    return CatchItemListSyntax(asSyntaxData)
+  }
+
   public var isConditionElement: Bool { return raw.kind == .conditionElement }
   public var asConditionElement: ConditionElementSyntax? {
     guard isConditionElement else { return nil }
@@ -1117,6 +1123,12 @@ extension SyntaxNode {
   public var asCaseItem: CaseItemSyntax? {
     guard isCaseItem else { return nil }
     return CaseItemSyntax(asSyntaxData)
+  }
+
+  public var isCatchItem: Bool { return raw.kind == .catchItem }
+  public var asCatchItem: CatchItemSyntax? {
+    guard isCatchItem else { return nil }
+    return CatchItemSyntax(asSyntaxData)
   }
 
   public var isSwitchCaseLabel: Bool { return raw.kind == .switchCaseLabel }
@@ -1775,6 +1787,8 @@ extension Syntax {
       return node
     case .caseItemList(let node):
       return node
+    case .catchItemList(let node):
+      return node
     case .conditionElement(let node):
       return node
     case .availabilityCondition(let node):
@@ -1800,6 +1814,8 @@ extension Syntax {
     case .switchDefaultLabel(let node):
       return node
     case .caseItem(let node):
+      return node
+    case .catchItem(let node):
       return node
     case .switchCaseLabel(let node):
       return node
@@ -1904,6 +1920,6 @@ extension Syntax {
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "-7765007021548643080"
+      "-1461032627210044719"
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
@@ -1254,6 +1254,13 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   override open func visitPost(_ node: CaseItemListSyntax) {
     visitAnyPost(node._syntaxNode)
   }
+  override open func visit(_ node: CatchItemListSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: CatchItemListSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
   override open func visit(_ node: ConditionElementSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
@@ -1343,6 +1350,13 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   }
 
   override open func visitPost(_ node: CaseItemSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: CatchItemSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: CatchItemSyntax) {
     visitAnyPost(node._syntaxNode)
   }
   override open func visit(_ node: SwitchCaseLabelSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
@@ -7609,6 +7609,251 @@ extension CaseItemListSyntax: BidirectionalCollection {
   }
 }
 
+/// `CatchItemListSyntax` represents a collection of one or more
+/// `CatchItemSyntax` nodes. CatchItemListSyntax behaves
+/// as a regular Swift collection, and has accessors that return new
+/// versions of the collection with different children.
+public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `CatchItemListSyntax` if possible. Returns 
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .catchItemList else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a Syntax node from the provided root and data. This assumes 
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .catchItemList)
+    self._syntaxNode = Syntax(data)
+  }
+
+  /// The number of elements, `present` or `missing`, in this collection.
+  public var count: Int { return raw.numberOfChildren }
+
+  /// Creates a new `CatchItemListSyntax` by replacing the underlying layout with
+  /// a different set of raw syntax nodes.
+  ///
+  /// - Parameter layout: The new list of raw syntax nodes underlying this
+  ///                     collection.
+  /// - Returns: A new `CatchItemListSyntax` with the new layout underlying it.
+  internal func replacingLayout(
+    _ layout: [RawSyntax?]) -> CatchItemListSyntax {
+    let newRaw = data.raw.replacingLayout(layout)
+    let newData = data.replacingSelf(newRaw)
+    return CatchItemListSyntax(newData)
+  }
+
+  /// Creates a new `CatchItemListSyntax` by appending the provided syntax element
+  /// to the children.
+  ///
+  /// - Parameter syntax: The element to append.
+  /// - Returns: A new `CatchItemListSyntax` with that element appended to the end.
+  public func appending(
+    _ syntax: CatchItemSyntax) -> CatchItemListSyntax {
+    var newLayout = data.raw.formLayoutArray()
+    newLayout.append(syntax.raw)
+    return replacingLayout(newLayout)
+  }
+
+  /// Creates a new `CatchItemListSyntax` by prepending the provided syntax element
+  /// to the children.
+  ///
+  /// - Parameter syntax: The element to prepend.
+  /// - Returns: A new `CatchItemListSyntax` with that element prepended to the
+  ///            beginning.
+  public func prepending(
+    _ syntax: CatchItemSyntax) -> CatchItemListSyntax {
+    return inserting(syntax, at: 0)
+  }
+
+  /// Creates a new `CatchItemListSyntax` by inserting the provided syntax element
+  /// at the provided index in the children.
+  ///
+  /// - Parameters:
+  ///   - syntax: The element to insert.
+  ///   - index: The index at which to insert the element in the collection.
+  ///
+  /// - Returns: A new `CatchItemListSyntax` with that element appended to the end.
+  public func inserting(_ syntax: CatchItemSyntax,
+                        at index: Int) -> CatchItemListSyntax {
+    var newLayout = data.raw.formLayoutArray()
+    /// Make sure the index is a valid insertion index (0 to 1 past the end)
+    precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
+                 "inserting node at invalid index \(index)")
+    newLayout.insert(syntax.raw, at: index)
+    return replacingLayout(newLayout)
+  }
+
+  /// Creates a new `CatchItemListSyntax` by replacing the syntax element
+  /// at the provided index.
+  ///
+  /// - Parameters:
+  ///   - index: The index at which to replace the element in the collection.
+  ///   - syntax: The element to replace with.
+  ///
+  /// - Returns: A new `CatchItemListSyntax` with the new element at the provided index.
+  public func replacing(childAt index: Int,
+                        with syntax: CatchItemSyntax) -> CatchItemListSyntax {
+    var newLayout = data.raw.formLayoutArray()
+    /// Make sure the index is a valid index for replacing
+    precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
+                 "replacing node at invalid index \(index)")
+    newLayout[index] = syntax.raw
+    return replacingLayout(newLayout)
+  }
+
+  /// Creates a new `CatchItemListSyntax` by removing the syntax element at the
+  /// provided index.
+  ///
+  /// - Parameter index: The index of the element to remove from the collection.
+  /// - Returns: A new `CatchItemListSyntax` with the element at the provided index
+  ///            removed.
+  public func removing(childAt index: Int) -> CatchItemListSyntax {
+    var newLayout = data.raw.formLayoutArray()
+    newLayout.remove(at: index)
+    return replacingLayout(newLayout)
+  }
+
+  /// Creates a new `CatchItemListSyntax` by removing the first element.
+  ///
+  /// - Returns: A new `CatchItemListSyntax` with the first element removed.
+  public func removingFirst() -> CatchItemListSyntax {
+    var newLayout = data.raw.formLayoutArray()
+    newLayout.removeFirst()
+    return replacingLayout(newLayout)
+  }
+
+  /// Creates a new `CatchItemListSyntax` by removing the last element.
+  ///
+  /// - Returns: A new `CatchItemListSyntax` with the last element removed.
+  public func removingLast() -> CatchItemListSyntax {
+    var newLayout = data.raw.formLayoutArray()
+    newLayout.removeLast()
+    return replacingLayout(newLayout)
+  }
+
+  /// Returns a new `CatchItemListSyntax` with its leading trivia replaced
+  /// by the provided trivia.
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> CatchItemListSyntax {
+    return CatchItemListSyntax(data.withLeadingTrivia(leadingTrivia))
+  }
+
+  /// Returns a new `CatchItemListSyntax` with its trailing trivia replaced
+  /// by the provided trivia.
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> CatchItemListSyntax {
+    return CatchItemListSyntax(data.withTrailingTrivia(trailingTrivia))
+  }
+
+  /// Returns a new `CatchItemListSyntax` with its leading trivia removed.
+  public func withoutLeadingTrivia() -> CatchItemListSyntax {
+    return withLeadingTrivia([])
+  }
+
+  /// Returns a new `CatchItemListSyntax` with its trailing trivia removed.
+  public func withoutTrailingTrivia() -> CatchItemListSyntax {
+    return withTrailingTrivia([])
+  }
+
+  /// Returns a new `CatchItemListSyntax` with all trivia removed.
+  public func withoutTrivia() -> CatchItemListSyntax {
+    return withoutLeadingTrivia().withoutTrailingTrivia()
+  }
+
+  /// The leading trivia (spaces, newlines, etc.) associated with this `CatchItemListSyntax`.
+  public var leadingTrivia: Trivia? {
+    get {
+      return raw.formLeadingTrivia()
+    }
+    set {
+      self = withLeadingTrivia(newValue ?? [])
+    }
+  }
+
+  /// The trailing trivia (spaces, newlines, etc.) associated with this `CatchItemListSyntax`.
+  public var trailingTrivia: Trivia? {
+    get {
+      return raw.formTrailingTrivia()
+    }
+    set {
+      self = withTrailingTrivia(newValue ?? [])
+    }
+  }
+
+  public func _validateLayout() {
+    // Check that all children match the expected element type
+    assert(self.allSatisfy { node in
+      return Syntax(node).is(CatchItemSyntax.self)
+    })
+  }
+}
+
+/// Conformance for `CatchItemListSyntax` to the `BidirectionalCollection` protocol.
+extension CatchItemListSyntax: BidirectionalCollection {
+  public typealias Element = CatchItemSyntax
+  public typealias Index = SyntaxChildrenIndex
+
+  public struct Iterator: IteratorProtocol {
+    private let parent: Syntax
+    private var iterator: RawSyntaxChildren.Iterator
+
+    init(parent: Syntax, rawChildren: RawSyntaxChildren) {
+      self.parent = parent
+      self.iterator = rawChildren.makeIterator()
+    }
+
+    public mutating func next() -> CatchItemSyntax? {
+      guard let (raw, info) = self.iterator.next() else {
+        return nil
+      }
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
+      let data = SyntaxData(absoluteRaw, parent: parent)
+      return CatchItemSyntax(data)
+    }
+  }
+
+  public func makeIterator() -> Iterator {
+    return Iterator(parent: Syntax(self), rawChildren: rawChildren)
+  }
+
+  private var rawChildren: RawSyntaxChildren {
+    // We know children in a syntax collection cannot be missing. So we can 
+    // use the low-level and faster RawSyntaxChildren collection instead of
+    // PresentRawSyntaxChildren.
+    return RawSyntaxChildren(self.data.absoluteRaw)
+  }
+
+  public var startIndex: SyntaxChildrenIndex {
+    return rawChildren.startIndex
+  }
+  public var endIndex: SyntaxChildrenIndex {
+    return rawChildren.endIndex
+  }
+
+  public func index(after index: SyntaxChildrenIndex) -> SyntaxChildrenIndex {
+    return rawChildren.index(after: index)
+  }
+
+  public func index(before index: SyntaxChildrenIndex) -> SyntaxChildrenIndex {
+    return rawChildren.index(before: index)
+  }
+
+  public func distance(from start: SyntaxChildrenIndex, to end: SyntaxChildrenIndex)
+      -> Int {
+    return rawChildren.distance(from: start, to: end)
+  }
+
+  public subscript(position: SyntaxChildrenIndex) -> CatchItemSyntax {
+    let (raw, info) = rawChildren[position]
+    let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
+    let data = SyntaxData(absoluteRaw, parent: Syntax(self))
+    return CatchItemSyntax(data)
+  }
+}
+
 /// `ConditionElementListSyntax` represents a collection of one or more
 /// `ConditionElementSyntax` nodes. ConditionElementListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
@@ -9720,6 +9965,11 @@ extension CatchClauseListSyntax: CustomReflectable {
   }
 }
 extension CaseItemListSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, unlabeledChildren: self.map{ $0 })
+  }
+}
+extension CatchItemListSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, unlabeledChildren: self.map{ $0 })
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -191,6 +191,7 @@ public enum SyntaxEnum {
   case fallthroughStmt(FallthroughStmtSyntax)
   case breakStmt(BreakStmtSyntax)
   case caseItemList(CaseItemListSyntax)
+  case catchItemList(CatchItemListSyntax)
   case conditionElement(ConditionElementSyntax)
   case availabilityCondition(AvailabilityConditionSyntax)
   case matchingPatternCondition(MatchingPatternConditionSyntax)
@@ -204,6 +205,7 @@ public enum SyntaxEnum {
   case switchCase(SwitchCaseSyntax)
   case switchDefaultLabel(SwitchDefaultLabelSyntax)
   case caseItem(CaseItemSyntax)
+  case catchItem(CatchItemSyntax)
   case switchCaseLabel(SwitchCaseLabelSyntax)
   case catchClause(CatchClauseSyntax)
   case poundAssertStmt(PoundAssertStmtSyntax)
@@ -612,6 +614,8 @@ public extension Syntax {
       return .breakStmt(BreakStmtSyntax(self)!)
     case .caseItemList:
       return .caseItemList(CaseItemListSyntax(self)!)
+    case .catchItemList:
+      return .catchItemList(CatchItemListSyntax(self)!)
     case .conditionElement:
       return .conditionElement(ConditionElementSyntax(self)!)
     case .availabilityCondition:
@@ -638,6 +642,8 @@ public extension Syntax {
       return .switchDefaultLabel(SwitchDefaultLabelSyntax(self)!)
     case .caseItem:
       return .caseItem(CaseItemSyntax(self)!)
+    case .catchItem:
+      return .catchItem(CatchItemSyntax(self)!)
     case .switchCaseLabel:
       return .switchCaseLabel(SwitchCaseLabelSyntax(self)!)
     case .catchClause:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -3437,6 +3437,20 @@ public enum SyntaxFactory {
     ], length: .zero, presence: .present))
     return CaseItemListSyntax(data)
   }
+  public static func makeCatchItemList(
+    _ elements: [CatchItemSyntax]) -> CatchItemListSyntax {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.catchItemList,
+      layout: elements.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    return CatchItemListSyntax(data)
+  }
+
+  public static func makeBlankCatchItemList() -> CatchItemListSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .catchItemList,
+      layout: [
+    ], length: .zero, presence: .present))
+    return CatchItemListSyntax(data)
+  }
   public static func makeConditionElement(condition: Syntax, trailingComma: TokenSyntax?) -> ConditionElementSyntax {
     let layout: [RawSyntax?] = [
       condition.raw,
@@ -3701,6 +3715,27 @@ public enum SyntaxFactory {
     ], length: .zero, presence: .present))
     return CaseItemSyntax(data)
   }
+  public static func makeCatchItem(pattern: PatternSyntax?, whereClause: WhereClauseSyntax?, trailingComma: TokenSyntax?) -> CatchItemSyntax {
+    let layout: [RawSyntax?] = [
+      pattern?.raw,
+      whereClause?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.catchItem,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    return CatchItemSyntax(data)
+  }
+
+  public static func makeBlankCatchItem() -> CatchItemSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .catchItem,
+      layout: [
+      nil,
+      nil,
+      nil,
+    ], length: .zero, presence: .present))
+    return CatchItemSyntax(data)
+  }
   public static func makeSwitchCaseLabel(caseKeyword: TokenSyntax, caseItems: CaseItemListSyntax, colon: TokenSyntax) -> SwitchCaseLabelSyntax {
     let layout: [RawSyntax?] = [
       caseKeyword.raw,
@@ -3722,11 +3757,10 @@ public enum SyntaxFactory {
     ], length: .zero, presence: .present))
     return SwitchCaseLabelSyntax(data)
   }
-  public static func makeCatchClause(catchKeyword: TokenSyntax, pattern: PatternSyntax?, whereClause: WhereClauseSyntax?, body: CodeBlockSyntax) -> CatchClauseSyntax {
+  public static func makeCatchClause(catchKeyword: TokenSyntax, catchItems: CatchItemListSyntax?, body: CodeBlockSyntax) -> CatchClauseSyntax {
     let layout: [RawSyntax?] = [
       catchKeyword.raw,
-      pattern?.raw,
-      whereClause?.raw,
+      catchItems?.raw,
       body.raw,
     ]
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.catchClause,
@@ -3739,7 +3773,6 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .catchClause,
       layout: [
       RawSyntax.missingToken(TokenKind.catchKeyword),
-      nil,
       nil,
       RawSyntax.missing(SyntaxKind.codeBlock),
     ], length: .zero, presence: .present))

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
@@ -191,6 +191,7 @@ internal enum SyntaxKind: CSyntaxKind {
   case fallthroughStmt = 82
   case breakStmt = 83
   case caseItemList = 192
+  case catchItemList = 244
   case conditionElement = 137
   case availabilityCondition = 138
   case matchingPatternCondition = 139
@@ -204,6 +205,7 @@ internal enum SyntaxKind: CSyntaxKind {
   case switchCase = 143
   case switchDefaultLabel = 144
   case caseItem = 145
+  case catchItem = 243
   case switchCaseLabel = 146
   case catchClause = 147
   case poundAssertStmt = 229
@@ -286,6 +288,7 @@ internal enum SyntaxKind: CSyntaxKind {
     case .switchCaseList: return true
     case .catchClauseList: return true
     case .caseItemList: return true
+    case .catchItemList: return true
     case .conditionElementList: return true
     case .genericRequirementList: return true
     case .genericParameterList: return true

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -1213,6 +1213,13 @@ open class SyntaxRewriter {
     return Syntax(visitChildren(node))
   }
 
+  /// Visit a `CatchItemListSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: CatchItemListSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
   /// Visit a `ConditionElementSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -1301,6 +1308,13 @@ open class SyntaxRewriter {
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
   open func visit(_ node: CaseItemSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
+  /// Visit a `CatchItemSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: CatchItemSyntax) -> Syntax {
     return Syntax(visitChildren(node))
   }
 
@@ -3432,6 +3446,16 @@ open class SyntaxRewriter {
   }
 
   /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplCatchItemListSyntax(_ data: SyntaxData) -> Syntax {
+      let node = CatchItemListSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplConditionElementSyntax(_ data: SyntaxData) -> Syntax {
       let node = ConditionElementSyntax(data)
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
@@ -3554,6 +3578,16 @@ open class SyntaxRewriter {
   /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplCaseItemSyntax(_ data: SyntaxData) -> Syntax {
       let node = CaseItemSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplCatchItemSyntax(_ data: SyntaxData) -> Syntax {
+      let node = CatchItemSyntax(data)
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
       visitPre(node._syntaxNode)
       defer { visitPost(node._syntaxNode) }
@@ -4443,6 +4477,8 @@ open class SyntaxRewriter {
       return visitImplBreakStmtSyntax
     case .caseItemList:
       return visitImplCaseItemListSyntax
+    case .catchItemList:
+      return visitImplCatchItemListSyntax
     case .conditionElement:
       return visitImplConditionElementSyntax
     case .availabilityCondition:
@@ -4469,6 +4505,8 @@ open class SyntaxRewriter {
       return visitImplSwitchDefaultLabelSyntax
     case .caseItem:
       return visitImplCaseItemSyntax
+    case .catchItem:
+      return visitImplCatchItemSyntax
     case .switchCaseLabel:
       return visitImplSwitchCaseLabelSyntax
     case .catchClause:
@@ -4930,6 +4968,8 @@ open class SyntaxRewriter {
       return visitImplBreakStmtSyntax(data)
     case .caseItemList:
       return visitImplCaseItemListSyntax(data)
+    case .catchItemList:
+      return visitImplCatchItemListSyntax(data)
     case .conditionElement:
       return visitImplConditionElementSyntax(data)
     case .availabilityCondition:
@@ -4956,6 +4996,8 @@ open class SyntaxRewriter {
       return visitImplSwitchDefaultLabelSyntax(data)
     case .caseItem:
       return visitImplCaseItemSyntax(data)
+    case .catchItem:
+      return visitImplCatchItemSyntax(data)
     case .switchCaseLabel:
       return visitImplSwitchCaseLabelSyntax(data)
     case .catchClause:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxTraits.swift
@@ -257,6 +257,8 @@ extension IfStmtSyntax: WithCodeBlockSyntax, LabeledSyntax {}
 extension ElseBlockSyntax: WithCodeBlockSyntax {}
 extension SwitchCaseSyntax: WithStatementsSyntax {}
 extension CaseItemSyntax: WithTrailingCommaSyntax {}
+extension CatchItemSyntax: WithTrailingCommaSyntax {}
+extension CatchClauseSyntax: WithCodeBlockSyntax {}
 extension GenericRequirementSyntax: WithTrailingCommaSyntax {}
 extension GenericParameterSyntax: WithTrailingCommaSyntax {}
 extension TupleTypeElementSyntax: WithTrailingCommaSyntax {}

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -1732,6 +1732,16 @@ open class SyntaxVisitor {
   /// The function called after visiting `CaseItemListSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: CaseItemListSyntax) {}
+  /// Visiting `CatchItemListSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: CatchItemListSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `CatchItemListSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: CatchItemListSyntax) {}
   /// Visiting `ConditionElementSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -1862,6 +1872,16 @@ open class SyntaxVisitor {
   /// The function called after visiting `CaseItemSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: CaseItemSyntax) {}
+  /// Visiting `CatchItemSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: CatchItemSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `CatchItemSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: CatchItemSyntax) {}
   /// Visiting `SwitchCaseLabelSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -4291,6 +4311,17 @@ open class SyntaxVisitor {
   }
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplCatchItemListSyntax(_ data: SyntaxData) {
+      let node = CatchItemListSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplConditionElementSyntax(_ data: SyntaxData) {
       let node = ConditionElementSyntax(data)
       let needsChildren = (visit(node) == .visitChildren)
@@ -4425,6 +4456,17 @@ open class SyntaxVisitor {
   /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplCaseItemSyntax(_ data: SyntaxData) {
       let node = CaseItemSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplCatchItemSyntax(_ data: SyntaxData) {
+      let node = CatchItemSyntax(data)
       let needsChildren = (visit(node) == .visitChildren)
       // Avoid calling into visitChildren if possible.
       if needsChildren && node.raw.numberOfChildren > 0 {
@@ -5331,6 +5373,8 @@ open class SyntaxVisitor {
       visitImplBreakStmtSyntax(data)
     case .caseItemList:
       visitImplCaseItemListSyntax(data)
+    case .catchItemList:
+      visitImplCatchItemListSyntax(data)
     case .conditionElement:
       visitImplConditionElementSyntax(data)
     case .availabilityCondition:
@@ -5357,6 +5401,8 @@ open class SyntaxVisitor {
       visitImplSwitchDefaultLabelSyntax(data)
     case .caseItem:
       visitImplCaseItemSyntax(data)
+    case .catchItem:
+      visitImplCatchItemSyntax(data)
     case .switchCaseLabel:
       visitImplSwitchCaseLabelSyntax(data)
     case .catchClause:


### PR DESCRIPTION
This is the swift-syntax counterpart to https://github.com/apple/swift/pull/27776 and https://github.com/apple/swift/pull/27905 , updating the gyb-generated files to reflect the compiler changes. Catch clauses may now have a comma-separated list of patterns