### PR TITLE
Add API to enable or disable bare slash regex parsing

### DIFF
--- a/lit_tests/print_regex.swift
+++ b/lit_tests/print_regex.swift
@@ -1,6 +1,10 @@
 // RUN: %empty-directory(%t)
- // RUN: %lit-test-helper -print-tree -source-file %s | %FileCheck %s --check-prefix REGEX
+// RUN: %lit-test-helper -print-tree -source-file %s | %FileCheck %s --check-prefix REGEX_DISABLED
+// RUN: %lit-test-helper -print-tree -source-file %s -enable-bare-slash-regex 1 -swift-version 5 | %FileCheck %s --check-prefix REGEX_ENABLED
 
- _ = /abc/
- // REGEX: _ </TokenSyntax></DiscardAssignmentExprSyntax><AssignmentExprSyntax><TokenSyntax>= </TokenSyntax></AssignmentExprSyntax><RegexLiteralExprSyntax><TokenSyntax>/abc/</TokenSyntax></RegexLiteralExprSyntax></ExprListSyntax></SequenceExprSyntax></CodeBlockItemSyntax></CodeBlockItemListSyntax><TokenSyntax>
- // REGEX: </TokenSyntax></SourceFileSyntax>
+_ = /abc/
+// REGEX_DISABLED: _ </TokenSyntax></DiscardAssignmentExprSyntax><AssignmentExprSyntax><TokenSyntax>= </TokenSyntax></AssignmentExprSyntax><PrefixOperatorExprSyntax><TokenSyntax>/</TokenSyntax><PostfixUnaryExprSyntax><IdentifierExprSyntax><TokenSyntax>abc</TokenSyntax></IdentifierExprSyntax><TokenSyntax>/</TokenSyntax></PostfixUnaryExprSyntax></PrefixOperatorExprSyntax></ExprListSyntax></SequenceExprSyntax></CodeBlockItemSyntax></CodeBlockItemListSyntax><TokenSyntax>
+// REGEX_DISABLED: </TokenSyntax></SourceFileSyntax>
+
+// REGEX_ENABLED: _ </TokenSyntax></DiscardAssignmentExprSyntax><AssignmentExprSyntax><TokenSyntax>= </TokenSyntax></AssignmentExprSyntax><RegexLiteralExprSyntax><TokenSyntax>/abc/</TokenSyntax></RegexLiteralExprSyntax></ExprListSyntax></SequenceExprSyntax></CodeBlockItemSyntax></CodeBlockItemListSyntax><TokenSyntax>
+// REGEX_ENABLED: </TokenSyntax></SourceFileSyntax>


### PR DESCRIPTION
Depends on https://github.com/apple/swift/pull/59018

---

Add a parameter to the `SyntaxParser.parse` functions to enable or disable bare slash regex parsing.

rdar://93750821