### PR TITLE
Generate `SYNTAX_NODES` in `SwiftSyntaxBuilderGeneration`

### DIFF
--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxNodes.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxNodes.swift
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+let SYNTAX_NODES: [Node] = COMMON_NODES
+  + EXPR_NODES
+  + DECL_NODES
+  + ATTRIBUTE_NODES
+  + STMT_NODES
+  + GENERIC_NODES
+  + TYPE_NODES
+  + PATTERN_NODES
+  + AVAILABILITY_NODES


### PR DESCRIPTION
A small patch that generates the Swift declarations for `SYNTAX_NODES` (thereby also moving [this declaration](https://github.com/apple/swift-syntax/blob/674aa55f9386392428c74d42a54fb5fa07c56676/Sources/SwiftSyntaxBuilderGeneration/Templates/ResultBuildersFile.swift#L17-L26) into its own file for #479). These are required by many `gyb` templates in `SwiftSyntaxBuilder` and let us move forward with the migration to Swift templates.

The definition of `SYNTAX_NODES` is analogous to [the corresponding declaration](https://github.com/apple/swift/blob/198b9746221cbccd7c525b1e8de18338f8336e51/utils/gyb_syntax_support/__init__.py#L21-L23) in `gyb_syntax_support`.

cc @ahoppen @kimdv 