### PR TITLE
Make `ExprList` initializable by result builder

### DIFF
--- a/Sources/SwiftSyntaxBuilder/gyb_generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/BuildableNodes.swift
@@ -842,6 +842,18 @@ public struct SequenceExpr: ExprBuildable, ExpressibleAsSequenceExpr {
     self.elements = elements.createExprList()
   }
 
+  /// A convenience initializer that allows:
+  ///  - Initializing syntax collections using result builders
+  ///  - Initializing tokens without default text using strings
+  public init(
+    leadingTrivia: Trivia = [],
+    @ExprListBuilder elementsBuilder: () -> ExpressibleAsExprList = { ExprList([]) }
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      elements: elementsBuilder()
+    )
+  }
 
   /// Builds a `SequenceExprSyntax`.
   /// - Parameter format: The `Format` to use.
@@ -10987,6 +10999,24 @@ public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
     assert(rightParen.text == ")")
   }
 
+  /// A convenience initializer that allows:
+  ///  - Initializing syntax collections using result builders
+  ///  - Initializing tokens without default text using strings
+  public init(
+    leadingTrivia: Trivia = [],
+    leftParen: TokenSyntax = TokenSyntax.`leftParen`,
+    trailingComma: TokenSyntax? = nil,
+    rightParen: TokenSyntax = TokenSyntax.`rightParen`,
+    @ExprListBuilder elementListBuilder: () -> ExpressibleAsExprList = { ExprList([]) }
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      leftParen: leftParen,
+      elementList: elementListBuilder(),
+      trailingComma: trailingComma,
+      rightParen: rightParen
+    )
+  }
 
   /// Builds a `YieldListSyntax`.
   /// - Parameter format: The `Format` to use.

--- a/Sources/SwiftSyntaxBuilder/gyb_helpers/BuilderInitializableTypes.py
+++ b/Sources/SwiftSyntaxBuilder/gyb_helpers/BuilderInitializableTypes.py
@@ -16,4 +16,5 @@ BUILDER_INITIALIZABLE_TYPES = {
     'CaseItemList': None,
     'GenericArgumentList': None,
     'TuplePatternElementList': None,
+    'ExprList': None,
 }

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/BuilderInitializableTypes.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/BuilderInitializableTypes.swift
@@ -30,4 +30,5 @@ let BUILDER_INITIALIZABLE_TYPES: [String: String?] = [
   "CaseItemList": nil,
   "GenericArgumentList": nil,
   "TuplePatternElementList": nil,
+  "ExprList": nil,
 ]

--- a/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
@@ -23,25 +23,25 @@ final class FunctionTests: XCTestCase {
         },
         body: ifCodeBlock)
 
-      ReturnStmt(expression: SequenceExpr(elements: ExprList {
+      ReturnStmt(expression: SequenceExpr {
         FunctionCallExpr("fibonacci") {
-          SequenceExpr(elements: ExprList {
+          SequenceExpr {
             IntegerLiteralExpr(digits: "n")
             BinaryOperatorExpr("-")
             IntegerLiteralExpr(1)
-          })
+          }
         }
 
         BinaryOperatorExpr("+")
 
         FunctionCallExpr(MemberAccessExpr(base: "self", name: "fibonacci")) {
-          SequenceExpr(elements: ExprList {
+          SequenceExpr {
             IntegerLiteralExpr(digits: "n")
             BinaryOperatorExpr("-")
             IntegerLiteralExpr(2)
-          })
+          }
         }
-      }))
+      })
     }
     let syntax = buildable.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
 


### PR DESCRIPTION
Since the `Array: ExpressibleAsExprList` conformance is [unlikely to be added](https://github.com/apple/swift-syntax/pull/528#issuecomment-1197399869) due to type system limitations, here is a small patch to make expression lists a bit more convenient to use by making them builder-initializable (currently only affects `SequenceExpr` and `YieldList`).

Using this we can shorten

```swift
SequenceExpr(elements: ExprList {
  ...
})
```

to

```swift
SequenceExpr {
  ...
}
```