### PR TITLE
Updating ClassDecl to also accept actor

### DIFF
--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -1952,6 +1952,6 @@ extension Syntax {
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "da7c0141bd1b9360eab92ecfd7c083ae49cd4b1a"
+      "20b92b603651f0f0f61d43f86e4c706a8a118216"
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
@@ -3959,8 +3959,8 @@ public struct ClassDeclSyntaxBuilder {
     }
   }
 
-  public mutating func useClassKeyword(_ node: TokenSyntax) {
-    let idx = ClassDeclSyntax.Cursor.classKeyword.rawValue
+  public mutating func useClassOrActorKeyword(_ node: TokenSyntax) {
+    let idx = ClassDeclSyntax.Cursor.classOrActorKeyword.rawValue
     layout[idx] = node.raw
   }
 

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -1837,11 +1837,11 @@ public enum SyntaxFactory {
     ], length: .zero, presence: .present))
     return TypeInheritanceClauseSyntax(data)
   }
-  public static func makeClassDecl(attributes: AttributeListSyntax?, modifiers: ModifierListSyntax?, classKeyword: TokenSyntax, identifier: TokenSyntax, genericParameterClause: GenericParameterClauseSyntax?, inheritanceClause: TypeInheritanceClauseSyntax?, genericWhereClause: GenericWhereClauseSyntax?, members: MemberDeclBlockSyntax) -> ClassDeclSyntax {
+  public static func makeClassDecl(attributes: AttributeListSyntax?, modifiers: ModifierListSyntax?, classOrActorKeyword: TokenSyntax, identifier: TokenSyntax, genericParameterClause: GenericParameterClauseSyntax?, inheritanceClause: TypeInheritanceClauseSyntax?, genericWhereClause: GenericWhereClauseSyntax?, members: MemberDeclBlockSyntax) -> ClassDeclSyntax {
     let layout: [RawSyntax?] = [
       attributes?.raw,
       modifiers?.raw,
-      classKeyword.raw,
+      classOrActorKeyword.raw,
       identifier.raw,
       genericParameterClause?.raw,
       inheritanceClause?.raw,

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -1295,7 +1295,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
     case attributes
     case modifiers
-    case classKeyword
+    case classOrActorKeyword
     case identifier
     case genericParameterClause
     case inheritanceClause
@@ -1406,24 +1406,24 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ClassDeclSyntax(newData)
   }
 
-  public var classKeyword: TokenSyntax {
+  public var classOrActorKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.classKeyword,
+      let childData = data.child(at: Cursor.classOrActorKeyword,
                                  parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
-      self = withClassKeyword(value)
+      self = withClassOrActorKeyword(value)
     }
   }
 
-  /// Returns a copy of the receiver with its `classKeyword` replaced.
-  /// - param newChild: The new `classKeyword` to replace the node's
-  ///                   current `classKeyword`, if present.
-  public func withClassKeyword(
+  /// Returns a copy of the receiver with its `classOrActorKeyword` replaced.
+  /// - param newChild: The new `classOrActorKeyword` to replace the node's
+  ///                   current `classOrActorKeyword`, if present.
+  public func withClassOrActorKeyword(
     _ newChild: TokenSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.classKeyword)
-    let newData = data.replacingChild(raw, at: Cursor.classKeyword)
+    let newData = data.replacingChild(raw, at: Cursor.classOrActorKeyword)
     return ClassDeclSyntax(newData)
   }
 
@@ -1614,7 +1614,7 @@ extension ClassDeclSyntax: CustomReflectable {
     return Mirror(self, children: [
       "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "classKeyword": Syntax(classKeyword).asProtocol(SyntaxProtocol.self),
+      "classOrActorKeyword": Syntax(classOrActorKeyword).asProtocol(SyntaxProtocol.self),
       "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
       "genericParameterClause": genericParameterClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "inheritanceClause": inheritanceClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,


### PR DESCRIPTION
This patch updates swift-syntax to accept actors in the place of the
class keyword.

Updates made by running: ./swift/utils/build-script --swiftsyntax --release

I'm not sure if I did this right, so let me know if something looks out of place.
It corresponds with the changes made in apple/swift fc41826da96894fa2e4851a2c905b838a90a8cbc.