### PR TITLE
Add an example on how to depend on SwiftSyntax with SwiftPM 5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ import PackageDescription
 let package = Package(
   name: "MyTool",
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", .exact("<#Specify Release tag#>")),
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("<#Specify Release tag#>")),
   ],
   targets: [
     .target(name: "MyTool", dependencies: ["SwiftSyntax"]),


### PR DESCRIPTION
SwiftPM 5.2 requires the last path component of a dependency to be the package name of the dependency. Since SwiftSyntax is named `SwiftSyntax` but lives the Git repo is named `swift-syntax`, we need to manually specify the package's name.