### PR TITLE
Update SPM instructions to swift-tools-version 5.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,18 @@ Its API is designed for performance-critical applications. It uses value types a
 Add this repository to the `Package.swift` manifest of your project:
 
 ```swift
-// swift-tools-version:5.3
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(
   name: "MyTool",
   dependencies: [
-    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("<#Specify Release tag#>")),
+    .package(url: "https://github.com/apple/swift-syntax.git", exact: "<#Specify Release tag#>"),
   ],
   targets: [
-    .target(name: "MyTool", dependencies: ["SwiftSyntax"]),
+    .target(name: "MyTool", dependencies: [
+      .product(name: "SwiftSyntax", package: "swift-syntax"),
+    ]),
   ]
 )
 ```


### PR DESCRIPTION
Swift 5.6 deprecates `.package(name:url:_:)` in favor of `.package(url:exact:)` and requires dependencies to explicitly specify the package their dependencies come from. For details, see:

- https://github.com/apple/swift-package-manager/pull/3641
- https://github.com/apple/swift-package-manager/blob/main/CHANGELOG.md#swift-56

This patch updates the instructions in the README to match these updated conventions.