### PR TITLE
Introduce `SyntaxText`  - light weight string representation

### DIFF
--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -148,7 +148,7 @@ extension SyntaxText: Hashable {
     if lhs.buffer.count != rhs.buffer.count {
       return false
     }
-    if lhs.buffer.baseAddress == rhs.buffer.baseAddress {
+    if lhs.isEmpty || lhs.buffer.baseAddress == rhs.buffer.baseAddress {
       return true
     }
     return compareMemory(lhs.baseAddress!, rhs.baseAddress!, lhs.count)

--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -1,0 +1,226 @@
+//===---------- SyntaxText.swift - Unowned String Representation  ---------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Represent a string.
+///
+/// This type does not own the string data. The data reside in some other buffer
+/// whose lifetime extends past that of the SyntaxText.
+///
+/// `SyntaxText` conforms to `Collection` where the element is `UInt8`.
+@_spi(Testing) // SPI name is subject to change
+public struct SyntaxText {
+  var buffer: UnsafeBufferPointer<UInt8>
+
+  public init(baseAddress: UnsafePointer<UInt8>?, count: Int) {
+    assert(count == 0 || baseAddress != nil,
+           "If count is not zero, base address must be exist")
+    buffer = .init(start: baseAddress, count: count)
+  }
+
+  /// Creates an empty `SyntaxText`
+  public init() {
+    self.init(baseAddress: nil, count: 0)
+  }
+
+  /// Creates a `SyntaxText` from a `StaticString`
+  public init(_ string: StaticString) {
+    self.init(baseAddress: string.utf8Start, count: string.utf8CodeUnitCount)
+  }
+
+  /// Base address of the memory range this string refers to.
+  public var baseAddress: UnsafePointer<UInt8>? {
+    buffer.baseAddress
+  }
+
+  /// Byte length of this string.
+  public var count: Int {
+    buffer.count
+  }
+
+  /// A Boolean value indicating whether a string has no characters.
+  public var isEmpty: Bool {
+    buffer.isEmpty
+  }
+
+  /// Returns `true` if the memory range of this string is a part of `other`.
+  ///
+  /// `text[n ..< m].isSliceOf(text)` is always true as long as `n` and `m` are
+  /// valid indices.
+  public func isSliceOf(_ other: SyntaxText) -> Bool {
+    guard !isEmpty && !other.isEmpty else {
+      return isEmpty == other.isEmpty
+    }
+    return (other.baseAddress! <= baseAddress! &&
+            baseAddress! + count <= other.baseAddress! + other.count)
+  }
+
+  /// Returns `true` if `other` is a substring of this `SyntaxText`.
+  ///
+  /// This should not be used because `SyntaxText` is a `Collection<UInt8>` and
+  /// `contains(_:)` is usually for checking a collection contains the element.
+  /// Using `contains(_:)` for subsequence is confusing.
+  @available(*, deprecated, message: "Use 'firstRange(of:) != nil'")
+  public func contains(_ other: SyntaxText) -> Bool {
+    return firstRange(of: other) != nil
+  }
+
+  /// Finds and returns the range of the first occurrence of `other` within this
+  /// string. Returns `nil` if `other` is not found.
+  public func firstRange(of other: SyntaxText) -> Range<Index>? {
+    if other.isEmpty { return nil }
+    let needle = other.baseAddress!
+    let stop = self.count - other.count
+    var start = 0
+    // If 'other' is longer than 'self', stop < 0.
+    while start <= stop {
+      if compareMemory(self.baseAddress! + start, needle, other.count) {
+        return start ..< (start + other.count)
+      } else {
+        start += 1
+      }
+    }
+    return nil
+  }
+
+  /// Returns `true` if the string begins with the specified prefix.
+  public func hasPrefix(_ other: SyntaxText) -> Bool {
+    guard self.count >= other.count else { return false }
+    guard !other.isEmpty else { return true }
+    return self[0..<other.count] == other
+  }
+
+  /// Returns `true` if the string ends with the specified suffix.
+  public func hasSuffix(_ other: SyntaxText) -> Bool {
+    guard self.count >= other.count else { return false }
+    guard !other.isEmpty else { return true }
+    return self[(self.count - other.count)..<self.count] == other
+  }
+}
+
+/// `SyntaxText` is a collection of `UInt8`.
+extension SyntaxText: RandomAccessCollection {
+  public typealias Element = UInt8
+  public typealias Index = Int
+  public typealias SubSequence = SyntaxText
+
+  public var startIndex: Index { buffer.startIndex }
+  public var endIndex: Index { buffer.endIndex }
+
+  public subscript(bounds: Range<Index>) -> SyntaxText {
+    if isEmpty && bounds.isEmpty { return self }
+    return SyntaxText(
+      baseAddress: buffer.baseAddress! + bounds.lowerBound,
+      count: bounds.count)
+  }
+
+  public subscript(position: Index) -> Element {
+    unsafeAddress { buffer.baseAddress!.advanced(by: position) }
+  }
+}
+
+extension SyntaxText: Hashable {
+  public static func ==(lhs: SyntaxText, rhs: SyntaxText) -> Bool {
+    if lhs.buffer.count != rhs.buffer.count {
+      return false
+    }
+    if lhs.buffer.baseAddress == rhs.buffer.baseAddress {
+      return true
+    }
+    return compareMemory(lhs.baseAddress!, rhs.baseAddress!, lhs.count)
+  }
+
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(bytes: .init(buffer))
+  }
+}
+
+extension SyntaxText: ExpressibleByStringLiteral {
+  public init(stringLiteral value: StaticString) { self.init(value) }
+  public init(unicodeScalarLiteral value: StaticString) { self.init(value) }
+  public init(extendedGraphemeClusterLiteral value: StaticString) { self.init(value) }
+}
+
+extension SyntaxText: CustomStringConvertible {
+  public var description: String { String(syntaxText: self) }
+}
+
+extension SyntaxText: CustomDebugStringConvertible {
+  public var debugDescription: String { description.debugDescription }
+}
+
+extension String {
+  /// Creates a `String` from a `SyntaxText`.
+  ///
+  /// Ill-formed UTF-8 sequences in `syntaxText` are replaced with the Unicode
+  /// replacement character `\u{FFFD}`.
+  @_spi(Testing)
+  public init(syntaxText: SyntaxText) {
+    guard !syntaxText.isEmpty else {
+      self = ""
+      return
+    }
+    let count = syntaxText.count
+    if #available(macOS 11.0, iOS 14.0, watchOS 7.0, tvOS 14.0, *) {
+      self.init(unsafeUninitializedCapacity: count) { strBuffer in
+        copyMemory(strBuffer.baseAddress!, syntaxText.baseAddress!, count)
+        return count
+      }
+    } else {
+      self.init(decoding: syntaxText, as: UTF8.self)
+    }
+  }
+
+  /// Runs `body` with a `SyntaxText` that refers the contiguous memory of this
+  /// string. Like `String.withUTF8(_:)`, this may mutates the string if this
+  /// string was not contiguous.
+  @_spi(Testing)
+  public mutating func withSyntaxText<R>(
+    _ body: (SyntaxText) throws -> R
+  ) rethrows -> R {
+    try withUTF8 { utf8 in
+      try body(SyntaxText(baseAddress: utf8.baseAddress, count: utf8.count))
+    }
+  }
+}
+
+private func compareMemory(
+  _ s1: UnsafePointer<UInt8>, _ s2: UnsafePointer<UInt8>, _ count: Int
+) -> Bool {
+  assert(count > 0)
+#if canImport(Darwin)
+  return Darwin.memcmp(s1, s2, count) == 0
+#elseif canImport(Glibc)
+  return Glibc.memcmp(s1, s2, count) == 0
+#else
+  return UnsafeBufferPointer(start: s1, count: count)
+    .elementsEqual(UnsafeBufferPointer(start: s2, count: count))
+#endif
+}
+
+private func copyMemory(
+  _ dst: UnsafeMutablePointer<UInt8>, _ src: UnsafePointer<UInt8>, _ count: Int
+) {
+  assert(count > 0)
+#if canImport(Darwin)
+  Darwin.memcpy(dst, src, count)
+#elseif canImport(Glibc)
+  Glibc.memcpy(dst, src, count)
+#else
+  dst.initialize(from: src, count: count)
+#endif
+}

