### PR TITLE
Add a convenience initializer for `IfStmt` (optionally taking a second trailing builder closure)

### DIFF
--- a/Sources/SwiftSyntaxBuilder/IfStmtConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/IfStmtConvenienceInitializers.swift
@@ -1,0 +1,34 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public extension IfStmt {
+  /// A convenience initializer that uses builder closures to express an
+  /// if body, potentially with a second trailing builder closure for an else
+  /// body.
+  init(
+    leadingTrivia: Trivia = [],
+    conditions: ExpressibleAsConditionElementList,
+    @CodeBlockItemListBuilder body: () -> ExpressibleAsCodeBlockItemList,
+    @CodeBlockItemListBuilder elseBody: () -> ExpressibleAsCodeBlockItemList? = { nil }
+  ) {
+    let generatedElseBody = elseBody()
+    self.init(
+      leadingTrivia: leadingTrivia,
+      conditions: conditions,
+      body: body(),
+      elseKeyword: generatedElseBody == nil ? nil : SyntaxFactory.makeElseKeyword(leadingTrivia: .space, trailingTrivia: []),
+      elseBody: generatedElseBody.map { CodeBlock(statements: $0) }
+    )
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/IfStmtTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/IfStmtTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+final class IfStmtTests: XCTestCase {
+  func testEmptyIfStmt() {
+    // Use the convenience initializer from IfStmtConvenienceInitializers. This is
+    // disambiguated by the absence of a labelName parameter and the use of a
+    // trailing closure.
+    let buildable = IfStmt(conditions: ExprList([BooleanLiteralExpr(false)])) {}
+    let syntax = buildable.buildSyntax(format: Format())
+    XCTAssertEqual(syntax.description, """
+      if false  {
+      }
+      """)
+  }
+
+  func testIfElseStmt() {
+    // Use the convenience initializer from IfStmtConvenienceInitializers
+    // with an else branch expressed by a second trailing closure.
+    let buildable = IfStmt(conditions: ExprList([BooleanLiteralExpr(true)])) {
+      FunctionCallExpr("print") {
+        TupleExprElement(expression: StringLiteralExpr("Hello from the if-branch!"))
+      }
+    } elseBody: {
+      FunctionCallExpr("print") {
+        TupleExprElement(expression: StringLiteralExpr("Hello from the else-branch!"))
+      }
+    }
+    let syntax = buildable.buildSyntax(format: Format())
+    XCTAssertEqual(syntax.description, """
+      if true  {
+          print("Hello from the if-branch!")
+      } else {
+          print("Hello from the else-branch!")
+      }
+      """)
+  }
+}


### PR DESCRIPTION
As proposed in https://github.com/apple/swift-syntax/pull/506#discussion_r925970287, this adds a new convenience initializer for `IfStmt` making both `if` and `if-else` statements nicely expressible using (multiple) trailing builder closures:

```swift
IfStmt(conditions: ...) {
  // if-body
}

IfStmt(conditions: ...) {
  // if-body
} elseBody: {
  // else-body
}
```