### PR TITLE
Add `ExpressibleAsExprBuildable: ExpressibleAsCodeBlockItem`

### DIFF
--- a/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
@@ -27,13 +27,17 @@ func createMemberDeclListItem() -> MemberDeclListItem {
     return MemberDeclListItem(decl: self)
   }
 }
-public protocol ExpressibleAsExprBuildable: ExpressibleAsExprList {
+public protocol ExpressibleAsExprBuildable: ExpressibleAsExprList, ExpressibleAsCodeBlockItem {
   func createExprBuildable() -> ExprBuildable
 }
 public extension ExpressibleAsExprBuildable {
   /// Conformance to `ExpressibleAsExprList`
 func createExprList() -> ExprList {
     return ExprList([self])
+  }
+  /// Conformance to ExpressibleAsCodeBlockItem
+func createCodeBlockItem() -> CodeBlockItem {
+    return CodeBlockItem(item: self)
   }
 }
 public protocol ExpressibleAsPatternBuildable {
@@ -222,7 +226,7 @@ public extension ExpressibleAsAssignmentExpr {
     return createAssignmentExpr()
   }
 }
-public protocol ExpressibleAsSequenceExpr: ExpressibleAsCodeBlockItem, ExpressibleAsTupleExprElement, ExpressibleAsExprBuildable {
+public protocol ExpressibleAsSequenceExpr: ExpressibleAsTupleExprElement, ExpressibleAsExprBuildable {
   func createSequenceExpr() -> SequenceExpr
 }
 public extension ExpressibleAsSequenceExpr {
@@ -528,14 +532,10 @@ func createMultipleTrailingClosureElementList() -> MultipleTrailingClosureElemen
 public protocol ExpressibleAsMultipleTrailingClosureElementList {
   func createMultipleTrailingClosureElementList() -> MultipleTrailingClosureElementList
 }
-public protocol ExpressibleAsFunctionCallExpr: ExpressibleAsCodeBlockItem, ExpressibleAsExprBuildable {
+public protocol ExpressibleAsFunctionCallExpr: ExpressibleAsExprBuildable {
   func createFunctionCallExpr() -> FunctionCallExpr
 }
 public extension ExpressibleAsFunctionCallExpr {
-  /// Conformance to ExpressibleAsCodeBlockItem
-func createCodeBlockItem() -> CodeBlockItem {
-    return CodeBlockItem(item: self)
-  }
   func createExprBuildable() -> ExprBuildable {
     return createFunctionCallExpr()
   }

--- a/Sources/SwiftSyntaxBuilder/gyb_helpers/ExpressibleAsConformances.py
+++ b/Sources/SwiftSyntaxBuilder/gyb_helpers/ExpressibleAsConformances.py
@@ -18,7 +18,7 @@ SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES = {
     'ExprList': [
         'ConditionElement'
     ],
-    'FunctionCallExpr': [
+    'ExprBuildable': [
         'CodeBlockItem'
     ],
     'MemberDeclList': [

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/ExpressibleAsConformances.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/ExpressibleAsConformances.swift
@@ -32,7 +32,7 @@ let SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES: [String: [String]] = [
   "ExprList": [
     "ConditionElement",
   ],
-  "FunctionCallExpr": [
+  "ExprBuildable": [
     "CodeBlockItem",
   ],
   "MemberDeclList": [

--- a/Tests/SwiftSyntaxBuilderTest/ExpressibleBuildablesTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ExpressibleBuildablesTests.swift
@@ -26,7 +26,7 @@ final class ExpressibleBuildablesTests: XCTestCase {
     """)
   }
 
-  func testExpressibleAsCodeBlockItem() {
+  func testDeclExpressibleAsCodeBlockItem() {
     let myCodeBlock = SourceFile(eofToken: .eof) {
       StructDecl(identifier: "MyStruct1") {}
 
@@ -39,6 +39,23 @@ final class ExpressibleBuildablesTests: XCTestCase {
     struct MyStruct1 {
     }
     struct MyStruct2 {
+    }
+    """)
+  }
+
+  func testExprExpressibleAsCodeBlockItem() {
+    let myCodeBlock = CodeBlock(leftBrace: .leftBrace.withLeadingTrivia([])) {
+      FunctionCallExpr("print") { TupleExprElement(expression: StringLiteralExpr("Hello world")) }
+      IntegerLiteralExpr(42)
+      "someIdentifier"
+    }
+    
+    let syntax = myCodeBlock.buildSyntax(format: Format())
+    XCTAssertEqual(syntax.description, """
+    {
+        print("Hello world")
+        42
+        someIdentifier
     }
     """)
   }


### PR DESCRIPTION
Fixes https://github.com/apple/swift-syntax/pull/506#discussion_r925959964. This patch generalizes the current conformance of `ExpressibleAsFunctionCallExpr` to `ExpressibleAsCodeBlockItem` to arbitrary expressions, thereby removing the need to wrap expressions explicitly in `CodeBlockItem`s:

```swift
CodeBlock {
  FunctionCallExpr("print") { TupleExprElement(expression: StringLiteralExpr("Hello world")) }
  IntegerLiteralExpr(42)
  "someIdentifier"
}
```