--- a/Tests/SwiftSyntaxTest/SyntaxTextTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTextTests.swift
@@ -27,26 +27,27 @@ final class SyntaxTextTests: XCTestCase {
   func testSlice() throws {
     let text: SyntaxText = "0123456789"
 
-    let slice1 = text[0..<4]
-    let slice2 = text[0..<text.count]
-    let slice3 = text[3..<text.count]
-    XCTAssert(slice1.isSliceOf(text))
-    XCTAssert(slice2.isSliceOf(text))
-    XCTAssert(slice3.isSliceOf(text))
+    let slice1 = SyntaxText(rebasing: text[0..<4])
+    let slice2 = SyntaxText(rebasing: text[0..<text.count])
+    let slice3 = SyntaxText(rebasing: text[3..<text.count])
+    XCTAssert(slice1.isSlice(of: text))
+    XCTAssert(slice2.isSlice(of: text))
+    XCTAssert(slice3.isSlice(of: text))
     XCTAssertNotNil(text.firstRange(of: slice1))
     XCTAssertNotNil(text.firstRange(of: slice2))
     XCTAssertNotNil(text.firstRange(of: slice3))
 
     let empty: SyntaxText = ""
-    let emptySlice: SyntaxText = empty[...]
-    XCTAssertTrue(emptySlice.isSliceOf(empty))
+    let emptySlice: SyntaxText = SyntaxText(rebasing: empty[...])
+    XCTAssertTrue(emptySlice.isSlice(of: empty))
+    XCTAssertEqual(emptySlice, "")
   }
 
   func testFirstRange() throws {
     let text: SyntaxText = "0123456789012345"
 
     XCTAssertEqual(text.firstRange(of: ""), nil)
-    XCTAssertEqual(text.firstRange(of: SyntaxText("012")[1..<1]), nil)
+    XCTAssertEqual(text.firstRange(of: SyntaxText(rebasing: SyntaxText("012")[1..<1])), nil)
     XCTAssertEqual(text.firstRange(of: "abc"), nil)
     XCTAssertEqual(text.firstRange(of: "01234567890123456"), nil)
 
@@ -57,9 +58,20 @@ final class SyntaxTextTests: XCTestCase {
     XCTAssertEqual(text.firstRange(of: "234"), 2 ..< 5)
     XCTAssertEqual(text.firstRange(of: "9012345"), 9 ..< 16)
 
-    XCTAssertEqual(text[2..<12].firstRange(of: "123"), nil)
-    XCTAssertEqual(text[5...].firstRange(of: "5"), 0 ..< 1)
-    XCTAssertEqual(text[5...].firstRange(of: "0"), 5 ..< 6)
+    XCTAssertEqual(SyntaxText(rebasing: text[2..<12]).firstRange(of: "123"), nil)
+    XCTAssertEqual(SyntaxText(rebasing: text[5...]).firstRange(of: "5"), 0 ..< 1)
+    XCTAssertEqual(SyntaxText(rebasing: text[5...]).firstRange(of: "0"), 5 ..< 6)
+  }
+
+  func testContains() throws {
+    let text: SyntaxText = "0123456789012345"
+    XCTAssertTrue(text.contains("123"))
+    XCTAssertTrue(text.contains("0123456789012345"))
+    XCTAssertTrue(text.contains("9012345"))
+
+    XCTAssertFalse(text.contains(""))
+    XCTAssertFalse(text.contains("foo"))
+    XCTAssertFalse(text.contains("01234567890123456"))
   }
 
   func testHasPrefixSuffix() throws {
@@ -83,8 +95,8 @@ final class SyntaxTextTests: XCTestCase {
   func testWithSyntaxText() throws {
     var str = "Lorem ipsum"
     str.withSyntaxText { text in
-      XCTAssertEqual(text[0..<5], "Lorem")
-      XCTAssertEqual(text[6..<9], "ips")
+      XCTAssertEqual(SyntaxText(rebasing: text[0..<5]), "Lorem")
+      XCTAssertEqual(SyntaxText(rebasing: text[6..<9]), "ips")
     }
   }
 }

--- a/Tests/SwiftSyntaxTest/SyntaxTextTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTextTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@_spi(Testing) import SwiftSyntax
+
+final class SyntaxTextTests: XCTestCase {
+  func testLiteral() throws {
+    let strBasic: SyntaxText = "foobar"
+    let strASCII: SyntaxText = "A"
+    let strHiragana: SyntaxText = "ら"
+    let strEmojiSingle: SyntaxText = "🤖"
+    let strUTF8: SyntaxText = "こんにちは世界！"
+
+    XCTAssertEqual(String(syntaxText: strBasic), String("foobar"))
+    XCTAssertEqual(String(syntaxText: strASCII), String("A"))
+    XCTAssertEqual(String(syntaxText: strHiragana), String("ら"))
+    XCTAssertEqual(String(syntaxText: strEmojiSingle), String("🤖"))
+    XCTAssertEqual(String(syntaxText: strUTF8), String("こんにちは世界！"))
+  }
+
+  func testInvalid() throws {
+    let invalidUTF8: [UInt8] = [0x43, 0x61, 0x66, 0xC3]
+    invalidUTF8.withUnsafeBufferPointer { buffer in
+      let fromData = SyntaxText(baseAddress: buffer.baseAddress, count: buffer.count)
+      XCTAssertEqual(String(syntaxText: fromData), "Caf\u{FFFD}")
+    }
+  }
+
+  func testSlice() throws {
+    let text: SyntaxText = "0123456789"
+
+    let slice1 = text[0..<4]
+    let slice2 = text[0..<text.count]
+    let slice3 = text[3..<text.count]
+    XCTAssert(slice1.isSliceOf(text))
+    XCTAssert(slice2.isSliceOf(text))
+    XCTAssert(slice3.isSliceOf(text))
+    XCTAssertNotNil(text.firstRange(of: slice1))
+    XCTAssertNotNil(text.firstRange(of: slice2))
+    XCTAssertNotNil(text.firstRange(of: slice3))
+
+    let empty: SyntaxText = ""
+    let emptySlice: SyntaxText = empty[...]
+    XCTAssertTrue(emptySlice.isSliceOf(empty))
+  }
+
+  func testFirstRange() throws {
+    let text: SyntaxText = "0123456789012345"
+
+    XCTAssertEqual(text.firstRange(of: ""), nil)
+    XCTAssertEqual(text.firstRange(of: SyntaxText("012")[1..<1]), nil)
+    XCTAssertEqual(text.firstRange(of: "abc"), nil)
+    XCTAssertEqual(text.firstRange(of: "01234567890123456"), nil)
+
+    XCTAssertEqual(text.firstRange(of: "0"), 0 ..< 1)
+    XCTAssertEqual(text.firstRange(of: "1"), 1 ..< 2)
+    XCTAssertEqual(text.firstRange(of: "5"), 5 ..< 6)
+    XCTAssertEqual(text.firstRange(of: "012"), 0 ..< 3)
+    XCTAssertEqual(text.firstRange(of: "234"), 2 ..< 5)
+    XCTAssertEqual(text.firstRange(of: "9012345"), 9 ..< 16)
+
+    XCTAssertEqual(text[2..<12].firstRange(of: "123"), nil)
+    XCTAssertEqual(text[5...].firstRange(of: "5"), 0 ..< 1)
+    XCTAssertEqual(text[5...].firstRange(of: "0"), 5 ..< 6)
+  }
+
+  func testHasPrefixSuffix() throws {
+    let text: SyntaxText = "0123456789012345"
+
+    XCTAssertTrue(text.hasPrefix(""))
+    XCTAssertTrue(text.hasPrefix("0"))
+    XCTAssertTrue(text.hasPrefix("0123"))
+    XCTAssertTrue(text.hasPrefix("0123456789012345"))
+    XCTAssertFalse(text.hasPrefix("345"))
+    XCTAssertFalse(text.hasPrefix("abc"))
+
+    XCTAssertTrue(text.hasSuffix(""))
+    XCTAssertTrue(text.hasSuffix("5"))
+    XCTAssertTrue(text.hasSuffix("12345"))
+    XCTAssertTrue(text.hasSuffix("0123456789012345"))
+    XCTAssertFalse(text.hasSuffix("012"))
+    XCTAssertFalse(text.hasSuffix("abc"))
+  }
+
+  func testWithSyntaxText() throws {
+    var str = "Lorem ipsum"
+    str.withSyntaxText { text in
+      XCTAssertEqual(text[0..<5], "Lorem")
+      XCTAssertEqual(text[6..<9], "ips")
+    }
+  }
+}
+

--- a/Tests/SwiftSyntaxTest/SyntaxTextTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTextTests.swift
@@ -41,6 +41,8 @@ final class SyntaxTextTests: XCTestCase {
     let emptySlice: SyntaxText = SyntaxText(rebasing: empty[...])
     XCTAssertTrue(emptySlice.isSlice(of: empty))
     XCTAssertEqual(emptySlice, "")
+
+    XCTAssertEqual(SyntaxText(rebasing: text[2..<2]), SyntaxText(rebasing: text[3..<3]))
   }
 
   func testFirstRange() throws {

--- a/utils/group.json
+++ b/utils/group.json
@@ -29,6 +29,7 @@
     "SyntaxClassification.swift",
     "SyntaxFactory.swift",
     "SyntaxRewriter.swift",
+    "SyntaxText.swift",
     "SyntaxVisitor.swift",
     "Misc.swift",
   ],


### PR DESCRIPTION
(Part of #512)

'SyntaxText' represents a string, but without owning the data. In future, this will be used in Syntax tree as string representation.

Provides basic `String`-like functionalities including:
- `Hashable` and `Equatable`
- Collection of `UInt8`
- Slicing
- Prefix/Postfix check
- Interconvertible with `Swift.String`
- Expressible by string literal