### PR TITLE
Fixed comments in trivia piece

### DIFF
--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -53,11 +53,18 @@ extension TriviaPiece: TextOutputStreamable {
 %   joined = ''.join(trivia.swift_characters)
     case let .${trivia.lower_name}s(count):
       printRepeated("${joined}", count: count)
-%   else:
-    case let .${trivia.lower_name}(text):
-      target.write(text)
 %   end
 % end
+    case let .lineComment(text):
+    target.write("// \(text)")
+    case let .blockComment(text):
+    target.write("/* \(text) */")
+    case let .docLineComment(text):
+    target.write("/// \(text)")
+    case let .docBlockComment(text):
+    target.write("/** \(text) */")
+    case let .garbageText(text):
+    target.write(text)
     }
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/Trivia.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Trivia.swift
@@ -74,15 +74,15 @@ extension TriviaPiece: TextOutputStreamable {
     case let .carriageReturnLineFeeds(count):
       printRepeated("\r\n", count: count)
     case let .lineComment(text):
-      target.write(text)
+    target.write("// \(text)")
     case let .blockComment(text):
-      target.write(text)
+    target.write("/* \(text) */")
     case let .docLineComment(text):
-      target.write(text)
+    target.write("/// \(text)")
     case let .docBlockComment(text):
-      target.write(text)
+    target.write("/** \(text) */")
     case let .garbageText(text):
-      target.write(text)
+    target.write(text)
     }
   }
 }

--- a/Tests/SwiftSyntaxBuilderTest/StructTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StructTests.swift
@@ -22,7 +22,7 @@ final class StructTests: XCTestCase {
   func testNestedStruct() {
     let leadingTrivia = Trivia.garbageText("␣")
     let emptyMembers = MemberDeclList([])
-    let nestedStruct = StructDecl(structKeyword: .struct.withLeadingTrivia(.docLineComment("/// A nested struct\n")),
+    let nestedStruct = StructDecl(structKeyword: .struct.withLeadingTrivia(.docLineComment("A nested struct\n")),
                                   identifier: "NestedStruct",
                                   members: emptyMembers)
     let members = MemberDeclListItem(decl: nestedStruct)


### PR DESCRIPTION
Hi, 

While working on better API support for comments in SwiftSyntaxBuilder, 

I noticed that all variations of comments in `TriviaPiece` have the same implementation, which just adds regular text to the output of Syntax, which doesn't reflect the naming of a used trivia.

 because the clients using the trivia would need to explicitly add the `///` when using it
`.docLineComment("/// This's a docLine comment")`

```swift
// This PR will let the users just pass the comment needed, without /* or /// ...etc

.docLineComment("This's a docLine comment")    // -> generated output: /// This's a docLine comment
.lineComment("This's a reuglar line comment") // -> generated output:  // This's a reuglar line comment
.blockComment("This's a block comment")      // -> generated output:  /* This's a block comment */


```

and same applies to the rest of the comment types


Please let me what do you think about the changes, and if there's something better we should do.

Thanks,
