### PR TITLE
Implement Additional Feedback on PR for SR-11580

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@ Note: This is in reverse chronological order, so newer entries are added to the 
 
 ## Swift 5.3
 
-* Introduced `integerValue` and `floatingValue` properties to `IntegerLiteralExprSyntax` and `FloatLiteralExprSyntax`, respectively. Converted their `digits` and `floatingDigits` setters, respectively, into throwing functions.
+* Introduced `integerLiteralValue` and `floatLiteralValue` properties to `IntegerLiteralExprSyntax` and `FloatLiteralExprSyntax`, respectively.
 
 * Introduced `FunctionCallExprSyntax.additionalTrailingClosures` property with type `MultipleTrailingClosureElementListSyntax?` for supporting [SE-0279 Multiple Trailing Closures](https://github.com/apple/swift-evolution/blob/master/proposals/0279-multiple-trailing-closures.md).
 

--- a/Sources/SwiftSyntax/SyntaxBuilders.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxBuilders.swift.gyb
@@ -85,11 +85,7 @@ extension ${node.name} {
   ///            incrementally build the structure of the node.
   /// - Returns: A `${node.name}` with all the fields populated in the builder
   ///            closure.
-%     if node.must_uphold_invariant:
-  public init?(_ build: (inout ${Builder}) -> Void) {
-%     else:
   public init(_ build: (inout ${Builder}) -> Void) {
-%     end
     var builder = ${Builder}()
     build(&builder)
     let data = builder.buildData()

--- a/Sources/SwiftSyntax/SyntaxConvenienceMethods.swift
+++ b/Sources/SwiftSyntax/SyntaxConvenienceMethods.swift
@@ -11,24 +11,20 @@
 //===----------------------------------------------------------------------===//
 
 public extension FloatLiteralExprSyntax {
-  var floatingValue: Double {
-    return potentialFloatingValue!
-  }
-
-  fileprivate var potentialFloatingValue: Double? {
+  var floatLiteralValue: Double? {
     let floatingDigitsWithoutUnderscores = floatingDigits.text.filter {
       $0 != "_"
     }
     return Double(floatingDigitsWithoutUnderscores)
   }
+
+  var isValid: Bool {
+    floatLiteralValue != nil
+  }
 }
 
 public extension IntegerLiteralExprSyntax {
-  var integerValue: Int {
-    return potentialIntegerValue!
-  }
-
-  fileprivate var potentialIntegerValue: Int? {
+  var integerLiteralValue: Int? {
     let text = digits.text
     let (prefixLength, radix) = IntegerLiteralExprSyntax.prefixLengthAndRadix(text: text)
     let digitsStartIndex = text.index(text.startIndex, offsetBy: prefixLength)
@@ -65,16 +61,8 @@ public extension IntegerLiteralExprSyntax {
       return (decimalPrefix.count, decimalRadix)
     }
   }
-}
 
-public extension IntegerLiteralExprSyntax {
   var isValid: Bool {
-    potentialIntegerValue != nil
-  }
-}
-
-public extension FloatLiteralExprSyntax {
-  var isValid: Bool {
-    potentialFloatingValue != nil
+    integerLiteralValue != nil
   }
 }

--- a/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -57,11 +57,7 @@ public enum SyntaxFactory {
 %            param_type = param_type + "?"
 %         child_params.append("%s: %s" % (child.swift_name, param_type))
 %     child_params = ', '.join(child_params)
-%     if node.must_uphold_invariant:
-  public static func make${node.syntax_kind}(${child_params}) -> ${node.name}? {
-%     else:
   public static func make${node.syntax_kind}(${child_params}) -> ${node.name} {
-%     end
     let layout: [RawSyntax?] = [
 %     for child in node.children:
 %       if child.is_optional:
@@ -86,7 +82,7 @@ public enum SyntaxFactory {
   }
 %   end
 
-%   if not node.is_base() and not node.must_uphold_invariant:
+%   if not node.is_base():
   public static func makeBlank${node.syntax_kind}() -> ${node.name} {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .${node.swift_syntax_kind},
       layout: [

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
@@ -70,29 +70,14 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
   public init?(_ syntax: Syntax) {
     guard syntax.raw.kind == .${node.swift_syntax_kind} else { return nil }
     self._syntaxNode = syntax
-  %   if node.must_uphold_invariant:
-    if !isValid {
-      fatalError("Instance of ${node.name} is invalid.")
-    }
-%   end
   }
 
   /// Creates a `${node.name}` node from the given `SyntaxData`. This assumes
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
-%   if node.must_uphold_invariant:
-  /// This initializer returns nil if the invariant is not satisfied.
-  internal init?(_ data: SyntaxData) {
-%   else:
   internal init(_ data: SyntaxData) {
-%   end
     assert(data.raw.kind == .${node.swift_syntax_kind})
     self._syntaxNode = Syntax(data)
-%   if node.must_uphold_invariant:
-    if !isValid {
-      return nil
-    }
-%   end
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -122,33 +107,10 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
 %       end
       return ${child.type_name}(childData!)
     }
-%       if not node.must_uphold_invariant:
     set(value) {
       self = with${child.name}(value)
     }
-%       end
   }
-%       if node.must_uphold_invariant:
-
-  public enum ${child.name}Error: Error, CustomStringConvertible {
-    case invalid(${child.swift_name}: ${ret_type})
-
-    public var description: String {
-      switch self {
-      case .invalid(let ${child.swift_name}):
-        return "attempted to use setter with invalid ${child.name} \"\(${child.swift_name})\""
-      }
-    }
-  }
-
-  mutating public func set${child.name}(_ ${child.swift_name}: ${ret_type}) throws {
-    if let childSyntax = with${child.name}(${child.swift_name}) {
-      self = childSyntax
-    } else {
-      throw ${child.name}Error.invalid(${child.swift_name}: ${child.swift_name})
-    }
-  }
-%       end
 %
 %       # ===============
 %       # Adding children
@@ -187,11 +149,7 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
   /// - param newChild: The new `${child.swift_name}` to replace the node's
   ///                   current `${child.swift_name}`, if present.
   public func with${child.name}(
-%       if node.must_uphold_invariant:
-    _ newChild: ${child.type_name}?) -> ${node.name}? {
-%       else:
     _ newChild: ${child.type_name}?) -> ${node.name} {
-%       end
 %       if child.is_optional:
     let raw = newChild?.raw
 %       else:

--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -91,12 +91,7 @@ open class SyntaxRewriter {
       if let newNode = visitAny(node._syntaxNode) { return newNode }
       return Syntax(visit(node))
 %   else:
-%     if node.must_uphold_invariant:
-      // We know that the SyntaxData is valid since we are walking a valid syntax tree and haven't modified the syntax data. Thus the initializer below will never return nil.
-      let node = ${node.name}(data)!
-%     else:
       let node = ${node.name}(data)
-%     end
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
       visitPre(node._syntaxNode)
       defer { visitPost(node._syntaxNode) }

--- a/Sources/SwiftSyntax/SyntaxVisitor.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxVisitor.swift.gyb
@@ -86,12 +86,7 @@ open class SyntaxVisitor {
       }
       visitPost(node)
 %   else:
-%     if node.must_uphold_invariant:
-      // We know that the SyntaxData is valid since we are walking a valid syntax tree and haven't modified the syntax data. Thus the initializer below will never return nil.
-      let node = ${node.name}(data)!
-%     else:
       let node = ${node.name}(data)
-%     end
       let needsChildren = (visit(node) == .visitChildren)
       // Avoid calling into visitChildren if possible.
       if needsChildren && node.raw.numberOfChildren > 0 {

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
@@ -1077,7 +1077,7 @@ extension FloatLiteralExprSyntax {
   ///            incrementally build the structure of the node.
   /// - Returns: A `FloatLiteralExprSyntax` with all the fields populated in the builder
   ///            closure.
-  public init?(_ build: (inout FloatLiteralExprSyntaxBuilder) -> Void) {
+  public init(_ build: (inout FloatLiteralExprSyntaxBuilder) -> Void) {
     var builder = FloatLiteralExprSyntaxBuilder()
     build(&builder)
     let data = builder.buildData()
@@ -1444,7 +1444,7 @@ extension IntegerLiteralExprSyntax {
   ///            incrementally build the structure of the node.
   /// - Returns: A `IntegerLiteralExprSyntax` with all the fields populated in the builder
   ///            closure.
-  public init?(_ build: (inout IntegerLiteralExprSyntaxBuilder) -> Void) {
+  public init(_ build: (inout IntegerLiteralExprSyntaxBuilder) -> Void) {
     var builder = IntegerLiteralExprSyntaxBuilder()
     build(&builder)
     let data = builder.buildData()

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -619,7 +619,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: .present))
     return ArrowExprSyntax(data)
   }
-  public static func makeFloatLiteralExpr(floatingDigits: TokenSyntax) -> FloatLiteralExprSyntax? {
+  public static func makeFloatLiteralExpr(floatingDigits: TokenSyntax) -> FloatLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       floatingDigits.raw,
     ]
@@ -629,6 +629,13 @@ public enum SyntaxFactory {
     return FloatLiteralExprSyntax(data)
   }
 
+  public static func makeBlankFloatLiteralExpr() -> FloatLiteralExprSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .floatLiteralExpr,
+      layout: [
+      RawSyntax.missingToken(TokenKind.floatingLiteral("")),
+    ], length: .zero, presence: .present))
+    return FloatLiteralExprSyntax(data)
+  }
   public static func makeTupleExpr(leftParen: TokenSyntax, elementList: TupleExprElementListSyntax, rightParen: TokenSyntax) -> TupleExprSyntax {
     let layout: [RawSyntax?] = [
       leftParen.raw,
@@ -757,7 +764,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: .present))
     return DictionaryElementSyntax(data)
   }
-  public static func makeIntegerLiteralExpr(digits: TokenSyntax) -> IntegerLiteralExprSyntax? {
+  public static func makeIntegerLiteralExpr(digits: TokenSyntax) -> IntegerLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       digits.raw,
     ]
@@ -767,6 +774,13 @@ public enum SyntaxFactory {
     return IntegerLiteralExprSyntax(data)
   }
 
+  public static func makeBlankIntegerLiteralExpr() -> IntegerLiteralExprSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .integerLiteralExpr,
+      layout: [
+      RawSyntax.missingToken(TokenKind.integerLiteral("")),
+    ], length: .zero, presence: .present))
+    return IntegerLiteralExprSyntax(data)
+  }
   public static func makeBooleanLiteralExpr(booleanLiteral: TokenSyntax) -> BooleanLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       booleanLiteral.raw,

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -2128,8 +2128,7 @@ open class SyntaxRewriter {
 
   /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplFloatLiteralExprSyntax(_ data: SyntaxData) -> Syntax {
-      // We know that the SyntaxData is valid since we are walking a valid syntax tree and haven't modified the syntax data. Thus the initializer below will never return nil.
-      let node = FloatLiteralExprSyntax(data)!
+      let node = FloatLiteralExprSyntax(data)
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
       visitPre(node._syntaxNode)
       defer { visitPost(node._syntaxNode) }
@@ -2199,8 +2198,7 @@ open class SyntaxRewriter {
 
   /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplIntegerLiteralExprSyntax(_ data: SyntaxData) -> Syntax {
-      // We know that the SyntaxData is valid since we are walking a valid syntax tree and haven't modified the syntax data. Thus the initializer below will never return nil.
-      let node = IntegerLiteralExprSyntax(data)!
+      let node = IntegerLiteralExprSyntax(data)
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
       visitPre(node._syntaxNode)
       defer { visitPost(node._syntaxNode) }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -2868,8 +2868,7 @@ open class SyntaxVisitor {
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplFloatLiteralExprSyntax(_ data: SyntaxData) {
-      // We know that the SyntaxData is valid since we are walking a valid syntax tree and haven't modified the syntax data. Thus the initializer below will never return nil.
-      let node = FloatLiteralExprSyntax(data)!
+      let node = FloatLiteralExprSyntax(data)
       let needsChildren = (visit(node) == .visitChildren)
       // Avoid calling into visitChildren if possible.
       if needsChildren && node.raw.numberOfChildren > 0 {
@@ -2946,8 +2945,7 @@ open class SyntaxVisitor {
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplIntegerLiteralExprSyntax(_ data: SyntaxData) {
-      // We know that the SyntaxData is valid since we are walking a valid syntax tree and haven't modified the syntax data. Thus the initializer below will never return nil.
-      let node = IntegerLiteralExprSyntax(data)!
+      let node = IntegerLiteralExprSyntax(data)
       let needsChildren = (visit(node) == .visitChildren)
       // Avoid calling into visitChildren if possible.
       if needsChildren && node.raw.numberOfChildren > 0 {

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -1833,21 +1833,14 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public init?(_ syntax: Syntax) {
     guard syntax.raw.kind == .floatLiteralExpr else { return nil }
     self._syntaxNode = syntax
-    if !isValid {
-      fatalError("Instance of FloatLiteralExprSyntax is invalid.")
-    }
   }
 
   /// Creates a `FloatLiteralExprSyntax` node from the given `SyntaxData`. This assumes
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
-  /// This initializer returns nil if the invariant is not satisfied.
-  internal init?(_ data: SyntaxData) {
+  internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .floatLiteralExpr)
     self._syntaxNode = Syntax(data)
-    if !isValid {
-      return nil
-    }
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1860,24 +1853,8 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
                                  parent: Syntax(self))
       return TokenSyntax(childData!)
     }
-  }
-
-  public enum FloatingDigitsError: Error, CustomStringConvertible {
-    case invalid(floatingDigits: TokenSyntax)
-
-    public var description: String {
-      switch self {
-      case .invalid(let floatingDigits):
-        return "attempted to use setter with invalid FloatingDigits \"\(floatingDigits)\""
-      }
-    }
-  }
-
-  mutating public func setFloatingDigits(_ floatingDigits: TokenSyntax) throws {
-    if let childSyntax = withFloatingDigits(floatingDigits) {
-      self = childSyntax
-    } else {
-      throw FloatingDigitsError.invalid(floatingDigits: floatingDigits)
+    set(value) {
+      self = withFloatingDigits(value)
     }
   }
 
@@ -1885,7 +1862,7 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `floatingDigits` to replace the node's
   ///                   current `floatingDigits`, if present.
   public func withFloatingDigits(
-    _ newChild: TokenSyntax?) -> FloatLiteralExprSyntax? {
+    _ newChild: TokenSyntax?) -> FloatLiteralExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.floatingLiteral(""))
     let newData = data.replacingChild(raw, at: Cursor.floatingDigits)
     return FloatLiteralExprSyntax(newData)
@@ -2378,21 +2355,14 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public init?(_ syntax: Syntax) {
     guard syntax.raw.kind == .integerLiteralExpr else { return nil }
     self._syntaxNode = syntax
-    if !isValid {
-      fatalError("Instance of IntegerLiteralExprSyntax is invalid.")
-    }
   }
 
   /// Creates a `IntegerLiteralExprSyntax` node from the given `SyntaxData`. This assumes
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
-  /// This initializer returns nil if the invariant is not satisfied.
-  internal init?(_ data: SyntaxData) {
+  internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .integerLiteralExpr)
     self._syntaxNode = Syntax(data)
-    if !isValid {
-      return nil
-    }
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -2405,24 +2375,8 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
                                  parent: Syntax(self))
       return TokenSyntax(childData!)
     }
-  }
-
-  public enum DigitsError: Error, CustomStringConvertible {
-    case invalid(digits: TokenSyntax)
-
-    public var description: String {
-      switch self {
-      case .invalid(let digits):
-        return "attempted to use setter with invalid Digits \"\(digits)\""
-      }
-    }
-  }
-
-  mutating public func setDigits(_ digits: TokenSyntax) throws {
-    if let childSyntax = withDigits(digits) {
-      self = childSyntax
-    } else {
-      throw DigitsError.invalid(digits: digits)
+    set(value) {
+      self = withDigits(value)
     }
   }
 
@@ -2430,7 +2384,7 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `digits` to replace the node's
   ///                   current `digits`, if present.
   public func withDigits(
-    _ newChild: TokenSyntax?) -> IntegerLiteralExprSyntax? {
+    _ newChild: TokenSyntax?) -> IntegerLiteralExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.integerLiteral(""))
     let newData = data.replacingChild(raw, at: Cursor.digits)
     return IntegerLiteralExprSyntax(newData)

--- a/Sources/SwiftSyntaxBuilder/ExprBuildables.swift
+++ b/Sources/SwiftSyntaxBuilder/ExprBuildables.swift
@@ -46,7 +46,7 @@ public struct IntegerLiteral: ExprBuildable {
     public func buildExpr(format: Format, leadingTrivia: Trivia) -> ExprSyntax {
         let integerLiteral = SyntaxFactory.makeIntegerLiteralExpr(
             digits: SyntaxFactory.makeIntegerLiteral(String(value))
-        )!.withLeadingTrivia(leadingTrivia)
+        ).withLeadingTrivia(leadingTrivia)
         return ExprSyntax(integerLiteral)
     }
 }

--- a/Tests/SwiftSyntaxTest/CustomReflecatbleTests.swift
+++ b/Tests/SwiftSyntaxTest/CustomReflecatbleTests.swift
@@ -101,12 +101,12 @@ public class CustomReflectableTests: XCTestCase {
                                              presence: .present,
                                              leadingTrivia: [],
                                              trailingTrivia: [])
-        let expr1 = SyntaxFactory.makeIntegerLiteralExpr(digits: token1)!
+        let expr1 = SyntaxFactory.makeIntegerLiteralExpr(digits: token1)
         let token2 = SyntaxFactory.makeToken(.integerLiteral("2"),
                                              presence: .present,
                                              leadingTrivia: [],
                                              trailingTrivia: [])
-        let expr2 = SyntaxFactory.makeIntegerLiteralExpr(digits: token2)!
+        let expr2 = SyntaxFactory.makeIntegerLiteralExpr(digits: token2)
         let elements = [SyntaxFactory.makeTupleExprElement(label: nil,
                                                        colon: nil,
                                                        expression: ExprSyntax(expr1),
@@ -153,12 +153,12 @@ public class CustomReflectableTests: XCTestCase {
                                              presence: .present,
                                              leadingTrivia: [],
                                              trailingTrivia: [])
-        let expr1 = SyntaxFactory.makeIntegerLiteralExpr(digits: token1)!
+        let expr1 = SyntaxFactory.makeIntegerLiteralExpr(digits: token1)
         let token2 = SyntaxFactory.makeToken(.integerLiteral("2"),
                                              presence: .present,
                                              leadingTrivia: [],
                                              trailingTrivia: [])
-        let expr2 = SyntaxFactory.makeIntegerLiteralExpr(digits: token2)!
+        let expr2 = SyntaxFactory.makeIntegerLiteralExpr(digits: token2)
         let elements = [SyntaxFactory.makeTupleExprElement(label: nil,
                                                        colon: nil,
                                                        expression: ExprSyntax(expr1),

--- a/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
@@ -4,7 +4,7 @@ import SwiftSyntax
 fileprivate func integerLiteralElement(_ int: Int) -> ArrayElementSyntax {
     let literal = SyntaxFactory.makeIntegerLiteral("\(int)")
     return SyntaxFactory.makeArrayElement(
-        expression: ExprSyntax(SyntaxFactory.makeIntegerLiteralExpr(digits: literal)!),
+        expression: ExprSyntax(SyntaxFactory.makeIntegerLiteralExpr(digits: literal)),
         trailingComma: nil)
 }
 

--- a/Tests/SwiftSyntaxTest/SyntaxConvenienceMethodsTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxConvenienceMethodsTests.swift
@@ -2,14 +2,16 @@ import XCTest
 import SwiftSyntax
 
 public class SyntaxConvenienceMethodsTests: XCTestCase {
-
-  public func testFloatingValues() {
-    testFloatingValue(text: "5.3_8", expectedValue: 5.38)
-    testFloatingValue(text: "12e3", expectedValue: 12000.0)
-    testFloatingValue(text: "32E1", expectedValue: 320.0)
-    testFloatingValue(text: "0xdEFACE.C0FFEEp+1", expectedValue: 0xdEFACE.C0FFEEp+1)
-    testFloatingValue(text: "0xaffab1e.e1fP-2", expectedValue: 0xaffab1e.e1fP-2)
-    testFloatingValue(text: "🥥", expectedValue: nil)
+  public func testFloatValues() {
+    testFloatValue(text: "5.3_8", expectedValue: 5.38)
+    testFloatValue(text: "12e3", expectedValue: 12000.0)
+    testFloatValue(text: "32E1", expectedValue: 320.0)
+    testFloatValue(text: "0xdEFACE.C0FFEEp+1", expectedValue: 0xdEFACE.C0FFEEp+1)
+    testFloatValue(text: "0xaffab1e.e1fP-2", expectedValue: 0xaffab1e.e1fP-2)
+    testFloatValue(text: "🥥", expectedValue: nil)
+    // The following results in a valid FloatLiteralExprSyntax, but because Double.greatestFiniteMagnitude
+    // is 1.7976931348623157e+308, floatLiteralValue should be nil.
+    testFloatValue(text: "1.7976931348623157e+309", expectedValue: nil)
   }
 
   public func testIntegerValues() {
@@ -18,25 +20,36 @@ public class SyntaxConvenienceMethodsTests: XCTestCase {
     testIntegerValue(text: "0o3434", expectedValue: 0o3434)
     testIntegerValue(text: "0xba11aD", expectedValue: 0xba11aD)
     testIntegerValue(text: "🐋", expectedValue: nil)
+    // The following results in a valid IntegerLiteralExprSyntax, but because Int.max is
+    // 9223372036854775807, integerLiteralValue should be nil.
+    testIntegerValue(text: "9223372036854775808", expectedValue: nil)
   }
 }
 
-fileprivate func testFloatingValue(text: String, expectedValue: Double?) {
+fileprivate func testFloatValue(text: String, expectedValue: Double?) {
   let digits = SyntaxFactory.makeFloatingLiteral(text)
-  let literalExpr = SyntaxFactory.makeFloatLiteralExpr(floatingDigits: digits)
-  if let expectedValue = expectedValue {
-    XCTAssertEqual(literalExpr!.floatingValue, expectedValue)
+
+  if let literalExpr = SyntaxFactory.makeFloatLiteralExpr(floatingDigits: digits) {
+    if let expectedValue = expectedValue {
+      XCTAssertEqual(literalExpr.floatLiteralValue!, expectedValue)
+    } else {
+      XCTAssertNil(literalExpr.floatLiteralValue)
+    }
   } else {
-    XCTAssertNil(literalExpr)
+    XCTAssertNil(expectedValue)
   }
 }
 
 fileprivate func testIntegerValue(text: String, expectedValue: Int?) {
   let digits = SyntaxFactory.makeIntegerLiteral(text)
-  let literalExpr = SyntaxFactory.makeIntegerLiteralExpr(digits: digits)
-  if let expectedValue = expectedValue {
-    XCTAssertEqual(literalExpr!.integerValue, expectedValue)
+
+  if let literalExpr = SyntaxFactory.makeIntegerLiteralExpr(digits: digits) {
+    if let expectedValue = expectedValue {
+      XCTAssertEqual(literalExpr.integerLiteralValue!, expectedValue)
+    } else {
+      XCTAssertNil(literalExpr.integerLiteralValue)
+    }
   } else {
-    XCTAssertNil(literalExpr)
+    XCTAssertNil(expectedValue)
   }
 }

--- a/Tests/SwiftSyntaxTest/SyntaxConvenienceMethodsTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxConvenienceMethodsTests.swift
@@ -29,27 +29,21 @@ public class SyntaxConvenienceMethodsTests: XCTestCase {
 fileprivate func testFloatValue(text: String, expectedValue: Double?) {
   let digits = SyntaxFactory.makeFloatingLiteral(text)
 
-  if let literalExpr = SyntaxFactory.makeFloatLiteralExpr(floatingDigits: digits) {
-    if let expectedValue = expectedValue {
-      XCTAssertEqual(literalExpr.floatLiteralValue!, expectedValue)
-    } else {
-      XCTAssertNil(literalExpr.floatLiteralValue)
-    }
+  let literalExpr = SyntaxFactory.makeFloatLiteralExpr(floatingDigits: digits)
+  if let expectedValue = expectedValue {
+    XCTAssertEqual(literalExpr.floatLiteralValue!, expectedValue)
   } else {
-    XCTAssertNil(expectedValue)
+    XCTAssertNil(literalExpr.floatLiteralValue)
   }
 }
 
 fileprivate func testIntegerValue(text: String, expectedValue: Int?) {
   let digits = SyntaxFactory.makeIntegerLiteral(text)
 
-  if let literalExpr = SyntaxFactory.makeIntegerLiteralExpr(digits: digits) {
-    if let expectedValue = expectedValue {
-      XCTAssertEqual(literalExpr.integerLiteralValue!, expectedValue)
-    } else {
-      XCTAssertNil(literalExpr.integerLiteralValue)
-    }
+  let literalExpr = SyntaxFactory.makeIntegerLiteralExpr(digits: digits)
+  if let expectedValue = expectedValue {
+    XCTAssertEqual(literalExpr.integerLiteralValue!, expectedValue)
   } else {
-    XCTAssertNil(expectedValue)
+    XCTAssertNil(literalExpr.integerLiteralValue)
   }
 }

--- a/Tests/SwiftSyntaxTest/SyntaxFactoryTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxFactoryTests.swift
@@ -168,10 +168,10 @@ public class SyntaxFactoryTests: XCTestCase {
   public func testMakeBinaryOperator() {
     let first = IntegerLiteralExprSyntax {
       $0.useDigits(SyntaxFactory.makeIntegerLiteral("1", trailingTrivia: .spaces(1)))
-    }!
+    }
     let second = IntegerLiteralExprSyntax {
       $0.useDigits(SyntaxFactory.makeIntegerLiteral("1"))
-    }!
+    }
     let operatorNames = ["==", "!=", "+", "-", "*", "/", "<", ">", "<=", ">="]
     operatorNames.forEach { operatorName in
       let operatorToken = SyntaxFactory.makeBinaryOperator(operatorName, trailingTrivia: .spaces(1))

--- a/Tests/SwiftSyntaxTest/SyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTests.swift
@@ -87,9 +87,9 @@ public class SyntaxTests: XCTestCase {
   public func testCasting() {
     let integerExpr = IntegerLiteralExprSyntax {
       $0.useDigits(SyntaxFactory.makeIntegerLiteral("1", trailingTrivia: .spaces(1)))
-    }!
+    }
 
-    let expr = ExprSyntax(integerExpr)!
+    let expr = ExprSyntax(integerExpr)
     let node = Syntax(expr)
     XCTAssertTrue(expr.is(IntegerLiteralExprSyntax.self))
     XCTAssertTrue(node.is(IntegerLiteralExprSyntax.self))
@@ -127,7 +127,7 @@ public class SyntaxTests: XCTestCase {
   public func testNodeType() {
     let integerExpr = IntegerLiteralExprSyntax {
       $0.useDigits(SyntaxFactory.makeIntegerLiteral("1", trailingTrivia: .spaces(1)))
-    }!
+    }
     let expr = ExprSyntax(integerExpr)
     let node = Syntax(expr)
 
@@ -139,60 +139,9 @@ public class SyntaxTests: XCTestCase {
   public func testConstructFromSyntaxProtocol() {
     let integerExpr = IntegerLiteralExprSyntax {
       $0.useDigits(SyntaxFactory.makeIntegerLiteral("1", trailingTrivia: .spaces(1)))
-    }!
+    }
 
     XCTAssertEqual(Syntax(integerExpr), Syntax(fromProtocol: integerExpr as SyntaxProtocol))
     XCTAssertEqual(Syntax(integerExpr), Syntax(fromProtocol: integerExpr as ExprSyntaxProtocol))
-  }
-
-  public func testNumericLiteralSetters() {
-    var integerExpr = IntegerLiteralExprSyntax {
-      $0.useDigits(SyntaxFactory.makeIntegerLiteral("1"))
-    }!
-    XCTAssert(integerExpr.isValid)
-
-    var token: TokenSyntax
-    var source = "2"
-    var tree = try! SyntaxParser.parse(source: source)
-    token = tree.firstToken!
-    try! integerExpr.setDigits(token)
-    XCTAssert(integerExpr.isValid)
-
-    let invalidNumericLiteral = "🥥"
-
-    source = invalidNumericLiteral
-    tree = try! SyntaxParser.parse(source: source)
-    token = tree.firstToken!
-
-    XCTAssertThrowsError(try integerExpr.setDigits(token)) { error in
-      if let error = error as? IntegerLiteralExprSyntax.DigitsError {
-        XCTAssertEqual("attempted to use setter with invalid Digits \"\(source)\"", error.description)
-      } else {
-        return XCTFail("unexpected error thrown")
-      }
-    }
-
-    var floatExpr = FloatLiteralExprSyntax {
-      $0.useFloatingDigits(SyntaxFactory.makeFloatingLiteral("4.2"))
-    }!
-    XCTAssert(floatExpr.isValid)
-
-    source = "2.4"
-    tree = try! SyntaxParser.parse(source: source)
-    token = tree.firstToken!
-    try! floatExpr.setFloatingDigits(token)
-    XCTAssert(floatExpr.isValid)
-
-    source = invalidNumericLiteral
-    tree = try! SyntaxParser.parse(source: source)
-    token = tree.firstToken!
-
-    XCTAssertThrowsError(try floatExpr.setFloatingDigits(token)) { error in
-      if let error = error as? FloatLiteralExprSyntax.FloatingDigitsError {
-        XCTAssertEqual("attempted to use setter with invalid FloatingDigits \"\(source)\"", error.description)
-      } else {
-        return XCTFail("unexpected error thrown")
-      }
-    }
   }
 }


### PR DESCRIPTION
After the [PR](https://github.com/apple/swift-syntax/pull/239) for [SR-11580](https://bugs.swift.org/browse/SR-11580) merged, there was consensus, based on feedback by @xwu, that the new convenience methods `floatingValue` and `integerValue`, should be optional in order to prevent potential crashes. This PR implements that change.

This PR also implements new names, suggested by @xwu, for `floatingValue` and `integerValue`: `floatLiteralValue` and `integerLiteralValue`. These names LGTM.

@xwu also [stated](https://github.com/apple/swift-syntax/pull/239#discussion_r492173603), "Ideally, [the convenience methods] would be generic over `T: ExpressibleByIntegerLiteral` and `T: ExpressibleByFloatLiteral` so users can get the value represented in any type they want." I am not a generics [power](https://giphy.com/gifs/zCv1NuGumldXa/html5) user, but I am familiar with their use in the context of, for example, making a `Node` type generic over an `Element` type. I was unable to translate this understanding of the purpose and use of generics into an implementation of @xwu's suggestion. I would welcome a suggested new signature for `floatLiteralValue` or `integerLiteralValue`.