### PR TITLE
Correct the Syntax of Primary Associated Types

### DIFF
--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -1255,6 +1255,12 @@ extension SyntaxNode {
     return ConformanceRequirementSyntax(asSyntaxData)
   }
 
+  public var isPrimaryAssociatedTypeClause: Bool { return raw.kind == .primaryAssociatedTypeClause }
+  public var asPrimaryAssociatedTypeClause: PrimaryAssociatedTypeClauseSyntax? {
+    guard isPrimaryAssociatedTypeClause else { return nil }
+    return PrimaryAssociatedTypeClauseSyntax(asSyntaxData)
+  }
+
   public var isSimpleTypeIdentifier: Bool { return raw.kind == .simpleTypeIdentifier }
   public var asSimpleTypeIdentifier: SimpleTypeIdentifierSyntax? {
     guard isSimpleTypeIdentifier else { return nil }
@@ -1916,6 +1922,8 @@ extension Syntax {
     case .genericParameterClause(let node):
       return node
     case .conformanceRequirement(let node):
+      return node
+    case .primaryAssociatedTypeClause(let node):
       return node
     case .simpleTypeIdentifier(let node):
       return node

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
@@ -1506,6 +1506,13 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   override open func visitPost(_ node: ConformanceRequirementSyntax) {
     visitAnyPost(node._syntaxNode)
   }
+  override open func visit(_ node: PrimaryAssociatedTypeClauseSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: PrimaryAssociatedTypeClauseSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
   override open func visit(_ node: SimpleTypeIdentifierSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
@@ -4207,7 +4207,7 @@ extension StructDeclSyntax {
 
 public struct ProtocolDeclSyntaxBuilder {
   private var layout =
-    Array<RawSyntax?>(repeating: nil, count: 7)
+    Array<RawSyntax?>(repeating: nil, count: 8)
 
   internal init() {}
 
@@ -4243,6 +4243,11 @@ public struct ProtocolDeclSyntaxBuilder {
     layout[idx] = node.raw
   }
 
+  public mutating func usePrimaryAssociatedTypeClause(_ node: PrimaryAssociatedTypeClauseSyntax) {
+    let idx = ProtocolDeclSyntax.Cursor.primaryAssociatedTypeClause.rawValue
+    layout[idx] = node.raw
+  }
+
   public mutating func useInheritanceClause(_ node: TypeInheritanceClauseSyntax) {
     let idx = ProtocolDeclSyntax.Cursor.inheritanceClause.rawValue
     layout[idx] = node.raw
@@ -4265,8 +4270,8 @@ public struct ProtocolDeclSyntaxBuilder {
     if (layout[3] == nil) {
       layout[3] = RawSyntax.missingToken(TokenKind.identifier(""))
     }
-    if (layout[6] == nil) {
-      layout[6] = RawSyntax.missing(SyntaxKind.memberDeclBlock)
+    if (layout[7] == nil) {
+      layout[7] = RawSyntax.missing(SyntaxKind.memberDeclBlock)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .protocolDecl,
@@ -9243,6 +9248,66 @@ extension ConformanceRequirementSyntax {
   ///            closure.
   public init(_ build: (inout ConformanceRequirementSyntaxBuilder) -> Void) {
     var builder = ConformanceRequirementSyntaxBuilder()
+    build(&builder)
+    let data = builder.buildData()
+    self.init(data)
+  }
+}
+
+public struct PrimaryAssociatedTypeClauseSyntaxBuilder {
+  private var layout =
+    Array<RawSyntax?>(repeating: nil, count: 3)
+
+  internal init() {}
+
+  public mutating func useLeftAngleBracket(_ node: TokenSyntax) {
+    let idx = PrimaryAssociatedTypeClauseSyntax.Cursor.leftAngleBracket.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func addPrimaryAssociatedType(_ elt: PrimaryAssociatedTypeSyntax) {
+    let idx = PrimaryAssociatedTypeClauseSyntax.Cursor.primaryAssociatedTypeList.rawValue
+    if let list = layout[idx] {
+      layout[idx] = list.appending(elt.raw)
+    } else {
+      layout[idx] = RawSyntax.create(kind: SyntaxKind.primaryAssociatedTypeList,
+        layout: [elt.raw], length: elt.raw.totalLength,
+        presence: SourcePresence.present)
+    }
+  }
+
+  public mutating func useRightAngleBracket(_ node: TokenSyntax) {
+    let idx = PrimaryAssociatedTypeClauseSyntax.Cursor.rightAngleBracket.rawValue
+    layout[idx] = node.raw
+  }
+
+  internal mutating func buildData() -> SyntaxData {
+    if (layout[0] == nil) {
+      layout[0] = RawSyntax.missingToken(TokenKind.leftAngle)
+    }
+    if (layout[1] == nil) {
+      layout[1] = RawSyntax.missing(SyntaxKind.primaryAssociatedTypeList)
+    }
+    if (layout[2] == nil) {
+      layout[2] = RawSyntax.missingToken(TokenKind.rightAngle)
+    }
+
+    return .forRoot(RawSyntax.createAndCalcLength(kind: .primaryAssociatedTypeClause,
+      layout: layout, presence: .present))
+  }
+}
+
+extension PrimaryAssociatedTypeClauseSyntax {
+  /// Creates a `PrimaryAssociatedTypeClauseSyntax` using the provided build function.
+  /// - Parameter:
+  ///   - build: A closure that will be invoked in order to initialize
+  ///            the fields of the syntax node.
+  ///            This closure is passed a `PrimaryAssociatedTypeClauseSyntaxBuilder` which you can use to
+  ///            incrementally build the structure of the node.
+  /// - Returns: A `PrimaryAssociatedTypeClauseSyntax` with all the fields populated in the builder
+  ///            closure.
+  public init(_ build: (inout PrimaryAssociatedTypeClauseSyntaxBuilder) -> Void) {
+    var builder = PrimaryAssociatedTypeClauseSyntaxBuilder()
     build(&builder)
     let data = builder.buildData()
     self.init(data)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -227,6 +227,7 @@ public enum SyntaxEnum {
   case primaryAssociatedType(PrimaryAssociatedTypeSyntax)
   case genericParameterClause(GenericParameterClauseSyntax)
   case conformanceRequirement(ConformanceRequirementSyntax)
+  case primaryAssociatedTypeClause(PrimaryAssociatedTypeClauseSyntax)
   case simpleTypeIdentifier(SimpleTypeIdentifierSyntax)
   case memberTypeIdentifier(MemberTypeIdentifierSyntax)
   case classRestrictionType(ClassRestrictionTypeSyntax)
@@ -696,6 +697,8 @@ public extension Syntax {
       return .genericParameterClause(GenericParameterClauseSyntax(self)!)
     case .conformanceRequirement:
       return .conformanceRequirement(ConformanceRequirementSyntax(self)!)
+    case .primaryAssociatedTypeClause:
+      return .primaryAssociatedTypeClause(PrimaryAssociatedTypeClauseSyntax(self)!)
     case .simpleTypeIdentifier:
       return .simpleTypeIdentifier(SimpleTypeIdentifierSyntax(self)!)
     case .memberTypeIdentifier:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -1937,12 +1937,13 @@ public enum SyntaxFactory {
     ], length: .zero, presence: .present))
     return StructDeclSyntax(data)
   }
-  public static func makeProtocolDecl(attributes: AttributeListSyntax?, modifiers: ModifierListSyntax?, protocolKeyword: TokenSyntax, identifier: TokenSyntax, inheritanceClause: TypeInheritanceClauseSyntax?, genericWhereClause: GenericWhereClauseSyntax?, members: MemberDeclBlockSyntax) -> ProtocolDeclSyntax {
+  public static func makeProtocolDecl(attributes: AttributeListSyntax?, modifiers: ModifierListSyntax?, protocolKeyword: TokenSyntax, identifier: TokenSyntax, primaryAssociatedTypeClause: PrimaryAssociatedTypeClauseSyntax?, inheritanceClause: TypeInheritanceClauseSyntax?, genericWhereClause: GenericWhereClauseSyntax?, members: MemberDeclBlockSyntax) -> ProtocolDeclSyntax {
     let layout: [RawSyntax?] = [
       attributes?.raw,
       modifiers?.raw,
       protocolKeyword.raw,
       identifier.raw,
+      primaryAssociatedTypeClause?.raw,
       inheritanceClause?.raw,
       genericWhereClause?.raw,
       members.raw,
@@ -1960,6 +1961,7 @@ public enum SyntaxFactory {
       nil,
       RawSyntax.missingToken(TokenKind.protocolKeyword),
       RawSyntax.missingToken(TokenKind.identifier("")),
+      nil,
       nil,
       nil,
       RawSyntax.missing(SyntaxKind.memberDeclBlock),
@@ -4176,6 +4178,27 @@ public enum SyntaxFactory {
       RawSyntax.missing(SyntaxKind.type),
     ], length: .zero, presence: .present))
     return ConformanceRequirementSyntax(data)
+  }
+  public static func makePrimaryAssociatedTypeClause(leftAngleBracket: TokenSyntax, primaryAssociatedTypeList: PrimaryAssociatedTypeListSyntax, rightAngleBracket: TokenSyntax) -> PrimaryAssociatedTypeClauseSyntax {
+    let layout: [RawSyntax?] = [
+      leftAngleBracket.raw,
+      primaryAssociatedTypeList.raw,
+      rightAngleBracket.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.primaryAssociatedTypeClause,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    return PrimaryAssociatedTypeClauseSyntax(data)
+  }
+
+  public static func makeBlankPrimaryAssociatedTypeClause() -> PrimaryAssociatedTypeClauseSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .primaryAssociatedTypeClause,
+      layout: [
+      RawSyntax.missingToken(TokenKind.leftAngle),
+      RawSyntax.missing(SyntaxKind.primaryAssociatedTypeList),
+      RawSyntax.missingToken(TokenKind.rightAngle),
+    ], length: .zero, presence: .present))
+    return PrimaryAssociatedTypeClauseSyntax(data)
   }
   public static func makeSimpleTypeIdentifier(name: TokenSyntax, genericArgumentClause: GenericArgumentClauseSyntax?) -> SimpleTypeIdentifierSyntax {
     let layout: [RawSyntax?] = [

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
@@ -227,6 +227,7 @@ internal enum SyntaxKind: CSyntaxKind {
   case primaryAssociatedType = 255
   case genericParameterClause = 151
   case conformanceRequirement = 152
+  case primaryAssociatedTypeClause = 256
   case simpleTypeIdentifier = 212
   case memberTypeIdentifier = 213
   case classRestrictionType = 214

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -1465,6 +1465,13 @@ open class SyntaxRewriter {
     return Syntax(visitChildren(node))
   }
 
+  /// Visit a `PrimaryAssociatedTypeClauseSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: PrimaryAssociatedTypeClauseSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
   /// Visit a `SimpleTypeIdentifierSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -3876,6 +3883,16 @@ open class SyntaxRewriter {
   }
 
   /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplPrimaryAssociatedTypeClauseSyntax(_ data: SyntaxData) -> Syntax {
+      let node = PrimaryAssociatedTypeClauseSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplSimpleTypeIdentifierSyntax(_ data: SyntaxData) -> Syntax {
       let node = SimpleTypeIdentifierSyntax(data)
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
@@ -4719,6 +4736,8 @@ open class SyntaxRewriter {
       return visitImplGenericParameterClauseSyntax
     case .conformanceRequirement:
       return visitImplConformanceRequirementSyntax
+    case .primaryAssociatedTypeClause:
+      return visitImplPrimaryAssociatedTypeClauseSyntax
     case .simpleTypeIdentifier:
       return visitImplSimpleTypeIdentifierSyntax
     case .memberTypeIdentifier:
@@ -5230,6 +5249,8 @@ open class SyntaxRewriter {
       return visitImplGenericParameterClauseSyntax(data)
     case .conformanceRequirement:
       return visitImplConformanceRequirementSyntax(data)
+    case .primaryAssociatedTypeClause:
+      return visitImplPrimaryAssociatedTypeClauseSyntax(data)
     case .simpleTypeIdentifier:
       return visitImplSimpleTypeIdentifierSyntax(data)
     case .memberTypeIdentifier:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -2092,6 +2092,16 @@ open class SyntaxVisitor {
   /// The function called after visiting `ConformanceRequirementSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: ConformanceRequirementSyntax) {}
+  /// Visiting `PrimaryAssociatedTypeClauseSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: PrimaryAssociatedTypeClauseSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `PrimaryAssociatedTypeClauseSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: PrimaryAssociatedTypeClauseSyntax) {}
   /// Visiting `SimpleTypeIdentifierSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -4807,6 +4817,17 @@ open class SyntaxVisitor {
   }
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplPrimaryAssociatedTypeClauseSyntax(_ data: SyntaxData) {
+      let node = PrimaryAssociatedTypeClauseSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplSimpleTypeIdentifierSyntax(_ data: SyntaxData) {
       let node = SimpleTypeIdentifierSyntax(data)
       let needsChildren = (visit(node) == .visitChildren)
@@ -5655,6 +5676,8 @@ open class SyntaxVisitor {
       visitImplGenericParameterClauseSyntax(data)
     case .conformanceRequirement:
       visitImplConformanceRequirementSyntax(data)
+    case .primaryAssociatedTypeClause:
+      visitImplPrimaryAssociatedTypeClauseSyntax(data)
     case .simpleTypeIdentifier:
       visitImplSimpleTypeIdentifierSyntax(data)
     case .memberTypeIdentifier:

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -1967,6 +1967,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     case modifiers
     case protocolKeyword
     case identifier
+    case primaryAssociatedTypeClause
     case inheritanceClause
     case genericWhereClause
     case members
@@ -2117,6 +2118,28 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ProtocolDeclSyntax(newData)
   }
 
+  public var primaryAssociatedTypeClause: PrimaryAssociatedTypeClauseSyntax? {
+    get {
+      let childData = data.child(at: Cursor.primaryAssociatedTypeClause,
+                                 parent: Syntax(self))
+      if childData == nil { return nil }
+      return PrimaryAssociatedTypeClauseSyntax(childData!)
+    }
+    set(value) {
+      self = withPrimaryAssociatedTypeClause(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `primaryAssociatedTypeClause` replaced.
+  /// - param newChild: The new `primaryAssociatedTypeClause` to replace the node's
+  ///                   current `primaryAssociatedTypeClause`, if present.
+  public func withPrimaryAssociatedTypeClause(
+    _ newChild: PrimaryAssociatedTypeClauseSyntax?) -> ProtocolDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: Cursor.primaryAssociatedTypeClause)
+    return ProtocolDeclSyntax(newData)
+  }
+
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
     get {
       let childData = data.child(at: Cursor.inheritanceClause,
@@ -2185,7 +2208,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public func _validateLayout() {
     let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
-    assert(rawChildren.count == 7)
+    assert(rawChildren.count == 8)
     // Check child #0 child is AttributeListSyntax or missing
     if let raw = rawChildren[0].raw {
       let info = rawChildren[0].syntaxInfo
@@ -2220,26 +2243,34 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(TokenSyntax.self))
     }
-    // Check child #4 child is TypeInheritanceClauseSyntax or missing
+    // Check child #4 child is PrimaryAssociatedTypeClauseSyntax or missing
     if let raw = rawChildren[4].raw {
       let info = rawChildren[4].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TypeInheritanceClauseSyntax.self))
+      assert(syntaxChild.is(PrimaryAssociatedTypeClauseSyntax.self))
     }
-    // Check child #5 child is GenericWhereClauseSyntax or missing
+    // Check child #5 child is TypeInheritanceClauseSyntax or missing
     if let raw = rawChildren[5].raw {
       let info = rawChildren[5].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(GenericWhereClauseSyntax.self))
+      assert(syntaxChild.is(TypeInheritanceClauseSyntax.self))
     }
-    // Check child #6 child is MemberDeclBlockSyntax 
-    assert(rawChildren[6].raw != nil)
+    // Check child #6 child is GenericWhereClauseSyntax or missing
     if let raw = rawChildren[6].raw {
       let info = rawChildren[6].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(GenericWhereClauseSyntax.self))
+    }
+    // Check child #7 child is MemberDeclBlockSyntax 
+    assert(rawChildren[7].raw != nil)
+    if let raw = rawChildren[7].raw {
+      let info = rawChildren[7].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
@@ -2255,6 +2286,7 @@ extension ProtocolDeclSyntax: CustomReflectable {
       "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "protocolKeyword": Syntax(protocolKeyword).asProtocol(SyntaxProtocol.self),
       "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "primaryAssociatedTypeClause": primaryAssociatedTypeClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "inheritanceClause": inheritanceClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "members": Syntax(members).asProtocol(SyntaxProtocol.self),

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -12177,6 +12177,162 @@ extension ConformanceRequirementSyntax: CustomReflectable {
   }
 }
 
+// MARK: - PrimaryAssociatedTypeClauseSyntax
+
+public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable {
+  enum Cursor: Int {
+    case leftAngleBracket
+    case primaryAssociatedTypeList
+    case rightAngleBracket
+  }
+
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `PrimaryAssociatedTypeClauseSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .primaryAssociatedTypeClause else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `PrimaryAssociatedTypeClauseSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .primaryAssociatedTypeClause)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public var syntaxNodeType: SyntaxProtocol.Type {
+    return Swift.type(of: self)
+  }
+
+  public var leftAngleBracket: TokenSyntax {
+    get {
+      let childData = data.child(at: Cursor.leftAngleBracket,
+                                 parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withLeftAngleBracket(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `leftAngleBracket` replaced.
+  /// - param newChild: The new `leftAngleBracket` to replace the node's
+  ///                   current `leftAngleBracket`, if present.
+  public func withLeftAngleBracket(
+    _ newChild: TokenSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.leftAngle)
+    let newData = data.replacingChild(raw, at: Cursor.leftAngleBracket)
+    return PrimaryAssociatedTypeClauseSyntax(newData)
+  }
+
+  public var primaryAssociatedTypeList: PrimaryAssociatedTypeListSyntax {
+    get {
+      let childData = data.child(at: Cursor.primaryAssociatedTypeList,
+                                 parent: Syntax(self))
+      return PrimaryAssociatedTypeListSyntax(childData!)
+    }
+    set(value) {
+      self = withPrimaryAssociatedTypeList(value)
+    }
+  }
+
+  /// Adds the provided `PrimaryAssociatedType` to the node's `primaryAssociatedTypeList`
+  /// collection.
+  /// - param element: The new `PrimaryAssociatedType` to add to the node's
+  ///                  `primaryAssociatedTypeList` collection.
+  /// - returns: A copy of the receiver with the provided `PrimaryAssociatedType`
+  ///            appended to its `primaryAssociatedTypeList` collection.
+  public func addPrimaryAssociatedType(_ element: PrimaryAssociatedTypeSyntax) -> PrimaryAssociatedTypeClauseSyntax {
+    var collection: RawSyntax
+    if let col = raw[Cursor.primaryAssociatedTypeList] {
+      collection = col.appending(element.raw)
+    } else {
+      collection = RawSyntax.create(kind: SyntaxKind.primaryAssociatedTypeList,
+        layout: [element.raw], length: element.raw.totalLength, presence: .present)
+    }
+    let newData = data.replacingChild(collection,
+                                      at: Cursor.primaryAssociatedTypeList)
+    return PrimaryAssociatedTypeClauseSyntax(newData)
+  }
+
+  /// Returns a copy of the receiver with its `primaryAssociatedTypeList` replaced.
+  /// - param newChild: The new `primaryAssociatedTypeList` to replace the node's
+  ///                   current `primaryAssociatedTypeList`, if present.
+  public func withPrimaryAssociatedTypeList(
+    _ newChild: PrimaryAssociatedTypeListSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.primaryAssociatedTypeList)
+    let newData = data.replacingChild(raw, at: Cursor.primaryAssociatedTypeList)
+    return PrimaryAssociatedTypeClauseSyntax(newData)
+  }
+
+  public var rightAngleBracket: TokenSyntax {
+    get {
+      let childData = data.child(at: Cursor.rightAngleBracket,
+                                 parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withRightAngleBracket(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `rightAngleBracket` replaced.
+  /// - param newChild: The new `rightAngleBracket` to replace the node's
+  ///                   current `rightAngleBracket`, if present.
+  public func withRightAngleBracket(
+    _ newChild: TokenSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.rightAngle)
+    let newData = data.replacingChild(raw, at: Cursor.rightAngleBracket)
+    return PrimaryAssociatedTypeClauseSyntax(newData)
+  }
+
+
+  public func _validateLayout() {
+    let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
+    assert(rawChildren.count == 3)
+    // Check child #0 child is TokenSyntax 
+    assert(rawChildren[0].raw != nil)
+    if let raw = rawChildren[0].raw {
+      let info = rawChildren[0].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(TokenSyntax.self))
+    }
+    // Check child #1 child is PrimaryAssociatedTypeListSyntax 
+    assert(rawChildren[1].raw != nil)
+    if let raw = rawChildren[1].raw {
+      let info = rawChildren[1].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(PrimaryAssociatedTypeListSyntax.self))
+    }
+    // Check child #2 child is TokenSyntax 
+    assert(rawChildren[2].raw != nil)
+    if let raw = rawChildren[2].raw {
+      let info = rawChildren[2].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(TokenSyntax.self))
+    }
+  }
+}
+
+extension PrimaryAssociatedTypeClauseSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "leftAngleBracket": Syntax(leftAngleBracket).asProtocol(SyntaxProtocol.self),
+      "primaryAssociatedTypeList": Syntax(primaryAssociatedTypeList).asProtocol(SyntaxProtocol.self),
+      "rightAngleBracket": Syntax(rightAngleBracket).asProtocol(SyntaxProtocol.self),
+    ])
+  }
+}
+
 // MARK: - CompositionTypeElementSyntax
 
 public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/ExpressibleAsProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/ExpressibleAsProtocols.swift
@@ -2033,6 +2033,16 @@ public extension ExpressibleAsConformanceRequirement {
   }
 }
 
+public protocol ExpressibleAsPrimaryAssociatedTypeClause: ExpressibleAsSyntaxBuildable {
+  func createPrimaryAssociatedTypeClause() -> PrimaryAssociatedTypeClause
+}
+
+public extension ExpressibleAsPrimaryAssociatedTypeClause {
+  func createSyntaxBuildable() -> SyntaxBuildable {
+    return self.createPrimaryAssociatedTypeClause()
+  }
+}
+
 public protocol ExpressibleAsSimpleTypeIdentifier: ExpressibleAsTypeAnnotation, ExpressibleAsTypeExpr, ExpressibleAsTypeBuildable {
   func createSimpleTypeIdentifier() -> SimpleTypeIdentifier
 }

--- a/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
@@ -17,6 +17,6 @@
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "e5ff5bcc958d3c9316a33df3f8da4c308d020fb8"
+      "4a9fe1bc2e1f6346b7c4427ac6bd056b0fc59998"
   }
 }


### PR DESCRIPTION
The prior syntax tree did not take into account that the clause itself should own the angle brackets.