### PR TITLE
Add `--gyb-only` flag to build script's `generate-source-code`

### DIFF
--- a/build-script.py
+++ b/build-script.py
@@ -656,15 +656,16 @@ def generate_source_code_command(args):
         printerr("FAIL: Generating .gyb files failed")
         printerr("Executing: %s" % " ".join(e.cmd))
         printerr(e.output)
-
-    run_code_generation(
-        toolchain=args.toolchain,
-        build_dir=realpath(args.build_dir),
-        multiroot_data_file=args.multiroot_data_file,
-        release=args.release,
-        verbose=args.verbose,
-        swiftsyntaxbuilder_destination=os.path.join(SWIFTSYNTAXBUILDER_DIR, "generated")
-    )
+    
+    if not args.gyb_only:
+        run_code_generation(
+            toolchain=args.toolchain,
+            build_dir=realpath(args.build_dir),
+            multiroot_data_file=args.multiroot_data_file,
+            release=args.release,
+            verbose=args.verbose,
+            swiftsyntaxbuilder_destination=os.path.join(SWIFTSYNTAXBUILDER_DIR, "generated")
+        )
 
 
 def verify_source_code_command(args):
@@ -833,6 +834,12 @@ def parse_args():
     generate_source_code_parser.set_defaults(func=generate_source_code_command)
     
     add_default_build_arguments(generate_source_code_parser)
+
+    generate_source_code_parser.add_argument(
+        "--gyb-only",
+        action="store_true",
+        help="Only generate gyb templates (and not SwiftSyntaxBuilderGeneration's templates)",
+    )
 
     generate_source_code_parser.add_argument(
         "--gyb-exec",


### PR DESCRIPTION
When working on `SwiftSyntaxBuilderGeneration`, it can occasionally be useful to only generate `gyb` templates (skipping `SwiftSyntaxBuilderGeneration`'s Swift templates). Previously this could be achieved with `--degyb-only`, with the refactoring of the build script, however, this option was removed in favor of `generate-source-code`, which performs all forms of code generation at once. While that is what most people want to do most of the time, having the option to only perform gyb generation can still be a useful tool sometimes, hence this new flag.

cc @kimdv @ahoppen 