### PR TITLE
[Test] Speculatively fix a non-deterministic issue

### DIFF
--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -424,7 +424,6 @@ func printParserDiags(args: CommandLineArguments) throws {
   class ParserDiagPrinter: DiagnosticConsumer {
     var counter : (error: Int, warning: Int, note: Int) = (0, 0, 0)
     var calculateLineColumn: Bool { return true }
-    func finalize() {}
     func handle(_ diag: Diagnostic) {
       switch diag.message.severity {
       case .error:
@@ -438,7 +437,7 @@ func printParserDiags(args: CommandLineArguments) throws {
       }
       print(diag.debugDescription)
     }
-    deinit {
+    func finalize() {
       print("\(counter.error) error(s) \(counter.warning) warnings(s) \(counter.note) note(s)")
     }
   }

--- a/lit_tests/parser-diags.swift
+++ b/lit_tests/parser-diags.swift
@@ -1,7 +1,5 @@
 // RUN: %lit-test-helper -source-file %s -dump-diags 2>&1 | %FileCheck %s
 
-// REQUIRES: rdar71046813
-
 // CHECK: [[@LINE+2]]:11 error: consecutive statements on a line must be separated by ';'
 // CHECK-NEXT: Fixit: ([[@LINE+1]]:11,[[@LINE+1]]:11) Text: ";"
 let number⁚ Int


### PR DESCRIPTION
Somehow, `deinit` isn't called deterministically. Instead of using `deinit` to print out the summary, use `finalize()` which is intended to finalize the diagnostics.

Fixes rdar://problem/71046813