### PR TITLE
Fix Swift tools version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Its API is designed for performance critical applications. It uses value types a
 Add this repository to the `Package.swift` manifest of your project:
 
 ```swift
-// swift-tools-version:4.2
+// swift-tools-version:5.2
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
Changed the swift tools version to 5.2 since in the same manifest, **Package.Dependency** is initialised taking package name into account which is only available from swift 5.2 and the one used is marked as obsoleted.