### PR TITLE
Add a project to list of examples

### DIFF
--- a/Examples/README.md
+++ b/Examples/README.md
@@ -32,3 +32,5 @@
 [**Piranha**](https://github.com/uber/piranha): a tool for refactoring code related to feature flags.
 
 [**STAR**](https://github.com/thumbtack/star): a tool to find how often specified Swift type(s) are used in a project.## Some Example Users
+
+[**Hatch**](https://github.com/sdidla/Hatch): Provides a simple, extensible parser to obtain a hierarchical list of symbols


### PR DESCRIPTION
- Adds a nice little project called [Hatch](https://github.com/sdidla/Hatch/) that uses SwiftSyntax 0.50600.1
- The CI set up runs tests and builds documentation with [DocC plugin](https://github.com/apple/swift-docc-plugin)