### PR TITLE
Code Generation example is fixed for 0.50600.1

### DIFF
--- a/Examples/CodeGenerationUsingSwiftSyntaxBuilder.swift
+++ b/Examples/CodeGenerationUsingSwiftSyntaxBuilder.swift
@@ -10,12 +10,12 @@ import SwiftSyntaxBuilder
 /// }
 ///```
 
-let source = SourceFile {
-  ImportDecl(path: "Foundation")
-  ImportDecl(path: "UIKit")
-  ClassDecl(classOrActorKeyword: .class, identifier: "SomeViewController", membersBuilder: {
+let source = SourceFile(eofToken: .eof) {
+  ImportDecl(path: AccessPathComponent(name: "Foundation"))
+  ImportDecl(path: AccessPathComponent(name: "UIKit"))
+  ClassDecl(classOrActorKeyword: .class, identifier: "SomeViewController", members: MemberDeclBlock(membersBuilder: {
     VariableDecl(.let, name: "tableView", type: "UITableView")
-  })
+  }))
 }
 
 let syntax = source.buildSyntax(format: Format())


### PR DESCRIPTION
I'm not sure if it is different for the latest `main`, but here are the changes I need to do to make the example code compilable with the `0.50600.1`.
BTW, `0.50500.0` requires other fixes, I think it worths to be mentioned somewhere in the docs
