### PR TITLE
disable virtually all lit tests to unblock Swift CI

### DIFF
--- a/lit_tests/coloring.swift
+++ b/lit_tests/coloring.swift
@@ -1,5 +1,7 @@
 // RUN: %lit-test-helper -classify-syntax -source-file %s | %FileCheck %s
 
+// REQUIRES: rdar90284916
+
 enum List<T> {
   case Nil
   // rdar://21927124

--- a/lit_tests/coloring_comments.swift
+++ b/lit_tests/coloring_comments.swift
@@ -1,5 +1,7 @@
 // RUN: %lit-test-helper -classify-syntax -source-file %s | %FileCheck %s
 
+// REQUIRES: rdar90284916
+
 // CHECK: <comment-block>/* foo is the best */</comment-block>
 /* foo is the best */
 func foo(n: Float) {}

--- a/lit_tests/coloring_configs.swift
+++ b/lit_tests/coloring_configs.swift
@@ -1,5 +1,7 @@
 // RUN: %lit-test-helper -classify-syntax -source-file %s | %FileCheck %s
 
+// REQUIRES: rdar90284916
+
 // CHECK: <kw>var</kw> <id>f</id> : <type>Int</type>
 var f : Int
 

--- a/lit_tests/coloring_keywords.swift
+++ b/lit_tests/coloring_keywords.swift
@@ -1,5 +1,7 @@
 // RUN: %lit-test-helper -classify-syntax -source-file %s | %FileCheck %s
 
+// REQUIRES: rdar90284916
+
 // CHECK: <kw>return</kw> <id>c</id>.<id>return</id>
 
 class C {

--- a/lit_tests/coloring_unclosed_hash_if.swift
+++ b/lit_tests/coloring_unclosed_hash_if.swift
@@ -1,5 +1,7 @@
 // RUN: %lit-test-helper -classify-syntax -source-file %s | %FileCheck %s
 
+// REQUIRES: rdar90284916
+
 // CHECK: <#kw>#if</#kw> <#id>d</#id>
 // CHECK-NEXT: <kw>func</kw> <id>bar</id>() {
 // CHECK-NEXT: <#kw>#if</#kw> <#id>d</#id>

--- a/lit_tests/incrParse/add-else-to-ifconfig.swift
+++ b/lit_tests/incrParse/add-else-to-ifconfig.swift
@@ -1,7 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %validate-incrparse %s --test-case ADD_ELSE
 
+// REQUIRES: rdar90284916
+
 func container() {
 #if false
   <<ADD_ELSE<|||#else>>>
-

--- a/lit_tests/incrParse/add-space-at-missing-brace.swift
+++ b/lit_tests/incrParse/add-space-at-missing-brace.swift
@@ -1,6 +1,8 @@
 // RUN: %empty-directory(%t)
 // RUN: %validate-incrparse %s --test-case INSERT_SPACE
 
+// REQUIRES: rdar90284916
+
 class AnimationType {
   func foo(x: Blah) {
     switch x {

--- a/lit_tests/incrParse/funcs.swift
+++ b/lit_tests/incrParse/funcs.swift
@@ -6,6 +6,8 @@
 // RUN: %validate-incrparse %s --test-case ADD_PARAM_NAME
 // RUN: %validate-incrparse %s --test-case ADD_PARAM_TYPE
 
+// REQUIRES: rdar90284916
+
 func start() {}
 
 class Bar

--- a/lit_tests/incrParse/inserted_text_starts_identifier.swift
+++ b/lit_tests/incrParse/inserted_text_starts_identifier.swift
@@ -3,4 +3,6 @@
 
 // SR-8995 rdar://problem/45259469
 
+// REQUIRES: rdar90284916
+
 self = <<STRING<|||_                            _>>>foo(1)[object1, object2] + o bar(1)

--- a/lit_tests/incrParse/invalid.swift
+++ b/lit_tests/incrParse/invalid.swift
@@ -2,6 +2,8 @@
 // RUN: %validate-incrparse %s --test-case NO_CHANGES
 // RUN: %validate-incrparse %s --test-case NESTED_INITIALIZERS
 
+// REQUIRES: rdar90284916
+
 func start() {}
 
 class Bar

--- a/lit_tests/incrParse/multi-edit-mapping.swift
+++ b/lit_tests/incrParse/multi-edit-mapping.swift
@@ -1,4 +1,6 @@
 // RUN: %empty-directory(%t)
 // RUN: %validate-incrparse %s --test-case MULTI
 
+// REQUIRES: rdar90284916
+
 let one: Int;<reparse MULTI>let two: Int; let three: Int; <<MULTI<|||                      >>><<MULTI<|||   >>>let found: Int;</reparse MULTI>let five: Int;

--- a/lit_tests/incrParse/reuse.swift
+++ b/lit_tests/incrParse/reuse.swift
@@ -4,6 +4,8 @@
 // RUN: %validate-incrparse %s --test-case UNWRAP_CLASS
 // RUN: %validate-incrparse %s --test-case NEXT_TOKEN_CALCULATION
 
+// REQUIRES: rdar90284916
+
 func start() {}
 
 <reparse ADD_PROPERTY>struct Foo {</reparse ADD_PROPERTY>
@@ -43,4 +45,3 @@ func start() {}
 // The indentation on these lines is important for the test case
     let a = "hello"
 <reparse NEXT_TOKEN_CALCULATION>    let c = "<<NEXT_TOKEN_CALCULATION< |||>>>world"</reparse NEXT_TOKEN_CALCULATION>
-

--- a/lit_tests/incrParse/simple.swift
+++ b/lit_tests/incrParse/simple.swift
@@ -15,6 +15,8 @@
 // RUN: %validate-incrparse %s --test-case ADD_IF_OPEN_BRACE
 // RUN: %validate-incrparse %s --test-case EXTEND_IDENTIFIER
 
+// REQUIRES: rdar90284916
+
 func start() {}
 
 <reparse REPLACE>

--- a/lit_tests/print_verify_tree.swift
+++ b/lit_tests/print_verify_tree.swift
@@ -2,6 +2,8 @@
 // RUN: %lit-test-helper -print-tree -source-file %s > %t.result
 // RUN: diff -u %t.result %S/output/print_verify_tree.swift.withkind
 
+// REQUIRES: rdar90284916
+
 func foo() {
 #if swift(>=3.2)
     components.append("-b \"\(string[..<string.index(before: string.endIndex)])\"")

--- a/lit_tests/round_trip_function.swift
+++ b/lit_tests/round_trip_function.swift
@@ -3,6 +3,8 @@
 // RUN: %lit-test-helper -roundtrip -source-file %s -out %t/afterRoundtrip.swift
 // RUN: diff -u %t/afterRoundtrip.swift %s
 
+// REQUIRES: rdar90284916
+
 func noArgs() {}
 func oneArg(x: Int) {}
 func oneUnlabeledArg(_ x: Int) {}


### PR DESCRIPTION
Something broke, leading to all CI tests failing with:

```
dyld: Library not loaded: @rpath/lib_InternalSwiftSyntaxParser.dylib
  Referenced from: /Users/ec2-user/jenkins/workspace/swift-PR-macos/branch-main/build/buildbot_incremental/unified-swiftpm-build-macosx-x86_64/x86_64-apple-macosx/release/lit-test-helper
  Reason: image not found
```

This PR is a temporary measure to get CI unblocked until an investigation can happen.