### PR TITLE
Revert "[5.7] Update gyb after updating async to contextual keyword"

### DIFF
--- a/Sources/SwiftSyntax/gyb_generated/SyntaxClassification.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxClassification.swift
@@ -67,14 +67,22 @@ extension SyntaxClassification {
       switch (parentKind, indexInParent) {
       case (.awaitExpr, 0):
         return (.keyword, false)
+      case (.arrowExpr, 0):
+        return (.keyword, false)
+      case (.closureSignature, 3):
+        return (.keyword, false)
       case (.expressionSegment, 2):
         return (.stringInterpolationAnchor, true)
+      case (.functionSignature, 1):
+        return (.keyword, false)
       case (.ifConfigClause, 0):
         return (.buildConfigId, false)
       case (.ifConfigDecl, 1):
         return (.buildConfigId, false)
       case (.declModifier, 0):
         return (.attribute, false)
+      case (.accessorDecl, 4):
+        return (.keyword, false)
       case (.precedenceGroupRelation, 0):
         return (.keyword, false)
       case (.precedenceGroupAssociativity, 0):
@@ -88,6 +96,8 @@ extension SyntaxClassification {
       case (.memberTypeIdentifier, 2):
         return (.typeIdentifier, false)
       case (.constrainedSugarType, 0):
+        return (.keyword, false)
+      case (.functionType, 3):
         return (.keyword, false)
       case (.availabilityVersionRestriction, 0):
         return (.keyword, false)

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/BuildableNodes.swift
@@ -1315,7 +1315,7 @@ public struct ArrowExpr: ExprBuildable, ExpressibleAsArrowExpr {
     arrowToken: TokenSyntax = TokenSyntax.`arrow`
   ) {
     self.init(
-      asyncKeyword: asyncKeyword.map(TokenSyntax.contextualKeyword),
+      asyncKeyword: asyncKeyword.map(TokenSyntax.identifier),
       throwsToken: throwsToken,
       arrowToken: arrowToken
     )
@@ -2464,7 +2464,7 @@ public struct ClosureSignature: SyntaxBuildable, ExpressibleAsClosureSignature {
       attributes: attributesBuilder(),
       capture: capture,
       input: input,
-      asyncKeyword: asyncKeyword.map(TokenSyntax.contextualKeyword),
+      asyncKeyword: asyncKeyword.map(TokenSyntax.identifier),
       throwsTok: throwsTok,
       output: output,
       inTok: inTok
@@ -4356,7 +4356,7 @@ public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature
   ) {
     self.init(
       input: input,
-      asyncOrReasyncKeyword: asyncOrReasyncKeyword.map(TokenSyntax.contextualKeyword),
+      asyncOrReasyncKeyword: asyncOrReasyncKeyword.map(TokenSyntax.identifier),
       throwsOrRethrowsKeyword: throwsOrRethrowsKeyword,
       output: output
     )
@@ -6533,7 +6533,7 @@ public struct AccessorDecl: DeclBuildable, ExpressibleAsAccessorDecl {
       modifier: modifier,
       accessorKind: accessorKind,
       parameter: parameter,
-      asyncKeyword: asyncKeyword.map(TokenSyntax.contextualKeyword),
+      asyncKeyword: asyncKeyword.map(TokenSyntax.identifier),
       throwsKeyword: throwsKeyword,
       body: body
     )
@@ -12433,7 +12433,7 @@ public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
   public init(
     leftParen: TokenSyntax = TokenSyntax.`leftParen`,
     rightParen: TokenSyntax = TokenSyntax.`rightParen`,
-    asyncKeyword: TokenSyntax? = nil,
+    asyncKeyword: String?,
     throwsOrRethrowsKeyword: TokenSyntax? = nil,
     arrow: TokenSyntax = TokenSyntax.`arrow`,
     returnType: ExpressibleAsTypeBuildable,
@@ -12443,7 +12443,7 @@ public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
       leftParen: leftParen,
       arguments: argumentsBuilder(),
       rightParen: rightParen,
-      asyncKeyword: asyncKeyword,
+      asyncKeyword: asyncKeyword.map(TokenSyntax.identifier),
       throwsOrRethrowsKeyword: throwsOrRethrowsKeyword,
       arrow: arrow,
       returnType: returnType

--- a/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
@@ -17,6 +17,6 @@
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "2ec3f7586996f875c3cb1e71ed98e0551f0ec8e7"
+      "9adb90dde0ca797a8bd9be567fefc6f4e027c3a5"
   }
 }


### PR DESCRIPTION
Reverts apple/swift-syntax#445 since release/5.7 is being used in release/5.7-04182022 and this change is incompatible there.