### PR TITLE
RFC: Remove lib_InternalSwiftSyntaxParser as a link-time dependency

### DIFF
--- a/Sources/SwiftSyntax/DLHandle.swift
+++ b/Sources/SwiftSyntax/DLHandle.swift
@@ -1,0 +1,136 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright (c) 2019 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+ */
+
+// Note: this is adapted from TSCUtility.DLHandle, with minor modifications to its imports.
+
+#if canImport(Glibc)
+@_implementationOnly import Glibc
+#elseif os(Windows)
+@_implementationOnly import CRT
+@_implementationOnly import WinSDK
+#else
+@_implementationOnly import Darwin.C
+#endif
+
+import protocol Foundation.CustomNSError
+import var Foundation.NSLocalizedDescriptionKey
+
+public final class DLHandle {
+  #if os(Windows)
+  typealias Handle = HMODULE
+  #else
+  typealias Handle = UnsafeMutableRawPointer
+  #endif
+  var rawValue: Handle? = nil
+
+  init(rawValue: Handle) {
+    self.rawValue = rawValue
+  }
+
+  deinit {
+    precondition(rawValue == nil, "DLHandle must be closed or explicitly leaked before destroying")
+  }
+
+  public func close() throws {
+    if let handle = rawValue {
+      #if os(Windows)
+      guard FreeLibrary(handle) else {
+        throw DLError.close("Failed to FreeLibrary: \(GetLastError())")
+      }
+      #else
+      guard dlclose(handle) == 0 else {
+        throw DLError.close(dlerror() ?? "unknown error")
+      }
+      #endif
+    }
+    rawValue = nil
+  }
+
+  public func leak() {
+    rawValue = nil
+  }
+}
+
+public struct DLOpenFlags: RawRepresentable, OptionSet {
+
+  #if !os(Windows)
+  public static let lazy: DLOpenFlags = DLOpenFlags(rawValue: RTLD_LAZY)
+  public static let now: DLOpenFlags = DLOpenFlags(rawValue: RTLD_NOW)
+  public static let local: DLOpenFlags = DLOpenFlags(rawValue: RTLD_LOCAL)
+  public static let global: DLOpenFlags = DLOpenFlags(rawValue: RTLD_GLOBAL)
+
+  // Platform-specific flags.
+  #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+  public static let first: DLOpenFlags = DLOpenFlags(rawValue: RTLD_FIRST)
+  public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: 0)
+  #else
+  public static let first: DLOpenFlags = DLOpenFlags(rawValue: 0)
+  #if !os(Android)
+  public static let deepBind: DLOpenFlags = DLOpenFlags(rawValue: RTLD_DEEPBIND)
+  #endif
+  #endif
+  #endif
+
+  public var rawValue: Int32
+
+  public init(rawValue: Int32) {
+    self.rawValue = rawValue
+  }
+}
+
+public enum DLError: Error {
+  case `open`(String)
+  case close(String)
+}
+
+extension DLError: CustomNSError {
+  public var errorUserInfo: [String : Any] {
+    return [NSLocalizedDescriptionKey: "\(self)"]
+  }
+}
+
+public func dlopen(_ path: String?, mode: DLOpenFlags) throws -> DLHandle {
+  #if os(Windows)
+  guard let handle = path?.withCString(encodedAs: UTF16.self, LoadLibraryW) else {
+    throw DLError.open("LoadLibraryW failed: \(GetLastError())")
+  }
+  #else
+  guard let handle = dlopen(path, mode.rawValue) else {
+    throw DLError.open(dlerror() ?? "unknown error")
+  }
+  #endif
+  return DLHandle(rawValue: handle)
+}
+
+public func dlsym<T>(_ handle: DLHandle, symbol: String) -> T? {
+  #if os(Windows)
+  guard let ptr = GetProcAddress(handle.rawValue!, symbol) else {
+    return nil
+  }
+  #else
+  guard let ptr = dlsym(handle.rawValue!, symbol) else {
+    return nil
+  }
+  #endif
+  return unsafeBitCast(ptr, to: T.self)
+}
+
+public func dlclose(_ handle: DLHandle) throws {
+  try handle.close()
+}
+
+#if !os(Windows)
+public func dlerror() -> String? {
+  if let err: UnsafeMutablePointer<Int8> = dlerror() {
+    return String(cString: err)
+  }
+  return nil
+}
+#endif

