### PR TITLE
Added README.md to exclude list

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,12 @@ let package = Package(
     .library(name: "SwiftSyntaxBuilder", type: .static, targets: ["SwiftSyntaxBuilder"])
   ],
   targets: [
-    .target(name: "_CSwiftSyntax"),
+    .target(
+      name: "_CSwiftSyntax",
+      exclude: [
+        "README.md"
+      ]
+    ),
     .target(
       name: "SwiftSyntax",
       dependencies: ["_CSwiftSyntax"],


### PR DESCRIPTION
The README.md was missing, so it generated a warning. 
Just excluded it as the other readme