### PR TITLE
Include Swift 5.5’s `_InternalSwiftSyntaxParser.dylib` in the repo

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 
 import PackageDescription
 import Foundation
@@ -6,17 +6,36 @@ import Foundation
 let package = Package(
   name: "SwiftSyntax",
   targets: [
-    .target(name: "_CSwiftSyntax"),
+    .target(name: "_CSwiftSyntax", exclude: ["README.md"]),
     .testTarget(name: "SwiftSyntaxTest", dependencies: ["SwiftSyntax"], exclude: ["Inputs"]),
-    .target(name: "SwiftSyntaxBuilder", dependencies: ["SwiftSyntax"]),
+    .target(name: "SwiftSyntaxBuilder", dependencies: ["SwiftSyntax"], exclude: ["README.md", "Tokens.swift.gyb"]),
     .testTarget(name: "SwiftSyntaxBuilderTest", dependencies: ["SwiftSyntaxBuilder"]),
     .target(name: "lit-test-helper", dependencies: ["SwiftSyntax"]),
-    .testTarget(name: "PerformanceTest", dependencies: ["SwiftSyntax"])
+    .testTarget(name: "PerformanceTest", dependencies: ["SwiftSyntax"], exclude: ["Inputs"]),
+    .binaryTarget(name: "_InternalSwiftSyntaxParser", url: "https://github.com/ahoppen/swift-syntax/releases/download/ahoppen-0.50500.2/_InternalSwiftSyntaxParser.xcframework.zip", checksum: "f1326cfbaee9924ba925c33a3c85fd326cdc2771f68c23653b7cd8d520d0afd4"),
     // Also see targets added below
   ]
 )
 
 let swiftSyntaxTarget: PackageDescription.Target
+
+let swiftSyntaxGybSources = [
+  "SyntaxCollections.swift.gyb",
+  "TokenKind.swift.gyb",
+  "SyntaxBuilders.swift.gyb",
+  "Trivia.swift.gyb",
+  "SyntaxKind.swift.gyb",
+  "SyntaxBaseNodes.swift.gyb",
+  "SyntaxFactory.swift.gyb",
+  "SyntaxEnum.swift.gyb",
+  "SyntaxRewriter.swift.gyb",
+  "SyntaxTraits.swift.gyb",
+  "Misc.swift.gyb",
+  "SyntaxClassification.swift.gyb",
+  "SyntaxNodes.swift.gyb.template",
+  "SyntaxAnyVisitor.swift.gyb",
+  "SyntaxVisitor.swift.gyb",
+]
 
 /// If we are in a controlled CI environment, we can use internal compiler flags
 /// to speed up the build or improve it.
@@ -32,11 +51,11 @@ if ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] != nil 
   // Disable it when we're in a controlled CI environment.
   swiftSyntaxUnsafeFlags += ["-enforce-exclusivity=unchecked"]
 
-  swiftSyntaxTarget = .target(name: "SwiftSyntax", dependencies: ["_CSwiftSyntax"],
+  swiftSyntaxTarget = .target(name: "SwiftSyntax", dependencies: ["_CSwiftSyntax", "_InternalSwiftSyntaxParser"], exclude: swiftSyntaxGybSources,
                               swiftSettings: [.unsafeFlags(swiftSyntaxUnsafeFlags)]
   )
 } else {
-  swiftSyntaxTarget = .target(name: "SwiftSyntax", dependencies: ["_CSwiftSyntax"])
+  swiftSyntaxTarget = .target(name: "SwiftSyntax", dependencies: ["_CSwiftSyntax", "_InternalSwiftSyntaxParser"], exclude: swiftSyntaxGybSources)
 }
 
 package.targets.append(swiftSyntaxTarget)


### PR DESCRIPTION
Previously, clients of SwiftSyntax always needed to provide a `_InternalSwiftSyntaxParser.dylib` that was matching the SwiftSyntax version they are using. This was fragile and annoying.

Add the `_InternalSwiftSyntaxParser.dylib` that was released as part of Swift 5.5 to the repo as a binary framework dependency. This way, users can just depend on the SwiftSyntax package and it will bring along the `_InternalSwiftSyntaxParser.dylib` it needs.

If you want to try it, create a Swift package and add the following dependency

```
.package(url: "https://github.com/ahoppen/swift-syntax.git", .branch("pr-5.5/include-parserlib"))
```

This PR also contains a few changes to `Package.swift` to fix warnings that resulted from upgrading the package manifest version to 5.3.

Since we need `_InternalSwiftSyntaxParser.dylib` to be built before we can add it to the repo, we can’t include the framework in the `main` development branch. My plan is to add it to the release branches once the corresponding Swift version has been released. If we merge this, I would like to tag the resulting commit `0.50500.1`.

### To-Dos

- [ ] The parser library is currently vended as an `.xcframework` that is only compatible with macOS. AFAICT it is just ignored on Linux. @neonichu Could you verify that this is indeed the case or do we need special checks for macOS in `Package.swift` before we include the binary target? When we release Swift 5.6 and have [SE-0305](https://github.com/apple/swift-evolution/blob/main/proposals/0305-swiftpm-binary-target-improvements.md) we should also be able to include the parser library for Linux.
- [ ] Update the parser library’s URL to a GitHub release hosted on Apple’s repository instead of my personal one.