### PR TITLE
Add a parsing performance test

### DIFF
--- a/Tests/PerformanceTest/ParsingPerformanceTests.swift
+++ b/Tests/PerformanceTest/ParsingPerformanceTests.swift
@@ -1,0 +1,22 @@
+import XCTest
+import SwiftSyntax
+
+public class ParsingPerformanceTests: XCTestCase {
+
+  var inputFile: URL {
+    return URL(fileURLWithPath: #file)
+      .deletingLastPathComponent()
+      .appendingPathComponent("Inputs")
+      .appendingPathComponent("MinimalCollections.swift.input")
+  }
+
+  func testParsingPerformance() {
+    measure {
+      do {
+        _ = try SyntaxParser.parse(inputFile)
+      } catch {
+        XCTFail(error.localizedDescription)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This is a small performance test, testing the time it takes to parse a source file into SwiftSyntax. I intend to use this to make sure we don't regress in performance during the libSyntax migration.