### PR TITLE
Fix indent when there is a leading new line

### DIFF
--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -77,10 +77,24 @@ extension TriviaPiece: CustomDebugStringConvertible {
   }
 }
 
+extension TriviaPiece {
+  /// Returns true if the trivia is `.newlines`, `.carriageReturns` or `.carriageReturnLineFeeds`
+  public var isNewline: Bool {
+    switch self {
+    case .newlines,
+         .carriageReturns,
+         .carriageReturnLineFeeds:
+      return true
+    default:
+      return false
+    }
+  }
+}
+
 /// A collection of leading or trailing trivia. This is the main data structure
 /// for thinking about trivia.
 public struct Trivia {
-  let pieces: [TriviaPiece]
+  public let pieces: [TriviaPiece]
 
   /// Creates Trivia with the provided underlying pieces.
   public init(pieces: [TriviaPiece]) {

--- a/Sources/SwiftSyntax/gyb_generated/Trivia.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Trivia.swift
@@ -123,10 +123,24 @@ extension TriviaPiece: CustomDebugStringConvertible {
   }
 }
 
+extension TriviaPiece {
+  /// Returns true if the trivia is `.newlines`, `.carriageReturns` or `.carriageReturnLineFeeds`
+  public var isNewline: Bool {
+    switch self {
+    case .newlines,
+         .carriageReturns,
+         .carriageReturnLineFeeds:
+      return true
+    default:
+      return false
+    }
+  }
+}
+
 /// A collection of leading or trailing trivia. This is the main data structure
 /// for thinking about trivia.
 public struct Trivia {
-  let pieces: [TriviaPiece]
+  public let pieces: [TriviaPiece]
 
   /// Creates Trivia with the provided underlying pieces.
   public init(pieces: [TriviaPiece]) {

--- a/Sources/SwiftSyntaxBuilder/BuildableCollectionNodes.swift.gyb
+++ b/Sources/SwiftSyntaxBuilder/BuildableCollectionNodes.swift.gyb
@@ -65,7 +65,7 @@ public struct ${type.buildable()}: ExpressibleByArrayLiteral, SyntaxBuildable, $
     })
 %   end
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }

