### PR TITLE
[5.6] Update SwiftSyntaxBuilder excludes for files only present in main

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -56,14 +56,10 @@ let package = Package(
       dependencies: ["SwiftSyntax"],
       exclude: [
         "README.md",
-        "gyb_helpers",
-        "ExpressibleAsProtocols.swift.gyb",
-        "BuildableBaseProtocols.swift.gyb",
-        "BuildableCollectionNodes.swift.gyb",
-        "BuildableNodes.swift.gyb",
+        "Buildables.swift.gyb",
+        "BuildablesConvenienceInitializers.swift.gyb",
         "ResultBuilders.swift.gyb",
         "Tokens.swift.gyb",
-        "TokenSyntax.swift.gyb",
       ]
     ),
     .target(name: "SwiftSyntaxParser", dependencies: ["SwiftSyntax"], exclude: [


### PR DESCRIPTION
When cherry-picking the update of the package manifest to 5.3 to release/5.6, I forgot to update the exclude list for files in `SwiftSyntaxBuilder` that are only present in `main` branch. Do so now.