### PR TITLE
Adding SwiftSyntaxBuilder to the build process

### DIFF
--- a/Sources/SwiftSyntax/TokenKind.swift.gyb
+++ b/Sources/SwiftSyntax/TokenKind.swift.gyb
@@ -76,7 +76,7 @@ public enum TokenKind {
     case .eof: return .zero
 % for token in SYNTAX_TOKENS:
 %   if token.text:
-    case .${token.swift_kind()}: return SourceLength(utf8Length: ${len(token.text.decode('string_escape'))})
+    case .${token.swift_kind()}: return SourceLength(utf8Length: ${len(token.text.encode('utf-8').decode('unicode_escape'))})
 %   else:
     case .${token.swift_kind()}(let text): return SourceLength(of: text)
 %   end
@@ -168,7 +168,7 @@ extension TokenKind {
 % for token in SYNTAX_TOKENS:
 %   if token.text:
     case .${token.swift_kind()}:
-      let length = ${len(token.text.decode('string_escape'))}
+      let length = ${len(token.text.encode('utf-8').decode('unicode_escape'))}
       return body(.init(kind: .${token.swift_kind()}, length: length))
 %   else:
     case .${token.swift_kind()}(var text):

--- a/Sources/SwiftSyntaxBuilder/gyb_helpers/SyntaxBuildableWrappers.py
+++ b/Sources/SwiftSyntaxBuilder/gyb_helpers/SyntaxBuildableWrappers.py
@@ -1,8 +1,8 @@
 from gyb_syntax_support import SYNTAX_TOKEN_MAP, create_node_map, SYNTAX_NODES
 from gyb_syntax_support.kinds import SYNTAX_BASE_KINDS
 from gyb_syntax_support.kinds import lowercase_first_word
-from ExpressibleAsConformances import SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES
-from utils import flat_documentation
+from .ExpressibleAsConformances import SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES
+from .utils import flat_documentation
 
 class SyntaxBuildableChild:
   """

--- a/Sources/SwiftSyntaxBuilder/gyb_helpers/__init__.py
+++ b/Sources/SwiftSyntaxBuilder/gyb_helpers/__init__.py
@@ -1,2 +1,2 @@
-from SyntaxBuildableWrappers import SyntaxBuildableChild, SyntaxBuildableNode, SyntaxBuildableType
-from utils import conformance_clause, flat_documentation
+from .SyntaxBuildableWrappers import SyntaxBuildableChild, SyntaxBuildableNode, SyntaxBuildableType
+from .utils import conformance_clause, flat_documentation

--- a/build-script.py
+++ b/build-script.py
@@ -760,6 +760,7 @@ def main():
         # targets simultaneously. For now, just build one product after the other.
         builder.build("SwiftSyntax")
         builder.build("SwiftSyntaxParser")
+        builder.build("SwiftSyntaxBuilder")
 
         # Only build lit-test-helper if we are planning to run tests
         if args.test:


### PR DESCRIPTION
The build process of SwiftSyntax, should build three shared objects:
* SwiftSyntax
* SwiftSyntaxParser
* SwiftSyntaxBuilder

The SwiftSyntaxBuilder one has not been called to be built, then this pull request adds such build call to the `build-script.py` file. Also, there are two points in the build process that was producing erros during the SwiftSyntaxBuilder build.
1. Python3 strings does not support `string_escape` encode. However, python2 strings supports encoding for `utf-8` and decoding as `unicode_escape`.\
I'm not sure about differences between `string.encode('utf-8').decode('unicode_escape')` and `string.decode('string_escape')` in Python2, but looking for the data that will be used to fill `Tokens.swift.gyb` we only have UTF-8 characters, and for that case these approaches are equivalent. See the values in the file [swift/utils/gyb_syntax_support/Token.py](https://github.com/apple/swift/blob/main/utils/gyb_syntax_support/Token.py#L144).
2. The local module import in [SyntaxBuildableWrappers.py](Sources/SwiftSyntaxBuilder/gyb_helpers/SyntaxBuildableWrappers.py) and [\_\_init\_\_.py](Sources/SwiftSyntaxBuilder/gyb_helpers/__init__.py) is failing. The dot must to be added to tell to pyhton3 interpreter that we are dealing with the local module (actually, the same directory).