### PR TITLE
Improve Debug Description for TriviaPieces

### DIFF
--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -65,7 +65,17 @@ extension TriviaPiece: TextOutputStreamable {
 extension TriviaPiece: CustomDebugStringConvertible {
   /// Returns a description used by dump.
   public var debugDescription: String {
-    return "TriviaPiece"
+    switch self {
+% for trivia in TRIVIAS:
+%   if trivia.is_collection():
+    case .${trivia.lower_name}s(let data):
+      return "${trivia.lower_name}s(\(data))"
+%   else:
+    case .${trivia.lower_name}(let name):
+      return "${trivia.lower_name}(\(name))"
+%   end
+% end
+    }
   }
 }
 

--- a/Sources/SwiftSyntax/gyb_generated/Trivia.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Trivia.swift
@@ -90,7 +90,32 @@ extension TriviaPiece: TextOutputStreamable {
 extension TriviaPiece: CustomDebugStringConvertible {
   /// Returns a description used by dump.
   public var debugDescription: String {
-    return "TriviaPiece"
+    switch self {
+    case .spaces(let data):
+      return "spaces(\(data))"
+    case .tabs(let data):
+      return "tabs(\(data))"
+    case .verticalTabs(let data):
+      return "verticalTabs(\(data))"
+    case .formfeeds(let data):
+      return "formfeeds(\(data))"
+    case .newlines(let data):
+      return "newlines(\(data))"
+    case .carriageReturns(let data):
+      return "carriageReturns(\(data))"
+    case .carriageReturnLineFeeds(let data):
+      return "carriageReturnLineFeeds(\(data))"
+    case .lineComment(let name):
+      return "lineComment(\(name))"
+    case .blockComment(let name):
+      return "blockComment(\(name))"
+    case .docLineComment(let name):
+      return "docLineComment(\(name))"
+    case .docBlockComment(let name):
+      return "docBlockComment(\(name))"
+    case .garbageText(let name):
+      return "garbageText(\(name))"
+    }
   }
 }
 


### PR DESCRIPTION
Print out the kind and number of trivia pieces instead of a "TriviaPiece"
placeholder. This makes debugging failures involving trivia a touch easier.