### PR TITLE
Pass length of source file to C parsing actions

### DIFF
--- a/Sources/SwiftSyntax/SyntaxParser.swift
+++ b/Sources/SwiftSyntax/SyntaxParser.swift
@@ -192,9 +192,11 @@ public enum SyntaxParser {
       swiftparse_parser_set_diagnostic_handler(c_parser, diagHandler)
     }
 
-    let c_top = swiftparse_parse_string(c_parser, source)
+    let c_top = source.withCString { buf in
+      swiftparse_parse_string(c_parser, buf, source.utf8.count)
+    }
 
-  // Get ownership back from the C parser.
+    // Get ownership back from the C parser.
     return RawSyntax.moveFromOpaque(c_top)!
   }
 }

--- a/Tests/SwiftSyntaxTest/SyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTests.swift
@@ -151,4 +151,10 @@ public class SyntaxTests: XCTestCase {
     let sourceNsString = "var 🎉 = 2" as NSString
     _ = try? SyntaxParser.parse(source: sourceNsString as String)
   }
+
+  public func testParseFileWithNullCharacter() throws {
+    let source = "var x = 1\0\nvar y = 2"
+    let tree = try SyntaxParser.parse(source: source)
+    XCTAssertEqual(tree.description, source)
+  }
 }


### PR DESCRIPTION
Previously, the string was implicitly terminated by the first null character. But a source file might contain a null character which shouldn't terminate it.