### PR TITLE
Add test cases for regex literal parsing

### DIFF
--- a/lit_tests/print_regex.swift
+++ b/lit_tests/print_regex.swift
@@ -1,0 +1,6 @@
+// RUN: %empty-directory(%t)
+ // RUN: %lit-test-helper -print-tree -source-file %s | %FileCheck %s --check-prefix REGEX
+
+ _ = /abc/
+ // REGEX: _ </TokenSyntax></DiscardAssignmentExprSyntax><AssignmentExprSyntax><TokenSyntax>= </TokenSyntax></AssignmentExprSyntax><RegexLiteralExprSyntax><TokenSyntax>/abc/</TokenSyntax></RegexLiteralExprSyntax></ExprListSyntax></SequenceExprSyntax></CodeBlockItemSyntax></CodeBlockItemListSyntax><TokenSyntax>
+ // REGEX: </TokenSyntax></SourceFileSyntax>

--- a/lit_tests/round_trip_regex.swift
+++ b/lit_tests/round_trip_regex.swift
@@ -1,0 +1,31 @@
+// RUN: %empty-directory(%t)
+// RUN: %lit-test-helper -roundtrip -source-file %s -out %t/afterRoundtrip.swift
+// RUN: diff -u %t/afterRoundtrip.swift %s
+
+
+_ = /abc/
+_ = #/abc/#
+_ = ##/abc/##
+
+func foo<T>(_ x: T...) {}
+foo(/abc/, #/abc/#, ##/abc/##)
+
+let arr = [/abc/, #/abc/#, ##/abc/##]
+
+_ = /\w+/.self
+_ = #/\w+/#.self
+_ = ##/\w+/##.self
+
+_ = /#\/\#\\/
+_ = #/#/\/\#\\/#
+_ = ##/#|\|\#\\/##
+
+_ = #/
+multiline
+/#
+
+_ = #/
+double
+multiline
+/#
+

--- a/lit_tests/round_trip_regex_invalid.swift
+++ b/lit_tests/round_trip_regex_invalid.swift
@@ -1,0 +1,18 @@
+// RUN: %empty-directory(%t)
+// RUN: %lit-test-helper -roundtrip -source-file %s -out %t/afterRoundtrip.swift
+// RUN: diff -u %t/afterRoundtrip.swift %s
+
+_ = /abc
+_ = #/abc
+_ = #/abc/
+_ = ##/abc/#
+
+_ #/x
+/#
+_ #/
+x/#
+
+_ //#
+_ /x/#
+
+_ = ""


### PR DESCRIPTION
This adds test cases to verify that regex literals can be correctly parsed.