### PR TITLE
Make `SyntaxBuildableType` hashable

### DIFF
--- a/Sources/SwiftSyntaxBuilder/gyb_helpers/SyntaxBuildableWrappers.py
+++ b/Sources/SwiftSyntaxBuilder/gyb_helpers/SyntaxBuildableWrappers.py
@@ -159,6 +159,9 @@ class SyntaxBuildableType:
     return self.syntax_kind == other.syntax_kind and \
            self.is_optional == other.is_optional and \
            self.token_kind == other.token_kind
+  
+  def __hash__(self):
+    return hash((self.syntax_kind, self.is_optional, self.token_kind))
 
   def _optional_question_mark(self):
     if self.is_optional:


### PR DESCRIPTION
This is a small change that implements `__hash__` for `SyntaxBuildableType` on the Python-side, thereby making it possible to use `SyntaxBuildableType` in sets and dictionaries as keys.

Since the type already implements a fieldwise `__eq__`, having a corresponding `__hash__` feels like a natural extension.

> Note that the Swift version of this type (in `SwiftSyntaxBuilderGeneration`) is also `Hashable`.