### PR TITLE
Space as default leading trivia for left brace

### DIFF
--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -5467,7 +5467,7 @@ public enum SyntaxFactory {
                      trailingTrivia: trailingTrivia)
   }
   public static func makeLeftBraceToken(
-    leadingTrivia: Trivia = [],
+    leadingTrivia: Trivia = .space,
     trailingTrivia: Trivia = []
   ) -> TokenSyntax {
     return makeToken(.leftBrace, presence: .present,

--- a/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
@@ -14,1984 +14,1984 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
-public protocol ExpressibleAsDeclBuildable: ExpressibleAsCodeBlockItem, ExpressibleAsMemberDeclListItem{
+public protocol ExpressibleAsDeclBuildable: ExpressibleAsCodeBlockItem, ExpressibleAsMemberDeclListItem {
   func createDeclBuildable()-> DeclBuildable
 }
-public extension ExpressibleAsDeclBuildable{
+public extension ExpressibleAsDeclBuildable {
   /// Conformance to ExpressibleAsCodeBlockItem
-func createCodeBlockItem()-> CodeBlockItem{
+func createCodeBlockItem()-> CodeBlockItem {
     return CodeBlockItem(item: self)
   }
   /// Conformance to ExpressibleAsMemberDeclListItem
-func createMemberDeclListItem()-> MemberDeclListItem{
+func createMemberDeclListItem()-> MemberDeclListItem {
     return MemberDeclListItem(decl: self)
   }
 }
-public protocol ExpressibleAsExprBuildable: ExpressibleAsExprList{
+public protocol ExpressibleAsExprBuildable: ExpressibleAsExprList {
   func createExprBuildable()-> ExprBuildable
 }
-public extension ExpressibleAsExprBuildable{
+public extension ExpressibleAsExprBuildable {
   /// Conformance to `ExpressibleAsExprList`
-func createExprList()-> ExprList{
+func createExprList()-> ExprList {
     return ExprList([self])
   }
 }
-public protocol ExpressibleAsPatternBuildable{
+public protocol ExpressibleAsPatternBuildable {
   func createPatternBuildable()-> PatternBuildable
 }
-public protocol ExpressibleAsStmtBuildable: ExpressibleAsCodeBlockItem{
+public protocol ExpressibleAsStmtBuildable: ExpressibleAsCodeBlockItem {
   func createStmtBuildable()-> StmtBuildable
 }
-public extension ExpressibleAsStmtBuildable{
+public extension ExpressibleAsStmtBuildable {
   /// Conformance to ExpressibleAsCodeBlockItem
-func createCodeBlockItem()-> CodeBlockItem{
+func createCodeBlockItem()-> CodeBlockItem {
     return CodeBlockItem(item: self)
   }
 }
-public protocol ExpressibleAsSyntaxBuildable: ExpressibleAsStringLiteralSegments, ExpressibleAsPrecedenceGroupAttributeList, ExpressibleAsAttributeList, ExpressibleAsSpecializeAttributeSpecList, ExpressibleAsSwitchCaseList{
+public protocol ExpressibleAsSyntaxBuildable: ExpressibleAsStringLiteralSegments, ExpressibleAsPrecedenceGroupAttributeList, ExpressibleAsAttributeList, ExpressibleAsSpecializeAttributeSpecList, ExpressibleAsSwitchCaseList {
   func createSyntaxBuildable()-> SyntaxBuildable
 }
-public extension ExpressibleAsSyntaxBuildable{
+public extension ExpressibleAsSyntaxBuildable {
   /// Conformance to `ExpressibleAsStringLiteralSegments`
-func createStringLiteralSegments()-> StringLiteralSegments{
+func createStringLiteralSegments()-> StringLiteralSegments {
     return StringLiteralSegments([self])
   }
   /// Conformance to `ExpressibleAsPrecedenceGroupAttributeList`
-func createPrecedenceGroupAttributeList()-> PrecedenceGroupAttributeList{
+func createPrecedenceGroupAttributeList()-> PrecedenceGroupAttributeList {
     return PrecedenceGroupAttributeList([self])
   }
   /// Conformance to `ExpressibleAsAttributeList`
-func createAttributeList()-> AttributeList{
+func createAttributeList()-> AttributeList {
     return AttributeList([self])
   }
   /// Conformance to `ExpressibleAsSpecializeAttributeSpecList`
-func createSpecializeAttributeSpecList()-> SpecializeAttributeSpecList{
+func createSpecializeAttributeSpecList()-> SpecializeAttributeSpecList {
     return SpecializeAttributeSpecList([self])
   }
   /// Conformance to `ExpressibleAsSwitchCaseList`
-func createSwitchCaseList()-> SwitchCaseList{
+func createSwitchCaseList()-> SwitchCaseList {
     return SwitchCaseList([self])
   }
 }
-public protocol ExpressibleAsTypeBuildable: ExpressibleAsReturnClause, ExpressibleAsTypeInitializerClause{
+public protocol ExpressibleAsTypeBuildable: ExpressibleAsReturnClause, ExpressibleAsTypeInitializerClause {
   func createTypeBuildable()-> TypeBuildable
 }
-public extension ExpressibleAsTypeBuildable{
+public extension ExpressibleAsTypeBuildable {
   /// Conformance to ExpressibleAsReturnClause
-func createReturnClause()-> ReturnClause{
+func createReturnClause()-> ReturnClause {
     return ReturnClause(returnType: self)
   }
   /// Conformance to ExpressibleAsTypeInitializerClause
-func createTypeInitializerClause()-> TypeInitializerClause{
+func createTypeInitializerClause()-> TypeInitializerClause {
     return TypeInitializerClause(value: self)
   }
 }
-public protocol ExpressibleAsCodeBlockItem: ExpressibleAsCodeBlockItemList{
+public protocol ExpressibleAsCodeBlockItem: ExpressibleAsCodeBlockItemList {
   func createCodeBlockItem()-> CodeBlockItem
 }
-public extension ExpressibleAsCodeBlockItem{
+public extension ExpressibleAsCodeBlockItem {
   /// Conformance to `ExpressibleAsCodeBlockItemList`
-func createCodeBlockItemList()-> CodeBlockItemList{
+func createCodeBlockItemList()-> CodeBlockItemList {
     return CodeBlockItemList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createCodeBlockItem()
   }
 }
-public protocol ExpressibleAsCodeBlockItemList: ExpressibleAsCodeBlock{
+public protocol ExpressibleAsCodeBlockItemList: ExpressibleAsCodeBlock {
   func createCodeBlockItemList()-> CodeBlockItemList
 }
-public extension ExpressibleAsCodeBlockItemList{
+public extension ExpressibleAsCodeBlockItemList {
   /// Conformance to ExpressibleAsCodeBlock
-func createCodeBlock()-> CodeBlock{
+func createCodeBlock()-> CodeBlock {
     return CodeBlock(statements: self)
   }
 }
-public protocol ExpressibleAsCodeBlock: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsCodeBlock: ExpressibleAsSyntaxBuildable {
   func createCodeBlock()-> CodeBlock
 }
-public extension ExpressibleAsCodeBlock{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsCodeBlock {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createCodeBlock()
   }
 }
-public protocol ExpressibleAsInOutExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsInOutExpr: ExpressibleAsExprBuildable {
   func createInOutExpr()-> InOutExpr
 }
-public extension ExpressibleAsInOutExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsInOutExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createInOutExpr()
   }
 }
-public protocol ExpressibleAsPoundColumnExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsPoundColumnExpr: ExpressibleAsExprBuildable {
   func createPoundColumnExpr()-> PoundColumnExpr
 }
-public extension ExpressibleAsPoundColumnExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsPoundColumnExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createPoundColumnExpr()
   }
 }
-public protocol ExpressibleAsTupleExprElementList{
+public protocol ExpressibleAsTupleExprElementList {
   func createTupleExprElementList()-> TupleExprElementList
 }
-public protocol ExpressibleAsArrayElementList{
+public protocol ExpressibleAsArrayElementList {
   func createArrayElementList()-> ArrayElementList
 }
-public protocol ExpressibleAsDictionaryElementList{
+public protocol ExpressibleAsDictionaryElementList {
   func createDictionaryElementList()-> DictionaryElementList
 }
-public protocol ExpressibleAsStringLiteralSegments{
+public protocol ExpressibleAsStringLiteralSegments {
   func createStringLiteralSegments()-> StringLiteralSegments
 }
-public protocol ExpressibleAsTryExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsTryExpr: ExpressibleAsExprBuildable {
   func createTryExpr()-> TryExpr
 }
-public extension ExpressibleAsTryExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsTryExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createTryExpr()
   }
 }
-public protocol ExpressibleAsAwaitExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsAwaitExpr: ExpressibleAsExprBuildable {
   func createAwaitExpr()-> AwaitExpr
 }
-public extension ExpressibleAsAwaitExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsAwaitExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createAwaitExpr()
   }
 }
-public protocol ExpressibleAsDeclNameArgument: ExpressibleAsDeclNameArgumentList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsDeclNameArgument: ExpressibleAsDeclNameArgumentList, ExpressibleAsSyntaxBuildable {
   func createDeclNameArgument()-> DeclNameArgument
 }
-public extension ExpressibleAsDeclNameArgument{
+public extension ExpressibleAsDeclNameArgument {
   /// Conformance to `ExpressibleAsDeclNameArgumentList`
-func createDeclNameArgumentList()-> DeclNameArgumentList{
+func createDeclNameArgumentList()-> DeclNameArgumentList {
     return DeclNameArgumentList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createDeclNameArgument()
   }
 }
-public protocol ExpressibleAsDeclNameArgumentList{
+public protocol ExpressibleAsDeclNameArgumentList {
   func createDeclNameArgumentList()-> DeclNameArgumentList
 }
-public protocol ExpressibleAsDeclNameArguments: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsDeclNameArguments: ExpressibleAsSyntaxBuildable {
   func createDeclNameArguments()-> DeclNameArguments
 }
-public extension ExpressibleAsDeclNameArguments{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsDeclNameArguments {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createDeclNameArguments()
   }
 }
-public protocol ExpressibleAsIdentifierExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsIdentifierExpr: ExpressibleAsExprBuildable {
   func createIdentifierExpr()-> IdentifierExpr
 }
-public extension ExpressibleAsIdentifierExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsIdentifierExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createIdentifierExpr()
   }
 }
-public protocol ExpressibleAsSuperRefExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsSuperRefExpr: ExpressibleAsExprBuildable {
   func createSuperRefExpr()-> SuperRefExpr
 }
-public extension ExpressibleAsSuperRefExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsSuperRefExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createSuperRefExpr()
   }
 }
-public protocol ExpressibleAsNilLiteralExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsNilLiteralExpr: ExpressibleAsExprBuildable {
   func createNilLiteralExpr()-> NilLiteralExpr
 }
-public extension ExpressibleAsNilLiteralExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsNilLiteralExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createNilLiteralExpr()
   }
 }
-public protocol ExpressibleAsDiscardAssignmentExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsDiscardAssignmentExpr: ExpressibleAsExprBuildable {
   func createDiscardAssignmentExpr()-> DiscardAssignmentExpr
 }
-public extension ExpressibleAsDiscardAssignmentExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsDiscardAssignmentExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createDiscardAssignmentExpr()
   }
 }
-public protocol ExpressibleAsAssignmentExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsAssignmentExpr: ExpressibleAsExprBuildable {
   func createAssignmentExpr()-> AssignmentExpr
 }
-public extension ExpressibleAsAssignmentExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsAssignmentExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createAssignmentExpr()
   }
 }
-public protocol ExpressibleAsSequenceExpr: ExpressibleAsCodeBlockItem, ExpressibleAsTupleExprElement, ExpressibleAsExprBuildable{
+public protocol ExpressibleAsSequenceExpr: ExpressibleAsCodeBlockItem, ExpressibleAsTupleExprElement, ExpressibleAsExprBuildable {
   func createSequenceExpr()-> SequenceExpr
 }
-public extension ExpressibleAsSequenceExpr{
+public extension ExpressibleAsSequenceExpr {
   /// Conformance to ExpressibleAsCodeBlockItem
-func createCodeBlockItem()-> CodeBlockItem{
+func createCodeBlockItem()-> CodeBlockItem {
     return CodeBlockItem(item: self)
   }
   /// Conformance to ExpressibleAsTupleExprElement
-func createTupleExprElement()-> TupleExprElement{
+func createTupleExprElement()-> TupleExprElement {
     return TupleExprElement(expression: self)
   }
-  func createExprBuildable()-> ExprBuildable{
+  func createExprBuildable()-> ExprBuildable {
     return createSequenceExpr()
   }
 }
-public protocol ExpressibleAsExprList: ExpressibleAsConditionElement{
+public protocol ExpressibleAsExprList: ExpressibleAsConditionElement {
   func createExprList()-> ExprList
 }
-public extension ExpressibleAsExprList{
+public extension ExpressibleAsExprList {
   /// Conformance to ExpressibleAsConditionElement
-func createConditionElement()-> ConditionElement{
+func createConditionElement()-> ConditionElement {
     return ConditionElement(condition: self)
   }
 }
-public protocol ExpressibleAsPoundLineExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsPoundLineExpr: ExpressibleAsExprBuildable {
   func createPoundLineExpr()-> PoundLineExpr
 }
-public extension ExpressibleAsPoundLineExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsPoundLineExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createPoundLineExpr()
   }
 }
-public protocol ExpressibleAsPoundFileExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsPoundFileExpr: ExpressibleAsExprBuildable {
   func createPoundFileExpr()-> PoundFileExpr
 }
-public extension ExpressibleAsPoundFileExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsPoundFileExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createPoundFileExpr()
   }
 }
-public protocol ExpressibleAsPoundFileIDExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsPoundFileIDExpr: ExpressibleAsExprBuildable {
   func createPoundFileIDExpr()-> PoundFileIDExpr
 }
-public extension ExpressibleAsPoundFileIDExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsPoundFileIDExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createPoundFileIDExpr()
   }
 }
-public protocol ExpressibleAsPoundFilePathExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsPoundFilePathExpr: ExpressibleAsExprBuildable {
   func createPoundFilePathExpr()-> PoundFilePathExpr
 }
-public extension ExpressibleAsPoundFilePathExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsPoundFilePathExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createPoundFilePathExpr()
   }
 }
-public protocol ExpressibleAsPoundFunctionExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsPoundFunctionExpr: ExpressibleAsExprBuildable {
   func createPoundFunctionExpr()-> PoundFunctionExpr
 }
-public extension ExpressibleAsPoundFunctionExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsPoundFunctionExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createPoundFunctionExpr()
   }
 }
-public protocol ExpressibleAsPoundDsohandleExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsPoundDsohandleExpr: ExpressibleAsExprBuildable {
   func createPoundDsohandleExpr()-> PoundDsohandleExpr
 }
-public extension ExpressibleAsPoundDsohandleExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsPoundDsohandleExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createPoundDsohandleExpr()
   }
 }
-public protocol ExpressibleAsSymbolicReferenceExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsSymbolicReferenceExpr: ExpressibleAsExprBuildable {
   func createSymbolicReferenceExpr()-> SymbolicReferenceExpr
 }
-public extension ExpressibleAsSymbolicReferenceExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsSymbolicReferenceExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createSymbolicReferenceExpr()
   }
 }
-public protocol ExpressibleAsPrefixOperatorExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsPrefixOperatorExpr: ExpressibleAsExprBuildable {
   func createPrefixOperatorExpr()-> PrefixOperatorExpr
 }
-public extension ExpressibleAsPrefixOperatorExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsPrefixOperatorExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createPrefixOperatorExpr()
   }
 }
-public protocol ExpressibleAsBinaryOperatorExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsBinaryOperatorExpr: ExpressibleAsExprBuildable {
   func createBinaryOperatorExpr()-> BinaryOperatorExpr
 }
-public extension ExpressibleAsBinaryOperatorExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsBinaryOperatorExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createBinaryOperatorExpr()
   }
 }
-public protocol ExpressibleAsArrowExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsArrowExpr: ExpressibleAsExprBuildable {
   func createArrowExpr()-> ArrowExpr
 }
-public extension ExpressibleAsArrowExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsArrowExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createArrowExpr()
   }
 }
-public protocol ExpressibleAsFloatLiteralExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsFloatLiteralExpr: ExpressibleAsExprBuildable {
   func createFloatLiteralExpr()-> FloatLiteralExpr
 }
-public extension ExpressibleAsFloatLiteralExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsFloatLiteralExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createFloatLiteralExpr()
   }
 }
-public protocol ExpressibleAsTupleExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsTupleExpr: ExpressibleAsExprBuildable {
   func createTupleExpr()-> TupleExpr
 }
-public extension ExpressibleAsTupleExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsTupleExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createTupleExpr()
   }
 }
-public protocol ExpressibleAsArrayExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsArrayExpr: ExpressibleAsExprBuildable {
   func createArrayExpr()-> ArrayExpr
 }
-public extension ExpressibleAsArrayExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsArrayExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createArrayExpr()
   }
 }
-public protocol ExpressibleAsDictionaryExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsDictionaryExpr: ExpressibleAsExprBuildable {
   func createDictionaryExpr()-> DictionaryExpr
 }
-public extension ExpressibleAsDictionaryExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsDictionaryExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createDictionaryExpr()
   }
 }
