### PR TITLE
Clean build-script by adding subcommands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@ To build the `main` branch of SwiftSyntax, follow the following instructions:
     ```
 
 4. To make sure everything is set up correctly, check the return statement of `xcrun --find swift`. It should point inside the latest installed trunk development toolchain. If it points inside an Xcode toolchain, check that you exported the `TOOLCHAINS` environment variable correctly. If it points inside a version-specific toolchain (like Swift 5.0-dev), you'll need to remove that toolchain.
-5. Run `swift-syntax/build-script.py --toolchain /path/to/recent/swift/development/snapshot.xctoolchain/usr`.
+5. Run `swift-syntax/build-script.py build --toolchain /path/to/recent/swift/development/snapshot.xctoolchain/usr`.
     If despite following those instructions, you get compiler errors, the Swift toolchain might be too old to contain recent changes in Swift's SwiftSyntaxParser C library. In that case, you'll have to build the compiler and SwiftSyntax together with the following command:
 
     ```bash


### PR DESCRIPTION
Based on this comment: https://github.com/apple/swift-syntax/pull/381#discussion_r881655025
> Also: Since `build-script-helper.py` now does so many things, we should probably migrate it to using argparse subcommands. But that’s something for a completely standalone PR.


I tried to come with an example on how it could be structured. A command could look like: `python3 ./build-script.py degyb --degyb-only --verbose`
What do you think @ahoppen ?

Then we don't need to pass the `--toolchain` etc if it's not needed