### PR TITLE
[build] invoke lit with python3 unconditionally

### DIFF
--- a/build-script.py
+++ b/build-script.py
@@ -468,13 +468,6 @@ def find_lit_test_helper_exec(toolchain, build_dir, release):
     return os.path.join(bin_dir.strip(), "lit-test-helper")
 
 
-def get_lit_exec_invocation():
-    if 'SWIFT_SYNTAX_LIT_TESTS_USE_PYTHON_DEFAULT' in os.environ:
-        return [LIT_EXEC]
-    else:
-        return ["python3", LIT_EXEC]
-
-
 def run_lit_tests(toolchain, build_dir, release, filecheck_exec, verbose):
     print("** Running lit-based tests **")
 
@@ -485,7 +478,7 @@ def run_lit_tests(toolchain, build_dir, release, filecheck_exec, verbose):
         toolchain=toolchain, build_dir=build_dir, release=release
     )
 
-    lit_call = get_lit_exec_invocation()
+    lit_call = ["python3", LIT_EXEC]
     lit_call.append(os.path.join(PACKAGE_DIR, "lit_tests"))
 
     if filecheck_exec:


### PR DESCRIPTION
The mechanism to revert to the old mechanism added in #272 was only
introduced for an abudance of caution.