### PR TITLE
Builder based initializer for `DictionaryExpr`

### DIFF
--- a/Sources/SwiftSyntaxBuilder/DictionaryExprConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/DictionaryExprConvenienceInitializers.swift
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+extension DictionaryExpr {
+  /// A convenience initializer that allows passing in members using a result builder
+  /// instead of having to wrap them in a `DictionaryElementList`.
+  public init(
+    leftSquare: TokenSyntax = .`leftSquareBracket`,
+    rightSquare: TokenSyntax = .`rightSquareBracket`,
+    @DictionaryElementListBuilder contentBuilder: () -> ExpressibleAsDictionaryElementList = { DictionaryElementList([]) }
+  ) {
+    let elementList = contentBuilder().createDictionaryElementList()
+    self.init(
+      leftSquare: leftSquare,
+      content: elementList.elements.isEmpty ? SyntaxFactory.makeColonToken() : elementList,
+      rightSquare: rightSquare
+    )
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/ExpressibleAsProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/ExpressibleAsProtocols.swift
@@ -2109,21 +2109,29 @@ public extension ExpressibleAsClassRestrictionType {
   }
 }
 
-public protocol ExpressibleAsArrayType: ExpressibleAsTypeBuildable {
+public protocol ExpressibleAsArrayType: ExpressibleAsTypeAnnotation, ExpressibleAsTypeBuildable {
   func createArrayType() -> ArrayType
 }
 
 public extension ExpressibleAsArrayType {
+  /// Conformance to `ExpressibleAsTypeAnnotation`.
+  func createTypeAnnotation() -> TypeAnnotation {
+    return TypeAnnotation(type: self)
+  }
   func createTypeBuildable() -> TypeBuildable {
     return self.createArrayType()
   }
 }
 
-public protocol ExpressibleAsDictionaryType: ExpressibleAsTypeBuildable {
+public protocol ExpressibleAsDictionaryType: ExpressibleAsTypeAnnotation, ExpressibleAsTypeBuildable {
   func createDictionaryType() -> DictionaryType
 }
 
 public extension ExpressibleAsDictionaryType {
+  /// Conformance to `ExpressibleAsTypeAnnotation`.
+  func createTypeAnnotation() -> TypeAnnotation {
+    return TypeAnnotation(type: self)
+  }
   func createTypeBuildable() -> TypeBuildable {
     return self.createDictionaryType()
   }

--- a/Sources/SwiftSyntaxBuilder/gyb_helpers/ExpressibleAsConformances.py
+++ b/Sources/SwiftSyntaxBuilder/gyb_helpers/ExpressibleAsConformances.py
@@ -2,12 +2,18 @@ SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES = {
     'AccessorList': [
         'AccessorBlock'
     ],
+    'ArrayType': [
+        'TypeAnnotation'
+    ],
     'CodeBlockItemList': [
         'CodeBlock'
     ],
     'DeclBuildable': [
         'CodeBlockItem',
         'MemberDeclListItem'
+    ],
+    'DictionaryType': [
+        'TypeAnnotation'
     ],
     'ExprList': [
         'ConditionElement'


### PR DESCRIPTION
Allow to use `ArrayType` and `DictionaryType` as `PatternBinding.typeAnnotation` argument