### PR TITLE
[5.7] Update gyb after updating async to contextual keyword

### DIFF
--- a/Sources/SwiftSyntax/gyb_generated/SyntaxClassification.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxClassification.swift
@@ -67,22 +67,14 @@ extension SyntaxClassification {
       switch (parentKind, indexInParent) {
       case (.awaitExpr, 0):
         return (.keyword, false)
-      case (.arrowExpr, 0):
-        return (.keyword, false)
-      case (.closureSignature, 3):
-        return (.keyword, false)
       case (.expressionSegment, 2):
         return (.stringInterpolationAnchor, true)
-      case (.functionSignature, 1):
-        return (.keyword, false)
       case (.ifConfigClause, 0):
         return (.buildConfigId, false)
       case (.ifConfigDecl, 1):
         return (.buildConfigId, false)
       case (.declModifier, 0):
         return (.attribute, false)
-      case (.accessorDecl, 4):
-        return (.keyword, false)
       case (.precedenceGroupRelation, 0):
         return (.keyword, false)
       case (.precedenceGroupAssociativity, 0):
@@ -96,8 +88,6 @@ extension SyntaxClassification {
       case (.memberTypeIdentifier, 2):
         return (.typeIdentifier, false)
       case (.constrainedSugarType, 0):
-        return (.keyword, false)
-      case (.functionType, 3):
         return (.keyword, false)
       case (.availabilityVersionRestriction, 0):
         return (.keyword, false)

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/BuildableNodes.swift
@@ -1315,7 +1315,7 @@ public struct ArrowExpr: ExprBuildable, ExpressibleAsArrowExpr {
     arrowToken: TokenSyntax = TokenSyntax.`arrow`
   ) {
     self.init(
-      asyncKeyword: asyncKeyword.map(TokenSyntax.identifier),
+      asyncKeyword: asyncKeyword.map(TokenSyntax.contextualKeyword),
       throwsToken: throwsToken,
       arrowToken: arrowToken
     )
@@ -2464,7 +2464,7 @@ public struct ClosureSignature: SyntaxBuildable, ExpressibleAsClosureSignature {
       attributes: attributesBuilder(),
       capture: capture,
       input: input,
-      asyncKeyword: asyncKeyword.map(TokenSyntax.identifier),
+      asyncKeyword: asyncKeyword.map(TokenSyntax.contextualKeyword),
       throwsTok: throwsTok,
       output: output,
       inTok: inTok
@@ -4356,7 +4356,7 @@ public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature
   ) {
     self.init(
       input: input,
-      asyncOrReasyncKeyword: asyncOrReasyncKeyword.map(TokenSyntax.identifier),
+      asyncOrReasyncKeyword: asyncOrReasyncKeyword.map(TokenSyntax.contextualKeyword),
       throwsOrRethrowsKeyword: throwsOrRethrowsKeyword,
       output: output
     )
@@ -6533,7 +6533,7 @@ public struct AccessorDecl: DeclBuildable, ExpressibleAsAccessorDecl {
       modifier: modifier,
       accessorKind: accessorKind,
       parameter: parameter,
-      asyncKeyword: asyncKeyword.map(TokenSyntax.identifier),
+      asyncKeyword: asyncKeyword.map(TokenSyntax.contextualKeyword),
       throwsKeyword: throwsKeyword,
       body: body
     )
@@ -12433,7 +12433,7 @@ public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
   public init(
     leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     rightParen: TokenSyntax = TokenSyntax.`rightParen`,
-    asyncKeyword: String?,
+    asyncKeyword: TokenSyntax? = nil,
     throwsOrRethrowsKeyword: TokenSyntax? = nil,
     arrow: TokenSyntax = TokenSyntax.`arrow`,
     returnType: ExpressibleAsTypeBuildable,
@@ -12443,7 +12443,7 @@ public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
       leftParen: leftParen,
       arguments: argumentsBuilder(),
       rightParen: rightParen,
-      asyncKeyword: asyncKeyword.map(TokenSyntax.identifier),
+      asyncKeyword: asyncKeyword,
       throwsOrRethrowsKeyword: throwsOrRethrowsKeyword,
       arrow: arrow,
       returnType: returnType

--- a/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
@@ -17,6 +17,6 @@
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "9adb90dde0ca797a8bd9be567fefc6f4e027c3a5"
+      "2ec3f7586996f875c3cb1e71ed98e0551f0ec8e7"
   }
 }


### PR DESCRIPTION
Cherry-picks c9e6ca01630e6932d843f003bdee4cd67e3a6a49 (https://github.com/apple/swift-syntax/pull/444) with an updated node hash since the version is different to main.

-----

Updates generated files for changes in
862f3fc4206b19b98dbda27e6d7c258a4bcf7344.