### PR TITLE
Always build SwiftSyntax as a static library

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -43,16 +43,6 @@ if ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] != nil 
 
 package.targets.append(swiftSyntaxTarget)
 
-let libraryType: Product.Library.LibraryType
-
-/// When we're in a build-script environment, we want to build a dylib instead
-/// of a static library since we install the dylib into the toolchain.
-if ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] != nil {
-  libraryType = .dynamic
-} else {
-  libraryType = .static
-}
-
-package.products.append(.library(name: "SwiftSyntax", type: libraryType, targets: ["SwiftSyntax"]))
-package.products.append(.library(name: "SwiftSyntaxParser", type: libraryType, targets: ["SwiftSyntaxParser"]))
-package.products.append(.library(name: "SwiftSyntaxBuilder", type: libraryType, targets: ["SwiftSyntaxBuilder"]))
+package.products.append(.library(name: "SwiftSyntax", type: .static, targets: ["SwiftSyntax"]))
+package.products.append(.library(name: "SwiftSyntaxParser", type: .static, targets: ["SwiftSyntaxParser"]))
+package.products.append(.library(name: "SwiftSyntaxBuilder", type: .static, targets: ["SwiftSyntaxBuilder"]))


### PR DESCRIPTION
Instead of including `SwiftSyntax.dylib` and `SwiftSyntaxParser.dylib` in the toolchain, make all tools that depend on SwiftSyntax link against it statically. This simplifies the way SwiftSyntax is built and slightly reduces the toolchain size, because we only include on copy of SwiftSyntax (statically linked into `sk-stress-test`) instead of two copies (`SwiftSyntax.dylib` and `SwiftSyntaxParser.dylib`).

rdar://83757810