### PR TITLE
Automatically generate leading/trailing space trivia for tokens in `SyntaxFactory`

### DIFF
--- a/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -101,24 +101,38 @@ public enum SyntaxFactory {
 
 /// MARK: Token Creation APIs
 
+%{
+  def token_trivia(requires_space):
+    return '[.spaces(1)]' if requires_space else '[]'
+}%
+
 % for token in SYNTAX_TOKENS:
+%   leading_trivia = token_trivia(token.requires_leading_space)
+%   trailing_trivia = token_trivia(token.requires_trailing_space)
 %   if token.is_keyword:
-  public static func make${token.name}Keyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func make${token.name}Keyword(
+    leadingTrivia: Trivia = ${leading_trivia},
+    trailingTrivia: Trivia = ${trailing_trivia}
+  ) -> TokenSyntax {
     return makeToken(.${token.swift_kind()}, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
 %   elif token.text:
-  public static func make${token.name}Token(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func make${token.name}Token(
+    leadingTrivia: Trivia = ${leading_trivia},
+    trailingTrivia: Trivia = ${trailing_trivia}
+  ) -> TokenSyntax {
     return makeToken(.${token.swift_kind()}, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
 %   else:
-  public static func make${token.name}(_ text: String,
-    leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func make${token.name}(
+    _ text: String,
+    leadingTrivia: Trivia = ${leading_trivia},
+    trailingTrivia: Trivia = ${trailing_trivia}
+  ) -> TokenSyntax {
     return makeToken(.${token.swift_kind()}(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -4985,746 +4985,1009 @@ public enum SyntaxFactory {
 
 /// MARK: Token Creation APIs
 
-  public static func makeAssociatedtypeKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+
+  public static func makeAssociatedtypeKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.associatedtypeKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeClassKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeClassKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.classKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeDeinitKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeDeinitKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.deinitKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeEnumKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeEnumKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.enumKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeExtensionKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeExtensionKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.extensionKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeFuncKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeFuncKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.funcKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeImportKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeImportKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.importKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeInitKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeInitKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.initKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeInoutKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeInoutKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.inoutKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeLetKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeLetKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.letKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeOperatorKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeOperatorKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.operatorKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePrecedencegroupKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePrecedencegroupKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.precedencegroupKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeProtocolKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeProtocolKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.protocolKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeStructKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeStructKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.structKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeSubscriptKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeSubscriptKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.subscriptKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeTypealiasKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeTypealiasKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.typealiasKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeVarKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeVarKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.varKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeFileprivateKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeFileprivateKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.fileprivateKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeInternalKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeInternalKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.internalKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePrivateKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePrivateKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.privateKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePublicKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePublicKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.publicKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeStaticKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeStaticKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.staticKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeDeferKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeDeferKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.deferKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeIfKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeIfKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.ifKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeGuardKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeGuardKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.guardKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeDoKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeDoKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.doKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeRepeatKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeRepeatKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.repeatKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeElseKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeElseKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.elseKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeForKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeForKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.forKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeInKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeInKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.inKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeWhileKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeWhileKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.whileKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeReturnKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeReturnKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.returnKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeBreakKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeBreakKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.breakKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeContinueKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeContinueKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.continueKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeFallthroughKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeFallthroughKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.fallthroughKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeSwitchKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeSwitchKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.switchKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeCaseKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeCaseKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.caseKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeDefaultKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeDefaultKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.defaultKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeWhereKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeWhereKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.whereKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeCatchKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeCatchKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.catchKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeThrowKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeThrowKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.throwKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeAsKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeAsKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.asKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeAnyKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeAnyKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.anyKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeFalseKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeFalseKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.falseKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeIsKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeIsKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.isKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeNilKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeNilKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.nilKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeRethrowsKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeRethrowsKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.rethrowsKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeSuperKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeSuperKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.superKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeSelfKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeSelfKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.selfKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeCapitalSelfKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeCapitalSelfKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.capitalSelfKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeTrueKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeTrueKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.trueKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeTryKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeTryKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.tryKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeThrowsKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeThrowsKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.throwsKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func make__FILE__Keyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func make__FILE__Keyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.__file__Keyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func make__LINE__Keyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func make__LINE__Keyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.__line__Keyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func make__COLUMN__Keyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func make__COLUMN__Keyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.__column__Keyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func make__FUNCTION__Keyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func make__FUNCTION__Keyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.__function__Keyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func make__DSO_HANDLE__Keyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func make__DSO_HANDLE__Keyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.__dso_handle__Keyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeWildcardKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeWildcardKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.wildcardKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeLeftParenToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeLeftParenToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.leftParen, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeRightParenToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeRightParenToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.rightParen, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeLeftBraceToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeLeftBraceToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.leftBrace, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeRightBraceToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeRightBraceToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.rightBrace, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeLeftSquareBracketToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeLeftSquareBracketToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.leftSquareBracket, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeRightSquareBracketToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeRightSquareBracketToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.rightSquareBracket, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeLeftAngleToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeLeftAngleToken(
+    leadingTrivia: Trivia = [.spaces(1)],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.leftAngle, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeRightAngleToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeRightAngleToken(
+    leadingTrivia: Trivia = [.spaces(1)],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.rightAngle, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePeriodToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePeriodToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.period, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePrefixPeriodToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePrefixPeriodToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.prefixPeriod, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeCommaToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeCommaToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.comma, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeEllipsisToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeEllipsisToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.ellipsis, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeColonToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeColonToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.colon, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeSemicolonToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeSemicolonToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.semicolon, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeEqualToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeEqualToken(
+    leadingTrivia: Trivia = [.spaces(1)],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.equal, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeAtSignToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeAtSignToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.atSign, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.pound, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePrefixAmpersandToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePrefixAmpersandToken(
+    leadingTrivia: Trivia = [.spaces(1)],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.prefixAmpersand, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeArrowToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeArrowToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.arrow, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeBacktickToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeBacktickToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.backtick, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeBackslashToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeBackslashToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.backslash, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeExclamationMarkToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeExclamationMarkToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.exclamationMark, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePostfixQuestionMarkToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePostfixQuestionMarkToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.postfixQuestionMark, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeInfixQuestionMarkToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeInfixQuestionMarkToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.infixQuestionMark, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeStringQuoteToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeStringQuoteToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.stringQuote, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeSingleQuoteToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeSingleQuoteToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.singleQuote, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeMultilineStringQuoteToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeMultilineStringQuoteToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.multilineStringQuote, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundKeyPathKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundKeyPathKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundKeyPathKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundLineKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundLineKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundLineKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundSelectorKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundSelectorKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundSelectorKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundFileKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundFileKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundFileKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundFileIDKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundFileIDKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundFileIDKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundFilePathKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundFilePathKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundFilePathKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundColumnKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundColumnKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundColumnKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundFunctionKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundFunctionKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundFunctionKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundDsohandleKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundDsohandleKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundDsohandleKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundAssertKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundAssertKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundAssertKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundSourceLocationKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundSourceLocationKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundSourceLocationKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundWarningKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundWarningKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundWarningKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundErrorKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundErrorKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundErrorKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundIfKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundIfKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundIfKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundElseKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundElseKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundElseKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundElseifKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundElseifKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundElseifKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundEndifKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundEndifKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundEndifKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundAvailableKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundAvailableKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundAvailableKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundUnavailableKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundUnavailableKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundUnavailableKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundFileLiteralKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundFileLiteralKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundFileLiteralKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundImageLiteralKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundImageLiteralKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundImageLiteralKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePoundColorLiteralKeyword(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePoundColorLiteralKeyword(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.poundColorLiteralKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeIntegerLiteral(_ text: String,
-    leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeIntegerLiteral(
+    _ text: String,
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.integerLiteral(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeFloatingLiteral(_ text: String,
-    leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeFloatingLiteral(
+    _ text: String,
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.floatingLiteral(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeStringLiteral(_ text: String,
-    leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeStringLiteral(
+    _ text: String,
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.stringLiteral(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeRegexLiteral(_ text: String,
-    leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeRegexLiteral(
+    _ text: String,
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.regexLiteral(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeUnknown(_ text: String,
-    leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeUnknown(
+    _ text: String,
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.unknown(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeIdentifier(_ text: String,
-    leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeIdentifier(
+    _ text: String,
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.identifier(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeUnspacedBinaryOperator(_ text: String,
-    leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeUnspacedBinaryOperator(
+    _ text: String,
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.unspacedBinaryOperator(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeSpacedBinaryOperator(_ text: String,
-    leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeSpacedBinaryOperator(
+    _ text: String,
+    leadingTrivia: Trivia = [.spaces(1)],
+    trailingTrivia: Trivia = [.spaces(1)]
+  ) -> TokenSyntax {
     return makeToken(.spacedBinaryOperator(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePostfixOperator(_ text: String,
-    leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePostfixOperator(
+    _ text: String,
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.postfixOperator(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makePrefixOperator(_ text: String,
-    leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makePrefixOperator(
+    _ text: String,
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.prefixOperator(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeDollarIdentifier(_ text: String,
-    leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeDollarIdentifier(
+    _ text: String,
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.dollarIdentifier(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeContextualKeyword(_ text: String,
-    leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeContextualKeyword(
+    _ text: String,
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.contextualKeyword(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeRawStringDelimiter(_ text: String,
-    leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeRawStringDelimiter(
+    _ text: String,
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.rawStringDelimiter(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeStringSegment(_ text: String,
-    leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeStringSegment(
+    _ text: String,
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.stringSegment(text), presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeStringInterpolationAnchorToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeStringInterpolationAnchorToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.stringInterpolationAnchor, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
-  public static func makeYieldToken(leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = []) -> TokenSyntax {
+  public static func makeYieldToken(
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = []
+  ) -> TokenSyntax {
     return makeToken(.yield, presence: .present,
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)

--- a/Sources/SwiftSyntaxBuilder/DictionaryExprConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/DictionaryExprConvenienceInitializers.swift
@@ -23,7 +23,7 @@ extension DictionaryExpr {
     let elementList = contentBuilder().createDictionaryElementList()
     self.init(
       leftSquare: leftSquare,
-      content: elementList.elements.isEmpty ? SyntaxFactory.makeColonToken() : elementList,
+      content: elementList.elements.isEmpty ? SyntaxFactory.makeColonToken(trailingTrivia: []) : elementList,
       rightSquare: rightSquare
     )
   }

--- a/Sources/SwiftSyntaxBuilder/generated/Tokens.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/Tokens.swift
@@ -21,355 +21,296 @@ public extension TokenSyntax{
 /// The `associatedtype` keyword
 static var `associatedtype`: TokenSyntax{
     SyntaxFactory.makeAssociatedtypeKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `class` keyword
 static var `class`: TokenSyntax{
     SyntaxFactory.makeClassKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `deinit` keyword
 static var `deinit`: TokenSyntax{
     SyntaxFactory.makeDeinitKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `enum` keyword
 static var `enum`: TokenSyntax{
     SyntaxFactory.makeEnumKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `extension` keyword
 static var `extension`: TokenSyntax{
     SyntaxFactory.makeExtensionKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `func` keyword
 static var `func`: TokenSyntax{
     SyntaxFactory.makeFuncKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `import` keyword
 static var `import`: TokenSyntax{
     SyntaxFactory.makeImportKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `init` keyword
 static var `init`: TokenSyntax{
     SyntaxFactory.makeInitKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `inout` keyword
 static var `inout`: TokenSyntax{
     SyntaxFactory.makeInoutKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `let` keyword
 static var `let`: TokenSyntax{
     SyntaxFactory.makeLetKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `operator` keyword
 static var `operator`: TokenSyntax{
     SyntaxFactory.makeOperatorKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `precedencegroup` keyword
 static var `precedencegroup`: TokenSyntax{
     SyntaxFactory.makePrecedencegroupKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `protocol` keyword
 static var `protocol`: TokenSyntax{
     SyntaxFactory.makeProtocolKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `struct` keyword
 static var `struct`: TokenSyntax{
     SyntaxFactory.makeStructKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `subscript` keyword
 static var `subscript`: TokenSyntax{
     SyntaxFactory.makeSubscriptKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `typealias` keyword
 static var `typealias`: TokenSyntax{
     SyntaxFactory.makeTypealiasKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `var` keyword
 static var `var`: TokenSyntax{
     SyntaxFactory.makeVarKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `fileprivate` keyword
 static var `fileprivate`: TokenSyntax{
     SyntaxFactory.makeFileprivateKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `internal` keyword
 static var `internal`: TokenSyntax{
     SyntaxFactory.makeInternalKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `private` keyword
 static var `private`: TokenSyntax{
     SyntaxFactory.makePrivateKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `public` keyword
 static var `public`: TokenSyntax{
     SyntaxFactory.makePublicKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `static` keyword
 static var `static`: TokenSyntax{
     SyntaxFactory.makeStaticKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `defer` keyword
 static var `defer`: TokenSyntax{
     SyntaxFactory.makeDeferKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `if` keyword
 static var `if`: TokenSyntax{
     SyntaxFactory.makeIfKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `guard` keyword
 static var `guard`: TokenSyntax{
     SyntaxFactory.makeGuardKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `do` keyword
 static var `do`: TokenSyntax{
     SyntaxFactory.makeDoKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `repeat` keyword
 static var `repeat`: TokenSyntax{
     SyntaxFactory.makeRepeatKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `else` keyword
 static var `else`: TokenSyntax{
     SyntaxFactory.makeElseKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `for` keyword
 static var `for`: TokenSyntax{
     SyntaxFactory.makeForKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `in` keyword
 static var `in`: TokenSyntax{
     SyntaxFactory.makeInKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `while` keyword
 static var `while`: TokenSyntax{
     SyntaxFactory.makeWhileKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `return` keyword
 static var `return`: TokenSyntax{
     SyntaxFactory.makeReturnKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `break` keyword
 static var `break`: TokenSyntax{
     SyntaxFactory.makeBreakKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `continue` keyword
 static var `continue`: TokenSyntax{
     SyntaxFactory.makeContinueKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `fallthrough` keyword
 static var `fallthrough`: TokenSyntax{
     SyntaxFactory.makeFallthroughKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `switch` keyword
 static var `switch`: TokenSyntax{
     SyntaxFactory.makeSwitchKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `case` keyword
 static var `case`: TokenSyntax{
     SyntaxFactory.makeCaseKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `default` keyword
 static var `default`: TokenSyntax{
     SyntaxFactory.makeDefaultKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `where` keyword
 static var `where`: TokenSyntax{
     SyntaxFactory.makeWhereKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `catch` keyword
 static var `catch`: TokenSyntax{
     SyntaxFactory.makeCatchKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `throw` keyword
 static var `throw`: TokenSyntax{
     SyntaxFactory.makeThrowKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `as` keyword
 static var `as`: TokenSyntax{
     SyntaxFactory.makeAsKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `Any` keyword
 static var `any`: TokenSyntax{
     SyntaxFactory.makeAnyKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `false` keyword
 static var `false`: TokenSyntax{
     SyntaxFactory.makeFalseKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `is` keyword
 static var `is`: TokenSyntax{
     SyntaxFactory.makeIsKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `nil` keyword
 static var `nil`: TokenSyntax{
     SyntaxFactory.makeNilKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `rethrows` keyword
 static var `rethrows`: TokenSyntax{
     SyntaxFactory.makeRethrowsKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `super` keyword
 static var `super`: TokenSyntax{
     SyntaxFactory.makeSuperKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `self` keyword
 static var `self`: TokenSyntax{
     SyntaxFactory.makeSelfKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `Self` keyword
 static var `capitalSelf`: TokenSyntax{
     SyntaxFactory.makeCapitalSelfKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `true` keyword
 static var `true`: TokenSyntax{
     SyntaxFactory.makeTrueKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `try` keyword
 static var `try`: TokenSyntax{
     SyntaxFactory.makeTryKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `throws` keyword
 static var `throws`: TokenSyntax{
     SyntaxFactory.makeThrowsKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `__FILE__` keyword
 static var `__FILE__`: TokenSyntax{
     SyntaxFactory.make__FILE__Keyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `__LINE__` keyword
 static var `__LINE__`: TokenSyntax{
     SyntaxFactory.make__LINE__Keyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `__COLUMN__` keyword
 static var `__COLUMN__`: TokenSyntax{
     SyntaxFactory.make__COLUMN__Keyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `__FUNCTION__` keyword
 static var `__FUNCTION__`: TokenSyntax{
     SyntaxFactory.make__FUNCTION__Keyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `__DSO_HANDLE__` keyword
 static var `__DSO_HANDLE__`: TokenSyntax{
     SyntaxFactory.make__DSO_HANDLE__Keyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `_` keyword
 static var `wildcard`: TokenSyntax{
     SyntaxFactory.makeWildcardKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `(` token
@@ -405,15 +346,11 @@ static var `rightSquareBracket`: TokenSyntax{
 /// The `<` token
 static var `leftAngle`: TokenSyntax{
     SyntaxFactory.makeLeftAngleToken()
-    .withLeadingTrivia(.spaces(1))
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `>` token
 static var `rightAngle`: TokenSyntax{
     SyntaxFactory.makeRightAngleToken()
-    .withLeadingTrivia(.spaces(1))
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `.` token
@@ -429,7 +366,6 @@ static var `prefixPeriod`: TokenSyntax{
 /// The `,` token
 static var `comma`: TokenSyntax{
     SyntaxFactory.makeCommaToken()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `...` token
@@ -440,7 +376,6 @@ static var `ellipsis`: TokenSyntax{
 /// The `:` token
 static var `colon`: TokenSyntax{
     SyntaxFactory.makeColonToken()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `;` token
@@ -451,8 +386,6 @@ static var `semicolon`: TokenSyntax{
 /// The `=` token
 static var `equal`: TokenSyntax{
     SyntaxFactory.makeEqualToken()
-    .withLeadingTrivia(.spaces(1))
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `@` token
@@ -468,14 +401,11 @@ static var `pound`: TokenSyntax{
 /// The `&` token
 static var `prefixAmpersand`: TokenSyntax{
     SyntaxFactory.makePrefixAmpersandToken()
-    .withLeadingTrivia(.spaces(1))
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `->` token
 static var `arrow`: TokenSyntax{
     SyntaxFactory.makeArrowToken()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The ``` token
@@ -521,133 +451,111 @@ static var `multilineStringQuote`: TokenSyntax{
 /// The `#keyPath` keyword
 static var `poundKeyPath`: TokenSyntax{
     SyntaxFactory.makePoundKeyPathKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#line` keyword
 static var `poundLine`: TokenSyntax{
     SyntaxFactory.makePoundLineKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#selector` keyword
 static var `poundSelector`: TokenSyntax{
     SyntaxFactory.makePoundSelectorKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#file` keyword
 static var `poundFile`: TokenSyntax{
     SyntaxFactory.makePoundFileKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#fileID` keyword
 static var `poundFileID`: TokenSyntax{
     SyntaxFactory.makePoundFileIDKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#filePath` keyword
 static var `poundFilePath`: TokenSyntax{
     SyntaxFactory.makePoundFilePathKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#column` keyword
 static var `poundColumn`: TokenSyntax{
     SyntaxFactory.makePoundColumnKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#function` keyword
 static var `poundFunction`: TokenSyntax{
     SyntaxFactory.makePoundFunctionKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#dsohandle` keyword
 static var `poundDsohandle`: TokenSyntax{
     SyntaxFactory.makePoundDsohandleKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#assert` keyword
 static var `poundAssert`: TokenSyntax{
     SyntaxFactory.makePoundAssertKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#sourceLocation` keyword
 static var `poundSourceLocation`: TokenSyntax{
     SyntaxFactory.makePoundSourceLocationKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#warning` keyword
 static var `poundWarning`: TokenSyntax{
     SyntaxFactory.makePoundWarningKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#error` keyword
 static var `poundError`: TokenSyntax{
     SyntaxFactory.makePoundErrorKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#if` keyword
 static var `poundIf`: TokenSyntax{
     SyntaxFactory.makePoundIfKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#else` keyword
 static var `poundElse`: TokenSyntax{
     SyntaxFactory.makePoundElseKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#elseif` keyword
 static var `poundElseif`: TokenSyntax{
     SyntaxFactory.makePoundElseifKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#endif` keyword
 static var `poundEndif`: TokenSyntax{
     SyntaxFactory.makePoundEndifKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#available` keyword
 static var `poundAvailable`: TokenSyntax{
     SyntaxFactory.makePoundAvailableKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#unavailable` keyword
 static var `poundUnavailable`: TokenSyntax{
     SyntaxFactory.makePoundUnavailableKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#fileLiteral` keyword
 static var `poundFileLiteral`: TokenSyntax{
     SyntaxFactory.makePoundFileLiteralKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#imageLiteral` keyword
 static var `poundImageLiteral`: TokenSyntax{
     SyntaxFactory.makePoundImageLiteralKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   
 /// The `#colorLiteral` keyword
 static var `poundColorLiteral`: TokenSyntax{
     SyntaxFactory.makePoundColorLiteralKeyword()
-    .withTrailingTrivia(.spaces(1))
   }
   static func `integerLiteral`(_ text: String) -> TokenSyntax{
     SyntaxFactory.makeIntegerLiteral(text)
@@ -672,8 +580,6 @@ static var `poundColorLiteral`: TokenSyntax{
   }
   static func `spacedBinaryOperator`(_ text: String) -> TokenSyntax{
     SyntaxFactory.makeSpacedBinaryOperator(text)
-    .withLeadingTrivia(.spaces(1))
-    .withTrailingTrivia(.spaces(1))
   }
   static func `postfixOperator`(_ text: String) -> TokenSyntax{
     SyntaxFactory.makePostfixOperator(text)

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/TokensFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/TokensFile.swift
@@ -31,14 +31,6 @@ let tokensFile = SourceFile {
 
           let accessor = CodeBlock {
             FunctionCallExpr(MemberAccessExpr(base: "SyntaxFactory", name: "make\(token.name)Keyword"))
-
-            if token.requiresLeadingSpace {
-              createWithLeadingTriviaCall()
-            }
-
-            if token.requiresTrailingSpace {
-              createWithTrailingTriviaCall()
-            }
           }
 
           createTokenSyntaxPatternBinding("`\(token.name.withFirstCharacterLowercased)`", accessor: accessor)
@@ -51,14 +43,6 @@ let tokensFile = SourceFile {
           // We need to use `CodeBlock` here to ensure there is braces around.
           let accessor = CodeBlock {
             FunctionCallExpr(MemberAccessExpr(base: "SyntaxFactory", name: "make\(token.name)Token"))
-
-            if token.requiresLeadingSpace {
-              createWithLeadingTriviaCall()
-            }
-
-            if token.requiresTrailingSpace {
-              createWithTrailingTriviaCall()
-            }
           }
 
           createTokenSyntaxPatternBinding("`\(token.name.withFirstCharacterLowercased)`", accessor: accessor)
@@ -85,14 +69,6 @@ let tokensFile = SourceFile {
         ) {
           FunctionCallExpr(MemberAccessExpr(base: "SyntaxFactory", name: "make\(token.name)")) {
             TupleExprElement(expression: IdentifierExpr("text"))
-          }
-
-          if token.requiresLeadingSpace {
-            createWithLeadingTriviaCall()
-          }
-
-          if token.requiresTrailingSpace {
-            createWithTrailingTriviaCall()
           }
         }
       }

--- a/Sources/SwiftSyntaxBuilderGeneration/Tokens.swift.gyb
+++ b/Sources/SwiftSyntaxBuilderGeneration/Tokens.swift.gyb
@@ -28,8 +28,6 @@ public class Token {
   public let text: String?
   public let classification: String
   public let isKeyword: Bool
-  public let requiresLeadingSpace: Bool
-  public let requiresTrailingSpace: Bool
 
   public var swiftKind: String {
     let name = self.name
@@ -41,7 +39,7 @@ public class Token {
     }
   }
 
-  public init(name: String, kind: String, serializationCode: Int, unprefixedKind: String? = nil, text: String? = nil, classification: String = "None", isKeyword: Bool = false, requiresLeadingSpace: Bool = false, requiresTrailingSpace: Bool = false) {
+  public init(name: String, kind: String, serializationCode: Int, unprefixedKind: String? = nil, text: String? = nil, classification: String = "None", isKeyword: Bool = false) {
     self.name = name
     self.kind = kind
     self.serializationCode = serializationCode
@@ -53,15 +51,13 @@ public class Token {
     self.text = text
     self.classification = classification
     self.isKeyword = isKeyword
-    self.requiresLeadingSpace = requiresLeadingSpace
-    self.requiresTrailingSpace = requiresTrailingSpace
   }
 }
 
 /// Represents a keyword token.
 public class Keyword: Token {
   public init(name: String, serializationCode: Int, text: String, classification: String = "Keyword") {
-    super.init(name: name, kind: "kw_\(text)", serializationCode: serializationCode, unprefixedKind: text, text: text, classification: classification, isKeyword: true, requiresTrailingSpace: true)
+    super.init(name: name, kind: "kw_\(text)", serializationCode: serializationCode, unprefixedKind: text, text: text, classification: classification, isKeyword: true)
   }
 }
 
@@ -79,7 +75,7 @@ public class SilKeyword: Keyword { }
 
 public class PoundKeyword: Token {
   public init(name: String, kind: String, serializationCode: Int, text: String, classification: String = "Keyword") {
-    super.init(name: name, kind: "pound_\(kind)", serializationCode: serializationCode, unprefixedKind: kind, text: text, classification: classification, isKeyword: true, requiresTrailingSpace: true)
+    super.init(name: name, kind: "pound_\(kind)", serializationCode: serializationCode, unprefixedKind: kind, text: text, classification: classification, isKeyword: true)
   }
 }
 
@@ -127,8 +123,6 @@ let SYNTAX_TOKENS: [Token] = [
 %     if token.text:
 %       parameters += ["text: \"%s\"" % token.text]
 %     end
-%     parameters += ["requiresLeadingSpace: true"] if token.requires_leading_space else []
-%     parameters += ["requiresTrailingSpace: true"] if token.requires_trailing_space else []
 %   elif class_name == 'PoundObjectLiteral':
 %     parameters += ["kind: \"%s\"" % token.kind, "serializationCode: %s" % token.serialization_code, "text: \"%s\"" % token.text, "description: \"%s\"" % token.description, "protocol: \"%s\"" % token.protocol]
 %   else:

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/Tokens.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/Tokens.swift
@@ -21,8 +21,6 @@ public class Token {
   public let text: String?
   public let classification: String
   public let isKeyword: Bool
-  public let requiresLeadingSpace: Bool
-  public let requiresTrailingSpace: Bool
 
   public var swiftKind: String {
     let name = self.name
@@ -34,7 +32,7 @@ public class Token {
     }
   }
 
-  public init(name: String, kind: String, serializationCode: Int, unprefixedKind: String? = nil, text: String? = nil, classification: String = "None", isKeyword: Bool = false, requiresLeadingSpace: Bool = false, requiresTrailingSpace: Bool = false) {
+  public init(name: String, kind: String, serializationCode: Int, unprefixedKind: String? = nil, text: String? = nil, classification: String = "None", isKeyword: Bool = false) {
     self.name = name
     self.kind = kind
     self.serializationCode = serializationCode
@@ -46,15 +44,13 @@ public class Token {
     self.text = text
     self.classification = classification
     self.isKeyword = isKeyword
-    self.requiresLeadingSpace = requiresLeadingSpace
-    self.requiresTrailingSpace = requiresTrailingSpace
   }
 }
 
 /// Represents a keyword token.
 public class Keyword: Token {
   public init(name: String, serializationCode: Int, text: String, classification: String = "Keyword") {
-    super.init(name: name, kind: "kw_\(text)", serializationCode: serializationCode, unprefixedKind: text, text: text, classification: classification, isKeyword: true, requiresTrailingSpace: true)
+    super.init(name: name, kind: "kw_\(text)", serializationCode: serializationCode, unprefixedKind: text, text: text, classification: classification, isKeyword: true)
   }
 }
 
@@ -72,7 +68,7 @@ public class SilKeyword: Keyword { }
 
 public class PoundKeyword: Token {
   public init(name: String, kind: String, serializationCode: Int, text: String, classification: String = "Keyword") {
-    super.init(name: name, kind: "pound_\(kind)", serializationCode: serializationCode, unprefixedKind: kind, text: text, classification: classification, isKeyword: true, requiresTrailingSpace: true)
+    super.init(name: name, kind: "pound_\(kind)", serializationCode: serializationCode, unprefixedKind: kind, text: text, classification: classification, isKeyword: true)
   }
 }
 
@@ -173,19 +169,19 @@ let SYNTAX_TOKENS: [Token] = [
     Punctuator(name: "RightBrace", kind: "r_brace", serializationCode: 91, text: "}"),
     Punctuator(name: "LeftSquareBracket", kind: "l_square", serializationCode: 92, text: "["),
     Punctuator(name: "RightSquareBracket", kind: "r_square", serializationCode: 93, text: "]"),
-    Punctuator(name: "LeftAngle", kind: "l_angle", serializationCode: 94, text: "<", requiresLeadingSpace: true, requiresTrailingSpace: true),
-    Punctuator(name: "RightAngle", kind: "r_angle", serializationCode: 95, text: ">", requiresLeadingSpace: true, requiresTrailingSpace: true),
+    Punctuator(name: "LeftAngle", kind: "l_angle", serializationCode: 94, text: "<"),
+    Punctuator(name: "RightAngle", kind: "r_angle", serializationCode: 95, text: ">"),
     Punctuator(name: "Period", kind: "period", serializationCode: 85, text: "."),
     Punctuator(name: "PrefixPeriod", kind: "period_prefix", serializationCode: 87, text: "."),
-    Punctuator(name: "Comma", kind: "comma", serializationCode: 84, text: ",", requiresTrailingSpace: true),
+    Punctuator(name: "Comma", kind: "comma", serializationCode: 84, text: ","),
     Punctuator(name: "Ellipsis", kind: "ellipsis", serializationCode: 118, text: "..."),
-    Punctuator(name: "Colon", kind: "colon", serializationCode: 82, text: ":", requiresTrailingSpace: true),
+    Punctuator(name: "Colon", kind: "colon", serializationCode: 82, text: ":"),
     Punctuator(name: "Semicolon", kind: "semi", serializationCode: 83, text: ";"),
-    Punctuator(name: "Equal", kind: "equal", serializationCode: 86, text: "=", requiresLeadingSpace: true, requiresTrailingSpace: true),
+    Punctuator(name: "Equal", kind: "equal", serializationCode: 86, text: "="),
     Punctuator(name: "AtSign", kind: "at_sign", serializationCode: 80, text: "@"),
     Punctuator(name: "Pound", kind: "pound", serializationCode: 81, text: "#"),
-    Punctuator(name: "PrefixAmpersand", kind: "amp_prefix", serializationCode: 96, text: "&", requiresLeadingSpace: true, requiresTrailingSpace: true),
-    Punctuator(name: "Arrow", kind: "arrow", serializationCode: 78, text: "->", requiresTrailingSpace: true),
+    Punctuator(name: "PrefixAmpersand", kind: "amp_prefix", serializationCode: 96, text: "&"),
+    Punctuator(name: "Arrow", kind: "arrow", serializationCode: 78, text: "->"),
     Punctuator(name: "Backtick", kind: "backtick", serializationCode: 79, text: "`"),
     Punctuator(name: "Backslash", kind: "backslash", serializationCode: 100, text: "\\"),
     Punctuator(name: "ExclamationMark", kind: "exclaim_postfix", serializationCode: 99, text: "!"),
@@ -223,7 +219,7 @@ let SYNTAX_TOKENS: [Token] = [
     Misc(name: "Unknown", kind: "unknown", serializationCode: 115),
     Misc(name: "Identifier", kind: "identifier", serializationCode: 105),
     Misc(name: "UnspacedBinaryOperator", kind: "oper_binary_unspaced", serializationCode: 107),
-    Misc(name: "SpacedBinaryOperator", kind: "oper_binary_spaced", serializationCode: 108, requiresLeadingSpace: true, requiresTrailingSpace: true),
+    Misc(name: "SpacedBinaryOperator", kind: "oper_binary_spaced", serializationCode: 108),
     Misc(name: "PostfixOperator", kind: "oper_postfix", serializationCode: 110),
     Misc(name: "PrefixOperator", kind: "oper_prefix", serializationCode: 109),
     Misc(name: "DollarIdentifier", kind: "dollarident", serializationCode: 106),

--- a/Tests/SwiftSyntaxTest/SyntaxFactoryTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxFactoryTests.swift
@@ -61,15 +61,15 @@ public class SyntaxFactoryTests: XCTestCase {
 
   public func testTokenSyntax() {
     let tok = SyntaxFactory.makeStructKeyword()
-    XCTAssertEqual("\(tok)", "struct")
+    XCTAssertEqual("\(tok)", "struct ")
     XCTAssertTrue(tok.isPresent)
 
     let preSpacedTok = tok.withLeadingTrivia(.spaces(3))
-    XCTAssertEqual("\(preSpacedTok)", "   struct")
+    XCTAssertEqual("\(preSpacedTok)", "   struct ")
 
     var mutablePreSpacedTok = tok
     mutablePreSpacedTok.leadingTrivia = .spaces(4)
-    XCTAssertEqual("\(mutablePreSpacedTok)", "    struct")
+    XCTAssertEqual("\(mutablePreSpacedTok)", "    struct ")
 
     let postSpacedTok = tok.withTrailingTrivia(.spaces(6))
     XCTAssertEqual("\(postSpacedTok)", "struct      ")

--- a/Tests/SwiftSyntaxTest/SyntaxTreeModifierTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTreeModifierTests.swift
@@ -4,7 +4,6 @@ import SwiftSyntax
 fileprivate func cannedVarDecl() -> VariableDeclSyntax {
   let identifierPattern = SyntaxFactory.makeIdentifierPattern(
     identifier: SyntaxFactory.makeIdentifier("a")
-                .withLeadingTrivia(.spaces(1))
   )
   let Pattern = SyntaxFactory.makePatternBinding(
     pattern: PatternSyntax(identifierPattern),
@@ -23,7 +22,7 @@ public class SyntaxTreeModifierTests: XCTestCase {
   public func testAccessorAsModifier() {
     var VD = cannedVarDecl()
     XCTAssertEqual("\(VD)", "let a: Int")
-    VD.letOrVarKeyword = SyntaxFactory.makeVarKeyword().withTrailingTrivia(.spaces(0))
+    VD.letOrVarKeyword = SyntaxFactory.makeVarKeyword()
     XCTAssertEqual("\(VD)", "var a: Int")
   }
 }


### PR DESCRIPTION
In an effort to clean up the `TokensFile` template in `SwiftSyntaxBuilderGeneration`, this branch moves the generation of leading/trailing space trivia around tokens into `SyntaxFactory`. In other words, calls like

```
SyntaxFactory.makeSwitchKeyword()
```

will now automatically generate a trailing space (although this is still overridable by explicitly passing `trailingTrivia: []` as a parameter).

cc @ahoppen 