### PR TITLE
Make SyntaxToken extend ExpressibleByStringLiteral

### DIFF
--- a/Sources/SwiftSyntaxBuilder/TokenSyntaxConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/TokenSyntaxConvenienceInitializers.swift
@@ -1,0 +1,19 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2021 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+extension TokenSyntax: ExpressibleByStringLiteral {
+  public init(stringLiteral value: String) {
+    self.init(value)
+  }
+}


### PR DESCRIPTION
@ahoppen I have open a PR, so we can discuss it here. 

From #291 

> 4a. TokenSyntax should be ExpressibleByStringLiteral. That way we wouldn’t need SyntaxFactory.makeIdentifier("myFirstVar"). It might also remove the need for convenience of passing in a String for a TokenSyntax in the convinience initializers because TokenSyntax can now just be expressed by a string literal.

I'm not sure how implement this.

Because if we add `ExpressibleByStringLiteral ` to `SyntaxToken`, how can it now to create a `identifier` token, just like when we use `SyntaxFactory.makeIdentifier("myOtherVar")`