-public protocol ExpressibleAsTupleExprElement: ExpressibleAsTupleExprElementList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsTupleExprElement: ExpressibleAsTupleExprElementList, ExpressibleAsSyntaxBuildable {
   func createTupleExprElement()-> TupleExprElement
 }
-public extension ExpressibleAsTupleExprElement{
+public extension ExpressibleAsTupleExprElement {
   /// Conformance to `ExpressibleAsTupleExprElementList`
-func createTupleExprElementList()-> TupleExprElementList{
+func createTupleExprElementList()-> TupleExprElementList {
     return TupleExprElementList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createTupleExprElement()
   }
 }
-public protocol ExpressibleAsArrayElement: ExpressibleAsArrayElementList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsArrayElement: ExpressibleAsArrayElementList, ExpressibleAsSyntaxBuildable {
   func createArrayElement()-> ArrayElement
 }
-public extension ExpressibleAsArrayElement{
+public extension ExpressibleAsArrayElement {
   /// Conformance to `ExpressibleAsArrayElementList`
-func createArrayElementList()-> ArrayElementList{
+func createArrayElementList()-> ArrayElementList {
     return ArrayElementList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createArrayElement()
   }
 }
-public protocol ExpressibleAsDictionaryElement: ExpressibleAsDictionaryElementList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsDictionaryElement: ExpressibleAsDictionaryElementList, ExpressibleAsSyntaxBuildable {
   func createDictionaryElement()-> DictionaryElement
 }
-public extension ExpressibleAsDictionaryElement{
+public extension ExpressibleAsDictionaryElement {
   /// Conformance to `ExpressibleAsDictionaryElementList`
-func createDictionaryElementList()-> DictionaryElementList{
+func createDictionaryElementList()-> DictionaryElementList {
     return DictionaryElementList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createDictionaryElement()
   }
 }
-public protocol ExpressibleAsIntegerLiteralExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsIntegerLiteralExpr: ExpressibleAsExprBuildable {
   func createIntegerLiteralExpr()-> IntegerLiteralExpr
 }
-public extension ExpressibleAsIntegerLiteralExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsIntegerLiteralExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createIntegerLiteralExpr()
   }
 }
-public protocol ExpressibleAsBooleanLiteralExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsBooleanLiteralExpr: ExpressibleAsExprBuildable {
   func createBooleanLiteralExpr()-> BooleanLiteralExpr
 }
-public extension ExpressibleAsBooleanLiteralExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsBooleanLiteralExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createBooleanLiteralExpr()
   }
 }
-public protocol ExpressibleAsTernaryExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsTernaryExpr: ExpressibleAsExprBuildable {
   func createTernaryExpr()-> TernaryExpr
 }
-public extension ExpressibleAsTernaryExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsTernaryExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createTernaryExpr()
   }
 }
-public protocol ExpressibleAsMemberAccessExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsMemberAccessExpr: ExpressibleAsExprBuildable {
   func createMemberAccessExpr()-> MemberAccessExpr
 }
-public extension ExpressibleAsMemberAccessExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsMemberAccessExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createMemberAccessExpr()
   }
 }
-public protocol ExpressibleAsIsExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsIsExpr: ExpressibleAsExprBuildable {
   func createIsExpr()-> IsExpr
 }
-public extension ExpressibleAsIsExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsIsExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createIsExpr()
   }
 }
-public protocol ExpressibleAsAsExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsAsExpr: ExpressibleAsExprBuildable {
   func createAsExpr()-> AsExpr
 }
-public extension ExpressibleAsAsExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsAsExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createAsExpr()
   }
 }
-public protocol ExpressibleAsTypeExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsTypeExpr: ExpressibleAsExprBuildable {
   func createTypeExpr()-> TypeExpr
 }
-public extension ExpressibleAsTypeExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsTypeExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createTypeExpr()
   }
 }
-public protocol ExpressibleAsClosureCaptureItem: ExpressibleAsClosureCaptureItemList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsClosureCaptureItem: ExpressibleAsClosureCaptureItemList, ExpressibleAsSyntaxBuildable {
   func createClosureCaptureItem()-> ClosureCaptureItem
 }
-public extension ExpressibleAsClosureCaptureItem{
+public extension ExpressibleAsClosureCaptureItem {
   /// Conformance to `ExpressibleAsClosureCaptureItemList`
-func createClosureCaptureItemList()-> ClosureCaptureItemList{
+func createClosureCaptureItemList()-> ClosureCaptureItemList {
     return ClosureCaptureItemList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createClosureCaptureItem()
   }
 }
-public protocol ExpressibleAsClosureCaptureItemList{
+public protocol ExpressibleAsClosureCaptureItemList {
   func createClosureCaptureItemList()-> ClosureCaptureItemList
 }
-public protocol ExpressibleAsClosureCaptureSignature: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsClosureCaptureSignature: ExpressibleAsSyntaxBuildable {
   func createClosureCaptureSignature()-> ClosureCaptureSignature
 }
-public extension ExpressibleAsClosureCaptureSignature{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsClosureCaptureSignature {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createClosureCaptureSignature()
   }
 }
-public protocol ExpressibleAsClosureParam: ExpressibleAsClosureParamList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsClosureParam: ExpressibleAsClosureParamList, ExpressibleAsSyntaxBuildable {
   func createClosureParam()-> ClosureParam
 }
-public extension ExpressibleAsClosureParam{
+public extension ExpressibleAsClosureParam {
   /// Conformance to `ExpressibleAsClosureParamList`
-func createClosureParamList()-> ClosureParamList{
+func createClosureParamList()-> ClosureParamList {
     return ClosureParamList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createClosureParam()
   }
 }
-public protocol ExpressibleAsClosureParamList{
+public protocol ExpressibleAsClosureParamList {
   func createClosureParamList()-> ClosureParamList
 }
-public protocol ExpressibleAsClosureSignature: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsClosureSignature: ExpressibleAsSyntaxBuildable {
   func createClosureSignature()-> ClosureSignature
 }
-public extension ExpressibleAsClosureSignature{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsClosureSignature {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createClosureSignature()
   }
 }
-public protocol ExpressibleAsClosureExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsClosureExpr: ExpressibleAsExprBuildable {
   func createClosureExpr()-> ClosureExpr
 }
-public extension ExpressibleAsClosureExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsClosureExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createClosureExpr()
   }
 }
-public protocol ExpressibleAsUnresolvedPatternExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsUnresolvedPatternExpr: ExpressibleAsExprBuildable {
   func createUnresolvedPatternExpr()-> UnresolvedPatternExpr
 }
-public extension ExpressibleAsUnresolvedPatternExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsUnresolvedPatternExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createUnresolvedPatternExpr()
   }
 }
-public protocol ExpressibleAsMultipleTrailingClosureElement: ExpressibleAsMultipleTrailingClosureElementList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsMultipleTrailingClosureElement: ExpressibleAsMultipleTrailingClosureElementList, ExpressibleAsSyntaxBuildable {
   func createMultipleTrailingClosureElement()-> MultipleTrailingClosureElement
 }
-public extension ExpressibleAsMultipleTrailingClosureElement{
+public extension ExpressibleAsMultipleTrailingClosureElement {
   /// Conformance to `ExpressibleAsMultipleTrailingClosureElementList`
-func createMultipleTrailingClosureElementList()-> MultipleTrailingClosureElementList{
+func createMultipleTrailingClosureElementList()-> MultipleTrailingClosureElementList {
     return MultipleTrailingClosureElementList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createMultipleTrailingClosureElement()
   }
 }
-public protocol ExpressibleAsMultipleTrailingClosureElementList{
+public protocol ExpressibleAsMultipleTrailingClosureElementList {
   func createMultipleTrailingClosureElementList()-> MultipleTrailingClosureElementList
 }
-public protocol ExpressibleAsFunctionCallExpr: ExpressibleAsCodeBlockItem, ExpressibleAsExprBuildable{
+public protocol ExpressibleAsFunctionCallExpr: ExpressibleAsCodeBlockItem, ExpressibleAsExprBuildable {
   func createFunctionCallExpr()-> FunctionCallExpr
 }
-public extension ExpressibleAsFunctionCallExpr{
+public extension ExpressibleAsFunctionCallExpr {
   /// Conformance to ExpressibleAsCodeBlockItem
-func createCodeBlockItem()-> CodeBlockItem{
+func createCodeBlockItem()-> CodeBlockItem {
     return CodeBlockItem(item: self)
   }
-  func createExprBuildable()-> ExprBuildable{
+  func createExprBuildable()-> ExprBuildable {
     return createFunctionCallExpr()
   }
 }
-public protocol ExpressibleAsSubscriptExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsSubscriptExpr: ExpressibleAsExprBuildable {
   func createSubscriptExpr()-> SubscriptExpr
 }
-public extension ExpressibleAsSubscriptExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsSubscriptExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createSubscriptExpr()
   }
 }
-public protocol ExpressibleAsOptionalChainingExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsOptionalChainingExpr: ExpressibleAsExprBuildable {
   func createOptionalChainingExpr()-> OptionalChainingExpr
 }
-public extension ExpressibleAsOptionalChainingExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsOptionalChainingExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createOptionalChainingExpr()
   }
 }
-public protocol ExpressibleAsForcedValueExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsForcedValueExpr: ExpressibleAsExprBuildable {
   func createForcedValueExpr()-> ForcedValueExpr
 }
-public extension ExpressibleAsForcedValueExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsForcedValueExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createForcedValueExpr()
   }
 }
-public protocol ExpressibleAsPostfixUnaryExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsPostfixUnaryExpr: ExpressibleAsExprBuildable {
   func createPostfixUnaryExpr()-> PostfixUnaryExpr
 }
-public extension ExpressibleAsPostfixUnaryExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsPostfixUnaryExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createPostfixUnaryExpr()
   }
 }
-public protocol ExpressibleAsSpecializeExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsSpecializeExpr: ExpressibleAsExprBuildable {
   func createSpecializeExpr()-> SpecializeExpr
 }
-public extension ExpressibleAsSpecializeExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsSpecializeExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createSpecializeExpr()
   }
 }
-public protocol ExpressibleAsStringSegment: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsStringSegment: ExpressibleAsSyntaxBuildable {
   func createStringSegment()-> StringSegment
 }
-public extension ExpressibleAsStringSegment{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsStringSegment {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createStringSegment()
   }
 }
-public protocol ExpressibleAsExpressionSegment: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsExpressionSegment: ExpressibleAsSyntaxBuildable {
   func createExpressionSegment()-> ExpressionSegment
 }
-public extension ExpressibleAsExpressionSegment{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsExpressionSegment {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createExpressionSegment()
   }
 }
-public protocol ExpressibleAsStringLiteralExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsStringLiteralExpr: ExpressibleAsExprBuildable {
   func createStringLiteralExpr()-> StringLiteralExpr
 }
-public extension ExpressibleAsStringLiteralExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsStringLiteralExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createStringLiteralExpr()
   }
 }
-public protocol ExpressibleAsRegexLiteralExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsRegexLiteralExpr: ExpressibleAsExprBuildable {
   func createRegexLiteralExpr()-> RegexLiteralExpr
 }
-public extension ExpressibleAsRegexLiteralExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsRegexLiteralExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createRegexLiteralExpr()
   }
 }
-public protocol ExpressibleAsKeyPathExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsKeyPathExpr: ExpressibleAsExprBuildable {
   func createKeyPathExpr()-> KeyPathExpr
 }
-public extension ExpressibleAsKeyPathExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsKeyPathExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createKeyPathExpr()
   }
 }
-public protocol ExpressibleAsKeyPathBaseExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsKeyPathBaseExpr: ExpressibleAsExprBuildable {
   func createKeyPathBaseExpr()-> KeyPathBaseExpr
 }
-public extension ExpressibleAsKeyPathBaseExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsKeyPathBaseExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createKeyPathBaseExpr()
   }
 }
-public protocol ExpressibleAsObjcNamePiece: ExpressibleAsObjcName, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsObjcNamePiece: ExpressibleAsObjcName, ExpressibleAsSyntaxBuildable {
   func createObjcNamePiece()-> ObjcNamePiece
 }
-public extension ExpressibleAsObjcNamePiece{
+public extension ExpressibleAsObjcNamePiece {
   /// Conformance to `ExpressibleAsObjcName`
-func createObjcName()-> ObjcName{
+func createObjcName()-> ObjcName {
     return ObjcName([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createObjcNamePiece()
   }
 }
-public protocol ExpressibleAsObjcName{
+public protocol ExpressibleAsObjcName {
   func createObjcName()-> ObjcName
 }
-public protocol ExpressibleAsObjcKeyPathExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsObjcKeyPathExpr: ExpressibleAsExprBuildable {
   func createObjcKeyPathExpr()-> ObjcKeyPathExpr
 }
-public extension ExpressibleAsObjcKeyPathExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsObjcKeyPathExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createObjcKeyPathExpr()
   }
 }
-public protocol ExpressibleAsObjcSelectorExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsObjcSelectorExpr: ExpressibleAsExprBuildable {
   func createObjcSelectorExpr()-> ObjcSelectorExpr
 }
-public extension ExpressibleAsObjcSelectorExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsObjcSelectorExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createObjcSelectorExpr()
   }
 }
-public protocol ExpressibleAsPostfixIfConfigExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsPostfixIfConfigExpr: ExpressibleAsExprBuildable {
   func createPostfixIfConfigExpr()-> PostfixIfConfigExpr
 }
-public extension ExpressibleAsPostfixIfConfigExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsPostfixIfConfigExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createPostfixIfConfigExpr()
   }
 }
-public protocol ExpressibleAsEditorPlaceholderExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsEditorPlaceholderExpr: ExpressibleAsExprBuildable {
   func createEditorPlaceholderExpr()-> EditorPlaceholderExpr
 }
-public extension ExpressibleAsEditorPlaceholderExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsEditorPlaceholderExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createEditorPlaceholderExpr()
   }
 }
