### PR TITLE
Add DocC to SwiftSyntax

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 
 import PackageDescription
 import Foundation
@@ -94,11 +94,11 @@ let package = Package(
       name: "_SwiftSyntaxTestSupport",
       dependencies: ["SwiftSyntax"]
     ),
-    .target(
+    .executableTarget(
       name: "lit-test-helper",
       dependencies: ["SwiftSyntax", "SwiftSyntaxParser"]
     ),
-    .target(
+    .executableTarget(
         name: "SwiftSyntaxBuilderGeneration",
         dependencies: ["SwiftSyntaxBuilder"],
         exclude: [
@@ -142,3 +142,7 @@ let package = Package(
     ),
   ]
 )
+
+if ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] == nil {
+    package.dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
+}

--- a/Sources/SwiftSyntax/Documentation.docc/Index.md
+++ b/Sources/SwiftSyntax/Documentation.docc/Index.md
@@ -1,0 +1,5 @@
+# ``SwiftSyntax``
+
+SwiftSyntax is a source accurate tree representation of Swift source code. It allows Swift tools to parse, inspect, generate, and transform Swift source code.
+
+Its API is designed for performance-critical applications. It uses value types almost exclusively and aims to avoid existential conversions where possible.

--- a/Sources/SwiftSyntaxBuilder/Documentation.docc/Index.md
+++ b/Sources/SwiftSyntaxBuilder/Documentation.docc/Index.md
@@ -1,0 +1,3 @@
+# ``SwiftSyntaxBuilder``
+
+SwiftSyntaxBuiler is a tool for generating Swift code in a convenient way using result builders.

--- a/Sources/SwiftSyntaxParser/Documentation.docc/Index.md
+++ b/Sources/SwiftSyntaxParser/Documentation.docc/Index.md
@@ -1,0 +1,3 @@
+# ``SwiftSyntaxParser``
+
+SwiftSyntaxParser allows parsing Swift source code into a SwiftSyntax tree.


### PR DESCRIPTION
I've been looking into moving the documentation gh-pages, so we can use DocC. 

An example can be found here: https://kimdv.github.io/swift-syntax/documentation/swiftsyntax/

I've also been considering to adding [Swift Package Index documentaion](https://blog.swiftpackageindex.com/posts/auto-generating-auto-hosting-and-auto-updating-docc-documentation/).

Let me hear what you think. 👍
