### PR TITLE
Minor internal API improvements

### DIFF
--- a/Sources/SwiftSyntax/SyntaxChildren.swift
+++ b/Sources/SwiftSyntax/SyntaxChildren.swift
@@ -156,7 +156,7 @@ struct RawSyntaxChildren: BidirectionalCollection {
     if index.indexInParent + 1 < numberOfChildren {
       // Compute the next materialized index
       let nodeLength = UInt32(node?.totalLength.utf8Length ?? 0)
-      let advancedIndexInTree = index.indexInTree.advancedBySibling(node)
+      let advancedIndexInTree = index.indexInTree.advancedBy(node)
       return SyntaxChildrenIndex(offset: index.offset + nodeLength,
                                  indexInParent: index.indexInParent + 1,
                                  indexInTree: advancedIndexInTree)
@@ -176,7 +176,7 @@ struct RawSyntaxChildren: BidirectionalCollection {
       // We are reversing a non-end index.
       let previousNode = parent.child(at: Int(index.indexInParent - 1))
       let previousNodeLength = UInt32(previousNode?.totalLength.utf8Length ?? 0)
-      let reversedIndexInTree = index.indexInTree.reversedBySibling(previousNode)
+      let reversedIndexInTree = index.indexInTree.reversedBy(previousNode)
       return SyntaxChildrenIndex(offset: index.offset - previousNodeLength,
                                  indexInParent: index.indexInParent - 1,
                                  indexInTree: reversedIndexInTree)

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -31,12 +31,6 @@ struct AbsoluteSyntaxPosition {
     return .init(offset: self.offset, indexInParent: 0)
   }
 
-  func advancedToEndOfChildren(_ raw: RawSyntax) -> AbsoluteSyntaxPosition {
-    let newOffset = self.offset + UInt32(truncatingIfNeeded: raw.totalLength.utf8Length)
-    let newIndexInParent = UInt32(truncatingIfNeeded: raw.numberOfChildren)
-    return .init(offset: newOffset, indexInParent: newIndexInParent)
-  }
-
   static var forRoot: AbsoluteSyntaxPosition {
     return .init(offset: 0, indexInParent: 0)
   }
@@ -70,12 +64,6 @@ struct AbsoluteSyntaxInfo {
     return .init(position: newPosition, nodeId: newNodeId)
   }
 
-  func advancedToEndOfChildren(_ raw: RawSyntax) -> AbsoluteSyntaxInfo {
-    let newPosition = position.advancedToEndOfChildren(raw)
-    let newNodeId = nodeId.advancedToEndOfChildren(raw)
-    return .init(position: newPosition, nodeId: newNodeId)
-  }
-
   static var forRoot: AbsoluteSyntaxInfo {
     return .init(position: .forRoot, nodeId: .newRoot())
   }
@@ -104,12 +92,6 @@ struct SyntaxIndexInTree: Hashable {
     return .init(indexInTree: newIndexInTree)
   }
 
-  func advancedToEndOfChildren(_ raw: RawSyntax) -> SyntaxIndexInTree {
-    let newIndexInTree = self.indexInTree +
-                         UInt32(truncatingIfNeeded: raw.totalNodes)
-    return .init(indexInTree: newIndexInTree)
-  }
-
   init(indexInTree: UInt32) {
     self.indexInTree = indexInTree
   }
@@ -134,11 +116,6 @@ public struct SyntaxIdentifier: Hashable {
 
   func advancedToFirstChild() -> SyntaxIdentifier {
     let newIndexInTree = self.indexInTree.advancedToFirstChild()
-    return .init(rootId: self.rootId, indexInTree: newIndexInTree)
-  }
-
-  func advancedToEndOfChildren(_ raw: RawSyntax) -> SyntaxIdentifier {
-    let newIndexInTree = self.indexInTree.advancedToEndOfChildren(raw)
     return .init(rootId: self.rootId, indexInTree: newIndexInTree)
   }
 

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -75,13 +75,17 @@ struct SyntaxIndexInTree: Hashable {
 
   static var zero: SyntaxIndexInTree = SyntaxIndexInTree(indexInTree: 0)
 
-  func advancedBySibling(_ raw: RawSyntax?) -> SyntaxIndexInTree {
+  /// Assuming that this index points to the start of `Raw`, so that it points
+  /// to the next sibling of `Raw`.
+  func advancedBy(_ raw: RawSyntax?) -> SyntaxIndexInTree {
     let newIndexInTree = self.indexInTree +
                          UInt32(truncatingIfNeeded: raw?.totalNodes ?? 0)
     return .init(indexInTree: newIndexInTree)
   }
 
-  func reversedBySibling(_ raw: RawSyntax?) -> SyntaxIndexInTree {
+  /// Assuming that this index points to the next sibling of `Raw`, reverse it
+  /// so that it points to the start of `Raw`.
+  func reversedBy(_ raw: RawSyntax?) -> SyntaxIndexInTree {
     let newIndexInTree = self.indexInTree -
                          UInt32(truncatingIfNeeded: raw?.totalNodes ?? 0)
     return .init(indexInTree: newIndexInTree)
@@ -105,12 +109,12 @@ public struct SyntaxIdentifier: Hashable {
   let indexInTree: SyntaxIndexInTree
 
   func advancedBySibling(_ raw: RawSyntax?) -> SyntaxIdentifier {
-    let newIndexInTree = indexInTree.advancedBySibling(raw)
+    let newIndexInTree = indexInTree.advancedBy(raw)
     return .init(rootId: self.rootId, indexInTree: newIndexInTree)
   }
 
   func reversedBySibling(_ raw: RawSyntax?) -> SyntaxIdentifier {
-    let newIndexInTree = self.indexInTree.reversedBySibling(raw)
+    let newIndexInTree = self.indexInTree.reversedBy(raw)
     return .init(rootId: self.rootId, indexInTree: newIndexInTree)
   }
 


### PR DESCRIPTION
Two minor internal API improvements:

1. Remove `advancedToEndOfChildren`
These methods are not used anywhere and are potentially incorrect (`indexInParent` should probably be initialized with `raw.numberOfChildren - 1`). Remove the until we really need them
2. Rename `advancedBySibling`/`reversedBySibling` to `advancedBy`/`reversedBy`
We are not actually advancing by a sibling but just by a node, simplify the method name to reflect this.