-public protocol ExpressibleAsObjectLiteralExpr: ExpressibleAsExprBuildable{
+public protocol ExpressibleAsObjectLiteralExpr: ExpressibleAsExprBuildable {
   func createObjectLiteralExpr()-> ObjectLiteralExpr
 }
-public extension ExpressibleAsObjectLiteralExpr{
-  func createExprBuildable()-> ExprBuildable{
+public extension ExpressibleAsObjectLiteralExpr {
+  func createExprBuildable()-> ExprBuildable {
     return createObjectLiteralExpr()
   }
 }
-public protocol ExpressibleAsTypeInitializerClause: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsTypeInitializerClause: ExpressibleAsSyntaxBuildable {
   func createTypeInitializerClause()-> TypeInitializerClause
 }
-public extension ExpressibleAsTypeInitializerClause{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsTypeInitializerClause {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createTypeInitializerClause()
   }
 }
-public protocol ExpressibleAsTypealiasDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsTypealiasDecl: ExpressibleAsDeclBuildable {
   func createTypealiasDecl()-> TypealiasDecl
 }
-public extension ExpressibleAsTypealiasDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsTypealiasDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createTypealiasDecl()
   }
 }
-public protocol ExpressibleAsAssociatedtypeDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsAssociatedtypeDecl: ExpressibleAsDeclBuildable {
   func createAssociatedtypeDecl()-> AssociatedtypeDecl
 }
-public extension ExpressibleAsAssociatedtypeDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsAssociatedtypeDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createAssociatedtypeDecl()
   }
 }
-public protocol ExpressibleAsFunctionParameterList{
+public protocol ExpressibleAsFunctionParameterList {
   func createFunctionParameterList()-> FunctionParameterList
 }
-public protocol ExpressibleAsParameterClause: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsParameterClause: ExpressibleAsSyntaxBuildable {
   func createParameterClause()-> ParameterClause
 }
-public extension ExpressibleAsParameterClause{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsParameterClause {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createParameterClause()
   }
 }
-public protocol ExpressibleAsReturnClause: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsReturnClause: ExpressibleAsSyntaxBuildable {
   func createReturnClause()-> ReturnClause
 }
-public extension ExpressibleAsReturnClause{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsReturnClause {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createReturnClause()
   }
 }
-public protocol ExpressibleAsFunctionSignature: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsFunctionSignature: ExpressibleAsSyntaxBuildable {
   func createFunctionSignature()-> FunctionSignature
 }
-public extension ExpressibleAsFunctionSignature{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsFunctionSignature {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createFunctionSignature()
   }
 }
-public protocol ExpressibleAsIfConfigClause: ExpressibleAsIfConfigClauseList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsIfConfigClause: ExpressibleAsIfConfigClauseList, ExpressibleAsSyntaxBuildable {
   func createIfConfigClause()-> IfConfigClause
 }
-public extension ExpressibleAsIfConfigClause{
+public extension ExpressibleAsIfConfigClause {
   /// Conformance to `ExpressibleAsIfConfigClauseList`
-func createIfConfigClauseList()-> IfConfigClauseList{
+func createIfConfigClauseList()-> IfConfigClauseList {
     return IfConfigClauseList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createIfConfigClause()
   }
 }
-public protocol ExpressibleAsIfConfigClauseList{
+public protocol ExpressibleAsIfConfigClauseList {
   func createIfConfigClauseList()-> IfConfigClauseList
 }
-public protocol ExpressibleAsIfConfigDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsIfConfigDecl: ExpressibleAsDeclBuildable {
   func createIfConfigDecl()-> IfConfigDecl
 }
-public extension ExpressibleAsIfConfigDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsIfConfigDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createIfConfigDecl()
   }
 }
-public protocol ExpressibleAsPoundErrorDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsPoundErrorDecl: ExpressibleAsDeclBuildable {
   func createPoundErrorDecl()-> PoundErrorDecl
 }
-public extension ExpressibleAsPoundErrorDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsPoundErrorDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createPoundErrorDecl()
   }
 }
-public protocol ExpressibleAsPoundWarningDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsPoundWarningDecl: ExpressibleAsDeclBuildable {
   func createPoundWarningDecl()-> PoundWarningDecl
 }
-public extension ExpressibleAsPoundWarningDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsPoundWarningDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createPoundWarningDecl()
   }
 }
-public protocol ExpressibleAsPoundSourceLocation: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsPoundSourceLocation: ExpressibleAsDeclBuildable {
   func createPoundSourceLocation()-> PoundSourceLocation
 }
-public extension ExpressibleAsPoundSourceLocation{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsPoundSourceLocation {
+  func createDeclBuildable()-> DeclBuildable {
     return createPoundSourceLocation()
   }
 }
-public protocol ExpressibleAsPoundSourceLocationArgs: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsPoundSourceLocationArgs: ExpressibleAsSyntaxBuildable {
   func createPoundSourceLocationArgs()-> PoundSourceLocationArgs
 }
-public extension ExpressibleAsPoundSourceLocationArgs{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsPoundSourceLocationArgs {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createPoundSourceLocationArgs()
   }
 }
-public protocol ExpressibleAsDeclModifier: ExpressibleAsModifierList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsDeclModifier: ExpressibleAsModifierList, ExpressibleAsSyntaxBuildable {
   func createDeclModifier()-> DeclModifier
 }
-public extension ExpressibleAsDeclModifier{
+public extension ExpressibleAsDeclModifier {
   /// Conformance to `ExpressibleAsModifierList`
-func createModifierList()-> ModifierList{
+func createModifierList()-> ModifierList {
     return ModifierList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createDeclModifier()
   }
 }
-public protocol ExpressibleAsInheritedType: ExpressibleAsInheritedTypeList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsInheritedType: ExpressibleAsInheritedTypeList, ExpressibleAsSyntaxBuildable {
   func createInheritedType()-> InheritedType
 }
-public extension ExpressibleAsInheritedType{
+public extension ExpressibleAsInheritedType {
   /// Conformance to `ExpressibleAsInheritedTypeList`
-func createInheritedTypeList()-> InheritedTypeList{
+func createInheritedTypeList()-> InheritedTypeList {
     return InheritedTypeList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createInheritedType()
   }
 }
-public protocol ExpressibleAsInheritedTypeList{
+public protocol ExpressibleAsInheritedTypeList {
   func createInheritedTypeList()-> InheritedTypeList
 }
-public protocol ExpressibleAsTypeInheritanceClause: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsTypeInheritanceClause: ExpressibleAsSyntaxBuildable {
   func createTypeInheritanceClause()-> TypeInheritanceClause
 }
-public extension ExpressibleAsTypeInheritanceClause{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsTypeInheritanceClause {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createTypeInheritanceClause()
   }
 }
-public protocol ExpressibleAsClassDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsClassDecl: ExpressibleAsDeclBuildable {
   func createClassDecl()-> ClassDecl
 }
-public extension ExpressibleAsClassDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsClassDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createClassDecl()
   }
 }
-public protocol ExpressibleAsStructDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsStructDecl: ExpressibleAsDeclBuildable {
   func createStructDecl()-> StructDecl
 }
-public extension ExpressibleAsStructDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsStructDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createStructDecl()
   }
 }
-public protocol ExpressibleAsProtocolDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsProtocolDecl: ExpressibleAsDeclBuildable {
   func createProtocolDecl()-> ProtocolDecl
 }
-public extension ExpressibleAsProtocolDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsProtocolDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createProtocolDecl()
   }
 }
-public protocol ExpressibleAsExtensionDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsExtensionDecl: ExpressibleAsDeclBuildable {
   func createExtensionDecl()-> ExtensionDecl
 }
-public extension ExpressibleAsExtensionDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsExtensionDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createExtensionDecl()
   }
 }
-public protocol ExpressibleAsMemberDeclBlock: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsMemberDeclBlock: ExpressibleAsSyntaxBuildable {
   func createMemberDeclBlock()-> MemberDeclBlock
 }
-public extension ExpressibleAsMemberDeclBlock{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsMemberDeclBlock {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createMemberDeclBlock()
   }
 }