--- a/Sources/SwiftSyntax/InternalSwiftSyntaxParser.swift
+++ b/Sources/SwiftSyntax/InternalSwiftSyntaxParser.swift
@@ -1,0 +1,66 @@
+//===----- InternalSwiftSyntaxParser.swift - Parser Library Interface -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_implementationOnly import _CSwiftSyntax
+
+/// Wrapper for lib_InternalSwiftSyntaxParser.
+internal final class InternalSwiftSyntaxParser {
+  /// The handle to the dylib.
+  private let dylib: DLHandle
+
+  /// libSwiftScan API functions.
+  let api: swiftparse_functions_t;
+
+  private init() throws {
+    #if os(Windows)
+    self.dylib = try dlopen("@rpath/lib_InternalSwiftSyntaxParser.dll", mode: [])
+    #elseif os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    self.dylib = try dlopen("@rpath/lib_InternalSwiftSyntaxParser.dylib", mode: [.lazy, .local, .first])
+    #else
+    self.dylib = try dlopen("@rpath/lib_InternalSwiftSyntaxParser.so", mode: [.lazy, .local, .first])
+    #endif
+    self.api = try swiftparse_functions_t(self.dylib)
+  }
+
+  static let shared = Result(catching: { try InternalSwiftSyntaxParser() })
+
+  deinit {
+    // FIXME: is it safe to dlclose() the library? If so, do that here.
+    // For now, let the handle leak.
+    dylib.leak()
+  }
+}
+
+private extension swiftparse_functions_t {
+  init(_ swiftparse: DLHandle) throws {
+    func loadRequired<T>(_ symbol: String) throws -> T {
+      guard let sym: T = dlsym(swiftparse, symbol: symbol) else {
+        throw ParserError.parserCompatibilityCheckFailed
+      }
+      return sym
+    }
+    self.init(swiftparse_parser_create: try loadRequired("swiftparse_parser_create"),
+              swiftparse_parser_dispose: try loadRequired("swiftparse_parser_dispose"),
+              swiftparse_parser_set_node_handler: try loadRequired("swiftparse_parser_set_node_handler"),
+              swiftparse_parser_set_node_lookup: try loadRequired("swiftparse_parser_set_node_lookup"),
+              swiftparse_parse_string: try loadRequired("swiftparse_parse_string"),
+              swiftparse_syntax_structure_versioning_identifier: try loadRequired("swiftparse_syntax_structure_versioning_identifier"),
+              swiftparse_parser_set_diagnostic_handler: try loadRequired("swiftparse_parser_set_diagnostic_handler"),
+              swiftparse_diagnostic_get_message: try loadRequired("swiftparse_diagnostic_get_message"),
+              swiftparse_diagnostic_get_source_loc: try loadRequired("swiftparse_diagnostic_get_source_loc"),
+              swiftparse_diagnostic_get_fixit_count: try loadRequired("swiftparse_diagnostic_get_fixit_count"),
+              swiftparse_diagnostic_get_fixit: try loadRequired("swiftparse_diagnostic_get_fixit"),
+              swiftparse_diagnostic_get_range_count: try loadRequired("swiftparse_diagnostic_get_range_count"),
+              swiftparse_diagnostic_get_range: try loadRequired("swiftparse_diagnostic_get_range"),
+              swiftparse_diagnostic_get_severity: try loadRequired("swiftparse_diagnostic_get_severity"))
+  }
+}

