### PR TITLE
Add precondition that a token’s range returned by the Parser is in the source file

### DIFF
--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -155,10 +155,14 @@ fileprivate struct TokenData {
     if hasCustomText {
       // Copy the full token text, including trivia.
       let startOffset = Int(data.range.offset)
-      var charPtr = UnsafeMutableRawPointer(curPtr).assumingMemoryBound(to: UInt8.self)
+      let length = Int(data.range.length)
       let utf8 = source.utf8
+      precondition(startOffset <= utf8.count)
+      precondition(startOffset + length <= utf8.count)
       let begin = utf8.index(utf8.startIndex, offsetBy: startOffset)
-      let end = utf8.index(begin, offsetBy: Int(data.range.length))
+      let end = utf8.index(begin, offsetBy: length)
+
+      var charPtr = UnsafeMutableRawPointer(curPtr).assumingMemoryBound(to: UInt8.self)
       for ch in utf8[begin..<end] {
         charPtr.pointee = ch
         charPtr = charPtr.successor()


### PR DESCRIPTION
We have been hitting crashes in
```swift
let begin = utf8.index(utf8.startIndex, offsetBy: startOffset)
```
presumably because `startOffset` is outside of the `UTF8View`’s bounds. I still can’t explain how this happens.

To further narrow down the issue, I propose we add preconditions that validate the start and end location of the range. This way, we will be crashing in our own code, hopefully giving us more insight into why the crash is happening.

Whenever these preconditions are violated, we should already be crashing today.