### PR TITLE
Clarify that edits passed to `IncrementalParseTransition` are concurrent and add function to transform sequential edits to concurrent

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -2,6 +2,10 @@
 
 Note: This is in reverse chronological order, so newer entries are added to the top.
 
+## `main`
+
+* To clarify that the edits passed to `IncrementalParseTransition` are applied concurrently, introduce a new `ConcurrentEdit` type that provides the guarantee and allows translation of sequentially applied edits to the expected concurrent form.
+
 ## Swift 5.3
 
 * Introduced `FunctionCallExprSyntax.additionalTrailingClosures` property with type `MultipleTrailingClosureElementListSyntax?` for supporting [SE-0279 Multiple Trailing Closures](https://github.com/apple/swift-evolution/blob/main/proposals/0279-multiple-trailing-closures.md).

--- a/Sources/SwiftSyntax/Utils.swift
+++ b/Sources/SwiftSyntax/Utils.swift
@@ -49,14 +49,30 @@ public struct ByteSourceRange: Equatable {
   }
 }
 
-public struct SourceEdit {
+public struct SourceEdit: Equatable {
   /// The byte range of the original source buffer that the edit applies to.
   public let range: ByteSourceRange
   /// The length of the edit replacement in UTF8 bytes.
   public let replacementLength: Int
 
+  public var offset: Int { return range.offset }
+
+  public var length: Int { return range.length }
+
+  public var endOffset: Int { return range.endOffset }
+
+  /// After the edit has been applied the range of the replacement text.
+  public var replacementRange: ByteSourceRange {
+    return ByteSourceRange(offset: offset, length: replacementLength)
+  }
+
   public init(range: ByteSourceRange, replacementLength: Int) {
     self.range = range
+    self.replacementLength = replacementLength
+  }
+
+  public init(offset: Int, length: Int, replacementLength: Int) {
+    self.range = ByteSourceRange(offset: offset, length: length)
     self.replacementLength = replacementLength
   }
 

--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -289,8 +289,11 @@ func performParseIncremental(args: CommandLineArguments) throws {
   let preEditTree = try SyntaxParser.parse(preEditURL)
   let edits = try parseIncrementalEditArguments(args: args)
   let regionCollector = IncrementalParseReusedNodeCollector()
-  let editTransition = IncrementalParseTransition(previousTree: preEditTree,
-    edits: edits, reusedNodeDelegate: regionCollector)
+  let editTransition = IncrementalParseTransition(
+    previousTree: preEditTree,
+    edits: ConcurrentEdits(concurrent: edits),
+    reusedNodeDelegate: regionCollector
+  )
 
   let postEditText = try String(contentsOf: postEditURL)
   let postEditTree =

--- a/Tests/SwiftSyntaxTest/IncrementalParsingTests.swift
+++ b/Tests/SwiftSyntaxTest/IncrementalParsingTests.swift
@@ -10,7 +10,7 @@ public class IncrementalParsingTests: XCTestCase {
 
     var tree = try! SyntaxParser.parse(source: original)
     let sourceEdit = SourceEdit(range: ByteSourceRange(offset: step.1.0, length: step.1.1), replacementLength: step.1.2.utf8.count)
-    let lookup = IncrementalParseTransition(previousTree: tree, edits: [sourceEdit])
+    let lookup = IncrementalParseTransition(previousTree: tree, edits: ConcurrentEdits(sourceEdit))
     tree = try! SyntaxParser.parse(source: step.0, parseTransition: lookup)
     XCTAssertEqual("\(tree)", step.0)
   }
@@ -23,7 +23,7 @@ public class IncrementalParsingTests: XCTestCase {
     let origTree = try! SyntaxParser.parse(source: original)
     let sourceEdit = SourceEdit(range: ByteSourceRange(offset: step.1.0, length: step.1.1), replacementLength: step.1.2.utf8.count)
     let reusedNodeCollector = IncrementalParseReusedNodeCollector()
-    let transition = IncrementalParseTransition(previousTree: origTree, edits: [sourceEdit], reusedNodeDelegate: reusedNodeCollector)
+    let transition = IncrementalParseTransition(previousTree: origTree, edits: ConcurrentEdits(sourceEdit), reusedNodeDelegate: reusedNodeCollector)
     let newTree = try! SyntaxParser.parse(source: step.0, parseTransition: transition)
     XCTAssertEqual("\(newTree)", step.0)
 

--- a/Tests/SwiftSyntaxTest/SequentialToConcurrentEditTranslationTests.swift
+++ b/Tests/SwiftSyntaxTest/SequentialToConcurrentEditTranslationTests.swift
@@ -1,0 +1,295 @@
+import XCTest
+import SwiftSyntax
+
+let longString = """
+1234567890abcdefghijklmnopqrstuvwxyz\
+1234567890abcdefghijklmnopqrstuvwxyz\
+1234567890abcdefghijklmnopqrstuvwxyz\
+1234567890abcdefghijklmnopqrstuvwxyz\
+1234567890abcdefghijklmnopqrstuvwxyz\
+1234567890abcdefghijklmnopqrstuvwxyz\
+1234567890abcdefghijklmnopqrstuvwxyz\
+1234567890abcdefghijklmnopqrstuvwxyz\
+1234567890abcdefghijklmnopqrstuvwxyz\
+1234567890abcdefghijklmnopqrstuvwzyz
+"""
+
+/// Apply the given edits to `testString` and return the resulting string.
+/// `concurrent` specifies whether the edits should be interpreted as being
+/// applied sequentially or concurrently.
+func applyEdits(
+  _ edits: [SourceEdit],
+  concurrent: Bool,
+  to testString: String = longString,
+  replacementChar: Character = "?"
+) -> String {
+  guard let replacementAscii = replacementChar.asciiValue else {
+    fatalError("replacementChar must be an ASCII character")
+  }
+  var edits = edits
+  if concurrent {
+    XCTAssert(ConcurrentEdits._isValidConcurrentEditArray(edits))
+
+    // If the edits are concurrent, sorted and not overlapping (as guaranteed by
+    // the check above, we can apply them sequentially to the string in reverse
+    // order because later edits don't affect earlier edits.
+    edits = edits.reversed()
+  }
+  var bytes = Array(testString.utf8)
+  for edit in edits {
+    assert(edit.endOffset <= bytes.count)
+    bytes.removeSubrange(edit.offset..<edit.endOffset)
+    bytes.insert(contentsOf: [UInt8](repeating: replacementAscii, count: edit.replacementLength), at: edit.offset)
+  }
+  return String(bytes: bytes, encoding: .utf8)!
+}
+
+/// Verifies that
+///  1. translation of the `sequential` edits results in the
+///     `expectedConcurrent` edits
+///  2. applying the `sequential` and concurrent edits to `testString` results
+///     in the same post-edit string
+func verifySequentialToConcurrentTranslation(
+  _ sequential: [SourceEdit],
+  _ expectedConcurrent: [SourceEdit],
+  testString: String = longString
+) {
+  let concurrent = ConcurrentEdits(fromSequential: sequential)
+  XCTAssertEqual(concurrent.edits, expectedConcurrent)
+  XCTAssertEqual(
+    applyEdits(sequential, concurrent: false, to: testString),
+    applyEdits(concurrent.edits, concurrent: true, to: testString)
+  )
+}
+
+
+final class TranslateSequentialToConcurrentEditsTests: XCTestCase {
+  func testEmpty() throws {
+    verifySequentialToConcurrentTranslation([], [])
+  }
+
+  func testSingleEdit1() throws {
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 5, length: 1, replacementLength: 0)
+    ], [
+      SourceEdit(offset: 5, length: 1, replacementLength: 0)
+    ])
+  }
+
+  func testSingleEdit2() throws {
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 5, length: 0, replacementLength: 1)
+    ], [
+      SourceEdit(offset: 5, length: 0, replacementLength: 1)
+    ])
+  }
+
+  func testTwoNonOverlappingDeletesInFrontToBackOrder() {
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 5, length: 1, replacementLength: 0),
+      SourceEdit(offset: 10, length: 2, replacementLength: 0),
+    ], [
+      SourceEdit(offset: 5, length: 1, replacementLength: 0),
+      SourceEdit(offset: 11, length: 2, replacementLength: 0),
+    ])
+  }
+
+  func testTwoNonOverlappingDeletesInBackToFrontOrder() {
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 10, length: 2, replacementLength: 0),
+      SourceEdit(offset: 5, length: 1, replacementLength: 0),
+    ], [
+      SourceEdit(offset: 5, length: 1, replacementLength: 0),
+      SourceEdit(offset: 10, length: 2, replacementLength: 0),
+    ])
+  }
+
+  func testTwoNonOverlappingInsertionsInFrontToBackOrder() {
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 5, length: 0, replacementLength: 2),
+      SourceEdit(offset: 10, length: 0, replacementLength: 3),
+    ], [
+      SourceEdit(offset: 5, length: 0, replacementLength: 2),
+      SourceEdit(offset: 8, length: 0, replacementLength: 3),
+    ])
+  }
+
+  func testTwoNonOverlappingInsertionsInBackToFrontOrder() {
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 10, length: 0, replacementLength: 3),
+      SourceEdit(offset: 5, length: 0, replacementLength: 2),
+    ], [
+      SourceEdit(offset: 5, length: 0, replacementLength: 2),
+      SourceEdit(offset: 10, length: 0, replacementLength: 3),
+    ])
+  }
+
+  func testTwoNonOverlappingReplacementsInFrontToBackOrder() {
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 5, length: 4, replacementLength: 2),
+      SourceEdit(offset: 20, length: 5, replacementLength: 3),
+    ], [
+      SourceEdit(offset: 5, length: 4, replacementLength: 2),
+      SourceEdit(offset: 22, length: 5, replacementLength: 3),
+    ])
+  }
+
+  func testTwoNonOverlappingReplacementsInBackToFrontOrder() {
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 20, length: 5, replacementLength: 3),
+      SourceEdit(offset: 5, length: 4, replacementLength: 2),
+    ], [
+      SourceEdit(offset: 5, length: 4, replacementLength: 2),
+      SourceEdit(offset: 20, length: 5, replacementLength: 3),
+    ])
+  }
+
+  func testMultipleNonOverlappingEdits() {
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 0, length: 6, replacementLength: 0),
+      SourceEdit(offset: 15, length: 7, replacementLength: 9),
+      SourceEdit(offset: 10, length: 0, replacementLength: 3),
+      SourceEdit(offset: 30, length: 2, replacementLength: 2)
+    ], [
+      SourceEdit(offset: 0, length: 6, replacementLength: 0),
+      SourceEdit(offset: 16, length: 0, replacementLength: 3),
+      SourceEdit(offset: 21, length: 7, replacementLength: 9),
+      SourceEdit(offset: 31, length: 2, replacementLength: 2)
+    ])
+  }
+
+  func testTwoAdjacentEditsInBackToFrontOrder() {
+    //                 [--- edit1 ----]
+    // [--- edit2 ----]
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 10, length: 1, replacementLength: 3),
+      SourceEdit(offset: 5, length: 5, replacementLength: 1),
+    ], [
+      SourceEdit(offset: 5, length: 6, replacementLength: 4),
+    ])
+  }
+
+  func testAdjacentReplaceAndDeleteInBackToFrontOrder() {
+    //                 [--- edit1 ----]
+    // [--- edit2 ----]
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 10, length: 1, replacementLength: 3),
+      SourceEdit(offset: 5, length: 5, replacementLength: 0),
+    ], [
+      SourceEdit(offset: 5, length: 6, replacementLength: 3),
+    ])
+  }
+
+  func testOverlappingBefore() {
+    //            [--- edit1 ----]
+    // [--- edit2 ----]
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 5, length: 3, replacementLength: 1),
+      SourceEdit(offset: 4, length: 2, replacementLength: 2),
+    ], [
+      SourceEdit(offset: 4, length: 4, replacementLength: 2),
+    ])
+  }
+
+  func testEnclosing() {
+    //      [--- edit1 ----]
+    // [------- edit2 --------]
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 5, length: 3, replacementLength: 1),
+      SourceEdit(offset: 4, length: 4, replacementLength: 2),
+    ], [
+      SourceEdit(offset: 4, length: 6, replacementLength: 2),
+    ])
+  }
+
+  func testTwoInsertionsAtSameLocation() {
+    // [--- edit1 (length 0) ----]
+    // [--- edit2 (length 0) ----]
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 5, length: 0, replacementLength: 1),
+      SourceEdit(offset: 5, length: 0, replacementLength: 2),
+    ], [
+      SourceEdit(offset: 5, length: 0, replacementLength: 3),
+    ])
+  }
+
+  func testTwoReplacementsAtSameLocation() {
+    // [--- edit1 ----]
+    // [--- edit2 ----]
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 5, length: 1, replacementLength: 2),
+      SourceEdit(offset: 5, length: 1, replacementLength: 3),
+    ], [
+      SourceEdit(offset: 5, length: 1, replacementLength: 4),
+    ])
+  }
+
+  func testTwoInsertionsAtSameLocationDifferentLength() {
+    // [----- edit1 ------]
+    // [--- edit2 ----]
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 5, length: 2, replacementLength: 2),
+      SourceEdit(offset: 5, length: 1, replacementLength: 3),
+    ], [
+      SourceEdit(offset: 5, length: 2, replacementLength: 4),
+    ])
+  }
+
+  func testEnclosed() {
+    // [-------- edit1 --------]
+    //        [--- edit2 ----]
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 5, length: 5, replacementLength: 2),
+      SourceEdit(offset: 6, length: 1, replacementLength: 0),
+    ], [
+      SourceEdit(offset: 5, length: 5, replacementLength: 1),
+    ])
+  }
+
+  func testOverlappingAfter() {
+    // [---- edit1 ----]
+    //        [--- edit2 ----]
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 3, length: 3, replacementLength: 2),
+      SourceEdit(offset: 4, length: 3, replacementLength: 2),
+    ], [
+      SourceEdit(offset: 3, length: 5, replacementLength: 3),
+    ])
+  }
+
+  func testTwoOverlappingInsertions() {
+    verifySequentialToConcurrentTranslation([
+      SourceEdit(offset: 5, length: 0, replacementLength: 3),
+      SourceEdit(offset: 6, length: 0, replacementLength: 2),
+    ], [
+      SourceEdit(offset: 5, length: 0, replacementLength: 5),
+    ])
+  }
+
+  /// Enable and run this test to randomly generate edit arrays and verify that
+  /// translating them to sequential edits results in the same post-edit string.
+  func disabledTestFuzz() throws {
+    var i = 0
+    while true {
+      i += 1
+      var edits: [SourceEdit] = []
+      let numEdits = Int.random(in: 1..<10)
+      for _ in 0..<numEdits {
+        edits.append(SourceEdit(
+          offset: Int.random(in: 0..<32),
+          length: Int.random(in: 0..<32),
+          replacementLength: Int.random(in: 0..<32)
+        ))
+      }
+      print(edits)
+      let normalizedEdits = ConcurrentEdits(fromSequential: edits)
+      if applyEdits(edits, concurrent: false) !=
+          applyEdits(normalizedEdits.edits, concurrent: true) {
+        print("failed \(i)")
+        fatalError()
+      } else {
+        print("passed \(i)")
+      }
+    }
+  }
+}


### PR DESCRIPTION
To clarify that the edits passed to `IncrementalParseTransition` are applied concurrently, introduce a new `ConcurrentEdit` type that provides the guarantee and allows translation of sequentially applied edits to the expected concurrent form.

Fixes rdar://72848263