### PR TITLE
Fix Readme Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ class AddOneToIntegerLiterals: SyntaxRewriter {
   override func visit(_ token: TokenSyntax) -> Syntax {
     // Only transform integer literals.
     guard case .integerLiteral(let text) = token.tokenKind else {
-      return super.visit(token)
+      return Syntax(token)
     }
 
     // Remove underscores from the original text.
@@ -194,7 +194,7 @@ class AddOneToIntegerLiterals: SyntaxRewriter {
     let newIntegerLiteralToken = token.withKind(.integerLiteral("\(int + 1)"))
     
     // Return the new integer literal.
-    return super.visit(newIntegerLiteralToken)
+    return Syntax(newIntegerLiteralToken)
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ class AddOneToIntegerLiterals: SyntaxRewriter {
   override func visit(_ token: TokenSyntax) -> Syntax {
     // Only transform integer literals.
     guard case .integerLiteral(let text) = token.tokenKind else {
-      return token
+      return super.visit(token)
     }
 
     // Remove underscores from the original text.
@@ -190,8 +190,11 @@ class AddOneToIntegerLiterals: SyntaxRewriter {
     // Parse out the integer.
     let int = Int(integerText)!
 
-    // Return a new integer literal token with `int + 1` as its text.
-    return token.withKind(.integerLiteral("\(int + 1)"))
+    // Create a new integer literal token with `int + 1` as its text.
+    let newIntegerLiteralToken = token.withKind(.integerLiteral("\(int + 1)"))
+    
+    // Return the new integer literal.
+    return super.visit(newIntegerLiteralToken)
   }
 }
 


### PR DESCRIPTION
Hi,
Directly returning the token invites a **compiler error** saying:  "Cannot convert return expression of type 'TokenSyntax' to return type 'Syntax' ".

Since the return type requires a SyntaxNode and this conversion is already being done at the base class: **SyntaxRewriter** using **Syntax(token)**, we can leverage that and this helps in fixing the compiler error.

**Environment**

1. SwiftSyntax version: "0.50200.0".
2. Xcode Version 11.4 (11E146)
3. Toolchain: Swift 5.2.1 Release 2020-03-30 (a)

