### PR TITLE
[5.5] Make `ConcurrentEdits.init(concurrent:)` throw instead of crash if edits are not concurrent

### DIFF
--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -291,7 +291,7 @@ func performParseIncremental(args: CommandLineArguments) throws {
   let regionCollector = IncrementalParseReusedNodeCollector()
   let editTransition = IncrementalParseTransition(
     previousTree: preEditTree,
-    edits: ConcurrentEdits(concurrent: edits),
+    edits: try ConcurrentEdits(concurrent: edits),
     reusedNodeDelegate: regionCollector
   )
 

--- a/Tests/SwiftSyntaxTest/SequentialToConcurrentEditTranslationTests.swift
+++ b/Tests/SwiftSyntaxTest/SequentialToConcurrentEditTranslationTests.swift
@@ -62,10 +62,18 @@ func verifySequentialToConcurrentTranslation(
   )
 }
 
-
 final class TranslateSequentialToConcurrentEditsTests: XCTestCase {
   func testEmpty() throws {
     verifySequentialToConcurrentTranslation([], [])
+  }
+
+  func testCreatingConcurrentFailsIfEditsDoNotSatisfyConcurrentRequirements() {
+    XCTAssertThrowsError(try {
+      try ConcurrentEdits(concurrent: [
+        SourceEdit(offset: 5, length: 1, replacementLength: 0),
+        SourceEdit(offset: 5, length: 1, replacementLength: 0)
+      ])
+    }())
   }
 
   func testSingleEdit1() throws {


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-syntax/pull/311 to 5.5.

The user of the `ConcurrentEdits.init(concurrent:)` should be able to control what happens if the edits passed to it do not satisfy the requirements. We shouldn’t presume that crashing is the right way to handle the failure.