### PR TITLE
Add Keyword Convenience Initializer To TokenKind

### DIFF
--- a/Sources/SwiftSyntax/TokenKind.swift.gyb
+++ b/Sources/SwiftSyntax/TokenKind.swift.gyb
@@ -31,6 +31,21 @@ public enum TokenKind {
   case ${kind}
 % end
 
+  /// Initializes a keyword token kind from its string representation. If the
+  /// given string is not a keyword, this function returns `nil`.
+  public init?(keyword: String) {
+    switch keyword {
+% for token in SYNTAX_TOKENS:
+%   if token.is_keyword:
+    case "${token.text}":
+      self = .${token.swift_kind()}
+%   end
+% end
+    default:
+      return nil
+    }
+  }
+
   /// The textual representation of this token kind.
   var text: String {
     switch self {

--- a/Sources/SwiftSyntax/gyb_generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/TokenKind.swift
@@ -140,8 +140,180 @@ public enum TokenKind {
   case stringInterpolationAnchor
   case yield
 
+  /// Initializes a keyword token kind from its string representation. If the
+  /// given string is not a keyword, this function returns `nil`.
+  public init?(keyword: String) {
+    switch keyword {
+    case "associatedtype":
+      self = .associatedtypeKeyword
+    case "class":
+      self = .classKeyword
+    case "deinit":
+      self = .deinitKeyword
+    case "enum":
+      self = .enumKeyword
+    case "extension":
+      self = .extensionKeyword
+    case "func":
+      self = .funcKeyword
+    case "import":
+      self = .importKeyword
+    case "init":
+      self = .initKeyword
+    case "inout":
+      self = .inoutKeyword
+    case "let":
+      self = .letKeyword
+    case "operator":
+      self = .operatorKeyword
+    case "precedencegroup":
+      self = .precedencegroupKeyword
+    case "protocol":
+      self = .protocolKeyword
+    case "struct":
+      self = .structKeyword
+    case "subscript":
+      self = .subscriptKeyword
+    case "typealias":
+      self = .typealiasKeyword
+    case "var":
+      self = .varKeyword
+    case "fileprivate":
+      self = .fileprivateKeyword
+    case "internal":
+      self = .internalKeyword
+    case "private":
+      self = .privateKeyword
+    case "public":
+      self = .publicKeyword
+    case "static":
+      self = .staticKeyword
+    case "defer":
+      self = .deferKeyword
+    case "if":
+      self = .ifKeyword
+    case "guard":
+      self = .guardKeyword
+    case "do":
+      self = .doKeyword
+    case "repeat":
+      self = .repeatKeyword
+    case "else":
+      self = .elseKeyword
+    case "for":
+      self = .forKeyword
+    case "in":
+      self = .inKeyword
+    case "while":
+      self = .whileKeyword
+    case "return":
+      self = .returnKeyword
+    case "break":
+      self = .breakKeyword
+    case "continue":
+      self = .continueKeyword
+    case "fallthrough":
+      self = .fallthroughKeyword
+    case "switch":
+      self = .switchKeyword
+    case "case":
+      self = .caseKeyword
+    case "default":
+      self = .defaultKeyword
+    case "where":
+      self = .whereKeyword
+    case "catch":
+      self = .catchKeyword
+    case "throw":
+      self = .throwKeyword
+    case "as":
+      self = .asKeyword
+    case "Any":
+      self = .anyKeyword
+    case "false":
+      self = .falseKeyword
+    case "is":
+      self = .isKeyword
+    case "nil":
+      self = .nilKeyword
+    case "rethrows":
+      self = .rethrowsKeyword
+    case "super":
+      self = .superKeyword
+    case "self":
+      self = .selfKeyword
+    case "Self":
+      self = .capitalSelfKeyword
+    case "true":
+      self = .trueKeyword
+    case "try":
+      self = .tryKeyword
+    case "throws":
+      self = .throwsKeyword
+    case "__FILE__":
+      self = .__file__Keyword
+    case "__LINE__":
+      self = .__line__Keyword
+    case "__COLUMN__":
+      self = .__column__Keyword
+    case "__FUNCTION__":
+      self = .__function__Keyword
+    case "__DSO_HANDLE__":
+      self = .__dso_handle__Keyword
+    case "_":
+      self = .wildcardKeyword
+    case "#keyPath":
+      self = .poundKeyPathKeyword
+    case "#line":
+      self = .poundLineKeyword
+    case "#selector":
+      self = .poundSelectorKeyword
+    case "#file":
+      self = .poundFileKeyword
+    case "#fileID":
+      self = .poundFileIDKeyword
+    case "#filePath":
+      self = .poundFilePathKeyword
+    case "#column":
+      self = .poundColumnKeyword
+    case "#function":
+      self = .poundFunctionKeyword
+    case "#dsohandle":
+      self = .poundDsohandleKeyword
+    case "#assert":
+      self = .poundAssertKeyword
+    case "#sourceLocation":
+      self = .poundSourceLocationKeyword
+    case "#warning":
+      self = .poundWarningKeyword
+    case "#error":
+      self = .poundErrorKeyword
+    case "#if":
+      self = .poundIfKeyword
+    case "#else":
+      self = .poundElseKeyword
+    case "#elseif":
+      self = .poundElseifKeyword
+    case "#endif":
+      self = .poundEndifKeyword
+    case "#available":
+      self = .poundAvailableKeyword
+    case "#unavailable":
+      self = .poundUnavailableKeyword
+    case "#fileLiteral":
+      self = .poundFileLiteralKeyword
+    case "#imageLiteral":
+      self = .poundImageLiteralKeyword
+    case "#colorLiteral":
+      self = .poundColorLiteralKeyword
+    default:
+      return nil
+    }
+  }
+
   /// The textual representation of this token kind.
-  var text: String {
+  @_spi(Testing)
+  public var text: String {
     switch self {
     case .eof: return ""
     case .associatedtypeKeyword: return "associatedtype"

--- a/Tests/SwiftSyntaxParserTest/TokenTest.swift
+++ b/Tests/SwiftSyntaxParserTest/TokenTest.swift
@@ -1,5 +1,5 @@
 import XCTest
-import SwiftSyntax
+@_spi(Testing) import SwiftSyntax
 import SwiftSyntaxParser
 
 public class TokenTests: XCTestCase {
@@ -21,5 +21,74 @@ public class TokenTests: XCTestCase {
     let tok2 = SyntaxFactory.makeMultilineStringQuoteToken()
     XCTAssertTrue(tok2.tokenKind == .multilineStringQuote)
     XCTAssertEqual(tok2.contentLength.utf8Length, 3)
+  }
+
+  public func testKeywordRoundTripping() throws {
+    let someKeywords = [
+      TokenKind.associatedtypeKeyword,
+      TokenKind.classKeyword,
+      TokenKind.deinitKeyword,
+      TokenKind.enumKeyword,
+      TokenKind.extensionKeyword,
+      TokenKind.funcKeyword,
+      TokenKind.importKeyword,
+      TokenKind.initKeyword,
+      TokenKind.inoutKeyword,
+      TokenKind.letKeyword,
+      TokenKind.operatorKeyword,
+      TokenKind.precedencegroupKeyword,
+      TokenKind.protocolKeyword,
+      TokenKind.structKeyword,
+      TokenKind.subscriptKeyword,
+      TokenKind.typealiasKeyword,
+      TokenKind.varKeyword,
+      TokenKind.fileprivateKeyword,
+      TokenKind.internalKeyword,
+      TokenKind.privateKeyword,
+      TokenKind.publicKeyword,
+      TokenKind.staticKeyword,
+      TokenKind.deferKeyword,
+      TokenKind.ifKeyword,
+      TokenKind.guardKeyword,
+      TokenKind.doKeyword,
+      TokenKind.repeatKeyword,
+      TokenKind.elseKeyword,
+      TokenKind.forKeyword,
+      TokenKind.inKeyword,
+      TokenKind.whileKeyword,
+      TokenKind.returnKeyword,
+      TokenKind.breakKeyword,
+      TokenKind.continueKeyword,
+      TokenKind.fallthroughKeyword,
+      TokenKind.switchKeyword,
+      TokenKind.caseKeyword,
+      TokenKind.defaultKeyword,
+      TokenKind.whereKeyword,
+      TokenKind.catchKeyword,
+      TokenKind.throwKeyword,
+      TokenKind.asKeyword,
+      TokenKind.anyKeyword,
+      TokenKind.falseKeyword,
+      TokenKind.isKeyword,
+      TokenKind.nilKeyword,
+      TokenKind.rethrowsKeyword,
+      TokenKind.superKeyword,
+      TokenKind.selfKeyword,
+      TokenKind.capitalSelfKeyword,
+      TokenKind.trueKeyword,
+      TokenKind.tryKeyword,
+      TokenKind.throwsKeyword,
+      TokenKind.__file__Keyword,
+      TokenKind.__line__Keyword,
+      TokenKind.__column__Keyword,
+      TokenKind.__function__Keyword,
+      TokenKind.__dso_handle__Keyword,
+      TokenKind.wildcardKeyword,
+    ]
+
+    for keyword in someKeywords {
+      let constructedKeyword = try XCTUnwrap(TokenKind(keyword: keyword.text))
+      XCTAssertEqual(keyword, constructedKeyword)
+    }
   }
 }


### PR DESCRIPTION
Add an API that allows the construction of specifically keyword token
kinds from text.