### PR TITLE
Support `open` in swiftSyntaxBuilder

### DIFF
--- a/Sources/SwiftSyntaxBuilder/Tokens.swift.gyb
+++ b/Sources/SwiftSyntaxBuilder/Tokens.swift.gyb
@@ -62,4 +62,9 @@ public extension TokenSyntax {
   static var eof: TokenSyntax {
     SyntaxFactory.makeToken(.eof, presence: .present)
   }
+  /// The `open` contextual token
+  static var open: TokenSyntax {
+        SyntaxFactory.makeContextualKeyword("open")
+          .withTrailingTrivia(.spaces(1))
+    }
 }

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/Tokens.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/Tokens.swift
@@ -720,4 +720,9 @@ public extension TokenSyntax {
   static var eof: TokenSyntax {
     SyntaxFactory.makeToken(.eof, presence: .present)
   }
+  /// The `open` contextual token
+  static var open: TokenSyntax {
+        SyntaxFactory.makeContextualKeyword("open")
+          .withTrailingTrivia(.spaces(1))
+    }
 }


### PR DESCRIPTION
This pull request adds support for the 'open' keyword as TokenSyntax in SwiftSyntaxBuilder
it's implemented as syntactic sugar based on `makeContextualKeyword ` 
and accessed in swift like this: TokenSyntax.public

I'm open to your feedback and suggestation to enhance my pull request 

greetings, Mostfa.