### PR TITLE
Get the realpath of the build directory when building SwiftSyntax

### DIFF
--- a/build-script.py
+++ b/build-script.py
@@ -851,7 +851,7 @@ def main():
     try:
         builder = Builder(
             toolchain=args.toolchain,
-            build_dir=args.build_dir,
+            build_dir=realpath(args.build_dir),
             multiroot_data_file=args.multiroot_data_file,
             release=args.release,
             verbose=args.verbose,


### PR DESCRIPTION
We were currently canonicalizing the build directory when testing SwiftSyntax but not when building it. This caused errors if the build directory was a symlink because module caches were created for the non-canonicalized path during the build and then referenced with the canonicalized path during testing.