### PR TITLE
Add 'BumpPtrAllocator'

### DIFF
--- a/Sources/SwiftSyntax/BumpPtrAllocator.swift
+++ b/Sources/SwiftSyntax/BumpPtrAllocator.swift
@@ -1,0 +1,114 @@
+//===---------- BumpPtrAllocator.swift - Bump-pointer Allocaiton ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Bump-pointer allocation.
+struct BumpPtrAllocator {
+  typealias Slab = UnsafeMutableRawBufferPointer
+
+  static private var SLAB_SIZE: Int = 4096
+  static private var GLOWTH_DELAY: Int = 128
+  static private var SLAB_ALIGNMENT: Int = 8
+
+  private var slabs: [Slab]
+  private var currentPtr: UnsafeMutableRawPointer?
+  private var endPtr: UnsafeMutableRawPointer?
+  private var customSizeSlabs: [Slab]
+  private(set) var totalSizeAllocated: Int
+
+  init() {
+    slabs = []
+    currentPtr = nil
+    endPtr = nil
+    customSizeSlabs = []
+    totalSizeAllocated = 0
+  }
+
+  /// Calculate the size of the slab at the index.
+  private static func slabSize(at index: Int) -> Int {
+    // Double the slab size every 'GLOWTH_DELAY' slabs.
+    return SLAB_SIZE * (1 << min(30, index / GLOWTH_DELAY))
+  }
+
+  private mutating func startNewSlab() {
+    let newSlabSize = Self.slabSize(at: slabs.count)
+    let newSlab = Slab.allocate(
+      byteCount: newSlabSize, alignment: Self.SLAB_ALIGNMENT)
+    slabs.append(newSlab)
+    currentPtr = newSlab.baseAddress!
+    endPtr = currentPtr!.advanced(by: newSlabSize)
+  }
+
+  /// Allocate 'byteCount' of memory.
+  mutating func allocate(byteCount: Int, alignment: Int) -> UnsafeMutableRawBufferPointer {
+
+    precondition(alignment <= Self.SLAB_ALIGNMENT)
+    guard byteCount > 0 else {
+      return .init(start: nil, count: 0)
+    }
+
+    // Track the total size we allocated.
+    totalSizeAllocated += byteCount
+
+    // Check if the current slab have enough space.
+    if !slabs.isEmpty {
+      let aligned = currentPtr!.alignedUp(toMultipleOf: alignment)
+      if (aligned + byteCount <= endPtr!) {
+        currentPtr = aligned + byteCount
+        return .init(start: aligned, count: byteCount)
+      }
+    }
+
+    // If the size is too big, allocate a dedicated slab for it.
+    if (byteCount >= Self.SLAB_SIZE) {
+      let customSlab = Slab.allocate(
+        byteCount: byteCount, alignment: alignment)
+      customSizeSlabs.append(customSlab)
+      return customSlab
+    }
+
+    // Otherwise, start a new slab and try again.
+    startNewSlab()
+    let aligned = currentPtr!.alignedUp(toMultipleOf: alignment)
+    assert(aligned + byteCount <= endPtr!, "Unable to allocate memory!")
+    currentPtr = aligned + byteCount
+    return .init(start: aligned, count: byteCount)
+  }
+
+  /// Allocate a chunk of memory of `MemoryLayout<T>.stride * count'.
+  mutating func allocate<T>(_: T.Type, count: Int) -> UnsafeMutableBufferPointer<T> {
+
+    let allocated = allocate(byteCount: MemoryLayout<T>.stride * count,
+                             alignment: MemoryLayout<T>.alignment)
+    return allocated.bindMemory(to: T.self)
+  }
+
+  /// Check if the address is managed by this allocator.
+  func contains(address: UnsafeRawPointer) -> Bool {
+    func test(_ slab: Slab) -> Bool {
+      slab.baseAddress! <= address && address < slab.baseAddress! + slab.count
+    }
+    return slabs.contains(where: test(_:)) || customSizeSlabs.contains(where: test(_:))
+  }
+
+  /// Deallocate all memory.
+  mutating func reset() {
+    totalSizeAllocated = 0
+    currentPtr = nil
+    endPtr = nil
+    while !slabs.isEmpty {
+      slabs.removeLast().deallocate()
+    }
+    while !customSizeSlabs.isEmpty {
+      customSizeSlabs.removeLast().deallocate()
+    }
+  }
+}

