### PR TITLE
Add fibonacci function example/test

### DIFF
--- a/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+final class FunctionTests: XCTestCase {
+  func testEmptyStruct() {
+    let leadingTrivia = Trivia.garbageText("␣")
+
+    let input = ParameterClause(parameterListBuilder: {
+      FunctionParameter(firstName: .wildcard, secondName: .identifier("n"), colon: .colon, type: SimpleTypeIdentifier("Int"), attributesBuilder: {})
+    })
+
+    let ifCodeBlock = CodeBlock(statementsBuilder: {
+      ReturnStmt(expression: SequenceExpr(elementsBuilder: {
+        IntegerLiteralExpr(digits: "n")
+      }))
+    })
+
+    let signature = FunctionSignature(input: input, output: ReturnClause(returnType: SimpleTypeIdentifier("Int")))
+    
+
+    let codeBlock = CodeBlock(statementsBuilder: {
+      IfStmt(labelName: nil, body: ifCodeBlock, conditionsBuilder: {
+        ConditionElement(condition: ExprList([
+          IntegerLiteralExpr(digits: "n"),
+
+          BinaryOperatorExpr(operatorToken: .unspacedBinaryOperator("<=")),
+
+          IntegerLiteralExpr(1)
+        ]))
+      })
+
+      ReturnStmt(expression: SequenceExpr(elementsBuilder: {
+        FunctionCallExpr(calledExpression: IdentifierExpr(identifier: .identifier("fibonacci")), leftParen: .leftParen, rightParen: .rightParen, argumentListBuilder: {
+          TupleExprElement(expression: SequenceExpr(elementsBuilder: {
+            IntegerLiteralExpr(digits: "n")
+
+            BinaryOperatorExpr(operatorToken: .unspacedBinaryOperator("-"))
+
+            IntegerLiteralExpr(1)
+          }))
+        })
+
+        BinaryOperatorExpr(operatorToken: .spacedBinaryOperator("+"))
+
+        FunctionCallExpr(calledExpression: IdentifierExpr(identifier: .identifier("fibonacci")), leftParen: .leftParen, rightParen: .rightParen, argumentListBuilder: {
+          TupleExprElement(expression: SequenceExpr(elementsBuilder: {
+            IntegerLiteralExpr(digits: "n")
+
+            BinaryOperatorExpr(operatorToken: .unspacedBinaryOperator("-"))
+
+            IntegerLiteralExpr(2)
+          }))
+        })
+      }))
+    })
+
+    let buildable = FunctionDecl(identifier: .identifier("fibonacci"), signature: signature, body: codeBlock, attributesBuilder: {})
+    let syntax = buildable.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
+
+    XCTAssertEqual(syntax.description, """
+      func fibonacci(_ n: Int)-> Int{
+          if n<=1{
+              return n
+          }
+          return fibonacci(n-1)+fibonacci(n-2)
+      }
+      """)
+  }
+}


### PR DESCRIPTION
I have added a `FunctionDecl` test. 
Made it a bit more advanced, so I made the Fibonacci function in swift. 

I think it will give us a good idea of what we could do, so it is easier to use and a bit more convenient.
Here is some ideas

`ReturnStmt` should take a buildable as parameter, so we don't need to wrap it in something like `SequenceExpr`.
  Example api could be 
```Swift
ReturnStmt(expressionBuilder: {
  IntegerLiteralExpr(digits: "n")
})
```


Same for `IfStmt` we need, somehow, to skip `ExprList`.
Example api 
``` Swift
IfStmt(labelName: nil, body: ifCodeBlock, conditionsBuilder: {
  ConditionElement(conditionBuilder: {
    IntegerLiteralExpr(digits: "n"),

    BinaryOperatorExpr(operatorToken: .unspacedBinaryOperator("<=")),

    IntegerLiteralExpr(1)
  }
})
```

Maybe also a convenient api so we could do   

``` Swift
IfStmt(labelName: nil, body: ifCodeBlock, conditionsBuilder: {
  IntegerLiteralExpr(digits: "n"),

  BinaryOperatorExpr(operatorToken: .unspacedBinaryOperator("<=")),

  IntegerLiteralExpr(1)
})
```

`FunctionCallExpr` should be able to take a `String` as identifier `FunctionCallExpr(calledExpression: IdentifierExpr(identifier: .identifier("fibonacci"))` -> `FunctionCallExpr(calledExpression: "fibonacci")`


This was just some of my findings! 
Let me hear what you think @ahoppen 