### PR TITLE
Make `ExprBuildable` expressible as `InitializerClause`

### DIFF
--- a/Sources/SwiftSyntaxBuilder/VariableDeclConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/VariableDeclConvenienceInitializers.swift
@@ -17,13 +17,13 @@ extension VariableDecl {
     _ letOrVarKeyword: TokenSyntax,
     name: ExpressibleAsIdentifierPattern,
     type: ExpressibleAsTypeAnnotation? = nil,
-    initializer: ExpressibleAsExprBuildable? = nil
+    initializer: ExpressibleAsInitializerClause? = nil
   ) {
     self.init(letOrVarKeyword: letOrVarKeyword) {
       PatternBinding(
         pattern: name,
         typeAnnotation: type,
-        initializer: initializer.map { InitializerClause(value: $0) }
+        initializer: initializer
       )
     }
   }

--- a/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
@@ -27,7 +27,7 @@ func createMemberDeclListItem() -> MemberDeclListItem {
     return MemberDeclListItem(decl: self)
   }
 }
-public protocol ExpressibleAsExprBuildable: ExpressibleAsExprList, ExpressibleAsCodeBlockItem {
+public protocol ExpressibleAsExprBuildable: ExpressibleAsExprList, ExpressibleAsCodeBlockItem, ExpressibleAsInitializerClause {
   func createExprBuildable() -> ExprBuildable
 }
 public extension ExpressibleAsExprBuildable {
@@ -38,6 +38,10 @@ func createExprList() -> ExprList {
   /// Conformance to ExpressibleAsCodeBlockItem
 func createCodeBlockItem() -> CodeBlockItem {
     return CodeBlockItem(item: self)
+  }
+  /// Conformance to ExpressibleAsInitializerClause
+func createInitializerClause() -> InitializerClause {
+    return InitializerClause(value: self)
   }
 }
 public protocol ExpressibleAsPatternBuildable {

--- a/Sources/SwiftSyntaxBuilder/gyb_helpers/ExpressibleAsConformances.py
+++ b/Sources/SwiftSyntaxBuilder/gyb_helpers/ExpressibleAsConformances.py
@@ -15,11 +15,12 @@ SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES = {
     'DictionaryType': [
         'TypeAnnotation'
     ],
+    'ExprBuildable': [
+        'CodeBlockItem',
+        'InitializerClause'
+    ],
     'ExprList': [
         'ConditionElement'
-    ],
-    'ExprBuildable': [
-        'CodeBlockItem'
     ],
     'MemberDeclList': [
         'MemberDeclBlock'

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/ExpressibleAsConformances.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/ExpressibleAsConformances.swift
@@ -29,11 +29,12 @@ let SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES: [String: [String]] = [
   "DictionaryType": [
     "TypeAnnotation",
   ],
-  "ExprList": [
-    "ConditionElement",
-  ],
   "ExprBuildable": [
     "CodeBlockItem",
+    "InitializerClause",
+  ],
+  "ExprList": [
+    "ConditionElement",
   ],
   "MemberDeclList": [
     "MemberDeclBlock",

--- a/Tests/SwiftSyntaxBuilderTest/EnumCaseElementTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/EnumCaseElementTests.swift
@@ -16,10 +16,10 @@ final class EnumCaseElementTests: XCTestCase {
       EnumCaseDecl {
         EnumCaseElement(
           identifier: "goodMorning",
-          rawValue: InitializerClause(value: StringLiteralExpr("Good Morning")))
+          rawValue: StringLiteralExpr("Good Morning"))
         EnumCaseElement(
           identifier: "helloWorld",
-          rawValue: InitializerClause(value: StringLiteralExpr("Hello World")))
+          rawValue: StringLiteralExpr("Hello World"))
         EnumCaseElement(identifier: "hi")
       }
     }

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -21,7 +21,7 @@ final class VariableTests: XCTestCase {
       PatternBinding(
         pattern: "d",
         typeAnnotation: DictionaryType(keyType: "String", valueType: "Int"),
-        initializer: InitializerClause(value: DictionaryExpr()))
+        initializer: DictionaryExpr())
     }
 
     let syntax = buildable.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
@@ -30,14 +30,13 @@ final class VariableTests: XCTestCase {
 
   func testVariableDeclWithExplicitTrailingCommas() {
     let buildable = VariableDecl(letOrVarKeyword: .let, bindings: [
-      PatternBinding(pattern: "a", initializer: InitializerClause(
-        value: ArrayExpr(leftSquare: .`leftSquareBracket`.withTrailingTrivia(.newline)) {
-          for i in 1...3 {
-            ArrayElement(
-              expression: IntegerLiteralExpr(i),
-              trailingComma: .comma.withoutTrailingTrivia().withTrailingTrivia(.newline))
-          }
-        }))
+      PatternBinding(pattern: "a", initializer: ArrayExpr(leftSquare: .`leftSquareBracket`.withTrailingTrivia(.newline)) {
+        for i in 1...3 {
+          ArrayElement(
+            expression: IntegerLiteralExpr(i),
+            trailingComma: .comma.withoutTrailingTrivia().withTrailingTrivia(.newline))
+        }
+      })
     ])
     let syntax = buildable.buildSyntax(format: Format())
     XCTAssertEqual(syntax.description, "let a = [\n1,\n2,\n3,\n]")
@@ -45,16 +44,16 @@ final class VariableTests: XCTestCase {
 
   func testMultiPatternVariableDecl() {
     let buildable = VariableDecl(letOrVarKeyword: .let) {
-      PatternBinding(pattern: "a", initializer: InitializerClause(value: ArrayExpr {
+      PatternBinding(pattern: "a", initializer: ArrayExpr {
         for i in 1...3 {
           ArrayElement(expression: IntegerLiteralExpr(i))
         }
-      }))
-      PatternBinding(pattern: "d", initializer: InitializerClause(value: DictionaryExpr {
+      })
+      PatternBinding(pattern: "d", initializer: DictionaryExpr {
         for i in 1...3 {
           DictionaryElement(keyExpression: StringLiteralExpr("key\(i)"), valueExpression: IntegerLiteralExpr(i))
         }
-      }))
+      })
       PatternBinding(pattern: "i", typeAnnotation: "Int")
       PatternBinding(pattern: "s", typeAnnotation: "String")
     }


### PR DESCRIPTION
This generalizes #523 slightly, letting the DSL accept expressions anywhere an `InitializerClause` is required (e.g. also in `OptionalBindingCondition` or `PatternBinding`):

```swift
// let x: String = "abc"
OptionalBindingCondition(
  letOrVarKeyword: .let,
  pattern: "x",
  typeAnnotation: "String",
  initializer: StringLiteralExpr("abc") // <- no longer needs an explicit InitializerClause wrap
)
```