### PR TITLE
Take attribute and modifier lists directly in declaration convenience initializers

### DIFF
--- a/Sources/SwiftSyntaxBuilder/ClassDeclConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ClassDeclConvenienceInitializers.swift
@@ -15,18 +15,18 @@ import SwiftSyntax
 extension ClassDecl {
   /// A convenience initializer that allows passing in members using a result builder instead of having to wrap them in a `MemberDeclBlock`.
   public init(
+    attributes: ExpressibleAsAttributeList? = nil,
+    modifiers: ExpressibleAsModifierList? = nil,
     classOrActorKeyword: TokenSyntax,
     identifier: String,
     genericParameterClause: ExpressibleAsGenericParameterClause? = nil,
     inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil,
     genericWhereClause: ExpressibleAsGenericWhereClause? = nil,
-    @AttributeListBuilder attributesBuilder: () -> ExpressibleAsAttributeList? = { nil },
-    @ModifierListBuilder modifiersBuilder: () -> ExpressibleAsModifierList? = { nil },
     @MemberDeclListBuilder membersBuilder: () -> ExpressibleAsMemberDeclList = { MemberDeclList([]) }
   ) {
     self.init(
-      attributes: attributesBuilder(),
-      modifiers: modifiersBuilder(),
+      attributes: attributes,
+      modifiers: modifiers,
       classOrActorKeyword: classOrActorKeyword,
       identifier: TokenSyntax.identifier(identifier),
       genericParameterClause: genericParameterClause,

--- a/Sources/SwiftSyntaxBuilder/EnumDeclConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/EnumDeclConvenienceInitializers.swift
@@ -15,18 +15,18 @@ import SwiftSyntax
 extension EnumDecl {
   /// A convenience initializer that allows passing in members using a result builder instead of having to wrap them in a `MemberDeclBlock`.
   public init(
+    attributes: ExpressibleAsAttributeList? = nil,
+    modifiers: ExpressibleAsModifierList? = nil,
     enumKeyword: TokenSyntax = TokenSyntax.`enum`,
     identifier: String,
     genericParameters: ExpressibleAsGenericParameterClause? = nil,
     inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil,
     genericWhereClause: ExpressibleAsGenericWhereClause? = nil,
-    @AttributeListBuilder attributesBuilder: () -> ExpressibleAsAttributeList? = { nil },
-    @ModifierListBuilder modifiersBuilder: () -> ExpressibleAsModifierList? = { nil },
     @MemberDeclListBuilder membersBuilder: () -> ExpressibleAsMemberDeclList = { MemberDeclList([]) }
   ) {
     self.init(
-      attributes: attributesBuilder(),
-      modifiers: modifiersBuilder(),
+      attributes: attributes,
+      modifiers: modifiers,
       enumKeyword: enumKeyword,
       identifier: TokenSyntax.identifier(identifier),
       genericParameters: genericParameters,

--- a/Sources/SwiftSyntaxBuilder/ExtensionDeclConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ExtensionDeclConvenienceInitializers.swift
@@ -15,17 +15,17 @@ import SwiftSyntax
 extension ExtensionDecl {
   /// A convenience initializer that allows passing in members using a result builder instead of having to wrap them in a `MemberDeclBlock`.
   public init(
+    attributes: ExpressibleAsAttributeList? = nil,
+    modifiers: ExpressibleAsModifierList? = nil,
     extensionKeyword: TokenSyntax = TokenSyntax.`extension`,
     extendedType: ExpressibleAsTypeBuildable,
     inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil,
     genericWhereClause: ExpressibleAsGenericWhereClause? = nil,
-    @AttributeListBuilder attributesBuilder: () -> ExpressibleAsAttributeList? = { nil },
-    @ModifierListBuilder modifiersBuilder: () -> ExpressibleAsModifierList? = { nil },
     @MemberDeclListBuilder membersBuilder: () -> ExpressibleAsMemberDeclList = { MemberDeclList([]) }
   ) {
     self.init(
-      attributes: attributesBuilder(),
-      modifiers: modifiersBuilder(),
+      attributes: attributes,
+      modifiers: modifiers,
       extensionKeyword: extensionKeyword,
       extendedType: extendedType,
       inheritanceClause: inheritanceClause,

--- a/Sources/SwiftSyntaxBuilder/FunctionDeclConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/FunctionDeclConvenienceInitializers.swift
@@ -15,18 +15,18 @@ import SwiftSyntax
 extension FunctionDecl {
   /// A convenience initializer that allows passing in members using a result builder instead of having to wrap them in a `MemberDeclBlock`.
   public init(
+    attributes: ExpressibleAsAttributeList? = nil,
+    modifiers: ExpressibleAsModifierList? = nil,
     funcKeyword: TokenSyntax = TokenSyntax.`func`,
     identifier: TokenSyntax,
     genericParameterClause: ExpressibleAsGenericParameterClause? = nil,
     signature: ExpressibleAsFunctionSignature,
     genericWhereClause: ExpressibleAsGenericWhereClause? = nil,
-    @AttributeListBuilder attributesBuilder: () -> ExpressibleAsAttributeList? = { nil },
-    @ModifierListBuilder modifiersBuilder: () -> ExpressibleAsModifierList? = { nil },
     @CodeBlockItemListBuilder bodyBuilder: () -> CodeBlockItemList? = { nil }
   ) {
     self.init(
-      attributes: attributesBuilder(),
-      modifiers: modifiersBuilder(),
+      attributes: attributes,
+      modifiers: modifiers,
       funcKeyword: funcKeyword,
       identifier: identifier,
       genericParameterClause: genericParameterClause,

--- a/Sources/SwiftSyntaxBuilder/ProtocolDeclConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ProtocolDeclConvenienceInitializers.swift
@@ -15,17 +15,17 @@ import SwiftSyntax
 extension ProtocolDecl {
   /// A convenience initializer that allows passing in members using a result builder instead of having to wrap them in a `MemberDeclBlock`.
   public init(
+    attributes: ExpressibleAsAttributeList? = nil,
+    modifiers: ExpressibleAsModifierList? = nil,
     protocolKeyword: TokenSyntax = TokenSyntax.`protocol`,
     identifier: String,
     inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil,
     genericWhereClause: ExpressibleAsGenericWhereClause? = nil,
-    @AttributeListBuilder attributesBuilder: () -> ExpressibleAsAttributeList? = { nil },
-    @ModifierListBuilder modifiersBuilder: () -> ExpressibleAsModifierList? = { nil },
     @MemberDeclListBuilder membersBuilder: () -> ExpressibleAsMemberDeclList = { MemberDeclList([]) }
   ) {
     self.init(
-      attributes: attributesBuilder(),
-      modifiers: modifiersBuilder(),
+      attributes: attributes,
+      modifiers: modifiers,
       protocolKeyword: protocolKeyword,
       identifier: TokenSyntax.identifier(identifier),
       inheritanceClause: inheritanceClause,

--- a/Sources/SwiftSyntaxBuilder/StructDeclConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/StructDeclConvenienceInitializers.swift
@@ -15,18 +15,18 @@ import SwiftSyntax
 extension StructDecl {
   /// A convenience initializer that allows passing in members using a result builder instead of having to wrap them in a `MemberDeclBlock`.
   public init(
+    attributes: ExpressibleAsAttributeList? = nil,
+    modifiers: ExpressibleAsModifierList? = nil,
     structKeyword: TokenSyntax = TokenSyntax.`struct`,
     identifier: String,
     genericParameterClause: ExpressibleAsGenericParameterClause? = nil,
     inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil,
     genericWhereClause: ExpressibleAsGenericWhereClause? = nil,
-    @AttributeListBuilder attributesBuilder: () -> ExpressibleAsAttributeList? = { nil },
-    @ModifierListBuilder modifiersBuilder: () -> ExpressibleAsModifierList? = { nil },
     @MemberDeclListBuilder membersBuilder: () -> ExpressibleAsMemberDeclList = { MemberDeclList([]) }
   ) {
     self.init(
-      attributes: attributesBuilder(),
-      modifiers: modifiersBuilder(),
+      attributes: attributes,
+      modifiers: modifiers,
       structKeyword: structKeyword,
       identifier: TokenSyntax.identifier(identifier),
       genericParameterClause: genericParameterClause,

--- a/Sources/SwiftSyntaxBuilder/VariableDeclConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/VariableDeclConvenienceInitializers.swift
@@ -21,4 +21,18 @@ extension VariableDecl {
                      typeAnnotation: type.createTypeAnnotation())
       })
   }
+
+  public init(
+    attributes: ExpressibleAsAttributeList? = nil,
+    modifiers: ExpressibleAsModifierList? = nil,
+    _ letOrVarKeyword: TokenSyntax,
+    @PatternBindingListBuilder bindingsBuilder: () -> ExpressibleAsPatternBindingList = { PatternBindingList([]) }
+  ) {
+    self.init(
+      attributes: attributes,
+      modifiers: modifiers,
+      letOrVarKeyword: letOrVarKeyword,
+      bindings: bindingsBuilder()
+    )
+  }
 }

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/TokensFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/TokensFile.swift
@@ -18,22 +18,14 @@ let tokensFile = SourceFile {
   ImportDecl(importTok: TokenSyntax.import.withLeadingTrivia(.docLineComment(copyrightHeader)), path: "SwiftSyntax")
 
   ExtensionDecl(
+    modifiers: ModifierList([TokenSyntax.public.withLeadingTrivia(.newlines(1) + .docLineComment("/// Namespace for commonly used tokens with default trivia.") + .newlines(1))]),
     extendedType: "TokenSyntax",
-    modifiersBuilder: {
-      TokenSyntax.public.withLeadingTrivia(.newlines(1) + .docLineComment("/// Namespace for commonly used tokens with default trivia.") + .newlines(1))
-    },
     membersBuilder: {
       for token in SYNTAX_TOKENS {
         if token.isKeyword {
           VariableDecl(
-            letOrVarKeyword: .var,
-            modifiersBuilder: {
-              if let text = token.text {
-                TokenSyntax.static.withLeadingTrivia(.newlines(1) + .docLineComment("/// The `\(text)` keyword") + .newlines(1))
-              } else {
-                TokenSyntax.static
-              }
-            },
+            modifiers: ModifierList([token.text.map { TokenSyntax.static.withLeadingTrivia(.newlines(1) + .docLineComment("/// The `\($0)` keyword") + .newlines(1)) } ?? TokenSyntax.static]),
+            .var,
             bindingsBuilder: {
               // We need to use `CodeBlock` here to ensure there is braces around.
 
@@ -52,16 +44,10 @@ let tokensFile = SourceFile {
               createTokenSyntaxPatternBinding("`\(token.name.withFirstCharacterLowercased)`", accessor: accessor)
             }
           )
-        } else if token.text != nil {
+        } else if let text = token.text {
           VariableDecl(
-            letOrVarKeyword: .var,
-            modifiersBuilder: {
-              if let text = token.text {
-                TokenSyntax.static.withLeadingTrivia(.newlines(1) + .docLineComment("/// The `\(text)` token") + .newlines(1))
-              } else {
-                TokenSyntax.static
-              }
-            },
+            modifiers: ModifierList([TokenSyntax.static.withLeadingTrivia(.newlines(1) + .docLineComment("/// The `\(text)` token") + .newlines(1))]),
+            .var,
             bindingsBuilder: {
               // We need to use `CodeBlock` here to ensure there is braces around.
               let accessor = CodeBlock {
@@ -95,15 +81,9 @@ let tokensFile = SourceFile {
           )
 
           FunctionDecl(
+            modifiers: ModifierList([TokenSyntax.static]),
             identifier: .identifier("`\(token.name.withFirstCharacterLowercased)`"),
             signature: signature,
-            modifiersBuilder: {
-              if let text = token.text {
-                TokenSyntax.static.withLeadingTrivia(.newlines(1) + .docLineComment("/// The `\(text)` token"))
-              } else {
-                TokenSyntax.static
-              }
-            },
             bodyBuilder: {
               FunctionCallExpr(
                 MemberAccessExpr(base: "SyntaxFactory", name: "make\(token.name)"),
@@ -124,8 +104,8 @@ let tokensFile = SourceFile {
         }
       }
       VariableDecl(
-        letOrVarKeyword: .var,
-        modifiersBuilder: { TokenSyntax.static.withLeadingTrivia(.newlines(1) + .docLineComment("/// The `eof` token") + .newlines(1)) },
+        modifiers: ModifierList([TokenSyntax.static.withLeadingTrivia(.newlines(1) + .docLineComment("/// The `eof` token") + .newlines(1))]),
+        .var,
         bindingsBuilder: {
           // We need to use `CodeBlock` here to ensure there is braces around.
           let body = CodeBlock {
@@ -142,8 +122,8 @@ let tokensFile = SourceFile {
         }
       )
       VariableDecl(
-        letOrVarKeyword: .var,
-        modifiersBuilder: { TokenSyntax.static.withLeadingTrivia(.newlines(1) + .docLineComment("/// The `open` contextual token") + .newlines(1)) },
+        modifiers: ModifierList([TokenSyntax.static.withLeadingTrivia(.newlines(1) + .docLineComment("/// The `open` contextual token") + .newlines(1))]),
+        .var,
         bindingsBuilder: {
           // We need to use `CodeBlock` here to ensure there is braces around.
           let body = CodeBlock {

--- a/Tests/SwiftSyntaxBuilderTest/ProtocolDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ProtocolDeclTests.swift
@@ -11,9 +11,9 @@ final class ProtocolDeclTests: XCTestCase {
     })
     let functionSignature = FunctionSignature(input: input, output: returnType)
 
-    let buildable = ProtocolDecl(identifier: "DeclListBuildable", attributesBuilder: { TokenSyntax.public }, membersBuilder: {
-      FunctionDecl(identifier: .identifier("buildDeclList"), signature: functionSignature, body: nil, modifiersBuilder: { })
-    })
+    let buildable = ProtocolDecl(attributes: AttributeList([TokenSyntax.public]), identifier: "DeclListBuildable") {
+      FunctionDecl(modifiers: nil, identifier: .identifier("buildDeclList"), signature: functionSignature, body: nil)
+    }
 
     let syntax = buildable.buildSyntax(format: Format())
 


### PR DESCRIPTION
As suggested by @ahoppen, this branch explores taking attributes and modifiers directly in the convenience initializers for declarations in `SwiftSyntaxBuilder` rather than as result builders, primarily to simplify the DSL and to improve the usability of trailing closures for the 'body' of most constructs.

Although the branch passes the build, there are a few challenges that I have encountered with this approach. For this reason I will mark the PR as draft for now, so these points can be discussed and addressed first:

#### We cannot use `ExpressibleByArrayLiteral` conformances in parameters

Since we pass attributes and modifiers as existentials (`ExpressibleAsAttributeList` and `ExpressibleAsModifierList`, respectively), we cannot use the conformance of `AttributeList`/`ModifierList` to `ExpressibleByArrayLiteral` directly. More specifically, we have to explicitly wrap these parameters as

```swift
ExtensionDecl(
  modifiers: ModifierList([...]),
  ...
)
```

rather than being able to say

```swift
ExtensionDecl(
  modifiers: [...],
  ...
)
```

As a potential solution we could take `AttributeList`/`ModifierList` directly in these initializers, at the cost of making the initializers less polymorphic (and less consistent, considering that the other arguments are taken existentially too).

- **Update:** Fixed by #461 

#### Not using result builders increases ambiguity with generated initializers

For example, `FunctionDecl` has three initializers:

- Two generated initializers in `BuildableNodes` (a direct initializers and one that takes attributes/modifiers as builders)
- A convenience initializer in `FunctionDeclConvenienceInitializers`, which now only takes the body as builder

The compiler can now only disambiguate these initializers by the final `bodyBuilder` closure, even passing it as a trailing closure (which we want to encourage with this API design) can cause ambiguities with the modifier builder closure from the generated initializer.

A potential solution would be to not generate builder-based initializers automatically at all and only include them in convenience initializers, this could potentially be a larger change though.

Thoughts? @ahoppen @kimdv