### PR TITLE
build: use Foundation instead of C for `getenv`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,12 +3,6 @@
 import PackageDescription
 import Foundation
 
-#if canImport(Glibc)
-import Glibc
-#else
-import Darwin.C
-#endif
-
 let package = Package(
   name: "SwiftSyntax",
   targets: [
@@ -26,7 +20,7 @@ let swiftSyntaxTarget: PackageDescription.Target
 
 /// If we are in a controlled CI environment, we can use internal compiler flags
 /// to speed up the build or improve it.
-if getenv("SWIFT_BUILD_SCRIPT_ENVIRONMENT") != nil {
+if ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] != nil {
   let groupFile = URL(fileURLWithPath: #file)
     .deletingLastPathComponent()
     .appendingPathComponent("utils")
@@ -51,7 +45,7 @@ let libraryType: Product.Library.LibraryType
 
 /// When we're in a build-script environment, we want to build a dylib instead
 /// of a static library since we install the dylib into the toolchain.
-if getenv("SWIFT_BUILD_SCRIPT_ENVIRONMENT") != nil {
+if ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] != nil {
   libraryType = .dynamic
 } else {
   libraryType = .static


### PR DESCRIPTION
`getenv` is different across different platforms.  Use Foundation to
abstract over the platform differences.

This cherry-picks the build changes from main to the 5.4 release to enable building on Windows.