### PR TITLE
Add test case that tests the performance of the SyntaxClassifier

### DIFF
--- a/Tests/PerformanceTest/SyntaxClassifierPerformanceTests.swift
+++ b/Tests/PerformanceTest/SyntaxClassifierPerformanceTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+import SwiftSyntax
+import SwiftSyntaxParser
+
+public class SyntaxClassifierPerformanceTests: XCTestCase {
+
+  var inputFile: URL {
+    return URL(fileURLWithPath: #file)
+      .deletingLastPathComponent()
+      .appendingPathComponent("Inputs")
+      .appendingPathComponent("MinimalCollections.swift.input")
+  }
+
+  func testParsingPerformance() {
+    XCTAssertNoThrow(try {
+      let parsed = try SyntaxParser.parse(inputFile)
+
+      measure {
+        for _ in 0..<10 {
+          for _ in parsed.classifications {}
+        }
+      }
+    }())
+  }
+}


### PR DESCRIPTION
Just found this branch in my local repo. Can’t remember what I created it for but seems useful.