### PR TITLE
Add Double and Int Convenience Properties

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,8 @@ Note: This is in reverse chronological order, so newer entries are added to the 
 
 ## Swift 5.3
 
+* Introduced `integerValue` and `floatingValue` properties to `IntegerLiteralExprSyntax` and `FloatLiteralExprSyntax`, respectively. Converted their `digits` and `floatingDigits` setters, respectively, into throwing functions.
+
 * Introduced `FunctionCallExprSyntax.additionalTrailingClosures` property with type `MultipleTrailingClosureElementListSyntax?` for supporting [SE-0279 Multiple Trailing Closures](https://github.com/apple/swift-evolution/blob/master/proposals/0279-multiple-trailing-closures.md).
 
 * Introduced `syntaxNodeType` property for all types conforming to `SyntaxProtocol`, which returns the underlying syntax node type. It is primarily intended as a debugging aid during development.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ swift/utils/build-script --swiftsyntax --swiftpm --llbuild -t --skip-test-cmark 
 ```
 This command will build SwiftSyntax and all its dependencies, tell the build script to run tests, but skip all tests but the SwiftSyntax tests.
 
-Note that it is not currently supported to SwiftSyntax while building the Swift compiler using Xcode.
+Note that it is not currently supported to build SwiftSyntax while building the Swift compiler using Xcode.
 
 ### CI Testing
 

--- a/Sources/SwiftSyntax/SyntaxBuilders.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxBuilders.swift.gyb
@@ -85,7 +85,11 @@ extension ${node.name} {
   ///            incrementally build the structure of the node.
   /// - Returns: A `${node.name}` with all the fields populated in the builder
   ///            closure.
+%     if node.must_uphold_invariant:
+  public init?(_ build: (inout ${Builder}) -> Void) {
+%     else:
   public init(_ build: (inout ${Builder}) -> Void) {
+%     end
     var builder = ${Builder}()
     build(&builder)
     let data = builder.buildData()

--- a/Sources/SwiftSyntax/SyntaxConvenienceMethods.swift
+++ b/Sources/SwiftSyntax/SyntaxConvenienceMethods.swift
@@ -1,0 +1,80 @@
+//===- SyntaxConvenienceMethods.swift - Convenience funcs for syntax nodes ===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public extension FloatLiteralExprSyntax {
+  var floatingValue: Double {
+    return potentialFloatingValue!
+  }
+
+  fileprivate var potentialFloatingValue: Double? {
+    let floatingDigitsWithoutUnderscores = floatingDigits.text.filter {
+      $0 != "_"
+    }
+    return Double(floatingDigitsWithoutUnderscores)
+  }
+}
+
+public extension IntegerLiteralExprSyntax {
+  var integerValue: Int {
+    return potentialIntegerValue!
+  }
+
+  fileprivate var potentialIntegerValue: Int? {
+    let text = digits.text
+    let (prefixLength, radix) = IntegerLiteralExprSyntax.prefixLengthAndRadix(text: text)
+    let digitsStartIndex = text.index(text.startIndex, offsetBy: prefixLength)
+    let textWithoutPrefix = text.suffix(from: digitsStartIndex)
+
+    let textWithoutPrefixOrUnderscores = textWithoutPrefix.filter {
+      $0 != "_"
+    }
+
+    return Int(textWithoutPrefixOrUnderscores, radix: radix)
+  }
+
+  private static func prefixLengthAndRadix(text: String) -> (Int, Int) {
+    let nonDecimalPrefixLength = 2
+
+    let binaryPrefix = "0b"
+    let octalPrefix = "0o"
+    let decimalPrefix = ""
+    let hexadecimalPrefix = "0x"
+
+    let binaryRadix = 2
+    let octalRadix = 8
+    let decimalRadix = 10
+    let hexadecimalRadix = 16
+
+    switch String(text.prefix(nonDecimalPrefixLength)) {
+    case binaryPrefix:
+      return (binaryPrefix.count, binaryRadix)
+    case octalPrefix:
+      return (octalPrefix.count, octalRadix)
+    case hexadecimalPrefix:
+      return (hexadecimalPrefix.count, hexadecimalRadix)
+    default:
+      return (decimalPrefix.count, decimalRadix)
+    }
+  }
+}
+
+public extension IntegerLiteralExprSyntax {
+  var isValid: Bool {
+    potentialIntegerValue != nil
+  }
+}
+
+public extension FloatLiteralExprSyntax {
+  var isValid: Bool {
+    potentialFloatingValue != nil
+  }
+}

--- a/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -57,7 +57,11 @@ public enum SyntaxFactory {
 %            param_type = param_type + "?"
 %         child_params.append("%s: %s" % (child.swift_name, param_type))
 %     child_params = ', '.join(child_params)
+%     if node.must_uphold_invariant:
+  public static func make${node.syntax_kind}(${child_params}) -> ${node.name}? {
+%     else:
   public static func make${node.syntax_kind}(${child_params}) -> ${node.name} {
+%     end
     let layout: [RawSyntax?] = [
 %     for child in node.children:
 %       if child.is_optional:
@@ -82,7 +86,7 @@ public enum SyntaxFactory {
   }
 %   end
 
-%   if not node.is_base():
+%   if not node.is_base() and not node.must_uphold_invariant:
   public static func makeBlank${node.syntax_kind}() -> ${node.name} {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .${node.swift_syntax_kind},
       layout: [

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
@@ -70,14 +70,29 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
   public init?(_ syntax: Syntax) {
     guard syntax.raw.kind == .${node.swift_syntax_kind} else { return nil }
     self._syntaxNode = syntax
+%   if node.must_uphold_invariant:
+    if !isValid {
+      fatalError("Instance of ${node.name} is invalid.")
+    }
+%   end
   }
 
   /// Creates a `${node.name}` node from the given `SyntaxData`. This assumes
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
+%   if node.must_uphold_invariant:
+  /// This initializer returns nil if the invariant is not satisfied.
+  internal init?(_ data: SyntaxData) {
+%   else:
   internal init(_ data: SyntaxData) {
+%   end
     assert(data.raw.kind == .${node.swift_syntax_kind})
     self._syntaxNode = Syntax(data)
+%   if node.must_uphold_invariant:
+    if !isValid {
+      return nil
+    }
+%   end
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -107,10 +122,33 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
 %       end
       return ${child.type_name}(childData!)
     }
+%       if not node.must_uphold_invariant:
     set(value) {
       self = with${child.name}(value)
     }
+%       end
   }
+%       if node.must_uphold_invariant:
+
+  public enum ${child.name}Error: Error, CustomStringConvertible {
+    case invalid(${child.swift_name}: ${ret_type})
+
+    public var description: String {
+      switch self {
+      case .invalid(let ${child.swift_name}):
+        return "attempted to use setter with invalid ${child.name} \"\(${child.swift_name})\""
+      }
+    }
+  }
+
+  mutating public func set${child.name}(_ ${child.swift_name}: ${ret_type}) throws {
+    if let childSyntax = with${child.name}(${child.swift_name}) {
+      self = childSyntax
+    } else {
+      throw ${child.name}Error.invalid(${child.swift_name}: ${child.swift_name})
+    }
+  }
+%       end
 %
 %       # ===============
 %       # Adding children
@@ -149,7 +187,11 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
   /// - param newChild: The new `${child.swift_name}` to replace the node's
   ///                   current `${child.swift_name}`, if present.
   public func with${child.name}(
+%       if node.must_uphold_invariant:
+    _ newChild: ${child.type_name}?) -> ${node.name}? {
+%       else:
     _ newChild: ${child.type_name}?) -> ${node.name} {
+%       end
 %       if child.is_optional:
     let raw = newChild?.raw
 %       else:

--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -91,7 +91,12 @@ open class SyntaxRewriter {
       if let newNode = visitAny(node._syntaxNode) { return newNode }
       return Syntax(visit(node))
 %   else:
+%     if node.must_uphold_invariant:
+      // We know that the SyntaxData is valid since we are walking a valid syntax tree and haven't modified the syntax data. Thus the initializer below will never return nil.
+      let node = ${node.name}(data)!
+%     else:
       let node = ${node.name}(data)
+%     end
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
       visitPre(node._syntaxNode)
       defer { visitPost(node._syntaxNode) }

--- a/Sources/SwiftSyntax/SyntaxVisitor.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxVisitor.swift.gyb
@@ -86,7 +86,12 @@ open class SyntaxVisitor {
       }
       visitPost(node)
 %   else:
+%     if node.must_uphold_invariant:
+      // We know that the SyntaxData is valid since we are walking a valid syntax tree and haven't modified the syntax data. Thus the initializer below will never return nil.
+      let node = ${node.name}(data)!
+%     else:
       let node = ${node.name}(data)
+%     end
       let needsChildren = (visit(node) == .visitChildren)
       // Avoid calling into visitChildren if possible.
       if needsChildren && node.raw.numberOfChildren > 0 {

--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -1944,6 +1944,6 @@ extension Syntax {
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "26709743ccc5ea2001419f44996c8fa671901c03"
+      "fd719aaf2e0dab2620af2d4d123d123b3d0de28d"
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
@@ -274,7 +274,7 @@ public struct AwaitExprSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missingToken(TokenKind.identifier(""))
+      layout[0] = RawSyntax.missingToken(TokenKind.awaitKeyword)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missing(SyntaxKind.expr)
@@ -1917,7 +1917,7 @@ extension ClosureParamSyntax {
 
 public struct ClosureSignatureSyntaxBuilder {
   private var layout =
-    Array<RawSyntax?>(repeating: nil, count: 6)
+    Array<RawSyntax?>(repeating: nil, count: 5)
 
   internal init() {}
 
@@ -1928,11 +1928,6 @@ public struct ClosureSignatureSyntaxBuilder {
 
   public mutating func useInput(_ node: Syntax) {
     let idx = ClosureSignatureSyntax.Cursor.input.rawValue
-    layout[idx] = node.raw
-  }
-
-  public mutating func useAsyncKeyword(_ node: TokenSyntax) {
-    let idx = ClosureSignatureSyntax.Cursor.asyncKeyword.rawValue
     layout[idx] = node.raw
   }
 
@@ -1952,8 +1947,8 @@ public struct ClosureSignatureSyntaxBuilder {
   }
 
   internal mutating func buildData() -> SyntaxData {
-    if (layout[5] == nil) {
-      layout[5] = RawSyntax.missingToken(TokenKind.inKeyword)
+    if (layout[4] == nil) {
+      layout[4] = RawSyntax.missingToken(TokenKind.inKeyword)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .closureSignature,

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
@@ -1077,7 +1077,7 @@ extension FloatLiteralExprSyntax {
   ///            incrementally build the structure of the node.
   /// - Returns: A `FloatLiteralExprSyntax` with all the fields populated in the builder
   ///            closure.
-  public init(_ build: (inout FloatLiteralExprSyntaxBuilder) -> Void) {
+  public init?(_ build: (inout FloatLiteralExprSyntaxBuilder) -> Void) {
     var builder = FloatLiteralExprSyntaxBuilder()
     build(&builder)
     let data = builder.buildData()
@@ -1444,7 +1444,7 @@ extension IntegerLiteralExprSyntax {
   ///            incrementally build the structure of the node.
   /// - Returns: A `IntegerLiteralExprSyntax` with all the fields populated in the builder
   ///            closure.
-  public init(_ build: (inout IntegerLiteralExprSyntaxBuilder) -> Void) {
+  public init?(_ build: (inout IntegerLiteralExprSyntaxBuilder) -> Void) {
     var builder = IntegerLiteralExprSyntaxBuilder()
     build(&builder)
     let data = builder.buildData()

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxClassification.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxClassification.swift
@@ -222,6 +222,8 @@ extension RawTokenKind {
       return .keyword
     case .throwsKeyword:
       return .keyword
+    case .awaitKeyword:
+      return .keyword
     case .__file__Keyword:
       return .keyword
     case .__line__Keyword:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxClassification.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxClassification.swift
@@ -65,16 +65,8 @@ extension SyntaxClassification {
     // Separate checks for token nodes (most common checks) versus checks for layout nodes.
     if childKind == .token {
       switch (parentKind, indexInParent) {
-      case (.awaitExpr, 0):
-        return (.keyword, false)
-      case (.arrowExpr, 0):
-        return (.keyword, false)
-      case (.closureSignature, 2):
-        return (.keyword, false)
       case (.expressionSegment, 2):
         return (.stringInterpolationAnchor, true)
-      case (.functionSignature, 1):
-        return (.keyword, false)
       case (.ifConfigClause, 0):
         return (.buildConfigId, false)
       case (.ifConfigDecl, 1):
@@ -92,8 +84,6 @@ extension SyntaxClassification {
       case (.memberTypeIdentifier, 2):
         return (.typeIdentifier, false)
       case (.someType, 0):
-        return (.keyword, false)
-      case (.functionType, 3):
         return (.keyword, false)
       case (.availabilityVersionRestriction, 0):
         return (.keyword, false)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -619,7 +619,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: .present))
     return ArrowExprSyntax(data)
   }
-  public static func makeFloatLiteralExpr(floatingDigits: TokenSyntax) -> FloatLiteralExprSyntax {
+  public static func makeFloatLiteralExpr(floatingDigits: TokenSyntax) -> FloatLiteralExprSyntax? {
     let layout: [RawSyntax?] = [
       floatingDigits.raw,
     ]
@@ -629,13 +629,6 @@ public enum SyntaxFactory {
     return FloatLiteralExprSyntax(data)
   }
 
-  public static func makeBlankFloatLiteralExpr() -> FloatLiteralExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.create(kind: .floatLiteralExpr,
-      layout: [
-      RawSyntax.missingToken(TokenKind.floatingLiteral("")),
-    ], length: .zero, presence: .present))
-    return FloatLiteralExprSyntax(data)
-  }
   public static func makeTupleExpr(leftParen: TokenSyntax, elementList: TupleExprElementListSyntax, rightParen: TokenSyntax) -> TupleExprSyntax {
     let layout: [RawSyntax?] = [
       leftParen.raw,
@@ -764,7 +757,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: .present))
     return DictionaryElementSyntax(data)
   }
-  public static func makeIntegerLiteralExpr(digits: TokenSyntax) -> IntegerLiteralExprSyntax {
+  public static func makeIntegerLiteralExpr(digits: TokenSyntax) -> IntegerLiteralExprSyntax? {
     let layout: [RawSyntax?] = [
       digits.raw,
     ]
@@ -774,13 +767,6 @@ public enum SyntaxFactory {
     return IntegerLiteralExprSyntax(data)
   }
 
-  public static func makeBlankIntegerLiteralExpr() -> IntegerLiteralExprSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.create(kind: .integerLiteralExpr,
-      layout: [
-      RawSyntax.missingToken(TokenKind.integerLiteral("")),
-    ], length: .zero, presence: .present))
-    return IntegerLiteralExprSyntax(data)
-  }
   public static func makeBooleanLiteralExpr(booleanLiteral: TokenSyntax) -> BooleanLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       booleanLiteral.raw,

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -264,7 +264,7 @@ public enum SyntaxFactory {
   public static func makeBlankAwaitExpr() -> AwaitExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .awaitExpr,
       layout: [
-      RawSyntax.missingToken(TokenKind.identifier("")),
+      RawSyntax.missingToken(TokenKind.awaitKeyword),
       RawSyntax.missing(SyntaxKind.expr),
     ], length: .zero, presence: .present))
     return AwaitExprSyntax(data)
@@ -982,11 +982,10 @@ public enum SyntaxFactory {
     ], length: .zero, presence: .present))
     return ClosureParamListSyntax(data)
   }
-  public static func makeClosureSignature(capture: ClosureCaptureSignatureSyntax?, input: Syntax?, asyncKeyword: TokenSyntax?, throwsTok: TokenSyntax?, output: ReturnClauseSyntax?, inTok: TokenSyntax) -> ClosureSignatureSyntax {
+  public static func makeClosureSignature(capture: ClosureCaptureSignatureSyntax?, input: Syntax?, throwsTok: TokenSyntax?, output: ReturnClauseSyntax?, inTok: TokenSyntax) -> ClosureSignatureSyntax {
     let layout: [RawSyntax?] = [
       capture?.raw,
       input?.raw,
-      asyncKeyword?.raw,
       throwsTok?.raw,
       output?.raw,
       inTok.raw,
@@ -1000,7 +999,6 @@ public enum SyntaxFactory {
   public static func makeBlankClosureSignature() -> ClosureSignatureSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .closureSignature,
       layout: [
-      nil,
       nil,
       nil,
       nil,

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -5066,6 +5066,12 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  public static func makeAwaitKeyword(leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []) -> TokenSyntax {
+    return makeToken(.awaitKeyword, presence: .present,
+                     leadingTrivia: leadingTrivia,
+                     trailingTrivia: trailingTrivia)
+  }
   public static func make__FILE__Keyword(leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> TokenSyntax {
     return makeToken(.__file__Keyword, presence: .present,

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -2128,7 +2128,8 @@ open class SyntaxRewriter {
 
   /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplFloatLiteralExprSyntax(_ data: SyntaxData) -> Syntax {
-      let node = FloatLiteralExprSyntax(data)
+      // We know that the SyntaxData is valid since we are walking a valid syntax tree and haven't modified the syntax data. Thus the initializer below will never return nil.
+      let node = FloatLiteralExprSyntax(data)!
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
       visitPre(node._syntaxNode)
       defer { visitPost(node._syntaxNode) }
@@ -2198,7 +2199,8 @@ open class SyntaxRewriter {
 
   /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplIntegerLiteralExprSyntax(_ data: SyntaxData) -> Syntax {
-      let node = IntegerLiteralExprSyntax(data)
+      // We know that the SyntaxData is valid since we are walking a valid syntax tree and haven't modified the syntax data. Thus the initializer below will never return nil.
+      let node = IntegerLiteralExprSyntax(data)!
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
       visitPre(node._syntaxNode)
       defer { visitPost(node._syntaxNode) }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -2868,7 +2868,8 @@ open class SyntaxVisitor {
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplFloatLiteralExprSyntax(_ data: SyntaxData) {
-      let node = FloatLiteralExprSyntax(data)
+      // We know that the SyntaxData is valid since we are walking a valid syntax tree and haven't modified the syntax data. Thus the initializer below will never return nil.
+      let node = FloatLiteralExprSyntax(data)!
       let needsChildren = (visit(node) == .visitChildren)
       // Avoid calling into visitChildren if possible.
       if needsChildren && node.raw.numberOfChildren > 0 {
@@ -2945,7 +2946,8 @@ open class SyntaxVisitor {
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplIntegerLiteralExprSyntax(_ data: SyntaxData) {
-      let node = IntegerLiteralExprSyntax(data)
+      // We know that the SyntaxData is valid since we are walking a valid syntax tree and haven't modified the syntax data. Thus the initializer below will never return nil.
+      let node = IntegerLiteralExprSyntax(data)!
       let needsChildren = (visit(node) == .visitChildren)
       // Avoid calling into visitChildren if possible.
       if needsChildren && node.raw.numberOfChildren > 0 {

--- a/Sources/SwiftSyntax/gyb_generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/TokenKind.swift
@@ -68,6 +68,7 @@ public enum TokenKind {
   case trueKeyword
   case tryKeyword
   case throwsKeyword
+  case awaitKeyword
   case __file__Keyword
   case __line__Keyword
   case __column__Keyword
@@ -195,6 +196,7 @@ public enum TokenKind {
     case .trueKeyword: return "true"
     case .tryKeyword: return "try"
     case .throwsKeyword: return "throws"
+    case .awaitKeyword: return "__await"
     case .__file__Keyword: return "__FILE__"
     case .__line__Keyword: return "__LINE__"
     case .__column__Keyword: return "__COLUMN__"
@@ -323,6 +325,7 @@ public enum TokenKind {
     case .trueKeyword: return true
     case .tryKeyword: return true
     case .throwsKeyword: return true
+    case .awaitKeyword: return true
     case .__file__Keyword: return true
     case .__line__Keyword: return true
     case .__column__Keyword: return true
@@ -451,6 +454,7 @@ public enum TokenKind {
     case .trueKeyword: return "kw_true"
     case .tryKeyword: return "kw_try"
     case .throwsKeyword: return "kw_throws"
+    case .awaitKeyword: return "kw___await"
     case .__file__Keyword: return "kw___FILE__"
     case .__line__Keyword: return "kw___LINE__"
     case .__column__Keyword: return "kw___COLUMN__"
@@ -579,6 +583,7 @@ public enum TokenKind {
     case .trueKeyword: return SourceLength(utf8Length: 4)
     case .tryKeyword: return SourceLength(utf8Length: 3)
     case .throwsKeyword: return SourceLength(utf8Length: 6)
+    case .awaitKeyword: return SourceLength(utf8Length: 7)
     case .__file__Keyword: return SourceLength(utf8Length: 8)
     case .__line__Keyword: return SourceLength(utf8Length: 8)
     case .__column__Keyword: return SourceLength(utf8Length: 10)
@@ -709,6 +714,7 @@ extension TokenKind: Equatable {
     case (.trueKeyword, .trueKeyword): return true
     case (.tryKeyword, .tryKeyword): return true
     case (.throwsKeyword, .throwsKeyword): return true
+    case (.awaitKeyword, .awaitKeyword): return true
     case (.__file__Keyword, .__file__Keyword): return true
     case (.__line__Keyword, .__line__Keyword): return true
     case (.__column__Keyword, .__column__Keyword): return true
@@ -907,6 +913,8 @@ extension TokenKind {
       return .tryKeyword
     case 53:
       return .throwsKeyword
+    case 123:
+      return .awaitKeyword
     case 54:
       return .__file__Keyword
     case 55:
@@ -1167,6 +1175,8 @@ extension TokenKind {
       return false
     case 53:
       return false
+    case 123:
+      return false
     case 54:
       return false
     case 55:
@@ -1367,6 +1377,7 @@ internal enum RawTokenKind: CTokenKind {
   case trueKeyword = 51
   case tryKeyword = 52
   case throwsKeyword = 53
+  case awaitKeyword = 123
   case __file__Keyword = 54
   case __line__Keyword = 55
   case __column__Keyword = 56
@@ -1608,6 +1619,9 @@ extension TokenKind {
     case .throwsKeyword:
       let length = 6
       return body(.init(kind: .throwsKeyword, length: length))
+    case .awaitKeyword:
+      let length = 7
+      return body(.init(kind: .awaitKeyword, length: length))
     case .__file__Keyword:
       let length = 8
       return body(.init(kind: .__file__Keyword, length: length))

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -412,7 +412,7 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `awaitKeyword`, if present.
   public func withAwaitKeyword(
     _ newChild: TokenSyntax?) -> AwaitExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.identifier(""))
+    let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.awaitKeyword)
     let newData = data.replacingChild(raw, at: Cursor.awaitKeyword)
     return AwaitExprSyntax(newData)
   }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -1833,14 +1833,21 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public init?(_ syntax: Syntax) {
     guard syntax.raw.kind == .floatLiteralExpr else { return nil }
     self._syntaxNode = syntax
+    if !isValid {
+      fatalError("Instance of FloatLiteralExprSyntax is invalid.")
+    }
   }
 
   /// Creates a `FloatLiteralExprSyntax` node from the given `SyntaxData`. This assumes
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
-  internal init(_ data: SyntaxData) {
+  /// This initializer returns nil if the invariant is not satisfied.
+  internal init?(_ data: SyntaxData) {
     assert(data.raw.kind == .floatLiteralExpr)
     self._syntaxNode = Syntax(data)
+    if !isValid {
+      return nil
+    }
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1853,8 +1860,24 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
                                  parent: Syntax(self))
       return TokenSyntax(childData!)
     }
-    set(value) {
-      self = withFloatingDigits(value)
+  }
+
+  public enum FloatingDigitsError: Error, CustomStringConvertible {
+    case invalid(floatingDigits: TokenSyntax)
+
+    public var description: String {
+      switch self {
+      case .invalid(let floatingDigits):
+        return "attempted to use setter with invalid FloatingDigits \"\(floatingDigits)\""
+      }
+    }
+  }
+
+  mutating public func setFloatingDigits(_ floatingDigits: TokenSyntax) throws {
+    if let childSyntax = withFloatingDigits(floatingDigits) {
+      self = childSyntax
+    } else {
+      throw FloatingDigitsError.invalid(floatingDigits: floatingDigits)
     }
   }
 
@@ -1862,7 +1885,7 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `floatingDigits` to replace the node's
   ///                   current `floatingDigits`, if present.
   public func withFloatingDigits(
-    _ newChild: TokenSyntax?) -> FloatLiteralExprSyntax {
+    _ newChild: TokenSyntax?) -> FloatLiteralExprSyntax? {
     let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.floatingLiteral(""))
     let newData = data.replacingChild(raw, at: Cursor.floatingDigits)
     return FloatLiteralExprSyntax(newData)
@@ -2355,14 +2378,21 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public init?(_ syntax: Syntax) {
     guard syntax.raw.kind == .integerLiteralExpr else { return nil }
     self._syntaxNode = syntax
+    if !isValid {
+      fatalError("Instance of IntegerLiteralExprSyntax is invalid.")
+    }
   }
 
   /// Creates a `IntegerLiteralExprSyntax` node from the given `SyntaxData`. This assumes
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
-  internal init(_ data: SyntaxData) {
+  /// This initializer returns nil if the invariant is not satisfied.
+  internal init?(_ data: SyntaxData) {
     assert(data.raw.kind == .integerLiteralExpr)
     self._syntaxNode = Syntax(data)
+    if !isValid {
+      return nil
+    }
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -2375,8 +2405,24 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
                                  parent: Syntax(self))
       return TokenSyntax(childData!)
     }
-    set(value) {
-      self = withDigits(value)
+  }
+
+  public enum DigitsError: Error, CustomStringConvertible {
+    case invalid(digits: TokenSyntax)
+
+    public var description: String {
+      switch self {
+      case .invalid(let digits):
+        return "attempted to use setter with invalid Digits \"\(digits)\""
+      }
+    }
+  }
+
+  mutating public func setDigits(_ digits: TokenSyntax) throws {
+    if let childSyntax = withDigits(digits) {
+      self = childSyntax
+    } else {
+      throw DigitsError.invalid(digits: digits)
     }
   }
 
@@ -2384,7 +2430,7 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `digits` to replace the node's
   ///                   current `digits`, if present.
   public func withDigits(
-    _ newChild: TokenSyntax?) -> IntegerLiteralExprSyntax {
+    _ newChild: TokenSyntax?) -> IntegerLiteralExprSyntax? {
     let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.integerLiteral(""))
     let newData = data.replacingChild(raw, at: Cursor.digits)
     return IntegerLiteralExprSyntax(newData)

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -1505,7 +1505,6 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case capture
     case input
-    case asyncKeyword
     case throwsTok
     case output
     case inTok
@@ -1573,28 +1572,6 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     _ newChild: Syntax?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: Cursor.input)
-    return ClosureSignatureSyntax(newData)
-  }
-
-  public var asyncKeyword: TokenSyntax? {
-    get {
-      let childData = data.child(at: Cursor.asyncKeyword,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withAsyncKeyword(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `asyncKeyword` replaced.
-  /// - param newChild: The new `asyncKeyword` to replace the node's
-  ///                   current `asyncKeyword`, if present.
-  public func withAsyncKeyword(
-    _ newChild: TokenSyntax?) -> ClosureSignatureSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.asyncKeyword)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -1666,7 +1643,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 
   public func _validateLayout() {
     let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
-    assert(rawChildren.count == 6)
+    assert(rawChildren.count == 5)
     // Check child #0 child is ClosureCaptureSignatureSyntax or missing
     if let raw = rawChildren[0].raw {
       let info = rawChildren[0].syntaxInfo
@@ -1691,26 +1668,18 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(TokenSyntax.self))
     }
-    // Check child #3 child is TokenSyntax or missing
+    // Check child #3 child is ReturnClauseSyntax or missing
     if let raw = rawChildren[3].raw {
       let info = rawChildren[3].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TokenSyntax.self))
-    }
-    // Check child #4 child is ReturnClauseSyntax or missing
-    if let raw = rawChildren[4].raw {
-      let info = rawChildren[4].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(ReturnClauseSyntax.self))
     }
-    // Check child #5 child is TokenSyntax 
-    assert(rawChildren[5].raw != nil)
-    if let raw = rawChildren[5].raw {
-      let info = rawChildren[5].syntaxInfo
+    // Check child #4 child is TokenSyntax 
+    assert(rawChildren[4].raw != nil)
+    if let raw = rawChildren[4].raw {
+      let info = rawChildren[4].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
@@ -1724,7 +1693,6 @@ extension ClosureSignatureSyntax: CustomReflectable {
     return Mirror(self, children: [
       "capture": capture.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "input": input.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "asyncKeyword": asyncKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "throwsTok": throwsTok.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "output": output.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "inTok": Syntax(inTok).asProtocol(SyntaxProtocol.self),

--- a/Sources/SwiftSyntaxBuilder/ExprBuildables.swift
+++ b/Sources/SwiftSyntaxBuilder/ExprBuildables.swift
@@ -46,7 +46,7 @@ public struct IntegerLiteral: ExprBuildable {
     public func buildExpr(format: Format, leadingTrivia: Trivia) -> ExprSyntax {
         let integerLiteral = SyntaxFactory.makeIntegerLiteralExpr(
             digits: SyntaxFactory.makeIntegerLiteral(String(value))
-        ).withLeadingTrivia(leadingTrivia)
+        )!.withLeadingTrivia(leadingTrivia)
         return ExprSyntax(integerLiteral)
     }
 }

--- a/Tests/SwiftSyntaxTest/CustomReflecatbleTests.swift
+++ b/Tests/SwiftSyntaxTest/CustomReflecatbleTests.swift
@@ -101,12 +101,12 @@ public class CustomReflectableTests: XCTestCase {
                                              presence: .present,
                                              leadingTrivia: [],
                                              trailingTrivia: [])
-        let expr1 = SyntaxFactory.makeIntegerLiteralExpr(digits: token1)
+        let expr1 = SyntaxFactory.makeIntegerLiteralExpr(digits: token1)!
         let token2 = SyntaxFactory.makeToken(.integerLiteral("2"),
                                              presence: .present,
                                              leadingTrivia: [],
                                              trailingTrivia: [])
-        let expr2 = SyntaxFactory.makeIntegerLiteralExpr(digits: token2)
+        let expr2 = SyntaxFactory.makeIntegerLiteralExpr(digits: token2)!
         let elements = [SyntaxFactory.makeTupleExprElement(label: nil,
                                                        colon: nil,
                                                        expression: ExprSyntax(expr1),
@@ -153,12 +153,12 @@ public class CustomReflectableTests: XCTestCase {
                                              presence: .present,
                                              leadingTrivia: [],
                                              trailingTrivia: [])
-        let expr1 = SyntaxFactory.makeIntegerLiteralExpr(digits: token1)
+        let expr1 = SyntaxFactory.makeIntegerLiteralExpr(digits: token1)!
         let token2 = SyntaxFactory.makeToken(.integerLiteral("2"),
                                              presence: .present,
                                              leadingTrivia: [],
                                              trailingTrivia: [])
-        let expr2 = SyntaxFactory.makeIntegerLiteralExpr(digits: token2)
+        let expr2 = SyntaxFactory.makeIntegerLiteralExpr(digits: token2)!
         let elements = [SyntaxFactory.makeTupleExprElement(label: nil,
                                                        colon: nil,
                                                        expression: ExprSyntax(expr1),

--- a/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
@@ -4,7 +4,7 @@ import SwiftSyntax
 fileprivate func integerLiteralElement(_ int: Int) -> ArrayElementSyntax {
     let literal = SyntaxFactory.makeIntegerLiteral("\(int)")
     return SyntaxFactory.makeArrayElement(
-        expression: ExprSyntax(SyntaxFactory.makeIntegerLiteralExpr(digits: literal)),
+        expression: ExprSyntax(SyntaxFactory.makeIntegerLiteralExpr(digits: literal)!),
         trailingComma: nil)
 }
 

--- a/Tests/SwiftSyntaxTest/SyntaxConvenienceMethodsTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxConvenienceMethodsTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+import SwiftSyntax
+
+public class SyntaxConvenienceMethodsTests: XCTestCase {
+
+  public func testFloatingValues() {
+    testFloatingValue(text: "5.3_8", expectedValue: 5.38)
+    testFloatingValue(text: "12e3", expectedValue: 12000.0)
+    testFloatingValue(text: "32E1", expectedValue: 320.0)
+    testFloatingValue(text: "0xdEFACE.C0FFEEp+1", expectedValue: 0xdEFACE.C0FFEEp+1)
+    testFloatingValue(text: "0xaffab1e.e1fP-2", expectedValue: 0xaffab1e.e1fP-2)
+    testFloatingValue(text: "🥥", expectedValue: nil)
+  }
+
+  public func testIntegerValues() {
+    testIntegerValue(text: "0b001100", expectedValue: 0b001100)
+    testIntegerValue(text: "4_2", expectedValue: 42)
+    testIntegerValue(text: "0o3434", expectedValue: 0o3434)
+    testIntegerValue(text: "0xba11aD", expectedValue: 0xba11aD)
+    testIntegerValue(text: "🐋", expectedValue: nil)
+  }
+}
+
+fileprivate func testFloatingValue(text: String, expectedValue: Double?) {
+  let digits = SyntaxFactory.makeFloatingLiteral(text)
+  let literalExpr = SyntaxFactory.makeFloatLiteralExpr(floatingDigits: digits)
+  if let expectedValue = expectedValue {
+    XCTAssertEqual(literalExpr!.floatingValue, expectedValue)
+  } else {
+    XCTAssertNil(literalExpr)
+  }
+}
+
+fileprivate func testIntegerValue(text: String, expectedValue: Int?) {
+  let digits = SyntaxFactory.makeIntegerLiteral(text)
+  let literalExpr = SyntaxFactory.makeIntegerLiteralExpr(digits: digits)
+  if let expectedValue = expectedValue {
+    XCTAssertEqual(literalExpr!.integerValue, expectedValue)
+  } else {
+    XCTAssertNil(literalExpr)
+  }
+}

--- a/Tests/SwiftSyntaxTest/SyntaxFactoryTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxFactoryTests.swift
@@ -168,10 +168,10 @@ public class SyntaxFactoryTests: XCTestCase {
   public func testMakeBinaryOperator() {
     let first = IntegerLiteralExprSyntax {
       $0.useDigits(SyntaxFactory.makeIntegerLiteral("1", trailingTrivia: .spaces(1)))
-    }
+    }!
     let second = IntegerLiteralExprSyntax {
       $0.useDigits(SyntaxFactory.makeIntegerLiteral("1"))
-    }
+    }!
     let operatorNames = ["==", "!=", "+", "-", "*", "/", "<", ">", "<=", ">="]
     operatorNames.forEach { operatorName in
       let operatorToken = SyntaxFactory.makeBinaryOperator(operatorName, trailingTrivia: .spaces(1))

--- a/utils/group.json
+++ b/utils/group.json
@@ -14,6 +14,7 @@
     "Syntax.swift",
     "SyntaxBaseNodes.swift",
     "SyntaxCollections.swift",
+    "SyntaxConvenienceMethods.swift",
     "SyntaxDeclNodes.swift",
     "SyntaxExprNodes.swift",
     "SyntaxNodes.swift",


### PR DESCRIPTION
Building on the [work](https://github.com/apple/swift-syntax/pull/148/files) of @ahoppen on [SR-11580](https://bugs.swift.org/browse/SR-11580), this PR adds convenience properties to get `Double` and `Int` values from `FloatLiteralExprSyntax` and `IntegerLiteralExprSyntax`, respectively.

The two new properties, `floatingValue` and `intValue`, use failable initializers of `Double` and `Int`: `init?<S>(_ text: S) where S : StringProtocol` and `init?<S>(_ text: S, radix: Int) where S : StringProtocol`. These initializers fail if the `String`s passed in do not represent valid `Double`s or `Int`s. The question arises: what should `floatingValue` and `intValue` return, if anything, if initialization fails? I considered the following possibilities, ultimately choosing the fourth.

1. `floatingValue` could return `Double.nan`. This would make sense because, for example, ``"🍕.🌍"`` is truly not a number, floating-point or otherwise. The problem with this approach is that there is no corresponding `Int.nan`, which would prevent `floatingValue` and `intValue` from returning the same sort of value given invalid input.  `Decimal` _does_ have a [`nan`](https://developer.apple.com/documentation/foundation/decimal/1780019-nan) value, so if `intValue` returned a `Decimal` rather than an `Int`, that would solve the problem, but I, as a consumer of the API, would find this counter-intuitive because `"42"` in a source file represents an `Int`, not a `Decimal`.

2. The return types of `floatingValue` and `intValue` could be optional. If `Double` or `Int` initialization fails, `floatingValue` and `intValue` could therefore return `nil`. I preferred not to impose on API consumers the burden of unwrapping.

3. The return types of `floatingValue` and `intValue` could be `Result<Double, LiteralError>` and `Result<Int, LiteralError>`, respectively. If `Double` or `Int` initialization fails, `floatingValue` and `intValue` could return `.failure(.invalid)`. I preferred not to impose on API consumers the burden of `switch`ing on the returned value.

4. The result of the `Double` or `Int` initialization can be force-unwrapped. This causes a crash if initialization fails. Crashing is [considered harmful](https://homepages.cwi.nl/~storm/teaching/reader/Dijkstra68.pdf), though [not](https://t.co/30VaX2WWHg?amp=1) by everyone. Force-unwrapping is the most convenient option for API consumers, which is why I chose it. I observe that force-unwrapping does appear elsewhere in SwiftSyntax, for example [here](https://github.com/apple/swift-syntax/blob/27bc2a11a7723dfe9bc5bda3caee49d5f5e2df59/Sources/SwiftSyntax/Diagnostic.swift#L173), [here](https://github.com/apple/swift-syntax/blob/27bc2a11a7723dfe9bc5bda3caee49d5f5e2df59/Sources/SwiftSyntax/SyntaxOtherNodes.swift#L97), [here](https://github.com/apple/swift-syntax/blob/27bc2a11a7723dfe9bc5bda3caee49d5f5e2df59/Sources/SwiftSyntax/SyntaxData.swift#L308), and [here](https://github.com/apple/swift-syntax/blob/27bc2a11a7723dfe9bc5bda3caee49d5f5e2df59/Sources/SwiftSyntax/Syntax.swift#L326), and I suspect that the authors of this code made similar judgments about the convenience of force-unwrapping versus the crashing risk it imposes.
