### PR TITLE
rewrite swiftSettings to avoid causing SPM build failures

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,7 +6,7 @@ import Foundation
 /// If we are in a controlled CI environment, we can use internal compiler flags
 /// to speed up the build or improve it.
 let swiftSyntaxSwiftSettings: [SwiftSetting] 
-if case _? = ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] {
+if ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] != nil {
   let groupFile = URL(fileURLWithPath: #file)
     .deletingLastPathComponent()
     .appendingPathComponent("utils")

--- a/Package.swift
+++ b/Package.swift
@@ -3,22 +3,21 @@
 import PackageDescription
 import Foundation
 
-var swiftSyntaxUnsafeSwiftFlags: [String] = []
-
 /// If we are in a controlled CI environment, we can use internal compiler flags
 /// to speed up the build or improve it.
-if ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] != nil {
+let swiftSettings:[SwiftSetting] = ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"].map { _ in 
   let groupFile = URL(fileURLWithPath: #file)
     .deletingLastPathComponent()
     .appendingPathComponent("utils")
     .appendingPathComponent("group.json")
-
-  swiftSyntaxUnsafeSwiftFlags += ["-Xfrontend", "-group-info-path",
-                                "-Xfrontend", groupFile.path]
-  // Enforcing exclusivity increases compile time of release builds by 2 minutes.
-  // Disable it when we're in a controlled CI environment.
-  swiftSyntaxUnsafeSwiftFlags += ["-enforce-exclusivity=unchecked"]
-}
+  return  [.unsafeFlags([
+    "-Xfrontend", "-group-info-path", 
+    "-Xfrontend", groupFile.path, 
+    // Enforcing exclusivity increases compile time of release builds by 2 minutes.
+    // Disable it when we're in a controlled CI environment.
+    "-enforce-exclusivity=unchecked",
+  ])]
+} ?? []
 
 let package = Package(
   name: "SwiftSyntax",
@@ -54,7 +53,7 @@ let package = Package(
         "SyntaxNodes.swift.gyb.template",
         "SyntaxKind.swift.gyb",
       ],
-      swiftSettings: [.unsafeFlags(swiftSyntaxUnsafeSwiftFlags)]
+      swiftSettings: swiftSettings
     ),
     .target(
       name: "SwiftSyntaxBuilder",

--- a/Package.swift
+++ b/Package.swift
@@ -5,19 +5,22 @@ import Foundation
 
 /// If we are in a controlled CI environment, we can use internal compiler flags
 /// to speed up the build or improve it.
-let swiftSettings:[SwiftSetting] = ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"].map { _ in 
+let swiftSyntaxSwiftSettings:[SwiftSetting] 
+if case _? = ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] {
   let groupFile = URL(fileURLWithPath: #file)
     .deletingLastPathComponent()
     .appendingPathComponent("utils")
     .appendingPathComponent("group.json")
-  return  [.unsafeFlags([
+  swiftSyntaxSwiftSettings = [.unsafeFlags([
     "-Xfrontend", "-group-info-path", 
     "-Xfrontend", groupFile.path, 
     // Enforcing exclusivity increases compile time of release builds by 2 minutes.
     // Disable it when we're in a controlled CI environment.
     "-enforce-exclusivity=unchecked",
   ])]
-} ?? []
+} else {
+    swiftSyntaxSwiftSettings = []
+}
 
 let package = Package(
   name: "SwiftSyntax",
@@ -53,7 +56,7 @@ let package = Package(
         "SyntaxNodes.swift.gyb.template",
         "SyntaxKind.swift.gyb",
       ],
-      swiftSettings: swiftSettings
+      swiftSettings: swiftSyntaxSwiftSettings
     ),
     .target(
       name: "SwiftSyntaxBuilder",

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import Foundation
 
 /// If we are in a controlled CI environment, we can use internal compiler flags
 /// to speed up the build or improve it.
-let swiftSyntaxSwiftSettings:[SwiftSetting] 
+let swiftSyntaxSwiftSettings: [SwiftSetting] 
 if case _? = ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] {
   let groupFile = URL(fileURLWithPath: #file)
     .deletingLastPathComponent()


### PR DESCRIPTION
fixes the issue [described here](https://forums.swift.org/t/cannot-edit-spm-package-with-a-swiftsyntax-dependency/55281) by kicking the unsafe flags logic up a level, so non-CI builds pass an empty array of `SwiftSetting`s instead of an empty array of unsafe flags.