### PR TITLE
Mark toolchain parameter as required

### DIFF
--- a/build-script.py
+++ b/build-script.py
@@ -563,7 +563,7 @@ def parse_args():
              'SwiftSyntax with other projects.')
 
     build_group.add_argument(
-        '--toolchain',
+        '--toolchain', required=True,
         help='The path to the toolchain that shall be used to build '
              'SwiftSyntax.')
 


### PR DESCRIPTION
If the toolchain was not provided, build-script would crash. Hence, we should mark it as required.