--- a/Sources/SwiftSyntaxBuilder/BuildableNodes.swift.gyb
+++ b/Sources/SwiftSyntaxBuilder/BuildableNodes.swift.gyb
@@ -120,7 +120,7 @@ public struct ${type.buildable()}${conformance_clause(conformances)} {
       ${',\n      '.join(['%s: %s' % (child.name(), child.generate_expr_build_syntax_node(child.name(), 'format')) for child in children])}
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `${base_type.buildable()}`.

--- a/Sources/SwiftSyntaxBuilder/Trivia+Extension.swift
+++ b/Sources/SwiftSyntaxBuilder/Trivia+Extension.swift
@@ -1,0 +1,52 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+extension Trivia {
+  /// Re-indents trivia that form a block comment to have consistent indentation.
+  ///
+  /// If the trivia start with a newline (i.e. the first non-whitespace trivia is on a fresh line) and that newline starts with spacing, the same spacing is applied to all the following lines. For example.
+  /// ```
+  ///   // first line
+  /// // second line
+  /// // third line
+  /// ```
+  /// picks up the indentation from the first line and transforms the trivia to
+  /// ```
+  ///   // first line
+  ///   // second line
+  ///   // third line
+  /// ```
+  func addingSpacingAfterNewlinesIfNeeded() -> Trivia {
+    var updatedTriviaPieces = self.pieces
+    if updatedTriviaPieces.count > 2,
+       updatedTriviaPieces[0].isNewline,
+       let indentation = self.makeIndentation(trivia: updatedTriviaPieces[1]) {
+      
+      for i in (2..<updatedTriviaPieces.count).reversed() where updatedTriviaPieces[i].isNewline {
+        updatedTriviaPieces.insert(indentation, at: i + 1)
+      }
+    }
+    
+    return Trivia(pieces: updatedTriviaPieces)
+  }
+  
+  private func makeIndentation(trivia: TriviaPiece) -> TriviaPiece? {
+    switch trivia {
+    case .spaces,
+         .tabs: return trivia
+    default:
+      return nil
+    }
+  }
+}

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableBaseProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableBaseProtocols.swift
@@ -16,202 +16,202 @@
 import SwiftSyntax
 public protocol DeclListBuildable: SyntaxListBuildable {
   /// Builds list of `DeclSyntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-func buildDeclList(format: Format, leadingTrivia: Trivia?) -> [DeclSyntax]
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  func buildDeclList(format: Format, leadingTrivia: Trivia?) -> [DeclSyntax]
 }
 public protocol DeclBuildable: ExpressibleAsDeclBuildable, DeclListBuildable, SyntaxBuildable {
   /// Builds list of `DeclSyntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-func buildDecl(format: Format, leadingTrivia: Trivia?) -> DeclSyntax
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  func buildDecl(format: Format, leadingTrivia: Trivia?) -> DeclSyntax
 }
 public extension DeclBuildable {
   /// Satisfies conformance to `ExpressibleAsDeclBuildable`.
-func createDeclBuildable() -> DeclBuildable {
+  func createDeclBuildable() -> DeclBuildable {
     return self
   }
   /// Builds list of `DeclSyntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-///
-/// Satisfies conformance to `DeclListBuildable`
-func buildDeclList(format: Format, leadingTrivia: Trivia? = nil) -> [DeclSyntax] {
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  ///
+  /// Satisfies conformance to `DeclListBuildable`
+  func buildDeclList(format: Format, leadingTrivia: Trivia? = nil) -> [DeclSyntax] {
     return [buildDecl(format: format, leadingTrivia: leadingTrivia)]
   }
   /// Builds a `DeclSyntax`.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-/// - Returns: A new `Syntax` with the built `DeclSyntax`.
-///
-/// Satisfies conformance to `SyntaxBuildable`.
-func buildSyntax(format: Format, leadingTrivia: Trivia? = nil) -> Syntax {
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  /// - Returns: A new `Syntax` with the built `DeclSyntax`.
+  ///
+  /// Satisfies conformance to `SyntaxBuildable`.
+  func buildSyntax(format: Format, leadingTrivia: Trivia? = nil) -> Syntax {
     return Syntax(buildDecl(format: format, leadingTrivia: leadingTrivia))
   }
 }
 public protocol ExprListBuildable: SyntaxListBuildable {
   /// Builds list of `ExprSyntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-func buildExprList(format: Format, leadingTrivia: Trivia?) -> [ExprSyntax]
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  func buildExprList(format: Format, leadingTrivia: Trivia?) -> [ExprSyntax]
 }
 public protocol ExprBuildable: ExpressibleAsExprBuildable, ExprListBuildable, SyntaxBuildable {
   /// Builds list of `ExprSyntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-func buildExpr(format: Format, leadingTrivia: Trivia?) -> ExprSyntax
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  func buildExpr(format: Format, leadingTrivia: Trivia?) -> ExprSyntax
 }
 public extension ExprBuildable {
   /// Satisfies conformance to `ExpressibleAsExprBuildable`.
-func createExprBuildable() -> ExprBuildable {
+  func createExprBuildable() -> ExprBuildable {
     return self
   }
   /// Builds list of `ExprSyntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-///
-/// Satisfies conformance to `ExprListBuildable`
-func buildExprList(format: Format, leadingTrivia: Trivia? = nil) -> [ExprSyntax] {
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  ///
+  /// Satisfies conformance to `ExprListBuildable`
+  func buildExprList(format: Format, leadingTrivia: Trivia? = nil) -> [ExprSyntax] {
     return [buildExpr(format: format, leadingTrivia: leadingTrivia)]
   }
   /// Builds a `ExprSyntax`.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-/// - Returns: A new `Syntax` with the built `ExprSyntax`.
-///
-/// Satisfies conformance to `SyntaxBuildable`.
-func buildSyntax(format: Format, leadingTrivia: Trivia? = nil) -> Syntax {
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  /// - Returns: A new `Syntax` with the built `ExprSyntax`.
+  ///
+  /// Satisfies conformance to `SyntaxBuildable`.
+  func buildSyntax(format: Format, leadingTrivia: Trivia? = nil) -> Syntax {
     return Syntax(buildExpr(format: format, leadingTrivia: leadingTrivia))
   }
 }
 public protocol PatternListBuildable: SyntaxListBuildable {
   /// Builds list of `PatternSyntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-func buildPatternList(format: Format, leadingTrivia: Trivia?) -> [PatternSyntax]
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  func buildPatternList(format: Format, leadingTrivia: Trivia?) -> [PatternSyntax]
 }
 public protocol PatternBuildable: ExpressibleAsPatternBuildable, PatternListBuildable, SyntaxBuildable {
   /// Builds list of `PatternSyntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-func buildPattern(format: Format, leadingTrivia: Trivia?) -> PatternSyntax
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  func buildPattern(format: Format, leadingTrivia: Trivia?) -> PatternSyntax
 }
 public extension PatternBuildable {
   /// Satisfies conformance to `ExpressibleAsPatternBuildable`.
-func createPatternBuildable() -> PatternBuildable {
+  func createPatternBuildable() -> PatternBuildable {
     return self
   }
   /// Builds list of `PatternSyntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-///
-/// Satisfies conformance to `PatternListBuildable`
-func buildPatternList(format: Format, leadingTrivia: Trivia? = nil) -> [PatternSyntax] {
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  ///
+  /// Satisfies conformance to `PatternListBuildable`
+  func buildPatternList(format: Format, leadingTrivia: Trivia? = nil) -> [PatternSyntax] {
     return [buildPattern(format: format, leadingTrivia: leadingTrivia)]
   }
   /// Builds a `PatternSyntax`.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-/// - Returns: A new `Syntax` with the built `PatternSyntax`.
-///
-/// Satisfies conformance to `SyntaxBuildable`.
-func buildSyntax(format: Format, leadingTrivia: Trivia? = nil) -> Syntax {
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  /// - Returns: A new `Syntax` with the built `PatternSyntax`.
+  ///
+  /// Satisfies conformance to `SyntaxBuildable`.
+  func buildSyntax(format: Format, leadingTrivia: Trivia? = nil) -> Syntax {
     return Syntax(buildPattern(format: format, leadingTrivia: leadingTrivia))
   }
 }
 public protocol StmtListBuildable: SyntaxListBuildable {
   /// Builds list of `StmtSyntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-func buildStmtList(format: Format, leadingTrivia: Trivia?) -> [StmtSyntax]
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  func buildStmtList(format: Format, leadingTrivia: Trivia?) -> [StmtSyntax]
 }
 public protocol StmtBuildable: ExpressibleAsStmtBuildable, StmtListBuildable, SyntaxBuildable {
   /// Builds list of `StmtSyntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-func buildStmt(format: Format, leadingTrivia: Trivia?) -> StmtSyntax
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  func buildStmt(format: Format, leadingTrivia: Trivia?) -> StmtSyntax
 }
 public extension StmtBuildable {
   /// Satisfies conformance to `ExpressibleAsStmtBuildable`.
-func createStmtBuildable() -> StmtBuildable {
+  func createStmtBuildable() -> StmtBuildable {
     return self
   }
   /// Builds list of `StmtSyntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-///
-/// Satisfies conformance to `StmtListBuildable`
-func buildStmtList(format: Format, leadingTrivia: Trivia? = nil) -> [StmtSyntax] {
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  ///
+  /// Satisfies conformance to `StmtListBuildable`
+  func buildStmtList(format: Format, leadingTrivia: Trivia? = nil) -> [StmtSyntax] {
     return [buildStmt(format: format, leadingTrivia: leadingTrivia)]
   }
   /// Builds a `StmtSyntax`.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-/// - Returns: A new `Syntax` with the built `StmtSyntax`.
-///
-/// Satisfies conformance to `SyntaxBuildable`.
-func buildSyntax(format: Format, leadingTrivia: Trivia? = nil) -> Syntax {
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  /// - Returns: A new `Syntax` with the built `StmtSyntax`.
+  ///
+  /// Satisfies conformance to `SyntaxBuildable`.
+  func buildSyntax(format: Format, leadingTrivia: Trivia? = nil) -> Syntax {
     return Syntax(buildStmt(format: format, leadingTrivia: leadingTrivia))
   }
 }
 public protocol SyntaxListBuildable {
   /// Builds list of `Syntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-func buildSyntaxList(format: Format, leadingTrivia: Trivia?) -> [Syntax]
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  func buildSyntaxList(format: Format, leadingTrivia: Trivia?) -> [Syntax]
 }
 public protocol SyntaxBuildable: ExpressibleAsSyntaxBuildable, SyntaxListBuildable {
   /// Builds list of `Syntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-func buildSyntax(format: Format, leadingTrivia: Trivia?) -> Syntax
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  func buildSyntax(format: Format, leadingTrivia: Trivia?) -> Syntax
 }
 public extension SyntaxBuildable {
   /// Satisfies conformance to `ExpressibleAsSyntaxBuildable`.
-func createSyntaxBuildable() -> SyntaxBuildable {
+  func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
   /// Builds list of `Syntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-///
-/// Satisfies conformance to `SyntaxListBuildable`
-func buildSyntaxList(format: Format, leadingTrivia: Trivia? = nil) -> [Syntax] {
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  ///
+  /// Satisfies conformance to `SyntaxListBuildable`
+  func buildSyntaxList(format: Format, leadingTrivia: Trivia? = nil) -> [Syntax] {
     return [buildSyntax(format: format, leadingTrivia: leadingTrivia)]
   }
 }
 public protocol TypeListBuildable: SyntaxListBuildable {
   /// Builds list of `TypeSyntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-func buildTypeList(format: Format, leadingTrivia: Trivia?) -> [TypeSyntax]
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  func buildTypeList(format: Format, leadingTrivia: Trivia?) -> [TypeSyntax]
 }
 public protocol TypeBuildable: ExpressibleAsTypeBuildable, TypeListBuildable, SyntaxBuildable {
   /// Builds list of `TypeSyntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-func buildType(format: Format, leadingTrivia: Trivia?) -> TypeSyntax
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  func buildType(format: Format, leadingTrivia: Trivia?) -> TypeSyntax
 }
 public extension TypeBuildable {
   /// Satisfies conformance to `ExpressibleAsTypeBuildable`.
-func createTypeBuildable() -> TypeBuildable {
+  func createTypeBuildable() -> TypeBuildable {
     return self
   }
   /// Builds list of `TypeSyntax`s.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-///
-/// Satisfies conformance to `TypeListBuildable`
-func buildTypeList(format: Format, leadingTrivia: Trivia? = nil) -> [TypeSyntax] {
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  ///
+  /// Satisfies conformance to `TypeListBuildable`
+  func buildTypeList(format: Format, leadingTrivia: Trivia? = nil) -> [TypeSyntax] {
     return [buildType(format: format, leadingTrivia: leadingTrivia)]
   }
   /// Builds a `TypeSyntax`.
-/// - Parameter format: The `Format` to use.
-/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
-/// - Returns: A new `Syntax` with the built `TypeSyntax`.
-///
-/// Satisfies conformance to `SyntaxBuildable`.
-func buildSyntax(format: Format, leadingTrivia: Trivia? = nil) -> Syntax {
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
+  /// - Returns: A new `Syntax` with the built `TypeSyntax`.
+  ///
+  /// Satisfies conformance to `SyntaxBuildable`.
+  func buildSyntax(format: Format, leadingTrivia: Trivia? = nil) -> Syntax {
     return Syntax(buildType(format: format, leadingTrivia: leadingTrivia))
   }
 }

--- a/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
@@ -19,11 +19,11 @@ public protocol ExpressibleAsDeclBuildable: ExpressibleAsCodeBlockItem, Expressi
 }
 public extension ExpressibleAsDeclBuildable {
   /// Conformance to ExpressibleAsCodeBlockItem
-func createCodeBlockItem() -> CodeBlockItem {
+  func createCodeBlockItem() -> CodeBlockItem {
     return CodeBlockItem(item: self)
   }
   /// Conformance to ExpressibleAsMemberDeclListItem
-func createMemberDeclListItem() -> MemberDeclListItem {
+  func createMemberDeclListItem() -> MemberDeclListItem {
     return MemberDeclListItem(decl: self)
   }
 }
@@ -32,15 +32,15 @@ public protocol ExpressibleAsExprBuildable: ExpressibleAsExprList, ExpressibleAs
 }
 public extension ExpressibleAsExprBuildable {
   /// Conformance to `ExpressibleAsExprList`
-func createExprList() -> ExprList {
+  func createExprList() -> ExprList {
     return ExprList([self])
   }
   /// Conformance to ExpressibleAsCodeBlockItem
-func createCodeBlockItem() -> CodeBlockItem {
+  func createCodeBlockItem() -> CodeBlockItem {
     return CodeBlockItem(item: self)
   }
   /// Conformance to ExpressibleAsInitializerClause
-func createInitializerClause() -> InitializerClause {
+  func createInitializerClause() -> InitializerClause {
     return InitializerClause(value: self)
   }
 }
@@ -52,7 +52,7 @@ public protocol ExpressibleAsStmtBuildable: ExpressibleAsCodeBlockItem {
 }
 public extension ExpressibleAsStmtBuildable {
   /// Conformance to ExpressibleAsCodeBlockItem
-func createCodeBlockItem() -> CodeBlockItem {
+  func createCodeBlockItem() -> CodeBlockItem {
     return CodeBlockItem(item: self)
   }
 }
@@ -61,23 +61,23 @@ public protocol ExpressibleAsSyntaxBuildable: ExpressibleAsStringLiteralSegments
 }
 public extension ExpressibleAsSyntaxBuildable {
   /// Conformance to `ExpressibleAsStringLiteralSegments`
-func createStringLiteralSegments() -> StringLiteralSegments {
+  func createStringLiteralSegments() -> StringLiteralSegments {
     return StringLiteralSegments([self])
   }
   /// Conformance to `ExpressibleAsPrecedenceGroupAttributeList`
-func createPrecedenceGroupAttributeList() -> PrecedenceGroupAttributeList {
+  func createPrecedenceGroupAttributeList() -> PrecedenceGroupAttributeList {
     return PrecedenceGroupAttributeList([self])
   }
   /// Conformance to `ExpressibleAsAttributeList`
-func createAttributeList() -> AttributeList {
+  func createAttributeList() -> AttributeList {
     return AttributeList([self])
   }
   /// Conformance to `ExpressibleAsSpecializeAttributeSpecList`
-func createSpecializeAttributeSpecList() -> SpecializeAttributeSpecList {
+  func createSpecializeAttributeSpecList() -> SpecializeAttributeSpecList {
     return SpecializeAttributeSpecList([self])
   }
   /// Conformance to `ExpressibleAsSwitchCaseList`
-func createSwitchCaseList() -> SwitchCaseList {
+  func createSwitchCaseList() -> SwitchCaseList {
     return SwitchCaseList([self])
   }
 }
@@ -86,11 +86,11 @@ public protocol ExpressibleAsTypeBuildable: ExpressibleAsReturnClause, Expressib
 }
 public extension ExpressibleAsTypeBuildable {
   /// Conformance to ExpressibleAsReturnClause
-func createReturnClause() -> ReturnClause {
+  func createReturnClause() -> ReturnClause {
     return ReturnClause(returnType: self)
   }
   /// Conformance to ExpressibleAsTypeInitializerClause
-func createTypeInitializerClause() -> TypeInitializerClause {
+  func createTypeInitializerClause() -> TypeInitializerClause {
     return TypeInitializerClause(value: self)
   }
 }
@@ -99,7 +99,7 @@ public protocol ExpressibleAsCodeBlockItem: ExpressibleAsCodeBlockItemList {
 }
 public extension ExpressibleAsCodeBlockItem {
   /// Conformance to `ExpressibleAsCodeBlockItemList`
-func createCodeBlockItemList() -> CodeBlockItemList {
+  func createCodeBlockItemList() -> CodeBlockItemList {
     return CodeBlockItemList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -111,7 +111,7 @@ public protocol ExpressibleAsCodeBlockItemList: ExpressibleAsCodeBlock {
 }
 public extension ExpressibleAsCodeBlockItemList {
   /// Conformance to ExpressibleAsCodeBlock
-func createCodeBlock() -> CodeBlock {
+  func createCodeBlock() -> CodeBlock {
     return CodeBlock(statements: self)
   }
 }
@@ -172,7 +172,7 @@ public protocol ExpressibleAsDeclNameArgument: ExpressibleAsDeclNameArgumentList
 }
 public extension ExpressibleAsDeclNameArgument {
   /// Conformance to `ExpressibleAsDeclNameArgumentList`
-func createDeclNameArgumentList() -> DeclNameArgumentList {
+  func createDeclNameArgumentList() -> DeclNameArgumentList {
     return DeclNameArgumentList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -235,11 +235,11 @@ public protocol ExpressibleAsSequenceExpr: ExpressibleAsTupleExprElement, Expres
 }
 public extension ExpressibleAsSequenceExpr {
   /// Conformance to ExpressibleAsCodeBlockItem
-func createCodeBlockItem() -> CodeBlockItem {
+  func createCodeBlockItem() -> CodeBlockItem {
     return CodeBlockItem(item: self)
   }
   /// Conformance to ExpressibleAsTupleExprElement
-func createTupleExprElement() -> TupleExprElement {
+  func createTupleExprElement() -> TupleExprElement {
     return TupleExprElement(expression: self)
   }
   func createExprBuildable() -> ExprBuildable {
@@ -251,7 +251,7 @@ public protocol ExpressibleAsExprList: ExpressibleAsConditionElement {
 }
 public extension ExpressibleAsExprList {
   /// Conformance to ExpressibleAsConditionElement
-func createConditionElement() -> ConditionElement {
+  func createConditionElement() -> ConditionElement {
     return ConditionElement(condition: self)
   }
 }
@@ -372,7 +372,7 @@ public protocol ExpressibleAsTupleExprElement: ExpressibleAsTupleExprElementList
 }
 public extension ExpressibleAsTupleExprElement {
   /// Conformance to `ExpressibleAsTupleExprElementList`
-func createTupleExprElementList() -> TupleExprElementList {
+  func createTupleExprElementList() -> TupleExprElementList {
     return TupleExprElementList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -384,7 +384,7 @@ public protocol ExpressibleAsArrayElement: ExpressibleAsArrayElementList, Expres
 }
 public extension ExpressibleAsArrayElement {
   /// Conformance to `ExpressibleAsArrayElementList`
-func createArrayElementList() -> ArrayElementList {
+  func createArrayElementList() -> ArrayElementList {
     return ArrayElementList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -396,7 +396,7 @@ public protocol ExpressibleAsDictionaryElement: ExpressibleAsDictionaryElementLi
 }
 public extension ExpressibleAsDictionaryElement {
   /// Conformance to `ExpressibleAsDictionaryElementList`
-func createDictionaryElementList() -> DictionaryElementList {
+  func createDictionaryElementList() -> DictionaryElementList {
     return DictionaryElementList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -464,7 +464,7 @@ public protocol ExpressibleAsClosureCaptureItem: ExpressibleAsClosureCaptureItem
 }
 public extension ExpressibleAsClosureCaptureItem {
   /// Conformance to `ExpressibleAsClosureCaptureItemList`
-func createClosureCaptureItemList() -> ClosureCaptureItemList {
+  func createClosureCaptureItemList() -> ClosureCaptureItemList {
     return ClosureCaptureItemList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -487,7 +487,7 @@ public protocol ExpressibleAsClosureParam: ExpressibleAsClosureParamList, Expres
 }
 public extension ExpressibleAsClosureParam {
   /// Conformance to `ExpressibleAsClosureParamList`
-func createClosureParamList() -> ClosureParamList {
+  func createClosureParamList() -> ClosureParamList {
     return ClosureParamList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -526,7 +526,7 @@ public protocol ExpressibleAsMultipleTrailingClosureElement: ExpressibleAsMultip
 }
 public extension ExpressibleAsMultipleTrailingClosureElement {
   /// Conformance to `ExpressibleAsMultipleTrailingClosureElementList`
-func createMultipleTrailingClosureElementList() -> MultipleTrailingClosureElementList {
+  func createMultipleTrailingClosureElementList() -> MultipleTrailingClosureElementList {
     return MultipleTrailingClosureElementList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -637,7 +637,7 @@ public protocol ExpressibleAsObjcNamePiece: ExpressibleAsObjcName, ExpressibleAs
 }
 public extension ExpressibleAsObjcNamePiece {
   /// Conformance to `ExpressibleAsObjcName`
-func createObjcName() -> ObjcName {
+  func createObjcName() -> ObjcName {
     return ObjcName([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -743,7 +743,7 @@ public protocol ExpressibleAsIfConfigClause: ExpressibleAsIfConfigClauseList, Ex
 }
 public extension ExpressibleAsIfConfigClause {
   /// Conformance to `ExpressibleAsIfConfigClauseList`
-func createIfConfigClauseList() -> IfConfigClauseList {
+  func createIfConfigClauseList() -> IfConfigClauseList {
     return IfConfigClauseList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -806,7 +806,7 @@ public protocol ExpressibleAsDeclModifier: ExpressibleAsModifierList, Expressibl
 }
 public extension ExpressibleAsDeclModifier {
   /// Conformance to `ExpressibleAsModifierList`
-func createModifierList() -> ModifierList {
+  func createModifierList() -> ModifierList {
     return ModifierList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -818,7 +818,7 @@ public protocol ExpressibleAsInheritedType: ExpressibleAsInheritedTypeList, Expr
 }
 public extension ExpressibleAsInheritedType {
   /// Conformance to `ExpressibleAsInheritedTypeList`
-func createInheritedTypeList() -> InheritedTypeList {
+  func createInheritedTypeList() -> InheritedTypeList {
     return InheritedTypeList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -889,7 +889,7 @@ public protocol ExpressibleAsMemberDeclList: ExpressibleAsMemberDeclBlock {
 }
 public extension ExpressibleAsMemberDeclList {
   /// Conformance to ExpressibleAsMemberDeclBlock
-func createMemberDeclBlock() -> MemberDeclBlock {
+  func createMemberDeclBlock() -> MemberDeclBlock {
     return MemberDeclBlock(members: self)
   }
 }
@@ -898,7 +898,7 @@ public protocol ExpressibleAsMemberDeclListItem: ExpressibleAsMemberDeclList {
 }
 public extension ExpressibleAsMemberDeclListItem {
   /// Conformance to `ExpressibleAsMemberDeclList`
-func createMemberDeclList() -> MemberDeclList {
+  func createMemberDeclList() -> MemberDeclList {
     return MemberDeclList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -926,7 +926,7 @@ public protocol ExpressibleAsFunctionParameter: ExpressibleAsFunctionParameterLi
 }
 public extension ExpressibleAsFunctionParameter {
   /// Conformance to `ExpressibleAsFunctionParameterList`
-func createFunctionParameterList() -> FunctionParameterList {
+  func createFunctionParameterList() -> FunctionParameterList {
     return FunctionParameterList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -981,7 +981,7 @@ public protocol ExpressibleAsAccessPathComponent: ExpressibleAsAccessPath, Expre
 }
 public extension ExpressibleAsAccessPathComponent {
   /// Conformance to `ExpressibleAsAccessPath`
-func createAccessPath() -> AccessPath {
+  func createAccessPath() -> AccessPath {
     return AccessPath([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1012,7 +1012,7 @@ public protocol ExpressibleAsAccessorDecl: ExpressibleAsAccessorList, Expressibl
 }
 public extension ExpressibleAsAccessorDecl {
   /// Conformance to `ExpressibleAsAccessorList`
-func createAccessorList() -> AccessorList {
+  func createAccessorList() -> AccessorList {
     return AccessorList([self])
   }
   func createDeclBuildable() -> DeclBuildable {
@@ -1024,7 +1024,7 @@ public protocol ExpressibleAsAccessorList: ExpressibleAsAccessorBlock {
 }
 public extension ExpressibleAsAccessorList {
   /// Conformance to ExpressibleAsAccessorBlock
-func createAccessorBlock() -> AccessorBlock {
+  func createAccessorBlock() -> AccessorBlock {
     return AccessorBlock(accessors: self)
   }
 }
@@ -1041,7 +1041,7 @@ public protocol ExpressibleAsPatternBinding: ExpressibleAsPatternBindingList, Ex
 }
 public extension ExpressibleAsPatternBinding {
   /// Conformance to `ExpressibleAsPatternBindingList`
-func createPatternBindingList() -> PatternBindingList {
+  func createPatternBindingList() -> PatternBindingList {
     return PatternBindingList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1064,7 +1064,7 @@ public protocol ExpressibleAsEnumCaseElement: ExpressibleAsEnumCaseElementList, 
 }
 public extension ExpressibleAsEnumCaseElement {
   /// Conformance to `ExpressibleAsEnumCaseElementList`
-func createEnumCaseElementList() -> EnumCaseElementList {
+  func createEnumCaseElementList() -> EnumCaseElementList {
     return EnumCaseElementList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1136,7 +1136,7 @@ public protocol ExpressibleAsPrecedenceGroupNameElement: ExpressibleAsPrecedence
 }
 public extension ExpressibleAsPrecedenceGroupNameElement {
   /// Conformance to `ExpressibleAsPrecedenceGroupNameList`
-func createPrecedenceGroupNameList() -> PrecedenceGroupNameList {
+  func createPrecedenceGroupNameList() -> PrecedenceGroupNameList {
     return PrecedenceGroupNameList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1240,7 +1240,7 @@ public protocol ExpressibleAsObjCSelectorPiece: ExpressibleAsObjCSelector, Expre
 }
 public extension ExpressibleAsObjCSelectorPiece {
   /// Conformance to `ExpressibleAsObjCSelector`
-func createObjCSelector() -> ObjCSelector {
+  func createObjCSelector() -> ObjCSelector {
     return ObjCSelector([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1282,7 +1282,7 @@ public protocol ExpressibleAsDifferentiabilityParam: ExpressibleAsDifferentiabil
 }
 public extension ExpressibleAsDifferentiabilityParam {
   /// Conformance to `ExpressibleAsDifferentiabilityParamList`
-func createDifferentiabilityParamList() -> DifferentiabilityParamList {
+  func createDifferentiabilityParamList() -> DifferentiabilityParamList {
     return DifferentiabilityParamList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1329,7 +1329,7 @@ public protocol ExpressibleAsBackDeployVersionArgument: ExpressibleAsBackDeployV
 }
 public extension ExpressibleAsBackDeployVersionArgument {
   /// Conformance to `ExpressibleAsBackDeployVersionList`
-func createBackDeployVersionList() -> BackDeployVersionList {
+  func createBackDeployVersionList() -> BackDeployVersionList {
     return BackDeployVersionList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1473,7 +1473,7 @@ public protocol ExpressibleAsConditionElement: ExpressibleAsConditionElementList
 }
 public extension ExpressibleAsConditionElement {
   /// Conformance to `ExpressibleAsConditionElementList`
-func createConditionElementList() -> ConditionElementList {
+  func createConditionElementList() -> ConditionElementList {
     return ConditionElementList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1493,7 +1493,7 @@ public protocol ExpressibleAsMatchingPatternCondition: ExpressibleAsConditionEle
 }
 public extension ExpressibleAsMatchingPatternCondition {
   /// Conformance to ExpressibleAsConditionElement
-func createConditionElement() -> ConditionElement {
+  func createConditionElement() -> ConditionElement {
     return ConditionElement(condition: self)
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1505,7 +1505,7 @@ public protocol ExpressibleAsOptionalBindingCondition: ExpressibleAsConditionEle
 }
 public extension ExpressibleAsOptionalBindingCondition {
   /// Conformance to ExpressibleAsConditionElement
-func createConditionElement() -> ConditionElement {
+  func createConditionElement() -> ConditionElement {
     return ConditionElement(condition: self)
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1584,7 +1584,7 @@ public protocol ExpressibleAsCaseItem: ExpressibleAsCaseItemList, ExpressibleAsS
 }
 public extension ExpressibleAsCaseItem {
   /// Conformance to `ExpressibleAsCaseItemList`
-func createCaseItemList() -> CaseItemList {
+  func createCaseItemList() -> CaseItemList {
     return CaseItemList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1596,7 +1596,7 @@ public protocol ExpressibleAsCatchItem: ExpressibleAsCatchItemList, ExpressibleA
 }
 public extension ExpressibleAsCatchItem {
   /// Conformance to `ExpressibleAsCatchItemList`
-func createCatchItemList() -> CatchItemList {
+  func createCatchItemList() -> CatchItemList {
     return CatchItemList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1616,7 +1616,7 @@ public protocol ExpressibleAsCatchClause: ExpressibleAsCatchClauseList, Expressi
 }
 public extension ExpressibleAsCatchClause {
   /// Conformance to `ExpressibleAsCatchClauseList`
-func createCatchClauseList() -> CatchClauseList {
+  func createCatchClauseList() -> CatchClauseList {
     return CatchClauseList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1647,7 +1647,7 @@ public protocol ExpressibleAsGenericRequirement: ExpressibleAsGenericRequirement
 }
 public extension ExpressibleAsGenericRequirement {
   /// Conformance to `ExpressibleAsGenericRequirementList`
-func createGenericRequirementList() -> GenericRequirementList {
+  func createGenericRequirementList() -> GenericRequirementList {
     return GenericRequirementList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1678,7 +1678,7 @@ public protocol ExpressibleAsGenericParameter: ExpressibleAsGenericParameterList
 }
 public extension ExpressibleAsGenericParameter {
   /// Conformance to `ExpressibleAsGenericParameterList`
-func createGenericParameterList() -> GenericParameterList {
+  func createGenericParameterList() -> GenericParameterList {
     return GenericParameterList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1693,7 +1693,7 @@ public protocol ExpressibleAsPrimaryAssociatedType: ExpressibleAsPrimaryAssociat
 }
 public extension ExpressibleAsPrimaryAssociatedType {
   /// Conformance to `ExpressibleAsPrimaryAssociatedTypeList`
-func createPrimaryAssociatedTypeList() -> PrimaryAssociatedTypeList {
+  func createPrimaryAssociatedTypeList() -> PrimaryAssociatedTypeList {
     return PrimaryAssociatedTypeList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1729,11 +1729,11 @@ public protocol ExpressibleAsSimpleTypeIdentifier: ExpressibleAsTypeAnnotation, 
 }
 public extension ExpressibleAsSimpleTypeIdentifier {
   /// Conformance to ExpressibleAsTypeAnnotation
-func createTypeAnnotation() -> TypeAnnotation {
+  func createTypeAnnotation() -> TypeAnnotation {
     return TypeAnnotation(type: self)
   }
   /// Conformance to ExpressibleAsTypeExpr
-func createTypeExpr() -> TypeExpr {
+  func createTypeExpr() -> TypeExpr {
     return TypeExpr(type: self)
   }
   func createTypeBuildable() -> TypeBuildable {
@@ -1761,7 +1761,7 @@ public protocol ExpressibleAsArrayType: ExpressibleAsTypeAnnotation, Expressible
 }
 public extension ExpressibleAsArrayType {
   /// Conformance to ExpressibleAsTypeAnnotation
-func createTypeAnnotation() -> TypeAnnotation {
+  func createTypeAnnotation() -> TypeAnnotation {
     return TypeAnnotation(type: self)
   }
   func createTypeBuildable() -> TypeBuildable {
@@ -1773,7 +1773,7 @@ public protocol ExpressibleAsDictionaryType: ExpressibleAsTypeAnnotation, Expres
 }
 public extension ExpressibleAsDictionaryType {
   /// Conformance to ExpressibleAsTypeAnnotation
-func createTypeAnnotation() -> TypeAnnotation {
+  func createTypeAnnotation() -> TypeAnnotation {
     return TypeAnnotation(type: self)
   }
   func createTypeBuildable() -> TypeBuildable {
@@ -1817,7 +1817,7 @@ public protocol ExpressibleAsCompositionTypeElement: ExpressibleAsCompositionTyp
 }
 public extension ExpressibleAsCompositionTypeElement {
   /// Conformance to `ExpressibleAsCompositionTypeElementList`
-func createCompositionTypeElementList() -> CompositionTypeElementList {
+  func createCompositionTypeElementList() -> CompositionTypeElementList {
     return CompositionTypeElementList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1840,7 +1840,7 @@ public protocol ExpressibleAsTupleTypeElement: ExpressibleAsTupleTypeElementList
 }
 public extension ExpressibleAsTupleTypeElement {
   /// Conformance to `ExpressibleAsTupleTypeElementList`
-func createTupleTypeElementList() -> TupleTypeElementList {
+  func createTupleTypeElementList() -> TupleTypeElementList {
     return TupleTypeElementList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1882,7 +1882,7 @@ public protocol ExpressibleAsGenericArgument: ExpressibleAsGenericArgumentList, 
 }
 public extension ExpressibleAsGenericArgument {
   /// Conformance to `ExpressibleAsGenericArgumentList`
-func createGenericArgumentList() -> GenericArgumentList {
+  func createGenericArgumentList() -> GenericArgumentList {
     return GenericArgumentList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1966,7 +1966,7 @@ public protocol ExpressibleAsTuplePatternElement: ExpressibleAsTuplePatternEleme
 }
 public extension ExpressibleAsTuplePatternElement {
   /// Conformance to `ExpressibleAsTuplePatternElementList`
-func createTuplePatternElementList() -> TuplePatternElementList {
+  func createTuplePatternElementList() -> TuplePatternElementList {
     return TuplePatternElementList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
@@ -2000,7 +2000,7 @@ public protocol ExpressibleAsAvailabilityArgument: ExpressibleAsAvailabilitySpec
 }
 public extension ExpressibleAsAvailabilityArgument {
   /// Conformance to `ExpressibleAsAvailabilitySpecList`
-func createAvailabilitySpecList() -> AvailabilitySpecList {
+  func createAvailabilitySpecList() -> AvailabilitySpecList {
     return AvailabilitySpecList([self])
   }
   func createSyntaxBuildable() -> SyntaxBuildable {

--- a/Sources/SwiftSyntaxBuilder/generated/TokenSyntax.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/TokenSyntax.swift
@@ -16,23 +16,23 @@
 import SwiftSyntax
 extension TokenSyntax: ExpressibleAsTokenList, ExpressibleAsNonEmptyTokenList, ExpressibleAsBinaryOperatorExpr, ExpressibleAsDeclModifier, ExpressibleAsIdentifierExpr {
   /// Conformance to ExpressibleAsTokenList
-public func createTokenList() -> TokenList {
+  public func createTokenList() -> TokenList {
     return TokenList([self])
   }
   /// Conformance to ExpressibleAsNonEmptyTokenList
-public func createNonEmptyTokenList() -> NonEmptyTokenList {
+  public func createNonEmptyTokenList() -> NonEmptyTokenList {
     return NonEmptyTokenList([self])
   }
   /// Conformance to ExpressibleAsBinaryOperatorExpr
-public func createBinaryOperatorExpr() -> BinaryOperatorExpr {
+  public func createBinaryOperatorExpr() -> BinaryOperatorExpr {
     return BinaryOperatorExpr(operatorToken: self)
   }
   /// Conformance to ExpressibleAsDeclModifier
-public func createDeclModifier() -> DeclModifier {
+  public func createDeclModifier() -> DeclModifier {
     return DeclModifier(name: self)
   }
   /// Conformance to ExpressibleAsIdentifierExpr
-public func createIdentifierExpr() -> IdentifierExpr {
+  public func createIdentifierExpr() -> IdentifierExpr {
     return IdentifierExpr(identifier: self)
   }
 }

--- a/Sources/SwiftSyntaxBuilder/generated/Tokens.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/Tokens.swift
@@ -18,543 +18,543 @@ import SwiftSyntax
 /// Namespace for commonly used tokens with default trivia.
 public extension TokenSyntax {
   
-/// The `associatedtype` keyword
-static var `associatedtype`: TokenSyntax {
+  /// The `associatedtype` keyword
+  static var `associatedtype`: TokenSyntax {
     SyntaxFactory.makeAssociatedtypeKeyword()
   }
   
-/// The `class` keyword
-static var `class`: TokenSyntax {
+  /// The `class` keyword
+  static var `class`: TokenSyntax {
     SyntaxFactory.makeClassKeyword()
   }
   
-/// The `deinit` keyword
-static var `deinit`: TokenSyntax {
+  /// The `deinit` keyword
+  static var `deinit`: TokenSyntax {
     SyntaxFactory.makeDeinitKeyword()
   }
   
-/// The `enum` keyword
-static var `enum`: TokenSyntax {
+  /// The `enum` keyword
+  static var `enum`: TokenSyntax {
     SyntaxFactory.makeEnumKeyword()
   }
   
-/// The `extension` keyword
-static var `extension`: TokenSyntax {
+  /// The `extension` keyword
+  static var `extension`: TokenSyntax {
     SyntaxFactory.makeExtensionKeyword()
   }
   
-/// The `func` keyword
-static var `func`: TokenSyntax {
+  /// The `func` keyword
+  static var `func`: TokenSyntax {
     SyntaxFactory.makeFuncKeyword()
   }
   
-/// The `import` keyword
-static var `import`: TokenSyntax {
+  /// The `import` keyword
+  static var `import`: TokenSyntax {
     SyntaxFactory.makeImportKeyword()
   }
   
-/// The `init` keyword
-static var `init`: TokenSyntax {
+  /// The `init` keyword
+  static var `init`: TokenSyntax {
     SyntaxFactory.makeInitKeyword()
   }
   
-/// The `inout` keyword
-static var `inout`: TokenSyntax {
+  /// The `inout` keyword
+  static var `inout`: TokenSyntax {
     SyntaxFactory.makeInoutKeyword()
   }
   
-/// The `let` keyword
-static var `let`: TokenSyntax {
+  /// The `let` keyword
+  static var `let`: TokenSyntax {
     SyntaxFactory.makeLetKeyword()
   }
   
-/// The `operator` keyword
-static var `operator`: TokenSyntax {
+  /// The `operator` keyword
+  static var `operator`: TokenSyntax {
     SyntaxFactory.makeOperatorKeyword()
   }
   
-/// The `precedencegroup` keyword
-static var `precedencegroup`: TokenSyntax {
+  /// The `precedencegroup` keyword
+  static var `precedencegroup`: TokenSyntax {
     SyntaxFactory.makePrecedencegroupKeyword()
   }
   
-/// The `protocol` keyword
-static var `protocol`: TokenSyntax {
+  /// The `protocol` keyword
+  static var `protocol`: TokenSyntax {
     SyntaxFactory.makeProtocolKeyword()
   }
   
-/// The `struct` keyword
-static var `struct`: TokenSyntax {
+  /// The `struct` keyword
+  static var `struct`: TokenSyntax {
     SyntaxFactory.makeStructKeyword()
   }
   
-/// The `subscript` keyword
-static var `subscript`: TokenSyntax {
+  /// The `subscript` keyword
+  static var `subscript`: TokenSyntax {
     SyntaxFactory.makeSubscriptKeyword()
   }
   
-/// The `typealias` keyword
-static var `typealias`: TokenSyntax {
+  /// The `typealias` keyword
+  static var `typealias`: TokenSyntax {
     SyntaxFactory.makeTypealiasKeyword()
   }
   
-/// The `var` keyword
-static var `var`: TokenSyntax {
+  /// The `var` keyword
+  static var `var`: TokenSyntax {
     SyntaxFactory.makeVarKeyword()
   }
   
-/// The `fileprivate` keyword
-static var `fileprivate`: TokenSyntax {
+  /// The `fileprivate` keyword
+  static var `fileprivate`: TokenSyntax {
     SyntaxFactory.makeFileprivateKeyword()
   }
   
-/// The `internal` keyword
-static var `internal`: TokenSyntax {
+  /// The `internal` keyword
+  static var `internal`: TokenSyntax {
     SyntaxFactory.makeInternalKeyword()
   }
   
-/// The `private` keyword
-static var `private`: TokenSyntax {
+  /// The `private` keyword
+  static var `private`: TokenSyntax {
     SyntaxFactory.makePrivateKeyword()
   }
   
-/// The `public` keyword
-static var `public`: TokenSyntax {
+  /// The `public` keyword
+  static var `public`: TokenSyntax {
     SyntaxFactory.makePublicKeyword()
   }
   
-/// The `static` keyword
-static var `static`: TokenSyntax {
+  /// The `static` keyword
+  static var `static`: TokenSyntax {
     SyntaxFactory.makeStaticKeyword()
   }
   
-/// The `defer` keyword
-static var `defer`: TokenSyntax {
+  /// The `defer` keyword
+  static var `defer`: TokenSyntax {
     SyntaxFactory.makeDeferKeyword()
   }
   
-/// The `if` keyword
-static var `if`: TokenSyntax {
+  /// The `if` keyword
+  static var `if`: TokenSyntax {
     SyntaxFactory.makeIfKeyword()
   }
   
-/// The `guard` keyword
-static var `guard`: TokenSyntax {
+  /// The `guard` keyword
+  static var `guard`: TokenSyntax {
     SyntaxFactory.makeGuardKeyword()
   }
   
-/// The `do` keyword
-static var `do`: TokenSyntax {
+  /// The `do` keyword
+  static var `do`: TokenSyntax {
     SyntaxFactory.makeDoKeyword()
   }
   
-/// The `repeat` keyword
-static var `repeat`: TokenSyntax {
+  /// The `repeat` keyword
+  static var `repeat`: TokenSyntax {
     SyntaxFactory.makeRepeatKeyword()
   }
   
-/// The `else` keyword
-static var `else`: TokenSyntax {
+  /// The `else` keyword
+  static var `else`: TokenSyntax {
     SyntaxFactory.makeElseKeyword()
   }
   
-/// The `for` keyword
-static var `for`: TokenSyntax {
+  /// The `for` keyword
+  static var `for`: TokenSyntax {
     SyntaxFactory.makeForKeyword()
   }
   
-/// The `in` keyword
-static var `in`: TokenSyntax {
+  /// The `in` keyword
+  static var `in`: TokenSyntax {
     SyntaxFactory.makeInKeyword()
   }
   
-/// The `while` keyword
-static var `while`: TokenSyntax {
+  /// The `while` keyword
+  static var `while`: TokenSyntax {
     SyntaxFactory.makeWhileKeyword()
   }
   
-/// The `return` keyword
-static var `return`: TokenSyntax {
+  /// The `return` keyword
+  static var `return`: TokenSyntax {
     SyntaxFactory.makeReturnKeyword()
   }
   
-/// The `break` keyword
-static var `break`: TokenSyntax {
+  /// The `break` keyword
+  static var `break`: TokenSyntax {
     SyntaxFactory.makeBreakKeyword()
   }
   
-/// The `continue` keyword
-static var `continue`: TokenSyntax {
+  /// The `continue` keyword
+  static var `continue`: TokenSyntax {
     SyntaxFactory.makeContinueKeyword()
   }
   
-/// The `fallthrough` keyword
-static var `fallthrough`: TokenSyntax {
+  /// The `fallthrough` keyword
+  static var `fallthrough`: TokenSyntax {
     SyntaxFactory.makeFallthroughKeyword()
   }
   
-/// The `switch` keyword
-static var `switch`: TokenSyntax {
+  /// The `switch` keyword
+  static var `switch`: TokenSyntax {
     SyntaxFactory.makeSwitchKeyword()
   }
   
-/// The `case` keyword
-static var `case`: TokenSyntax {
+  /// The `case` keyword
+  static var `case`: TokenSyntax {
     SyntaxFactory.makeCaseKeyword()
   }
   
-/// The `default` keyword
-static var `default`: TokenSyntax {
+  /// The `default` keyword
+  static var `default`: TokenSyntax {
     SyntaxFactory.makeDefaultKeyword()
   }
   
-/// The `where` keyword
-static var `where`: TokenSyntax {
+  /// The `where` keyword
+  static var `where`: TokenSyntax {
     SyntaxFactory.makeWhereKeyword()
   }
   
-/// The `catch` keyword
-static var `catch`: TokenSyntax {
+  /// The `catch` keyword
+  static var `catch`: TokenSyntax {
     SyntaxFactory.makeCatchKeyword()
   }
   
-/// The `throw` keyword
-static var `throw`: TokenSyntax {
+  /// The `throw` keyword
+  static var `throw`: TokenSyntax {
     SyntaxFactory.makeThrowKeyword()
   }
   
-/// The `as` keyword
-static var `as`: TokenSyntax {
+  /// The `as` keyword
+  static var `as`: TokenSyntax {
     SyntaxFactory.makeAsKeyword()
   }
   
-/// The `Any` keyword
-static var `any`: TokenSyntax {
+  /// The `Any` keyword
+  static var `any`: TokenSyntax {
     SyntaxFactory.makeAnyKeyword()
   }
   
-/// The `false` keyword
-static var `false`: TokenSyntax {
+  /// The `false` keyword
+  static var `false`: TokenSyntax {
     SyntaxFactory.makeFalseKeyword()
   }
   
-/// The `is` keyword
-static var `is`: TokenSyntax {
+  /// The `is` keyword
+  static var `is`: TokenSyntax {
     SyntaxFactory.makeIsKeyword()
   }
   
-/// The `nil` keyword
-static var `nil`: TokenSyntax {
+  /// The `nil` keyword
+  static var `nil`: TokenSyntax {
     SyntaxFactory.makeNilKeyword()
   }
   
-/// The `rethrows` keyword
-static var `rethrows`: TokenSyntax {
+  /// The `rethrows` keyword
+  static var `rethrows`: TokenSyntax {
     SyntaxFactory.makeRethrowsKeyword()
   }
   
-/// The `super` keyword
-static var `super`: TokenSyntax {
+  /// The `super` keyword
+  static var `super`: TokenSyntax {
     SyntaxFactory.makeSuperKeyword()
   }
   
-/// The `self` keyword
-static var `self`: TokenSyntax {
+  /// The `self` keyword
+  static var `self`: TokenSyntax {
     SyntaxFactory.makeSelfKeyword()
   }
   
-/// The `Self` keyword
-static var `capitalSelf`: TokenSyntax {
+  /// The `Self` keyword
+  static var `capitalSelf`: TokenSyntax {
     SyntaxFactory.makeCapitalSelfKeyword()
   }
   
-/// The `true` keyword
-static var `true`: TokenSyntax {
+  /// The `true` keyword
+  static var `true`: TokenSyntax {
     SyntaxFactory.makeTrueKeyword()
   }
   
-/// The `try` keyword
-static var `try`: TokenSyntax {
+  /// The `try` keyword
+  static var `try`: TokenSyntax {
     SyntaxFactory.makeTryKeyword()
   }
   
-/// The `throws` keyword
-static var `throws`: TokenSyntax {
+  /// The `throws` keyword
+  static var `throws`: TokenSyntax {
     SyntaxFactory.makeThrowsKeyword()
   }
   
-/// The `__FILE__` keyword
-static var `__FILE__`: TokenSyntax {
+  /// The `__FILE__` keyword
+  static var `__FILE__`: TokenSyntax {
     SyntaxFactory.make__FILE__Keyword()
   }
   
-/// The `__LINE__` keyword
-static var `__LINE__`: TokenSyntax {
+  /// The `__LINE__` keyword
+  static var `__LINE__`: TokenSyntax {
     SyntaxFactory.make__LINE__Keyword()
   }
   
-/// The `__COLUMN__` keyword
-static var `__COLUMN__`: TokenSyntax {
+  /// The `__COLUMN__` keyword
+  static var `__COLUMN__`: TokenSyntax {
     SyntaxFactory.make__COLUMN__Keyword()
   }
   
-/// The `__FUNCTION__` keyword
-static var `__FUNCTION__`: TokenSyntax {
+  /// The `__FUNCTION__` keyword
+  static var `__FUNCTION__`: TokenSyntax {
     SyntaxFactory.make__FUNCTION__Keyword()
   }
   
-/// The `__DSO_HANDLE__` keyword
-static var `__DSO_HANDLE__`: TokenSyntax {
+  /// The `__DSO_HANDLE__` keyword
+  static var `__DSO_HANDLE__`: TokenSyntax {
     SyntaxFactory.make__DSO_HANDLE__Keyword()
   }
   
-/// The `_` keyword
-static var `wildcard`: TokenSyntax {
+  /// The `_` keyword
+  static var `wildcard`: TokenSyntax {
     SyntaxFactory.makeWildcardKeyword()
   }
   
-/// The `(` token
-static var `leftParen`: TokenSyntax {
+  /// The `(` token
+  static var `leftParen`: TokenSyntax {
     SyntaxFactory.makeLeftParenToken()
   }
   
-/// The `)` token
-static var `rightParen`: TokenSyntax {
+  /// The `)` token
+  static var `rightParen`: TokenSyntax {
     SyntaxFactory.makeRightParenToken()
   }
   
-/// The `{` token
-static var `leftBrace`: TokenSyntax {
+  /// The `{` token
+  static var `leftBrace`: TokenSyntax {
     SyntaxFactory.makeLeftBraceToken()
   }
   
-/// The `}` token
-static var `rightBrace`: TokenSyntax {
+  /// The `}` token
+  static var `rightBrace`: TokenSyntax {
     SyntaxFactory.makeRightBraceToken()
   }
   
-/// The `[` token
-static var `leftSquareBracket`: TokenSyntax {
+  /// The `[` token
+  static var `leftSquareBracket`: TokenSyntax {
     SyntaxFactory.makeLeftSquareBracketToken()
   }
   
-/// The `]` token
-static var `rightSquareBracket`: TokenSyntax {
+  /// The `]` token
+  static var `rightSquareBracket`: TokenSyntax {
     SyntaxFactory.makeRightSquareBracketToken()
   }
   
-/// The `<` token
-static var `leftAngle`: TokenSyntax {
+  /// The `<` token
+  static var `leftAngle`: TokenSyntax {
     SyntaxFactory.makeLeftAngleToken()
   }
   
-/// The `>` token
-static var `rightAngle`: TokenSyntax {
+  /// The `>` token
+  static var `rightAngle`: TokenSyntax {
     SyntaxFactory.makeRightAngleToken()
   }
   
-/// The `.` token
-static var `period`: TokenSyntax {
+  /// The `.` token
+  static var `period`: TokenSyntax {
     SyntaxFactory.makePeriodToken()
   }
   
-/// The `.` token
-static var `prefixPeriod`: TokenSyntax {
+  /// The `.` token
+  static var `prefixPeriod`: TokenSyntax {
     SyntaxFactory.makePrefixPeriodToken()
   }
   
-/// The `,` token
-static var `comma`: TokenSyntax {
+  /// The `,` token
+  static var `comma`: TokenSyntax {
     SyntaxFactory.makeCommaToken()
   }
   
-/// The `...` token
-static var `ellipsis`: TokenSyntax {
+  /// The `...` token
+  static var `ellipsis`: TokenSyntax {
     SyntaxFactory.makeEllipsisToken()
   }
   
-/// The `:` token
-static var `colon`: TokenSyntax {
+  /// The `:` token
+  static var `colon`: TokenSyntax {
     SyntaxFactory.makeColonToken()
   }
   
-/// The `;` token
-static var `semicolon`: TokenSyntax {
+  /// The `;` token
+  static var `semicolon`: TokenSyntax {
     SyntaxFactory.makeSemicolonToken()
   }
   
-/// The `=` token
-static var `equal`: TokenSyntax {
+  /// The `=` token
+  static var `equal`: TokenSyntax {
     SyntaxFactory.makeEqualToken()
   }
   
-/// The `@` token
-static var `atSign`: TokenSyntax {
+  /// The `@` token
+  static var `atSign`: TokenSyntax {
     SyntaxFactory.makeAtSignToken()
   }
   
-/// The `#` token
-static var `pound`: TokenSyntax {
+  /// The `#` token
+  static var `pound`: TokenSyntax {
     SyntaxFactory.makePoundToken()
   }
   
-/// The `&` token
-static var `prefixAmpersand`: TokenSyntax {
+  /// The `&` token
+  static var `prefixAmpersand`: TokenSyntax {
     SyntaxFactory.makePrefixAmpersandToken()
   }
   
-/// The `->` token
-static var `arrow`: TokenSyntax {
+  /// The `->` token
+  static var `arrow`: TokenSyntax {
     SyntaxFactory.makeArrowToken()
   }
   
-/// The ``` token
-static var `backtick`: TokenSyntax {
+  /// The ``` token
+  static var `backtick`: TokenSyntax {
     SyntaxFactory.makeBacktickToken()
   }
   
-/// The `\` token
-static var `backslash`: TokenSyntax {
+  /// The `\` token
+  static var `backslash`: TokenSyntax {
     SyntaxFactory.makeBackslashToken()
   }
   
-/// The `!` token
-static var `exclamationMark`: TokenSyntax {
+  /// The `!` token
+  static var `exclamationMark`: TokenSyntax {
     SyntaxFactory.makeExclamationMarkToken()
   }
   
-/// The `?` token
-static var `postfixQuestionMark`: TokenSyntax {
+  /// The `?` token
+  static var `postfixQuestionMark`: TokenSyntax {
     SyntaxFactory.makePostfixQuestionMarkToken()
   }
   
-/// The `?` token
-static var `infixQuestionMark`: TokenSyntax {
+  /// The `?` token
+  static var `infixQuestionMark`: TokenSyntax {
     SyntaxFactory.makeInfixQuestionMarkToken()
   }
   
-/// The `"` token
-static var `stringQuote`: TokenSyntax {
+  /// The `"` token
+  static var `stringQuote`: TokenSyntax {
     SyntaxFactory.makeStringQuoteToken()
   }
   
-/// The `'` token
-static var `singleQuote`: TokenSyntax {
+  /// The `'` token
+  static var `singleQuote`: TokenSyntax {
     SyntaxFactory.makeSingleQuoteToken()
   }
   
-/// The `"""` token
-static var `multilineStringQuote`: TokenSyntax {
+  /// The `"""` token
+  static var `multilineStringQuote`: TokenSyntax {
     SyntaxFactory.makeMultilineStringQuoteToken()
   }
   
-/// The `#keyPath` keyword
-static var `poundKeyPath`: TokenSyntax {
+  /// The `#keyPath` keyword
+  static var `poundKeyPath`: TokenSyntax {
     SyntaxFactory.makePoundKeyPathKeyword()
   }
   
-/// The `#line` keyword
-static var `poundLine`: TokenSyntax {
+  /// The `#line` keyword
+  static var `poundLine`: TokenSyntax {
     SyntaxFactory.makePoundLineKeyword()
   }
   
-/// The `#selector` keyword
-static var `poundSelector`: TokenSyntax {
+  /// The `#selector` keyword
+  static var `poundSelector`: TokenSyntax {
     SyntaxFactory.makePoundSelectorKeyword()
   }
   
-/// The `#file` keyword
-static var `poundFile`: TokenSyntax {
+  /// The `#file` keyword
+  static var `poundFile`: TokenSyntax {
     SyntaxFactory.makePoundFileKeyword()
   }
   
-/// The `#fileID` keyword
-static var `poundFileID`: TokenSyntax {
+  /// The `#fileID` keyword
+  static var `poundFileID`: TokenSyntax {
     SyntaxFactory.makePoundFileIDKeyword()
   }
   
-/// The `#filePath` keyword
-static var `poundFilePath`: TokenSyntax {
+  /// The `#filePath` keyword
+  static var `poundFilePath`: TokenSyntax {
     SyntaxFactory.makePoundFilePathKeyword()
   }
   
-/// The `#column` keyword
-static var `poundColumn`: TokenSyntax {
+  /// The `#column` keyword
+  static var `poundColumn`: TokenSyntax {
     SyntaxFactory.makePoundColumnKeyword()
   }
   
-/// The `#function` keyword
-static var `poundFunction`: TokenSyntax {
+  /// The `#function` keyword
+  static var `poundFunction`: TokenSyntax {
     SyntaxFactory.makePoundFunctionKeyword()
   }
   
-/// The `#dsohandle` keyword
-static var `poundDsohandle`: TokenSyntax {
+  /// The `#dsohandle` keyword
+  static var `poundDsohandle`: TokenSyntax {
     SyntaxFactory.makePoundDsohandleKeyword()
   }
   
-/// The `#assert` keyword
-static var `poundAssert`: TokenSyntax {
+  /// The `#assert` keyword
+  static var `poundAssert`: TokenSyntax {
     SyntaxFactory.makePoundAssertKeyword()
   }
   
-/// The `#sourceLocation` keyword
-static var `poundSourceLocation`: TokenSyntax {
+  /// The `#sourceLocation` keyword
+  static var `poundSourceLocation`: TokenSyntax {
     SyntaxFactory.makePoundSourceLocationKeyword()
   }
   
-/// The `#warning` keyword
-static var `poundWarning`: TokenSyntax {
+  /// The `#warning` keyword
+  static var `poundWarning`: TokenSyntax {
     SyntaxFactory.makePoundWarningKeyword()
   }
   
-/// The `#error` keyword
-static var `poundError`: TokenSyntax {
+  /// The `#error` keyword
+  static var `poundError`: TokenSyntax {
     SyntaxFactory.makePoundErrorKeyword()
   }
   
-/// The `#if` keyword
-static var `poundIf`: TokenSyntax {
+  /// The `#if` keyword
+  static var `poundIf`: TokenSyntax {
     SyntaxFactory.makePoundIfKeyword()
   }
   
-/// The `#else` keyword
-static var `poundElse`: TokenSyntax {
+  /// The `#else` keyword
+  static var `poundElse`: TokenSyntax {
     SyntaxFactory.makePoundElseKeyword()
   }
   
-/// The `#elseif` keyword
-static var `poundElseif`: TokenSyntax {
+  /// The `#elseif` keyword
+  static var `poundElseif`: TokenSyntax {
     SyntaxFactory.makePoundElseifKeyword()
   }
   
-/// The `#endif` keyword
-static var `poundEndif`: TokenSyntax {
+  /// The `#endif` keyword
+  static var `poundEndif`: TokenSyntax {
     SyntaxFactory.makePoundEndifKeyword()
   }
   
-/// The `#available` keyword
-static var `poundAvailable`: TokenSyntax {
+  /// The `#available` keyword
+  static var `poundAvailable`: TokenSyntax {
     SyntaxFactory.makePoundAvailableKeyword()
   }
   
-/// The `#unavailable` keyword
-static var `poundUnavailable`: TokenSyntax {
+  /// The `#unavailable` keyword
+  static var `poundUnavailable`: TokenSyntax {
     SyntaxFactory.makePoundUnavailableKeyword()
   }
   
-/// The `#fileLiteral` keyword
-static var `poundFileLiteral`: TokenSyntax {
+  /// The `#fileLiteral` keyword
+  static var `poundFileLiteral`: TokenSyntax {
     SyntaxFactory.makePoundFileLiteralKeyword()
   }
   
-/// The `#imageLiteral` keyword
-static var `poundImageLiteral`: TokenSyntax {
+  /// The `#imageLiteral` keyword
+  static var `poundImageLiteral`: TokenSyntax {
     SyntaxFactory.makePoundImageLiteralKeyword()
   }
   
-/// The `#colorLiteral` keyword
-static var `poundColorLiteral`: TokenSyntax {
+  /// The `#colorLiteral` keyword
+  static var `poundColorLiteral`: TokenSyntax {
     SyntaxFactory.makePoundColorLiteralKeyword()
   }
   static func `integerLiteral`(_ text: String) -> TokenSyntax {
@@ -600,23 +600,23 @@ static var `poundColorLiteral`: TokenSyntax {
     SyntaxFactory.makeStringSegment(text)
   }
   
-/// The `)` token
-static var `stringInterpolationAnchor`: TokenSyntax {
+  /// The `)` token
+  static var `stringInterpolationAnchor`: TokenSyntax {
     SyntaxFactory.makeStringInterpolationAnchorToken()
   }
   
-/// The `yield` token
-static var `yield`: TokenSyntax {
+  /// The `yield` token
+  static var `yield`: TokenSyntax {
     SyntaxFactory.makeYieldToken()
   }
   
-/// The `eof` token
-static var eof: TokenSyntax {
+  /// The `eof` token
+  static var eof: TokenSyntax {
     SyntaxFactory.makeToken(.eof, presence: .present)
   }
   
-/// The `open` contextual token
-static var open: TokenSyntax {
+  /// The `open` contextual token
+  static var open: TokenSyntax {
     SyntaxFactory.makeContextualKeyword("open")
     .withTrailingTrivia(.space)
   }

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/BuildableCollectionNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/BuildableCollectionNodes.swift
@@ -41,7 +41,7 @@ public struct CodeBlockItemList: ExpressibleByArrayLiteral, SyntaxBuildable, Exp
       $0.buildCodeBlockItem(format: format, leadingTrivia: Trivia.newline + format._makeIndent())
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -92,7 +92,7 @@ public struct TupleExprElementList: ExpressibleByArrayLiteral, SyntaxBuildable, 
       $0.buildTupleExprElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -148,7 +148,7 @@ public struct ArrayElementList: ExpressibleByArrayLiteral, SyntaxBuildable, Expr
       $0.buildArrayElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -204,7 +204,7 @@ public struct DictionaryElementList: ExpressibleByArrayLiteral, SyntaxBuildable,
       $0.buildDictionaryElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -260,7 +260,7 @@ public struct StringLiteralSegments: ExpressibleByArrayLiteral, SyntaxBuildable,
       $0.buildSyntax(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -316,7 +316,7 @@ public struct DeclNameArgumentList: ExpressibleByArrayLiteral, SyntaxBuildable, 
       $0.buildDeclNameArgument(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -372,7 +372,7 @@ public struct ExprList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleA
       $0.buildExpr(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -423,7 +423,7 @@ public struct ClosureCaptureItemList: ExpressibleByArrayLiteral, SyntaxBuildable
       $0.buildClosureCaptureItem(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -479,7 +479,7 @@ public struct ClosureParamList: ExpressibleByArrayLiteral, SyntaxBuildable, Expr
       $0.buildClosureParam(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -535,7 +535,7 @@ public struct MultipleTrailingClosureElementList: ExpressibleByArrayLiteral, Syn
       $0.buildMultipleTrailingClosureElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -591,7 +591,7 @@ public struct ObjcName: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleA
       $0.buildObjcNamePiece(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -647,7 +647,7 @@ public struct FunctionParameterList: ExpressibleByArrayLiteral, SyntaxBuildable,
       $0.buildFunctionParameter(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -703,7 +703,7 @@ public struct IfConfigClauseList: ExpressibleByArrayLiteral, SyntaxBuildable, Ex
       $0.buildIfConfigClause(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -759,7 +759,7 @@ public struct InheritedTypeList: ExpressibleByArrayLiteral, SyntaxBuildable, Exp
       $0.buildInheritedType(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -815,7 +815,7 @@ public struct MemberDeclList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
       $0.buildMemberDeclListItem(format: format, leadingTrivia: Trivia.newline + format._makeIndent())
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -866,7 +866,7 @@ public struct ModifierList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
       $0.buildDeclModifier(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -922,7 +922,7 @@ public struct AccessPath: ExpressibleByArrayLiteral, SyntaxBuildable, Expressibl
       $0.buildAccessPathComponent(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -978,7 +978,7 @@ public struct AccessorList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
       $0.buildAccessorDecl(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1029,7 +1029,7 @@ public struct PatternBindingList: ExpressibleByArrayLiteral, SyntaxBuildable, Ex
       $0.buildPatternBinding(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1085,7 +1085,7 @@ public struct EnumCaseElementList: ExpressibleByArrayLiteral, SyntaxBuildable, E
       $0.buildEnumCaseElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1139,7 +1139,7 @@ public struct IdentifierList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
   public func buildIdentifierList(format: Format, leadingTrivia: Trivia? = nil) -> IdentifierListSyntax {
     let result = SyntaxFactory.makeIdentifierList(elements)
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1195,7 +1195,7 @@ public struct PrecedenceGroupAttributeList: ExpressibleByArrayLiteral, SyntaxBui
       $0.buildSyntax(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1251,7 +1251,7 @@ public struct PrecedenceGroupNameList: ExpressibleByArrayLiteral, SyntaxBuildabl
       $0.buildPrecedenceGroupNameElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1305,7 +1305,7 @@ public struct TokenList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressible
   public func buildTokenList(format: Format, leadingTrivia: Trivia? = nil) -> TokenListSyntax {
     let result = SyntaxFactory.makeTokenList(elements)
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1359,7 +1359,7 @@ public struct NonEmptyTokenList: ExpressibleByArrayLiteral, SyntaxBuildable, Exp
   public func buildNonEmptyTokenList(format: Format, leadingTrivia: Trivia? = nil) -> NonEmptyTokenListSyntax {
     let result = SyntaxFactory.makeNonEmptyTokenList(elements)
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1415,7 +1415,7 @@ public struct AttributeList: ExpressibleByArrayLiteral, SyntaxBuildable, Express
       $0.buildSyntax(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1471,7 +1471,7 @@ public struct SpecializeAttributeSpecList: ExpressibleByArrayLiteral, SyntaxBuil
       $0.buildSyntax(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1527,7 +1527,7 @@ public struct ObjCSelector: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
       $0.buildObjCSelectorPiece(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1583,7 +1583,7 @@ public struct DifferentiabilityParamList: ExpressibleByArrayLiteral, SyntaxBuild
       $0.buildDifferentiabilityParam(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1639,7 +1639,7 @@ public struct BackDeployVersionList: ExpressibleByArrayLiteral, SyntaxBuildable,
       $0.buildBackDeployVersionArgument(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1695,7 +1695,7 @@ public struct SwitchCaseList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
       $0.buildSyntax(format: format, leadingTrivia: Trivia.newline + format._makeIndent())
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1751,7 +1751,7 @@ public struct CatchClauseList: ExpressibleByArrayLiteral, SyntaxBuildable, Expre
       $0.buildCatchClause(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1807,7 +1807,7 @@ public struct CaseItemList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
       $0.buildCaseItem(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1863,7 +1863,7 @@ public struct CatchItemList: ExpressibleByArrayLiteral, SyntaxBuildable, Express
       $0.buildCatchItem(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1919,7 +1919,7 @@ public struct ConditionElementList: ExpressibleByArrayLiteral, SyntaxBuildable, 
       $0.buildConditionElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -1975,7 +1975,7 @@ public struct GenericRequirementList: ExpressibleByArrayLiteral, SyntaxBuildable
       $0.buildGenericRequirement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -2031,7 +2031,7 @@ public struct GenericParameterList: ExpressibleByArrayLiteral, SyntaxBuildable, 
       $0.buildGenericParameter(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -2087,7 +2087,7 @@ public struct PrimaryAssociatedTypeList: ExpressibleByArrayLiteral, SyntaxBuilda
       $0.buildPrimaryAssociatedType(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -2143,7 +2143,7 @@ public struct CompositionTypeElementList: ExpressibleByArrayLiteral, SyntaxBuild
       $0.buildCompositionTypeElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -2199,7 +2199,7 @@ public struct TupleTypeElementList: ExpressibleByArrayLiteral, SyntaxBuildable, 
       $0.buildTupleTypeElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -2255,7 +2255,7 @@ public struct GenericArgumentList: ExpressibleByArrayLiteral, SyntaxBuildable, E
       $0.buildGenericArgument(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -2311,7 +2311,7 @@ public struct TuplePatternElementList: ExpressibleByArrayLiteral, SyntaxBuildabl
       $0.buildTuplePatternElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }
@@ -2367,7 +2367,7 @@ public struct AvailabilitySpecList: ExpressibleByArrayLiteral, SyntaxBuildable, 
       $0.buildAvailabilityArgument(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
-      return result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+      return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
       return result
     }

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/BuildableNodes.swift
@@ -54,7 +54,7 @@ public struct CodeBlockItem: SyntaxBuildable, ExpressibleAsCodeBlockItem {
       errorTokens: errorTokens?.buildSyntax(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -132,7 +132,7 @@ public struct CodeBlock: SyntaxBuildable, ExpressibleAsCodeBlock {
       rightBrace: rightBrace.withLeadingTrivia(.newline + format._makeIndent() + (rightBrace.leadingTrivia ?? []))
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -188,7 +188,7 @@ public struct InOutExpr: ExprBuildable, ExpressibleAsInOutExpr {
       expression: expression.buildExpr(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -245,7 +245,7 @@ public struct PoundColumnExpr: ExprBuildable, ExpressibleAsPoundColumnExpr {
       poundColumn: poundColumn
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -313,7 +313,7 @@ public struct TryExpr: ExprBuildable, ExpressibleAsTryExpr {
       expression: expression.buildExpr(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -389,7 +389,7 @@ public struct AwaitExpr: ExprBuildable, ExpressibleAsAwaitExpr {
       expression: expression.buildExpr(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -451,7 +451,7 @@ public struct DeclNameArgument: SyntaxBuildable, ExpressibleAsDeclNameArgument {
       colon: colon
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -513,7 +513,7 @@ public struct DeclNameArguments: SyntaxBuildable, ExpressibleAsDeclNameArguments
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -568,7 +568,7 @@ public struct IdentifierExpr: ExprBuildable, ExpressibleAsIdentifierExpr {
       declNameArguments: declNameArguments?.buildDeclNameArguments(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -625,7 +625,7 @@ public struct SuperRefExpr: ExprBuildable, ExpressibleAsSuperRefExpr {
       superKeyword: superKeyword
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -682,7 +682,7 @@ public struct NilLiteralExpr: ExprBuildable, ExpressibleAsNilLiteralExpr {
       nilKeyword: nilKeyword
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -739,7 +739,7 @@ public struct DiscardAssignmentExpr: ExprBuildable, ExpressibleAsDiscardAssignme
       wildcard: wildcard
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -796,7 +796,7 @@ public struct AssignmentExpr: ExprBuildable, ExpressibleAsAssignmentExpr {
       assignToken: assignToken
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -864,7 +864,7 @@ public struct SequenceExpr: ExprBuildable, ExpressibleAsSequenceExpr {
       elements: elements.buildExprList(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -921,7 +921,7 @@ public struct PoundLineExpr: ExprBuildable, ExpressibleAsPoundLineExpr {
       poundLine: poundLine
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -978,7 +978,7 @@ public struct PoundFileExpr: ExprBuildable, ExpressibleAsPoundFileExpr {
       poundFile: poundFile
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -1035,7 +1035,7 @@ public struct PoundFileIDExpr: ExprBuildable, ExpressibleAsPoundFileIDExpr {
       poundFileID: poundFileID
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -1092,7 +1092,7 @@ public struct PoundFilePathExpr: ExprBuildable, ExpressibleAsPoundFilePathExpr {
       poundFilePath: poundFilePath
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -1149,7 +1149,7 @@ public struct PoundFunctionExpr: ExprBuildable, ExpressibleAsPoundFunctionExpr {
       poundFunction: poundFunction
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -1206,7 +1206,7 @@ public struct PoundDsohandleExpr: ExprBuildable, ExpressibleAsPoundDsohandleExpr
       poundDsohandle: poundDsohandle
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -1281,7 +1281,7 @@ public struct SymbolicReferenceExpr: ExprBuildable, ExpressibleAsSymbolicReferen
       genericArgumentClause: genericArgumentClause?.buildGenericArgumentClause(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -1356,7 +1356,7 @@ public struct PrefixOperatorExpr: ExprBuildable, ExpressibleAsPrefixOperatorExpr
       postfixExpression: postfixExpression.buildExpr(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -1412,7 +1412,7 @@ public struct BinaryOperatorExpr: ExprBuildable, ExpressibleAsBinaryOperatorExpr
       operatorToken: operatorToken
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -1497,7 +1497,7 @@ public struct ArrowExpr: ExprBuildable, ExpressibleAsArrowExpr {
       arrowToken: arrowToken
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -1565,7 +1565,7 @@ public struct FloatLiteralExpr: ExprBuildable, ExpressibleAsFloatLiteralExpr {
       floatingDigits: floatingDigits
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -1649,7 +1649,7 @@ public struct TupleExpr: ExprBuildable, ExpressibleAsTupleExpr {
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -1733,7 +1733,7 @@ public struct ArrayExpr: ExprBuildable, ExpressibleAsArrayExpr {
       rightSquare: rightSquare
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -1801,7 +1801,7 @@ public struct DictionaryExpr: ExprBuildable, ExpressibleAsDictionaryExpr {
       rightSquare: rightSquare
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -1874,7 +1874,7 @@ public struct TupleExprElement: SyntaxBuildable, ExpressibleAsTupleExprElement, 
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -1940,7 +1940,7 @@ public struct ArrayElement: SyntaxBuildable, ExpressibleAsArrayElement, HasTrail
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -2015,7 +2015,7 @@ public struct DictionaryElement: SyntaxBuildable, ExpressibleAsDictionaryElement
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -2087,7 +2087,7 @@ public struct IntegerLiteralExpr: ExprBuildable, ExpressibleAsIntegerLiteralExpr
       digits: digits
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -2144,7 +2144,7 @@ public struct BooleanLiteralExpr: ExprBuildable, ExpressibleAsBooleanLiteralExpr
       booleanLiteral: booleanLiteral
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -2222,7 +2222,7 @@ public struct TernaryExpr: ExprBuildable, ExpressibleAsTernaryExpr {
       secondChoice: secondChoice.buildExpr(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -2294,7 +2294,7 @@ public struct MemberAccessExpr: ExprBuildable, ExpressibleAsMemberAccessExpr {
       declNameArguments: declNameArguments?.buildDeclNameArguments(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -2356,7 +2356,7 @@ public struct IsExpr: ExprBuildable, ExpressibleAsIsExpr {
       typeName: typeName.buildType(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -2424,7 +2424,7 @@ public struct AsExpr: ExprBuildable, ExpressibleAsAsExpr {
       typeName: typeName.buildType(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -2480,7 +2480,7 @@ public struct TypeExpr: ExprBuildable, ExpressibleAsTypeExpr {
       type: type.buildType(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -2578,7 +2578,7 @@ public struct ClosureCaptureItem: SyntaxBuildable, ExpressibleAsClosureCaptureIt
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -2667,7 +2667,7 @@ public struct ClosureCaptureSignature: SyntaxBuildable, ExpressibleAsClosureCapt
       rightSquare: rightSquare
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -2723,7 +2723,7 @@ public struct ClosureParam: SyntaxBuildable, ExpressibleAsClosureParam, HasTrail
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -2838,7 +2838,7 @@ public struct ClosureSignature: SyntaxBuildable, ExpressibleAsClosureSignature {
       inTok: inTok
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -2923,7 +2923,7 @@ public struct ClosureExpr: ExprBuildable, ExpressibleAsClosureExpr {
       rightBrace: rightBrace.withLeadingTrivia(.newline + format._makeIndent() + (rightBrace.leadingTrivia ?? []))
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -2979,7 +2979,7 @@ public struct UnresolvedPatternExpr: ExprBuildable, ExpressibleAsUnresolvedPatte
       pattern: pattern.buildPattern(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -3046,7 +3046,7 @@ public struct MultipleTrailingClosureElement: SyntaxBuildable, ExpressibleAsMult
       closure: closure.buildClosureExpr(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -3145,7 +3145,7 @@ public struct FunctionCallExpr: ExprBuildable, ExpressibleAsFunctionCallExpr {
       additionalTrailingClosures: additionalTrailingClosures?.buildMultipleTrailingClosureElementList(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -3250,7 +3250,7 @@ public struct SubscriptExpr: ExprBuildable, ExpressibleAsSubscriptExpr {
       additionalTrailingClosures: additionalTrailingClosures?.buildMultipleTrailingClosureElementList(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -3312,7 +3312,7 @@ public struct OptionalChainingExpr: ExprBuildable, ExpressibleAsOptionalChaining
       questionMark: questionMark
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -3374,7 +3374,7 @@ public struct ForcedValueExpr: ExprBuildable, ExpressibleAsForcedValueExpr {
       exclamationMark: exclamationMark
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -3449,7 +3449,7 @@ public struct PostfixUnaryExpr: ExprBuildable, ExpressibleAsPostfixUnaryExpr {
       operatorToken: operatorToken
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -3510,7 +3510,7 @@ public struct SpecializeExpr: ExprBuildable, ExpressibleAsSpecializeExpr {
       genericArgumentClause: genericArgumentClause.buildGenericArgumentClause(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -3578,7 +3578,7 @@ public struct StringSegment: SyntaxBuildable, ExpressibleAsStringSegment {
       content: content
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -3671,7 +3671,7 @@ public struct ExpressionSegment: SyntaxBuildable, ExpressibleAsExpressionSegment
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -3763,7 +3763,7 @@ public struct StringLiteralExpr: ExprBuildable, ExpressibleAsStringLiteralExpr {
       closeDelimiter: closeDelimiter
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -3831,7 +3831,7 @@ public struct RegexLiteralExpr: ExprBuildable, ExpressibleAsRegexLiteralExpr {
       regex: regex
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -3898,7 +3898,7 @@ public struct KeyPathExpr: ExprBuildable, ExpressibleAsKeyPathExpr {
       expression: expression.buildExpr(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -3955,7 +3955,7 @@ public struct KeyPathBaseExpr: ExprBuildable, ExpressibleAsKeyPathBaseExpr {
       period: period
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -4031,7 +4031,7 @@ public struct ObjcNamePiece: SyntaxBuildable, ExpressibleAsObjcNamePiece {
       dot: dot
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -4099,7 +4099,7 @@ public struct ObjcKeyPathExpr: ExprBuildable, ExpressibleAsObjcKeyPathExpr {
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -4207,7 +4207,7 @@ public struct ObjcSelectorExpr: ExprBuildable, ExpressibleAsObjcSelectorExpr {
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -4268,7 +4268,7 @@ public struct PostfixIfConfigExpr: ExprBuildable, ExpressibleAsPostfixIfConfigEx
       config: config.buildIfConfigDecl(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -4336,7 +4336,7 @@ public struct EditorPlaceholderExpr: ExprBuildable, ExpressibleAsEditorPlacehold
       identifier: identifier
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -4428,7 +4428,7 @@ public struct ObjectLiteralExpr: ExprBuildable, ExpressibleAsObjectLiteralExpr {
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `ExprBuildable`.
@@ -4490,7 +4490,7 @@ public struct TypeInitializerClause: SyntaxBuildable, ExpressibleAsTypeInitializ
       value: value.buildType(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -4595,7 +4595,7 @@ public struct TypealiasDecl: DeclBuildable, ExpressibleAsTypealiasDecl {
       genericWhereClause: genericWhereClause?.buildGenericWhereClause(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -4706,7 +4706,7 @@ public struct AssociatedtypeDecl: DeclBuildable, ExpressibleAsAssociatedtypeDecl
       genericWhereClause: genericWhereClause?.buildGenericWhereClause(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -4790,7 +4790,7 @@ public struct ParameterClause: SyntaxBuildable, ExpressibleAsParameterClause {
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -4846,7 +4846,7 @@ public struct ReturnClause: SyntaxBuildable, ExpressibleAsReturnClause {
       returnType: returnType.buildType(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -4931,7 +4931,7 @@ public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature
       output: output?.buildReturnClause(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -4992,7 +4992,7 @@ public struct IfConfigClause: SyntaxBuildable, ExpressibleAsIfConfigClause {
       elements: elements.buildSyntax(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -5048,7 +5048,7 @@ public struct IfConfigDecl: DeclBuildable, ExpressibleAsIfConfigDecl {
       poundEndif: poundEndif
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -5122,7 +5122,7 @@ public struct PoundErrorDecl: DeclBuildable, ExpressibleAsPoundErrorDecl {
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -5196,7 +5196,7 @@ public struct PoundWarningDecl: DeclBuildable, ExpressibleAsPoundWarningDecl {
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -5270,7 +5270,7 @@ public struct PoundSourceLocation: DeclBuildable, ExpressibleAsPoundSourceLocati
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -5385,7 +5385,7 @@ public struct PoundSourceLocationArgs: SyntaxBuildable, ExpressibleAsPoundSource
       lineNumber: lineNumber
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -5463,7 +5463,7 @@ public struct DeclModifierDetail: SyntaxBuildable, ExpressibleAsDeclModifierDeta
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -5519,7 +5519,7 @@ public struct DeclModifier: SyntaxBuildable, ExpressibleAsDeclModifier {
       detail: detail?.buildDeclModifierDetail(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -5575,7 +5575,7 @@ public struct InheritedType: SyntaxBuildable, ExpressibleAsInheritedType, HasTra
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -5653,7 +5653,7 @@ public struct TypeInheritanceClause: SyntaxBuildable, ExpressibleAsTypeInheritan
       inheritedTypeCollection: inheritedTypeCollection.buildInheritedTypeList(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -5765,7 +5765,7 @@ public struct ClassDecl: DeclBuildable, ExpressibleAsClassDecl {
       members: members.buildMemberDeclBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -5883,7 +5883,7 @@ public struct ActorDecl: DeclBuildable, ExpressibleAsActorDecl {
       members: members.buildMemberDeclBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -6001,7 +6001,7 @@ public struct StructDecl: DeclBuildable, ExpressibleAsStructDecl {
       members: members.buildMemberDeclBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -6119,7 +6119,7 @@ public struct ProtocolDecl: DeclBuildable, ExpressibleAsProtocolDecl {
       members: members.buildMemberDeclBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -6230,7 +6230,7 @@ public struct ExtensionDecl: DeclBuildable, ExpressibleAsExtensionDecl {
       members: members.buildMemberDeclBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -6314,7 +6314,7 @@ public struct MemberDeclBlock: SyntaxBuildable, ExpressibleAsMemberDeclBlock {
       rightBrace: rightBrace.withLeadingTrivia(.newline + format._makeIndent() + (rightBrace.leadingTrivia ?? []))
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -6371,7 +6371,7 @@ public struct MemberDeclListItem: SyntaxBuildable, ExpressibleAsMemberDeclListIt
       semicolon: semicolon
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -6440,7 +6440,7 @@ public struct SourceFile: SyntaxBuildable, ExpressibleAsSourceFile {
       eofToken: eofToken
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -6496,7 +6496,7 @@ public struct InitializerClause: SyntaxBuildable, ExpressibleAsInitializerClause
       value: value.buildExpr(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -6584,7 +6584,7 @@ public struct FunctionParameter: SyntaxBuildable, ExpressibleAsFunctionParameter
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -6710,7 +6710,7 @@ public struct FunctionDecl: DeclBuildable, ExpressibleAsFunctionDecl {
       body: body?.buildCodeBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -6829,7 +6829,7 @@ public struct InitializerDecl: DeclBuildable, ExpressibleAsInitializerDecl {
       body: body?.buildCodeBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -6919,7 +6919,7 @@ public struct DeinitializerDecl: DeclBuildable, ExpressibleAsDeinitializerDecl {
       body: body?.buildCodeBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -7011,7 +7011,7 @@ public struct SubscriptDecl: DeclBuildable, ExpressibleAsSubscriptDecl {
       accessor: accessor?.buildSyntax(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -7086,7 +7086,7 @@ public struct AccessLevelModifier: SyntaxBuildable, ExpressibleAsAccessLevelModi
       modifier: modifier?.buildDeclModifierDetail(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -7156,7 +7156,7 @@ public struct AccessPathComponent: SyntaxBuildable, ExpressibleAsAccessPathCompo
       trailingDot: trailingDot
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -7228,7 +7228,7 @@ public struct ImportDecl: DeclBuildable, ExpressibleAsImportDecl {
       path: path.buildAccessPath(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -7312,7 +7312,7 @@ public struct AccessorParameter: SyntaxBuildable, ExpressibleAsAccessorParameter
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -7419,7 +7419,7 @@ public struct AccessorDecl: DeclBuildable, ExpressibleAsAccessorDecl {
       body: body?.buildCodeBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -7487,7 +7487,7 @@ public struct AccessorBlock: SyntaxBuildable, ExpressibleAsAccessorBlock {
       rightBrace: rightBrace
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -7558,7 +7558,7 @@ public struct PatternBinding: SyntaxBuildable, ExpressibleAsPatternBinding, HasT
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -7653,7 +7653,7 @@ public struct VariableDecl: DeclBuildable, ExpressibleAsVariableDecl {
       bindings: bindings.buildPatternBindingList(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -7744,7 +7744,7 @@ public struct EnumCaseElement: SyntaxBuildable, ExpressibleAsEnumCaseElement, Ha
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -7839,7 +7839,7 @@ public struct EnumCaseDecl: DeclBuildable, ExpressibleAsEnumCaseDecl {
       elements: elements.buildEnumCaseElementList(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -7958,7 +7958,7 @@ public struct EnumDecl: DeclBuildable, ExpressibleAsEnumDecl {
       members: members.buildMemberDeclBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -8036,7 +8036,7 @@ public struct OperatorDecl: DeclBuildable, ExpressibleAsOperatorDecl {
       operatorPrecedenceAndTypes: operatorPrecedenceAndTypes?.buildOperatorPrecedenceAndTypes(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -8099,7 +8099,7 @@ public struct OperatorPrecedenceAndTypes: SyntaxBuildable, ExpressibleAsOperator
       precedenceGroupAndDesignatedTypes: precedenceGroupAndDesignatedTypes.buildIdentifierList(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -8207,7 +8207,7 @@ public struct PrecedenceGroupDecl: DeclBuildable, ExpressibleAsPrecedenceGroupDe
       rightBrace: rightBrace
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `DeclBuildable`.
@@ -8292,7 +8292,7 @@ public struct PrecedenceGroupRelation: SyntaxBuildable, ExpressibleAsPrecedenceG
       otherNames: otherNames.buildPrecedenceGroupNameList(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -8362,7 +8362,7 @@ public struct PrecedenceGroupNameElement: SyntaxBuildable, ExpressibleAsPreceden
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -8442,7 +8442,7 @@ public struct PrecedenceGroupAssignment: SyntaxBuildable, ExpressibleAsPrecedenc
       flag: flag
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -8522,7 +8522,7 @@ public struct PrecedenceGroupAssociativity: SyntaxBuildable, ExpressibleAsPreced
       value: value
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -8616,7 +8616,7 @@ public struct CustomAttribute: SyntaxBuildable, ExpressibleAsCustomAttribute {
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -8695,7 +8695,7 @@ public struct Attribute: SyntaxBuildable, ExpressibleAsAttribute {
       tokenList: tokenList?.buildTokenList(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -8781,7 +8781,7 @@ public struct AvailabilityEntry: SyntaxBuildable, ExpressibleAsAvailabilityEntry
       semicolon: semicolon
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -8867,7 +8867,7 @@ public struct LabeledSpecializeEntry: SyntaxBuildable, ExpressibleAsLabeledSpeci
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -8963,7 +8963,7 @@ public struct TargetFunctionEntry: SyntaxBuildable, ExpressibleAsTargetFunctionE
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -9035,7 +9035,7 @@ public struct NamedAttributeStringArgument: SyntaxBuildable, ExpressibleAsNamedA
       stringOrDeclname: stringOrDeclname.buildSyntax(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -9090,7 +9090,7 @@ public struct DeclName: SyntaxBuildable, ExpressibleAsDeclName {
       declNameArguments: declNameArguments?.buildDeclNameArguments(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -9157,7 +9157,7 @@ public struct ImplementsAttributeArguments: SyntaxBuildable, ExpressibleAsImplem
       declNameArguments: declNameArguments?.buildDeclNameArguments(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -9228,7 +9228,7 @@ public struct ObjCSelectorPiece: SyntaxBuildable, ExpressibleAsObjCSelectorPiece
       colon: colon
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -9322,7 +9322,7 @@ public struct DifferentiableAttributeArguments: SyntaxBuildable, ExpressibleAsDi
       whereClause: whereClause?.buildGenericWhereClause(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -9401,7 +9401,7 @@ public struct DifferentiabilityParamsClause: SyntaxBuildable, ExpressibleAsDiffe
       parameters: parameters.buildSyntax(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -9464,7 +9464,7 @@ public struct DifferentiabilityParams: SyntaxBuildable, ExpressibleAsDifferentia
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -9521,7 +9521,7 @@ public struct DifferentiabilityParam: SyntaxBuildable, ExpressibleAsDifferentiab
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -9639,7 +9639,7 @@ public struct DerivativeRegistrationAttributeArguments: SyntaxBuildable, Express
       diffParams: diffParams?.buildDifferentiabilityParamsClause(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -9706,7 +9706,7 @@ public struct QualifiedDeclName: SyntaxBuildable, ExpressibleAsQualifiedDeclName
       arguments: arguments?.buildDeclNameArguments(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -9762,7 +9762,7 @@ public struct FunctionDeclName: SyntaxBuildable, ExpressibleAsFunctionDeclName {
       arguments: arguments?.buildDeclNameArguments(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -9841,7 +9841,7 @@ public struct BackDeployAttributeSpecList: SyntaxBuildable, ExpressibleAsBackDep
       versionList: versionList.buildBackDeployVersionList(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -9898,7 +9898,7 @@ public struct BackDeployVersionArgument: SyntaxBuildable, ExpressibleAsBackDeplo
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -9968,7 +9968,7 @@ public struct ContinueStmt: StmtBuildable, ExpressibleAsContinueStmt {
       label: label
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -10066,7 +10066,7 @@ public struct WhileStmt: StmtBuildable, ExpressibleAsWhileStmt {
       body: body.buildCodeBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -10142,7 +10142,7 @@ public struct DeferStmt: StmtBuildable, ExpressibleAsDeferStmt {
       body: body.buildCodeBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -10198,7 +10198,7 @@ public struct ExpressionStmt: StmtBuildable, ExpressibleAsExpressionStmt {
       expression: expression.buildExpr(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -10304,7 +10304,7 @@ public struct RepeatWhileStmt: StmtBuildable, ExpressibleAsRepeatWhileStmt {
       condition: condition.buildExpr(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -10395,7 +10395,7 @@ public struct GuardStmt: StmtBuildable, ExpressibleAsGuardStmt {
       body: body.buildCodeBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -10457,7 +10457,7 @@ public struct WhereClause: SyntaxBuildable, ExpressibleAsWhereClause {
       guardResult: guardResult.buildExpr(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -10602,7 +10602,7 @@ public struct ForInStmt: StmtBuildable, ExpressibleAsForInStmt {
       body: body.buildCodeBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -10716,7 +10716,7 @@ public struct SwitchStmt: StmtBuildable, ExpressibleAsSwitchStmt {
       rightBrace: rightBrace.withLeadingTrivia(.newline + format._makeIndent() + (rightBrace.leadingTrivia ?? []))
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -10814,7 +10814,7 @@ public struct DoStmt: StmtBuildable, ExpressibleAsDoStmt {
       catchClauses: catchClauses?.buildCatchClauseList(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -10876,7 +10876,7 @@ public struct ReturnStmt: StmtBuildable, ExpressibleAsReturnStmt {
       expression: expression?.buildExpr(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -10938,7 +10938,7 @@ public struct YieldStmt: StmtBuildable, ExpressibleAsYieldStmt {
       yields: yields.buildSyntax(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -11030,7 +11030,7 @@ public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -11081,7 +11081,7 @@ public struct FallthroughStmt: StmtBuildable, ExpressibleAsFallthroughStmt {
       fallthroughKeyword: fallthroughKeyword
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -11157,7 +11157,7 @@ public struct BreakStmt: StmtBuildable, ExpressibleAsBreakStmt {
       label: label
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -11219,7 +11219,7 @@ public struct ConditionElement: SyntaxBuildable, ExpressibleAsConditionElement, 
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -11295,7 +11295,7 @@ public struct AvailabilityCondition: SyntaxBuildable, ExpressibleAsAvailabilityC
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -11361,7 +11361,7 @@ public struct MatchingPatternCondition: SyntaxBuildable, ExpressibleAsMatchingPa
       initializer: initializer.buildInitializerClause(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -11427,7 +11427,7 @@ public struct OptionalBindingCondition: SyntaxBuildable, ExpressibleAsOptionalBi
       initializer: initializer?.buildInitializerClause(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -11495,7 +11495,7 @@ public struct UnavailabilityCondition: SyntaxBuildable, ExpressibleAsUnavailabil
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -11545,7 +11545,7 @@ public struct DeclarationStmt: StmtBuildable, ExpressibleAsDeclarationStmt {
       declaration: declaration.buildDecl(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -11607,7 +11607,7 @@ public struct ThrowStmt: StmtBuildable, ExpressibleAsThrowStmt {
       expression: expression.buildExpr(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -11720,7 +11720,7 @@ public struct IfStmt: StmtBuildable, ExpressibleAsIfStmt {
       elseBody: elseBody?.buildSyntax(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -11776,7 +11776,7 @@ public struct ElseIfContinuation: SyntaxBuildable, ExpressibleAsElseIfContinuati
       ifStatement: ifStatement.buildIfStmt(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -11846,7 +11846,7 @@ public struct ElseBlock: SyntaxBuildable, ExpressibleAsElseBlock {
       body: body.buildCodeBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -11922,7 +11922,7 @@ public struct SwitchCase: SyntaxBuildable, ExpressibleAsSwitchCase {
       statements: statements.buildCodeBlockItemList(format: format._indented(), leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -11979,7 +11979,7 @@ public struct SwitchDefaultLabel: SyntaxBuildable, ExpressibleAsSwitchDefaultLab
       colon: colon
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -12040,7 +12040,7 @@ public struct CaseItem: SyntaxBuildable, ExpressibleAsCaseItem, HasTrailingComma
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -12110,7 +12110,7 @@ public struct CatchItem: SyntaxBuildable, ExpressibleAsCatchItem, HasTrailingCom
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -12197,7 +12197,7 @@ public struct SwitchCaseLabel: SyntaxBuildable, ExpressibleAsSwitchCaseLabel {
       colon: colon
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -12274,7 +12274,7 @@ public struct CatchClause: SyntaxBuildable, ExpressibleAsCatchClause {
       body: body.buildCodeBlock(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -12375,7 +12375,7 @@ public struct PoundAssertStmt: StmtBuildable, ExpressibleAsPoundAssertStmt {
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `StmtBuildable`.
@@ -12451,7 +12451,7 @@ public struct GenericWhereClause: SyntaxBuildable, ExpressibleAsGenericWhereClau
       requirementList: requirementList.buildGenericRequirementList(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -12507,7 +12507,7 @@ public struct GenericRequirement: SyntaxBuildable, ExpressibleAsGenericRequireme
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -12575,7 +12575,7 @@ public struct SameTypeRequirement: SyntaxBuildable, ExpressibleAsSameTypeRequire
       rightTypeIdentifier: rightTypeIdentifier.buildType(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -12690,7 +12690,7 @@ public struct LayoutRequirement: SyntaxBuildable, ExpressibleAsLayoutRequirement
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -12782,7 +12782,7 @@ public struct GenericParameter: SyntaxBuildable, ExpressibleAsGenericParameter, 
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -12863,7 +12863,7 @@ public struct PrimaryAssociatedType: SyntaxBuildable, ExpressibleAsPrimaryAssoci
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -12949,7 +12949,7 @@ public struct GenericParameterClause: SyntaxBuildable, ExpressibleAsGenericParam
       rightAngleBracket: rightAngleBracket
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -13010,7 +13010,7 @@ public struct ConformanceRequirement: SyntaxBuildable, ExpressibleAsConformanceR
       rightTypeIdentifier: rightTypeIdentifier.buildType(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -13072,7 +13072,7 @@ public struct PrimaryAssociatedTypeClause: SyntaxBuildable, ExpressibleAsPrimary
       rightAngleBracket: rightAngleBracket
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -13127,7 +13127,7 @@ public struct SimpleTypeIdentifier: TypeBuildable, ExpressibleAsSimpleTypeIdenti
       genericArgumentClause: genericArgumentClause?.buildGenericArgumentClause(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `TypeBuildable`.
@@ -13199,7 +13199,7 @@ public struct MemberTypeIdentifier: TypeBuildable, ExpressibleAsMemberTypeIdenti
       genericArgumentClause: genericArgumentClause?.buildGenericArgumentClause(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `TypeBuildable`.
@@ -13256,7 +13256,7 @@ public struct ClassRestrictionType: TypeBuildable, ExpressibleAsClassRestriction
       classKeyword: classKeyword
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `TypeBuildable`.
@@ -13324,7 +13324,7 @@ public struct ArrayType: TypeBuildable, ExpressibleAsArrayType {
       rightSquareBracket: rightSquareBracket
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `TypeBuildable`.
@@ -13403,7 +13403,7 @@ public struct DictionaryType: TypeBuildable, ExpressibleAsDictionaryType {
       rightSquareBracket: rightSquareBracket
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `TypeBuildable`.
@@ -13487,7 +13487,7 @@ public struct MetatypeType: TypeBuildable, ExpressibleAsMetatypeType {
       typeOrProtocol: typeOrProtocol
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `TypeBuildable`.
@@ -13549,7 +13549,7 @@ public struct OptionalType: TypeBuildable, ExpressibleAsOptionalType {
       questionMark: questionMark
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `TypeBuildable`.
@@ -13625,7 +13625,7 @@ public struct ConstrainedSugarType: TypeBuildable, ExpressibleAsConstrainedSugar
       baseType: baseType.buildType(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `TypeBuildable`.
@@ -13687,7 +13687,7 @@ public struct ImplicitlyUnwrappedOptionalType: TypeBuildable, ExpressibleAsImpli
       exclamationMark: exclamationMark
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `TypeBuildable`.
@@ -13749,7 +13749,7 @@ public struct CompositionTypeElement: SyntaxBuildable, ExpressibleAsCompositionT
       ampersand: ampersand
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -13799,7 +13799,7 @@ public struct CompositionType: TypeBuildable, ExpressibleAsCompositionType {
       elements: elements.buildCompositionTypeElementList(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `TypeBuildable`.
@@ -13894,7 +13894,7 @@ public struct TupleTypeElement: SyntaxBuildable, ExpressibleAsTupleTypeElement, 
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -13970,7 +13970,7 @@ public struct TupleType: TypeBuildable, ExpressibleAsTupleType {
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `TypeBuildable`.
@@ -14061,7 +14061,7 @@ public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
       returnType: returnType.buildType(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `TypeBuildable`.
@@ -14128,7 +14128,7 @@ public struct AttributedType: TypeBuildable, ExpressibleAsAttributedType {
       baseType: baseType.buildType(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `TypeBuildable`.
@@ -14190,7 +14190,7 @@ public struct GenericArgument: SyntaxBuildable, ExpressibleAsGenericArgument, Ha
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -14276,7 +14276,7 @@ public struct GenericArgumentClause: SyntaxBuildable, ExpressibleAsGenericArgume
       rightAngleBracket: rightAngleBracket
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -14332,7 +14332,7 @@ public struct TypeAnnotation: SyntaxBuildable, ExpressibleAsTypeAnnotation {
       type: type.buildType(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -14416,7 +14416,7 @@ public struct EnumCasePattern: PatternBuildable, ExpressibleAsEnumCasePattern {
       associatedTuple: associatedTuple?.buildTuplePattern(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `PatternBuildable`.
@@ -14478,7 +14478,7 @@ public struct IsTypePattern: PatternBuildable, ExpressibleAsIsTypePattern {
       type: type.buildType(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `PatternBuildable`.
@@ -14540,7 +14540,7 @@ public struct OptionalPattern: PatternBuildable, ExpressibleAsOptionalPattern {
       questionMark: questionMark
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `PatternBuildable`.
@@ -14596,7 +14596,7 @@ public struct IdentifierPattern: PatternBuildable, ExpressibleAsIdentifierPatter
       identifier: identifier
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `PatternBuildable`.
@@ -14663,7 +14663,7 @@ public struct AsTypePattern: PatternBuildable, ExpressibleAsAsTypePattern {
       type: type.buildType(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `PatternBuildable`.
@@ -14747,7 +14747,7 @@ public struct TuplePattern: PatternBuildable, ExpressibleAsTuplePattern {
       rightParen: rightParen
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `PatternBuildable`.
@@ -14809,7 +14809,7 @@ public struct WildcardPattern: PatternBuildable, ExpressibleAsWildcardPattern {
       typeAnnotation: typeAnnotation?.buildTypeAnnotation(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `PatternBuildable`.
@@ -14900,7 +14900,7 @@ public struct TuplePatternElement: SyntaxBuildable, ExpressibleAsTuplePatternEle
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -14960,7 +14960,7 @@ public struct ExpressionPattern: PatternBuildable, ExpressibleAsExpressionPatter
       expression: expression.buildExpr(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `PatternBuildable`.
@@ -15022,7 +15022,7 @@ public struct ValueBindingPattern: PatternBuildable, ExpressibleAsValueBindingPa
       valuePattern: valuePattern.buildPattern(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `PatternBuildable`.
@@ -15085,7 +15085,7 @@ public struct AvailabilityArgument: SyntaxBuildable, ExpressibleAsAvailabilityAr
       trailingComma: trailingComma
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -15163,7 +15163,7 @@ public struct AvailabilityLabeledArgument: SyntaxBuildable, ExpressibleAsAvailab
       value: value.buildSyntax(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -15233,7 +15233,7 @@ public struct AvailabilityVersionRestriction: SyntaxBuildable, ExpressibleAsAvai
       version: version?.buildVersionTuple(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.
@@ -15311,7 +15311,7 @@ public struct VersionTuple: SyntaxBuildable, ExpressibleAsVersionTuple {
       patchVersion: patchVersion
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia)
+    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
   }
 
   /// Conformance to `SyntaxBuildable`.


### PR DESCRIPTION
The list of Tricia pieces look likes this

```
TriviaPiece with 1 Newlines
TriviaPiece with 4 Spaces
TriviaPiece with '/// A nested struct' DocLineComment
TriviaPiece with 1 Newlines
TriviaPiece with '/// with multi line comment' DocLineComment
TriviaPiece with 1 Newlines
```

That need to be replaces with

```
TriviaPiece with 1 Newlines
TriviaPiece with 4 Spaces
TriviaPiece with '/// A nested struct' DocLineComment
TriviaPiece with 1 Newlines
TriviaPiece with 4 Spaces
TriviaPiece with '/// with multi line comment' DocLineComment
TriviaPiece with 1 Newlines
TriviaPiece with 4 Spaces
```