### PR TITLE
[5.7] Add API to enable or disable bare slash regex parsing

### DIFF
--- a/lit_tests/print_regex.swift
+++ b/lit_tests/print_regex.swift
@@ -1,0 +1,10 @@
+// RUN: %empty-directory(%t)
+// RUN: %lit-test-helper -print-tree -source-file %s | %FileCheck %s --check-prefix REGEX_DISABLED
+// RUN: %lit-test-helper -print-tree -source-file %s -enable-bare-slash-regex 1 -swift-version 5 | %FileCheck %s --check-prefix REGEX_ENABLED
+
+_ = /abc/
+// REGEX_DISABLED: _ </TokenSyntax></DiscardAssignmentExprSyntax><AssignmentExprSyntax><TokenSyntax>= </TokenSyntax></AssignmentExprSyntax><PrefixOperatorExprSyntax><TokenSyntax>/</TokenSyntax><PostfixUnaryExprSyntax><IdentifierExprSyntax><TokenSyntax>abc</TokenSyntax></IdentifierExprSyntax><TokenSyntax>/</TokenSyntax></PostfixUnaryExprSyntax></PrefixOperatorExprSyntax></ExprListSyntax></SequenceExprSyntax></CodeBlockItemSyntax></CodeBlockItemListSyntax><TokenSyntax>
+// REGEX_DISABLED: </TokenSyntax></SourceFileSyntax>
+
+// REGEX_ENABLED: _ </TokenSyntax></DiscardAssignmentExprSyntax><AssignmentExprSyntax><TokenSyntax>= </TokenSyntax></AssignmentExprSyntax><RegexLiteralExprSyntax><TokenSyntax>/abc/</TokenSyntax></RegexLiteralExprSyntax></ExprListSyntax></SequenceExprSyntax></CodeBlockItemSyntax></CodeBlockItemListSyntax><TokenSyntax>
+// REGEX_ENABLED: </TokenSyntax></SourceFileSyntax>


### PR DESCRIPTION
Depends on https://github.com/apple/swift/pull/59150

---

* **Explanation**: https://github.com/apple/swift/pull/58998 enabled bare slash regex literals for SwiftSyntax parsing by default. This adds parameters to the `SyntaxParser.parse` functions that allow specifying whether bare slash regex literal parsing should be enabled.
* **Scope**: Parsing of SwiftSyntax trees
* **Risk**: Low
* **Testing**: Added regression tests
* **Issue**: rdar://93750821
* **Reviewer**: @rintaro on https://github.com/apple/swift-syntax/pull/448