### PR TITLE
[5.6] Update Package manifest to tools version 5.3

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,24 +1,9 @@
-// swift-tools-version:5.1
+// swift-tools-version:5.3
 
 import PackageDescription
 import Foundation
 
-let package = Package(
-  name: "SwiftSyntax",
-  targets: [
-    .target(name: "_CSwiftSyntax"),
-    .testTarget(name: "SwiftSyntaxTest", dependencies: ["SwiftSyntax"]),
-    .target(name: "SwiftSyntaxBuilder", dependencies: ["SwiftSyntax"]),
-    .testTarget(name: "SwiftSyntaxBuilderTest", dependencies: ["SwiftSyntaxBuilder"]),
-    .target(name: "SwiftSyntaxParser", dependencies: ["SwiftSyntax"]),
-    .testTarget(name: "SwiftSyntaxParserTest", dependencies: ["SwiftSyntaxParser"], exclude: ["Inputs"]),
-    .target(name: "lit-test-helper", dependencies: ["SwiftSyntax", "SwiftSyntaxParser"]),
-    .testTarget(name: "PerformanceTest", dependencies: ["SwiftSyntax", "SwiftSyntaxParser"])
-    // Also see targets added below
-  ]
-)
-
-let swiftSyntaxTarget: PackageDescription.Target
+var swiftSyntaxUnsafeSwiftFlags: [String] = []
 
 /// If we are in a controlled CI environment, we can use internal compiler flags
 /// to speed up the build or improve it.
@@ -28,21 +13,83 @@ if ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] != nil 
     .appendingPathComponent("utils")
     .appendingPathComponent("group.json")
 
-  var swiftSyntaxUnsafeFlags = ["-Xfrontend", "-group-info-path",
+  swiftSyntaxUnsafeSwiftFlags += ["-Xfrontend", "-group-info-path",
                                 "-Xfrontend", groupFile.path]
   // Enforcing exclusivity increases compile time of release builds by 2 minutes.
   // Disable it when we're in a controlled CI environment.
-  swiftSyntaxUnsafeFlags += ["-enforce-exclusivity=unchecked"]
-
-  swiftSyntaxTarget = .target(name: "SwiftSyntax", dependencies: ["_CSwiftSyntax"],
-                              swiftSettings: [.unsafeFlags(swiftSyntaxUnsafeFlags)]
-  )
-} else {
-  swiftSyntaxTarget = .target(name: "SwiftSyntax", dependencies: ["_CSwiftSyntax"])
+  swiftSyntaxUnsafeSwiftFlags += ["-enforce-exclusivity=unchecked"]
 }
 
-package.targets.append(swiftSyntaxTarget)
-
-package.products.append(.library(name: "SwiftSyntax", type: .static, targets: ["SwiftSyntax"]))
-package.products.append(.library(name: "SwiftSyntaxParser", type: .static, targets: ["SwiftSyntaxParser"]))
-package.products.append(.library(name: "SwiftSyntaxBuilder", type: .static, targets: ["SwiftSyntaxBuilder"]))
+let package = Package(
+  name: "SwiftSyntax",
+  products: [
+    .library(name: "SwiftSyntax", type: .static, targets: ["SwiftSyntax"]),
+    .library(name: "SwiftSyntaxParser", type: .static, targets: ["SwiftSyntaxParser"]),
+    .library(name: "SwiftSyntaxBuilder", type: .static, targets: ["SwiftSyntaxBuilder"])
+  ],
+  targets: [
+    .target(name: "_CSwiftSyntax"),
+    .target(
+      name: "SwiftSyntax",
+      dependencies: ["_CSwiftSyntax"],
+      exclude: [
+        "SyntaxFactory.swift.gyb",
+        "SyntaxTraits.swift.gyb",
+        "Trivia.swift.gyb",
+        "Misc.swift.gyb",
+        "SyntaxRewriter.swift.gyb",
+        "SyntaxEnum.swift.gyb",
+        "SyntaxClassification.swift.gyb",
+        "SyntaxBuilders.swift.gyb",
+        "TokenKind.swift.gyb",
+        "SyntaxVisitor.swift.gyb",
+        "SyntaxCollections.swift.gyb",
+        "SyntaxBaseNodes.swift.gyb",
+        "SyntaxAnyVisitor.swift.gyb",
+        "SyntaxNodes.swift.gyb.template",
+        "SyntaxKind.swift.gyb",
+      ],
+      swiftSettings: [.unsafeFlags(swiftSyntaxUnsafeSwiftFlags)]
+    ),
+    .target(
+      name: "SwiftSyntaxBuilder",
+      dependencies: ["SwiftSyntax"],
+      exclude: [
+        "README.md",
+        "gyb_helpers",
+        "ExpressibleAsProtocols.swift.gyb",
+        "BuildableBaseProtocols.swift.gyb",
+        "BuildableCollectionNodes.swift.gyb",
+        "BuildableNodes.swift.gyb",
+        "ResultBuilders.swift.gyb",
+        "Tokens.swift.gyb",
+        "TokenSyntax.swift.gyb",
+      ]
+    ),
+    .target(name: "SwiftSyntaxParser", dependencies: ["SwiftSyntax"], exclude: [
+      "NodeDeclarationHash.swift.gyb"
+    ]),
+    .target(
+      name: "lit-test-helper",
+      dependencies: ["SwiftSyntax", "SwiftSyntaxParser"]
+    ),
+    .testTarget(
+      name: "SwiftSyntaxTest",
+      dependencies: ["SwiftSyntax"]
+    ),
+    .testTarget(
+      name: "SwiftSyntaxBuilderTest",
+      dependencies: ["SwiftSyntaxBuilder"]
+    ),
+    .testTarget(
+      name: "SwiftSyntaxParserTest",
+      dependencies: ["SwiftSyntaxParser"],
+      exclude: ["Inputs"]
+    ),
+    .testTarget(
+      name: "PerformanceTest",
+      dependencies: ["SwiftSyntax", "SwiftSyntaxParser"],
+      exclude: ["Inputs"]
+    ),
+  ]
+)


### PR DESCRIPTION
Cherry-pick of https://github.com/apple/swift-syntax/pull/352.

---

Vending the parser library as a binary dependency requires Swift tools version 5.3. In prepration for that, update the tools version, without making any semantic changes.

Syntactically, the following has chagned:
- Some cleanup to add all targets and products in the `Package` initializer call. It looks like previous, dynamic addition is not needed anymore, possibly because SwiftSyntax now always links statically
- Explicitly add non-Swift files to the exclude list, as required by 5.3 tools version.