### PR TITLE
Move Token helpers to TokenSyntax extension

### DIFF
--- a/Sources/SwiftSyntaxBuilder/BooleanLiteralExprConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/BooleanLiteralExprConvenienceInitializers.swift
@@ -14,7 +14,7 @@ import SwiftSyntax
 
 extension BooleanLiteralExpr {
   public init(_ value: Bool) {
-    self.init(booleanLiteral: value ? Tokens.true : Tokens.false)
+    self.init(booleanLiteral: value ? .true : .false)
   }
 }
 

--- a/Sources/SwiftSyntaxBuilder/BuildablesConvenienceInitializers.swift.gyb
+++ b/Sources/SwiftSyntaxBuilder/BuildablesConvenienceInitializers.swift.gyb
@@ -72,9 +72,9 @@ extension ${node.syntax_kind} {
 %         end
 %       elif token and not token.text:
 %         if child.is_optional:
-%           init_parameters.append("%s: %s.map(Tokens.%s)" % (child.swift_name, child.swift_name, lowercase_first_word(token.name)))
+%           init_parameters.append("%s: %s.map(TokenSyntax.%s)" % (child.swift_name, child.swift_name, lowercase_first_word(token.name)))
 %         else:
-%           init_parameters.append("%s: Tokens.%s(%s)" % (child.swift_name, lowercase_first_word(token.name), child.swift_name))
+%           init_parameters.append("%s: TokenSyntax.%s(%s)" % (child.swift_name, lowercase_first_word(token.name), child.swift_name))
 %         end
 %       else:
 %         init_parameters.append("%s: %s" % (child.swift_name, child.swift_name))

--- a/Sources/SwiftSyntaxBuilder/StringLiteralExprConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/StringLiteralExprConvenienceInitializers.swift
@@ -18,9 +18,9 @@ extension StringLiteralExpr {
     let segment = StringSegment(content: content)
     let segments = StringLiteralSegments([segment])
 
-    self.init(openQuote: Tokens.stringQuote,
+    self.init(openQuote: .stringQuote,
               segments: segments,
-              closeQuote: Tokens.stringQuote)
+              closeQuote: .stringQuote)
   }
 }
 

--- a/Sources/SwiftSyntaxBuilder/Tokens.swift.gyb
+++ b/Sources/SwiftSyntaxBuilder/Tokens.swift.gyb
@@ -21,11 +21,11 @@
 import SwiftSyntax
 
 /// Namespace for commonly used tokens with default trivia.
