### PR TITLE
build: explicitly specify python interpreter

### DIFF
--- a/build-script.py
+++ b/build-script.py
@@ -141,6 +141,7 @@ def generate_single_gyb_file(
 
     # Generate the new file
     gyb_command = [
+        sys.executable,
         gyb_exec,
         gyb_file,
         "-o",


### PR DESCRIPTION
This ensures that the build system can control the python interpreter
rather than relying on the `PATH` or the shebang.