### PR TITLE
Add a method to SyntaxProtocol to dump a node recursively for debugging purposes

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -442,6 +442,13 @@ public extension SyntaxProtocol {
     return String(reflecting: type(of: self))
   }
 
+  /// Dumps the syntax node and all of its children for debugging purposes.
+  var recursiveDescription: String {
+    var result = ""
+    dump(self, to: &result)
+    return result
+  }
+
   /// Prints the raw value of this node to the provided stream.
   /// - Parameter stream: The stream to which to print the raw tree.
   func write<Target>(to target: inout Target)


### PR DESCRIPTION
Swift’s reflection mechanism is actually really good to print syntax trees, we just need a convenient way to access it.

This produces output as can be seen in [CustomReflectableTests.swift](https://github.com/apple/swift-syntax/blob/main/Tests/SwiftSyntaxTest/CustomReflectableTests.swift).