### PR TITLE
[5.5] SwiftSyntax: avoid a possible deadlock situtation

### DIFF
--- a/Sources/SwiftSyntax/DiagnosticEngine.swift
+++ b/Sources/SwiftSyntax/DiagnosticEngine.swift
@@ -95,7 +95,7 @@ public class DiagnosticEngine {
 
   /// Tells each consumer to finalize their diagnostic output.
   deinit {
-    for consumer in consumers {
+    for consumer in _consumers {
       consumer.finalize()
     }
   }


### PR DESCRIPTION
Access the consumers list in the DiagnosticsEngine directly to the
storage rather than the accessor.  This prevents a possible issue with
invalid usage of `dispatch_sync`.  It has been observed on Windows (and
Linux) that there are times where dispatch would trigger an assertion
that `dispatch_sync` was called on a queue owned by the current thread.

It is possible that a thread of execution would invoke the `consumers`
setter, which enqueues a block with barrier semantics.  Because the task
is async, the `DiagnosticsEngine` instance has the reference count
incremented.  The caller then continues execution immediately (due to
the async nature) and then proceeds to terminate.  The
`DiagnosticEngine`'s instance is now effectively owned by the queue.
When the enqueued block executes, the `deinit` invocation will execute
on the thread owning the `consumersQueue`.  The `deinit` then proceeds
to access the `consumers` through a `dispatch_sync`, resulting in a
deadlock.

This issue was uncovered by running the swift-format testsuite on
Windows.

Special thanks to @allevato for his invaluable discussion and insight
into what may be occurring here.