### PR TITLE
Port `SyntaxBuildableWrappers` to Swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -104,6 +104,7 @@ let package = Package(
           "gyb_helpers",
           "AttributeNodes.swift.gyb",
           "AvailabilityNodes.swift.gyb",
+          "BuilderInitializableTypes.swift.gyb",
           "Classification.swift.gyb",
           "CommonNodes.swift.gyb",
           "DeclNodes.swift.gyb",

--- a/Package.swift
+++ b/Package.swift
@@ -107,6 +107,7 @@ let package = Package(
           "Classification.swift.gyb",
           "CommonNodes.swift.gyb",
           "DeclNodes.swift.gyb",
+          "ExpressibleAsConformances.swift.gyb",
           "ExprNodes.swift.gyb",
           "GenericNodes.swift.gyb",
           "Kinds.swift.gyb",

--- a/Package.swift
+++ b/Package.swift
@@ -113,6 +113,7 @@ let package = Package(
           "NodeSerializationCodes.swift.gyb",
           "PatternNodes.swift.gyb",
           "StmtNodes.swift.gyb",
+          "SyntaxBaseKinds.swift.gyb",
           "Tokens.swift.gyb",
           "Traits.swift.gyb",
           "Trivia.swift.gyb",

--- a/Sources/SwiftSyntaxBuilderGeneration/BuilderInitializableTypes.swift.gyb
+++ b/Sources/SwiftSyntaxBuilderGeneration/BuilderInitializableTypes.swift.gyb
@@ -1,0 +1,25 @@
+%{
+  from gyb_syntax_support import *
+  from gyb_helpers import BUILDER_INITIALIZABLE_TYPES
+  # -*- mode: Swift -*-
+  # Ignore the following admonition; it applies to the resulting .swift file only
+}%
+//// Automatically Generated From BuilderInitializableTypes.swift.gyb.
+//// Do Not Edit Directly!
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+let BUILDER_INITIALIZABLE_TYPES: [String: String?] = [
+% for type, resolved_type in BUILDER_INITIALIZABLE_TYPES.items():
+  "${type}": ${'"' + resolved_type + '"' if resolved_type is not None else 'nil'},
+% end
+]

--- a/Sources/SwiftSyntaxBuilderGeneration/ExpressibleAsConformances.swift.gyb
+++ b/Sources/SwiftSyntaxBuilderGeneration/ExpressibleAsConformances.swift.gyb
@@ -1,0 +1,29 @@
+%{
+  from gyb_syntax_support import *
+  from gyb_helpers import SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES
+  # -*- mode: Swift -*-
+  # Ignore the following admonition; it applies to the resulting .swift file only
+}%
+//// Automatically Generated From ExpressibleAsConformances.swift.gyb.
+//// Do Not Edit Directly!
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+let SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES: [String: [String]] = [
+% for buildable, conformances in SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES.items():
+  "${buildable}": [
+%   for conformance in conformances:
+    "${conformance}",
+%   end
+  ],
+% end
+]

--- a/Sources/SwiftSyntaxBuilderGeneration/Node.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Node.swift
@@ -28,18 +28,6 @@ class Node {
   let elementsSeparatedByNewline: Bool
   let collectionElement: String
 
-  var baseType: String {
-    if self.baseKind == "SyntaxCollection" {
-      return "Syntax"
-    } else {
-      return kindToType(kind: baseKind)
-    }
-  }
-
-  var collectionElementType: String {
-    return kindToType(kind: collectionElement)
-  }
-
   /// Returns `True` if this node declares one of the base syntax kinds.
   var isBase: Bool {
     return SyntaxBaseKinds.contains(syntaxKind)

--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxBaseKinds.swift.gyb
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxBaseKinds.swift.gyb
@@ -1,0 +1,25 @@
+%{
+  from gyb_syntax_support import *
+  from gyb_syntax_support.kinds import SYNTAX_BASE_KINDS
+  # -*- mode: Swift -*-
+  # Ignore the following admonition; it applies to the resulting .swift file only
+}%
+//// Automatically Generated From SyntaxBaseKinds.swift.gyb.
+//// Do Not Edit Directly!
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+let SYNTAX_BASE_KINDS: Set<String> = [
+% for name in SYNTAX_BASE_KINDS:
+  "${name}",
+% end
+]

--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableChild.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableChild.swift
@@ -1,0 +1,81 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Extension to the `Child` type to provide functionality specific to
+/// SwiftSyntaxBuilder.
+extension Child {
+  /// The type of this child, represented by a `SyntaxBuildableType`, which can
+  /// be used to create the corresponding `Buildable` and `ExpressibleAs` types.
+  var type: SyntaxBuildableType {
+    SyntaxBuildableType(
+      syntaxKind: syntaxKind,
+      isOptional: isOptional
+    )
+  }
+
+  /// If the child node has documentation associated with it, return it as single
+  /// line string. Otherwise return an empty string.
+  var documentation: String {
+    flattened(indentedDocumentation: description ?? "")
+  }
+
+  /// Generate a Swift expression that creates a proper SwiftSyntax node of type
+  /// `type.syntax` from a variable named `varName` of type `type.buildable` that
+  /// represents this child node.
+  func generateExprBuildSyntaxNode(varName: String, formatName: String) -> String {
+    if type.isToken {
+      if requiresLeadingNewline {
+        return "\(varName).withLeadingTrivia(.newline + \(formatName)._makeIndent() + (\(varName).leadingTrivia ?? []))"
+      } else {
+        return varName
+      }
+    } else {
+      let format = formatName + (isIndented ? "._indented()" : "")
+      let expr = "\(varName)\(type.optionalQuestionMark)"
+      return "\(expr).build\(type.baseName)(format: \(format), leadingTrivia: nil)"
+    }
+  }
+
+  /// If this node is a token that can't contain arbitrary text, generate a Swift
+  /// `assert` statement that verifies the variable with name var_name and of type
+  /// `TokenSyntax` contains one of the supported text options. Otherwise return `nil`.
+  func generateAssertStmtTextChoices(varName: String) -> String? {
+    guard type.isToken else {
+      return nil
+    }
+
+    let choices: [String]
+    if !textChoices.isEmpty {
+      choices = textChoices
+    } else if !tokenChoices.isEmpty {
+      let optionalChoices = tokenChoices.map { SYNTAX_TOKEN_MAP["\($0.name)Token"]?.text }
+      choices = optionalChoices.compactMap { $0 }
+      guard choices.count == optionalChoices.count else {
+        // If `nil` is in the text choices, one of the token options can contain arbitrary
+        // text. Don't generate an assert statement.
+        return nil
+      }
+    } else {
+      return nil
+    }
+
+    var assertChoices: [String] = []
+    if type.isOptional {
+      assertChoices.append("\(varName) == nil")
+    }
+    let unwrap = type.isOptional ? "!" : ""
+    for textChoice in choices {
+      assertChoices.append("\(varName)\(unwrap) == \"\(textChoice)\"")
+    }
+    return "assert(\(assertChoices.joined(separator: " || ")))"
+  }
+}

--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableNode.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableNode.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Extension to the `Node` type to provide functionality specific to
+/// SwiftSyntaxBuilder.
+extension Node {
+  /// The node's syntax kind as `SyntaxBuildableType`.
+  var type: SyntaxBuildableType {
+    SyntaxBuildableType(syntaxKind: syntaxKind)
+  }
+
+  /// The node's syntax kind as `SyntaxBuildableType`.
+  var baseType: SyntaxBuildableType {
+    SyntaxBuildableType(syntaxKind: baseKind)
+  }
+
+  /// If documentation exists for this node, return it as a single-line string.
+  /// Otherwise return an empty string.
+  var documentation: String {
+    guard let description = description,
+          !description.isEmpty else {
+      return ""
+    }
+    if isSyntaxCollection {
+      return "`\(syntaxKind)` represents a collection of `\(description)`"
+    } else {
+      return flattened(indentedDocumentation: description)
+    }
+  }
+
+  /// Assuming this node is a syntax collection, the type of its elements.
+  var collectionElementType: SyntaxBuildableType {
+    assert(isSyntaxCollection)
+    return SyntaxBuildableType(syntaxKind: collectionElement)
+  }
+
+  /// Assuming this node has a single child without a default value, that child.
+  var singleNonDefaultedChild: Child {
+    let nonDefaultedParams = children.filter(\.type.defaultInitialization.isEmpty)
+    assert(nonDefaultedParams.count == 1)
+    return nonDefaultedParams[0]
+  }
+
+  static func from(type: SyntaxBuildableType) -> Node {
+    let baseName = type.baseName
+    guard let node = SYNTAX_NODE_MAP[baseName] else {
+      fatalError("Base name \(baseName) does not have a syntax node")
+    }
+    return node
+  }
+}

--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableType.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableType.swift
@@ -1,0 +1,223 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Wrapper around the syntax kind strings to provide functionality specific to
+/// SwiftSyntaxBuilder. In particular, this includes the functionality to create
+/// the `*Buildable`, `ExpressibleAs*` and `*Syntax` Swift types from the syntax
+/// kind.
+struct SyntaxBuildableType: Hashable {
+  let syntaxKind: String
+  let tokenKind: String?
+  let isOptional: Bool
+
+  /// If optional `?`, otherwise the empty string.
+  var optionalQuestionMark: String {
+    isOptional ? "?" : ""
+  }
+
+  /// Whether this is a token.
+  var isToken: Bool {
+    syntaxKind == "Token"
+  }
+
+  /// This type with `isOptional` set to false.
+  var nonOptional: Self {
+    tokenKind.map { Self(syntaxKind: $0) } ?? Self(syntaxKind: syntaxKind)
+  }
+
+  /// The token if this is a token.
+  var token: Token? {
+    tokenKind.flatMap { SYNTAX_TOKEN_MAP[$0] }
+  }
+
+  /// If the type has a default value (because it is optional or a token
+  /// with fixed test), return an expression of the form ` = defaultValue`
+  /// that can be used as the default value for a function parameter.
+  /// Otherwise, return the empty string.
+  var defaultInitialization: String {
+    if isOptional {
+      return " = nil"
+    } else if isToken {
+      if let token = token, token.text != nil {
+        return " = TokenSyntax.`\(lowercaseFirstWord(name: token.name))`"
+      } else if tokenKind == "EOFToken" {
+        return " = TokenSyntax.eof"
+      }
+    }
+    return ""
+  }
+
+  /// Whether the type is a syntax collection.
+  var isSyntaxCollection: Bool {
+    syntaxKind == "SyntaxCollection"
+      || (baseType.map(\.isSyntaxCollection) ?? false)
+  }
+
+  /// The raw base name of this kind. Used for the `build*` methods in the
+  /// defined in the buildable types.
+  var baseName: String {
+    syntaxKind
+  }
+
+  /// Return the name of the `Buildable` type that is the main entry point for building
+  /// SwiftSyntax trees using `SwiftSyntaxBuilder`.
+  ///
+  /// These names look as follows:
+  ///  - For nodes: The node name, e.g. `IdentifierExpr` (these are implemented as structs)
+  ///  - For base kinds: `<BaseKind>Buildable`, e.g. `ExprBuildable` (these are implemented as protocols)
+  ///  - For token: `TokenSyntax` (tokens don't have a dedicated type in SwiftSyntaxBuilder)
+  /// If the type is optional, this terminates with a '?'.
+  var buildable: String {
+    if isToken {
+      // Tokens don't have a dedicated buildable type.
+      return "TokenSyntax\(optionalQuestionMark)"
+    } else if SYNTAX_BASE_KINDS.contains(syntaxKind) {
+      return "\(syntaxKind)Buildable\(optionalQuestionMark)"
+    } else {
+      return "\(syntaxKind)\(optionalQuestionMark)"
+    }
+  }
+
+  /// Whether parameters of this type should be initializable by a result builder.
+  /// Used for certain syntax collections and block-like structures (e.g. `CodeBlock`,
+  /// `MemberDeclList`).
+  var isBuilderInitializable: Bool {
+    BUILDER_INITIALIZABLE_TYPES.keys.contains(nonOptional.buildable)
+  }
+
+  /// A type suitable for initializing this type through a result builder (e.g.
+  /// returns `CodeBlockItemList` for `CodeBlock`) and otherwise itself.
+  var builderInitializableType: Self {
+    let buildable = nonOptional.buildable
+    return Self(
+      syntaxKind: BUILDER_INITIALIZABLE_TYPES[buildable].flatMap { $0 } ?? buildable,
+      isOptional: isOptional
+    )
+  }
+
+  /// The type from `buildable()` without any question marks attached.
+  /// This is used for the `create*` methods defined in the `ExpressibleAs*` protocols.
+  var buildableBaseName: String {
+    nonOptional.buildable
+  }
+
+  /// The `ExpressibleAs*` Swift type for this syntax kind. Tokens don't
+  /// have an `ExpressibleAs*` type, so for those this method just returns
+  /// `TokenSyntax`. If the type is optional, this terminates with a `?`.
+  var expressibleAs: String {
+    if isToken {
+      // Tokens don't have a dedicated ExpressibleAs type.
+      return buildable
+    } else {
+      return "ExpressibleAs\(buildable)"
+    }
+  }
+
+  /// The corresponding `*Syntax` type defined in the `SwiftSyntax` module,
+  /// which will eventually get built from `SwiftSyntaxBuilder`. If the type
+  /// is optional, this terminates with a `?`.
+  var syntax: String {
+    if syntaxKind == "Syntax" {
+      return "Syntax\(optionalQuestionMark)"
+    } else {
+      return "\(syntaxKind)Syntax\(optionalQuestionMark)"
+    }
+  }
+
+  /// Assuming that this is a collection type, the type of the result builder
+  /// that can be used to build the collection.
+  var resultBuilder: String {
+    "\(syntaxKind)Builder\(optionalQuestionMark)"
+  }
+
+  /// The collection types in which this type occurs as an element.
+  /// We automatically make the `ExpressibleAs*` protocols conform to the
+  /// `ExpressibleAs*` protocol of the collection they occur in.
+  var elementInCollections: [Self] {
+    SYNTAX_NODES
+      .filter { $0.isSyntaxCollection && $0.collectionElementType == self }
+      .map { $0.type }
+  }
+
+  /// Whether this type has the `WithTrailingComma` trait.
+  var hasWithTrailingCommaTrait: Bool {
+    SYNTAX_NODES.contains { $0.type == self && $0.traits.contains("WithTrailingComma") }
+  }
+
+  /// Types that take a single non-optional parameter of this types
+  /// and to which this type is thus convertible. We automatically
+  /// make the `ExpressibleAs*` of this type conform to the `ExpressibleAs*`
+  /// protocol of the convertible types.
+  var convertibleToTypes: [Self] {
+    (SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES[buildable] ?? [])
+      .map { Self(syntaxKind: $0) }
+  }
+
+  /// If this type is not a base kind, its base type (see `SyntaxBuildableNode.base_type()`),
+  /// otherwise `nil`.
+  var baseType: Self? {
+    if !SYNTAX_BASE_KINDS.contains(syntaxKind) && !isToken {
+      return Node.from(type: self).baseType
+    } else {
+      return nil
+    }
+  }
+
+  /// The types to which this `ExpressibleAs*` type conforms to via
+  /// automatically generated conformances.
+  var generatedExpressibleAsConformances: [Self] {
+    var conformances = elementInCollections + convertibleToTypes
+    if let baseType = baseType, baseType.baseName != "SyntaxCollection" {
+      conformances.append(baseType)
+    }
+    return conformances
+  }
+
+  /// The types to which this `ExpressibleAs*` type conforms to via
+  /// automatically generated conformances, including transitive conformances.
+  var transitiveExpressibleAsConformances: [Self] {
+    generatedExpressibleAsConformances.flatMap { conformance in
+      [conformance] + conformance.transitiveExpressibleAsConformances
+    }
+  }
+
+  /// The types to which this `ExpressibleAs*` type implicitly conforms
+  /// to via transitive conformances. These conformances don't need to be
+  /// spelled out explicitly in the source code.
+  var impliedExpressibleAsConformances: [Self] {
+    generatedExpressibleAsConformances.flatMap { conformance in
+      conformance.transitiveExpressibleAsConformances
+    }
+  }
+
+  init(syntaxKind: String, isOptional: Bool = false) {
+    self.isOptional = isOptional
+    if syntaxKind.hasSuffix("Token") {
+      // There are different token kinds but all of them are represented by `Token` in the Swift source (see `kind_to_type` in `gyb_syntax_support`).
+      self.syntaxKind = "Token"
+      self.tokenKind = syntaxKind
+    } else {
+      self.syntaxKind = syntaxKind
+      self.tokenKind = nil
+    }
+  }
+
+  /// Generate an expression that converts a variable named `varName`
+  /// which is of `expressibleAs` type to an object of type `buildable`.
+  func generateExprConvertParamTypeToStorageType(varName: String) -> String {
+    if isToken {
+      return varName
+    } else {
+      return "\(varName)\(optionalQuestionMark).create\(buildableBaseName)()"
+    }
+  }
+}

--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxNodes.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxNodes.swift
@@ -19,3 +19,8 @@ let SYNTAX_NODES: [Node] = COMMON_NODES
   + TYPE_NODES
   + PATTERN_NODES
   + AVAILABILITY_NODES
+
+/// A lookup table of nodes indexed by their kind.
+let SYNTAX_NODE_MAP: [String: Node] = Dictionary(
+  uniqueKeysWithValues: SYNTAX_NODES.map { node in (node.syntaxKind, node) }
+)

--- a/Sources/SwiftSyntaxBuilderGeneration/Utils.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Utils.swift
@@ -51,3 +51,22 @@ func lowercaseFirstWord(name: String) -> String {
 
   return name.prefix(wordIndex).lowercased() + name[name.index(name.startIndex, offsetBy: wordIndex)..<name.endIndex]
 }
+
+/// Trims leading and trailing whitespace from each line.
+func dedented<Lines: Sequence>(lines: Lines) -> [String] where Lines.Element: StringProtocol {
+  lines.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+}
+
+/// Trims leading and trailing whitespace from each line.
+func dedented(string: String) -> String {
+  dedented(lines: string.split(separator: "\n"))
+    .joined(separator: "\n")
+}
+
+/// Creates a single-line documentation string from indented
+/// documentation as written in `gyb_syntax_support`.
+func flattened(indentedDocumentation: String) -> String {
+  dedented(string: indentedDocumentation)
+    .replacingOccurrences(of: "\n", with: "")
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+}

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/BuilderInitializableTypes.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/BuilderInitializableTypes.swift
@@ -1,0 +1,33 @@
+//// Automatically Generated From BuilderInitializableTypes.swift.gyb.
+//// Do Not Edit Directly!
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+let BUILDER_INITIALIZABLE_TYPES: [String: String?] = [
+  "CodeBlock": "CodeBlockItemList",
+  "MemberDeclBlock": "MemberDeclList",
+  "CodeBlockItemList": nil,
+  "MemberDeclList": nil,
+  "PatternBindingList": nil,
+  "SwitchCaseList": nil,
+  "ArrayElementList": nil,
+  "TupleExprElementList": nil,
+  "EnumCaseElementList": nil,
+  "FunctionParameterList": nil,
+  "GenericParameterList": nil,
+  "GenericRequirementList": nil,
+  "InheritedTypeList": nil,
+  "ClosureCaptureItemList": nil,
+  "CaseItemList": nil,
+  "GenericArgumentList": nil,
+  "TuplePatternElementList": nil,
+]

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/ExpressibleAsConformances.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/ExpressibleAsConformances.swift
@@ -1,0 +1,61 @@
+//// Automatically Generated From ExpressibleAsConformances.swift.gyb.
+//// Do Not Edit Directly!
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+let SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES: [String: [String]] = [
+  "AccessorList": [
+    "AccessorBlock",
+  ],
+  "ArrayType": [
+    "TypeAnnotation",
+  ],
+  "CodeBlockItemList": [
+    "CodeBlock",
+  ],
+  "DeclBuildable": [
+    "CodeBlockItem",
+    "MemberDeclListItem",
+  ],
+  "DictionaryType": [
+    "TypeAnnotation",
+  ],
+  "ExprList": [
+    "ConditionElement",
+  ],
+  "FunctionCallExpr": [
+    "CodeBlockItem",
+  ],
+  "MemberDeclList": [
+    "MemberDeclBlock",
+  ],
+  "SequenceExpr": [
+    "CodeBlockItem",
+    "TupleExprElement",
+  ],
+  "SimpleTypeIdentifier": [
+    "TypeAnnotation",
+    "TypeExpr",
+  ],
+  "StmtBuildable": [
+    "CodeBlockItem",
+  ],
+  "TokenSyntax": [
+    "BinaryOperatorExpr",
+    "DeclModifier",
+    "IdentifierExpr",
+  ],
+  "TypeBuildable": [
+    "ReturnClause",
+    "TypeInitializerClause",
+  ],
+]

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/SyntaxBaseKinds.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/SyntaxBaseKinds.swift
@@ -1,0 +1,23 @@
+//// Automatically Generated From SyntaxBaseKinds.swift.gyb.
+//// Do Not Edit Directly!
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+let SYNTAX_BASE_KINDS: Set<String> = [
+  "Decl",
+  "Expr",
+  "Pattern",
+  "Stmt",
+  "Syntax",
+  "SyntaxCollection",
+  "Type",
+]

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_helpers/BuilderInitializableTypes.py
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_helpers/BuilderInitializableTypes.py
@@ -1,0 +1,1 @@
+../../SwiftSyntaxBuilder/gyb_helpers/BuilderInitializableTypes.py

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_helpers/ExpressibleAsConformances.py
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_helpers/ExpressibleAsConformances.py
@@ -1,0 +1,1 @@
+../../SwiftSyntaxBuilder/gyb_helpers/ExpressibleAsConformances.py

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_helpers/__init__.py
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_helpers/__init__.py
@@ -1,1 +1,2 @@
 from .utils import make_swift_child, make_swift_node
+from .ExpressibleAsConformances import SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_helpers/__init__.py
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_helpers/__init__.py
@@ -1,2 +1,3 @@
 from .utils import make_swift_child, make_swift_node
+from .BuilderInitializableTypes import BUILDER_INITIALIZABLE_TYPES
 from .ExpressibleAsConformances import SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES


### PR DESCRIPTION
Based on #482.

This branch ports the `SyntaxBuildableWrappers` from `gyb_helpers` to Swift for use in `SwiftSyntaxBuilderGeneration`. The API is kept as close as possible to the original (with slight modifications to make it more swifty), hoping that it will make the translation of gyb templates to Swift as seamless as possible.

Currently WIP since only a subset of the API surface has been ported.