--- a/Sources/SwiftSyntax/Misc.swift.gyb
+++ b/Sources/SwiftSyntax/Misc.swift.gyb
@@ -19,7 +19,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _InternalSwiftSyntaxParser
+@_implementationOnly import _CSwiftSyntax
 
 extension SyntaxNode {
   public var isUnknown: Bool { return raw.kind.isUnknown }
@@ -65,8 +65,8 @@ extension Syntax {
 }
 
 extension SyntaxParser {
-  static func verifyNodeDeclarationHash() -> Bool {
-    return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
+  static func verifyNodeDeclarationHash(parserLibrary: InternalSwiftSyntaxParser) -> Bool {
+    return String(cString: parserLibrary.api.swiftparse_syntax_structure_versioning_identifier()!) ==
       "${calculate_node_hash()}"
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import _InternalSwiftSyntaxParser
+@_implementationOnly import _CSwiftSyntax
 
 extension SyntaxNode {
   public var isUnknown: Bool { return raw.kind.isUnknown }
@@ -1958,8 +1958,8 @@ extension Syntax {
 }
 
 extension SyntaxParser {
-  static func verifyNodeDeclarationHash() -> Bool {
-    return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
+  static func verifyNodeDeclarationHash(parserLibrary: InternalSwiftSyntaxParser) -> Bool {
+    return String(cString: parserLibrary.api.swiftparse_syntax_structure_versioning_identifier()!) ==
       "a66df9d44b9128aee3da17e9b0d2aed27ce7ec61"
   }
 }

--- a/Sources/_CSwiftSyntax/include/SwiftSyntaxParser.h
+++ b/Sources/_CSwiftSyntax/include/SwiftSyntaxParser.h
@@ -1,0 +1,247 @@
+//===--- SwiftSyntaxParser.h - C API for Swift Syntax Parsing -----*- C -*-===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2019 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+//
+// This C API is primarily intended to serve as the Swift parsing component
+// of SwiftSyntax (https://github.com/apple/swift-syntax).
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SWIFT_C_SYNTAX_PARSER_H
+#define SWIFT_C_SYNTAX_PARSER_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define SWIFTPARSE_VERSION_MAJOR 0
+#define SWIFTPARSE_VERSION_MINOR 1
+
+#ifndef __has_feature
+# define __has_feature(x) 0
+#endif
+
+#if !__has_feature(blocks)
+# error -fblocks is required
+#endif
+
+
+//=== Syntax Data Types ---------------------------------------------------===//
+
+/// Offset+length in UTF8 bytes.
+typedef struct {
+  uint32_t offset;
+  uint32_t length;
+} swiftparse_range_t;
+
+typedef uint8_t swiftparse_trivia_kind_t;
+typedef uint8_t swiftparse_token_kind_t;
+typedef uint16_t swiftparse_syntax_kind_t;
+
+/// This is for the client to provide an opaque pointer that the parser will
+/// associate with a syntax node.
+typedef void *swiftparse_client_node_t;
+
+typedef struct {
+  /// The length in source this trivia piece occupies, in UTF8 bytes.
+  uint32_t length;
+  swiftparse_trivia_kind_t kind;
+} swiftparse_trivia_piece_t;
+
+typedef struct {
+  const swiftparse_trivia_piece_t *leading_trivia;
+  const swiftparse_trivia_piece_t *trailing_trivia;
+  uint16_t leading_trivia_count;
+  uint16_t trailing_trivia_count;
+  swiftparse_token_kind_t kind;
+  /// Represents the range for the node, including trivia.
+  swiftparse_range_t range;
+} swiftparse_token_data_t;
+
+typedef struct {
+  const swiftparse_client_node_t *nodes;
+  uint32_t nodes_count;
+} swiftparse_layout_data_t;
+
+typedef struct {
+  union {
+    swiftparse_token_data_t token_data;
+    swiftparse_layout_data_t layout_data;
+  };
+  /// The syntax kind. A value of '0' means this is a token node.
+  swiftparse_syntax_kind_t kind;
+  bool present;
+} swiftparse_syntax_node_t;
+
+/// Container of the configuration state for parsing.
+///
+/// It keeps track of the callback blocks for parsing. Any other additional
+/// configuration option (like parsing options) could be set by a adding a
+/// function that accepts a \c swiftparse_parser_t object and modifies its
+/// state.
+typedef void *swiftparse_parser_t;
+
+/// Invoked by the parser when a syntax node is parsed. The client should
+/// return a pointer to associate with that particular node.
+typedef swiftparse_client_node_t
+    (^swiftparse_node_handler_t)(const swiftparse_syntax_node_t *);
+
+typedef struct {
+  /// Length of the source region in UTF8 bytes that the parser should skip.
+  /// If it is set to 0 it indicates that the parser should continue parsing
+  /// and the \c node object is ignored.
+  size_t length;
+  /// Node to associate for the skipped source region. It will be ignored if
+  /// \c length is 0.
+  swiftparse_client_node_t node;
+} swiftparse_lookup_result_t;
+
+/// Invoked by the parser at certain points to query whether a source region
+/// should be skipped. See \c swiftparse_lookup_result_t.
+typedef swiftparse_lookup_result_t
+    (^swiftparse_node_lookup_t)(size_t offset, swiftparse_syntax_kind_t);
+
+typedef struct {
+  /// Represents the range for the fixit.
+  swiftparse_range_t range;
+  /// Represent the text for replacement.
+  const char* text;
+} swiftparse_diagnostic_fixit_t;
+
+typedef enum {
+  SWIFTPARSER_DIAGNOSTIC_SEVERITY_ERROR = 0,
+  SWIFTPARSER_DIAGNOSTIC_SEVERITY_WARNING = 1,
+  SWIFTPARSER_DIAGNOSTIC_SEVERITY_NOTE = 2,
+} swiftparser_diagnostic_severity_t;
+
+/// This is for the client to ask further information about a diagnostic that is
+/// associated with the pointer.
+/// This pointer is only valid to access from within the
+/// swiftparse_diagnostic_handler_t block
+typedef const void* swiftparser_diagnostic_t;
+
+/// Invoked by the parser when a diagnostic is emitted.
+typedef void(^swiftparse_diagnostic_handler_t)(swiftparser_diagnostic_t);
+
+//=== Parser Functions ----------------------------------------------------===//
+
+typedef struct {
+  swiftparse_parser_t (*swiftparse_parser_create)(void);
+
+  void (*swiftparse_parser_dispose)(swiftparse_parser_t);
+
+  /// Set the \c swiftparse_node_handler_t block to be used by the parser.
+  ///
+  /// It is required to set a \c swiftparse_node_handler_t block before any calls
+  /// to \c swiftparse_parse_string. \c swiftparse_parser_set_node_handler can be
+  /// called multiple times to change the block before subsequent parses.
+  void (*swiftparse_parser_set_node_handler)(swiftparse_parser_t,
+                                             swiftparse_node_handler_t);
+
+  /// Set the \c swiftparse_node_lookup_t block to be used by the parser.
+  ///
+  /// It is not required to set a \c swiftparse_node_lookup_t block before calling
+  /// \c swiftparse_parse_string. Not setting a \c swiftparse_node_lookup_t block
+  /// has same semantics as never skipping any source regions.
+  /// \c swiftparse_parser_set_node_lookup can be called multiple times to change
+  /// the block before subsequent parses.
+  void (*swiftparse_parser_set_node_lookup)(swiftparse_parser_t,
+                                            swiftparse_node_lookup_t);
+
+  /// Parse the provided \p source and invoke the callback that was set via
+  /// \c swiftparse_parser_set_node_handler as each syntax node is parsed.
+  ///
+  /// Syntax nodes are provided in a depth-first, source order. For example,
+  /// token nodes will be provided ahead of the syntax node whose layout they are
+  /// a part of. The memory that \c swiftparse_syntax_node_t points to is only
+  /// valid to access for the duration of the \c swiftparse_node_handler_t block
+  /// execution, the client should copy the data if it wants to persist it beyond
+  /// the duration of the block.
+  ///
+  /// The client provides \c swiftparse_client_node_t pointers to associate with
+  /// each syntax node and the parser will pass back these pointers as part of the
+  /// \c swiftparse_layout_data_t of the syntax node that they are a part of.
+  /// \c swiftparse_client_node_t pointers are completely opaque to the parser,
+  /// it doesn't try to interpret them in any way. There is no requirement that
+  /// each node gets a unique \c swiftparse_client_node_t, it is up to the client
+  /// to reuse \c swiftparse_client_node_t pointers as it deems necessary.
+  ///
+  /// If the \c swiftparse_client_node_t pointers represent managed memory, the
+  /// semantics of interacting with the parser should be considered as follows:
+  ///
+  /// * \c swiftparse_node_handler_t and \c swiftparse_node_lookup_t return a
+  /// \c swiftparse_client_node_t and transfer ownership of the pointer to the
+  /// parser.
+  ///
+  /// * The array of \c swiftparse_client_node_t pointers in
+  /// \c swiftparse_layout_data_t should be considered as the parser transferring
+  /// ownership of those pointers back to the client.
+  ///
+  /// * The \c swiftparse_client_node_t returned by \c swiftparse_parse_string
+  /// should be considered as the parser transferring back ownership of the
+  /// pointer.
+  ///
+  /// The parser guarantees that any \c swiftparse_client_node_t, given to the
+  /// parser by \c swiftparse_node_handler_t or \c swiftparse_node_lookup_t, will
+  /// be returned back to the client, either via \c swiftparse_layout_data_t or
+  /// via the return value of \c swiftparse_parse_string.
+  ///
+  /// \param source a null-terminated UTF8 string buffer.
+  /// \param len The length of the source string. This allows \p source to contain
+  ///            intermediate null characters.
+  swiftparse_client_node_t (*swiftparse_parse_string)(swiftparse_parser_t,
+                                                      const char *source,
+                                                      size_t len);
+
+  /// Returns a constant string pointer for verification purposes.
+  ///
+  /// Working as a hash value, the constant string is calculated during compilation
+  /// time from syntax node declarations.
+  ///
+  /// During runtime, SwiftSyntax client can compare its own version of the hash
+  /// value with the result of the function call. Mismatch indicates the parser
+  /// library isn't compatible with the client side, e.g. added/removed node
+  /// declarations, etc.
+  const char* (*swiftparse_syntax_structure_versioning_identifier)(void);
+
+  /// Set the \c swiftparse_diagnostic_handler_t block to be used by the parser.
+  ///
+  /// It isn't required to set a \c swiftparse_diagnostic_handler_t block.
+  void (*swiftparse_parser_set_diagnostic_handler)(swiftparse_parser_t,
+                                                swiftparse_diagnostic_handler_t);
+
+  /// Get the message of a swiftparser_diagnostic_t
+  const char* (*swiftparse_diagnostic_get_message)(swiftparser_diagnostic_t);
+
+  /// Get the source location in byte offset to where the diagnostic is issued
+  /// in the source buffer.
+  unsigned (*swiftparse_diagnostic_get_source_loc)(swiftparser_diagnostic_t diag);
+
+  /// Get the number of fixits of a swiftparser_diagnostic_t
+  unsigned (*swiftparse_diagnostic_get_fixit_count)(swiftparser_diagnostic_t);
+
+  /// Get the fixit at the specified index of a swiftparser_diagnostic_t
+  swiftparse_diagnostic_fixit_t (*swiftparse_diagnostic_get_fixit)(swiftparser_diagnostic_t, unsigned);
+
+  /// Get the number of highlight ranges of a swiftparser_diagnostic_t
+  unsigned (*swiftparse_diagnostic_get_range_count)(swiftparser_diagnostic_t);
+
+  /// Get the highlight range at the specified index of a swiftparser_diagnostic_t
+  swiftparse_range_t (*swiftparse_diagnostic_get_range)(swiftparser_diagnostic_t,
+                                                        unsigned);
+
+  /// Get the severity of a swiftparser_diagnostic_t
+  swiftparser_diagnostic_severity_t (*swiftparse_diagnostic_get_severity)(swiftparser_diagnostic_t diag);
+} swiftparse_functions_t;
+
+
+
+#endif

--- a/utils/group.json
+++ b/utils/group.json
@@ -23,6 +23,7 @@
     "SyntaxTypeNodes.swift",
   ],
   "Utils": [
+    "DLHandle.swift",
     "SyntaxAnyVisitor.swift",
     "SyntaxBuilders.swift",
     "SyntaxClassifier.swift",
@@ -48,6 +49,7 @@
   ],
   "Parse": [
     "IncrementalParseTransition.swift",
+    "InternalSwiftSyntaxParser.swift",
     "SyntaxParser.swift",
   ],
   "Internal": [


### PR DESCRIPTION
I'd appreciate any thoughts & feedback anyone has on this!

This PR removes the link-time dependency on a compatible lib_InternalSwiftSyntaxParser. Instead, it uses dlopen & dlsym at runtime, following the approach SwiftDriver uses to load the dependency scanning library. The motivation here is to be able to add a SwiftSyntax dependency to SwiftPM to implement SE-301's package manifest editing commands. Per the discussion [here](https://github.com/apple/swift-package-manager/pull/3034), the SwiftPM team wants to be able to build the package syntax support library (which uses SwiftSyntax) when there's no compatible parser library available, so that breaking changes can be detected before testing on CI. This change should make that possible, and a SwiftPM built in a local dev environment without a compatible library will report a library mismatch error.

The main downside of this approach is that it requires keeping the parser library's header in-sync with the one in the main swift repository, and I had to copy over a bit of TSCUtility code for cross-platform dlopen.