### PR TITLE
Fix exampe: Adding SwiftSyntaxParser import

### DIFF
--- a/Examples/AddOneToIntegerLiterals.swift
+++ b/Examples/AddOneToIntegerLiterals.swift
@@ -1,4 +1,5 @@
 import SwiftSyntax
+import SwiftSyntaxParser
 import Foundation
 
 /// AddOneToIntegerLiterals will visit each token in the Syntax tree, and


### PR DESCRIPTION
The SwiftSyntaxParser is not present in SwiftSyntax module, so it is necessary to import it explicitly.