### PR TITLE
Replace unevaluated gyb values in documentation comments

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -332,17 +332,17 @@ public extension SyntaxProtocol {
     return Self(Syntax(data.withTrailingTrivia(trailingTrivia)))!
   }
 
-  /// Returns a new `${node.name}` with its leading trivia removed.
+  /// Returns a new syntax node with its leading trivia removed.
   func withoutLeadingTrivia() -> Self {
     return withLeadingTrivia([])
   }
 
-  /// Returns a new `${node.name}` with its trailing trivia removed.
+  /// Returns a new syntax node with its trailing trivia removed.
   func withoutTrailingTrivia() -> Self {
     return withTrailingTrivia([])
   }
 
-  /// Returns a new `${node.name}` with all trivia removed.
+  /// Returns a new syntax node with all trivia removed.
   func withoutTrivia() -> Self {
     return withoutLeadingTrivia().withoutTrailingTrivia()
   }


### PR DESCRIPTION
Some of the documentation comments in `SyntaxProtocol` include unescaped GYB expressions (`${node.name}`), which appear to be a copy-paste error introduced in 65a49c426aeccfe8e5738a6fafad7c99ccaff6e5. This PR replaces them with the phrase "syntax node", to match the other documentation comments.