### PR TITLE
Add an initializer to construct Syntax nodes from syntax protocol types

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -39,6 +39,15 @@ public struct Syntax: SyntaxProtocol, SyntaxHashable {
     guard let syntax = syntax else { return nil }
     self = syntax._syntaxNode
   }
+  
+  public init(fromProtocol syntax: SyntaxProtocol) {
+    self = syntax._syntaxNode
+  }
+  
+  public init?(fromProtocol syntax: SyntaxProtocol?) {
+    guard let syntax = syntax else { return nil }
+    self = syntax._syntaxNode
+  }
 
   public func hash(into hasher: inout Hasher) {
     return data.nodeId.hash(into: &hasher)

--- a/Tests/SwiftSyntaxTest/SyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTests.swift
@@ -135,4 +135,13 @@ public class SyntaxTests: XCTestCase {
     XCTAssertTrue(integerExpr.syntaxNodeType == node.syntaxNodeType)
     XCTAssertEqual("\(integerExpr.syntaxNodeType)", "IntegerLiteralExprSyntax")
   }
+
+  public func testConstructFromSyntaxProtocol() {
+    let integerExpr = IntegerLiteralExprSyntax {
+      $0.useDigits(SyntaxFactory.makeIntegerLiteral("1", trailingTrivia: .spaces(1)))
+    }
+
+    XCTAssertEqual(Syntax(integerExpr), Syntax(fromProtocol: integerExpr as SyntaxProtocol))
+    XCTAssertEqual(Syntax(integerExpr), Syntax(fromProtocol: integerExpr as ExprSyntaxProtocol))
+  }
 }


### PR DESCRIPTION
Resolving https://forums.swift.org/t/swiftsyntax-as-conversions/37166, we are missing an initialiser to create `Syntax` nodes from `SyntaxProtocol` (and `ExprSyntaxProtocol` etc.) types. This adds the necessary initialiser.

Note that I needed to add an argument label `fromProtocol` to the initialiser to avoid ambiguity with the following existing initialiser. I think it also makes it clear that we are dealing with existentials here, similar to how we have `asProtocol` etc.

```swift
public init<S: SyntaxProtocol>(_ syntax: S) {
  self = syntax._syntaxNode
}
```