### PR TITLE
[Distributed] gyb generate, after added 'distributed' decl modifier

### DIFF
--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -1960,6 +1960,6 @@ extension Syntax {
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "4f85168b3860f575ce60ac0d223fc89da37014df"
+      "a66df9d44b9128aee3da17e9b0d2aed27ce7ec61"
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
@@ -1917,9 +1917,20 @@ extension ClosureParamSyntax {
 
 public struct ClosureSignatureSyntaxBuilder {
   private var layout =
-    Array<RawSyntax?>(repeating: nil, count: 6)
+    Array<RawSyntax?>(repeating: nil, count: 7)
 
   internal init() {}
+
+  public mutating func addAttribute(_ elt: Syntax) {
+    let idx = ClosureSignatureSyntax.Cursor.attributes.rawValue
+    if let list = layout[idx] {
+      layout[idx] = list.appending(elt.raw)
+    } else {
+      layout[idx] = RawSyntax.create(kind: SyntaxKind.attributeList,
+        layout: [elt.raw], length: elt.raw.totalLength,
+        presence: SourcePresence.present)
+    }
+  }
 
   public mutating func useCapture(_ node: ClosureCaptureSignatureSyntax) {
     let idx = ClosureSignatureSyntax.Cursor.capture.rawValue
@@ -1952,8 +1963,8 @@ public struct ClosureSignatureSyntaxBuilder {
   }
 
   internal mutating func buildData() -> SyntaxData {
-    if (layout[5] == nil) {
-      layout[5] = RawSyntax.missingToken(TokenKind.inKeyword)
+    if (layout[6] == nil) {
+      layout[6] = RawSyntax.missingToken(TokenKind.inKeyword)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .closureSignature,

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxClassification.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxClassification.swift
@@ -69,7 +69,7 @@ extension SyntaxClassification {
         return (.keyword, false)
       case (.arrowExpr, 0):
         return (.keyword, false)
-      case (.closureSignature, 2):
+      case (.closureSignature, 3):
         return (.keyword, false)
       case (.expressionSegment, 2):
         return (.stringInterpolationAnchor, true)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -996,8 +996,9 @@ public enum SyntaxFactory {
     ], length: .zero, presence: .present))
     return ClosureParamListSyntax(data)
   }
-  public static func makeClosureSignature(capture: ClosureCaptureSignatureSyntax?, input: Syntax?, asyncKeyword: TokenSyntax?, throwsTok: TokenSyntax?, output: ReturnClauseSyntax?, inTok: TokenSyntax) -> ClosureSignatureSyntax {
+  public static func makeClosureSignature(attributes: AttributeListSyntax?, capture: ClosureCaptureSignatureSyntax?, input: Syntax?, asyncKeyword: TokenSyntax?, throwsTok: TokenSyntax?, output: ReturnClauseSyntax?, inTok: TokenSyntax) -> ClosureSignatureSyntax {
     let layout: [RawSyntax?] = [
+      attributes?.raw,
       capture?.raw,
       input?.raw,
       asyncKeyword?.raw,
@@ -1014,6 +1015,7 @@ public enum SyntaxFactory {
   public static func makeBlankClosureSignature() -> ClosureSignatureSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .closureSignature,
       layout: [
+      nil,
       nil,
       nil,
       nil,

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/Buildables.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/Buildables.swift
@@ -1878,6 +1878,7 @@ public struct ClosureParamList: SyntaxBuildable {
 }
 
 public struct ClosureSignature: SyntaxBuildable {
+  let attributes: AttributeList?
   let capture: ClosureCaptureSignature?
   let input: SyntaxBuildable?
   let asyncKeyword: TokenSyntax?
@@ -1886,6 +1887,7 @@ public struct ClosureSignature: SyntaxBuildable {
   let inTok: TokenSyntax
 
   public init(
+    attributes: AttributeList? = nil,
     capture: ClosureCaptureSignature? = nil,
     input: SyntaxBuildable? = nil,
     asyncKeyword: TokenSyntax? = nil,
@@ -1893,6 +1895,7 @@ public struct ClosureSignature: SyntaxBuildable {
     output: ReturnClause? = nil,
     inTok: TokenSyntax
   ) {
+    self.attributes = attributes
     self.capture = capture
     self.input = input
     self.asyncKeyword = asyncKeyword
@@ -1903,6 +1906,7 @@ public struct ClosureSignature: SyntaxBuildable {
   
   func buildClosureSignature(format: Format, leadingTrivia: Trivia? = nil) -> ClosureSignatureSyntax {
     let closureSignature = SyntaxFactory.makeClosureSignature(
+      attributes: attributes?.buildAttributeList(format: format),
       capture: capture?.buildClosureCaptureSignature(format: format),
       input: input?.buildSyntax(format: format),
       asyncKeyword: asyncKeyword,


### PR DESCRIPTION
This is the result of running `./build-script.py --toolchain ../build/Ninja-RelWithDebInfoAssert/swift-macosx-x86_64 --degyb-only` on a repo with https://github.com/apple/swift/pull/38020

I guess it adjusted the number of attributes... but not sure if this looks right or not?

Did I get this right or do I need to run `./utils/build-script --swiftsyntax --release` of the swift project itself?

--- 

For context, the new syntax is: `distributed func` and `distributed actor` only.