### PR TITLE
Add convenience initialiser for `MemberAccessExpr`

### DIFF
--- a/Sources/SwiftSyntaxBuilder/MemberAccessExprConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/MemberAccessExprConvenienceInitializers.swift
@@ -1,0 +1,25 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+extension MemberAccessExpr {
+  /// Creates a `MemberAccessExpr` using the provided parameters.
+  public init(
+    base: ExpressibleAsExprBuildable? = nil,
+    dot: TokenSyntax = .period,
+    name: String,
+    declNameArguments: ExpressibleAsDeclNameArguments? = nil
+  ) {
+    self.init(base: base, dot: dot, name: SyntaxFactory.makeIdentifier(name), declNameArguments: declNameArguments)
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/MemberAccessTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/MemberAccessTests.swift
@@ -1,0 +1,17 @@
+import XCTest
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+final class MemberAccessTests: XCTestCase {
+  func testMemberAccessExprConvenienceInitializers() {
+    let leadingTrivia = Trivia.garbageText("␣")
+
+    let builder = MemberAccessExpr(base: "Foo", name: "bar")
+    let syntax = builder.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
+
+    var text = ""
+    syntax.write(to: &text)
+
+    XCTAssertEqual(text, "␣Foo.bar")
+  }
+}


### PR DESCRIPTION
From comment: https://github.com/apple/swift-syntax/pull/381#discussion_r876745511

> To keep this PR focussed, do you think we could pull this change out into a separate PR? Also, I think you’re missing descriptions for the parameters. I think we should either remove the per-parameter documentation altogether or provide descriptions.

@ahoppen the parameters are from the generated init method. 
I think the best would be to actually add them in the gyb files, to have documentation.

Removed them here.