### PR TITLE
Make `OptionalBindingCondition` and `MatchingPatternCondition` expressible as `ConditionElement`

### DIFF
--- a/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
@@ -1488,18 +1488,26 @@ public extension ExpressibleAsAvailabilityCondition {
     return createAvailabilityCondition()
   }
 }
-public protocol ExpressibleAsMatchingPatternCondition: ExpressibleAsSyntaxBuildable {
+public protocol ExpressibleAsMatchingPatternCondition: ExpressibleAsConditionElement {
   func createMatchingPatternCondition() -> MatchingPatternCondition
 }
 public extension ExpressibleAsMatchingPatternCondition {
+  /// Conformance to ExpressibleAsConditionElement
+func createConditionElement() -> ConditionElement {
+    return ConditionElement(condition: self)
+  }
   func createSyntaxBuildable() -> SyntaxBuildable {
     return createMatchingPatternCondition()
   }
 }
-public protocol ExpressibleAsOptionalBindingCondition: ExpressibleAsSyntaxBuildable {
+public protocol ExpressibleAsOptionalBindingCondition: ExpressibleAsConditionElement {
   func createOptionalBindingCondition() -> OptionalBindingCondition
 }
 public extension ExpressibleAsOptionalBindingCondition {
+  /// Conformance to ExpressibleAsConditionElement
+func createConditionElement() -> ConditionElement {
+    return ConditionElement(condition: self)
+  }
   func createSyntaxBuildable() -> SyntaxBuildable {
     return createOptionalBindingCondition()
   }

--- a/Sources/SwiftSyntaxBuilder/gyb_helpers/ExpressibleAsConformances.py
+++ b/Sources/SwiftSyntaxBuilder/gyb_helpers/ExpressibleAsConformances.py
@@ -22,8 +22,14 @@ SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES = {
     'ExprList': [
         'ConditionElement'
     ],
+    'MatchingPatternCondition': [
+        'ConditionElement'
+    ],
     'MemberDeclList': [
         'MemberDeclBlock'
+    ],
+    'OptionalBindingCondition': [
+        'ConditionElement'
     ],
     'SequenceExpr': [
         'CodeBlockItem',

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/ExpressibleAsConformances.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/ExpressibleAsConformances.swift
@@ -36,8 +36,14 @@ let SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES: [String: [String]] = [
   "ExprList": [
     "ConditionElement",
   ],
+  "MatchingPatternCondition": [
+    "ConditionElement",
+  ],
   "MemberDeclList": [
     "MemberDeclBlock",
+  ],
+  "OptionalBindingCondition": [
+    "ConditionElement",
   ],
   "SequenceExpr": [
     "CodeBlockItem",

--- a/Tests/SwiftSyntaxBuilderTest/IfStmtTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/IfStmtTests.swift
@@ -36,4 +36,33 @@ final class IfStmtTests: XCTestCase {
       }
       """)
   }
+
+  func testIfLetStmt() {
+    let buildable = IfStmt(
+      conditions: OptionalBindingCondition(
+        letOrVarKeyword: .let,
+        pattern: "x",
+        initializer: InitializerClause(value: "y")
+      )
+    ) {}
+    let syntax = buildable.buildSyntax(format: Format())
+    XCTAssertEqual(syntax.description, """
+      if let x = y {
+      }
+      """)
+  }
+
+  func testIfCaseStmt() {
+    let buildable = IfStmt(
+      conditions: MatchingPatternCondition(
+        pattern: ExpressionPattern(expression: MemberAccessExpr(name: "x")),
+        initializer: InitializerClause(value: "y")
+      )
+    ) {}
+    let syntax = buildable.buildSyntax(format: Format())
+    XCTAssertEqual(syntax.description, """
+      if case .x = y {
+      }
+      """)
+  }
 }


### PR DESCRIPTION
As proposed in https://github.com/apple/swift-syntax/pull/506#discussion_r926007457, this conforms `ExpressibleAsOptionalBindingCondition` and `ExpressibleAsMatchingPatternCondition` to `ExpressibleAsConditionElement`, making it more convenient to express `if-let` and `if-case` statements with the DSL:

```swift
// if let x = y { ... }
IfStmt(
  conditions: OptionalBindingCondition(
    letOrVarKeyword: .let,
    pattern: "x",
    initializer: InitializerClause(value: "y")
  )
) { ... }

// if case .x = y { ... }
IfStmt(
  conditions: MatchingPatternCondition(
    pattern: ExpressionPattern(expression: MemberAccessExpr(name: "x")),
    initializer: InitializerClause(value: "y")
  )
) { ... }
```