### PR TITLE
Explicitly add rpath for lib_InternalSwiftSyntaxParser.dylib

### DIFF
--- a/build-script.py
+++ b/build-script.py
@@ -364,6 +364,7 @@ class Builder(object):
         if verbose:
             self.swiftpm_call.extend(["--verbose"])
         self.verbose = verbose
+        self.toolchain = toolchain
 
     def build(self, product_name):
         print("** Building " + product_name + " **")
@@ -374,6 +375,7 @@ class Builder(object):
         env["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] = "1"
         # Tell other projects in the unified build to use local dependencies
         env["SWIFTCI_USE_LOCAL_DEPS"] = "1"
+        env["SWIFT_SYNTAX_PARSER_LIB_SEARCH_PATH"] = os.path.join(self.toolchain, "lib", "swift", "macosx")
         check_call(command, env=env, verbose=self.verbose)
 
 
@@ -572,6 +574,7 @@ def run_xctests(toolchain, build_dir, multiroot_data_file, release, verbose):
     env["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] = "1"
     # Tell other projects in the unified build to use local dependencies
     env["SWIFTCI_USE_LOCAL_DEPS"] = "1"
+    env["SWIFT_SYNTAX_PARSER_LIB_SEARCH_PATH"] = os.path.join(toolchain, "lib", "swift", "macosx")
     return call(swiftpm_call, env=env, verbose=verbose) == 0
 
 


### PR DESCRIPTION
Previously, we were relying on SwiftPM adding the toolchain’s stdlib to the rpaths and we were finding `lib_InternalSwiftSyntaxParser.dylib` inside the stdlib directory. This behavior was removed in apple/swift-package-manager#4208.

Explicitly add the directory that contains `lib_InternalSwiftSyntaxParser.dylib` as an rpath to SwiftSyntaxParser when compiling SwiftSyntax using build-script.py.

The major downsides of this approach are
- You can no longer run SwiftSyntaxParser tests for SwiftSyntax in Xcode with an open source toolchain
  - Maybe this isn’t too bad because it only affects SwiftSyntaxParser tests and those can be run from the command line
- All adopters of SwiftSyntax also need to explicitly specify the `lib_InternalSwiftSyntaxParser.dylib` rpath
  - Maybe this isn’t too bad because on Linux `lib_InternalSwiftSyntaxParser.dylib` is in the standard search paths and on macOS we start shipping `lib_InternalSwiftSyntaxParser.dylib` as a binary dependency.