### PR TITLE
[NFC] Scale Back Foundation Dependency

### DIFF
--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -134,7 +134,7 @@ public final class SourceLocationConverter {
   public init(file: String, source: String) {
     self.file = file
     (self.lines, endOfFile) = computeLines(source)
-    assert(source.lengthOfBytes(using: .utf8) == endOfFile.utf8Offset)
+    assert(source.utf8.count == endOfFile.utf8Offset)
   }
 
   /// Convert a `AbsolutePosition` to a `SourceLocation`. If the position is

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -17,8 +17,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
-
 /// A contiguous stretch of a single kind of trivia. The constituent part of
 /// a `Trivia` collection.
 ///

--- a/Sources/SwiftSyntax/gyb_generated/Trivia.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Trivia.swift
@@ -12,8 +12,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-import Foundation
-
 /// A contiguous stretch of a single kind of trivia. The constituent part of
 /// a `Trivia` collection.
 ///


### PR DESCRIPTION
Remove SwiftSyntax's dependency on Foundation - there's nothing in this library that really needs that big a dependency.