### PR TITLE
Support optional initializer expression in `VariableDecl` convenience inititializer

### DIFF
--- a/Sources/SwiftSyntaxBuilder/VariableDeclConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/VariableDeclConvenienceInitializers.swift
@@ -13,12 +13,18 @@
 import SwiftSyntax
 
 extension VariableDecl {
-  public init(_ letOrVarKeyword: TokenSyntax,
-              name: ExpressibleAsIdentifierPattern,
-              type: ExpressibleAsTypeAnnotation) {
+  public init(
+    _ letOrVarKeyword: TokenSyntax,
+    name: ExpressibleAsIdentifierPattern,
+    type: ExpressibleAsTypeAnnotation? = nil,
+    initializer: ExpressibleAsExprBuildable? = nil
+  ) {
     self.init(letOrVarKeyword: letOrVarKeyword) {
-      PatternBinding(pattern: name.createIdentifierPattern(),
-                     typeAnnotation: type.createTypeAnnotation())
+      PatternBinding(
+        pattern: name,
+        typeAnnotation: type,
+        initializer: initializer.map { InitializerClause(value: $0) }
+      )
     }
   }
 }

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -74,14 +74,16 @@ final class VariableTests: XCTestCase {
   func testConvenienceInitializer() {
     let leadingTrivia = Trivia.garbageText("␣")
 
-    let testCases: [UInt: (TokenSyntax, String, String, String)] = [
-      #line: (.let, "foo", "Int", "␣let foo: Int"),
-      #line: (.var, "bar", "Baz", "␣var bar: Baz")
+    let testCases: [UInt: (TokenSyntax, String, String?, ExpressibleAsExprBuildable?, String)] = [
+      #line: (.let, "foo", "Int", nil, "␣let foo: Int"),
+      #line: (.var, "bar", "Baz", nil, "␣var bar: Baz"),
+      #line: (.var, "typed", "String", StringLiteralExpr("abc"), #"␣var typed: String = "abc""#),
+      #line: (.let, "inferred", nil, "typed", "␣let inferred = typed"),
     ]
 
     for (line, testCase) in testCases {
-      let (keyword, name, type, expected) = testCase
-      let builder = VariableDecl(keyword, name: name, type: type)
+      let (keyword, name, type, initializer, expected) = testCase
+      let builder = VariableDecl(keyword, name: name, type: type, initializer: initializer)
       let syntax = builder.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
 
       XCTAssertEqual(syntax.description, expected, line: line)


### PR DESCRIPTION
As proposed in https://github.com/apple/swift-syntax/pull/506#discussion_r925966346, this is a small QoL change that extends the existing convenience initializer for `VariableDecl` to support optional initializer expressions (and also makes the type annotation optional):

```swift
// let x = y
VariableDecl(.let, name: "x", initializer: "y")

// var x: String = "abc"
VariableDecl(
  .var,
  name: "x",
  type: "String",
  initializer: StringLiteralExpr("abc")
)
```