--- a/Tests/SwiftSyntaxTest/BumpPtrAllocatorTests.swift
+++ b/Tests/SwiftSyntaxTest/BumpPtrAllocatorTests.swift
@@ -1,0 +1,39 @@
+#if DEBUG
+
+import XCTest
+@testable import SwiftSyntax
+
+final class BumpPtrAllocatorTests: XCTestCase {
+
+    func testBasic() throws {
+      var allocator = BumpPtrAllocator()
+
+      let byteBuffer = allocator.allocate(byteCount: 42, alignment: 4)
+      XCTAssertNotNil(byteBuffer.baseAddress)
+      XCTAssertEqual(byteBuffer.count, 42)
+      XCTAssertEqual(byteBuffer.baseAddress?.alignedUp(toMultipleOf: 4),
+                     byteBuffer.baseAddress)
+
+      let emptyBuffer = allocator.allocate(byteCount: 0, alignment: 8)
+      XCTAssertNil(emptyBuffer.baseAddress)
+      XCTAssertEqual(emptyBuffer.count, 0)
+
+      let typedBuffer = allocator.allocate(UInt64.self, count: 12)
+      XCTAssertNotNil(typedBuffer.baseAddress)
+      XCTAssertEqual(typedBuffer.count, 12)
+      XCTAssertEqual(UnsafeRawBufferPointer(typedBuffer).count,
+                     MemoryLayout<UInt64>.stride * 12)
+      XCTAssertEqual(byteBuffer.baseAddress?.alignedUp(toMultipleOf: MemoryLayout<UInt64>.alignment),
+                     byteBuffer.baseAddress)
+
+      let typedEmptyBuffer = allocator.allocate(String.self, count: 0)
+      XCTAssertNil(typedEmptyBuffer.baseAddress)
+      XCTAssertEqual(typedEmptyBuffer.count, 0)
+
+
+      XCTAssertEqual(allocator.totalSizeAllocated,
+                     42 + MemoryLayout<UInt64>.stride * 12)
+    }
+}
+
+#endif

--- a/Tests/SwiftSyntaxTest/BumpPtrAllocatorTests.swift
+++ b/Tests/SwiftSyntaxTest/BumpPtrAllocatorTests.swift
@@ -1,4 +1,6 @@
 #if DEBUG
+// 'BumpPtrAllocator' is not a public API. Test it only when the module is built
+// with @testable (i.e. `DEBUG`)
 
 import XCTest
 @testable import SwiftSyntax
@@ -6,7 +8,7 @@ import XCTest
 final class BumpPtrAllocatorTests: XCTestCase {
 
     func testBasic() throws {
-      var allocator = BumpPtrAllocator()
+      let allocator = BumpPtrAllocator()
 
       let byteBuffer = allocator.allocate(byteCount: 42, alignment: 4)
       XCTAssertNotNil(byteBuffer.baseAddress)
@@ -30,6 +32,8 @@ final class BumpPtrAllocatorTests: XCTestCase {
       XCTAssertNil(typedEmptyBuffer.baseAddress)
       XCTAssertEqual(typedEmptyBuffer.count, 0)
 
+      XCTAssertTrue(allocator.contains(address: typedBuffer.baseAddress!))
+      XCTAssertTrue(allocator.contains(address: typedBuffer.baseAddress!.advanced(by: typedBuffer.count)))
 
       XCTAssertEqual(allocator.totalSizeAllocated,
                      42 + MemoryLayout<UInt64>.stride * 12)

--- a/Tests/SwiftSyntaxTest/BumpPtrAllocatorTests.swift
+++ b/Tests/SwiftSyntaxTest/BumpPtrAllocatorTests.swift
@@ -1,9 +1,5 @@
-#if DEBUG
-// 'BumpPtrAllocator' is not a public API. Test it only when the module is built
-// with @testable (i.e. `DEBUG`)
-
 import XCTest
-@testable import SwiftSyntax
+@_spi(Testing) import SwiftSyntax
 
 final class BumpPtrAllocatorTests: XCTestCase {
 
@@ -35,9 +31,9 @@ final class BumpPtrAllocatorTests: XCTestCase {
       XCTAssertTrue(allocator.contains(address: typedBuffer.baseAddress!))
       XCTAssertTrue(allocator.contains(address: typedBuffer.baseAddress!.advanced(by: typedBuffer.count)))
 
-      XCTAssertEqual(allocator.totalSizeAllocated,
+      XCTAssertEqual(allocator.totalByteSizeAllocated,
                      42 + MemoryLayout<UInt64>.stride * 12)
+      XCTAssert(allocator.totalMemorySize >= allocator.totalByteSizeAllocated)
     }
 }
 
-#endif

--- a/utils/group.json
+++ b/utils/group.json
@@ -47,5 +47,6 @@
     "CNodes.swift",
     "AtomicCounter.swift",
     "SyntaxVerifier.swift",
+    "BumpPtrAllocator.swift",
   ]
 }


### PR DESCRIPTION
For future usage. The implementation is basically Swift copy of `llvm::BumpPtrAllocator`, but without customizable slab size etc.