### PR TITLE
Allow retrieval of syntax/token kind and isPresent flag by the parser

### DIFF
--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -769,6 +769,16 @@ struct RawSyntaxBase {
     }
   }
 
+  /// Returns the `TokenKind` for a token node.
+  /// - Returns: nil if called on a layout node.
+  fileprivate func formRawTokenKind(extraPtr: DataElementPtr) -> RawTokenKind? {
+    switch data {
+    case .token(let data):
+      return RawTokenKind.fromRawValue(data.tokenKind)
+    case .layout(_): return nil
+    }
+  }
+
   /// Returns the leading `Trivia` length for a token node.
   /// - Returns: .zero if called on a layout node.
   fileprivate func getTokenLeadingTriviaLength(
@@ -1010,6 +1020,12 @@ final class RawSyntax: ManagedBuffer<RawSyntaxBase, RawSyntaxDataElement> {
   func formTokenKind() -> TokenKind? {
     return withUnsafeMutablePointers {
       $0.pointee.formTokenKind(extraPtr: $1)
+    }
+  }
+
+  func formRawTokenKind() -> RawTokenKind? {
+    return withUnsafeMutablePointers {
+      $0.pointee.formRawTokenKind(extraPtr: $1)
     }
   }
 

--- a/Sources/SwiftSyntax/SyntaxParser.swift
+++ b/Sources/SwiftSyntax/SyntaxParser.swift
@@ -140,7 +140,19 @@ public enum SyntaxParser {
       let bits = Unmanaged.passRetained(node)
       return bits.toOpaque()
     }
-    swiftparse_parser_set_node_handler(c_parser, nodeHandler);
+    let getSyntaxKind = { (cnode: CClientNode?) -> CSyntaxKind in
+      precondition(cnode != nil)
+      return RawSyntax.getFromOpaque(cnode)!.kind.rawValue
+    }
+    let getTokenKind = { (cnode: CClientNode?) -> CTokenKind in
+      precondition(cnode != nil)
+      return RawSyntax.getFromOpaque(cnode)!.formRawTokenKind()!.rawValue
+    }
+    let isPresent = { (cnode: CClientNode?) -> Bool in
+      precondition(cnode != nil)
+      return RawSyntax.getFromOpaque(cnode)!.isPresent
+    }
+    swiftparse_parser_set_required_callbacks(c_parser, nodeHandler, getSyntaxKind, getTokenKind, isPresent);
 
     if let parseTransition = parseTransition {
       var parseLookup = IncrementalParseLookup(transition: parseTransition)


### PR DESCRIPTION
This frees the parser from keeping track of these flags itself, providing further opportunities for optimisations.

Accompanies https://github.com/apple/swift/pull/36382