### PR TITLE
Improvements for `do` and related statements

### DIFF
--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -6643,7 +6643,7 @@ public enum SyntaxFactory {
   }
   public static func makeDoKeyword(
     leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = .space
+    trailingTrivia: Trivia = []
   ) -> TokenSyntax {
     return makeToken(.doKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,
@@ -6746,7 +6746,7 @@ public enum SyntaxFactory {
                      trailingTrivia: trailingTrivia)
   }
   public static func makeWhereKeyword(
-    leadingTrivia: Trivia = [],
+    leadingTrivia: Trivia = .space,
     trailingTrivia: Trivia = .space
   ) -> TokenSyntax {
     return makeToken(.whereKeyword, presence: .present,
@@ -6754,8 +6754,8 @@ public enum SyntaxFactory {
                      trailingTrivia: trailingTrivia)
   }
   public static func makeCatchKeyword(
-    leadingTrivia: Trivia = [],
-    trailingTrivia: Trivia = .space
+    leadingTrivia: Trivia = .space,
+    trailingTrivia: Trivia = []
   ) -> TokenSyntax {
     return makeToken(.catchKeyword, presence: .present,
                      leadingTrivia: leadingTrivia,

--- a/Sources/SwiftSyntaxBuilder/CatchClauseConvenienceInitializer.swift
+++ b/Sources/SwiftSyntaxBuilder/CatchClauseConvenienceInitializer.swift
@@ -1,0 +1,29 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+extension CatchClause {
+  /// A convenience initializer that calculates spacing around the `catch` keyword.
+  public init(
+    leadingTrivia: Trivia = [],
+    _ catchItems: CatchItemList,
+    @CodeBlockItemListBuilder bodyBuilder: () -> ExpressibleAsCodeBlockItemList
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      catchKeyword: SyntaxFactory.makeCatchKeyword(trailingTrivia: catchItems.elements.isEmpty ? [] : .space),
+      catchItems: catchItems,
+      body: bodyBuilder()
+    )
+  }
+}

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableCollectionNodesFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableCollectionNodesFile.swift
@@ -55,7 +55,7 @@ let buildableCollectionNodesFile = SourceFile {
         inheritanceClause: TypeInheritanceClause {
           InheritedType(typeName: type.expressibleAs)
         },
-        genericWhereClause: GenericWhereClause(leadingTrivia: .space) {
+        genericWhereClause: GenericWhereClause {
           GenericRequirement(body: SameTypeRequirement(
             leftTypeIdentifier: "Element",
             equalityToken: .spacedBinaryOperator("=="),

--- a/Tests/SwiftSyntaxBuilderTest/DoStmtTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/DoStmtTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+import SwiftSyntaxBuilder
+
+final class DoStmtTests: XCTestCase {
+  func testDoStmt() {
+    let buildable = DoStmt(
+      labelName: nil,
+      body: CodeBlock(statementsBuilder: {
+        CodeBlockItem(item: TryExpr(expression: FunctionCallExpr(MemberAccessExpr(base: "a", name: "b"))))
+      }),
+      catchClauses: [
+        CatchClause(CatchItemList {
+          CatchItem(pattern: "Error1")
+          CatchItem(pattern: "Error2")
+        }) {
+          FunctionCallExpr("print") {
+            TupleExprElement(expression: StringLiteralExpr("Known error"))
+          }
+        },
+        CatchClause(CatchItemList {
+          CatchItem(
+            pattern: "Error3", whereClause: WhereClause(guardResult: MemberAccessExpr(base: "error", name: "isError4")))
+        }) {
+          ThrowStmt(expression: MemberAccessExpr(base: "Error4", name: "error3"))
+        },
+        CatchClause {
+          FunctionCallExpr("print") {
+            TupleExprElement(expression: "error")
+          }
+        }
+      ])
+
+    let syntax = buildable.buildSyntax(format: Format())
+    XCTAssertEqual(
+      syntax.description,
+      """
+      do {
+          try a.b()
+      } catch Error1, Error2 {
+          print("Known error")
+      } catch Error3 where error.isError4 {
+          throw Error4.error3
+      } catch {
+          print(error)
+      }
+      """)
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/StructTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StructTests.swift
@@ -28,7 +28,7 @@ final class StructTests: XCTestCase {
       ],
       structKeyword: .struct,
       identifier: "NestedStruct",
-      genericParameterClause: GenericParameterClause {
+      genericParameterClause: GenericParameterClause(rightAngleBracket: .rightAngle.withoutTrailingTrivia()) {
         GenericParameter(name: "A")
         GenericParameter(name: "B", colon: .colon, inheritedType: "C")
         GenericParameter(name: "D")


### PR DESCRIPTION
* Leading/trailing spaces are updated to make statements well formatted
* `CatchClause` convenience initializer that calculates spacing around the `catch` keyword
* Test coverage for above changes

https://github.com/apple/swift/pull/60204