-public protocol ExpressibleAsMemberDeclList: ExpressibleAsMemberDeclBlock{
+public protocol ExpressibleAsMemberDeclList: ExpressibleAsMemberDeclBlock {
   func createMemberDeclList()-> MemberDeclList
 }
-public extension ExpressibleAsMemberDeclList{
+public extension ExpressibleAsMemberDeclList {
   /// Conformance to ExpressibleAsMemberDeclBlock
-func createMemberDeclBlock()-> MemberDeclBlock{
+func createMemberDeclBlock()-> MemberDeclBlock {
     return MemberDeclBlock(members: self)
   }
 }
-public protocol ExpressibleAsMemberDeclListItem: ExpressibleAsMemberDeclList{
+public protocol ExpressibleAsMemberDeclListItem: ExpressibleAsMemberDeclList {
   func createMemberDeclListItem()-> MemberDeclListItem
 }
-public extension ExpressibleAsMemberDeclListItem{
+public extension ExpressibleAsMemberDeclListItem {
   /// Conformance to `ExpressibleAsMemberDeclList`
-func createMemberDeclList()-> MemberDeclList{
+func createMemberDeclList()-> MemberDeclList {
     return MemberDeclList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createMemberDeclListItem()
   }
 }
-public protocol ExpressibleAsSourceFile: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsSourceFile: ExpressibleAsSyntaxBuildable {
   func createSourceFile()-> SourceFile
 }
-public extension ExpressibleAsSourceFile{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsSourceFile {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createSourceFile()
   }
 }
-public protocol ExpressibleAsInitializerClause: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsInitializerClause: ExpressibleAsSyntaxBuildable {
   func createInitializerClause()-> InitializerClause
 }
-public extension ExpressibleAsInitializerClause{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsInitializerClause {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createInitializerClause()
   }
 }
-public protocol ExpressibleAsFunctionParameter: ExpressibleAsFunctionParameterList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsFunctionParameter: ExpressibleAsFunctionParameterList, ExpressibleAsSyntaxBuildable {
   func createFunctionParameter()-> FunctionParameter
 }
-public extension ExpressibleAsFunctionParameter{
+public extension ExpressibleAsFunctionParameter {
   /// Conformance to `ExpressibleAsFunctionParameterList`
-func createFunctionParameterList()-> FunctionParameterList{
+func createFunctionParameterList()-> FunctionParameterList {
     return FunctionParameterList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createFunctionParameter()
   }
 }
-public protocol ExpressibleAsModifierList{
+public protocol ExpressibleAsModifierList {
   func createModifierList()-> ModifierList
 }
-public protocol ExpressibleAsFunctionDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsFunctionDecl: ExpressibleAsDeclBuildable {
   func createFunctionDecl()-> FunctionDecl
 }
-public extension ExpressibleAsFunctionDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsFunctionDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createFunctionDecl()
   }
 }
-public protocol ExpressibleAsInitializerDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsInitializerDecl: ExpressibleAsDeclBuildable {
   func createInitializerDecl()-> InitializerDecl
 }
-public extension ExpressibleAsInitializerDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsInitializerDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createInitializerDecl()
   }
 }
-public protocol ExpressibleAsDeinitializerDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsDeinitializerDecl: ExpressibleAsDeclBuildable {
   func createDeinitializerDecl()-> DeinitializerDecl
 }
-public extension ExpressibleAsDeinitializerDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsDeinitializerDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createDeinitializerDecl()
   }
 }
-public protocol ExpressibleAsSubscriptDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsSubscriptDecl: ExpressibleAsDeclBuildable {
   func createSubscriptDecl()-> SubscriptDecl
 }
-public extension ExpressibleAsSubscriptDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsSubscriptDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createSubscriptDecl()
   }
 }
-public protocol ExpressibleAsAccessLevelModifier: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsAccessLevelModifier: ExpressibleAsSyntaxBuildable {
   func createAccessLevelModifier()-> AccessLevelModifier
 }
-public extension ExpressibleAsAccessLevelModifier{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsAccessLevelModifier {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createAccessLevelModifier()
   }
 }
-public protocol ExpressibleAsAccessPathComponent: ExpressibleAsAccessPath, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsAccessPathComponent: ExpressibleAsAccessPath, ExpressibleAsSyntaxBuildable {
   func createAccessPathComponent()-> AccessPathComponent
 }
-public extension ExpressibleAsAccessPathComponent{
+public extension ExpressibleAsAccessPathComponent {
   /// Conformance to `ExpressibleAsAccessPath`
-func createAccessPath()-> AccessPath{
+func createAccessPath()-> AccessPath {
     return AccessPath([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createAccessPathComponent()
   }
 }
-public protocol ExpressibleAsAccessPath{
+public protocol ExpressibleAsAccessPath {
   func createAccessPath()-> AccessPath
 }
-public protocol ExpressibleAsImportDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsImportDecl: ExpressibleAsDeclBuildable {
   func createImportDecl()-> ImportDecl
 }
-public extension ExpressibleAsImportDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsImportDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createImportDecl()
   }
 }
-public protocol ExpressibleAsAccessorParameter: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsAccessorParameter: ExpressibleAsSyntaxBuildable {
   func createAccessorParameter()-> AccessorParameter
 }
-public extension ExpressibleAsAccessorParameter{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsAccessorParameter {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createAccessorParameter()
   }
 }
-public protocol ExpressibleAsAccessorDecl: ExpressibleAsAccessorList, ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsAccessorDecl: ExpressibleAsAccessorList, ExpressibleAsDeclBuildable {
   func createAccessorDecl()-> AccessorDecl
 }
-public extension ExpressibleAsAccessorDecl{
+public extension ExpressibleAsAccessorDecl {
   /// Conformance to `ExpressibleAsAccessorList`
-func createAccessorList()-> AccessorList{
+func createAccessorList()-> AccessorList {
     return AccessorList([self])
   }
-  func createDeclBuildable()-> DeclBuildable{
+  func createDeclBuildable()-> DeclBuildable {
     return createAccessorDecl()
   }
 }
-public protocol ExpressibleAsAccessorList: ExpressibleAsAccessorBlock{
+public protocol ExpressibleAsAccessorList: ExpressibleAsAccessorBlock {
   func createAccessorList()-> AccessorList
 }
-public extension ExpressibleAsAccessorList{
+public extension ExpressibleAsAccessorList {
   /// Conformance to ExpressibleAsAccessorBlock
-func createAccessorBlock()-> AccessorBlock{
+func createAccessorBlock()-> AccessorBlock {
     return AccessorBlock(accessors: self)
   }
 }
-public protocol ExpressibleAsAccessorBlock: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsAccessorBlock: ExpressibleAsSyntaxBuildable {
   func createAccessorBlock()-> AccessorBlock
 }
-public extension ExpressibleAsAccessorBlock{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsAccessorBlock {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createAccessorBlock()
   }
 }
-public protocol ExpressibleAsPatternBinding: ExpressibleAsPatternBindingList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsPatternBinding: ExpressibleAsPatternBindingList, ExpressibleAsSyntaxBuildable {
   func createPatternBinding()-> PatternBinding
 }
-public extension ExpressibleAsPatternBinding{
+public extension ExpressibleAsPatternBinding {
   /// Conformance to `ExpressibleAsPatternBindingList`
-func createPatternBindingList()-> PatternBindingList{
+func createPatternBindingList()-> PatternBindingList {
     return PatternBindingList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createPatternBinding()
   }
 }
-public protocol ExpressibleAsPatternBindingList{
+public protocol ExpressibleAsPatternBindingList {
   func createPatternBindingList()-> PatternBindingList
 }
-public protocol ExpressibleAsVariableDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsVariableDecl: ExpressibleAsDeclBuildable {
   func createVariableDecl()-> VariableDecl
 }
-public extension ExpressibleAsVariableDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsVariableDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createVariableDecl()
   }
 }
-public protocol ExpressibleAsEnumCaseElement: ExpressibleAsEnumCaseElementList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsEnumCaseElement: ExpressibleAsEnumCaseElementList, ExpressibleAsSyntaxBuildable {
   func createEnumCaseElement()-> EnumCaseElement
 }
-public extension ExpressibleAsEnumCaseElement{
+public extension ExpressibleAsEnumCaseElement {
   /// Conformance to `ExpressibleAsEnumCaseElementList`
-func createEnumCaseElementList()-> EnumCaseElementList{
+func createEnumCaseElementList()-> EnumCaseElementList {
     return EnumCaseElementList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createEnumCaseElement()
   }
 }
-public protocol ExpressibleAsEnumCaseElementList{
+public protocol ExpressibleAsEnumCaseElementList {
   func createEnumCaseElementList()-> EnumCaseElementList
 }
-public protocol ExpressibleAsEnumCaseDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsEnumCaseDecl: ExpressibleAsDeclBuildable {
   func createEnumCaseDecl()-> EnumCaseDecl
 }
-public extension ExpressibleAsEnumCaseDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsEnumCaseDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createEnumCaseDecl()
   }
 }
-public protocol ExpressibleAsEnumDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsEnumDecl: ExpressibleAsDeclBuildable {
   func createEnumDecl()-> EnumDecl
 }
-public extension ExpressibleAsEnumDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsEnumDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createEnumDecl()
   }
 }
-public protocol ExpressibleAsOperatorDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsOperatorDecl: ExpressibleAsDeclBuildable {
   func createOperatorDecl()-> OperatorDecl
 }
-public extension ExpressibleAsOperatorDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsOperatorDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createOperatorDecl()
   }
 }
-public protocol ExpressibleAsIdentifierList{
+public protocol ExpressibleAsIdentifierList {
   func createIdentifierList()-> IdentifierList
 }
-public protocol ExpressibleAsOperatorPrecedenceAndTypes: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsOperatorPrecedenceAndTypes: ExpressibleAsSyntaxBuildable {
   func createOperatorPrecedenceAndTypes()-> OperatorPrecedenceAndTypes
 }
-public extension ExpressibleAsOperatorPrecedenceAndTypes{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsOperatorPrecedenceAndTypes {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createOperatorPrecedenceAndTypes()
   }
 }
-public protocol ExpressibleAsPrecedenceGroupDecl: ExpressibleAsDeclBuildable{
+public protocol ExpressibleAsPrecedenceGroupDecl: ExpressibleAsDeclBuildable {
   func createPrecedenceGroupDecl()-> PrecedenceGroupDecl
 }
-public extension ExpressibleAsPrecedenceGroupDecl{
-  func createDeclBuildable()-> DeclBuildable{
+public extension ExpressibleAsPrecedenceGroupDecl {
+  func createDeclBuildable()-> DeclBuildable {
     return createPrecedenceGroupDecl()
   }
 }
-public protocol ExpressibleAsPrecedenceGroupAttributeList{
+public protocol ExpressibleAsPrecedenceGroupAttributeList {
   func createPrecedenceGroupAttributeList()-> PrecedenceGroupAttributeList
 }
-public protocol ExpressibleAsPrecedenceGroupRelation: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsPrecedenceGroupRelation: ExpressibleAsSyntaxBuildable {
   func createPrecedenceGroupRelation()-> PrecedenceGroupRelation
 }
-public extension ExpressibleAsPrecedenceGroupRelation{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsPrecedenceGroupRelation {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createPrecedenceGroupRelation()
   }
 }
-public protocol ExpressibleAsPrecedenceGroupNameList{
+public protocol ExpressibleAsPrecedenceGroupNameList {
   func createPrecedenceGroupNameList()-> PrecedenceGroupNameList
 }
-public protocol ExpressibleAsPrecedenceGroupNameElement: ExpressibleAsPrecedenceGroupNameList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsPrecedenceGroupNameElement: ExpressibleAsPrecedenceGroupNameList, ExpressibleAsSyntaxBuildable {
   func createPrecedenceGroupNameElement()-> PrecedenceGroupNameElement
 }
-public extension ExpressibleAsPrecedenceGroupNameElement{
+public extension ExpressibleAsPrecedenceGroupNameElement {
   /// Conformance to `ExpressibleAsPrecedenceGroupNameList`
-func createPrecedenceGroupNameList()-> PrecedenceGroupNameList{
+func createPrecedenceGroupNameList()-> PrecedenceGroupNameList {
     return PrecedenceGroupNameList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createPrecedenceGroupNameElement()
   }
 }
-public protocol ExpressibleAsPrecedenceGroupAssignment: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsPrecedenceGroupAssignment: ExpressibleAsSyntaxBuildable {
   func createPrecedenceGroupAssignment()-> PrecedenceGroupAssignment
 }
-public extension ExpressibleAsPrecedenceGroupAssignment{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsPrecedenceGroupAssignment {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createPrecedenceGroupAssignment()
   }
 }
-public protocol ExpressibleAsPrecedenceGroupAssociativity: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsPrecedenceGroupAssociativity: ExpressibleAsSyntaxBuildable {
   func createPrecedenceGroupAssociativity()-> PrecedenceGroupAssociativity
 }
-public extension ExpressibleAsPrecedenceGroupAssociativity{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsPrecedenceGroupAssociativity {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createPrecedenceGroupAssociativity()
   }
 }
-public protocol ExpressibleAsTokenList{
+public protocol ExpressibleAsTokenList {
   func createTokenList()-> TokenList
 }
-public protocol ExpressibleAsNonEmptyTokenList{
+public protocol ExpressibleAsNonEmptyTokenList {
   func createNonEmptyTokenList()-> NonEmptyTokenList
 }
-public protocol ExpressibleAsCustomAttribute: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsCustomAttribute: ExpressibleAsSyntaxBuildable {
   func createCustomAttribute()-> CustomAttribute
 }
-public extension ExpressibleAsCustomAttribute{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsCustomAttribute {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createCustomAttribute()
   }
 }
-public protocol ExpressibleAsAttribute: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsAttribute: ExpressibleAsSyntaxBuildable {
   func createAttribute()-> Attribute
 }
-public extension ExpressibleAsAttribute{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsAttribute {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createAttribute()
   }
 }
-public protocol ExpressibleAsAttributeList{
+public protocol ExpressibleAsAttributeList {
   func createAttributeList()-> AttributeList
 }
-public protocol ExpressibleAsSpecializeAttributeSpecList{
+public protocol ExpressibleAsSpecializeAttributeSpecList {
   func createSpecializeAttributeSpecList()-> SpecializeAttributeSpecList
 }
-public protocol ExpressibleAsAvailabilityEntry: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsAvailabilityEntry: ExpressibleAsSyntaxBuildable {
   func createAvailabilityEntry()-> AvailabilityEntry
 }
-public extension ExpressibleAsAvailabilityEntry{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsAvailabilityEntry {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createAvailabilityEntry()
   }
 }
-public protocol ExpressibleAsLabeledSpecializeEntry: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsLabeledSpecializeEntry: ExpressibleAsSyntaxBuildable {
   func createLabeledSpecializeEntry()-> LabeledSpecializeEntry
 }
-public extension ExpressibleAsLabeledSpecializeEntry{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsLabeledSpecializeEntry {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createLabeledSpecializeEntry()
   }
 }
-public protocol ExpressibleAsTargetFunctionEntry: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsTargetFunctionEntry: ExpressibleAsSyntaxBuildable {
   func createTargetFunctionEntry()-> TargetFunctionEntry
 }
-public extension ExpressibleAsTargetFunctionEntry{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsTargetFunctionEntry {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createTargetFunctionEntry()
   }
 }
-public protocol ExpressibleAsNamedAttributeStringArgument: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsNamedAttributeStringArgument: ExpressibleAsSyntaxBuildable {
   func createNamedAttributeStringArgument()-> NamedAttributeStringArgument
 }
-public extension ExpressibleAsNamedAttributeStringArgument{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsNamedAttributeStringArgument {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createNamedAttributeStringArgument()
   }
 }
-public protocol ExpressibleAsDeclName: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsDeclName: ExpressibleAsSyntaxBuildable {
   func createDeclName()-> DeclName
 }
-public extension ExpressibleAsDeclName{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsDeclName {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createDeclName()
   }
 }
-public protocol ExpressibleAsImplementsAttributeArguments: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsImplementsAttributeArguments: ExpressibleAsSyntaxBuildable {
   func createImplementsAttributeArguments()-> ImplementsAttributeArguments
 }
-public extension ExpressibleAsImplementsAttributeArguments{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsImplementsAttributeArguments {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createImplementsAttributeArguments()
   }
 }
-public protocol ExpressibleAsObjCSelectorPiece: ExpressibleAsObjCSelector, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsObjCSelectorPiece: ExpressibleAsObjCSelector, ExpressibleAsSyntaxBuildable {
   func createObjCSelectorPiece()-> ObjCSelectorPiece
 }
-public extension ExpressibleAsObjCSelectorPiece{
+public extension ExpressibleAsObjCSelectorPiece {
   /// Conformance to `ExpressibleAsObjCSelector`
-func createObjCSelector()-> ObjCSelector{
+func createObjCSelector()-> ObjCSelector {
     return ObjCSelector([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createObjCSelectorPiece()
   }
 }
-public protocol ExpressibleAsObjCSelector{
+public protocol ExpressibleAsObjCSelector {
   func createObjCSelector()-> ObjCSelector
 }
-public protocol ExpressibleAsDifferentiableAttributeArguments: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsDifferentiableAttributeArguments: ExpressibleAsSyntaxBuildable {
   func createDifferentiableAttributeArguments()-> DifferentiableAttributeArguments
 }
-public extension ExpressibleAsDifferentiableAttributeArguments{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsDifferentiableAttributeArguments {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createDifferentiableAttributeArguments()
   }
 }
-public protocol ExpressibleAsDifferentiabilityParamsClause: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsDifferentiabilityParamsClause: ExpressibleAsSyntaxBuildable {
   func createDifferentiabilityParamsClause()-> DifferentiabilityParamsClause
 }
-public extension ExpressibleAsDifferentiabilityParamsClause{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsDifferentiabilityParamsClause {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createDifferentiabilityParamsClause()
   }
 }
-public protocol ExpressibleAsDifferentiabilityParams: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsDifferentiabilityParams: ExpressibleAsSyntaxBuildable {
   func createDifferentiabilityParams()-> DifferentiabilityParams
 }
-public extension ExpressibleAsDifferentiabilityParams{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsDifferentiabilityParams {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createDifferentiabilityParams()
   }
 }
-public protocol ExpressibleAsDifferentiabilityParamList{
+public protocol ExpressibleAsDifferentiabilityParamList {
   func createDifferentiabilityParamList()-> DifferentiabilityParamList
 }
-public protocol ExpressibleAsDifferentiabilityParam: ExpressibleAsDifferentiabilityParamList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsDifferentiabilityParam: ExpressibleAsDifferentiabilityParamList, ExpressibleAsSyntaxBuildable {
   func createDifferentiabilityParam()-> DifferentiabilityParam
 }
-public extension ExpressibleAsDifferentiabilityParam{
+public extension ExpressibleAsDifferentiabilityParam {
   /// Conformance to `ExpressibleAsDifferentiabilityParamList`
-func createDifferentiabilityParamList()-> DifferentiabilityParamList{
+func createDifferentiabilityParamList()-> DifferentiabilityParamList {
     return DifferentiabilityParamList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createDifferentiabilityParam()
   }
 }
-public protocol ExpressibleAsDerivativeRegistrationAttributeArguments: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsDerivativeRegistrationAttributeArguments: ExpressibleAsSyntaxBuildable {
   func createDerivativeRegistrationAttributeArguments()-> DerivativeRegistrationAttributeArguments
 }
-public extension ExpressibleAsDerivativeRegistrationAttributeArguments{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsDerivativeRegistrationAttributeArguments {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createDerivativeRegistrationAttributeArguments()
   }
 }
-public protocol ExpressibleAsQualifiedDeclName: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsQualifiedDeclName: ExpressibleAsSyntaxBuildable {
   func createQualifiedDeclName()-> QualifiedDeclName
 }
-public extension ExpressibleAsQualifiedDeclName{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsQualifiedDeclName {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createQualifiedDeclName()
   }
 }
-public protocol ExpressibleAsFunctionDeclName: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsFunctionDeclName: ExpressibleAsSyntaxBuildable {
   func createFunctionDeclName()-> FunctionDeclName
 }
-public extension ExpressibleAsFunctionDeclName{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsFunctionDeclName {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createFunctionDeclName()
   }
 }
-public protocol ExpressibleAsBackDeployAttributeSpecList: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsBackDeployAttributeSpecList: ExpressibleAsSyntaxBuildable {
   func createBackDeployAttributeSpecList()-> BackDeployAttributeSpecList
 }
-public extension ExpressibleAsBackDeployAttributeSpecList{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsBackDeployAttributeSpecList {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createBackDeployAttributeSpecList()
   }
 }
-public protocol ExpressibleAsBackDeployVersionList{
+public protocol ExpressibleAsBackDeployVersionList {
   func createBackDeployVersionList()-> BackDeployVersionList
 }
-public protocol ExpressibleAsBackDeployVersionArgument: ExpressibleAsBackDeployVersionList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsBackDeployVersionArgument: ExpressibleAsBackDeployVersionList, ExpressibleAsSyntaxBuildable {
   func createBackDeployVersionArgument()-> BackDeployVersionArgument
 }
-public extension ExpressibleAsBackDeployVersionArgument{
+public extension ExpressibleAsBackDeployVersionArgument {
   /// Conformance to `ExpressibleAsBackDeployVersionList`
-func createBackDeployVersionList()-> BackDeployVersionList{
+func createBackDeployVersionList()-> BackDeployVersionList {
     return BackDeployVersionList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createBackDeployVersionArgument()
   }
 }
-public protocol ExpressibleAsContinueStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsContinueStmt: ExpressibleAsStmtBuildable {
   func createContinueStmt()-> ContinueStmt
 }
-public extension ExpressibleAsContinueStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsContinueStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createContinueStmt()
   }
 }
-public protocol ExpressibleAsWhileStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsWhileStmt: ExpressibleAsStmtBuildable {
   func createWhileStmt()-> WhileStmt
 }
-public extension ExpressibleAsWhileStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsWhileStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createWhileStmt()
   }
 }
-public protocol ExpressibleAsDeferStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsDeferStmt: ExpressibleAsStmtBuildable {
   func createDeferStmt()-> DeferStmt
 }
-public extension ExpressibleAsDeferStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsDeferStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createDeferStmt()
   }
 }
-public protocol ExpressibleAsExpressionStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsExpressionStmt: ExpressibleAsStmtBuildable {
   func createExpressionStmt()-> ExpressionStmt
 }
-public extension ExpressibleAsExpressionStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsExpressionStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createExpressionStmt()
   }
 }
-public protocol ExpressibleAsSwitchCaseList{
+public protocol ExpressibleAsSwitchCaseList {
   func createSwitchCaseList()-> SwitchCaseList
 }
-public protocol ExpressibleAsRepeatWhileStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsRepeatWhileStmt: ExpressibleAsStmtBuildable {
   func createRepeatWhileStmt()-> RepeatWhileStmt
 }
-public extension ExpressibleAsRepeatWhileStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsRepeatWhileStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createRepeatWhileStmt()
   }
 }
-public protocol ExpressibleAsGuardStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsGuardStmt: ExpressibleAsStmtBuildable {
   func createGuardStmt()-> GuardStmt
 }
-public extension ExpressibleAsGuardStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsGuardStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createGuardStmt()
   }
 }
-public protocol ExpressibleAsWhereClause: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsWhereClause: ExpressibleAsSyntaxBuildable {
   func createWhereClause()-> WhereClause
 }
-public extension ExpressibleAsWhereClause{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsWhereClause {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createWhereClause()
   }
 }
-public protocol ExpressibleAsForInStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsForInStmt: ExpressibleAsStmtBuildable {
   func createForInStmt()-> ForInStmt
 }
-public extension ExpressibleAsForInStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsForInStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createForInStmt()
   }
 }
-public protocol ExpressibleAsSwitchStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsSwitchStmt: ExpressibleAsStmtBuildable {
   func createSwitchStmt()-> SwitchStmt
 }
-public extension ExpressibleAsSwitchStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsSwitchStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createSwitchStmt()
   }
 }
-public protocol ExpressibleAsCatchClauseList{
+public protocol ExpressibleAsCatchClauseList {
   func createCatchClauseList()-> CatchClauseList
 }
-public protocol ExpressibleAsDoStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsDoStmt: ExpressibleAsStmtBuildable {
   func createDoStmt()-> DoStmt
 }
-public extension ExpressibleAsDoStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsDoStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createDoStmt()
   }
 }
-public protocol ExpressibleAsReturnStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsReturnStmt: ExpressibleAsStmtBuildable {
   func createReturnStmt()-> ReturnStmt
 }
-public extension ExpressibleAsReturnStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsReturnStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createReturnStmt()
   }
 }
-public protocol ExpressibleAsYieldStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsYieldStmt: ExpressibleAsStmtBuildable {
   func createYieldStmt()-> YieldStmt
 }
-public extension ExpressibleAsYieldStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsYieldStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createYieldStmt()
   }
 }
-public protocol ExpressibleAsYieldList: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsYieldList: ExpressibleAsSyntaxBuildable {
   func createYieldList()-> YieldList
 }
-public extension ExpressibleAsYieldList{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsYieldList {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createYieldList()
   }
 }
-public protocol ExpressibleAsFallthroughStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsFallthroughStmt: ExpressibleAsStmtBuildable {
   func createFallthroughStmt()-> FallthroughStmt
 }
-public extension ExpressibleAsFallthroughStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsFallthroughStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createFallthroughStmt()
   }
 }
-public protocol ExpressibleAsBreakStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsBreakStmt: ExpressibleAsStmtBuildable {
   func createBreakStmt()-> BreakStmt
 }
-public extension ExpressibleAsBreakStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsBreakStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createBreakStmt()
   }
 }
-public protocol ExpressibleAsCaseItemList{
+public protocol ExpressibleAsCaseItemList {
   func createCaseItemList()-> CaseItemList
 }
-public protocol ExpressibleAsCatchItemList{
+public protocol ExpressibleAsCatchItemList {
   func createCatchItemList()-> CatchItemList
 }
-public protocol ExpressibleAsConditionElement: ExpressibleAsConditionElementList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsConditionElement: ExpressibleAsConditionElementList, ExpressibleAsSyntaxBuildable {
   func createConditionElement()-> ConditionElement
 }
-public extension ExpressibleAsConditionElement{
+public extension ExpressibleAsConditionElement {
   /// Conformance to `ExpressibleAsConditionElementList`
-func createConditionElementList()-> ConditionElementList{
+func createConditionElementList()-> ConditionElementList {
     return ConditionElementList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createConditionElement()
   }
 }
-public protocol ExpressibleAsAvailabilityCondition: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsAvailabilityCondition: ExpressibleAsSyntaxBuildable {
   func createAvailabilityCondition()-> AvailabilityCondition
 }
-public extension ExpressibleAsAvailabilityCondition{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsAvailabilityCondition {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createAvailabilityCondition()
   }
 }
-public protocol ExpressibleAsMatchingPatternCondition: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsMatchingPatternCondition: ExpressibleAsSyntaxBuildable {
   func createMatchingPatternCondition()-> MatchingPatternCondition
 }
-public extension ExpressibleAsMatchingPatternCondition{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsMatchingPatternCondition {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createMatchingPatternCondition()
   }
 }
-public protocol ExpressibleAsOptionalBindingCondition: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsOptionalBindingCondition: ExpressibleAsSyntaxBuildable {
   func createOptionalBindingCondition()-> OptionalBindingCondition
 }
-public extension ExpressibleAsOptionalBindingCondition{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsOptionalBindingCondition {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createOptionalBindingCondition()
   }
 }
-public protocol ExpressibleAsUnavailabilityCondition: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsUnavailabilityCondition: ExpressibleAsSyntaxBuildable {
   func createUnavailabilityCondition()-> UnavailabilityCondition
 }
-public extension ExpressibleAsUnavailabilityCondition{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsUnavailabilityCondition {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createUnavailabilityCondition()
   }
 }
-public protocol ExpressibleAsConditionElementList{
+public protocol ExpressibleAsConditionElementList {
   func createConditionElementList()-> ConditionElementList
 }
-public protocol ExpressibleAsDeclarationStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsDeclarationStmt: ExpressibleAsStmtBuildable {
   func createDeclarationStmt()-> DeclarationStmt
 }
-public extension ExpressibleAsDeclarationStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsDeclarationStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createDeclarationStmt()
   }
 }
-public protocol ExpressibleAsThrowStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsThrowStmt: ExpressibleAsStmtBuildable {
   func createThrowStmt()-> ThrowStmt
 }
-public extension ExpressibleAsThrowStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsThrowStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createThrowStmt()
   }
 }
-public protocol ExpressibleAsIfStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsIfStmt: ExpressibleAsStmtBuildable {
   func createIfStmt()-> IfStmt
 }
-public extension ExpressibleAsIfStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsIfStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createIfStmt()
   }
 }
-public protocol ExpressibleAsElseIfContinuation: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsElseIfContinuation: ExpressibleAsSyntaxBuildable {
   func createElseIfContinuation()-> ElseIfContinuation
 }
-public extension ExpressibleAsElseIfContinuation{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsElseIfContinuation {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createElseIfContinuation()
   }
 }
-public protocol ExpressibleAsElseBlock: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsElseBlock: ExpressibleAsSyntaxBuildable {
   func createElseBlock()-> ElseBlock
 }
-public extension ExpressibleAsElseBlock{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsElseBlock {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createElseBlock()
   }
 }
-public protocol ExpressibleAsSwitchCase: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsSwitchCase: ExpressibleAsSyntaxBuildable {
   func createSwitchCase()-> SwitchCase
 }
-public extension ExpressibleAsSwitchCase{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsSwitchCase {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createSwitchCase()
   }
 }
-public protocol ExpressibleAsSwitchDefaultLabel: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsSwitchDefaultLabel: ExpressibleAsSyntaxBuildable {
   func createSwitchDefaultLabel()-> SwitchDefaultLabel
 }
-public extension ExpressibleAsSwitchDefaultLabel{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsSwitchDefaultLabel {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createSwitchDefaultLabel()
   }
 }
-public protocol ExpressibleAsCaseItem: ExpressibleAsCaseItemList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsCaseItem: ExpressibleAsCaseItemList, ExpressibleAsSyntaxBuildable {
   func createCaseItem()-> CaseItem
 }
-public extension ExpressibleAsCaseItem{
+public extension ExpressibleAsCaseItem {
   /// Conformance to `ExpressibleAsCaseItemList`
-func createCaseItemList()-> CaseItemList{
+func createCaseItemList()-> CaseItemList {
     return CaseItemList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createCaseItem()
   }
 }
-public protocol ExpressibleAsCatchItem: ExpressibleAsCatchItemList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsCatchItem: ExpressibleAsCatchItemList, ExpressibleAsSyntaxBuildable {
   func createCatchItem()-> CatchItem
 }
-public extension ExpressibleAsCatchItem{
+public extension ExpressibleAsCatchItem {
   /// Conformance to `ExpressibleAsCatchItemList`
-func createCatchItemList()-> CatchItemList{
+func createCatchItemList()-> CatchItemList {
     return CatchItemList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createCatchItem()
   }
 }
-public protocol ExpressibleAsSwitchCaseLabel: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsSwitchCaseLabel: ExpressibleAsSyntaxBuildable {
   func createSwitchCaseLabel()-> SwitchCaseLabel
 }
-public extension ExpressibleAsSwitchCaseLabel{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsSwitchCaseLabel {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createSwitchCaseLabel()
   }
 }
-public protocol ExpressibleAsCatchClause: ExpressibleAsCatchClauseList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsCatchClause: ExpressibleAsCatchClauseList, ExpressibleAsSyntaxBuildable {
   func createCatchClause()-> CatchClause
 }
-public extension ExpressibleAsCatchClause{
+public extension ExpressibleAsCatchClause {
   /// Conformance to `ExpressibleAsCatchClauseList`
-func createCatchClauseList()-> CatchClauseList{
+func createCatchClauseList()-> CatchClauseList {
     return CatchClauseList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createCatchClause()
   }
 }
-public protocol ExpressibleAsPoundAssertStmt: ExpressibleAsStmtBuildable{
+public protocol ExpressibleAsPoundAssertStmt: ExpressibleAsStmtBuildable {
   func createPoundAssertStmt()-> PoundAssertStmt
 }
-public extension ExpressibleAsPoundAssertStmt{
-  func createStmtBuildable()-> StmtBuildable{
+public extension ExpressibleAsPoundAssertStmt {
+  func createStmtBuildable()-> StmtBuildable {
     return createPoundAssertStmt()
   }
 }
-public protocol ExpressibleAsGenericWhereClause: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsGenericWhereClause: ExpressibleAsSyntaxBuildable {
   func createGenericWhereClause()-> GenericWhereClause
 }
-public extension ExpressibleAsGenericWhereClause{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsGenericWhereClause {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createGenericWhereClause()
   }
 }
-public protocol ExpressibleAsGenericRequirementList{
+public protocol ExpressibleAsGenericRequirementList {
   func createGenericRequirementList()-> GenericRequirementList
 }
-public protocol ExpressibleAsGenericRequirement: ExpressibleAsGenericRequirementList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsGenericRequirement: ExpressibleAsGenericRequirementList, ExpressibleAsSyntaxBuildable {
   func createGenericRequirement()-> GenericRequirement
 }
-public extension ExpressibleAsGenericRequirement{
+public extension ExpressibleAsGenericRequirement {
   /// Conformance to `ExpressibleAsGenericRequirementList`
-func createGenericRequirementList()-> GenericRequirementList{
+func createGenericRequirementList()-> GenericRequirementList {
     return GenericRequirementList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createGenericRequirement()
   }
 }
-public protocol ExpressibleAsSameTypeRequirement: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsSameTypeRequirement: ExpressibleAsSyntaxBuildable {
   func createSameTypeRequirement()-> SameTypeRequirement
 }
-public extension ExpressibleAsSameTypeRequirement{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsSameTypeRequirement {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createSameTypeRequirement()
   }
 }
-public protocol ExpressibleAsGenericParameterList{
+public protocol ExpressibleAsGenericParameterList {
   func createGenericParameterList()-> GenericParameterList
 }
-public protocol ExpressibleAsGenericParameter: ExpressibleAsGenericParameterList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsGenericParameter: ExpressibleAsGenericParameterList, ExpressibleAsSyntaxBuildable {
   func createGenericParameter()-> GenericParameter
 }
-public extension ExpressibleAsGenericParameter{
+public extension ExpressibleAsGenericParameter {
   /// Conformance to `ExpressibleAsGenericParameterList`
-func createGenericParameterList()-> GenericParameterList{
+func createGenericParameterList()-> GenericParameterList {
     return GenericParameterList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createGenericParameter()
   }
 }
-public protocol ExpressibleAsPrimaryAssociatedTypeList{
+public protocol ExpressibleAsPrimaryAssociatedTypeList {
   func createPrimaryAssociatedTypeList()-> PrimaryAssociatedTypeList
 }
-public protocol ExpressibleAsPrimaryAssociatedType: ExpressibleAsPrimaryAssociatedTypeList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsPrimaryAssociatedType: ExpressibleAsPrimaryAssociatedTypeList, ExpressibleAsSyntaxBuildable {
   func createPrimaryAssociatedType()-> PrimaryAssociatedType
 }
-public extension ExpressibleAsPrimaryAssociatedType{
+public extension ExpressibleAsPrimaryAssociatedType {
   /// Conformance to `ExpressibleAsPrimaryAssociatedTypeList`
-func createPrimaryAssociatedTypeList()-> PrimaryAssociatedTypeList{
+func createPrimaryAssociatedTypeList()-> PrimaryAssociatedTypeList {
     return PrimaryAssociatedTypeList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createPrimaryAssociatedType()
   }
 }
-public protocol ExpressibleAsGenericParameterClause: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsGenericParameterClause: ExpressibleAsSyntaxBuildable {
   func createGenericParameterClause()-> GenericParameterClause
 }
-public extension ExpressibleAsGenericParameterClause{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsGenericParameterClause {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createGenericParameterClause()
   }
 }
-public protocol ExpressibleAsConformanceRequirement: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsConformanceRequirement: ExpressibleAsSyntaxBuildable {
   func createConformanceRequirement()-> ConformanceRequirement
 }
-public extension ExpressibleAsConformanceRequirement{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsConformanceRequirement {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createConformanceRequirement()
   }
 }
-public protocol ExpressibleAsPrimaryAssociatedTypeClause: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsPrimaryAssociatedTypeClause: ExpressibleAsSyntaxBuildable {
   func createPrimaryAssociatedTypeClause()-> PrimaryAssociatedTypeClause
 }
-public extension ExpressibleAsPrimaryAssociatedTypeClause{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsPrimaryAssociatedTypeClause {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createPrimaryAssociatedTypeClause()
   }
 }
-public protocol ExpressibleAsSimpleTypeIdentifier: ExpressibleAsTypeAnnotation, ExpressibleAsTypeExpr, ExpressibleAsTypeBuildable{
+public protocol ExpressibleAsSimpleTypeIdentifier: ExpressibleAsTypeAnnotation, ExpressibleAsTypeExpr, ExpressibleAsTypeBuildable {
   func createSimpleTypeIdentifier()-> SimpleTypeIdentifier
 }
-public extension ExpressibleAsSimpleTypeIdentifier{
+public extension ExpressibleAsSimpleTypeIdentifier {
   /// Conformance to ExpressibleAsTypeAnnotation
-func createTypeAnnotation()-> TypeAnnotation{
+func createTypeAnnotation()-> TypeAnnotation {
     return TypeAnnotation(type: self)
   }
   /// Conformance to ExpressibleAsTypeExpr
-func createTypeExpr()-> TypeExpr{
+func createTypeExpr()-> TypeExpr {
     return TypeExpr(type: self)
   }
-  func createTypeBuildable()-> TypeBuildable{
+  func createTypeBuildable()-> TypeBuildable {
     return createSimpleTypeIdentifier()
   }
 }
-public protocol ExpressibleAsMemberTypeIdentifier: ExpressibleAsTypeBuildable{
+public protocol ExpressibleAsMemberTypeIdentifier: ExpressibleAsTypeBuildable {
   func createMemberTypeIdentifier()-> MemberTypeIdentifier
 }
-public extension ExpressibleAsMemberTypeIdentifier{
-  func createTypeBuildable()-> TypeBuildable{
+public extension ExpressibleAsMemberTypeIdentifier {
+  func createTypeBuildable()-> TypeBuildable {
     return createMemberTypeIdentifier()
   }
 }
-public protocol ExpressibleAsClassRestrictionType: ExpressibleAsTypeBuildable{
+public protocol ExpressibleAsClassRestrictionType: ExpressibleAsTypeBuildable {
   func createClassRestrictionType()-> ClassRestrictionType
 }
-public extension ExpressibleAsClassRestrictionType{
-  func createTypeBuildable()-> TypeBuildable{
+public extension ExpressibleAsClassRestrictionType {
+  func createTypeBuildable()-> TypeBuildable {
     return createClassRestrictionType()
   }
 }
-public protocol ExpressibleAsArrayType: ExpressibleAsTypeAnnotation, ExpressibleAsTypeBuildable{
+public protocol ExpressibleAsArrayType: ExpressibleAsTypeAnnotation, ExpressibleAsTypeBuildable {
   func createArrayType()-> ArrayType
 }
-public extension ExpressibleAsArrayType{
+public extension ExpressibleAsArrayType {
   /// Conformance to ExpressibleAsTypeAnnotation
-func createTypeAnnotation()-> TypeAnnotation{
+func createTypeAnnotation()-> TypeAnnotation {
     return TypeAnnotation(type: self)
   }
-  func createTypeBuildable()-> TypeBuildable{
+  func createTypeBuildable()-> TypeBuildable {
     return createArrayType()
   }
 }
-public protocol ExpressibleAsDictionaryType: ExpressibleAsTypeAnnotation, ExpressibleAsTypeBuildable{
+public protocol ExpressibleAsDictionaryType: ExpressibleAsTypeAnnotation, ExpressibleAsTypeBuildable {
   func createDictionaryType()-> DictionaryType
 }
-public extension ExpressibleAsDictionaryType{
+public extension ExpressibleAsDictionaryType {
   /// Conformance to ExpressibleAsTypeAnnotation
-func createTypeAnnotation()-> TypeAnnotation{
+func createTypeAnnotation()-> TypeAnnotation {
     return TypeAnnotation(type: self)
   }
-  func createTypeBuildable()-> TypeBuildable{
+  func createTypeBuildable()-> TypeBuildable {
     return createDictionaryType()
   }
 }
-public protocol ExpressibleAsMetatypeType: ExpressibleAsTypeBuildable{
+public protocol ExpressibleAsMetatypeType: ExpressibleAsTypeBuildable {
   func createMetatypeType()-> MetatypeType
 }
-public extension ExpressibleAsMetatypeType{
-  func createTypeBuildable()-> TypeBuildable{
+public extension ExpressibleAsMetatypeType {
+  func createTypeBuildable()-> TypeBuildable {
     return createMetatypeType()
   }
 }
-public protocol ExpressibleAsOptionalType: ExpressibleAsTypeBuildable{
+public protocol ExpressibleAsOptionalType: ExpressibleAsTypeBuildable {
   func createOptionalType()-> OptionalType
 }
-public extension ExpressibleAsOptionalType{
-  func createTypeBuildable()-> TypeBuildable{
+public extension ExpressibleAsOptionalType {
+  func createTypeBuildable()-> TypeBuildable {
     return createOptionalType()
   }
 }
-public protocol ExpressibleAsConstrainedSugarType: ExpressibleAsTypeBuildable{
+public protocol ExpressibleAsConstrainedSugarType: ExpressibleAsTypeBuildable {
   func createConstrainedSugarType()-> ConstrainedSugarType
 }
-public extension ExpressibleAsConstrainedSugarType{
-  func createTypeBuildable()-> TypeBuildable{
+public extension ExpressibleAsConstrainedSugarType {
+  func createTypeBuildable()-> TypeBuildable {
     return createConstrainedSugarType()
   }
 }
-public protocol ExpressibleAsImplicitlyUnwrappedOptionalType: ExpressibleAsTypeBuildable{
+public protocol ExpressibleAsImplicitlyUnwrappedOptionalType: ExpressibleAsTypeBuildable {
   func createImplicitlyUnwrappedOptionalType()-> ImplicitlyUnwrappedOptionalType
 }
-public extension ExpressibleAsImplicitlyUnwrappedOptionalType{
-  func createTypeBuildable()-> TypeBuildable{
+public extension ExpressibleAsImplicitlyUnwrappedOptionalType {
+  func createTypeBuildable()-> TypeBuildable {
     return createImplicitlyUnwrappedOptionalType()
   }
 }
-public protocol ExpressibleAsCompositionTypeElement: ExpressibleAsCompositionTypeElementList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsCompositionTypeElement: ExpressibleAsCompositionTypeElementList, ExpressibleAsSyntaxBuildable {
   func createCompositionTypeElement()-> CompositionTypeElement
 }
-public extension ExpressibleAsCompositionTypeElement{
+public extension ExpressibleAsCompositionTypeElement {
   /// Conformance to `ExpressibleAsCompositionTypeElementList`
-func createCompositionTypeElementList()-> CompositionTypeElementList{
+func createCompositionTypeElementList()-> CompositionTypeElementList {
     return CompositionTypeElementList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createCompositionTypeElement()
   }
 }
-public protocol ExpressibleAsCompositionTypeElementList{
+public protocol ExpressibleAsCompositionTypeElementList {
   func createCompositionTypeElementList()-> CompositionTypeElementList
 }
-public protocol ExpressibleAsCompositionType: ExpressibleAsTypeBuildable{
+public protocol ExpressibleAsCompositionType: ExpressibleAsTypeBuildable {
   func createCompositionType()-> CompositionType
 }
-public extension ExpressibleAsCompositionType{
-  func createTypeBuildable()-> TypeBuildable{
+public extension ExpressibleAsCompositionType {
+  func createTypeBuildable()-> TypeBuildable {
     return createCompositionType()
   }
 }
-public protocol ExpressibleAsTupleTypeElement: ExpressibleAsTupleTypeElementList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsTupleTypeElement: ExpressibleAsTupleTypeElementList, ExpressibleAsSyntaxBuildable {
   func createTupleTypeElement()-> TupleTypeElement
 }
-public extension ExpressibleAsTupleTypeElement{
+public extension ExpressibleAsTupleTypeElement {
   /// Conformance to `ExpressibleAsTupleTypeElementList`
-func createTupleTypeElementList()-> TupleTypeElementList{
+func createTupleTypeElementList()-> TupleTypeElementList {
     return TupleTypeElementList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createTupleTypeElement()
   }
 }
-public protocol ExpressibleAsTupleTypeElementList{
+public protocol ExpressibleAsTupleTypeElementList {
   func createTupleTypeElementList()-> TupleTypeElementList
 }
-public protocol ExpressibleAsTupleType: ExpressibleAsTypeBuildable{
+public protocol ExpressibleAsTupleType: ExpressibleAsTypeBuildable {
   func createTupleType()-> TupleType
 }
-public extension ExpressibleAsTupleType{
-  func createTypeBuildable()-> TypeBuildable{
+public extension ExpressibleAsTupleType {
+  func createTypeBuildable()-> TypeBuildable {
     return createTupleType()
   }
 }
-public protocol ExpressibleAsFunctionType: ExpressibleAsTypeBuildable{
+public protocol ExpressibleAsFunctionType: ExpressibleAsTypeBuildable {
   func createFunctionType()-> FunctionType
 }
-public extension ExpressibleAsFunctionType{
-  func createTypeBuildable()-> TypeBuildable{
+public extension ExpressibleAsFunctionType {
+  func createTypeBuildable()-> TypeBuildable {
     return createFunctionType()
   }
 }
-public protocol ExpressibleAsAttributedType: ExpressibleAsTypeBuildable{
+public protocol ExpressibleAsAttributedType: ExpressibleAsTypeBuildable {
   func createAttributedType()-> AttributedType
 }
-public extension ExpressibleAsAttributedType{
-  func createTypeBuildable()-> TypeBuildable{
+public extension ExpressibleAsAttributedType {
+  func createTypeBuildable()-> TypeBuildable {
     return createAttributedType()
   }
 }
-public protocol ExpressibleAsGenericArgumentList{
+public protocol ExpressibleAsGenericArgumentList {
   func createGenericArgumentList()-> GenericArgumentList
 }
-public protocol ExpressibleAsGenericArgument: ExpressibleAsGenericArgumentList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsGenericArgument: ExpressibleAsGenericArgumentList, ExpressibleAsSyntaxBuildable {
   func createGenericArgument()-> GenericArgument
 }
-public extension ExpressibleAsGenericArgument{
+public extension ExpressibleAsGenericArgument {
   /// Conformance to `ExpressibleAsGenericArgumentList`
-func createGenericArgumentList()-> GenericArgumentList{
+func createGenericArgumentList()-> GenericArgumentList {
     return GenericArgumentList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createGenericArgument()
   }
 }
-public protocol ExpressibleAsGenericArgumentClause: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsGenericArgumentClause: ExpressibleAsSyntaxBuildable {
   func createGenericArgumentClause()-> GenericArgumentClause
 }
-public extension ExpressibleAsGenericArgumentClause{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsGenericArgumentClause {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createGenericArgumentClause()
   }
 }
-public protocol ExpressibleAsTypeAnnotation: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsTypeAnnotation: ExpressibleAsSyntaxBuildable {
   func createTypeAnnotation()-> TypeAnnotation
 }
-public extension ExpressibleAsTypeAnnotation{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsTypeAnnotation {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createTypeAnnotation()
   }
 }
-public protocol ExpressibleAsEnumCasePattern: ExpressibleAsPatternBuildable{
+public protocol ExpressibleAsEnumCasePattern: ExpressibleAsPatternBuildable {
   func createEnumCasePattern()-> EnumCasePattern
 }
-public extension ExpressibleAsEnumCasePattern{
-  func createPatternBuildable()-> PatternBuildable{
+public extension ExpressibleAsEnumCasePattern {
+  func createPatternBuildable()-> PatternBuildable {
     return createEnumCasePattern()
   }
 }
-public protocol ExpressibleAsIsTypePattern: ExpressibleAsPatternBuildable{
+public protocol ExpressibleAsIsTypePattern: ExpressibleAsPatternBuildable {
   func createIsTypePattern()-> IsTypePattern
 }
-public extension ExpressibleAsIsTypePattern{
-  func createPatternBuildable()-> PatternBuildable{
+public extension ExpressibleAsIsTypePattern {
+  func createPatternBuildable()-> PatternBuildable {
     return createIsTypePattern()
   }
 }
-public protocol ExpressibleAsOptionalPattern: ExpressibleAsPatternBuildable{
+public protocol ExpressibleAsOptionalPattern: ExpressibleAsPatternBuildable {
   func createOptionalPattern()-> OptionalPattern
 }
-public extension ExpressibleAsOptionalPattern{
-  func createPatternBuildable()-> PatternBuildable{
+public extension ExpressibleAsOptionalPattern {
+  func createPatternBuildable()-> PatternBuildable {
     return createOptionalPattern()
   }
 }
-public protocol ExpressibleAsIdentifierPattern: ExpressibleAsPatternBuildable{
+public protocol ExpressibleAsIdentifierPattern: ExpressibleAsPatternBuildable {
   func createIdentifierPattern()-> IdentifierPattern
 }
-public extension ExpressibleAsIdentifierPattern{
-  func createPatternBuildable()-> PatternBuildable{
+public extension ExpressibleAsIdentifierPattern {
+  func createPatternBuildable()-> PatternBuildable {
     return createIdentifierPattern()
   }
 }
-public protocol ExpressibleAsAsTypePattern: ExpressibleAsPatternBuildable{
+public protocol ExpressibleAsAsTypePattern: ExpressibleAsPatternBuildable {
   func createAsTypePattern()-> AsTypePattern
 }
-public extension ExpressibleAsAsTypePattern{
-  func createPatternBuildable()-> PatternBuildable{
+public extension ExpressibleAsAsTypePattern {
+  func createPatternBuildable()-> PatternBuildable {
     return createAsTypePattern()
   }
 }
-public protocol ExpressibleAsTuplePattern: ExpressibleAsPatternBuildable{
+public protocol ExpressibleAsTuplePattern: ExpressibleAsPatternBuildable {
   func createTuplePattern()-> TuplePattern
 }
-public extension ExpressibleAsTuplePattern{
-  func createPatternBuildable()-> PatternBuildable{
+public extension ExpressibleAsTuplePattern {
+  func createPatternBuildable()-> PatternBuildable {
     return createTuplePattern()
   }
 }
-public protocol ExpressibleAsWildcardPattern: ExpressibleAsPatternBuildable{
+public protocol ExpressibleAsWildcardPattern: ExpressibleAsPatternBuildable {
   func createWildcardPattern()-> WildcardPattern
 }
-public extension ExpressibleAsWildcardPattern{
-  func createPatternBuildable()-> PatternBuildable{
+public extension ExpressibleAsWildcardPattern {
+  func createPatternBuildable()-> PatternBuildable {
     return createWildcardPattern()
   }
 }
-public protocol ExpressibleAsTuplePatternElement: ExpressibleAsTuplePatternElementList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsTuplePatternElement: ExpressibleAsTuplePatternElementList, ExpressibleAsSyntaxBuildable {
   func createTuplePatternElement()-> TuplePatternElement
 }
-public extension ExpressibleAsTuplePatternElement{
+public extension ExpressibleAsTuplePatternElement {
   /// Conformance to `ExpressibleAsTuplePatternElementList`
-func createTuplePatternElementList()-> TuplePatternElementList{
+func createTuplePatternElementList()-> TuplePatternElementList {
     return TuplePatternElementList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createTuplePatternElement()
   }
 }
-public protocol ExpressibleAsExpressionPattern: ExpressibleAsPatternBuildable{
+public protocol ExpressibleAsExpressionPattern: ExpressibleAsPatternBuildable {
   func createExpressionPattern()-> ExpressionPattern
 }
-public extension ExpressibleAsExpressionPattern{
-  func createPatternBuildable()-> PatternBuildable{
+public extension ExpressibleAsExpressionPattern {
+  func createPatternBuildable()-> PatternBuildable {
     return createExpressionPattern()
   }
 }
-public protocol ExpressibleAsTuplePatternElementList{
+public protocol ExpressibleAsTuplePatternElementList {
   func createTuplePatternElementList()-> TuplePatternElementList
 }
-public protocol ExpressibleAsValueBindingPattern: ExpressibleAsPatternBuildable{
+public protocol ExpressibleAsValueBindingPattern: ExpressibleAsPatternBuildable {
   func createValueBindingPattern()-> ValueBindingPattern
 }
-public extension ExpressibleAsValueBindingPattern{
-  func createPatternBuildable()-> PatternBuildable{
+public extension ExpressibleAsValueBindingPattern {
+  func createPatternBuildable()-> PatternBuildable {
     return createValueBindingPattern()
   }
 }
-public protocol ExpressibleAsAvailabilitySpecList{
+public protocol ExpressibleAsAvailabilitySpecList {
   func createAvailabilitySpecList()-> AvailabilitySpecList
 }
-public protocol ExpressibleAsAvailabilityArgument: ExpressibleAsAvailabilitySpecList, ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsAvailabilityArgument: ExpressibleAsAvailabilitySpecList, ExpressibleAsSyntaxBuildable {
   func createAvailabilityArgument()-> AvailabilityArgument
 }
-public extension ExpressibleAsAvailabilityArgument{
+public extension ExpressibleAsAvailabilityArgument {
   /// Conformance to `ExpressibleAsAvailabilitySpecList`
-func createAvailabilitySpecList()-> AvailabilitySpecList{
+func createAvailabilitySpecList()-> AvailabilitySpecList {
     return AvailabilitySpecList([self])
   }
-  func createSyntaxBuildable()-> SyntaxBuildable{
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createAvailabilityArgument()
   }
 }
-public protocol ExpressibleAsAvailabilityLabeledArgument: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsAvailabilityLabeledArgument: ExpressibleAsSyntaxBuildable {
   func createAvailabilityLabeledArgument()-> AvailabilityLabeledArgument
 }
-public extension ExpressibleAsAvailabilityLabeledArgument{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsAvailabilityLabeledArgument {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createAvailabilityLabeledArgument()
   }
 }
-public protocol ExpressibleAsAvailabilityVersionRestriction: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsAvailabilityVersionRestriction: ExpressibleAsSyntaxBuildable {
   func createAvailabilityVersionRestriction()-> AvailabilityVersionRestriction
 }
-public extension ExpressibleAsAvailabilityVersionRestriction{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsAvailabilityVersionRestriction {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createAvailabilityVersionRestriction()
   }
 }
-public protocol ExpressibleAsVersionTuple: ExpressibleAsSyntaxBuildable{
+public protocol ExpressibleAsVersionTuple: ExpressibleAsSyntaxBuildable {
   func createVersionTuple()-> VersionTuple
 }
-public extension ExpressibleAsVersionTuple{
-  func createSyntaxBuildable()-> SyntaxBuildable{
+public extension ExpressibleAsVersionTuple {
+  func createSyntaxBuildable()-> SyntaxBuildable {
     return createVersionTuple()
   }
 }

--- a/Sources/SwiftSyntaxBuilder/generated/TokenSyntax.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/TokenSyntax.swift
@@ -14,35 +14,35 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
-extension TokenSyntax: ExpressibleAsTokenList, ExpressibleAsNonEmptyTokenList, ExpressibleAsBinaryOperatorExpr, ExpressibleAsDeclModifier, ExpressibleAsIdentifierExpr{
+extension TokenSyntax: ExpressibleAsTokenList, ExpressibleAsNonEmptyTokenList, ExpressibleAsBinaryOperatorExpr, ExpressibleAsDeclModifier, ExpressibleAsIdentifierExpr {
   /// Conformance to ExpressibleAsTokenList
-public func createTokenList()-> TokenList{
+public func createTokenList()-> TokenList {
     return TokenList([self])
   }
   /// Conformance to ExpressibleAsNonEmptyTokenList
-public func createNonEmptyTokenList()-> NonEmptyTokenList{
+public func createNonEmptyTokenList()-> NonEmptyTokenList {
     return NonEmptyTokenList([self])
   }
   /// Conformance to ExpressibleAsBinaryOperatorExpr
-public func createBinaryOperatorExpr()-> BinaryOperatorExpr{
+public func createBinaryOperatorExpr()-> BinaryOperatorExpr {
     return BinaryOperatorExpr(operatorToken: self)
   }
   /// Conformance to ExpressibleAsDeclModifier
-public func createDeclModifier()-> DeclModifier{
+public func createDeclModifier()-> DeclModifier {
     return DeclModifier(name: self)
   }
   /// Conformance to ExpressibleAsIdentifierExpr
-public func createIdentifierExpr()-> IdentifierExpr{
+public func createIdentifierExpr()-> IdentifierExpr {
     return IdentifierExpr(identifier: self)
   }
 }
 
 /// `TokenSyntax` conforms to `SyntaxBuildable` and `ExprBuildable` via different paths, so we need to pick one default conversion path to create an `ExprSyntax` (and `Syntax`) from a `String`. We choose `IdentifierExpr`.
-extension TokenSyntax{
-  public func createSyntaxBuildable()-> SyntaxBuildable{
+extension TokenSyntax {
+  public func createSyntaxBuildable()-> SyntaxBuildable {
     return createIdentifierExpr()
   }
-  public func createExprBuildable()-> ExprBuildable{
+  public func createExprBuildable()-> ExprBuildable {
     return createIdentifierExpr()
   }
 }

--- a/Sources/SwiftSyntaxBuilder/generated/Tokens.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/Tokens.swift
@@ -16,607 +16,607 @@
 import SwiftSyntax
 
 /// Namespace for commonly used tokens with default trivia.
-public extension TokenSyntax{
+public extension TokenSyntax {
   
 /// The `associatedtype` keyword
-static var `associatedtype`: TokenSyntax{
+static var `associatedtype`: TokenSyntax {
     SyntaxFactory.makeAssociatedtypeKeyword()
   }
   
 /// The `class` keyword
-static var `class`: TokenSyntax{
+static var `class`: TokenSyntax {
     SyntaxFactory.makeClassKeyword()
   }
   
 /// The `deinit` keyword
-static var `deinit`: TokenSyntax{
+static var `deinit`: TokenSyntax {
     SyntaxFactory.makeDeinitKeyword()
   }
   
 /// The `enum` keyword
-static var `enum`: TokenSyntax{
+static var `enum`: TokenSyntax {
     SyntaxFactory.makeEnumKeyword()
   }
   
 /// The `extension` keyword
-static var `extension`: TokenSyntax{
+static var `extension`: TokenSyntax {
     SyntaxFactory.makeExtensionKeyword()
   }
   
 /// The `func` keyword
-static var `func`: TokenSyntax{
+static var `func`: TokenSyntax {
     SyntaxFactory.makeFuncKeyword()
   }
   
 /// The `import` keyword
-static var `import`: TokenSyntax{
+static var `import`: TokenSyntax {
     SyntaxFactory.makeImportKeyword()
   }
   
 /// The `init` keyword
-static var `init`: TokenSyntax{
+static var `init`: TokenSyntax {
     SyntaxFactory.makeInitKeyword()
   }
   
 /// The `inout` keyword
-static var `inout`: TokenSyntax{
+static var `inout`: TokenSyntax {
     SyntaxFactory.makeInoutKeyword()
   }
   
 /// The `let` keyword
-static var `let`: TokenSyntax{
+static var `let`: TokenSyntax {
     SyntaxFactory.makeLetKeyword()
   }
   
 /// The `operator` keyword
-static var `operator`: TokenSyntax{
+static var `operator`: TokenSyntax {
     SyntaxFactory.makeOperatorKeyword()
   }
   
 /// The `precedencegroup` keyword
-static var `precedencegroup`: TokenSyntax{
+static var `precedencegroup`: TokenSyntax {
     SyntaxFactory.makePrecedencegroupKeyword()
   }
   
 /// The `protocol` keyword
-static var `protocol`: TokenSyntax{
+static var `protocol`: TokenSyntax {
     SyntaxFactory.makeProtocolKeyword()
   }
   
 /// The `struct` keyword
-static var `struct`: TokenSyntax{
+static var `struct`: TokenSyntax {
     SyntaxFactory.makeStructKeyword()
   }
   
 /// The `subscript` keyword
-static var `subscript`: TokenSyntax{
+static var `subscript`: TokenSyntax {
     SyntaxFactory.makeSubscriptKeyword()
   }
   
 /// The `typealias` keyword
-static var `typealias`: TokenSyntax{
+static var `typealias`: TokenSyntax {
     SyntaxFactory.makeTypealiasKeyword()
   }
   
 /// The `var` keyword
-static var `var`: TokenSyntax{
+static var `var`: TokenSyntax {
     SyntaxFactory.makeVarKeyword()
   }
   
 /// The `fileprivate` keyword
-static var `fileprivate`: TokenSyntax{
+static var `fileprivate`: TokenSyntax {
     SyntaxFactory.makeFileprivateKeyword()
   }
   
 /// The `internal` keyword
-static var `internal`: TokenSyntax{
+static var `internal`: TokenSyntax {
     SyntaxFactory.makeInternalKeyword()
   }
   
 /// The `private` keyword
-static var `private`: TokenSyntax{
+static var `private`: TokenSyntax {
     SyntaxFactory.makePrivateKeyword()
   }
   
 /// The `public` keyword
-static var `public`: TokenSyntax{
+static var `public`: TokenSyntax {
     SyntaxFactory.makePublicKeyword()
   }
   
 /// The `static` keyword
-static var `static`: TokenSyntax{
+static var `static`: TokenSyntax {
     SyntaxFactory.makeStaticKeyword()
   }
   
 /// The `defer` keyword
-static var `defer`: TokenSyntax{
+static var `defer`: TokenSyntax {
     SyntaxFactory.makeDeferKeyword()
   }
   
 /// The `if` keyword
-static var `if`: TokenSyntax{
+static var `if`: TokenSyntax {
     SyntaxFactory.makeIfKeyword()
   }
   
 /// The `guard` keyword
-static var `guard`: TokenSyntax{
+static var `guard`: TokenSyntax {
     SyntaxFactory.makeGuardKeyword()
   }
   
 /// The `do` keyword
-static var `do`: TokenSyntax{
+static var `do`: TokenSyntax {
     SyntaxFactory.makeDoKeyword()
   }
   
 /// The `repeat` keyword
-static var `repeat`: TokenSyntax{
+static var `repeat`: TokenSyntax {
     SyntaxFactory.makeRepeatKeyword()
   }
   
 /// The `else` keyword
-static var `else`: TokenSyntax{
+static var `else`: TokenSyntax {
     SyntaxFactory.makeElseKeyword()
   }
   
 /// The `for` keyword
-static var `for`: TokenSyntax{
+static var `for`: TokenSyntax {
     SyntaxFactory.makeForKeyword()
   }
   
 /// The `in` keyword
-static var `in`: TokenSyntax{
+static var `in`: TokenSyntax {
     SyntaxFactory.makeInKeyword()
   }
   
 /// The `while` keyword
-static var `while`: TokenSyntax{
+static var `while`: TokenSyntax {
     SyntaxFactory.makeWhileKeyword()
   }
   
 /// The `return` keyword
-static var `return`: TokenSyntax{
+static var `return`: TokenSyntax {
     SyntaxFactory.makeReturnKeyword()
   }
   
 /// The `break` keyword
-static var `break`: TokenSyntax{
+static var `break`: TokenSyntax {
     SyntaxFactory.makeBreakKeyword()
   }
   
 /// The `continue` keyword
-static var `continue`: TokenSyntax{
+static var `continue`: TokenSyntax {
     SyntaxFactory.makeContinueKeyword()
   }
   
 /// The `fallthrough` keyword
-static var `fallthrough`: TokenSyntax{
+static var `fallthrough`: TokenSyntax {
     SyntaxFactory.makeFallthroughKeyword()
   }
   
 /// The `switch` keyword
-static var `switch`: TokenSyntax{
+static var `switch`: TokenSyntax {
     SyntaxFactory.makeSwitchKeyword()
   }
   
 /// The `case` keyword
-static var `case`: TokenSyntax{
+static var `case`: TokenSyntax {
     SyntaxFactory.makeCaseKeyword()
   }
   
 /// The `default` keyword
-static var `default`: TokenSyntax{
+static var `default`: TokenSyntax {
     SyntaxFactory.makeDefaultKeyword()
   }
   
 /// The `where` keyword
-static var `where`: TokenSyntax{
+static var `where`: TokenSyntax {
     SyntaxFactory.makeWhereKeyword()
   }
   
 /// The `catch` keyword
-static var `catch`: TokenSyntax{
+static var `catch`: TokenSyntax {
     SyntaxFactory.makeCatchKeyword()
   }
   
 /// The `throw` keyword
-static var `throw`: TokenSyntax{
+static var `throw`: TokenSyntax {
     SyntaxFactory.makeThrowKeyword()
   }
   
 /// The `as` keyword
-static var `as`: TokenSyntax{
+static var `as`: TokenSyntax {
     SyntaxFactory.makeAsKeyword()
   }
   
 /// The `Any` keyword
-static var `any`: TokenSyntax{
+static var `any`: TokenSyntax {
     SyntaxFactory.makeAnyKeyword()
   }
   
 /// The `false` keyword
-static var `false`: TokenSyntax{
+static var `false`: TokenSyntax {
     SyntaxFactory.makeFalseKeyword()
   }
   
 /// The `is` keyword
-static var `is`: TokenSyntax{
+static var `is`: TokenSyntax {
     SyntaxFactory.makeIsKeyword()
   }
   
 /// The `nil` keyword
-static var `nil`: TokenSyntax{
+static var `nil`: TokenSyntax {
     SyntaxFactory.makeNilKeyword()
   }
   
 /// The `rethrows` keyword
-static var `rethrows`: TokenSyntax{
+static var `rethrows`: TokenSyntax {
     SyntaxFactory.makeRethrowsKeyword()
   }
   
 /// The `super` keyword
-static var `super`: TokenSyntax{
+static var `super`: TokenSyntax {
     SyntaxFactory.makeSuperKeyword()
   }
   
 /// The `self` keyword
-static var `self`: TokenSyntax{
+static var `self`: TokenSyntax {
     SyntaxFactory.makeSelfKeyword()
   }
   
 /// The `Self` keyword
-static var `capitalSelf`: TokenSyntax{
+static var `capitalSelf`: TokenSyntax {
     SyntaxFactory.makeCapitalSelfKeyword()
   }
   
 /// The `true` keyword
-static var `true`: TokenSyntax{
+static var `true`: TokenSyntax {
     SyntaxFactory.makeTrueKeyword()
   }
   
 /// The `try` keyword
-static var `try`: TokenSyntax{
+static var `try`: TokenSyntax {
     SyntaxFactory.makeTryKeyword()
   }
   
 /// The `throws` keyword
-static var `throws`: TokenSyntax{
+static var `throws`: TokenSyntax {
     SyntaxFactory.makeThrowsKeyword()
   }
   
 /// The `__FILE__` keyword
-static var `__FILE__`: TokenSyntax{
+static var `__FILE__`: TokenSyntax {
     SyntaxFactory.make__FILE__Keyword()
   }
   
 /// The `__LINE__` keyword
-static var `__LINE__`: TokenSyntax{
+static var `__LINE__`: TokenSyntax {
     SyntaxFactory.make__LINE__Keyword()
   }
   
 /// The `__COLUMN__` keyword
-static var `__COLUMN__`: TokenSyntax{
+static var `__COLUMN__`: TokenSyntax {
     SyntaxFactory.make__COLUMN__Keyword()
   }
   
 /// The `__FUNCTION__` keyword
-static var `__FUNCTION__`: TokenSyntax{
+static var `__FUNCTION__`: TokenSyntax {
     SyntaxFactory.make__FUNCTION__Keyword()
   }
   
 /// The `__DSO_HANDLE__` keyword
-static var `__DSO_HANDLE__`: TokenSyntax{
+static var `__DSO_HANDLE__`: TokenSyntax {
     SyntaxFactory.make__DSO_HANDLE__Keyword()
   }
   
 /// The `_` keyword
-static var `wildcard`: TokenSyntax{
+static var `wildcard`: TokenSyntax {
     SyntaxFactory.makeWildcardKeyword()
   }
   
 /// The `(` token
-static var `leftParen`: TokenSyntax{
+static var `leftParen`: TokenSyntax {
     SyntaxFactory.makeLeftParenToken()
   }
   
 /// The `)` token
-static var `rightParen`: TokenSyntax{
+static var `rightParen`: TokenSyntax {
     SyntaxFactory.makeRightParenToken()
   }
   
 /// The `{` token
-static var `leftBrace`: TokenSyntax{
+static var `leftBrace`: TokenSyntax {
     SyntaxFactory.makeLeftBraceToken()
   }
   
 /// The `}` token
-static var `rightBrace`: TokenSyntax{
+static var `rightBrace`: TokenSyntax {
     SyntaxFactory.makeRightBraceToken()
   }
   
 /// The `[` token
-static var `leftSquareBracket`: TokenSyntax{
+static var `leftSquareBracket`: TokenSyntax {
     SyntaxFactory.makeLeftSquareBracketToken()
   }
   
 /// The `]` token
-static var `rightSquareBracket`: TokenSyntax{
+static var `rightSquareBracket`: TokenSyntax {
     SyntaxFactory.makeRightSquareBracketToken()
   }
   
 /// The `<` token
-static var `leftAngle`: TokenSyntax{
+static var `leftAngle`: TokenSyntax {
     SyntaxFactory.makeLeftAngleToken()
   }
   
 /// The `>` token
-static var `rightAngle`: TokenSyntax{
+static var `rightAngle`: TokenSyntax {
     SyntaxFactory.makeRightAngleToken()
   }
   
 /// The `.` token
-static var `period`: TokenSyntax{
+static var `period`: TokenSyntax {
     SyntaxFactory.makePeriodToken()
   }
   
 /// The `.` token
-static var `prefixPeriod`: TokenSyntax{
+static var `prefixPeriod`: TokenSyntax {
     SyntaxFactory.makePrefixPeriodToken()
   }
   
 /// The `,` token
-static var `comma`: TokenSyntax{
+static var `comma`: TokenSyntax {
     SyntaxFactory.makeCommaToken()
   }
   
 /// The `...` token
-static var `ellipsis`: TokenSyntax{
+static var `ellipsis`: TokenSyntax {
     SyntaxFactory.makeEllipsisToken()
   }
   
 /// The `:` token
-static var `colon`: TokenSyntax{
+static var `colon`: TokenSyntax {
     SyntaxFactory.makeColonToken()
   }
   
 /// The `;` token
-static var `semicolon`: TokenSyntax{
+static var `semicolon`: TokenSyntax {
     SyntaxFactory.makeSemicolonToken()
   }
   
 /// The `=` token
-static var `equal`: TokenSyntax{
+static var `equal`: TokenSyntax {
     SyntaxFactory.makeEqualToken()
   }
   
 /// The `@` token
-static var `atSign`: TokenSyntax{
+static var `atSign`: TokenSyntax {
     SyntaxFactory.makeAtSignToken()
   }
   
 /// The `#` token
-static var `pound`: TokenSyntax{
+static var `pound`: TokenSyntax {
     SyntaxFactory.makePoundToken()
   }
   
 /// The `&` token
-static var `prefixAmpersand`: TokenSyntax{
+static var `prefixAmpersand`: TokenSyntax {
     SyntaxFactory.makePrefixAmpersandToken()
   }
   
 /// The `->` token
-static var `arrow`: TokenSyntax{
+static var `arrow`: TokenSyntax {
     SyntaxFactory.makeArrowToken()
   }
   
 /// The ``` token
-static var `backtick`: TokenSyntax{
+static var `backtick`: TokenSyntax {
     SyntaxFactory.makeBacktickToken()
   }
   
 /// The `\` token
-static var `backslash`: TokenSyntax{
+static var `backslash`: TokenSyntax {
     SyntaxFactory.makeBackslashToken()
   }
   
 /// The `!` token
-static var `exclamationMark`: TokenSyntax{
+static var `exclamationMark`: TokenSyntax {
     SyntaxFactory.makeExclamationMarkToken()
   }
   
 /// The `?` token
-static var `postfixQuestionMark`: TokenSyntax{
+static var `postfixQuestionMark`: TokenSyntax {
     SyntaxFactory.makePostfixQuestionMarkToken()
   }
   
 /// The `?` token
-static var `infixQuestionMark`: TokenSyntax{
+static var `infixQuestionMark`: TokenSyntax {
     SyntaxFactory.makeInfixQuestionMarkToken()
   }
   
 /// The `"` token
-static var `stringQuote`: TokenSyntax{
+static var `stringQuote`: TokenSyntax {
     SyntaxFactory.makeStringQuoteToken()
   }
   
 /// The `'` token
-static var `singleQuote`: TokenSyntax{
+static var `singleQuote`: TokenSyntax {
     SyntaxFactory.makeSingleQuoteToken()
   }
   
 /// The `"""` token
-static var `multilineStringQuote`: TokenSyntax{
+static var `multilineStringQuote`: TokenSyntax {
     SyntaxFactory.makeMultilineStringQuoteToken()
   }
   
 /// The `#keyPath` keyword
-static var `poundKeyPath`: TokenSyntax{
+static var `poundKeyPath`: TokenSyntax {
     SyntaxFactory.makePoundKeyPathKeyword()
   }
   
 /// The `#line` keyword
-static var `poundLine`: TokenSyntax{
+static var `poundLine`: TokenSyntax {
     SyntaxFactory.makePoundLineKeyword()
   }
   
 /// The `#selector` keyword
-static var `poundSelector`: TokenSyntax{
+static var `poundSelector`: TokenSyntax {
     SyntaxFactory.makePoundSelectorKeyword()
   }
   
 /// The `#file` keyword
-static var `poundFile`: TokenSyntax{
+static var `poundFile`: TokenSyntax {
     SyntaxFactory.makePoundFileKeyword()
   }
   
 /// The `#fileID` keyword
-static var `poundFileID`: TokenSyntax{
+static var `poundFileID`: TokenSyntax {
     SyntaxFactory.makePoundFileIDKeyword()
   }
   
 /// The `#filePath` keyword
-static var `poundFilePath`: TokenSyntax{
+static var `poundFilePath`: TokenSyntax {
     SyntaxFactory.makePoundFilePathKeyword()
   }
   
 /// The `#column` keyword
-static var `poundColumn`: TokenSyntax{
+static var `poundColumn`: TokenSyntax {
     SyntaxFactory.makePoundColumnKeyword()
   }
   
 /// The `#function` keyword
-static var `poundFunction`: TokenSyntax{
+static var `poundFunction`: TokenSyntax {
     SyntaxFactory.makePoundFunctionKeyword()
   }
   
 /// The `#dsohandle` keyword
-static var `poundDsohandle`: TokenSyntax{
+static var `poundDsohandle`: TokenSyntax {
     SyntaxFactory.makePoundDsohandleKeyword()
   }
   
 /// The `#assert` keyword
-static var `poundAssert`: TokenSyntax{
+static var `poundAssert`: TokenSyntax {
     SyntaxFactory.makePoundAssertKeyword()
   }
   
 /// The `#sourceLocation` keyword
-static var `poundSourceLocation`: TokenSyntax{
+static var `poundSourceLocation`: TokenSyntax {
     SyntaxFactory.makePoundSourceLocationKeyword()
   }
   
 /// The `#warning` keyword
-static var `poundWarning`: TokenSyntax{
+static var `poundWarning`: TokenSyntax {
     SyntaxFactory.makePoundWarningKeyword()
   }
   
 /// The `#error` keyword
-static var `poundError`: TokenSyntax{
+static var `poundError`: TokenSyntax {
     SyntaxFactory.makePoundErrorKeyword()
   }
   
 /// The `#if` keyword
-static var `poundIf`: TokenSyntax{
+static var `poundIf`: TokenSyntax {
     SyntaxFactory.makePoundIfKeyword()
   }
   
 /// The `#else` keyword
-static var `poundElse`: TokenSyntax{
+static var `poundElse`: TokenSyntax {
     SyntaxFactory.makePoundElseKeyword()
   }
   
 /// The `#elseif` keyword
-static var `poundElseif`: TokenSyntax{
+static var `poundElseif`: TokenSyntax {
     SyntaxFactory.makePoundElseifKeyword()
   }
   
 /// The `#endif` keyword
-static var `poundEndif`: TokenSyntax{
+static var `poundEndif`: TokenSyntax {
     SyntaxFactory.makePoundEndifKeyword()
   }
   
 /// The `#available` keyword
-static var `poundAvailable`: TokenSyntax{
+static var `poundAvailable`: TokenSyntax {
     SyntaxFactory.makePoundAvailableKeyword()
   }
   
 /// The `#unavailable` keyword
-static var `poundUnavailable`: TokenSyntax{
+static var `poundUnavailable`: TokenSyntax {
     SyntaxFactory.makePoundUnavailableKeyword()
   }
   
 /// The `#fileLiteral` keyword
-static var `poundFileLiteral`: TokenSyntax{
+static var `poundFileLiteral`: TokenSyntax {
     SyntaxFactory.makePoundFileLiteralKeyword()
   }
   
 /// The `#imageLiteral` keyword
-static var `poundImageLiteral`: TokenSyntax{
+static var `poundImageLiteral`: TokenSyntax {
     SyntaxFactory.makePoundImageLiteralKeyword()
   }
   
 /// The `#colorLiteral` keyword
-static var `poundColorLiteral`: TokenSyntax{
+static var `poundColorLiteral`: TokenSyntax {
     SyntaxFactory.makePoundColorLiteralKeyword()
   }
-  static func `integerLiteral`(_ text: String) -> TokenSyntax{
+  static func `integerLiteral`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeIntegerLiteral(text)
   }
-  static func `floatingLiteral`(_ text: String) -> TokenSyntax{
+  static func `floatingLiteral`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeFloatingLiteral(text)
   }
-  static func `stringLiteral`(_ text: String) -> TokenSyntax{
+  static func `stringLiteral`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeStringLiteral(text)
   }
-  static func `regexLiteral`(_ text: String) -> TokenSyntax{
+  static func `regexLiteral`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeRegexLiteral(text)
   }
-  static func `unknown`(_ text: String) -> TokenSyntax{
+  static func `unknown`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeUnknown(text)
   }
-  static func `identifier`(_ text: String) -> TokenSyntax{
+  static func `identifier`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeIdentifier(text)
   }
-  static func `unspacedBinaryOperator`(_ text: String) -> TokenSyntax{
+  static func `unspacedBinaryOperator`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeUnspacedBinaryOperator(text)
   }
-  static func `spacedBinaryOperator`(_ text: String) -> TokenSyntax{
+  static func `spacedBinaryOperator`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeSpacedBinaryOperator(text)
   }
-  static func `postfixOperator`(_ text: String) -> TokenSyntax{
+  static func `postfixOperator`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makePostfixOperator(text)
   }
-  static func `prefixOperator`(_ text: String) -> TokenSyntax{
+  static func `prefixOperator`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makePrefixOperator(text)
   }
-  static func `dollarIdentifier`(_ text: String) -> TokenSyntax{
+  static func `dollarIdentifier`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeDollarIdentifier(text)
   }
-  static func `contextualKeyword`(_ text: String) -> TokenSyntax{
+  static func `contextualKeyword`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeContextualKeyword(text)
   }
-  static func `rawStringDelimiter`(_ text: String) -> TokenSyntax{
+  static func `rawStringDelimiter`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeRawStringDelimiter(text)
   }
-  static func `stringSegment`(_ text: String) -> TokenSyntax{
+  static func `stringSegment`(_ text: String) -> TokenSyntax {
     SyntaxFactory.makeStringSegment(text)
   }
   
 /// The `)` token
-static var `stringInterpolationAnchor`: TokenSyntax{
+static var `stringInterpolationAnchor`: TokenSyntax {
     SyntaxFactory.makeStringInterpolationAnchorToken()
   }
   
 /// The `yield` token
-static var `yield`: TokenSyntax{
+static var `yield`: TokenSyntax {
     SyntaxFactory.makeYieldToken()
   }
   
 /// The `eof` token
-static var eof: TokenSyntax{
+static var eof: TokenSyntax {
     SyntaxFactory.makeToken(.eof, presence: .present)
   }
   
 /// The `open` contextual token
-static var open: TokenSyntax{
+static var open: TokenSyntax {
     SyntaxFactory.makeContextualKeyword("open")
     .withTrailingTrivia(.space)
   }

--- a/Tests/SwiftSyntaxBuilderTest/CollectionNodeFlatteningTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/CollectionNodeFlatteningTests.swift
@@ -29,7 +29,7 @@ final class CollectionNodeFlatteningTests: XCTestCase {
     var result = ""
     test.write(to: &result)
     XCTAssertEqual(result, """
-      ␣{
+      ␣ {
           outsideBuilder()
           outerBuilder()
           innerBuilder()
@@ -67,7 +67,7 @@ final class CollectionNodeFlatteningTests: XCTestCase {
       var result = ""
       test.write(to: &result)
       XCTAssertEqual(result, """
-        ␣{
+        ␣ {
             outsideBuilder()
             outerBuilder()
             innerBuilder()

--- a/Tests/SwiftSyntaxBuilderTest/EnumCaseElementTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/EnumCaseElementTests.swift
@@ -27,7 +27,7 @@ final class EnumCaseElementTests: XCTestCase {
 
     XCTAssertEqual(syntax.description,
       """
-      ␣enum Greeting: String, Codable, Equatable{
+      ␣enum Greeting: String, Codable, Equatable {
           case goodMorning = "Good Morning", helloWorld = "Hello World", hi
       }
       """)

--- a/Tests/SwiftSyntaxBuilderTest/ExpressibleBuildablesTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ExpressibleBuildablesTests.swift
@@ -17,10 +17,10 @@ final class ExpressibleBuildablesTests: XCTestCase {
 
     let syntax = myStruct.buildSyntax(format: Format())
     XCTAssertEqual(syntax.description, """
-    struct MyStruct{
+    struct MyStruct {
         var myFirstVar: Int
         let myOtherLet: String
-        struct InnerStruct{
+        struct InnerStruct {
         }
     }
     """)
@@ -36,9 +36,9 @@ final class ExpressibleBuildablesTests: XCTestCase {
     let syntax = myCodeBlock.buildSyntax(format: Format())
     XCTAssertEqual(syntax.description, """
 
-    struct MyStruct1{
+    struct MyStruct1 {
     }
-    struct MyStruct2{
+    struct MyStruct2 {
     }
     """)
   }
@@ -64,7 +64,7 @@ final class ExpressibleBuildablesTests: XCTestCase {
     XCTAssertEqual(
       syntax.description,
       """
-      switch version{
+      switch version {
       case .version_1: 
           return "1.0.0"
       case .version_2: 

--- a/Tests/SwiftSyntaxBuilderTest/ExtensionDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ExtensionDeclTests.swift
@@ -32,11 +32,11 @@ final class ExtensionDeclTests: XCTestCase {
     syntax.write(to: &text)
 
     XCTAssertEqual(text, """
-    extension TokenSyntax{
-        public var `associatedtype`: TokenSyntax{
+    extension TokenSyntax {
+        public var `associatedtype`: TokenSyntax {
             SyntaxFactory.makeassociatedtypeKeyword()
         }
-        public var `class`: TokenSyntax{
+        public var `class`: TokenSyntax {
             SyntaxFactory.makeclassKeyword()
         }
     }

--- a/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
@@ -44,8 +44,8 @@ final class FunctionTests: XCTestCase {
     let syntax = buildable.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
 
     XCTAssertEqual(syntax.description, """
-      ␣func fibonacci(_ n: Int)-> Int{
-          if n <= 1{
+      ␣func fibonacci(_ n: Int)-> Int {
+          if n <= 1 {
               return n
           }
           return fibonacci(n - 1) + self.fibonacci(n - 2)
@@ -74,7 +74,7 @@ final class FunctionTests: XCTestCase {
       TupleExprElement(expression: "42")
     }
     let syntax = buildable.buildSyntax(format: Format())
-    XCTAssertEqual(syntax.description, "test(42){\n}")
+    XCTAssertEqual(syntax.description, "test(42) {\n}")
   }
 
   func testParensOmittedForNoArgumentsAndTrailingClosure() {
@@ -88,7 +88,7 @@ final class FunctionTests: XCTestCase {
     XCTAssertEqual(
       syntax.description,
       """
-      test{
+      test {
           f(a)
       }
       """)

--- a/Tests/SwiftSyntaxBuilderTest/ProtocolDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ProtocolDeclTests.swift
@@ -21,7 +21,7 @@ final class ProtocolDeclTests: XCTestCase {
     syntax.write(to: &text)
 
     XCTAssertEqual(text, """
-    public protocol DeclListBuildable{
+    public protocol DeclListBuildable {
         func buildDeclList(format: Format, leadingTrivia: Trivia?)-> [DeclSyntax]
     }
     """)

--- a/Tests/SwiftSyntaxBuilderTest/SourceFileTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/SourceFileTests.swift
@@ -21,7 +21,7 @@ final class SourceFileTests: XCTestCase {
 
       import Foundation
       import UIKit
-      class SomeViewController{
+      class SomeViewController {
           let tableView: UITableView
       }
       """)

--- a/Tests/SwiftSyntaxBuilderTest/StructTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StructTests.swift
@@ -12,7 +12,7 @@ final class StructTests: XCTestCase {
     syntax.write(to: &text)
 
     XCTAssertEqual(text, """
-    ␣struct TestStruct{
+    ␣struct TestStruct {
     }
     """)
   }
@@ -46,9 +46,9 @@ final class StructTests: XCTestCase {
 
     // FIXME: We should indent the nested struct by adding the indentation after every newline in the leading trivia.
     XCTAssertEqual(text, """
-    ␣public struct TestStruct{
+    ␣public struct TestStruct {
         /// A nested struct
-    struct NestedStruct < A, B: C, D > where A: X, A.P==D{
+    struct NestedStruct < A, B: C, D > where A: X, A.P==D {
         }
     }
     """)
@@ -69,7 +69,7 @@ final class StructTests: XCTestCase {
     }
     let syntax = myStruct.buildSyntax(format: Format())
     XCTAssertEqual(syntax.description, """
-    struct MyStruct{
+    struct MyStruct {
         let var0: String
         let var2: String
         let var4: String

--- a/Tests/SwiftSyntaxTest/SyntaxFactoryTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxFactoryTests.swift
@@ -3,7 +3,7 @@ import SwiftSyntax
 
 fileprivate func cannedStructDecl() -> StructDeclSyntax {
   let structKW = SyntaxFactory.makeStructKeyword(trailingTrivia: .space)
-  let fooID = SyntaxFactory.makeIdentifier("Foo", trailingTrivia: .space)
+  let fooID = SyntaxFactory.makeIdentifier("Foo")
   let rBrace = SyntaxFactory.makeRightBraceToken(leadingTrivia: .newline)
   let members = MemberDeclBlockSyntax {
     $0.useLeftBrace(SyntaxFactory.makeLeftBraceToken())
@@ -28,11 +28,7 @@ public class SyntaxFactoryTests: XCTestCase {
                    }
                    """)
 
-    let forType = SyntaxFactory.makeIdentifier("`for`",
-                                               leadingTrivia: [],
-                                               trailingTrivia: [
-                                                 .spaces(1)
-                                               ])
+    let forType = SyntaxFactory.makeIdentifier("`for`")
     let newBrace = SyntaxFactory.makeRightBraceToken(leadingTrivia: .newlines(2))
 
     let renamed = structDecl.withIdentifier(forType)


### PR DESCRIPTION
https://github.com/apple/swift/pull/59980

The next approaches didn't work:
* Pass space trivia as the build expression argument − it leaves property/subscript accessors untouched because there is `AccessorBlock`/`CodeBlock` choice and build expression has no context regarding actual syntax type and related traits.
* set default value of `leadingTrivia` for syntax types with the `Braced` trait − it breaks on the `SwitchStmt`, which doesn't start with the brace.