### PR TITLE
Migrate to use Python 3

### DIFF
--- a/Sources/SwiftSyntax/TokenKind.swift.gyb
+++ b/Sources/SwiftSyntax/TokenKind.swift.gyb
@@ -76,7 +76,7 @@ public enum TokenKind {
     case .eof: return .zero
 % for token in SYNTAX_TOKENS:
 %   if token.text:
-    case .${token.swift_kind()}: return SourceLength(utf8Length: ${len(token.text.decode('string_escape'))})
+    case .${token.swift_kind()}: return SourceLength(utf8Length: ${len(token.text.encode('utf-8').decode('unicode-escape'))})
 %   else:
     case .${token.swift_kind()}(let text): return SourceLength(of: text)
 %   end
@@ -168,7 +168,7 @@ extension TokenKind {
 % for token in SYNTAX_TOKENS:
 %   if token.text:
     case .${token.swift_kind()}:
-      let length = ${len(token.text.decode('string_escape'))}
+      let length = ${len(token.text.encode('utf-8').decode('unicode-escape'))}
       return body(.init(kind: .${token.swift_kind()}, length: length))
 %   else:
     case .${token.swift_kind()}(var text):

--- a/Sources/SwiftSyntaxBuilder/gyb_helpers/SyntaxBuildableWrappers.py
+++ b/Sources/SwiftSyntaxBuilder/gyb_helpers/SyntaxBuildableWrappers.py
@@ -1,8 +1,8 @@
 from gyb_syntax_support import SYNTAX_TOKEN_MAP, create_node_map, SYNTAX_NODES
 from gyb_syntax_support.kinds import SYNTAX_BASE_KINDS
 from gyb_syntax_support.kinds import lowercase_first_word
-from ExpressibleAsConformances import SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES
-from utils import flat_documentation
+from .ExpressibleAsConformances import SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES
+from .utils import flat_documentation
 
 class SyntaxBuildableChild:
   """

--- a/Sources/SwiftSyntaxBuilder/gyb_helpers/__init__.py
+++ b/Sources/SwiftSyntaxBuilder/gyb_helpers/__init__.py
@@ -1,2 +1,2 @@
-from SyntaxBuildableWrappers import SyntaxBuildableChild, SyntaxBuildableNode, SyntaxBuildableType
-from utils import conformance_clause, flat_documentation
+from .SyntaxBuildableWrappers import SyntaxBuildableChild, SyntaxBuildableNode, SyntaxBuildableType
+from .utils import conformance_clause, flat_documentation

--- a/build-script.py
+++ b/build-script.py
@@ -1,7 +1,4 @@
-#!/usr/bin/env python
-
-
-from __future__ import absolute_import, print_function, unicode_literals
+#!/usr/bin/env python3
 
 import argparse
 import os
@@ -519,7 +516,7 @@ def find_lit_test_helper_exec(toolchain, build_dir, release):
     swiftpm_call.extend(["--show-bin-path"])
 
     bin_dir = subprocess.check_output(swiftpm_call)
-    return os.path.join(bin_dir.strip(), "lit-test-helper")
+    return os.path.join(bin_dir.strip().decode('utf-8'), "lit-test-helper")
 
 
 def run_lit_tests(toolchain, build_dir, release, filecheck_exec, verbose):


### PR DESCRIPTION
Migrate Python code to Python 3 by:

1. update scripts' shebang
2. migrate syntax in Python modules
3. delete unnecessary imports