### PR TITLE
Use `let` bindings in `BuildableBaseProtocolsFile`

### DIFF
--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableBaseProtocolsFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableBaseProtocolsFile.swift
@@ -30,8 +30,8 @@ let buildableBaseProtocolsFile = SourceFile {
     let syntaxType = SyntaxBuildableType(syntaxKind: "Syntax")
     let isSyntax = type == syntaxType
     // Types that the `*Buildable` conforms to
-    var buildableConformances: [String] = [type.expressibleAs, type.listBuildable] + (isSyntax ? [] : [syntaxType.buildable])
-    var listConformances: [String] = isSyntax ? [] : [syntaxType.listBuildable]
+    let buildableConformances: [String] = [type.expressibleAs, type.listBuildable] + (isSyntax ? [] : [syntaxType.buildable])
+    let listConformances: [String] = isSyntax ? [] : [syntaxType.listBuildable]
 
     ProtocolDecl(
       modifiers: [TokenSyntax.public],


### PR DESCRIPTION
A minor stylistic oversight that originated from translating a variable mutation from Python, which we however ended up rewriting in an immutable style. This patch therefore updates these variables to be `let`-bindings.