### PR TITLE
Include stdint.h from c-syntax-nodes.h

### DIFF
--- a/Sources/_CSwiftSyntax/include/c-syntax-nodes.h
+++ b/Sources/_CSwiftSyntax/include/c-syntax-nodes.h
@@ -27,6 +27,7 @@
 #define SWIFT_C_SYNTAX_C_DATA_TYPES_H
 
 #include <stdbool.h>
+#include <stdint.h>
 
 /// Offset+length in UTF8 bytes.
 typedef struct {


### PR DESCRIPTION
Depending on the environment, the missing include could cause compilation errors.