### PR TITLE
Add `.eof` for token syntax

### DIFF
--- a/Sources/SwiftSyntaxBuilder/Tokens.swift.gyb
+++ b/Sources/SwiftSyntaxBuilder/Tokens.swift.gyb
@@ -54,4 +54,6 @@ public extension TokenSyntax {
 %   end
 
 % end
+  /// The `eof` token
+  static let eof = SyntaxFactory.makeToken(.eof, presence: .present)
 }

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/Tokens.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/Tokens.swift
@@ -490,4 +490,6 @@ public extension TokenSyntax {
   /// The `yield` token
   static let `yield` = SyntaxFactory.makeYieldToken()
 
+  /// The `eof` token
+  static let eof = SyntaxFactory.makeToken(.eof, presence: .present)
 }

--- a/Tests/SwiftSyntaxBuilderTest/ExpressibleBuildablesTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ExpressibleBuildablesTests.swift
@@ -31,7 +31,7 @@ final class ExpressibleBuildablesTests: XCTestCase {
     }
 
     func testExpressibleAsCodeBlockItem() {
-        let myCodeBlock = SourceFile(eofToken: SyntaxFactory.makeToken(.eof, presence: .present)) {
+        let myCodeBlock = SourceFile(eofToken: .eof) {
             StructDecl(identifier: "MyStruct1", members: MemberDeclBlock())
 
             StructDecl(identifier: "MyStruct2", members: MemberDeclBlock())


### PR DESCRIPTION
Add `.eof` for token syntax. 

Taken from https://github.com/apple/swift-syntax/pull/305#discussion_r715459987