### PR TITLE
[build] Invoke lit.py with python3

### DIFF
--- a/build-script.py
+++ b/build-script.py
@@ -471,7 +471,7 @@ def find_lit_test_helper_exec(toolchain, build_dir, release):
 def get_lit_exec_invocation():
     if 'SWIFT_SYNTAX_LIT_TESTS_USE_PYTHON_DEFAULT' in os.environ:
         return [LIT_EXEC]
-    else
+    else:
         return ["python3", LIT_EXEC]
 
 

--- a/build-script.py
+++ b/build-script.py
@@ -468,6 +468,13 @@ def find_lit_test_helper_exec(toolchain, build_dir, release):
     return os.path.join(bin_dir.strip(), "lit-test-helper")
 
 
+def get_lit_exec_invocation():
+    if 'SWIFT_SYNTAX_LIT_TESTS_USE_PYTHON_DEFAULT' in os.environ:
+        return [LIT_EXEC]
+    else
+        return ["python3", LIT_EXEC]
+
+
 def run_lit_tests(toolchain, build_dir, release, filecheck_exec, verbose):
     print("** Running lit-based tests **")
 
@@ -478,7 +485,7 @@ def run_lit_tests(toolchain, build_dir, release, filecheck_exec, verbose):
         toolchain=toolchain, build_dir=build_dir, release=release
     )
 
-    lit_call = [LIT_EXEC]
+    lit_call = get_lit_exec_invocation()
     lit_call.append(os.path.join(PACKAGE_DIR, "lit_tests"))
 
     if filecheck_exec:


### PR DESCRIPTION
Also provide an environment variable to allow to launch `lit.py`
directly.

LLVM is transitioning its script infrastructure to python3 and we may
run into issues if we continue using the system-default python2 on some
platforms.

Addresses rdar://75886813