### PR TITLE
Fix leading trivia is not applied if raw syntax is empty

### DIFF
--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -1113,7 +1113,11 @@ final class RawSyntax: ManagedBuffer<RawSyntaxBase, RawSyntaxDataElement> {
     }
   }
 
-  func withLeadingTrivia(_ leadingTrivia: Trivia) -> RawSyntax {
+  /// Replaces the leading trivia of the first token in this syntax tree by `leadingTrivia`.
+  /// If the syntax tree did not contain a token and thus no trivia could be attached to it, `nil` is returned.
+  /// - Parameters:
+  ///   - leadingTrivia: The trivia to attach.
+  func withLeadingTrivia(_ leadingTrivia: Trivia) -> RawSyntax? {
     if isToken {
       return RawSyntax.createAndCalcLength(
         kind: formTokenKind()!,
@@ -1123,16 +1127,20 @@ final class RawSyntax: ManagedBuffer<RawSyntaxBase, RawSyntaxDataElement> {
     } else {
       var layout = formLayoutArray()
       for (index, raw) in layout.enumerated() {
-        if let raw = raw {
-          layout[index] = raw.withLeadingTrivia(leadingTrivia)
+        if let raw = raw, let newRaw = raw.withLeadingTrivia(leadingTrivia) {
+          layout[index] = newRaw
           return replacingLayout(layout)
         }
       }
-      return self
+      return nil
     }
   }
 
-  func withTrailingTrivia(_ trailingTrivia: Trivia) -> RawSyntax {
+  /// Replaces the trailing trivia of the first token in this syntax tree by `trailingTrivia`.
+  /// If the syntax tree did not contain a token and thus no trivia could be attached to it, `nil` is returned.
+  /// - Parameters:
+  ///   - trailingTrivia: The trivia to attach.
+  func withTrailingTrivia(_ trailingTrivia: Trivia) -> RawSyntax? {
     if isToken {
       return RawSyntax.createAndCalcLength(
         kind: formTokenKind()!,
@@ -1142,12 +1150,12 @@ final class RawSyntax: ManagedBuffer<RawSyntaxBase, RawSyntaxDataElement> {
     } else {
       var layout = formLayoutArray()
       for (index, raw) in layout.enumerated().reversed() {
-        if let raw = raw {
-          layout[index] = raw.withTrailingTrivia(trailingTrivia)
+        if let raw = raw, let newRaw = raw.withTrailingTrivia(trailingTrivia) {
+          layout[index] = newRaw
           return replacingLayout(layout)
         }
       }
-      return self
+      return nil
     }
   }
 

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -356,10 +356,18 @@ struct SyntaxData {
   }
 
   func withLeadingTrivia(_ leadingTrivia: Trivia) -> SyntaxData {
-    return replacingSelf(raw.withLeadingTrivia(leadingTrivia))
+    if let raw = raw.withLeadingTrivia(leadingTrivia) {
+      return replacingSelf(raw)
+    } else {
+      return self
+    }
   }
 
   func withTrailingTrivia(_ trailingTrivia: Trivia) -> SyntaxData {
-    return replacingSelf(raw.withTrailingTrivia(trailingTrivia))
+    if let raw = raw.withTrailingTrivia(trailingTrivia) {
+      return replacingSelf(raw)
+    } else {
+      return self
+    }
   }
 }

--- a/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
@@ -52,7 +52,7 @@ final class FunctionTests: XCTestCase {
     let syntax = buildable.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
 
     XCTAssertEqual(syntax.description, """
-      func fibonacci(_ n: Int)-> Int{
+      ␣func fibonacci(_ n: Int)-> Int{
           if n <= 1{
               return n
           }

--- a/Tests/SwiftSyntaxBuilderTest/ProtocolDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ProtocolDeclTests.swift
@@ -12,8 +12,7 @@ final class ProtocolDeclTests: XCTestCase {
     let functionSignature = FunctionSignature(input: input, output: returnType)
 
     let buildable = ProtocolDecl(identifier: "DeclListBuildable", attributesBuilder: { TokenSyntax.public }, membersBuilder: {
-      // FIXME: We need to add the `modifiersBuilder` with a non-empty value, otherwise will the builder omit newline.
-      FunctionDecl(identifier: .identifier("buildDeclList"), signature: functionSignature, body: nil, modifiersBuilder: { TokenSyntax.public })
+      FunctionDecl(identifier: .identifier("buildDeclList"), signature: functionSignature, body: nil, modifiersBuilder: { })
     })
 
     let syntax = buildable.buildSyntax(format: Format())
@@ -23,7 +22,7 @@ final class ProtocolDeclTests: XCTestCase {
 
     XCTAssertEqual(text, """
     public protocol DeclListBuildable{
-        public func buildDeclList(format: Format, leadingTrivia: Trivia?)-> [DeclSyntax]
+        func buildDeclList(format: Format, leadingTrivia: Trivia?)-> [DeclSyntax]
     }
     """)
   }


### PR DESCRIPTION
Not sure if we should create a test class for `RawSyntax` where we can add the test case, or it is enough with the current ones