### PR TITLE
Conform `TokenSyntax` to `ExpressibleByStringLiteral` and `ExpressibleByStringInterpolation`

### DIFF
--- a/Sources/SwiftSyntaxBuilder/generated/TokenSyntax.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/TokenSyntax.swift
@@ -46,7 +46,7 @@ extension TokenSyntax {
     return createIdentifierExpr()
   }
 }
-extension TokenSyntax: ExpressibleByStringLiteral {
+extension TokenSyntax: ExpressibleByStringLiteral, ExpressibleByStringInterpolation {
   public init (stringLiteral: String) {
     self = .identifier(stringLiteral)
   }

--- a/Sources/SwiftSyntaxBuilder/generated/TokenSyntax.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/TokenSyntax.swift
@@ -46,3 +46,8 @@ extension TokenSyntax {
     return createIdentifierExpr()
   }
 }
+extension TokenSyntax: ExpressibleByStringLiteral {
+  public init (stringLiteral: String) {
+    self = .identifier(stringLiteral)
+  }
+}

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableBaseProtocolsFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableBaseProtocolsFile.swift
@@ -44,7 +44,7 @@ let buildableBaseProtocolsFile = SourceFile {
           "/// - Parameter format: The `Format` to use.",
           "/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.",
         ].map { .docLineComment($0) + .newline }.reduce([], +),
-        identifier: .identifier("build\(type.baseName)List"),
+        identifier: "build\(type.baseName)List",
         signature: FunctionSignature(
           input: formatLeadingTriviaParameters(),
           output: ArrayType(elementType: type.syntax)
@@ -64,7 +64,7 @@ let buildableBaseProtocolsFile = SourceFile {
           "/// - Parameter format: The `Format` to use.",
           "/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.",
         ].map { .docLineComment($0) + .newline }.reduce([], +),
-        identifier: .identifier("build\(type.baseName)"),
+        identifier: "build\(type.baseName)",
         signature: FunctionSignature(
           input: formatLeadingTriviaParameters(),
           output: type.syntax
@@ -79,7 +79,7 @@ let buildableBaseProtocolsFile = SourceFile {
     ) {
       FunctionDecl(
         leadingTrivia: .docLineComment("/// Satisfies conformance to `\(type.expressibleAs)`.") + .newline,
-        identifier: .identifier("create\(type.buildableBaseName)"),
+        identifier: "create\(type.buildableBaseName)",
         signature: FunctionSignature(
           input: ParameterClause(),
           output: type.buildable
@@ -96,7 +96,7 @@ let buildableBaseProtocolsFile = SourceFile {
           "///",
           "/// Satisfies conformance to `\(type.listBuildable)`",
         ].map { .docLineComment($0) + .newline }.reduce([], +),
-        identifier: .identifier("build\(type.baseName)List"),
+        identifier: "build\(type.baseName)List",
         signature: FunctionSignature(
           input: formatLeadingTriviaParameters(withDefaultTrivia: true),
           output: ArrayType(elementType: type.syntax)
@@ -120,7 +120,7 @@ let buildableBaseProtocolsFile = SourceFile {
           "///",
           "/// Satisfies conformance to `SyntaxBuildable`.",
         ].map { .docLineComment($0) + .newline }.reduce([], +),
-          identifier: .identifier("buildSyntax"),
+          identifier: "buildSyntax",
           signature: FunctionSignature(
             input: formatLeadingTriviaParameters(withDefaultTrivia: true),
             output: "Syntax"
@@ -144,13 +144,13 @@ private func formatLeadingTriviaParameters(withDefaultTrivia: Bool = false) -> P
   ParameterClause(
     parameterList: [
       FunctionParameter(
-        firstName: .identifier("format"),
+        firstName: "format",
         colon: .colon,
         type: "Format",
         trailingComma: .comma
       ),
       FunctionParameter(
-        firstName: .identifier("leadingTrivia"),
+        firstName: "leadingTrivia",
         colon: .colon,
         type: OptionalType(wrappedType: "Trivia"),
         defaultArgument: withDefaultTrivia ? InitializerClause(value: "nil") : nil

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/ExpressibleAsProtocolsFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/ExpressibleAsProtocolsFile.swift
@@ -43,7 +43,7 @@ let expressibleAsProtocolsFile = SourceFile {
       inheritanceClause: createTypeInheritanceClause(conformances: declaredConformances.map(\.expressibleAs))
     ) {
       FunctionDecl(
-        identifier: .identifier("create\(type.buildableBaseName)"),
+        identifier: "create\(type.buildableBaseName)",
         signature: FunctionSignature(
           input: ParameterClause(),
           output: type.buildable
@@ -60,7 +60,7 @@ let expressibleAsProtocolsFile = SourceFile {
         for conformance in type.elementInCollections {
           FunctionDecl(
             leadingTrivia: .docLineComment("/// Conformance to `\(conformance.expressibleAs)`") + .newline,
-            identifier: .identifier("create\(conformance.buildableBaseName)"),
+            identifier: "create\(conformance.buildableBaseName)",
             signature: FunctionSignature(
               input: ParameterClause(),
               output: conformance.buildable
@@ -77,7 +77,7 @@ let expressibleAsProtocolsFile = SourceFile {
           let param = Node.from(type: conformance).singleNonDefaultedChild
           FunctionDecl(
             leadingTrivia: .docLineComment("/// Conformance to \(conformance.expressibleAs)") + .newline,
-            identifier: .identifier("create\(conformance.buildableBaseName)"),
+            identifier: "create\(conformance.buildableBaseName)",
             signature: FunctionSignature(
               input: ParameterClause(),
               output: conformance.buildable
@@ -90,7 +90,7 @@ let expressibleAsProtocolsFile = SourceFile {
         }
         if let baseType = baseType, baseType.baseName != "SyntaxCollection" {
           FunctionDecl(
-            identifier: .identifier("create\(baseType.buildableBaseName)"),
+            identifier: "create\(baseType.buildableBaseName)",
             signature: FunctionSignature(
               input: ParameterClause(),
               output: baseType.buildable

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/TokenSyntaxFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/TokenSyntaxFile.swift
@@ -31,7 +31,7 @@ let tokenSyntaxFile = SourceFile {
       FunctionDecl(
         leadingTrivia: .docLineComment("/// Conformance to \(conformance.expressibleAs)") + .newline,
         modifiers: [TokenSyntax.public],
-        identifier: .identifier("create\(conformance.buildableBaseName)"),
+        identifier: "create\(conformance.buildableBaseName)",
         signature: FunctionSignature(
           input: ParameterClause(),
           output: conformance.buildable
@@ -49,7 +49,7 @@ let tokenSyntaxFile = SourceFile {
       FunctionDecl(
         leadingTrivia: .docLineComment("/// Conformance to \(conformance.expressibleAs)") + .newline,
         modifiers: [TokenSyntax.public],
-        identifier: .identifier("create\(conformance.buildableBaseName)"),
+        identifier: "create\(conformance.buildableBaseName)",
         signature: FunctionSignature(
           input: ParameterClause(),
           output: conformance.buildable
@@ -69,7 +69,7 @@ let tokenSyntaxFile = SourceFile {
     for buildable in ["SyntaxBuildable", "ExprBuildable"] {
       FunctionDecl(
         modifiers: [TokenSyntax.public],
-        identifier: .identifier("create\(buildable)"),
+        identifier: "create\(buildable)",
         signature: FunctionSignature(
           input: ParameterClause(),
           output: buildable
@@ -92,7 +92,7 @@ let tokenSyntaxFile = SourceFile {
       parameters: ParameterClause(
         parameterList: [
           FunctionParameter(
-            firstName: .identifier("stringLiteral"),
+            firstName: "stringLiteral",
             colon: .colon,
             type: "String"
           )

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/TokenSyntaxFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/TokenSyntaxFile.swift
@@ -82,7 +82,10 @@ let tokenSyntaxFile = SourceFile {
 
   ExtensionDecl(
     extendedType: "TokenSyntax",
-    inheritanceClause: createTypeInheritanceClause(conformances: ["ExpressibleByStringLiteral"])
+    inheritanceClause: createTypeInheritanceClause(conformances: [
+      "ExpressibleByStringLiteral",
+      "ExpressibleByStringInterpolation"
+    ])
   ) {
     InitializerDecl(
       modifiers: [TokenSyntax.public],

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/TokenSyntaxFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/TokenSyntaxFile.swift
@@ -79,4 +79,30 @@ let tokenSyntaxFile = SourceFile {
       }
     }
   }
+
+  ExtensionDecl(
+    extendedType: "TokenSyntax",
+    inheritanceClause: createTypeInheritanceClause(conformances: ["ExpressibleByStringLiteral"])
+  ) {
+    InitializerDecl(
+      modifiers: [TokenSyntax.public],
+      parameters: ParameterClause(
+        parameterList: [
+          FunctionParameter(
+            firstName: .identifier("stringLiteral"),
+            colon: .colon,
+            type: "String"
+          )
+        ]
+      )
+    ) {
+      SequenceExpr(elements: ExprList([
+        "self",
+        AssignmentExpr(),
+        FunctionCallExpr(MemberAccessExpr(name: "identifier")) {
+          TupleExprElement(expression: "stringLiteral")
+        }
+      ]))
+    }
+  }
 }

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/TokensFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/TokensFile.swift
@@ -59,7 +59,7 @@ let tokensFile = SourceFile {
             parameterList: FunctionParameter(
               attributes: nil,
               firstName: .wildcard,
-              secondName: .identifier("text"),
+              secondName: "text",
               colon: .colon,
               type: "String"
             ),
@@ -70,7 +70,7 @@ let tokensFile = SourceFile {
 
         FunctionDecl(
           modifiers: [TokenSyntax.static],
-          identifier: .identifier("`\(token.name.withFirstCharacterLowercased)`"),
+          identifier: "`\(token.name.withFirstCharacterLowercased)`",
           signature: signature
         ) {
           FunctionCallExpr(MemberAccessExpr(base: "SyntaxFactory", name: "make\(token.name)")) {

--- a/Tests/SwiftSyntaxBuilderTest/ArrayExpressibleAsTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ArrayExpressibleAsTests.swift
@@ -35,7 +35,7 @@ final class ArrayExpressibleAsTests: XCTestCase {
           FunctionParameter(
             attributes: nil,
             firstName: .wildcard,
-            secondName: .identifier("args"),
+            secondName: "args",
             colon: .colon,
             type: ArrayType(elementType: "String")
           )

--- a/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
@@ -7,14 +7,14 @@ final class FunctionTests: XCTestCase {
     let leadingTrivia = Trivia.garbageText("␣")
 
     let input = ParameterClause(parameterList: [
-      FunctionParameter(firstName: .wildcard, secondName: .identifier("n"), colon: .colon, type: "Int")
+      FunctionParameter(firstName: .wildcard, secondName: "n", colon: .colon, type: "Int")
     ])
 
     let ifCodeBlock = ReturnStmt(expression: IntegerLiteralExpr(digits: "n"))
     
     let signature = FunctionSignature(input: input, output: "Int")
     
-    let buildable = FunctionDecl(identifier: .identifier("fibonacci"), signature: signature) {
+    let buildable = FunctionDecl(identifier: "fibonacci", signature: signature) {
       IfStmt(conditions: ExprList([
         IntegerLiteralExpr(digits: "n"),
         BinaryOperatorExpr("<="),

--- a/Tests/SwiftSyntaxBuilderTest/IdentifierExprTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/IdentifierExprTests.swift
@@ -7,7 +7,7 @@ final class IdentifierExprTests: XCTestCase {
     let leadingTrivia = Trivia.garbageText("␣")
 
     let testCases: [UInt: (ExpressibleAsIdentifierExpr, String)] = [
-      #line: (IdentifierExpr(identifier: .identifier("Test")), "␣Test"),
+      #line: (IdentifierExpr(identifier: "Test"), "␣Test"),
       #line: (IdentifierExpr("Test"), "␣Test"),
       #line: ("Test", "␣Test")
     ]

--- a/Tests/SwiftSyntaxBuilderTest/IdentifierPatternTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/IdentifierPatternTests.swift
@@ -7,7 +7,7 @@ final class IdentifierPatternTests: XCTestCase {
     let leadingTrivia = Trivia.garbageText("␣")
 
     let testCases: [UInt: (ExpressibleAsIdentifierPattern, String)] = [
-      #line: (IdentifierPattern(identifier: .identifier("Test")), "␣Test"),
+      #line: (IdentifierPattern(identifier: "Test"), "␣Test"),
       #line: (IdentifierPattern("Test"), "␣Test"),
       #line: ("Test", "␣Test")
     ]

--- a/Tests/SwiftSyntaxBuilderTest/ProtocolDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ProtocolDeclTests.swift
@@ -6,13 +6,13 @@ final class ProtocolDeclTests: XCTestCase {
   func testProtocolDecl() {
     let returnType = ArrayType(elementType: "DeclSyntax")
     let input = ParameterClause {
-      FunctionParameter(firstName: .identifier("format"), colon: .colon, type: "Format")
-      FunctionParameter(firstName: .identifier("leadingTrivia"), colon: .colon, type: OptionalType(wrappedType: "Trivia"))
+      FunctionParameter(firstName: "format", colon: .colon, type: "Format")
+      FunctionParameter(firstName: "leadingTrivia", colon: .colon, type: OptionalType(wrappedType: "Trivia"))
     }
     let functionSignature = FunctionSignature(input: input, output: returnType)
 
     let buildable = ProtocolDecl(modifiers: [TokenSyntax.public], identifier: "DeclListBuildable") {
-      FunctionDecl(identifier: .identifier("buildDeclList"), signature: functionSignature, body: nil)
+      FunctionDecl(identifier: "buildDeclList", signature: functionSignature, body: nil)
     }
 
     let syntax = buildable.buildSyntax(format: Format())

--- a/Tests/SwiftSyntaxBuilderTest/SimpleTypeIdentifierTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/SimpleTypeIdentifierTests.swift
@@ -7,7 +7,7 @@ final class SimpleTypeIdentifierTests: XCTestCase {
     let leadingTrivia = Trivia.garbageText("␣")
 
     let testCases: [UInt: (ExpressibleAsSimpleTypeIdentifier, String)] = [
-      #line: (SimpleTypeIdentifier(name: .identifier("Foo")), "␣Foo"),
+      #line: (SimpleTypeIdentifier(name: "Foo"), "␣Foo"),
       #line: (SimpleTypeIdentifier("Foo"), "␣Foo"),
       #line: ("Foo", "␣Foo")
     ]

--- a/Tests/SwiftSyntaxBuilderTest/StructTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StructTests.swift
@@ -30,7 +30,7 @@ final class StructTests: XCTestCase {
       genericWhereClause: GenericWhereClause {
         GenericRequirement(body: ConformanceRequirement(leftTypeIdentifier: "A", rightTypeIdentifier: "X"))
         GenericRequirement(body: SameTypeRequirement(
-            leftTypeIdentifier: "A.P", equalityToken: .identifier("=="), rightTypeIdentifier: "D"))
+            leftTypeIdentifier: "A.P", equalityToken: "==", rightTypeIdentifier: "D"))
       }
     ) {}
     let testStruct = StructDecl(


### PR DESCRIPTION
As mentioned in https://github.com/apple/swift-syntax/pull/506#discussion_r925972714, we are using `TokenSyntax.identifier` quite a lot in `SwiftSyntaxBuilderGeneration`.

This PR  therefore conforms `TokenSyntax` to `ExpressibleByStringLiteral` and `ExpressibleByStringInterpolation`, thereby making the use site more concise. This is also consistent with how we can use `String`s to express many identifier-like nodes (see `StringConvenienceInitializers`).

Previously:

```swift
FunctionDecl(
  identifier: .identifier("xyz")
)
```

Now:

```swift
FunctionDecl(
  identifier: "xyz"
)
```

Since the `.identifier` function still exists, this should be a fully backwards-compatible change.