-public enum Tokens {
+public extension TokenSyntax {
 % for token in SYNTAX_TOKENS:
 %   if token.is_keyword:
   /// The `${token.text.encode('utf-8').decode('unicode_escape')}` keyword
-  public static let `${lowercase_first_word(token.name)}` = SyntaxFactory.make${token.name}Keyword()
+  static let `${lowercase_first_word(token.name)}` = SyntaxFactory.make${token.name}Keyword()
 %   if token.requires_leading_space:
     .withLeadingTrivia(.spaces(1))
 %   end
@@ -34,7 +34,7 @@ public enum Tokens {
 %   end
 %   elif token.text:
   /// The `${token.text.encode('utf-8').decode('unicode_escape')}` token
-  public static let `${lowercase_first_word(token.name)}` = SyntaxFactory.make${token.name}Token()
+  static let `${lowercase_first_word(token.name)}` = SyntaxFactory.make${token.name}Token()
 %   if token.requires_leading_space:
     .withLeadingTrivia(.spaces(1))
 %   end
@@ -42,7 +42,7 @@ public enum Tokens {
     .withTrailingTrivia(.spaces(1))
 %   end
 %   else:
-  public static func `${lowercase_first_word(token.name)}`(_ text: String) -> TokenSyntax {
+  static func `${lowercase_first_word(token.name)}`(_ text: String) -> TokenSyntax {
     SyntaxFactory.make${token.name}(text)
 %   if token.requires_leading_space:
     .withLeadingTrivia(.spaces(1))

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/Buildables.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/Buildables.swift
@@ -362,9 +362,9 @@ public struct CodeBlock: SyntaxBuildable {
   let rightBrace: TokenSyntax
 
   public init(
-    leftBrace: TokenSyntax = Tokens.`leftBrace`,
+    leftBrace: TokenSyntax = TokenSyntax.`leftBrace`,
     statements: CodeBlockItemList,
-    rightBrace: TokenSyntax = Tokens.`rightBrace`
+    rightBrace: TokenSyntax = TokenSyntax.`rightBrace`
   ) {
     self.leftBrace = leftBrace
     self.statements = statements
@@ -397,7 +397,7 @@ public struct InOutExpr: ExprBuildable {
   let expression: ExprBuildable
 
   public init(
-    ampersand: TokenSyntax = Tokens.`prefixAmpersand`,
+    ampersand: TokenSyntax = TokenSyntax.`prefixAmpersand`,
     expression: ExprBuildable
   ) {
     self.ampersand = ampersand
@@ -428,7 +428,7 @@ public struct PoundColumnExpr: ExprBuildable {
   let poundColumn: TokenSyntax
 
   public init(
-    poundColumn: TokenSyntax = Tokens.`poundColumn`
+    poundColumn: TokenSyntax = TokenSyntax.`poundColumn`
   ) {
     self.poundColumn = poundColumn
   }
@@ -570,7 +570,7 @@ public struct TryExpr: ExprBuildable {
   let expression: ExprBuildable
 
   public init(
-    tryKeyword: TokenSyntax = Tokens.`try`,
+    tryKeyword: TokenSyntax = TokenSyntax.`try`,
     questionOrExclamationMark: TokenSyntax? = nil,
     expression: ExprBuildable
   ) {
@@ -638,7 +638,7 @@ public struct DeclNameArgument: SyntaxBuildable {
 
   public init(
     name: TokenSyntax,
-    colon: TokenSyntax = Tokens.`colon`
+    colon: TokenSyntax = TokenSyntax.`colon`
   ) {
     self.name = name
     self.colon = colon
@@ -698,9 +698,9 @@ public struct DeclNameArguments: SyntaxBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     arguments: DeclNameArgumentList,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.leftParen = leftParen
     self.arguments = arguments
@@ -764,7 +764,7 @@ public struct SuperRefExpr: ExprBuildable {
   let superKeyword: TokenSyntax
 
   public init(
-    superKeyword: TokenSyntax = Tokens.`super`
+    superKeyword: TokenSyntax = TokenSyntax.`super`
   ) {
     self.superKeyword = superKeyword
   }
@@ -792,7 +792,7 @@ public struct NilLiteralExpr: ExprBuildable {
   let nilKeyword: TokenSyntax
 
   public init(
-    nilKeyword: TokenSyntax = Tokens.`nil`
+    nilKeyword: TokenSyntax = TokenSyntax.`nil`
   ) {
     self.nilKeyword = nilKeyword
   }
@@ -820,7 +820,7 @@ public struct DiscardAssignmentExpr: ExprBuildable {
   let wildcard: TokenSyntax
 
   public init(
-    wildcard: TokenSyntax = Tokens.`wildcard`
+    wildcard: TokenSyntax = TokenSyntax.`wildcard`
   ) {
     self.wildcard = wildcard
   }
@@ -848,7 +848,7 @@ public struct AssignmentExpr: ExprBuildable {
   let assignToken: TokenSyntax
 
   public init(
-    assignToken: TokenSyntax = Tokens.`equal`
+    assignToken: TokenSyntax = TokenSyntax.`equal`
   ) {
     self.assignToken = assignToken
   }
@@ -934,7 +934,7 @@ public struct PoundLineExpr: ExprBuildable {
   let poundLine: TokenSyntax
 
   public init(
-    poundLine: TokenSyntax = Tokens.`poundLine`
+    poundLine: TokenSyntax = TokenSyntax.`poundLine`
   ) {
     self.poundLine = poundLine
   }
@@ -962,7 +962,7 @@ public struct PoundFileExpr: ExprBuildable {
   let poundFile: TokenSyntax
 
   public init(
-    poundFile: TokenSyntax = Tokens.`poundFile`
+    poundFile: TokenSyntax = TokenSyntax.`poundFile`
   ) {
     self.poundFile = poundFile
   }
@@ -990,7 +990,7 @@ public struct PoundFileIDExpr: ExprBuildable {
   let poundFileID: TokenSyntax
 
   public init(
-    poundFileID: TokenSyntax = Tokens.`poundFileID`
+    poundFileID: TokenSyntax = TokenSyntax.`poundFileID`
   ) {
     self.poundFileID = poundFileID
   }
@@ -1018,7 +1018,7 @@ public struct PoundFilePathExpr: ExprBuildable {
   let poundFilePath: TokenSyntax
 
   public init(
-    poundFilePath: TokenSyntax = Tokens.`poundFilePath`
+    poundFilePath: TokenSyntax = TokenSyntax.`poundFilePath`
   ) {
     self.poundFilePath = poundFilePath
   }
@@ -1046,7 +1046,7 @@ public struct PoundFunctionExpr: ExprBuildable {
   let poundFunction: TokenSyntax
 
   public init(
-    poundFunction: TokenSyntax = Tokens.`poundFunction`
+    poundFunction: TokenSyntax = TokenSyntax.`poundFunction`
   ) {
     self.poundFunction = poundFunction
   }
@@ -1074,7 +1074,7 @@ public struct PoundDsohandleExpr: ExprBuildable {
   let poundDsohandle: TokenSyntax
 
   public init(
-    poundDsohandle: TokenSyntax = Tokens.`poundDsohandle`
+    poundDsohandle: TokenSyntax = TokenSyntax.`poundDsohandle`
   ) {
     self.poundDsohandle = poundDsohandle
   }
@@ -1198,7 +1198,7 @@ public struct ArrowExpr: ExprBuildable {
   public init(
     asyncKeyword: TokenSyntax? = nil,
     throwsToken: TokenSyntax? = nil,
-    arrowToken: TokenSyntax = Tokens.`arrow`
+    arrowToken: TokenSyntax = TokenSyntax.`arrow`
   ) {
     self.asyncKeyword = asyncKeyword
     self.throwsToken = throwsToken
@@ -1260,9 +1260,9 @@ public struct TupleExpr: ExprBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     elementList: TupleExprElementList,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.leftParen = leftParen
     self.elementList = elementList
@@ -1296,9 +1296,9 @@ public struct ArrayExpr: ExprBuildable {
   let rightSquare: TokenSyntax
 
   public init(
-    leftSquare: TokenSyntax = Tokens.`leftSquareBracket`,
+    leftSquare: TokenSyntax = TokenSyntax.`leftSquareBracket`,
     elements: ArrayElementList,
-    rightSquare: TokenSyntax = Tokens.`rightSquareBracket`
+    rightSquare: TokenSyntax = TokenSyntax.`rightSquareBracket`
   ) {
     self.leftSquare = leftSquare
     self.elements = elements
@@ -1332,9 +1332,9 @@ public struct DictionaryExpr: ExprBuildable {
   let rightSquare: TokenSyntax
 
   public init(
-    leftSquare: TokenSyntax = Tokens.`leftSquareBracket`,
+    leftSquare: TokenSyntax = TokenSyntax.`leftSquareBracket`,
     content: SyntaxBuildable,
-    rightSquare: TokenSyntax = Tokens.`rightSquareBracket`
+    rightSquare: TokenSyntax = TokenSyntax.`rightSquareBracket`
   ) {
     self.leftSquare = leftSquare
     self.content = content
@@ -1442,7 +1442,7 @@ public struct DictionaryElement: SyntaxBuildable {
 
   public init(
     keyExpression: ExprBuildable,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     valueExpression: ExprBuildable,
     trailingComma: TokenSyntax? = nil
   ) {
@@ -1539,9 +1539,9 @@ public struct TernaryExpr: ExprBuildable {
 
   public init(
     conditionExpression: ExprBuildable,
-    questionMark: TokenSyntax = Tokens.`infixQuestionMark`,
+    questionMark: TokenSyntax = TokenSyntax.`infixQuestionMark`,
     firstChoice: ExprBuildable,
-    colonMark: TokenSyntax = Tokens.`colon`,
+    colonMark: TokenSyntax = TokenSyntax.`colon`,
     secondChoice: ExprBuildable
   ) {
     self.conditionExpression = conditionExpression
@@ -1619,7 +1619,7 @@ public struct IsExpr: ExprBuildable {
   let typeName: TypeBuildable
 
   public init(
-    isTok: TokenSyntax = Tokens.`is`,
+    isTok: TokenSyntax = TokenSyntax.`is`,
     typeName: TypeBuildable
   ) {
     self.isTok = isTok
@@ -1652,7 +1652,7 @@ public struct AsExpr: ExprBuildable {
   let typeName: TypeBuildable
 
   public init(
-    asTok: TokenSyntax = Tokens.`as`,
+    asTok: TokenSyntax = TokenSyntax.`as`,
     questionOrExclamationMark: TokenSyntax? = nil,
     typeName: TypeBuildable
   ) {
@@ -1788,9 +1788,9 @@ public struct ClosureCaptureSignature: SyntaxBuildable {
   let rightSquare: TokenSyntax
 
   public init(
-    leftSquare: TokenSyntax = Tokens.`leftSquareBracket`,
+    leftSquare: TokenSyntax = TokenSyntax.`leftSquareBracket`,
     items: ClosureCaptureItemList? = nil,
-    rightSquare: TokenSyntax = Tokens.`rightSquareBracket`
+    rightSquare: TokenSyntax = TokenSyntax.`rightSquareBracket`
   ) {
     self.leftSquare = leftSquare
     self.items = items
@@ -1894,7 +1894,7 @@ public struct ClosureSignature: SyntaxBuildable {
     asyncKeyword: TokenSyntax? = nil,
     throwsTok: TokenSyntax? = nil,
     output: ReturnClause? = nil,
-    inTok: TokenSyntax = Tokens.`in`
+    inTok: TokenSyntax = TokenSyntax.`in`
   ) {
     self.attributes = attributes
     self.capture = capture
@@ -1937,10 +1937,10 @@ public struct ClosureExpr: ExprBuildable {
   let rightBrace: TokenSyntax
 
   public init(
-    leftBrace: TokenSyntax = Tokens.`leftBrace`,
+    leftBrace: TokenSyntax = TokenSyntax.`leftBrace`,
     signature: ClosureSignature? = nil,
     statements: CodeBlockItemList,
-    rightBrace: TokenSyntax = Tokens.`rightBrace`
+    rightBrace: TokenSyntax = TokenSyntax.`rightBrace`
   ) {
     self.leftBrace = leftBrace
     self.signature = signature
@@ -2005,7 +2005,7 @@ public struct MultipleTrailingClosureElement: SyntaxBuildable {
 
   public init(
     label: TokenSyntax,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     closure: ClosureExpr
   ) {
     self.label = label
@@ -2120,9 +2120,9 @@ public struct SubscriptExpr: ExprBuildable {
 
   public init(
     calledExpression: ExprBuildable,
-    leftBracket: TokenSyntax = Tokens.`leftSquareBracket`,
+    leftBracket: TokenSyntax = TokenSyntax.`leftSquareBracket`,
     argumentList: TupleExprElementList,
-    rightBracket: TokenSyntax = Tokens.`rightSquareBracket`,
+    rightBracket: TokenSyntax = TokenSyntax.`rightSquareBracket`,
     trailingClosure: ClosureExpr? = nil,
     additionalTrailingClosures: MultipleTrailingClosureElementList? = nil
   ) {
@@ -2164,7 +2164,7 @@ public struct OptionalChainingExpr: ExprBuildable {
 
   public init(
     expression: ExprBuildable,
-    questionMark: TokenSyntax = Tokens.`postfixQuestionMark`
+    questionMark: TokenSyntax = TokenSyntax.`postfixQuestionMark`
   ) {
     self.expression = expression
     self.questionMark = questionMark
@@ -2196,7 +2196,7 @@ public struct ForcedValueExpr: ExprBuildable {
 
   public init(
     expression: ExprBuildable,
-    exclamationMark: TokenSyntax = Tokens.`exclamationMark`
+    exclamationMark: TokenSyntax = TokenSyntax.`exclamationMark`
   ) {
     self.expression = expression
     self.exclamationMark = exclamationMark
@@ -2322,11 +2322,11 @@ public struct ExpressionSegment: SyntaxBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    backslash: TokenSyntax = Tokens.`backslash`,
+    backslash: TokenSyntax = TokenSyntax.`backslash`,
     delimiter: TokenSyntax? = nil,
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     expressions: TupleExprElementList,
-    rightParen: TokenSyntax = Tokens.`stringInterpolationAnchor`
+    rightParen: TokenSyntax = TokenSyntax.`stringInterpolationAnchor`
   ) {
     self.backslash = backslash
     self.delimiter = delimiter
@@ -2408,7 +2408,7 @@ public struct KeyPathExpr: ExprBuildable {
   let expression: ExprBuildable
 
   public init(
-    backslash: TokenSyntax = Tokens.`backslash`,
+    backslash: TokenSyntax = TokenSyntax.`backslash`,
     rootExpr: ExprBuildable? = nil,
     expression: ExprBuildable
   ) {
@@ -2442,7 +2442,7 @@ public struct KeyPathBaseExpr: ExprBuildable {
   let period: TokenSyntax
 
   public init(
-    period: TokenSyntax = Tokens.`period`
+    period: TokenSyntax = TokenSyntax.`period`
   ) {
     self.period = period
   }
@@ -2533,10 +2533,10 @@ public struct ObjcKeyPathExpr: ExprBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    keyPath: TokenSyntax = Tokens.`poundKeyPath`,
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    keyPath: TokenSyntax = TokenSyntax.`poundKeyPath`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     name: ObjcName,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.keyPath = keyPath
     self.leftParen = leftParen
@@ -2575,12 +2575,12 @@ public struct ObjcSelectorExpr: ExprBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    poundSelector: TokenSyntax = Tokens.`poundSelector`,
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    poundSelector: TokenSyntax = TokenSyntax.`poundSelector`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     kind: TokenSyntax? = nil,
     colon: TokenSyntax? = nil,
     name: ExprBuildable,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.poundSelector = poundSelector
     self.leftParen = leftParen
@@ -2682,9 +2682,9 @@ public struct ObjectLiteralExpr: ExprBuildable {
 
   public init(
     identifier: TokenSyntax,
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     arguments: TupleExprElementList,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.identifier = identifier
     self.leftParen = leftParen
@@ -2719,7 +2719,7 @@ public struct TypeInitializerClause: SyntaxBuildable {
   let value: TypeBuildable
 
   public init(
-    equal: TokenSyntax = Tokens.`equal`,
+    equal: TokenSyntax = TokenSyntax.`equal`,
     value: TypeBuildable
   ) {
     self.equal = equal
@@ -2758,7 +2758,7 @@ public struct TypealiasDecl: DeclBuildable {
   public init(
     attributes: AttributeList? = nil,
     modifiers: ModifierList? = nil,
-    typealiasKeyword: TokenSyntax = Tokens.`typealias`,
+    typealiasKeyword: TokenSyntax = TokenSyntax.`typealias`,
     identifier: TokenSyntax,
     genericParameterClause: GenericParameterClause? = nil,
     initializer: TypeInitializerClause? = nil,
@@ -2810,7 +2810,7 @@ public struct AssociatedtypeDecl: DeclBuildable {
   public init(
     attributes: AttributeList? = nil,
     modifiers: ModifierList? = nil,
-    associatedtypeKeyword: TokenSyntax = Tokens.`associatedtype`,
+    associatedtypeKeyword: TokenSyntax = TokenSyntax.`associatedtype`,
     identifier: TokenSyntax,
     inheritanceClause: TypeInheritanceClause? = nil,
     initializer: TypeInitializerClause? = nil,
@@ -2884,9 +2884,9 @@ public struct ParameterClause: SyntaxBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     parameterList: FunctionParameterList,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.leftParen = leftParen
     self.parameterList = parameterList
@@ -2919,7 +2919,7 @@ public struct ReturnClause: SyntaxBuildable {
   let returnType: TypeBuildable
 
   public init(
-    arrow: TokenSyntax = Tokens.`arrow`,
+    arrow: TokenSyntax = TokenSyntax.`arrow`,
     returnType: TypeBuildable
   ) {
     self.arrow = arrow
@@ -3056,7 +3056,7 @@ public struct IfConfigDecl: DeclBuildable {
 
   public init(
     clauses: IfConfigClauseList,
-    poundEndif: TokenSyntax = Tokens.`poundEndif`
+    poundEndif: TokenSyntax = TokenSyntax.`poundEndif`
   ) {
     self.clauses = clauses
     self.poundEndif = poundEndif
@@ -3089,10 +3089,10 @@ public struct PoundErrorDecl: DeclBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    poundError: TokenSyntax = Tokens.`poundError`,
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    poundError: TokenSyntax = TokenSyntax.`poundError`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     message: StringLiteralExpr,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.poundError = poundError
     self.leftParen = leftParen
@@ -3129,10 +3129,10 @@ public struct PoundWarningDecl: DeclBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    poundWarning: TokenSyntax = Tokens.`poundWarning`,
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    poundWarning: TokenSyntax = TokenSyntax.`poundWarning`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     message: StringLiteralExpr,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.poundWarning = poundWarning
     self.leftParen = leftParen
@@ -3169,10 +3169,10 @@ public struct PoundSourceLocation: DeclBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    poundSourceLocation: TokenSyntax = Tokens.`poundSourceLocation`,
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    poundSourceLocation: TokenSyntax = TokenSyntax.`poundSourceLocation`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     args: PoundSourceLocationArgs? = nil,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.poundSourceLocation = poundSourceLocation
     self.leftParen = leftParen
@@ -3213,11 +3213,11 @@ public struct PoundSourceLocationArgs: SyntaxBuildable {
 
   public init(
     fileArgLabel: TokenSyntax,
-    fileArgColon: TokenSyntax = Tokens.`colon`,
+    fileArgColon: TokenSyntax = TokenSyntax.`colon`,
     fileName: TokenSyntax,
-    comma: TokenSyntax = Tokens.`comma`,
+    comma: TokenSyntax = TokenSyntax.`comma`,
     lineArgLabel: TokenSyntax,
-    lineArgColon: TokenSyntax = Tokens.`colon`,
+    lineArgColon: TokenSyntax = TokenSyntax.`colon`,
     lineNumber: TokenSyntax
   ) {
     self.fileArgLabel = fileArgLabel
@@ -3359,7 +3359,7 @@ public struct TypeInheritanceClause: SyntaxBuildable {
   let inheritedTypeCollection: InheritedTypeList
 
   public init(
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     inheritedTypeCollection: InheritedTypeList
   ) {
     self.colon = colon
@@ -3455,7 +3455,7 @@ public struct StructDecl: DeclBuildable {
   public init(
     attributes: AttributeList? = nil,
     modifiers: ModifierList? = nil,
-    structKeyword: TokenSyntax = Tokens.`struct`,
+    structKeyword: TokenSyntax = TokenSyntax.`struct`,
     identifier: TokenSyntax,
     genericParameterClause: GenericParameterClause? = nil,
     inheritanceClause: TypeInheritanceClause? = nil,
@@ -3510,7 +3510,7 @@ public struct ProtocolDecl: DeclBuildable {
   public init(
     attributes: AttributeList? = nil,
     modifiers: ModifierList? = nil,
-    protocolKeyword: TokenSyntax = Tokens.`protocol`,
+    protocolKeyword: TokenSyntax = TokenSyntax.`protocol`,
     identifier: TokenSyntax,
     inheritanceClause: TypeInheritanceClause? = nil,
     genericWhereClause: GenericWhereClause? = nil,
@@ -3562,7 +3562,7 @@ public struct ExtensionDecl: DeclBuildable {
   public init(
     attributes: AttributeList? = nil,
     modifiers: ModifierList? = nil,
-    extensionKeyword: TokenSyntax = Tokens.`extension`,
+    extensionKeyword: TokenSyntax = TokenSyntax.`extension`,
     extendedType: TypeBuildable,
     inheritanceClause: TypeInheritanceClause? = nil,
     genericWhereClause: GenericWhereClause? = nil,
@@ -3608,9 +3608,9 @@ public struct MemberDeclBlock: SyntaxBuildable {
   let rightBrace: TokenSyntax
 
   public init(
-    leftBrace: TokenSyntax = Tokens.`leftBrace`,
+    leftBrace: TokenSyntax = TokenSyntax.`leftBrace`,
     members: MemberDeclList,
-    rightBrace: TokenSyntax = Tokens.`rightBrace`
+    rightBrace: TokenSyntax = TokenSyntax.`rightBrace`
   ) {
     self.leftBrace = leftBrace
     self.members = members
@@ -3739,7 +3739,7 @@ public struct InitializerClause: SyntaxBuildable {
   let value: ExprBuildable
 
   public init(
-    equal: TokenSyntax = Tokens.`equal`,
+    equal: TokenSyntax = TokenSyntax.`equal`,
     value: ExprBuildable
   ) {
     self.equal = equal
@@ -3863,7 +3863,7 @@ public struct FunctionDecl: DeclBuildable {
   public init(
     attributes: AttributeList? = nil,
     modifiers: ModifierList? = nil,
-    funcKeyword: TokenSyntax = Tokens.`func`,
+    funcKeyword: TokenSyntax = TokenSyntax.`func`,
     identifier: TokenSyntax,
     genericParameterClause: GenericParameterClause? = nil,
     signature: FunctionSignature,
@@ -3920,7 +3920,7 @@ public struct InitializerDecl: DeclBuildable {
   public init(
     attributes: AttributeList? = nil,
     modifiers: ModifierList? = nil,
-    initKeyword: TokenSyntax = Tokens.`init`,
+    initKeyword: TokenSyntax = TokenSyntax.`init`,
     optionalMark: TokenSyntax? = nil,
     genericParameterClause: GenericParameterClause? = nil,
     parameters: ParameterClause,
@@ -3975,7 +3975,7 @@ public struct DeinitializerDecl: DeclBuildable {
   public init(
     attributes: AttributeList? = nil,
     modifiers: ModifierList? = nil,
-    deinitKeyword: TokenSyntax = Tokens.`deinit`,
+    deinitKeyword: TokenSyntax = TokenSyntax.`deinit`,
     body: CodeBlock
   ) {
     self.attributes = attributes
@@ -4019,7 +4019,7 @@ public struct SubscriptDecl: DeclBuildable {
   public init(
     attributes: AttributeList? = nil,
     modifiers: ModifierList? = nil,
-    subscriptKeyword: TokenSyntax = Tokens.`subscript`,
+    subscriptKeyword: TokenSyntax = TokenSyntax.`subscript`,
     genericParameterClause: GenericParameterClause? = nil,
     indices: ParameterClause,
     result: ReturnClause,
@@ -4172,7 +4172,7 @@ public struct ImportDecl: DeclBuildable {
   public init(
     attributes: AttributeList? = nil,
     modifiers: ModifierList? = nil,
-    importTok: TokenSyntax = Tokens.`import`,
+    importTok: TokenSyntax = TokenSyntax.`import`,
     importKind: TokenSyntax? = nil,
     path: AccessPath
   ) {
@@ -4212,9 +4212,9 @@ public struct AccessorParameter: SyntaxBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     name: TokenSyntax,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.leftParen = leftParen
     self.name = name
@@ -4328,9 +4328,9 @@ public struct AccessorBlock: SyntaxBuildable {
   let rightBrace: TokenSyntax
 
   public init(
-    leftBrace: TokenSyntax = Tokens.`leftBrace`,
+    leftBrace: TokenSyntax = TokenSyntax.`leftBrace`,
     accessors: AccessorList,
-    rightBrace: TokenSyntax = Tokens.`rightBrace`
+    rightBrace: TokenSyntax = TokenSyntax.`rightBrace`
   ) {
     self.leftBrace = leftBrace
     self.accessors = accessors
@@ -4555,7 +4555,7 @@ public struct EnumCaseDecl: DeclBuildable {
   public init(
     attributes: AttributeList? = nil,
     modifiers: ModifierList? = nil,
-    caseKeyword: TokenSyntax = Tokens.`case`,
+    caseKeyword: TokenSyntax = TokenSyntax.`case`,
     elements: EnumCaseElementList
   ) {
     self.attributes = attributes
@@ -4600,7 +4600,7 @@ public struct EnumDecl: DeclBuildable {
   public init(
     attributes: AttributeList? = nil,
     modifiers: ModifierList? = nil,
-    enumKeyword: TokenSyntax = Tokens.`enum`,
+    enumKeyword: TokenSyntax = TokenSyntax.`enum`,
     identifier: TokenSyntax,
     genericParameters: GenericParameterClause? = nil,
     inheritanceClause: TypeInheritanceClause? = nil,
@@ -4654,7 +4654,7 @@ public struct OperatorDecl: DeclBuildable {
   public init(
     attributes: AttributeList? = nil,
     modifiers: ModifierList? = nil,
-    operatorKeyword: TokenSyntax = Tokens.`operator`,
+    operatorKeyword: TokenSyntax = TokenSyntax.`operator`,
     identifier: TokenSyntax,
     operatorPrecedenceAndTypes: OperatorPrecedenceAndTypes? = nil
   ) {
@@ -4722,7 +4722,7 @@ public struct OperatorPrecedenceAndTypes: SyntaxBuildable {
   let precedenceGroupAndDesignatedTypes: IdentifierList
 
   public init(
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     precedenceGroupAndDesignatedTypes: IdentifierList
   ) {
     self.colon = colon
@@ -4762,11 +4762,11 @@ public struct PrecedenceGroupDecl: DeclBuildable {
   public init(
     attributes: AttributeList? = nil,
     modifiers: ModifierList? = nil,
-    precedencegroupKeyword: TokenSyntax = Tokens.`precedencegroup`,
+    precedencegroupKeyword: TokenSyntax = TokenSyntax.`precedencegroup`,
     identifier: TokenSyntax,
-    leftBrace: TokenSyntax = Tokens.`leftBrace`,
+    leftBrace: TokenSyntax = TokenSyntax.`leftBrace`,
     groupAttributes: PrecedenceGroupAttributeList,
-    rightBrace: TokenSyntax = Tokens.`rightBrace`
+    rightBrace: TokenSyntax = TokenSyntax.`rightBrace`
   ) {
     self.attributes = attributes
     self.modifiers = modifiers
@@ -4841,7 +4841,7 @@ public struct PrecedenceGroupRelation: SyntaxBuildable {
 
   public init(
     higherThanOrLowerThan: TokenSyntax,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     otherNames: PrecedenceGroupNameList
   ) {
     self.higherThanOrLowerThan = higherThanOrLowerThan
@@ -4941,7 +4941,7 @@ public struct PrecedenceGroupAssignment: SyntaxBuildable {
 
   public init(
     assignmentKeyword: TokenSyntax,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     flag: TokenSyntax
   ) {
     self.assignmentKeyword = assignmentKeyword
@@ -4981,7 +4981,7 @@ public struct PrecedenceGroupAssociativity: SyntaxBuildable {
 
   public init(
     associativityKeyword: TokenSyntax,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     value: TokenSyntax
   ) {
     self.associativityKeyword = associativityKeyword
@@ -5073,7 +5073,7 @@ public struct CustomAttribute: SyntaxBuildable {
   let rightParen: TokenSyntax?
 
   public init(
-    atSignToken: TokenSyntax = Tokens.`atSign`,
+    atSignToken: TokenSyntax = TokenSyntax.`atSign`,
     attributeName: TypeBuildable,
     leftParen: TokenSyntax? = nil,
     argumentList: TupleExprElementList? = nil,
@@ -5121,7 +5121,7 @@ public struct Attribute: SyntaxBuildable {
   let tokenList: TokenList?
 
   public init(
-    atSignToken: TokenSyntax = Tokens.`atSign`,
+    atSignToken: TokenSyntax = TokenSyntax.`atSign`,
     attributeName: TokenSyntax,
     leftParen: TokenSyntax? = nil,
     argument: SyntaxBuildable? = nil,
@@ -5229,7 +5229,7 @@ public struct LabeledSpecializeEntry: SyntaxBuildable {
 
   public init(
     label: TokenSyntax,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     value: TokenSyntax,
     trailingComma: TokenSyntax? = nil
   ) {
@@ -5274,7 +5274,7 @@ public struct TargetFunctionEntry: SyntaxBuildable {
 
   public init(
     label: TokenSyntax,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     delcname: DeclName,
     trailingComma: TokenSyntax? = nil
   ) {
@@ -5318,7 +5318,7 @@ public struct NamedAttributeStringArgument: SyntaxBuildable {
 
   public init(
     nameTok: TokenSyntax,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     stringOrDeclname: SyntaxBuildable
   ) {
     self.nameTok = nameTok
@@ -5391,7 +5391,7 @@ public struct ImplementsAttributeArguments: SyntaxBuildable {
 
   public init(
     type: SimpleTypeIdentifier,
-    comma: TokenSyntax = Tokens.`comma`,
+    comma: TokenSyntax = TokenSyntax.`comma`,
     declBaseName: SyntaxBuildable,
     declNameArguments: DeclNameArguments? = nil
   ) {
@@ -5545,7 +5545,7 @@ public struct DifferentiabilityParamsClause: SyntaxBuildable {
 
   public init(
     wrtLabel: TokenSyntax,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     parameters: SyntaxBuildable
   ) {
     self.wrtLabel = wrtLabel
@@ -5581,9 +5581,9 @@ public struct DifferentiabilityParams: SyntaxBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     diffParams: DifferentiabilityParamList,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.leftParen = leftParen
     self.diffParams = diffParams
@@ -5691,7 +5691,7 @@ public struct DerivativeRegistrationAttributeArguments: SyntaxBuildable {
 
   public init(
     ofLabel: TokenSyntax,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     originalDeclName: QualifiedDeclName,
     period: TokenSyntax? = nil,
     accessorKind: TokenSyntax? = nil,
@@ -5814,7 +5814,7 @@ public struct ContinueStmt: StmtBuildable {
   let label: TokenSyntax?
 
   public init(
-    continueKeyword: TokenSyntax = Tokens.`continue`,
+    continueKeyword: TokenSyntax = TokenSyntax.`continue`,
     label: TokenSyntax? = nil
   ) {
     self.continueKeyword = continueKeyword
@@ -5851,7 +5851,7 @@ public struct WhileStmt: StmtBuildable {
   public init(
     labelName: TokenSyntax? = nil,
     labelColon: TokenSyntax? = nil,
-    whileKeyword: TokenSyntax = Tokens.`while`,
+    whileKeyword: TokenSyntax = TokenSyntax.`while`,
     conditions: ConditionElementList,
     body: CodeBlock
   ) {
@@ -5890,7 +5890,7 @@ public struct DeferStmt: StmtBuildable {
   let body: CodeBlock
 
   public init(
-    deferKeyword: TokenSyntax = Tokens.`defer`,
+    deferKeyword: TokenSyntax = TokenSyntax.`defer`,
     body: CodeBlock
   ) {
     self.deferKeyword = deferKeyword
@@ -5984,9 +5984,9 @@ public struct RepeatWhileStmt: StmtBuildable {
   public init(
     labelName: TokenSyntax? = nil,
     labelColon: TokenSyntax? = nil,
-    repeatKeyword: TokenSyntax = Tokens.`repeat`,
+    repeatKeyword: TokenSyntax = TokenSyntax.`repeat`,
     body: CodeBlock,
-    whileKeyword: TokenSyntax = Tokens.`while`,
+    whileKeyword: TokenSyntax = TokenSyntax.`while`,
     condition: ExprBuildable
   ) {
     self.labelName = labelName
@@ -6028,9 +6028,9 @@ public struct GuardStmt: StmtBuildable {
   let body: CodeBlock
 
   public init(
-    guardKeyword: TokenSyntax = Tokens.`guard`,
+    guardKeyword: TokenSyntax = TokenSyntax.`guard`,
     conditions: ConditionElementList,
-    elseKeyword: TokenSyntax = Tokens.`else`,
+    elseKeyword: TokenSyntax = TokenSyntax.`else`,
     body: CodeBlock
   ) {
     self.guardKeyword = guardKeyword
@@ -6066,7 +6066,7 @@ public struct WhereClause: SyntaxBuildable {
   let guardResult: ExprBuildable
 
   public init(
-    whereKeyword: TokenSyntax = Tokens.`where`,
+    whereKeyword: TokenSyntax = TokenSyntax.`where`,
     guardResult: ExprBuildable
   ) {
     self.whereKeyword = whereKeyword
@@ -6110,13 +6110,13 @@ public struct ForInStmt: StmtBuildable {
   public init(
     labelName: TokenSyntax? = nil,
     labelColon: TokenSyntax? = nil,
-    forKeyword: TokenSyntax = Tokens.`for`,
+    forKeyword: TokenSyntax = TokenSyntax.`for`,
     tryKeyword: TokenSyntax? = nil,
     awaitKeyword: TokenSyntax? = nil,
     caseKeyword: TokenSyntax? = nil,
     pattern: PatternBuildable,
     typeAnnotation: TypeAnnotation? = nil,
-    inKeyword: TokenSyntax = Tokens.`in`,
+    inKeyword: TokenSyntax = TokenSyntax.`in`,
     sequenceExpr: ExprBuildable,
     whereClause: WhereClause? = nil,
     body: CodeBlock
@@ -6177,11 +6177,11 @@ public struct SwitchStmt: StmtBuildable {
   public init(
     labelName: TokenSyntax? = nil,
     labelColon: TokenSyntax? = nil,
-    switchKeyword: TokenSyntax = Tokens.`switch`,
+    switchKeyword: TokenSyntax = TokenSyntax.`switch`,
     expression: ExprBuildable,
-    leftBrace: TokenSyntax = Tokens.`leftBrace`,
+    leftBrace: TokenSyntax = TokenSyntax.`leftBrace`,
     cases: SwitchCaseList,
-    rightBrace: TokenSyntax = Tokens.`rightBrace`
+    rightBrace: TokenSyntax = TokenSyntax.`rightBrace`
   ) {
     self.labelName = labelName
     self.labelColon = labelColon
@@ -6255,7 +6255,7 @@ public struct DoStmt: StmtBuildable {
   public init(
     labelName: TokenSyntax? = nil,
     labelColon: TokenSyntax? = nil,
-    doKeyword: TokenSyntax = Tokens.`do`,
+    doKeyword: TokenSyntax = TokenSyntax.`do`,
     body: CodeBlock,
     catchClauses: CatchClauseList? = nil
   ) {
@@ -6294,7 +6294,7 @@ public struct ReturnStmt: StmtBuildable {
   let expression: ExprBuildable?
 
   public init(
-    returnKeyword: TokenSyntax = Tokens.`return`,
+    returnKeyword: TokenSyntax = TokenSyntax.`return`,
     expression: ExprBuildable? = nil
   ) {
     self.returnKeyword = returnKeyword
@@ -6326,7 +6326,7 @@ public struct YieldStmt: StmtBuildable {
   let yields: SyntaxBuildable
 
   public init(
-    yieldKeyword: TokenSyntax = Tokens.`yield`,
+    yieldKeyword: TokenSyntax = TokenSyntax.`yield`,
     yields: SyntaxBuildable
   ) {
     self.yieldKeyword = yieldKeyword
@@ -6360,10 +6360,10 @@ public struct YieldList: SyntaxBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     elementList: ExprList,
     trailingComma: TokenSyntax? = nil,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.leftParen = leftParen
     self.elementList = elementList
@@ -6397,7 +6397,7 @@ public struct FallthroughStmt: StmtBuildable {
   let fallthroughKeyword: TokenSyntax
 
   public init(
-    fallthroughKeyword: TokenSyntax = Tokens.`fallthrough`
+    fallthroughKeyword: TokenSyntax = TokenSyntax.`fallthrough`
   ) {
     self.fallthroughKeyword = fallthroughKeyword
   }
@@ -6426,7 +6426,7 @@ public struct BreakStmt: StmtBuildable {
   let label: TokenSyntax?
 
   public init(
-    breakKeyword: TokenSyntax = Tokens.`break`,
+    breakKeyword: TokenSyntax = TokenSyntax.`break`,
     label: TokenSyntax? = nil
   ) {
     self.breakKeyword = breakKeyword
@@ -6548,10 +6548,10 @@ public struct AvailabilityCondition: SyntaxBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    poundAvailableKeyword: TokenSyntax = Tokens.`poundAvailable`,
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    poundAvailableKeyword: TokenSyntax = TokenSyntax.`poundAvailable`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     availabilitySpec: AvailabilitySpecList,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.poundAvailableKeyword = poundAvailableKeyword
     self.leftParen = leftParen
@@ -6588,7 +6588,7 @@ public struct MatchingPatternCondition: SyntaxBuildable {
   let initializer: InitializerClause
 
   public init(
-    caseKeyword: TokenSyntax = Tokens.`case`,
+    caseKeyword: TokenSyntax = TokenSyntax.`case`,
     pattern: PatternBuildable,
     typeAnnotation: TypeAnnotation? = nil,
     initializer: InitializerClause
@@ -6722,7 +6722,7 @@ public struct ThrowStmt: StmtBuildable {
   let expression: ExprBuildable
 
   public init(
-    throwKeyword: TokenSyntax = Tokens.`throw`,
+    throwKeyword: TokenSyntax = TokenSyntax.`throw`,
     expression: ExprBuildable
   ) {
     self.throwKeyword = throwKeyword
@@ -6761,7 +6761,7 @@ public struct IfStmt: StmtBuildable {
   public init(
     labelName: TokenSyntax? = nil,
     labelColon: TokenSyntax? = nil,
-    ifKeyword: TokenSyntax = Tokens.`if`,
+    ifKeyword: TokenSyntax = TokenSyntax.`if`,
     conditions: ConditionElementList,
     body: CodeBlock,
     elseKeyword: TokenSyntax? = nil,
@@ -6834,7 +6834,7 @@ public struct ElseBlock: SyntaxBuildable {
   let body: CodeBlock
 
   public init(
-    elseKeyword: TokenSyntax = Tokens.`else`,
+    elseKeyword: TokenSyntax = TokenSyntax.`else`,
     body: CodeBlock
   ) {
     self.elseKeyword = elseKeyword
@@ -6902,8 +6902,8 @@ public struct SwitchDefaultLabel: SyntaxBuildable {
   let colon: TokenSyntax
 
   public init(
-    defaultKeyword: TokenSyntax = Tokens.`default`,
-    colon: TokenSyntax = Tokens.`colon`
+    defaultKeyword: TokenSyntax = TokenSyntax.`default`,
+    colon: TokenSyntax = TokenSyntax.`colon`
   ) {
     self.defaultKeyword = defaultKeyword
     self.colon = colon
@@ -7007,9 +7007,9 @@ public struct SwitchCaseLabel: SyntaxBuildable {
   let colon: TokenSyntax
 
   public init(
-    caseKeyword: TokenSyntax = Tokens.`case`,
+    caseKeyword: TokenSyntax = TokenSyntax.`case`,
     caseItems: CaseItemList,
-    colon: TokenSyntax = Tokens.`colon`
+    colon: TokenSyntax = TokenSyntax.`colon`
   ) {
     self.caseKeyword = caseKeyword
     self.caseItems = caseItems
@@ -7043,7 +7043,7 @@ public struct CatchClause: SyntaxBuildable {
   let body: CodeBlock
 
   public init(
-    catchKeyword: TokenSyntax = Tokens.`catch`,
+    catchKeyword: TokenSyntax = TokenSyntax.`catch`,
     catchItems: CatchItemList? = nil,
     body: CodeBlock
   ) {
@@ -7082,12 +7082,12 @@ public struct PoundAssertStmt: StmtBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    poundAssert: TokenSyntax = Tokens.`poundAssert`,
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    poundAssert: TokenSyntax = TokenSyntax.`poundAssert`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     condition: ExprBuildable,
     comma: TokenSyntax? = nil,
     message: TokenSyntax? = nil,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.poundAssert = poundAssert
     self.leftParen = leftParen
@@ -7126,7 +7126,7 @@ public struct GenericWhereClause: SyntaxBuildable {
   let requirementList: GenericRequirementList
 
   public init(
-    whereKeyword: TokenSyntax = Tokens.`where`,
+    whereKeyword: TokenSyntax = TokenSyntax.`where`,
     requirementList: GenericRequirementList
   ) {
     self.whereKeyword = whereKeyword
@@ -7327,9 +7327,9 @@ public struct GenericParameterClause: SyntaxBuildable {
   let rightAngleBracket: TokenSyntax
 
   public init(
-    leftAngleBracket: TokenSyntax = Tokens.`leftAngle`,
+    leftAngleBracket: TokenSyntax = TokenSyntax.`leftAngle`,
     genericParameterList: GenericParameterList,
-    rightAngleBracket: TokenSyntax = Tokens.`rightAngle`
+    rightAngleBracket: TokenSyntax = TokenSyntax.`rightAngle`
   ) {
     self.leftAngleBracket = leftAngleBracket
     self.genericParameterList = genericParameterList
@@ -7364,7 +7364,7 @@ public struct ConformanceRequirement: SyntaxBuildable {
 
   public init(
     leftTypeIdentifier: TypeBuildable,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     rightTypeIdentifier: TypeBuildable
   ) {
     self.leftTypeIdentifier = leftTypeIdentifier
@@ -7469,7 +7469,7 @@ public struct ClassRestrictionType: TypeBuildable {
   let classKeyword: TokenSyntax
 
   public init(
-    classKeyword: TokenSyntax = Tokens.`class`
+    classKeyword: TokenSyntax = TokenSyntax.`class`
   ) {
     self.classKeyword = classKeyword
   }
@@ -7499,9 +7499,9 @@ public struct ArrayType: TypeBuildable {
   let rightSquareBracket: TokenSyntax
 
   public init(
-    leftSquareBracket: TokenSyntax = Tokens.`leftSquareBracket`,
+    leftSquareBracket: TokenSyntax = TokenSyntax.`leftSquareBracket`,
     elementType: TypeBuildable,
-    rightSquareBracket: TokenSyntax = Tokens.`rightSquareBracket`
+    rightSquareBracket: TokenSyntax = TokenSyntax.`rightSquareBracket`
   ) {
     self.leftSquareBracket = leftSquareBracket
     self.elementType = elementType
@@ -7537,11 +7537,11 @@ public struct DictionaryType: TypeBuildable {
   let rightSquareBracket: TokenSyntax
 
   public init(
-    leftSquareBracket: TokenSyntax = Tokens.`leftSquareBracket`,
+    leftSquareBracket: TokenSyntax = TokenSyntax.`leftSquareBracket`,
     keyType: TypeBuildable,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     valueType: TypeBuildable,
-    rightSquareBracket: TokenSyntax = Tokens.`rightSquareBracket`
+    rightSquareBracket: TokenSyntax = TokenSyntax.`rightSquareBracket`
   ) {
     self.leftSquareBracket = leftSquareBracket
     self.keyType = keyType
@@ -7580,7 +7580,7 @@ public struct MetatypeType: TypeBuildable {
 
   public init(
     baseType: TypeBuildable,
-    period: TokenSyntax = Tokens.`period`,
+    period: TokenSyntax = TokenSyntax.`period`,
     typeOrProtocol: TokenSyntax
   ) {
     self.baseType = baseType
@@ -7615,7 +7615,7 @@ public struct OptionalType: TypeBuildable {
 
   public init(
     wrappedType: TypeBuildable,
-    questionMark: TokenSyntax = Tokens.`postfixQuestionMark`
+    questionMark: TokenSyntax = TokenSyntax.`postfixQuestionMark`
   ) {
     self.wrappedType = wrappedType
     self.questionMark = questionMark
@@ -7679,7 +7679,7 @@ public struct ImplicitlyUnwrappedOptionalType: TypeBuildable {
 
   public init(
     wrappedType: TypeBuildable,
-    exclamationMark: TokenSyntax = Tokens.`exclamationMark`
+    exclamationMark: TokenSyntax = TokenSyntax.`exclamationMark`
   ) {
     self.wrappedType = wrappedType
     self.exclamationMark = exclamationMark
@@ -7883,9 +7883,9 @@ public struct TupleType: TypeBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     elements: TupleTypeElementList,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.leftParen = leftParen
     self.elements = elements
@@ -7923,12 +7923,12 @@ public struct FunctionType: TypeBuildable {
   let returnType: TypeBuildable
 
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     arguments: TupleTypeElementList,
-    rightParen: TokenSyntax = Tokens.`rightParen`,
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`,
     asyncKeyword: TokenSyntax? = nil,
     throwsOrRethrowsKeyword: TokenSyntax? = nil,
-    arrow: TokenSyntax = Tokens.`arrow`,
+    arrow: TokenSyntax = TokenSyntax.`arrow`,
     returnType: TypeBuildable
   ) {
     self.leftParen = leftParen
@@ -8067,9 +8067,9 @@ public struct GenericArgumentClause: SyntaxBuildable {
   let rightAngleBracket: TokenSyntax
 
   public init(
-    leftAngleBracket: TokenSyntax = Tokens.`leftAngle`,
+    leftAngleBracket: TokenSyntax = TokenSyntax.`leftAngle`,
     arguments: GenericArgumentList,
-    rightAngleBracket: TokenSyntax = Tokens.`rightAngle`
+    rightAngleBracket: TokenSyntax = TokenSyntax.`rightAngle`
   ) {
     self.leftAngleBracket = leftAngleBracket
     self.arguments = arguments
@@ -8102,7 +8102,7 @@ public struct TypeAnnotation: SyntaxBuildable {
   let type: TypeBuildable
 
   public init(
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     type: TypeBuildable
   ) {
     self.colon = colon
@@ -8137,7 +8137,7 @@ public struct EnumCasePattern: PatternBuildable {
 
   public init(
     type: TypeBuildable? = nil,
-    period: TokenSyntax = Tokens.`period`,
+    period: TokenSyntax = TokenSyntax.`period`,
     caseName: TokenSyntax,
     associatedTuple: TuplePattern? = nil
   ) {
@@ -8174,7 +8174,7 @@ public struct IsTypePattern: PatternBuildable {
   let type: TypeBuildable
 
   public init(
-    isKeyword: TokenSyntax = Tokens.`is`,
+    isKeyword: TokenSyntax = TokenSyntax.`is`,
     type: TypeBuildable
   ) {
     self.isKeyword = isKeyword
@@ -8207,7 +8207,7 @@ public struct OptionalPattern: PatternBuildable {
 
   public init(
     subPattern: PatternBuildable,
-    questionMark: TokenSyntax = Tokens.`postfixQuestionMark`
+    questionMark: TokenSyntax = TokenSyntax.`postfixQuestionMark`
   ) {
     self.subPattern = subPattern
     self.questionMark = questionMark
@@ -8268,7 +8268,7 @@ public struct AsTypePattern: PatternBuildable {
 
   public init(
     pattern: PatternBuildable,
-    asKeyword: TokenSyntax = Tokens.`as`,
+    asKeyword: TokenSyntax = TokenSyntax.`as`,
     type: TypeBuildable
   ) {
     self.pattern = pattern
@@ -8303,9 +8303,9 @@ public struct TuplePattern: PatternBuildable {
   let rightParen: TokenSyntax
 
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     elements: TuplePatternElementList,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.leftParen = leftParen
     self.elements = elements
@@ -8338,7 +8338,7 @@ public struct WildcardPattern: PatternBuildable {
   let typeAnnotation: TypeAnnotation?
 
   public init(
-    wildcard: TokenSyntax = Tokens.`wildcard`,
+    wildcard: TokenSyntax = TokenSyntax.`wildcard`,
     typeAnnotation: TypeAnnotation? = nil
   ) {
     self.wildcard = wildcard
@@ -8568,7 +8568,7 @@ public struct AvailabilityLabeledArgument: SyntaxBuildable {
 
   public init(
     label: TokenSyntax,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     value: SyntaxBuildable
   ) {
     self.label = label

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/BuildablesConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/BuildablesConvenienceInitializers.swift
@@ -16,9 +16,9 @@ import SwiftSyntax
 
 extension CodeBlock {
   public init(
-    leftBrace: TokenSyntax = Tokens.`leftBrace`,
+    leftBrace: TokenSyntax = TokenSyntax.`leftBrace`,
     @CodeBlockItemListBuilder statementsBuilder: () -> CodeBlockItemList = { .empty },
-    rightBrace: TokenSyntax = Tokens.`rightBrace`
+    rightBrace: TokenSyntax = TokenSyntax.`rightBrace`
   ) {
     self.init(
       leftBrace: leftBrace,
@@ -42,9 +42,9 @@ extension AwaitExpr {
 
 extension DeclNameArguments {
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     @DeclNameArgumentListBuilder argumentsBuilder: () -> DeclNameArgumentList = { .empty },
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.init(
       leftParen: leftParen,
@@ -82,7 +82,7 @@ extension PrefixOperatorExpr {
     postfixExpression: ExprBuildable
   ) {
     self.init(
-      operatorToken: operatorToken.map(Tokens.prefixOperator),
+      operatorToken: operatorToken.map(TokenSyntax.prefixOperator),
       postfixExpression: postfixExpression
     )
   }
@@ -92,7 +92,7 @@ extension ArrowExpr {
   public init(
     asyncKeyword: String?,
     throwsToken: TokenSyntax? = nil,
-    arrowToken: TokenSyntax = Tokens.`arrow`
+    arrowToken: TokenSyntax = TokenSyntax.`arrow`
   ) {
     self.init(
       asyncKeyword: asyncKeyword.map({ SyntaxFactory.makeIdentifier($0) }),
@@ -107,16 +107,16 @@ extension FloatLiteralExpr {
     floatingDigits: String
   ) {
     self.init(
-      floatingDigits: Tokens.floatingLiteral(floatingDigits)
+      floatingDigits: TokenSyntax.floatingLiteral(floatingDigits)
     )
   }
 }
 
 extension TupleExpr {
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     @TupleExprElementListBuilder elementListBuilder: () -> TupleExprElementList = { .empty },
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.init(
       leftParen: leftParen,
@@ -128,9 +128,9 @@ extension TupleExpr {
 
 extension ArrayExpr {
   public init(
-    leftSquare: TokenSyntax = Tokens.`leftSquareBracket`,
+    leftSquare: TokenSyntax = TokenSyntax.`leftSquareBracket`,
     @ArrayElementListBuilder elementsBuilder: () -> ArrayElementList = { .empty },
-    rightSquare: TokenSyntax = Tokens.`rightSquareBracket`
+    rightSquare: TokenSyntax = TokenSyntax.`rightSquareBracket`
   ) {
     self.init(
       leftSquare: leftSquare,
@@ -145,7 +145,7 @@ extension IntegerLiteralExpr {
     digits: String
   ) {
     self.init(
-      digits: Tokens.integerLiteral(digits)
+      digits: TokenSyntax.integerLiteral(digits)
     )
   }
 }
@@ -170,9 +170,9 @@ extension ClosureCaptureItem {
 
 extension ClosureCaptureSignature {
   public init(
-    leftSquare: TokenSyntax = Tokens.`leftSquareBracket`,
+    leftSquare: TokenSyntax = TokenSyntax.`leftSquareBracket`,
     @ClosureCaptureItemListBuilder itemsBuilder: () -> ClosureCaptureItemList? = { nil },
-    rightSquare: TokenSyntax = Tokens.`rightSquareBracket`
+    rightSquare: TokenSyntax = TokenSyntax.`rightSquareBracket`
   ) {
     self.init(
       leftSquare: leftSquare,
@@ -190,7 +190,7 @@ extension ClosureSignature {
     asyncKeyword: String?,
     throwsTok: TokenSyntax? = nil,
     output: ReturnClause? = nil,
-    inTok: TokenSyntax = Tokens.`in`
+    inTok: TokenSyntax = TokenSyntax.`in`
   ) {
     self.init(
       attributes: attributesBuilder(),
@@ -206,10 +206,10 @@ extension ClosureSignature {
 
 extension ClosureExpr {
   public init(
-    leftBrace: TokenSyntax = Tokens.`leftBrace`,
+    leftBrace: TokenSyntax = TokenSyntax.`leftBrace`,
     signature: ClosureSignature? = nil,
     @CodeBlockItemListBuilder statementsBuilder: () -> CodeBlockItemList = { .empty },
-    rightBrace: TokenSyntax = Tokens.`rightBrace`
+    rightBrace: TokenSyntax = TokenSyntax.`rightBrace`
   ) {
     self.init(
       leftBrace: leftBrace,
@@ -243,9 +243,9 @@ extension FunctionCallExpr {
 extension SubscriptExpr {
   public init(
     calledExpression: ExprBuildable,
-    leftBracket: TokenSyntax = Tokens.`leftSquareBracket`,
+    leftBracket: TokenSyntax = TokenSyntax.`leftSquareBracket`,
     @TupleExprElementListBuilder argumentListBuilder: () -> TupleExprElementList = { .empty },
-    rightBracket: TokenSyntax = Tokens.`rightSquareBracket`,
+    rightBracket: TokenSyntax = TokenSyntax.`rightSquareBracket`,
     trailingClosure: ClosureExpr? = nil,
     @MultipleTrailingClosureElementListBuilder additionalTrailingClosuresBuilder: () -> MultipleTrailingClosureElementList? = { nil }
   ) {
@@ -267,7 +267,7 @@ extension PostfixUnaryExpr {
   ) {
     self.init(
       expression: expression,
-      operatorToken: Tokens.postfixOperator(operatorToken)
+      operatorToken: TokenSyntax.postfixOperator(operatorToken)
     )
   }
 }
@@ -277,22 +277,22 @@ extension StringSegment {
     content: String
   ) {
     self.init(
-      content: Tokens.stringSegment(content)
+      content: TokenSyntax.stringSegment(content)
     )
   }
 }
 
 extension ExpressionSegment {
   public init(
-    backslash: TokenSyntax = Tokens.`backslash`,
+    backslash: TokenSyntax = TokenSyntax.`backslash`,
     delimiter: String?,
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     @TupleExprElementListBuilder expressionsBuilder: () -> TupleExprElementList = { .empty },
-    rightParen: TokenSyntax = Tokens.`stringInterpolationAnchor`
+    rightParen: TokenSyntax = TokenSyntax.`stringInterpolationAnchor`
   ) {
     self.init(
       backslash: backslash,
-      delimiter: delimiter.map(Tokens.rawStringDelimiter),
+      delimiter: delimiter.map(TokenSyntax.rawStringDelimiter),
       leftParen: leftParen,
       expressions: expressionsBuilder(),
       rightParen: rightParen
@@ -309,11 +309,11 @@ extension StringLiteralExpr {
     closeDelimiter: String?
   ) {
     self.init(
-      openDelimiter: openDelimiter.map(Tokens.rawStringDelimiter),
+      openDelimiter: openDelimiter.map(TokenSyntax.rawStringDelimiter),
       openQuote: openQuote,
       segments: segmentsBuilder(),
       closeQuote: closeQuote,
-      closeDelimiter: closeDelimiter.map(Tokens.rawStringDelimiter)
+      closeDelimiter: closeDelimiter.map(TokenSyntax.rawStringDelimiter)
     )
   }
 }
@@ -332,10 +332,10 @@ extension ObjcNamePiece {
 
 extension ObjcKeyPathExpr {
   public init(
-    keyPath: TokenSyntax = Tokens.`poundKeyPath`,
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    keyPath: TokenSyntax = TokenSyntax.`poundKeyPath`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     @ObjcNameBuilder nameBuilder: () -> ObjcName = { .empty },
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.init(
       keyPath: keyPath,
@@ -348,17 +348,17 @@ extension ObjcKeyPathExpr {
 
 extension ObjcSelectorExpr {
   public init(
-    poundSelector: TokenSyntax = Tokens.`poundSelector`,
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    poundSelector: TokenSyntax = TokenSyntax.`poundSelector`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     kind: String?,
     colon: TokenSyntax? = nil,
     name: ExprBuildable,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.init(
       poundSelector: poundSelector,
       leftParen: leftParen,
-      kind: kind.map(Tokens.contextualKeyword),
+      kind: kind.map(TokenSyntax.contextualKeyword),
       colon: colon,
       name: name,
       rightParen: rightParen
@@ -379,9 +379,9 @@ extension EditorPlaceholderExpr {
 extension ObjectLiteralExpr {
   public init(
     identifier: TokenSyntax,
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     @TupleExprElementListBuilder argumentsBuilder: () -> TupleExprElementList = { .empty },
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.init(
       identifier: identifier,
@@ -396,7 +396,7 @@ extension TypealiasDecl {
   public init(
     @AttributeListBuilder attributesBuilder: () -> AttributeList? = { nil },
     @ModifierListBuilder modifiersBuilder: () -> ModifierList? = { nil },
-    typealiasKeyword: TokenSyntax = Tokens.`typealias`,
+    typealiasKeyword: TokenSyntax = TokenSyntax.`typealias`,
     identifier: String,
     genericParameterClause: GenericParameterClause? = nil,
     initializer: TypeInitializerClause? = nil,
@@ -418,7 +418,7 @@ extension AssociatedtypeDecl {
   public init(
     @AttributeListBuilder attributesBuilder: () -> AttributeList? = { nil },
     @ModifierListBuilder modifiersBuilder: () -> ModifierList? = { nil },
-    associatedtypeKeyword: TokenSyntax = Tokens.`associatedtype`,
+    associatedtypeKeyword: TokenSyntax = TokenSyntax.`associatedtype`,
     identifier: String,
     inheritanceClause: TypeInheritanceClause? = nil,
     initializer: TypeInitializerClause? = nil,
@@ -438,9 +438,9 @@ extension AssociatedtypeDecl {
 
 extension ParameterClause {
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     @FunctionParameterListBuilder parameterListBuilder: () -> FunctionParameterList = { .empty },
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.init(
       leftParen: leftParen,
@@ -469,7 +469,7 @@ extension FunctionSignature {
 extension IfConfigDecl {
   public init(
     @IfConfigClauseListBuilder clausesBuilder: () -> IfConfigClauseList = { .empty },
-    poundEndif: TokenSyntax = Tokens.`poundEndif`
+    poundEndif: TokenSyntax = TokenSyntax.`poundEndif`
   ) {
     self.init(
       clauses: clausesBuilder(),
@@ -481,21 +481,21 @@ extension IfConfigDecl {
 extension PoundSourceLocationArgs {
   public init(
     fileArgLabel: String,
-    fileArgColon: TokenSyntax = Tokens.`colon`,
+    fileArgColon: TokenSyntax = TokenSyntax.`colon`,
     fileName: String,
-    comma: TokenSyntax = Tokens.`comma`,
+    comma: TokenSyntax = TokenSyntax.`comma`,
     lineArgLabel: String,
-    lineArgColon: TokenSyntax = Tokens.`colon`,
+    lineArgColon: TokenSyntax = TokenSyntax.`colon`,
     lineNumber: String
   ) {
     self.init(
       fileArgLabel: SyntaxFactory.makeIdentifier(fileArgLabel),
       fileArgColon: fileArgColon,
-      fileName: Tokens.stringLiteral(fileName),
+      fileName: TokenSyntax.stringLiteral(fileName),
       comma: comma,
       lineArgLabel: SyntaxFactory.makeIdentifier(lineArgLabel),
       lineArgColon: lineArgColon,
-      lineNumber: Tokens.integerLiteral(lineNumber)
+      lineNumber: TokenSyntax.integerLiteral(lineNumber)
     )
   }
 }
@@ -518,7 +518,7 @@ extension DeclModifier {
 
 extension TypeInheritanceClause {
   public init(
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     @InheritedTypeListBuilder inheritedTypeCollectionBuilder: () -> InheritedTypeList = { .empty }
   ) {
     self.init(
@@ -556,7 +556,7 @@ extension StructDecl {
   public init(
     @AttributeListBuilder attributesBuilder: () -> AttributeList? = { nil },
     @ModifierListBuilder modifiersBuilder: () -> ModifierList? = { nil },
-    structKeyword: TokenSyntax = Tokens.`struct`,
+    structKeyword: TokenSyntax = TokenSyntax.`struct`,
     identifier: String,
     genericParameterClause: GenericParameterClause? = nil,
     inheritanceClause: TypeInheritanceClause? = nil,
@@ -580,7 +580,7 @@ extension ProtocolDecl {
   public init(
     @AttributeListBuilder attributesBuilder: () -> AttributeList? = { nil },
     @ModifierListBuilder modifiersBuilder: () -> ModifierList? = { nil },
-    protocolKeyword: TokenSyntax = Tokens.`protocol`,
+    protocolKeyword: TokenSyntax = TokenSyntax.`protocol`,
     identifier: String,
     inheritanceClause: TypeInheritanceClause? = nil,
     genericWhereClause: GenericWhereClause? = nil,
@@ -602,7 +602,7 @@ extension ExtensionDecl {
   public init(
     @AttributeListBuilder attributesBuilder: () -> AttributeList? = { nil },
     @ModifierListBuilder modifiersBuilder: () -> ModifierList? = { nil },
-    extensionKeyword: TokenSyntax = Tokens.`extension`,
+    extensionKeyword: TokenSyntax = TokenSyntax.`extension`,
     extendedType: TypeBuildable,
     inheritanceClause: TypeInheritanceClause? = nil,
     genericWhereClause: GenericWhereClause? = nil,
@@ -622,9 +622,9 @@ extension ExtensionDecl {
 
 extension MemberDeclBlock {
   public init(
-    leftBrace: TokenSyntax = Tokens.`leftBrace`,
+    leftBrace: TokenSyntax = TokenSyntax.`leftBrace`,
     @MemberDeclListBuilder membersBuilder: () -> MemberDeclList = { .empty },
-    rightBrace: TokenSyntax = Tokens.`rightBrace`
+    rightBrace: TokenSyntax = TokenSyntax.`rightBrace`
   ) {
     self.init(
       leftBrace: leftBrace,
@@ -674,7 +674,7 @@ extension FunctionDecl {
   public init(
     @AttributeListBuilder attributesBuilder: () -> AttributeList? = { nil },
     @ModifierListBuilder modifiersBuilder: () -> ModifierList? = { nil },
-    funcKeyword: TokenSyntax = Tokens.`func`,
+    funcKeyword: TokenSyntax = TokenSyntax.`func`,
     identifier: TokenSyntax,
     genericParameterClause: GenericParameterClause? = nil,
     signature: FunctionSignature,
@@ -698,7 +698,7 @@ extension InitializerDecl {
   public init(
     @AttributeListBuilder attributesBuilder: () -> AttributeList? = { nil },
     @ModifierListBuilder modifiersBuilder: () -> ModifierList? = { nil },
-    initKeyword: TokenSyntax = Tokens.`init`,
+    initKeyword: TokenSyntax = TokenSyntax.`init`,
     optionalMark: TokenSyntax? = nil,
     genericParameterClause: GenericParameterClause? = nil,
     parameters: ParameterClause,
@@ -724,7 +724,7 @@ extension DeinitializerDecl {
   public init(
     @AttributeListBuilder attributesBuilder: () -> AttributeList? = { nil },
     @ModifierListBuilder modifiersBuilder: () -> ModifierList? = { nil },
-    deinitKeyword: TokenSyntax = Tokens.`deinit`,
+    deinitKeyword: TokenSyntax = TokenSyntax.`deinit`,
     body: CodeBlock
   ) {
     self.init(
@@ -740,7 +740,7 @@ extension SubscriptDecl {
   public init(
     @AttributeListBuilder attributesBuilder: () -> AttributeList? = { nil },
     @ModifierListBuilder modifiersBuilder: () -> ModifierList? = { nil },
-    subscriptKeyword: TokenSyntax = Tokens.`subscript`,
+    subscriptKeyword: TokenSyntax = TokenSyntax.`subscript`,
     genericParameterClause: GenericParameterClause? = nil,
     indices: ParameterClause,
     result: ReturnClause,
@@ -792,7 +792,7 @@ extension ImportDecl {
   public init(
     @AttributeListBuilder attributesBuilder: () -> AttributeList? = { nil },
     @ModifierListBuilder modifiersBuilder: () -> ModifierList? = { nil },
-    importTok: TokenSyntax = Tokens.`import`,
+    importTok: TokenSyntax = TokenSyntax.`import`,
     importKind: TokenSyntax? = nil,
     @AccessPathBuilder pathBuilder: () -> AccessPath = { .empty }
   ) {
@@ -808,9 +808,9 @@ extension ImportDecl {
 
 extension AccessorParameter {
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     name: String,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.init(
       leftParen: leftParen,
@@ -844,9 +844,9 @@ extension AccessorDecl {
 
 extension AccessorBlock {
   public init(
-    leftBrace: TokenSyntax = Tokens.`leftBrace`,
+    leftBrace: TokenSyntax = TokenSyntax.`leftBrace`,
     @AccessorListBuilder accessorsBuilder: () -> AccessorList = { .empty },
-    rightBrace: TokenSyntax = Tokens.`rightBrace`
+    rightBrace: TokenSyntax = TokenSyntax.`rightBrace`
   ) {
     self.init(
       leftBrace: leftBrace,
@@ -892,7 +892,7 @@ extension EnumCaseDecl {
   public init(
     @AttributeListBuilder attributesBuilder: () -> AttributeList? = { nil },
     @ModifierListBuilder modifiersBuilder: () -> ModifierList? = { nil },
-    caseKeyword: TokenSyntax = Tokens.`case`,
+    caseKeyword: TokenSyntax = TokenSyntax.`case`,
     @EnumCaseElementListBuilder elementsBuilder: () -> EnumCaseElementList = { .empty }
   ) {
     self.init(
@@ -908,7 +908,7 @@ extension EnumDecl {
   public init(
     @AttributeListBuilder attributesBuilder: () -> AttributeList? = { nil },
     @ModifierListBuilder modifiersBuilder: () -> ModifierList? = { nil },
-    enumKeyword: TokenSyntax = Tokens.`enum`,
+    enumKeyword: TokenSyntax = TokenSyntax.`enum`,
     identifier: String,
     genericParameters: GenericParameterClause? = nil,
     inheritanceClause: TypeInheritanceClause? = nil,
@@ -932,7 +932,7 @@ extension OperatorDecl {
   public init(
     @AttributeListBuilder attributesBuilder: () -> AttributeList? = { nil },
     @ModifierListBuilder modifiersBuilder: () -> ModifierList? = { nil },
-    operatorKeyword: TokenSyntax = Tokens.`operator`,
+    operatorKeyword: TokenSyntax = TokenSyntax.`operator`,
     identifier: TokenSyntax,
     operatorPrecedenceAndTypes: OperatorPrecedenceAndTypes? = nil
   ) {
@@ -948,7 +948,7 @@ extension OperatorDecl {
 
 extension OperatorPrecedenceAndTypes {
   public init(
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     @IdentifierListBuilder precedenceGroupAndDesignatedTypesBuilder: () -> IdentifierList = { .empty }
   ) {
     self.init(
@@ -962,11 +962,11 @@ extension PrecedenceGroupDecl {
   public init(
     @AttributeListBuilder attributesBuilder: () -> AttributeList? = { nil },
     @ModifierListBuilder modifiersBuilder: () -> ModifierList? = { nil },
-    precedencegroupKeyword: TokenSyntax = Tokens.`precedencegroup`,
+    precedencegroupKeyword: TokenSyntax = TokenSyntax.`precedencegroup`,
     identifier: String,
-    leftBrace: TokenSyntax = Tokens.`leftBrace`,
+    leftBrace: TokenSyntax = TokenSyntax.`leftBrace`,
     @PrecedenceGroupAttributeListBuilder groupAttributesBuilder: () -> PrecedenceGroupAttributeList = { .empty },
-    rightBrace: TokenSyntax = Tokens.`rightBrace`
+    rightBrace: TokenSyntax = TokenSyntax.`rightBrace`
   ) {
     self.init(
       attributes: attributesBuilder(),
@@ -983,7 +983,7 @@ extension PrecedenceGroupDecl {
 extension PrecedenceGroupRelation {
   public init(
     higherThanOrLowerThan: String,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     @PrecedenceGroupNameListBuilder otherNamesBuilder: () -> PrecedenceGroupNameList = { .empty }
   ) {
     self.init(
@@ -1009,7 +1009,7 @@ extension PrecedenceGroupNameElement {
 extension PrecedenceGroupAssignment {
   public init(
     assignmentKeyword: String,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     flag: TokenSyntax
   ) {
     self.init(
@@ -1023,7 +1023,7 @@ extension PrecedenceGroupAssignment {
 extension PrecedenceGroupAssociativity {
   public init(
     associativityKeyword: String,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     value: String
   ) {
     self.init(
@@ -1036,7 +1036,7 @@ extension PrecedenceGroupAssociativity {
 
 extension CustomAttribute {
   public init(
-    atSignToken: TokenSyntax = Tokens.`atSign`,
+    atSignToken: TokenSyntax = TokenSyntax.`atSign`,
     attributeName: TypeBuildable,
     leftParen: TokenSyntax? = nil,
     @TupleExprElementListBuilder argumentListBuilder: () -> TupleExprElementList? = { nil },
@@ -1054,7 +1054,7 @@ extension CustomAttribute {
 
 extension Attribute {
   public init(
-    atSignToken: TokenSyntax = Tokens.`atSign`,
+    atSignToken: TokenSyntax = TokenSyntax.`atSign`,
     attributeName: TokenSyntax,
     leftParen: TokenSyntax? = nil,
     argument: SyntaxBuildable? = nil,
@@ -1075,7 +1075,7 @@ extension Attribute {
 extension LabeledSpecializeEntry {
   public init(
     label: String,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     value: TokenSyntax,
     trailingComma: TokenSyntax? = nil
   ) {
@@ -1091,7 +1091,7 @@ extension LabeledSpecializeEntry {
 extension TargetFunctionEntry {
   public init(
     label: String,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     delcname: DeclName,
     trailingComma: TokenSyntax? = nil
   ) {
@@ -1137,7 +1137,7 @@ extension DifferentiableAttributeArguments {
 extension DifferentiabilityParamsClause {
   public init(
     wrtLabel: String,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     parameters: SyntaxBuildable
   ) {
     self.init(
@@ -1150,9 +1150,9 @@ extension DifferentiabilityParamsClause {
 
 extension DifferentiabilityParams {
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     @DifferentiabilityParamListBuilder diffParamsBuilder: () -> DifferentiabilityParamList = { .empty },
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.init(
       leftParen: leftParen,
@@ -1165,7 +1165,7 @@ extension DifferentiabilityParams {
 extension DerivativeRegistrationAttributeArguments {
   public init(
     ofLabel: String,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     originalDeclName: QualifiedDeclName,
     period: TokenSyntax? = nil,
     accessorKind: String?,
@@ -1186,7 +1186,7 @@ extension DerivativeRegistrationAttributeArguments {
 
 extension ContinueStmt {
   public init(
-    continueKeyword: TokenSyntax = Tokens.`continue`,
+    continueKeyword: TokenSyntax = TokenSyntax.`continue`,
     label: String?
   ) {
     self.init(
@@ -1200,7 +1200,7 @@ extension WhileStmt {
   public init(
     labelName: String?,
     labelColon: TokenSyntax? = nil,
-    whileKeyword: TokenSyntax = Tokens.`while`,
+    whileKeyword: TokenSyntax = TokenSyntax.`while`,
     @ConditionElementListBuilder conditionsBuilder: () -> ConditionElementList = { .empty },
     body: CodeBlock
   ) {
@@ -1218,9 +1218,9 @@ extension RepeatWhileStmt {
   public init(
     labelName: String?,
     labelColon: TokenSyntax? = nil,
-    repeatKeyword: TokenSyntax = Tokens.`repeat`,
+    repeatKeyword: TokenSyntax = TokenSyntax.`repeat`,
     body: CodeBlock,
-    whileKeyword: TokenSyntax = Tokens.`while`,
+    whileKeyword: TokenSyntax = TokenSyntax.`while`,
     condition: ExprBuildable
   ) {
     self.init(
@@ -1236,9 +1236,9 @@ extension RepeatWhileStmt {
 
 extension GuardStmt {
   public init(
-    guardKeyword: TokenSyntax = Tokens.`guard`,
+    guardKeyword: TokenSyntax = TokenSyntax.`guard`,
     @ConditionElementListBuilder conditionsBuilder: () -> ConditionElementList = { .empty },
-    elseKeyword: TokenSyntax = Tokens.`else`,
+    elseKeyword: TokenSyntax = TokenSyntax.`else`,
     body: CodeBlock
   ) {
     self.init(
@@ -1254,13 +1254,13 @@ extension ForInStmt {
   public init(
     labelName: String?,
     labelColon: TokenSyntax? = nil,
-    forKeyword: TokenSyntax = Tokens.`for`,
+    forKeyword: TokenSyntax = TokenSyntax.`for`,
     tryKeyword: TokenSyntax? = nil,
     awaitKeyword: String?,
     caseKeyword: TokenSyntax? = nil,
     pattern: PatternBuildable,
     typeAnnotation: TypeAnnotation? = nil,
-    inKeyword: TokenSyntax = Tokens.`in`,
+    inKeyword: TokenSyntax = TokenSyntax.`in`,
     sequenceExpr: ExprBuildable,
     whereClause: WhereClause? = nil,
     body: CodeBlock
@@ -1286,11 +1286,11 @@ extension SwitchStmt {
   public init(
     labelName: String?,
     labelColon: TokenSyntax? = nil,
-    switchKeyword: TokenSyntax = Tokens.`switch`,
+    switchKeyword: TokenSyntax = TokenSyntax.`switch`,
     expression: ExprBuildable,
-    leftBrace: TokenSyntax = Tokens.`leftBrace`,
+    leftBrace: TokenSyntax = TokenSyntax.`leftBrace`,
     @SwitchCaseListBuilder casesBuilder: () -> SwitchCaseList = { .empty },
-    rightBrace: TokenSyntax = Tokens.`rightBrace`
+    rightBrace: TokenSyntax = TokenSyntax.`rightBrace`
   ) {
     self.init(
       labelName: labelName.map({ SyntaxFactory.makeIdentifier($0) }),
@@ -1308,7 +1308,7 @@ extension DoStmt {
   public init(
     labelName: String?,
     labelColon: TokenSyntax? = nil,
-    doKeyword: TokenSyntax = Tokens.`do`,
+    doKeyword: TokenSyntax = TokenSyntax.`do`,
     body: CodeBlock,
     @CatchClauseListBuilder catchClausesBuilder: () -> CatchClauseList? = { nil }
   ) {
@@ -1324,10 +1324,10 @@ extension DoStmt {
 
 extension YieldList {
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     @ExprListBuilder elementListBuilder: () -> ExprList = { .empty },
     trailingComma: TokenSyntax? = nil,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.init(
       leftParen: leftParen,
@@ -1340,7 +1340,7 @@ extension YieldList {
 
 extension BreakStmt {
   public init(
-    breakKeyword: TokenSyntax = Tokens.`break`,
+    breakKeyword: TokenSyntax = TokenSyntax.`break`,
     label: String?
   ) {
     self.init(
@@ -1352,10 +1352,10 @@ extension BreakStmt {
 
 extension AvailabilityCondition {
   public init(
-    poundAvailableKeyword: TokenSyntax = Tokens.`poundAvailable`,
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    poundAvailableKeyword: TokenSyntax = TokenSyntax.`poundAvailable`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     @AvailabilitySpecListBuilder availabilitySpecBuilder: () -> AvailabilitySpecList = { .empty },
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.init(
       poundAvailableKeyword: poundAvailableKeyword,
@@ -1370,7 +1370,7 @@ extension IfStmt {
   public init(
     labelName: String?,
     labelColon: TokenSyntax? = nil,
-    ifKeyword: TokenSyntax = Tokens.`if`,
+    ifKeyword: TokenSyntax = TokenSyntax.`if`,
     @ConditionElementListBuilder conditionsBuilder: () -> ConditionElementList = { .empty },
     body: CodeBlock,
     elseKeyword: TokenSyntax? = nil,
@@ -1404,9 +1404,9 @@ extension SwitchCase {
 
 extension SwitchCaseLabel {
   public init(
-    caseKeyword: TokenSyntax = Tokens.`case`,
+    caseKeyword: TokenSyntax = TokenSyntax.`case`,
     @CaseItemListBuilder caseItemsBuilder: () -> CaseItemList = { .empty },
-    colon: TokenSyntax = Tokens.`colon`
+    colon: TokenSyntax = TokenSyntax.`colon`
   ) {
     self.init(
       caseKeyword: caseKeyword,
@@ -1418,7 +1418,7 @@ extension SwitchCaseLabel {
 
 extension CatchClause {
   public init(
-    catchKeyword: TokenSyntax = Tokens.`catch`,
+    catchKeyword: TokenSyntax = TokenSyntax.`catch`,
     @CatchItemListBuilder catchItemsBuilder: () -> CatchItemList? = { nil },
     body: CodeBlock
   ) {
@@ -1432,19 +1432,19 @@ extension CatchClause {
 
 extension PoundAssertStmt {
   public init(
-    poundAssert: TokenSyntax = Tokens.`poundAssert`,
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    poundAssert: TokenSyntax = TokenSyntax.`poundAssert`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     condition: ExprBuildable,
     comma: TokenSyntax? = nil,
     message: String?,
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.init(
       poundAssert: poundAssert,
       leftParen: leftParen,
       condition: condition,
       comma: comma,
-      message: message.map(Tokens.stringLiteral),
+      message: message.map(TokenSyntax.stringLiteral),
       rightParen: rightParen
     )
   }
@@ -1452,7 +1452,7 @@ extension PoundAssertStmt {
 
 extension GenericWhereClause {
   public init(
-    whereKeyword: TokenSyntax = Tokens.`where`,
+    whereKeyword: TokenSyntax = TokenSyntax.`where`,
     @GenericRequirementListBuilder requirementListBuilder: () -> GenericRequirementList = { .empty }
   ) {
     self.init(
@@ -1482,9 +1482,9 @@ extension GenericParameter {
 
 extension GenericParameterClause {
   public init(
-    leftAngleBracket: TokenSyntax = Tokens.`leftAngle`,
+    leftAngleBracket: TokenSyntax = TokenSyntax.`leftAngle`,
     @GenericParameterListBuilder genericParameterListBuilder: () -> GenericParameterList = { .empty },
-    rightAngleBracket: TokenSyntax = Tokens.`rightAngle`
+    rightAngleBracket: TokenSyntax = TokenSyntax.`rightAngle`
   ) {
     self.init(
       leftAngleBracket: leftAngleBracket,
@@ -1497,7 +1497,7 @@ extension GenericParameterClause {
 extension MetatypeType {
   public init(
     baseType: TypeBuildable,
-    period: TokenSyntax = Tokens.`period`,
+    period: TokenSyntax = TokenSyntax.`period`,
     typeOrProtocol: String
   ) {
     self.init(
@@ -1532,9 +1532,9 @@ extension CompositionType {
 
 extension TupleType {
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     @TupleTypeElementListBuilder elementsBuilder: () -> TupleTypeElementList = { .empty },
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.init(
       leftParen: leftParen,
@@ -1546,12 +1546,12 @@ extension TupleType {
 
 extension FunctionType {
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     @TupleTypeElementListBuilder argumentsBuilder: () -> TupleTypeElementList = { .empty },
-    rightParen: TokenSyntax = Tokens.`rightParen`,
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`,
     asyncKeyword: String?,
     throwsOrRethrowsKeyword: TokenSyntax? = nil,
-    arrow: TokenSyntax = Tokens.`arrow`,
+    arrow: TokenSyntax = TokenSyntax.`arrow`,
     returnType: TypeBuildable
   ) {
     self.init(
@@ -1582,9 +1582,9 @@ extension AttributedType {
 
 extension GenericArgumentClause {
   public init(
-    leftAngleBracket: TokenSyntax = Tokens.`leftAngle`,
+    leftAngleBracket: TokenSyntax = TokenSyntax.`leftAngle`,
     @GenericArgumentListBuilder argumentsBuilder: () -> GenericArgumentList = { .empty },
-    rightAngleBracket: TokenSyntax = Tokens.`rightAngle`
+    rightAngleBracket: TokenSyntax = TokenSyntax.`rightAngle`
   ) {
     self.init(
       leftAngleBracket: leftAngleBracket,
@@ -1597,7 +1597,7 @@ extension GenericArgumentClause {
 extension EnumCasePattern {
   public init(
     type: TypeBuildable? = nil,
-    period: TokenSyntax = Tokens.`period`,
+    period: TokenSyntax = TokenSyntax.`period`,
     caseName: String,
     associatedTuple: TuplePattern? = nil
   ) {
@@ -1612,9 +1612,9 @@ extension EnumCasePattern {
 
 extension TuplePattern {
   public init(
-    leftParen: TokenSyntax = Tokens.`leftParen`,
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     @TuplePatternElementListBuilder elementsBuilder: () -> TuplePatternElementList = { .empty },
-    rightParen: TokenSyntax = Tokens.`rightParen`
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`
   ) {
     self.init(
       leftParen: leftParen,
@@ -1643,7 +1643,7 @@ extension TuplePatternElement {
 extension AvailabilityLabeledArgument {
   public init(
     label: String,
-    colon: TokenSyntax = Tokens.`colon`,
+    colon: TokenSyntax = TokenSyntax.`colon`,
     value: SyntaxBuildable
   ) {
     self.init(
@@ -1675,7 +1675,7 @@ extension VersionTuple {
     self.init(
       majorMinor: majorMinor,
       patchPeriod: patchPeriod,
-      patchVersion: patchVersion.map(Tokens.integerLiteral)
+      patchVersion: patchVersion.map(TokenSyntax.integerLiteral)
     )
   }
 }

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/Tokens.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/Tokens.swift
@@ -15,475 +15,475 @@
 import SwiftSyntax
 
 /// Namespace for commonly used tokens with default trivia.
-public enum Tokens {
+public extension TokenSyntax {
   /// The `associatedtype` keyword
-  public static let `associatedtype` = SyntaxFactory.makeAssociatedtypeKeyword()
+  static let `associatedtype` = SyntaxFactory.makeAssociatedtypeKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `class` keyword
-  public static let `class` = SyntaxFactory.makeClassKeyword()
+  static let `class` = SyntaxFactory.makeClassKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `deinit` keyword
-  public static let `deinit` = SyntaxFactory.makeDeinitKeyword()
+  static let `deinit` = SyntaxFactory.makeDeinitKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `enum` keyword
-  public static let `enum` = SyntaxFactory.makeEnumKeyword()
+  static let `enum` = SyntaxFactory.makeEnumKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `extension` keyword
-  public static let `extension` = SyntaxFactory.makeExtensionKeyword()
+  static let `extension` = SyntaxFactory.makeExtensionKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `func` keyword
-  public static let `func` = SyntaxFactory.makeFuncKeyword()
+  static let `func` = SyntaxFactory.makeFuncKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `import` keyword
-  public static let `import` = SyntaxFactory.makeImportKeyword()
+  static let `import` = SyntaxFactory.makeImportKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `init` keyword
-  public static let `init` = SyntaxFactory.makeInitKeyword()
+  static let `init` = SyntaxFactory.makeInitKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `inout` keyword
-  public static let `inout` = SyntaxFactory.makeInoutKeyword()
+  static let `inout` = SyntaxFactory.makeInoutKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `let` keyword
-  public static let `let` = SyntaxFactory.makeLetKeyword()
+  static let `let` = SyntaxFactory.makeLetKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `operator` keyword
-  public static let `operator` = SyntaxFactory.makeOperatorKeyword()
+  static let `operator` = SyntaxFactory.makeOperatorKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `precedencegroup` keyword
-  public static let `precedencegroup` = SyntaxFactory.makePrecedencegroupKeyword()
+  static let `precedencegroup` = SyntaxFactory.makePrecedencegroupKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `protocol` keyword
-  public static let `protocol` = SyntaxFactory.makeProtocolKeyword()
+  static let `protocol` = SyntaxFactory.makeProtocolKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `struct` keyword
-  public static let `struct` = SyntaxFactory.makeStructKeyword()
+  static let `struct` = SyntaxFactory.makeStructKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `subscript` keyword
-  public static let `subscript` = SyntaxFactory.makeSubscriptKeyword()
+  static let `subscript` = SyntaxFactory.makeSubscriptKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `typealias` keyword
-  public static let `typealias` = SyntaxFactory.makeTypealiasKeyword()
+  static let `typealias` = SyntaxFactory.makeTypealiasKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `var` keyword
-  public static let `var` = SyntaxFactory.makeVarKeyword()
+  static let `var` = SyntaxFactory.makeVarKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `fileprivate` keyword
-  public static let `fileprivate` = SyntaxFactory.makeFileprivateKeyword()
+  static let `fileprivate` = SyntaxFactory.makeFileprivateKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `internal` keyword
-  public static let `internal` = SyntaxFactory.makeInternalKeyword()
+  static let `internal` = SyntaxFactory.makeInternalKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `private` keyword
-  public static let `private` = SyntaxFactory.makePrivateKeyword()
+  static let `private` = SyntaxFactory.makePrivateKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `public` keyword
-  public static let `public` = SyntaxFactory.makePublicKeyword()
+  static let `public` = SyntaxFactory.makePublicKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `static` keyword
-  public static let `static` = SyntaxFactory.makeStaticKeyword()
+  static let `static` = SyntaxFactory.makeStaticKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `defer` keyword
-  public static let `defer` = SyntaxFactory.makeDeferKeyword()
+  static let `defer` = SyntaxFactory.makeDeferKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `if` keyword
-  public static let `if` = SyntaxFactory.makeIfKeyword()
+  static let `if` = SyntaxFactory.makeIfKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `guard` keyword
-  public static let `guard` = SyntaxFactory.makeGuardKeyword()
+  static let `guard` = SyntaxFactory.makeGuardKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `do` keyword
-  public static let `do` = SyntaxFactory.makeDoKeyword()
+  static let `do` = SyntaxFactory.makeDoKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `repeat` keyword
-  public static let `repeat` = SyntaxFactory.makeRepeatKeyword()
+  static let `repeat` = SyntaxFactory.makeRepeatKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `else` keyword
-  public static let `else` = SyntaxFactory.makeElseKeyword()
+  static let `else` = SyntaxFactory.makeElseKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `for` keyword
-  public static let `for` = SyntaxFactory.makeForKeyword()
+  static let `for` = SyntaxFactory.makeForKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `in` keyword
-  public static let `in` = SyntaxFactory.makeInKeyword()
+  static let `in` = SyntaxFactory.makeInKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `while` keyword
-  public static let `while` = SyntaxFactory.makeWhileKeyword()
+  static let `while` = SyntaxFactory.makeWhileKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `return` keyword
-  public static let `return` = SyntaxFactory.makeReturnKeyword()
+  static let `return` = SyntaxFactory.makeReturnKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `break` keyword
-  public static let `break` = SyntaxFactory.makeBreakKeyword()
+  static let `break` = SyntaxFactory.makeBreakKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `continue` keyword
-  public static let `continue` = SyntaxFactory.makeContinueKeyword()
+  static let `continue` = SyntaxFactory.makeContinueKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `fallthrough` keyword
-  public static let `fallthrough` = SyntaxFactory.makeFallthroughKeyword()
+  static let `fallthrough` = SyntaxFactory.makeFallthroughKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `switch` keyword
-  public static let `switch` = SyntaxFactory.makeSwitchKeyword()
+  static let `switch` = SyntaxFactory.makeSwitchKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `case` keyword
-  public static let `case` = SyntaxFactory.makeCaseKeyword()
+  static let `case` = SyntaxFactory.makeCaseKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `default` keyword
-  public static let `default` = SyntaxFactory.makeDefaultKeyword()
+  static let `default` = SyntaxFactory.makeDefaultKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `where` keyword
-  public static let `where` = SyntaxFactory.makeWhereKeyword()
+  static let `where` = SyntaxFactory.makeWhereKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `catch` keyword
-  public static let `catch` = SyntaxFactory.makeCatchKeyword()
+  static let `catch` = SyntaxFactory.makeCatchKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `throw` keyword
-  public static let `throw` = SyntaxFactory.makeThrowKeyword()
+  static let `throw` = SyntaxFactory.makeThrowKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `as` keyword
-  public static let `as` = SyntaxFactory.makeAsKeyword()
+  static let `as` = SyntaxFactory.makeAsKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `Any` keyword
-  public static let `any` = SyntaxFactory.makeAnyKeyword()
+  static let `any` = SyntaxFactory.makeAnyKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `false` keyword
-  public static let `false` = SyntaxFactory.makeFalseKeyword()
+  static let `false` = SyntaxFactory.makeFalseKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `is` keyword
-  public static let `is` = SyntaxFactory.makeIsKeyword()
+  static let `is` = SyntaxFactory.makeIsKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `nil` keyword
-  public static let `nil` = SyntaxFactory.makeNilKeyword()
+  static let `nil` = SyntaxFactory.makeNilKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `rethrows` keyword
-  public static let `rethrows` = SyntaxFactory.makeRethrowsKeyword()
+  static let `rethrows` = SyntaxFactory.makeRethrowsKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `super` keyword
-  public static let `super` = SyntaxFactory.makeSuperKeyword()
+  static let `super` = SyntaxFactory.makeSuperKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `self` keyword
-  public static let `self` = SyntaxFactory.makeSelfKeyword()
+  static let `self` = SyntaxFactory.makeSelfKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `Self` keyword
-  public static let `capitalSelf` = SyntaxFactory.makeCapitalSelfKeyword()
+  static let `capitalSelf` = SyntaxFactory.makeCapitalSelfKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `true` keyword
-  public static let `true` = SyntaxFactory.makeTrueKeyword()
+  static let `true` = SyntaxFactory.makeTrueKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `try` keyword
-  public static let `try` = SyntaxFactory.makeTryKeyword()
+  static let `try` = SyntaxFactory.makeTryKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `throws` keyword
-  public static let `throws` = SyntaxFactory.makeThrowsKeyword()
+  static let `throws` = SyntaxFactory.makeThrowsKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `__FILE__` keyword
-  public static let `__file__` = SyntaxFactory.make__FILE__Keyword()
+  static let `__file__` = SyntaxFactory.make__FILE__Keyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `__LINE__` keyword
-  public static let `__line__` = SyntaxFactory.make__LINE__Keyword()
+  static let `__line__` = SyntaxFactory.make__LINE__Keyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `__COLUMN__` keyword
-  public static let `__column__` = SyntaxFactory.make__COLUMN__Keyword()
+  static let `__column__` = SyntaxFactory.make__COLUMN__Keyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `__FUNCTION__` keyword
-  public static let `__function__` = SyntaxFactory.make__FUNCTION__Keyword()
+  static let `__function__` = SyntaxFactory.make__FUNCTION__Keyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `__DSO_HANDLE__` keyword
-  public static let `__dso_handle__` = SyntaxFactory.make__DSO_HANDLE__Keyword()
+  static let `__dso_handle__` = SyntaxFactory.make__DSO_HANDLE__Keyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `_` keyword
-  public static let `wildcard` = SyntaxFactory.makeWildcardKeyword()
+  static let `wildcard` = SyntaxFactory.makeWildcardKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `(` token
-  public static let `leftParen` = SyntaxFactory.makeLeftParenToken()
+  static let `leftParen` = SyntaxFactory.makeLeftParenToken()
 
   /// The `)` token
-  public static let `rightParen` = SyntaxFactory.makeRightParenToken()
+  static let `rightParen` = SyntaxFactory.makeRightParenToken()
 
   /// The `{` token
-  public static let `leftBrace` = SyntaxFactory.makeLeftBraceToken()
+  static let `leftBrace` = SyntaxFactory.makeLeftBraceToken()
 
   /// The `}` token
-  public static let `rightBrace` = SyntaxFactory.makeRightBraceToken()
+  static let `rightBrace` = SyntaxFactory.makeRightBraceToken()
 
   /// The `[` token
-  public static let `leftSquareBracket` = SyntaxFactory.makeLeftSquareBracketToken()
+  static let `leftSquareBracket` = SyntaxFactory.makeLeftSquareBracketToken()
 
   /// The `]` token
-  public static let `rightSquareBracket` = SyntaxFactory.makeRightSquareBracketToken()
+  static let `rightSquareBracket` = SyntaxFactory.makeRightSquareBracketToken()
 
   /// The `<` token
-  public static let `leftAngle` = SyntaxFactory.makeLeftAngleToken()
+  static let `leftAngle` = SyntaxFactory.makeLeftAngleToken()
     .withLeadingTrivia(.spaces(1))
     .withTrailingTrivia(.spaces(1))
 
   /// The `>` token
-  public static let `rightAngle` = SyntaxFactory.makeRightAngleToken()
+  static let `rightAngle` = SyntaxFactory.makeRightAngleToken()
     .withLeadingTrivia(.spaces(1))
     .withTrailingTrivia(.spaces(1))
 
   /// The `.` token
-  public static let `period` = SyntaxFactory.makePeriodToken()
+  static let `period` = SyntaxFactory.makePeriodToken()
 
   /// The `.` token
-  public static let `prefixPeriod` = SyntaxFactory.makePrefixPeriodToken()
+  static let `prefixPeriod` = SyntaxFactory.makePrefixPeriodToken()
 
   /// The `,` token
-  public static let `comma` = SyntaxFactory.makeCommaToken()
+  static let `comma` = SyntaxFactory.makeCommaToken()
     .withTrailingTrivia(.spaces(1))
 
   /// The `...` token
-  public static let `ellipsis` = SyntaxFactory.makeEllipsisToken()
+  static let `ellipsis` = SyntaxFactory.makeEllipsisToken()
 
   /// The `:` token
-  public static let `colon` = SyntaxFactory.makeColonToken()
+  static let `colon` = SyntaxFactory.makeColonToken()
     .withTrailingTrivia(.spaces(1))
 
   /// The `;` token
-  public static let `semicolon` = SyntaxFactory.makeSemicolonToken()
+  static let `semicolon` = SyntaxFactory.makeSemicolonToken()
 
   /// The `=` token
-  public static let `equal` = SyntaxFactory.makeEqualToken()
+  static let `equal` = SyntaxFactory.makeEqualToken()
     .withLeadingTrivia(.spaces(1))
     .withTrailingTrivia(.spaces(1))
 
   /// The `@` token
-  public static let `atSign` = SyntaxFactory.makeAtSignToken()
+  static let `atSign` = SyntaxFactory.makeAtSignToken()
 
   /// The `#` token
-  public static let `pound` = SyntaxFactory.makePoundToken()
+  static let `pound` = SyntaxFactory.makePoundToken()
 
   /// The `&` token
-  public static let `prefixAmpersand` = SyntaxFactory.makePrefixAmpersandToken()
+  static let `prefixAmpersand` = SyntaxFactory.makePrefixAmpersandToken()
     .withLeadingTrivia(.spaces(1))
     .withTrailingTrivia(.spaces(1))
 
   /// The `->` token
-  public static let `arrow` = SyntaxFactory.makeArrowToken()
+  static let `arrow` = SyntaxFactory.makeArrowToken()
     .withTrailingTrivia(.spaces(1))
 
   /// The ``` token
-  public static let `backtick` = SyntaxFactory.makeBacktickToken()
+  static let `backtick` = SyntaxFactory.makeBacktickToken()
 
   /// The `\` token
-  public static let `backslash` = SyntaxFactory.makeBackslashToken()
+  static let `backslash` = SyntaxFactory.makeBackslashToken()
 
   /// The `!` token
-  public static let `exclamationMark` = SyntaxFactory.makeExclamationMarkToken()
+  static let `exclamationMark` = SyntaxFactory.makeExclamationMarkToken()
 
   /// The `?` token
-  public static let `postfixQuestionMark` = SyntaxFactory.makePostfixQuestionMarkToken()
+  static let `postfixQuestionMark` = SyntaxFactory.makePostfixQuestionMarkToken()
 
   /// The `?` token
-  public static let `infixQuestionMark` = SyntaxFactory.makeInfixQuestionMarkToken()
+  static let `infixQuestionMark` = SyntaxFactory.makeInfixQuestionMarkToken()
 
   /// The `"` token
-  public static let `stringQuote` = SyntaxFactory.makeStringQuoteToken()
+  static let `stringQuote` = SyntaxFactory.makeStringQuoteToken()
 
   /// The `'` token
-  public static let `singleQuote` = SyntaxFactory.makeSingleQuoteToken()
+  static let `singleQuote` = SyntaxFactory.makeSingleQuoteToken()
 
   /// The `"""` token
-  public static let `multilineStringQuote` = SyntaxFactory.makeMultilineStringQuoteToken()
+  static let `multilineStringQuote` = SyntaxFactory.makeMultilineStringQuoteToken()
 
   /// The `#keyPath` keyword
-  public static let `poundKeyPath` = SyntaxFactory.makePoundKeyPathKeyword()
+  static let `poundKeyPath` = SyntaxFactory.makePoundKeyPathKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#line` keyword
-  public static let `poundLine` = SyntaxFactory.makePoundLineKeyword()
+  static let `poundLine` = SyntaxFactory.makePoundLineKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#selector` keyword
-  public static let `poundSelector` = SyntaxFactory.makePoundSelectorKeyword()
+  static let `poundSelector` = SyntaxFactory.makePoundSelectorKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#file` keyword
-  public static let `poundFile` = SyntaxFactory.makePoundFileKeyword()
+  static let `poundFile` = SyntaxFactory.makePoundFileKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#fileID` keyword
-  public static let `poundFileID` = SyntaxFactory.makePoundFileIDKeyword()
+  static let `poundFileID` = SyntaxFactory.makePoundFileIDKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#filePath` keyword
-  public static let `poundFilePath` = SyntaxFactory.makePoundFilePathKeyword()
+  static let `poundFilePath` = SyntaxFactory.makePoundFilePathKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#column` keyword
-  public static let `poundColumn` = SyntaxFactory.makePoundColumnKeyword()
+  static let `poundColumn` = SyntaxFactory.makePoundColumnKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#function` keyword
-  public static let `poundFunction` = SyntaxFactory.makePoundFunctionKeyword()
+  static let `poundFunction` = SyntaxFactory.makePoundFunctionKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#dsohandle` keyword
-  public static let `poundDsohandle` = SyntaxFactory.makePoundDsohandleKeyword()
+  static let `poundDsohandle` = SyntaxFactory.makePoundDsohandleKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#assert` keyword
-  public static let `poundAssert` = SyntaxFactory.makePoundAssertKeyword()
+  static let `poundAssert` = SyntaxFactory.makePoundAssertKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#sourceLocation` keyword
-  public static let `poundSourceLocation` = SyntaxFactory.makePoundSourceLocationKeyword()
+  static let `poundSourceLocation` = SyntaxFactory.makePoundSourceLocationKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#warning` keyword
-  public static let `poundWarning` = SyntaxFactory.makePoundWarningKeyword()
+  static let `poundWarning` = SyntaxFactory.makePoundWarningKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#error` keyword
-  public static let `poundError` = SyntaxFactory.makePoundErrorKeyword()
+  static let `poundError` = SyntaxFactory.makePoundErrorKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#if` keyword
-  public static let `poundIf` = SyntaxFactory.makePoundIfKeyword()
+  static let `poundIf` = SyntaxFactory.makePoundIfKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#else` keyword
-  public static let `poundElse` = SyntaxFactory.makePoundElseKeyword()
+  static let `poundElse` = SyntaxFactory.makePoundElseKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#elseif` keyword
-  public static let `poundElseif` = SyntaxFactory.makePoundElseifKeyword()
+  static let `poundElseif` = SyntaxFactory.makePoundElseifKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#endif` keyword
-  public static let `poundEndif` = SyntaxFactory.makePoundEndifKeyword()
+  static let `poundEndif` = SyntaxFactory.makePoundEndifKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#available` keyword
-  public static let `poundAvailable` = SyntaxFactory.makePoundAvailableKeyword()
+  static let `poundAvailable` = SyntaxFactory.makePoundAvailableKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#fileLiteral` keyword
-  public static let `poundFileLiteral` = SyntaxFactory.makePoundFileLiteralKeyword()
+  static let `poundFileLiteral` = SyntaxFactory.makePoundFileLiteralKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#imageLiteral` keyword
-  public static let `poundImageLiteral` = SyntaxFactory.makePoundImageLiteralKeyword()
+  static let `poundImageLiteral` = SyntaxFactory.makePoundImageLiteralKeyword()
     .withTrailingTrivia(.spaces(1))
 
   /// The `#colorLiteral` keyword
-  public static let `poundColorLiteral` = SyntaxFactory.makePoundColorLiteralKeyword()
+  static let `poundColorLiteral` = SyntaxFactory.makePoundColorLiteralKeyword()
     .withTrailingTrivia(.spaces(1))
 
-  public static func `integerLiteral`(_ text: String) -> TokenSyntax {
+  static func `integerLiteral`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeIntegerLiteral(text)
   }
 
-  public static func `floatingLiteral`(_ text: String) -> TokenSyntax {
+  static func `floatingLiteral`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeFloatingLiteral(text)
   }
 
-  public static func `stringLiteral`(_ text: String) -> TokenSyntax {
+  static func `stringLiteral`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeStringLiteral(text)
   }
 
-  public static func `unknown`(_ text: String) -> TokenSyntax {
+  static func `unknown`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeUnknown(text)
   }
 
-  public static func `identifier`(_ text: String) -> TokenSyntax {
+  static func `identifier`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeIdentifier(text)
   }
 
-  public static func `unspacedBinaryOperator`(_ text: String) -> TokenSyntax {
+  static func `unspacedBinaryOperator`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeUnspacedBinaryOperator(text)
   }
 
-  public static func `spacedBinaryOperator`(_ text: String) -> TokenSyntax {
+  static func `spacedBinaryOperator`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeSpacedBinaryOperator(text)
   }
 
-  public static func `postfixOperator`(_ text: String) -> TokenSyntax {
+  static func `postfixOperator`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makePostfixOperator(text)
   }
 
-  public static func `prefixOperator`(_ text: String) -> TokenSyntax {
+  static func `prefixOperator`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makePrefixOperator(text)
   }
 
-  public static func `dollarIdentifier`(_ text: String) -> TokenSyntax {
+  static func `dollarIdentifier`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeDollarIdentifier(text)
   }
 
-  public static func `contextualKeyword`(_ text: String) -> TokenSyntax {
+  static func `contextualKeyword`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeContextualKeyword(text)
   }
 
-  public static func `rawStringDelimiter`(_ text: String) -> TokenSyntax {
+  static func `rawStringDelimiter`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeRawStringDelimiter(text)
   }
 
-  public static func `stringSegment`(_ text: String) -> TokenSyntax {
+  static func `stringSegment`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeStringSegment(text)
   }
 
   /// The `)` token
-  public static let `stringInterpolationAnchor` = SyntaxFactory.makeStringInterpolationAnchorToken()
+  static let `stringInterpolationAnchor` = SyntaxFactory.makeStringInterpolationAnchorToken()
 
   /// The `yield` token
-  public static let `yield` = SyntaxFactory.makeYieldToken()
+  static let `yield` = SyntaxFactory.makeYieldToken()
 
 }

--- a/Tests/SwiftSyntaxBuilderTest/BooleanLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/BooleanLiteralTests.swift
@@ -8,8 +8,8 @@ final class BooleanLiteralTests: XCTestCase {
     let leadingTrivia = Trivia.garbageText("␣")
 
     let testCases: [UInt: (BooleanLiteralExpr, String)] = [
-      #line: (BooleanLiteralExpr(booleanLiteral: Tokens.true), "␣true "),
-      #line: (BooleanLiteralExpr(booleanLiteral: Tokens.false), "␣false "),
+      #line: (BooleanLiteralExpr(booleanLiteral: .true), "␣true "),
+      #line: (BooleanLiteralExpr(booleanLiteral: .false), "␣false "),
       #line: (BooleanLiteralExpr(true), "␣true "),
       #line: (BooleanLiteralExpr(false), "␣false "),
       #line: (true, "␣true "),

--- a/Tests/SwiftSyntaxBuilderTest/EnumCaseElementTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/EnumCaseElementTests.swift
@@ -9,9 +9,9 @@ final class EnumCaseElementTests: XCTestCase {
     let segment = StringSegment(content: string)
     let segments = StringLiteralSegments([segment])
 
-    let stringLiteralExpr: ExprBuildable = StringLiteralExpr(openQuote: Tokens.stringQuote,
+    let stringLiteralExpr: ExprBuildable = StringLiteralExpr(openQuote: .stringQuote,
                                                              segments: segments,
-                                                             closeQuote: Tokens.stringQuote)
+                                                             closeQuote: .stringQuote)
 
     let initializerClause = InitializerClause(value: stringLiteralExpr)
 

--- a/Tests/SwiftSyntaxBuilderTest/FloatLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FloatLiteralTests.swift
@@ -8,8 +8,8 @@ final class FloatLiteralTests: XCTestCase {
     let leadingTrivia = Trivia.garbageText("␣")
 
     let testCases: [UInt: (FloatLiteralExpr, String)] = [
-      #line: (FloatLiteralExpr(floatingDigits: Tokens.floatingLiteral(String(123.321))), "␣123.321"),
-      #line: (FloatLiteralExpr(floatingDigits: Tokens.floatingLiteral(String(-123.321))), "␣-123.321"),
+      #line: (FloatLiteralExpr(floatingDigits: .floatingLiteral(String(123.321))), "␣123.321"),
+      #line: (FloatLiteralExpr(floatingDigits: .floatingLiteral(String(-123.321))), "␣-123.321"),
       #line: (FloatLiteralExpr(floatingDigits: "2_123.321"), "␣2_123.321"),
       #line: (FloatLiteralExpr(floatingDigits: "-2_123.321"), "␣-2_123.321"),
       #line: (FloatLiteralExpr(2_123.321), "␣2123.321"),

--- a/Tests/SwiftSyntaxBuilderTest/IntegerLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/IntegerLiteralTests.swift
@@ -8,8 +8,8 @@ final class IntegerLiteralTests: XCTestCase {
     let leadingTrivia = Trivia.garbageText("␣")
 
     let testCases: [UInt: (IntegerLiteralExpr, String)] = [
-      #line: (IntegerLiteralExpr(digits: Tokens.integerLiteral(String(123))), "␣123"),
-      #line: (IntegerLiteralExpr(digits: Tokens.integerLiteral(String(-123))), "␣-123"),
+      #line: (IntegerLiteralExpr(digits: .integerLiteral(String(123))), "␣123"),
+      #line: (IntegerLiteralExpr(digits: .integerLiteral(String(-123))), "␣-123"),
       #line: (IntegerLiteralExpr(digits: "1_000"), "␣1_000"),
       #line: (IntegerLiteralExpr(digits: "-1_000"), "␣-1_000"),
       #line: (IntegerLiteralExpr(1_000), "␣1000"),

--- a/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
@@ -15,9 +15,9 @@ final class StringLiteralTests: XCTestCase {
       let (value, expected) = testCase
       let string = SyntaxFactory.makeStringSegment(value)
       let segment = StringSegment(content: string)
-      let builder = StringLiteralExpr(openQuote: Tokens.stringQuote,
+      let builder = StringLiteralExpr(openQuote: .stringQuote,
                                       segments: StringLiteralSegments([segment]),
-                                      closeQuote: Tokens.stringQuote)
+                                      closeQuote: .stringQuote)
       let syntax = builder.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
 
       var text = ""

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -7,7 +7,7 @@ final class VariableTests: XCTestCase {
   func testVariableDecl() {
     let leadingTrivia = Trivia.garbageText("␣")
 
-    let buildable = VariableDecl(letOrVarKeyword: Tokens.let) {
+    let buildable = VariableDecl(letOrVarKeyword: .let) {
         PatternBinding(pattern: IdentifierPattern(identifier: SyntaxFactory.makeIdentifier("color")),
                        typeAnnotation: TypeAnnotation(type: SimpleTypeIdentifier("UIColor")))
     }
@@ -25,10 +25,10 @@ final class VariableTests: XCTestCase {
   func testVariableDeclWithValue() {
     let leadingTrivia = Trivia.garbageText("␣")
 
-    let buildable = VariableDecl(letOrVarKeyword: Tokens.var) {
+    let buildable = VariableDecl(letOrVarKeyword: .var) {
         PatternBinding(pattern: IdentifierPattern(identifier: SyntaxFactory.makeIdentifier("number")),
                        typeAnnotation: TypeAnnotation(type: SimpleTypeIdentifier("Int")),
-                       initializer: InitializerClause(value: IntegerLiteralExpr(digits: Tokens.integerLiteral("123"))))
+                       initializer: InitializerClause(value: IntegerLiteralExpr(digits: .integerLiteral("123"))))
     }
 
     let syntax = buildable.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)


### PR DESCRIPTION
Move `Token` helpers to `TokenSyntax` extension, so we can use dot notation

Idea from #291 

Swift PR https://github.com/apple/swift/pull/38026