### PR TITLE
Fix bug that caused the rootId of a node to not be updated if it was created by a replacing* function

### DIFF
--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -188,8 +188,10 @@ struct AbsoluteRawSyntax {
     return nil
   }
 
-  func replacingSelf(_ newRaw: RawSyntax) -> AbsoluteRawSyntax {
-    return .init(raw: newRaw, info: info)
+  func replacingSelf(_ newRaw: RawSyntax, newRootId: UInt32) -> AbsoluteRawSyntax {
+    let nodeId = SyntaxIdentifier(rootId: newRootId, indexInTree: info.nodeId.indexInTree)
+    let newInfo = AbsoluteSyntaxInfo(position: info.position, nodeId: nodeId)
+    return .init(raw: newRaw, info: newInfo)
   }
 
   static func forRoot(_ raw: RawSyntax) -> AbsoluteRawSyntax {
@@ -334,7 +336,7 @@ struct SyntaxData {
     if let parent = parent {
       let parentData = parent.data.replacingChild(newRaw, at: indexInParent)
       let newParent = Syntax(parentData)
-      return SyntaxData(absoluteRaw.replacingSelf(newRaw), parent: newParent)
+      return SyntaxData(absoluteRaw.replacingSelf(newRaw, newRootId: parentData.nodeId.rootId), parent: newParent)
     } else {
       // Otherwise, we're already the root, so return the new root data.
       return .forRoot(newRaw)

--- a/Tests/SwiftSyntaxTest/SyntaxVisitorTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxVisitorTests.swift
@@ -94,4 +94,19 @@ public class SyntaxVisitorTests: XCTestCase {
       XCTAssertEqual(hashBefore, parsed.hashValue)
     }())
   }
+
+  public func testRewriteTrivia() {
+    class TriviaRemover: SyntaxRewriter {
+      override func visit(_ token: TokenSyntax) -> Syntax {
+        return Syntax(token.withTrailingTrivia(.zero))
+      }
+    }
+
+    XCTAssertNoThrow(try {
+      let parsed = try SyntaxParser.parse(source: "let a = 5")
+      let visitor = TriviaRemover()
+      let rewritten = visitor.visit(parsed)
+      XCTAssertEqual(rewritten.description, "leta=5")
+    }())
+  }
 }


### PR DESCRIPTION
When creating a node using e.g. `replacingTrailingTrivia`, it would still have the same the same rootId as before. Because of this `SyntaxRewriter` would not detect the node as having changed, thus failing to replace it in the rewritten tree.