### PR TITLE
Exit build-script verify-source-code with non-zero exit code if files don’t match

### DIFF
--- a/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
@@ -789,6 +789,14 @@ public extension ExpressibleAsPoundSourceLocationArgs {
     return createPoundSourceLocationArgs()
   }
 }
+public protocol ExpressibleAsDeclModifierDetail: ExpressibleAsSyntaxBuildable {
+  func createDeclModifierDetail() -> DeclModifierDetail
+}
+public extension ExpressibleAsDeclModifierDetail {
+  func createSyntaxBuildable() -> SyntaxBuildable {
+    return createDeclModifierDetail()
+  }
+}
 public protocol ExpressibleAsDeclModifier: ExpressibleAsModifierList, ExpressibleAsSyntaxBuildable {
   func createDeclModifier() -> DeclModifier
 }
@@ -799,14 +807,6 @@ func createModifierList() -> ModifierList {
   }
   func createSyntaxBuildable() -> SyntaxBuildable {
     return createDeclModifier()
-  }
-}
-public protocol ExpressibleAsDeclModifierDetail: ExpressibleAsSyntaxBuildable {
-  func createDeclModifierDetail() -> DeclModifierDetail
-}
-public extension ExpressibleAsDeclModifierDetail {
-  func createSyntaxBuildable() -> SyntaxBuildable {
-    return createDeclModifierDetail()
   }
 }
 public protocol ExpressibleAsInheritedType: ExpressibleAsInheritedTypeList, ExpressibleAsSyntaxBuildable {

--- a/build-script.py
+++ b/build-script.py
@@ -689,6 +689,7 @@ def verify_source_code_command(args):
             "SwiftSyntax project and merge it alongside the main PR."
             "$ swift-syntax/build-script.py generate-source-code --toolchain /path/to/toolchain.xctoolchain/usr"
         )
+        raise SystemExit(1)
 
 
 def build_command(args):


### PR DESCRIPTION
Previously, `build-script.py verify-source-code` would just print an error if the generated files didn’t match, but return with exit code 0, which didn’t fail Swift CI.