### PR TITLE
Introduce a new syntax kind to represent missing base nodes

### DIFF
--- a/Sources/SwiftSyntax/Misc.swift.gyb
+++ b/Sources/SwiftSyntax/Misc.swift.gyb
@@ -54,7 +54,7 @@ extension Syntax {
       return node
     case .unknown(let node):
       return node
-% for node in SYNTAX_NODES:
+% for node in NON_BASE_SYNTAX_NODES:
     case .${node.swift_syntax_kind}(let node):
       return node
 % end

--- a/Sources/SwiftSyntax/SyntaxEnum.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxEnum.swift.gyb
@@ -23,7 +23,7 @@
 public enum SyntaxEnum {
   case unknown(UnknownSyntax)
   case token(TokenSyntax)
-% for node in SYNTAX_NODES:
+% for node in NON_BASE_SYNTAX_NODES:
 %   if node.is_base():
   case ${node.swift_syntax_kind}(Unknown${node.name})
 %   else:
@@ -40,7 +40,7 @@ public extension Syntax {
       return .token(TokenSyntax(self)!)
     case .unknown:
       return .unknown(UnknownSyntax(self)!)
-% for node in SYNTAX_NODES:
+% for node in NON_BASE_SYNTAX_NODES:
     case .${node.swift_syntax_kind}:
 %   if node.is_base():
       return .${node.swift_syntax_kind}(Unknown${node.name}(self)!)

--- a/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -83,7 +83,8 @@ public enum SyntaxFactory {
 %   end
 
 %   if not node.is_base():
-  public static func makeBlank${node.syntax_kind}(presence: SourcePresence = .present) -> ${node.name} {
+%   default_presence = 'missing' if node.is_missing() else 'present'
+  public static func makeBlank${node.syntax_kind}(presence: SourcePresence = .${default_presence}) -> ${node.name} {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .${node.swift_syntax_kind},
       layout: [
 %     for child in node.children:

--- a/Sources/SwiftSyntax/SyntaxKind.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxKind.swift.gyb
@@ -22,7 +22,7 @@
 internal enum SyntaxKind: CSyntaxKind {
   case token = 0
   case unknown = 1
-% for node in SYNTAX_NODES:
+% for node in NON_BASE_SYNTAX_NODES:
   case ${node.swift_syntax_kind} = ${SYNTAX_NODE_SERIALIZATION_CODES[node.syntax_kind]}
 % end
 

--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -157,7 +157,7 @@ open class SyntaxRewriter {
       return visitImplTokenSyntax
     case .unknown:
       return visitImplUnknownSyntax
-  % for node in SYNTAX_NODES:
+  % for node in NON_BASE_SYNTAX_NODES:
     case .${node.swift_syntax_kind}:
       return visitImpl${node.name}
   % end
@@ -176,7 +176,7 @@ open class SyntaxRewriter {
       return visitImplTokenSyntax(data)
     case .unknown:
       return visitImplUnknownSyntax(data)
-  % for node in SYNTAX_NODES:
+  % for node in NON_BASE_SYNTAX_NODES:
     case .${node.swift_syntax_kind}:
       return visitImpl${node.name}(data)
   % end

--- a/Sources/SwiftSyntax/SyntaxVisitor.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxVisitor.swift.gyb
@@ -126,7 +126,7 @@ open class SyntaxVisitor {
     // circumvents an issue where the compiler allocates stack space for every
     // case statement next to each other in debug builds, causing it to allocate
     // ~50KB per call to this function. rdar://55929175
-  % for node in SYNTAX_NODES:
+  % for node in NON_BASE_SYNTAX_NODES:
     case .${node.swift_syntax_kind}:
       visitImpl${node.name}(data)
   % end

--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -49,6 +49,42 @@ extension SyntaxNode {
     return UnknownPatternSyntax(asSyntaxData)
   }
 
+  public var isMissing: Bool { return raw.kind == .missing }
+  public var asMissing: MissingSyntax? {
+    guard isMissing else { return nil }
+    return MissingSyntax(asSyntaxData)
+  }
+
+  public var isMissingDecl: Bool { return raw.kind == .missingDecl }
+  public var asMissingDecl: MissingDeclSyntax? {
+    guard isMissingDecl else { return nil }
+    return MissingDeclSyntax(asSyntaxData)
+  }
+
+  public var isMissingExpr: Bool { return raw.kind == .missingExpr }
+  public var asMissingExpr: MissingExprSyntax? {
+    guard isMissingExpr else { return nil }
+    return MissingExprSyntax(asSyntaxData)
+  }
+
+  public var isMissingStmt: Bool { return raw.kind == .missingStmt }
+  public var asMissingStmt: MissingStmtSyntax? {
+    guard isMissingStmt else { return nil }
+    return MissingStmtSyntax(asSyntaxData)
+  }
+
+  public var isMissingType: Bool { return raw.kind == .missingType }
+  public var asMissingType: MissingTypeSyntax? {
+    guard isMissingType else { return nil }
+    return MissingTypeSyntax(asSyntaxData)
+  }
+
+  public var isMissingPattern: Bool { return raw.kind == .missingPattern }
+  public var asMissingPattern: MissingPatternSyntax? {
+    guard isMissingPattern else { return nil }
+    return MissingPatternSyntax(asSyntaxData)
+  }
+
   public var isCodeBlockItem: Bool { return raw.kind == .codeBlockItem }
   public var asCodeBlockItem: CodeBlockItemSyntax? {
     guard isCodeBlockItem else { return nil }
@@ -1531,16 +1567,6 @@ extension Syntax {
       return node
     case .unknown(let node):
       return node
-    case .decl(let node):
-      return node
-    case .expr(let node):
-      return node
-    case .stmt(let node):
-      return node
-    case .type(let node):
-      return node
-    case .pattern(let node):
-      return node
     case .unknownDecl(let node):
       return node
     case .unknownExpr(let node):
@@ -1550,6 +1576,18 @@ extension Syntax {
     case .unknownType(let node):
       return node
     case .unknownPattern(let node):
+      return node
+    case .missing(let node):
+      return node
+    case .missingDecl(let node):
+      return node
+    case .missingExpr(let node):
+      return node
+    case .missingStmt(let node):
+      return node
+    case .missingType(let node):
+      return node
+    case .missingPattern(let node):
       return node
     case .codeBlockItem(let node):
       return node

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
@@ -99,6 +99,48 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   override open func visitPost(_ node: UnknownPatternSyntax) {
     visitAnyPost(node._syntaxNode)
   }
+  override open func visit(_ node: MissingSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: MissingSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: MissingDeclSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: MissingDeclSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: MissingExprSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: MissingExprSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: MissingStmtSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: MissingStmtSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: MissingTypeSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: MissingTypeSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: MissingPatternSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: MissingPatternSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
   override open func visit(_ node: CodeBlockItemSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
@@ -56,7 +56,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// `nil` if the conversion is not possible.
   public init?(_ syntax: Syntax) {
     switch syntax.raw.kind {
-    case .unknownDecl, .typealiasDecl, .associatedtypeDecl, .ifConfigDecl, .poundErrorDecl, .poundWarningDecl, .poundSourceLocation, .classDecl, .actorDecl, .structDecl, .protocolDecl, .extensionDecl, .functionDecl, .initializerDecl, .deinitializerDecl, .subscriptDecl, .importDecl, .accessorDecl, .variableDecl, .enumCaseDecl, .enumDecl, .operatorDecl, .precedenceGroupDecl:
+    case .unknownDecl, .missingDecl, .typealiasDecl, .associatedtypeDecl, .ifConfigDecl, .poundErrorDecl, .poundWarningDecl, .poundSourceLocation, .classDecl, .actorDecl, .structDecl, .protocolDecl, .extensionDecl, .functionDecl, .initializerDecl, .deinitializerDecl, .subscriptDecl, .importDecl, .accessorDecl, .variableDecl, .enumCaseDecl, .enumDecl, .operatorDecl, .precedenceGroupDecl:
       self._syntaxNode = syntax
     default:
       return nil
@@ -70,7 +70,7 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     // Assert that the kind of the given data matches in debug builds.
 #if DEBUG
     switch data.raw.kind {
-    case .unknownDecl, .typealiasDecl, .associatedtypeDecl, .ifConfigDecl, .poundErrorDecl, .poundWarningDecl, .poundSourceLocation, .classDecl, .actorDecl, .structDecl, .protocolDecl, .extensionDecl, .functionDecl, .initializerDecl, .deinitializerDecl, .subscriptDecl, .importDecl, .accessorDecl, .variableDecl, .enumCaseDecl, .enumDecl, .operatorDecl, .precedenceGroupDecl:
+    case .unknownDecl, .missingDecl, .typealiasDecl, .associatedtypeDecl, .ifConfigDecl, .poundErrorDecl, .poundWarningDecl, .poundSourceLocation, .classDecl, .actorDecl, .structDecl, .protocolDecl, .extensionDecl, .functionDecl, .initializerDecl, .deinitializerDecl, .subscriptDecl, .importDecl, .accessorDecl, .variableDecl, .enumCaseDecl, .enumDecl, .operatorDecl, .precedenceGroupDecl:
       break
     default:
       fatalError("Unable to create DeclSyntax from \(data.raw.kind)")
@@ -164,7 +164,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// `nil` if the conversion is not possible.
   public init?(_ syntax: Syntax) {
     switch syntax.raw.kind {
-    case .unknownExpr, .inOutExpr, .poundColumnExpr, .tryExpr, .awaitExpr, .identifierExpr, .superRefExpr, .nilLiteralExpr, .discardAssignmentExpr, .assignmentExpr, .sequenceExpr, .poundLineExpr, .poundFileExpr, .poundFileIDExpr, .poundFilePathExpr, .poundFunctionExpr, .poundDsohandleExpr, .symbolicReferenceExpr, .prefixOperatorExpr, .binaryOperatorExpr, .arrowExpr, .floatLiteralExpr, .tupleExpr, .arrayExpr, .dictionaryExpr, .integerLiteralExpr, .booleanLiteralExpr, .ternaryExpr, .memberAccessExpr, .isExpr, .asExpr, .typeExpr, .closureExpr, .unresolvedPatternExpr, .functionCallExpr, .subscriptExpr, .optionalChainingExpr, .forcedValueExpr, .postfixUnaryExpr, .specializeExpr, .stringLiteralExpr, .regexLiteralExpr, .keyPathExpr, .keyPathBaseExpr, .objcKeyPathExpr, .objcSelectorExpr, .postfixIfConfigExpr, .editorPlaceholderExpr, .objectLiteralExpr:
+    case .unknownExpr, .missingExpr, .inOutExpr, .poundColumnExpr, .tryExpr, .awaitExpr, .identifierExpr, .superRefExpr, .nilLiteralExpr, .discardAssignmentExpr, .assignmentExpr, .sequenceExpr, .poundLineExpr, .poundFileExpr, .poundFileIDExpr, .poundFilePathExpr, .poundFunctionExpr, .poundDsohandleExpr, .symbolicReferenceExpr, .prefixOperatorExpr, .binaryOperatorExpr, .arrowExpr, .floatLiteralExpr, .tupleExpr, .arrayExpr, .dictionaryExpr, .integerLiteralExpr, .booleanLiteralExpr, .ternaryExpr, .memberAccessExpr, .isExpr, .asExpr, .typeExpr, .closureExpr, .unresolvedPatternExpr, .functionCallExpr, .subscriptExpr, .optionalChainingExpr, .forcedValueExpr, .postfixUnaryExpr, .specializeExpr, .stringLiteralExpr, .regexLiteralExpr, .keyPathExpr, .keyPathBaseExpr, .objcKeyPathExpr, .objcSelectorExpr, .postfixIfConfigExpr, .editorPlaceholderExpr, .objectLiteralExpr:
       self._syntaxNode = syntax
     default:
       return nil
@@ -178,7 +178,7 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     // Assert that the kind of the given data matches in debug builds.
 #if DEBUG
     switch data.raw.kind {
-    case .unknownExpr, .inOutExpr, .poundColumnExpr, .tryExpr, .awaitExpr, .identifierExpr, .superRefExpr, .nilLiteralExpr, .discardAssignmentExpr, .assignmentExpr, .sequenceExpr, .poundLineExpr, .poundFileExpr, .poundFileIDExpr, .poundFilePathExpr, .poundFunctionExpr, .poundDsohandleExpr, .symbolicReferenceExpr, .prefixOperatorExpr, .binaryOperatorExpr, .arrowExpr, .floatLiteralExpr, .tupleExpr, .arrayExpr, .dictionaryExpr, .integerLiteralExpr, .booleanLiteralExpr, .ternaryExpr, .memberAccessExpr, .isExpr, .asExpr, .typeExpr, .closureExpr, .unresolvedPatternExpr, .functionCallExpr, .subscriptExpr, .optionalChainingExpr, .forcedValueExpr, .postfixUnaryExpr, .specializeExpr, .stringLiteralExpr, .regexLiteralExpr, .keyPathExpr, .keyPathBaseExpr, .objcKeyPathExpr, .objcSelectorExpr, .postfixIfConfigExpr, .editorPlaceholderExpr, .objectLiteralExpr:
+    case .unknownExpr, .missingExpr, .inOutExpr, .poundColumnExpr, .tryExpr, .awaitExpr, .identifierExpr, .superRefExpr, .nilLiteralExpr, .discardAssignmentExpr, .assignmentExpr, .sequenceExpr, .poundLineExpr, .poundFileExpr, .poundFileIDExpr, .poundFilePathExpr, .poundFunctionExpr, .poundDsohandleExpr, .symbolicReferenceExpr, .prefixOperatorExpr, .binaryOperatorExpr, .arrowExpr, .floatLiteralExpr, .tupleExpr, .arrayExpr, .dictionaryExpr, .integerLiteralExpr, .booleanLiteralExpr, .ternaryExpr, .memberAccessExpr, .isExpr, .asExpr, .typeExpr, .closureExpr, .unresolvedPatternExpr, .functionCallExpr, .subscriptExpr, .optionalChainingExpr, .forcedValueExpr, .postfixUnaryExpr, .specializeExpr, .stringLiteralExpr, .regexLiteralExpr, .keyPathExpr, .keyPathBaseExpr, .objcKeyPathExpr, .objcSelectorExpr, .postfixIfConfigExpr, .editorPlaceholderExpr, .objectLiteralExpr:
       break
     default:
       fatalError("Unable to create ExprSyntax from \(data.raw.kind)")
@@ -272,7 +272,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// `nil` if the conversion is not possible.
   public init?(_ syntax: Syntax) {
     switch syntax.raw.kind {
-    case .unknownStmt, .continueStmt, .whileStmt, .deferStmt, .expressionStmt, .repeatWhileStmt, .guardStmt, .forInStmt, .switchStmt, .doStmt, .returnStmt, .yieldStmt, .fallthroughStmt, .breakStmt, .declarationStmt, .throwStmt, .ifStmt, .poundAssertStmt:
+    case .unknownStmt, .missingStmt, .continueStmt, .whileStmt, .deferStmt, .expressionStmt, .repeatWhileStmt, .guardStmt, .forInStmt, .switchStmt, .doStmt, .returnStmt, .yieldStmt, .fallthroughStmt, .breakStmt, .declarationStmt, .throwStmt, .ifStmt, .poundAssertStmt:
       self._syntaxNode = syntax
     default:
       return nil
@@ -286,7 +286,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     // Assert that the kind of the given data matches in debug builds.
 #if DEBUG
     switch data.raw.kind {
-    case .unknownStmt, .continueStmt, .whileStmt, .deferStmt, .expressionStmt, .repeatWhileStmt, .guardStmt, .forInStmt, .switchStmt, .doStmt, .returnStmt, .yieldStmt, .fallthroughStmt, .breakStmt, .declarationStmt, .throwStmt, .ifStmt, .poundAssertStmt:
+    case .unknownStmt, .missingStmt, .continueStmt, .whileStmt, .deferStmt, .expressionStmt, .repeatWhileStmt, .guardStmt, .forInStmt, .switchStmt, .doStmt, .returnStmt, .yieldStmt, .fallthroughStmt, .breakStmt, .declarationStmt, .throwStmt, .ifStmt, .poundAssertStmt:
       break
     default:
       fatalError("Unable to create StmtSyntax from \(data.raw.kind)")
@@ -380,7 +380,7 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   /// `nil` if the conversion is not possible.
   public init?(_ syntax: Syntax) {
     switch syntax.raw.kind {
-    case .unknownType, .simpleTypeIdentifier, .memberTypeIdentifier, .classRestrictionType, .arrayType, .dictionaryType, .metatypeType, .optionalType, .constrainedSugarType, .implicitlyUnwrappedOptionalType, .compositionType, .tupleType, .functionType, .attributedType:
+    case .unknownType, .missingType, .simpleTypeIdentifier, .memberTypeIdentifier, .classRestrictionType, .arrayType, .dictionaryType, .metatypeType, .optionalType, .constrainedSugarType, .implicitlyUnwrappedOptionalType, .compositionType, .tupleType, .functionType, .attributedType:
       self._syntaxNode = syntax
     default:
       return nil
@@ -394,7 +394,7 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     // Assert that the kind of the given data matches in debug builds.
 #if DEBUG
     switch data.raw.kind {
-    case .unknownType, .simpleTypeIdentifier, .memberTypeIdentifier, .classRestrictionType, .arrayType, .dictionaryType, .metatypeType, .optionalType, .constrainedSugarType, .implicitlyUnwrappedOptionalType, .compositionType, .tupleType, .functionType, .attributedType:
+    case .unknownType, .missingType, .simpleTypeIdentifier, .memberTypeIdentifier, .classRestrictionType, .arrayType, .dictionaryType, .metatypeType, .optionalType, .constrainedSugarType, .implicitlyUnwrappedOptionalType, .compositionType, .tupleType, .functionType, .attributedType:
       break
     default:
       fatalError("Unable to create TypeSyntax from \(data.raw.kind)")
@@ -488,7 +488,7 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// `nil` if the conversion is not possible.
   public init?(_ syntax: Syntax) {
     switch syntax.raw.kind {
-    case .unknownPattern, .enumCasePattern, .isTypePattern, .optionalPattern, .identifierPattern, .asTypePattern, .tuplePattern, .wildcardPattern, .expressionPattern, .valueBindingPattern:
+    case .unknownPattern, .missingPattern, .enumCasePattern, .isTypePattern, .optionalPattern, .identifierPattern, .asTypePattern, .tuplePattern, .wildcardPattern, .expressionPattern, .valueBindingPattern:
       self._syntaxNode = syntax
     default:
       return nil
@@ -502,7 +502,7 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     // Assert that the kind of the given data matches in debug builds.
 #if DEBUG
     switch data.raw.kind {
-    case .unknownPattern, .enumCasePattern, .isTypePattern, .optionalPattern, .identifierPattern, .asTypePattern, .tuplePattern, .wildcardPattern, .expressionPattern, .valueBindingPattern:
+    case .unknownPattern, .missingPattern, .enumCasePattern, .isTypePattern, .optionalPattern, .identifierPattern, .asTypePattern, .tuplePattern, .wildcardPattern, .expressionPattern, .valueBindingPattern:
       break
     default:
       fatalError("Unable to create PatternSyntax from \(data.raw.kind)")

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
@@ -142,7 +142,7 @@ public struct InOutExprSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.prefixAmpersand)
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.expr)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .inOutExpr,
@@ -231,7 +231,7 @@ public struct TryExprSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.tryKeyword)
     }
     if (layout[2] == nil) {
-      layout[2] = RawSyntax.missing(SyntaxKind.expr)
+      layout[2] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .tryExpr,
@@ -277,7 +277,7 @@ public struct AwaitExprSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.contextualKeyword(""))
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.expr)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .awaitExpr,
@@ -936,7 +936,7 @@ public struct PrefixOperatorExprSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.expr)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .prefixOperatorExpr,
@@ -1287,7 +1287,7 @@ public struct TupleExprElementSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[2] == nil) {
-      layout[2] = RawSyntax.missing(SyntaxKind.expr)
+      layout[2] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .tupleExprElement,
@@ -1330,7 +1330,7 @@ public struct ArrayElementSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.expr)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .arrayElement,
@@ -1383,13 +1383,13 @@ public struct DictionaryElementSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.expr)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missingToken(TokenKind.colon)
     }
     if (layout[2] == nil) {
-      layout[2] = RawSyntax.missing(SyntaxKind.expr)
+      layout[2] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .dictionaryElement,
@@ -1523,19 +1523,19 @@ public struct TernaryExprSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.expr)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missingToken(TokenKind.infixQuestionMark)
     }
     if (layout[2] == nil) {
-      layout[2] = RawSyntax.missing(SyntaxKind.expr)
+      layout[2] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
     if (layout[3] == nil) {
       layout[3] = RawSyntax.missingToken(TokenKind.colon)
     }
     if (layout[4] == nil) {
-      layout[4] = RawSyntax.missing(SyntaxKind.expr)
+      layout[4] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .ternaryExpr,
@@ -1637,7 +1637,7 @@ public struct IsExprSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.isKeyword)
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.type)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .isExpr,
@@ -1688,7 +1688,7 @@ public struct AsExprSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.asKeyword)
     }
     if (layout[2] == nil) {
-      layout[2] = RawSyntax.missing(SyntaxKind.type)
+      layout[2] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .asExpr,
@@ -1726,7 +1726,7 @@ public struct TypeExprSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.type)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .typeExpr,
@@ -1790,7 +1790,7 @@ public struct ClosureCaptureItemSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[3] == nil) {
-      layout[3] = RawSyntax.missing(SyntaxKind.expr)
+      layout[3] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .closureCaptureItem,
@@ -2067,7 +2067,7 @@ public struct UnresolvedPatternExprSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.pattern)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingPattern)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .unresolvedPatternExpr,
@@ -2196,7 +2196,7 @@ public struct FunctionCallExprSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.expr)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
     if (layout[2] == nil) {
       layout[2] = RawSyntax.missing(SyntaxKind.tupleExprElementList)
@@ -2274,7 +2274,7 @@ public struct SubscriptExprSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.expr)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missingToken(TokenKind.leftSquareBracket)
@@ -2326,7 +2326,7 @@ public struct OptionalChainingExprSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.expr)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missingToken(TokenKind.postfixQuestionMark)
@@ -2372,7 +2372,7 @@ public struct ForcedValueExprSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.expr)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missingToken(TokenKind.exclamationMark)
@@ -2418,7 +2418,7 @@ public struct PostfixUnaryExprSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.expr)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missingToken(TokenKind.postfixOperator(""))
@@ -2464,7 +2464,7 @@ public struct SpecializeExprSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.expr)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missing(SyntaxKind.genericArgumentClause)
@@ -2737,7 +2737,7 @@ public struct KeyPathExprSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.backslash)
     }
     if (layout[2] == nil) {
-      layout[2] = RawSyntax.missing(SyntaxKind.expr)
+      layout[2] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .keyPathExpr,
@@ -2955,7 +2955,7 @@ public struct ObjcSelectorExprSyntaxBuilder {
       layout[1] = RawSyntax.missingToken(TokenKind.leftParen)
     }
     if (layout[4] == nil) {
-      layout[4] = RawSyntax.missing(SyntaxKind.expr)
+      layout[4] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
     if (layout[5] == nil) {
       layout[5] = RawSyntax.missingToken(TokenKind.rightParen)
@@ -3153,7 +3153,7 @@ public struct TypeInitializerClauseSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.equal)
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.type)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .typeInitializerClause,
@@ -3428,7 +3428,7 @@ public struct ReturnClauseSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.arrow)
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.type)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .returnClause,
@@ -3993,7 +3993,7 @@ public struct InheritedTypeSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.type)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .inheritedType,
@@ -4492,7 +4492,7 @@ public struct ExtensionDeclSyntaxBuilder {
       layout[2] = RawSyntax.missingToken(TokenKind.extensionKeyword)
     }
     if (layout[3] == nil) {
-      layout[3] = RawSyntax.missing(SyntaxKind.type)
+      layout[3] = RawSyntax.missing(SyntaxKind.missingType)
     }
     if (layout[6] == nil) {
       layout[6] = RawSyntax.missing(SyntaxKind.memberDeclBlock)
@@ -4598,7 +4598,7 @@ public struct MemberDeclListItemSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.decl)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingDecl)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .memberDeclListItem,
@@ -4696,7 +4696,7 @@ public struct InitializerClauseSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.equal)
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.expr)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .initializerClause,
@@ -5518,7 +5518,7 @@ public struct PatternBindingSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.pattern)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingPattern)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .patternBinding,
@@ -6311,7 +6311,7 @@ public struct CustomAttributeSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.atSign)
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.type)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .customAttribute,
@@ -7447,7 +7447,7 @@ public struct ExpressionStmtSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.expr)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .expressionStmt,
@@ -7519,7 +7519,7 @@ public struct RepeatWhileStmtSyntaxBuilder {
       layout[4] = RawSyntax.missingToken(TokenKind.whileKeyword)
     }
     if (layout[5] == nil) {
-      layout[5] = RawSyntax.missing(SyntaxKind.expr)
+      layout[5] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .repeatWhileStmt,
@@ -7633,7 +7633,7 @@ public struct WhereClauseSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.whereKeyword)
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.expr)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .whereClause,
@@ -7729,13 +7729,13 @@ public struct ForInStmtSyntaxBuilder {
       layout[2] = RawSyntax.missingToken(TokenKind.forKeyword)
     }
     if (layout[6] == nil) {
-      layout[6] = RawSyntax.missing(SyntaxKind.pattern)
+      layout[6] = RawSyntax.missing(SyntaxKind.missingPattern)
     }
     if (layout[8] == nil) {
       layout[8] = RawSyntax.missingToken(TokenKind.inKeyword)
     }
     if (layout[9] == nil) {
-      layout[9] = RawSyntax.missing(SyntaxKind.expr)
+      layout[9] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
     if (layout[11] == nil) {
       layout[11] = RawSyntax.missing(SyntaxKind.codeBlock)
@@ -7815,7 +7815,7 @@ public struct SwitchStmtSyntaxBuilder {
       layout[2] = RawSyntax.missingToken(TokenKind.switchKeyword)
     }
     if (layout[3] == nil) {
-      layout[3] = RawSyntax.missing(SyntaxKind.expr)
+      layout[3] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
     if (layout[4] == nil) {
       layout[4] = RawSyntax.missingToken(TokenKind.leftBrace)
@@ -8293,7 +8293,7 @@ public struct MatchingPatternConditionSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.caseKeyword)
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.pattern)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingPattern)
     }
     if (layout[3] == nil) {
       layout[3] = RawSyntax.missing(SyntaxKind.initializerClause)
@@ -8352,7 +8352,7 @@ public struct OptionalBindingConditionSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.letKeyword)
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.pattern)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingPattern)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .optionalBindingCondition,
@@ -8458,7 +8458,7 @@ public struct DeclarationStmtSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.decl)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingDecl)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .declarationStmt,
@@ -8504,7 +8504,7 @@ public struct ThrowStmtSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.throwKeyword)
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.expr)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .throwStmt,
@@ -8819,7 +8819,7 @@ public struct CaseItemSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.pattern)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingPattern)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .caseItem,
@@ -9050,7 +9050,7 @@ public struct PoundAssertStmtSyntaxBuilder {
       layout[1] = RawSyntax.missingToken(TokenKind.leftParen)
     }
     if (layout[2] == nil) {
-      layout[2] = RawSyntax.missing(SyntaxKind.expr)
+      layout[2] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
     if (layout[5] == nil) {
       layout[5] = RawSyntax.missingToken(TokenKind.rightParen)
@@ -9196,13 +9196,13 @@ public struct SameTypeRequirementSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.type)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingType)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missingToken(TokenKind.spacedBinaryOperator(""))
     }
     if (layout[2] == nil) {
-      layout[2] = RawSyntax.missing(SyntaxKind.type)
+      layout[2] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .sameTypeRequirement,
@@ -9417,13 +9417,13 @@ public struct ConformanceRequirementSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.type)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingType)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missingToken(TokenKind.colon)
     }
     if (layout[2] == nil) {
-      layout[2] = RawSyntax.missing(SyntaxKind.type)
+      layout[2] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .conformanceRequirement,
@@ -9579,7 +9579,7 @@ public struct MemberTypeIdentifierSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.type)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingType)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missingToken(TokenKind.period)
@@ -9674,7 +9674,7 @@ public struct ArrayTypeSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.leftSquareBracket)
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.type)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingType)
     }
     if (layout[2] == nil) {
       layout[2] = RawSyntax.missingToken(TokenKind.rightSquareBracket)
@@ -9738,13 +9738,13 @@ public struct DictionaryTypeSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.leftSquareBracket)
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.type)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingType)
     }
     if (layout[2] == nil) {
       layout[2] = RawSyntax.missingToken(TokenKind.colon)
     }
     if (layout[3] == nil) {
-      layout[3] = RawSyntax.missing(SyntaxKind.type)
+      layout[3] = RawSyntax.missing(SyntaxKind.missingType)
     }
     if (layout[4] == nil) {
       layout[4] = RawSyntax.missingToken(TokenKind.rightSquareBracket)
@@ -9795,7 +9795,7 @@ public struct MetatypeTypeSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.type)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingType)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missingToken(TokenKind.period)
@@ -9844,7 +9844,7 @@ public struct OptionalTypeSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.type)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingType)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missingToken(TokenKind.postfixQuestionMark)
@@ -9893,7 +9893,7 @@ public struct ConstrainedSugarTypeSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.identifier(""))
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.type)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .constrainedSugarType,
@@ -9936,7 +9936,7 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.type)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingType)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missingToken(TokenKind.exclamationMark)
@@ -9982,7 +9982,7 @@ public struct CompositionTypeElementSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.type)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .compositionTypeElement,
@@ -10099,7 +10099,7 @@ public struct TupleTypeElementSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[4] == nil) {
-      layout[4] = RawSyntax.missing(SyntaxKind.type)
+      layout[4] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .tupleTypeElement,
@@ -10245,7 +10245,7 @@ public struct FunctionTypeSyntaxBuilder {
       layout[5] = RawSyntax.missingToken(TokenKind.arrow)
     }
     if (layout[6] == nil) {
-      layout[6] = RawSyntax.missing(SyntaxKind.type)
+      layout[6] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .functionType,
@@ -10299,7 +10299,7 @@ public struct AttributedTypeSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[2] == nil) {
-      layout[2] = RawSyntax.missing(SyntaxKind.type)
+      layout[2] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .attributedType,
@@ -10342,7 +10342,7 @@ public struct GenericArgumentSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.type)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .genericArgument,
@@ -10448,7 +10448,7 @@ public struct TypeAnnotationSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.colon)
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.type)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .typeAnnotation,
@@ -10550,7 +10550,7 @@ public struct IsTypePatternSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.isKeyword)
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.type)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .isTypePattern,
@@ -10593,7 +10593,7 @@ public struct OptionalPatternSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.pattern)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingPattern)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missingToken(TokenKind.postfixQuestionMark)
@@ -10682,13 +10682,13 @@ public struct AsTypePatternSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.pattern)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingPattern)
     }
     if (layout[1] == nil) {
       layout[1] = RawSyntax.missingToken(TokenKind.asKeyword)
     }
     if (layout[2] == nil) {
-      layout[2] = RawSyntax.missing(SyntaxKind.type)
+      layout[2] = RawSyntax.missing(SyntaxKind.missingType)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .asTypePattern,
@@ -10844,7 +10844,7 @@ public struct TuplePatternElementSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[2] == nil) {
-      layout[2] = RawSyntax.missing(SyntaxKind.pattern)
+      layout[2] = RawSyntax.missing(SyntaxKind.missingPattern)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .tuplePatternElement,
@@ -10882,7 +10882,7 @@ public struct ExpressionPatternSyntaxBuilder {
 
   internal mutating func buildData() -> SyntaxData {
     if (layout[0] == nil) {
-      layout[0] = RawSyntax.missing(SyntaxKind.expr)
+      layout[0] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .expressionPattern,
@@ -10928,7 +10928,7 @@ public struct ValueBindingPatternSyntaxBuilder {
       layout[0] = RawSyntax.missingToken(TokenKind.letKeyword)
     }
     if (layout[1] == nil) {
-      layout[1] = RawSyntax.missing(SyntaxKind.pattern)
+      layout[1] = RawSyntax.missing(SyntaxKind.missingPattern)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .valueBindingPattern,

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -16,16 +16,17 @@
 public enum SyntaxEnum {
   case unknown(UnknownSyntax)
   case token(TokenSyntax)
-  case decl(UnknownDeclSyntax)
-  case expr(UnknownExprSyntax)
-  case stmt(UnknownStmtSyntax)
-  case type(UnknownTypeSyntax)
-  case pattern(UnknownPatternSyntax)
   case unknownDecl(UnknownDeclSyntax)
   case unknownExpr(UnknownExprSyntax)
   case unknownStmt(UnknownStmtSyntax)
   case unknownType(UnknownTypeSyntax)
   case unknownPattern(UnknownPatternSyntax)
+  case missing(MissingSyntax)
+  case missingDecl(MissingDeclSyntax)
+  case missingExpr(MissingExprSyntax)
+  case missingStmt(MissingStmtSyntax)
+  case missingType(MissingTypeSyntax)
+  case missingPattern(MissingPatternSyntax)
   case codeBlockItem(CodeBlockItemSyntax)
   case codeBlockItemList(CodeBlockItemListSyntax)
   case codeBlock(CodeBlockSyntax)
@@ -280,16 +281,6 @@ public extension Syntax {
       return .token(TokenSyntax(self)!)
     case .unknown:
       return .unknown(UnknownSyntax(self)!)
-    case .decl:
-      return .decl(UnknownDeclSyntax(self)!)
-    case .expr:
-      return .expr(UnknownExprSyntax(self)!)
-    case .stmt:
-      return .stmt(UnknownStmtSyntax(self)!)
-    case .type:
-      return .type(UnknownTypeSyntax(self)!)
-    case .pattern:
-      return .pattern(UnknownPatternSyntax(self)!)
     case .unknownDecl:
       return .unknownDecl(UnknownDeclSyntax(self)!)
     case .unknownExpr:
@@ -300,6 +291,18 @@ public extension Syntax {
       return .unknownType(UnknownTypeSyntax(self)!)
     case .unknownPattern:
       return .unknownPattern(UnknownPatternSyntax(self)!)
+    case .missing:
+      return .missing(MissingSyntax(self)!)
+    case .missingDecl:
+      return .missingDecl(MissingDeclSyntax(self)!)
+    case .missingExpr:
+      return .missingExpr(MissingExprSyntax(self)!)
+    case .missingStmt:
+      return .missingStmt(MissingStmtSyntax(self)!)
+    case .missingType:
+      return .missingType(MissingTypeSyntax(self)!)
+    case .missingPattern:
+      return .missingPattern(MissingPatternSyntax(self)!)
     case .codeBlockItem:
       return .codeBlockItem(CodeBlockItemSyntax(self)!)
     case .codeBlockItemList:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -81,6 +81,48 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return UnknownPatternSyntax(data)
   }
+
+  public static func makeBlankMissing(presence: SourcePresence = .missing) -> MissingSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .missing,
+      layout: [
+    ], length: .zero, presence: presence))
+    return MissingSyntax(data)
+  }
+
+  public static func makeBlankMissingDecl(presence: SourcePresence = .missing) -> MissingDeclSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .missingDecl,
+      layout: [
+    ], length: .zero, presence: presence))
+    return MissingDeclSyntax(data)
+  }
+
+  public static func makeBlankMissingExpr(presence: SourcePresence = .missing) -> MissingExprSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .missingExpr,
+      layout: [
+    ], length: .zero, presence: presence))
+    return MissingExprSyntax(data)
+  }
+
+  public static func makeBlankMissingStmt(presence: SourcePresence = .missing) -> MissingStmtSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .missingStmt,
+      layout: [
+    ], length: .zero, presence: presence))
+    return MissingStmtSyntax(data)
+  }
+
+  public static func makeBlankMissingType(presence: SourcePresence = .missing) -> MissingTypeSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .missingType,
+      layout: [
+    ], length: .zero, presence: presence))
+    return MissingTypeSyntax(data)
+  }
+
+  public static func makeBlankMissingPattern(presence: SourcePresence = .missing) -> MissingPatternSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .missingPattern,
+      layout: [
+    ], length: .zero, presence: presence))
+    return MissingPatternSyntax(data)
+  }
   public static func makeCodeBlockItem(item: Syntax, semicolon: TokenSyntax?, errorTokens: Syntax?) -> CodeBlockItemSyntax {
     let layout: [RawSyntax?] = [
       item.raw,
@@ -152,7 +194,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .inOutExpr,
       layout: [
       RawSyntax.missingToken(TokenKind.prefixAmpersand),
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
     ], length: .zero, presence: presence))
     return InOutExprSyntax(data)
   }
@@ -246,7 +288,7 @@ public enum SyntaxFactory {
       layout: [
       RawSyntax.missingToken(TokenKind.tryKeyword),
       nil,
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
     ], length: .zero, presence: presence))
     return TryExprSyntax(data)
   }
@@ -265,7 +307,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .awaitExpr,
       layout: [
       RawSyntax.missingToken(TokenKind.contextualKeyword("")),
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
     ], length: .zero, presence: presence))
     return AwaitExprSyntax(data)
   }
@@ -577,7 +619,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .prefixOperatorExpr,
       layout: [
       nil,
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
     ], length: .zero, presence: presence))
     return PrefixOperatorExprSyntax(data)
   }
@@ -717,7 +759,7 @@ public enum SyntaxFactory {
       layout: [
       nil,
       nil,
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       nil,
     ], length: .zero, presence: presence))
     return TupleExprElementSyntax(data)
@@ -736,7 +778,7 @@ public enum SyntaxFactory {
   public static func makeBlankArrayElement(presence: SourcePresence = .present) -> ArrayElementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .arrayElement,
       layout: [
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       nil,
     ], length: .zero, presence: presence))
     return ArrayElementSyntax(data)
@@ -757,9 +799,9 @@ public enum SyntaxFactory {
   public static func makeBlankDictionaryElement(presence: SourcePresence = .present) -> DictionaryElementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .dictionaryElement,
       layout: [
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       RawSyntax.missingToken(TokenKind.colon),
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       nil,
     ], length: .zero, presence: presence))
     return DictionaryElementSyntax(data)
@@ -815,11 +857,11 @@ public enum SyntaxFactory {
   public static func makeBlankTernaryExpr(presence: SourcePresence = .present) -> TernaryExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .ternaryExpr,
       layout: [
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       RawSyntax.missingToken(TokenKind.infixQuestionMark),
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       RawSyntax.missingToken(TokenKind.colon),
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
     ], length: .zero, presence: presence))
     return TernaryExprSyntax(data)
   }
@@ -861,7 +903,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .isExpr,
       layout: [
       RawSyntax.missingToken(TokenKind.isKeyword),
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
     ], length: .zero, presence: presence))
     return IsExprSyntax(data)
   }
@@ -882,7 +924,7 @@ public enum SyntaxFactory {
       layout: [
       RawSyntax.missingToken(TokenKind.asKeyword),
       nil,
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
     ], length: .zero, presence: presence))
     return AsExprSyntax(data)
   }
@@ -899,7 +941,7 @@ public enum SyntaxFactory {
   public static func makeBlankTypeExpr(presence: SourcePresence = .present) -> TypeExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .typeExpr,
       layout: [
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
     ], length: .zero, presence: presence))
     return TypeExprSyntax(data)
   }
@@ -923,7 +965,7 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       nil,
     ], length: .zero, presence: presence))
     return ClosureCaptureItemSyntax(data)
@@ -1061,7 +1103,7 @@ public enum SyntaxFactory {
   public static func makeBlankUnresolvedPatternExpr(presence: SourcePresence = .present) -> UnresolvedPatternExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .unresolvedPatternExpr,
       layout: [
-      RawSyntax.missing(SyntaxKind.pattern),
+      RawSyntax.missing(SyntaxKind.missingPattern),
     ], length: .zero, presence: presence))
     return UnresolvedPatternExprSyntax(data)
   }
@@ -1118,7 +1160,7 @@ public enum SyntaxFactory {
   public static func makeBlankFunctionCallExpr(presence: SourcePresence = .present) -> FunctionCallExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .functionCallExpr,
       layout: [
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       nil,
       RawSyntax.missing(SyntaxKind.tupleExprElementList),
       nil,
@@ -1145,7 +1187,7 @@ public enum SyntaxFactory {
   public static func makeBlankSubscriptExpr(presence: SourcePresence = .present) -> SubscriptExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .subscriptExpr,
       layout: [
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       RawSyntax.missingToken(TokenKind.leftSquareBracket),
       RawSyntax.missing(SyntaxKind.tupleExprElementList),
       RawSyntax.missingToken(TokenKind.rightSquareBracket),
@@ -1168,7 +1210,7 @@ public enum SyntaxFactory {
   public static func makeBlankOptionalChainingExpr(presence: SourcePresence = .present) -> OptionalChainingExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .optionalChainingExpr,
       layout: [
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       RawSyntax.missingToken(TokenKind.postfixQuestionMark),
     ], length: .zero, presence: presence))
     return OptionalChainingExprSyntax(data)
@@ -1187,7 +1229,7 @@ public enum SyntaxFactory {
   public static func makeBlankForcedValueExpr(presence: SourcePresence = .present) -> ForcedValueExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .forcedValueExpr,
       layout: [
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       RawSyntax.missingToken(TokenKind.exclamationMark),
     ], length: .zero, presence: presence))
     return ForcedValueExprSyntax(data)
@@ -1206,7 +1248,7 @@ public enum SyntaxFactory {
   public static func makeBlankPostfixUnaryExpr(presence: SourcePresence = .present) -> PostfixUnaryExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .postfixUnaryExpr,
       layout: [
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       RawSyntax.missingToken(TokenKind.postfixOperator("")),
     ], length: .zero, presence: presence))
     return PostfixUnaryExprSyntax(data)
@@ -1225,7 +1267,7 @@ public enum SyntaxFactory {
   public static func makeBlankSpecializeExpr(presence: SourcePresence = .present) -> SpecializeExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .specializeExpr,
       layout: [
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       RawSyntax.missing(SyntaxKind.genericArgumentClause),
     ], length: .zero, presence: presence))
     return SpecializeExprSyntax(data)
@@ -1331,7 +1373,7 @@ public enum SyntaxFactory {
       layout: [
       RawSyntax.missingToken(TokenKind.backslash),
       nil,
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
     ], length: .zero, presence: presence))
     return KeyPathExprSyntax(data)
   }
@@ -1430,7 +1472,7 @@ public enum SyntaxFactory {
       RawSyntax.missingToken(TokenKind.leftParen),
       nil,
       nil,
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       RawSyntax.missingToken(TokenKind.rightParen),
     ], length: .zero, presence: presence))
     return ObjcSelectorExprSyntax(data)
@@ -1509,7 +1551,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .typeInitializerClause,
       layout: [
       RawSyntax.missingToken(TokenKind.equal),
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
     ], length: .zero, presence: presence))
     return TypeInitializerClauseSyntax(data)
   }
@@ -1621,7 +1663,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .returnClause,
       layout: [
       RawSyntax.missingToken(TokenKind.arrow),
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
     ], length: .zero, presence: presence))
     return ReturnClauseSyntax(data)
   }
@@ -1854,7 +1896,7 @@ public enum SyntaxFactory {
   public static func makeBlankInheritedType(presence: SourcePresence = .present) -> InheritedTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .inheritedType,
       layout: [
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
       nil,
     ], length: .zero, presence: presence))
     return InheritedTypeSyntax(data)
@@ -2038,7 +2080,7 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.missingToken(TokenKind.extensionKeyword),
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
       nil,
       nil,
       RawSyntax.missing(SyntaxKind.memberDeclBlock),
@@ -2094,7 +2136,7 @@ public enum SyntaxFactory {
   public static func makeBlankMemberDeclListItem(presence: SourcePresence = .present) -> MemberDeclListItemSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .memberDeclListItem,
       layout: [
-      RawSyntax.missing(SyntaxKind.decl),
+      RawSyntax.missing(SyntaxKind.missingDecl),
       nil,
     ], length: .zero, presence: presence))
     return MemberDeclListItemSyntax(data)
@@ -2133,7 +2175,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .initializerClause,
       layout: [
       RawSyntax.missingToken(TokenKind.equal),
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
     ], length: .zero, presence: presence))
     return InitializerClauseSyntax(data)
   }
@@ -2477,7 +2519,7 @@ public enum SyntaxFactory {
   public static func makeBlankPatternBinding(presence: SourcePresence = .present) -> PatternBindingSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .patternBinding,
       layout: [
-      RawSyntax.missing(SyntaxKind.pattern),
+      RawSyntax.missing(SyntaxKind.missingPattern),
       nil,
       nil,
       nil,
@@ -2856,7 +2898,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .customAttribute,
       layout: [
       RawSyntax.missingToken(TokenKind.atSign),
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
       nil,
       nil,
       nil,
@@ -3384,7 +3426,7 @@ public enum SyntaxFactory {
   public static func makeBlankExpressionStmt(presence: SourcePresence = .present) -> ExpressionStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .expressionStmt,
       layout: [
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
     ], length: .zero, presence: presence))
     return ExpressionStmtSyntax(data)
   }
@@ -3425,7 +3467,7 @@ public enum SyntaxFactory {
       RawSyntax.missingToken(TokenKind.repeatKeyword),
       RawSyntax.missing(SyntaxKind.codeBlock),
       RawSyntax.missingToken(TokenKind.whileKeyword),
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
     ], length: .zero, presence: presence))
     return RepeatWhileStmtSyntax(data)
   }
@@ -3467,7 +3509,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .whereClause,
       layout: [
       RawSyntax.missingToken(TokenKind.whereKeyword),
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
     ], length: .zero, presence: presence))
     return WhereClauseSyntax(data)
   }
@@ -3501,10 +3543,10 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
-      RawSyntax.missing(SyntaxKind.pattern),
+      RawSyntax.missing(SyntaxKind.missingPattern),
       nil,
       RawSyntax.missingToken(TokenKind.inKeyword),
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       nil,
       RawSyntax.missing(SyntaxKind.codeBlock),
     ], length: .zero, presence: presence))
@@ -3532,7 +3574,7 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.missingToken(TokenKind.switchKeyword),
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       RawSyntax.missingToken(TokenKind.leftBrace),
       RawSyntax.missing(SyntaxKind.switchCaseList),
       RawSyntax.missingToken(TokenKind.rightBrace),
@@ -3762,7 +3804,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .matchingPatternCondition,
       layout: [
       RawSyntax.missingToken(TokenKind.caseKeyword),
-      RawSyntax.missing(SyntaxKind.pattern),
+      RawSyntax.missing(SyntaxKind.missingPattern),
       nil,
       RawSyntax.missing(SyntaxKind.initializerClause),
     ], length: .zero, presence: presence))
@@ -3785,7 +3827,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .optionalBindingCondition,
       layout: [
       RawSyntax.missingToken(TokenKind.letKeyword),
-      RawSyntax.missing(SyntaxKind.pattern),
+      RawSyntax.missing(SyntaxKind.missingPattern),
       nil,
       nil,
     ], length: .zero, presence: presence))
@@ -3841,7 +3883,7 @@ public enum SyntaxFactory {
   public static func makeBlankDeclarationStmt(presence: SourcePresence = .present) -> DeclarationStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .declarationStmt,
       layout: [
-      RawSyntax.missing(SyntaxKind.decl),
+      RawSyntax.missing(SyntaxKind.missingDecl),
     ], length: .zero, presence: presence))
     return DeclarationStmtSyntax(data)
   }
@@ -3860,7 +3902,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .throwStmt,
       layout: [
       RawSyntax.missingToken(TokenKind.throwKeyword),
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
     ], length: .zero, presence: presence))
     return ThrowStmtSyntax(data)
   }
@@ -3984,7 +4026,7 @@ public enum SyntaxFactory {
   public static func makeBlankCaseItem(presence: SourcePresence = .present) -> CaseItemSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .caseItem,
       layout: [
-      RawSyntax.missing(SyntaxKind.pattern),
+      RawSyntax.missing(SyntaxKind.missingPattern),
       nil,
       nil,
     ], length: .zero, presence: presence))
@@ -4073,7 +4115,7 @@ public enum SyntaxFactory {
       layout: [
       RawSyntax.missingToken(TokenKind.poundAssertKeyword),
       RawSyntax.missingToken(TokenKind.leftParen),
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
       nil,
       nil,
       RawSyntax.missingToken(TokenKind.rightParen),
@@ -4147,9 +4189,9 @@ public enum SyntaxFactory {
   public static func makeBlankSameTypeRequirement(presence: SourcePresence = .present) -> SameTypeRequirementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .sameTypeRequirement,
       layout: [
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
       RawSyntax.missingToken(TokenKind.spacedBinaryOperator("")),
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
     ], length: .zero, presence: presence))
     return SameTypeRequirementSyntax(data)
   }
@@ -4261,9 +4303,9 @@ public enum SyntaxFactory {
   public static func makeBlankConformanceRequirement(presence: SourcePresence = .present) -> ConformanceRequirementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .conformanceRequirement,
       layout: [
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
       RawSyntax.missingToken(TokenKind.colon),
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
     ], length: .zero, presence: presence))
     return ConformanceRequirementSyntax(data)
   }
@@ -4323,7 +4365,7 @@ public enum SyntaxFactory {
   public static func makeBlankMemberTypeIdentifier(presence: SourcePresence = .present) -> MemberTypeIdentifierSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .memberTypeIdentifier,
       layout: [
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
       RawSyntax.missingToken(TokenKind.period),
       RawSyntax.missingToken(TokenKind.identifier("")),
       nil,
@@ -4363,7 +4405,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .arrayType,
       layout: [
       RawSyntax.missingToken(TokenKind.leftSquareBracket),
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
       RawSyntax.missingToken(TokenKind.rightSquareBracket),
     ], length: .zero, presence: presence))
     return ArrayTypeSyntax(data)
@@ -4386,9 +4428,9 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .dictionaryType,
       layout: [
       RawSyntax.missingToken(TokenKind.leftSquareBracket),
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
       RawSyntax.missingToken(TokenKind.colon),
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
       RawSyntax.missingToken(TokenKind.rightSquareBracket),
     ], length: .zero, presence: presence))
     return DictionaryTypeSyntax(data)
@@ -4408,7 +4450,7 @@ public enum SyntaxFactory {
   public static func makeBlankMetatypeType(presence: SourcePresence = .present) -> MetatypeTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .metatypeType,
       layout: [
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
       RawSyntax.missingToken(TokenKind.period),
       RawSyntax.missingToken(TokenKind.identifier("")),
     ], length: .zero, presence: presence))
@@ -4428,7 +4470,7 @@ public enum SyntaxFactory {
   public static func makeBlankOptionalType(presence: SourcePresence = .present) -> OptionalTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .optionalType,
       layout: [
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
       RawSyntax.missingToken(TokenKind.postfixQuestionMark),
     ], length: .zero, presence: presence))
     return OptionalTypeSyntax(data)
@@ -4448,7 +4490,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .constrainedSugarType,
       layout: [
       RawSyntax.missingToken(TokenKind.identifier("")),
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
     ], length: .zero, presence: presence))
     return ConstrainedSugarTypeSyntax(data)
   }
@@ -4466,7 +4508,7 @@ public enum SyntaxFactory {
   public static func makeBlankImplicitlyUnwrappedOptionalType(presence: SourcePresence = .present) -> ImplicitlyUnwrappedOptionalTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .implicitlyUnwrappedOptionalType,
       layout: [
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
       RawSyntax.missingToken(TokenKind.exclamationMark),
     ], length: .zero, presence: presence))
     return ImplicitlyUnwrappedOptionalTypeSyntax(data)
@@ -4485,7 +4527,7 @@ public enum SyntaxFactory {
   public static func makeBlankCompositionTypeElement(presence: SourcePresence = .present) -> CompositionTypeElementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .compositionTypeElement,
       layout: [
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
       nil,
     ], length: .zero, presence: presence))
     return CompositionTypeElementSyntax(data)
@@ -4545,7 +4587,7 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
       nil,
       nil,
       nil,
@@ -4612,7 +4654,7 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.missingToken(TokenKind.arrow),
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
     ], length: .zero, presence: presence))
     return FunctionTypeSyntax(data)
   }
@@ -4633,7 +4675,7 @@ public enum SyntaxFactory {
       layout: [
       nil,
       nil,
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
     ], length: .zero, presence: presence))
     return AttributedTypeSyntax(data)
   }
@@ -4665,7 +4707,7 @@ public enum SyntaxFactory {
   public static func makeBlankGenericArgument(presence: SourcePresence = .present) -> GenericArgumentSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .genericArgument,
       layout: [
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
       nil,
     ], length: .zero, presence: presence))
     return GenericArgumentSyntax(data)
@@ -4706,7 +4748,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .typeAnnotation,
       layout: [
       RawSyntax.missingToken(TokenKind.colon),
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
     ], length: .zero, presence: presence))
     return TypeAnnotationSyntax(data)
   }
@@ -4748,7 +4790,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .isTypePattern,
       layout: [
       RawSyntax.missingToken(TokenKind.isKeyword),
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
     ], length: .zero, presence: presence))
     return IsTypePatternSyntax(data)
   }
@@ -4766,7 +4808,7 @@ public enum SyntaxFactory {
   public static func makeBlankOptionalPattern(presence: SourcePresence = .present) -> OptionalPatternSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .optionalPattern,
       layout: [
-      RawSyntax.missing(SyntaxKind.pattern),
+      RawSyntax.missing(SyntaxKind.missingPattern),
       RawSyntax.missingToken(TokenKind.postfixQuestionMark),
     ], length: .zero, presence: presence))
     return OptionalPatternSyntax(data)
@@ -4803,9 +4845,9 @@ public enum SyntaxFactory {
   public static func makeBlankAsTypePattern(presence: SourcePresence = .present) -> AsTypePatternSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .asTypePattern,
       layout: [
-      RawSyntax.missing(SyntaxKind.pattern),
+      RawSyntax.missing(SyntaxKind.missingPattern),
       RawSyntax.missingToken(TokenKind.asKeyword),
-      RawSyntax.missing(SyntaxKind.type),
+      RawSyntax.missing(SyntaxKind.missingType),
     ], length: .zero, presence: presence))
     return AsTypePatternSyntax(data)
   }
@@ -4867,7 +4909,7 @@ public enum SyntaxFactory {
       layout: [
       nil,
       nil,
-      RawSyntax.missing(SyntaxKind.pattern),
+      RawSyntax.missing(SyntaxKind.missingPattern),
       nil,
     ], length: .zero, presence: presence))
     return TuplePatternElementSyntax(data)
@@ -4885,7 +4927,7 @@ public enum SyntaxFactory {
   public static func makeBlankExpressionPattern(presence: SourcePresence = .present) -> ExpressionPatternSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .expressionPattern,
       layout: [
-      RawSyntax.missing(SyntaxKind.expr),
+      RawSyntax.missing(SyntaxKind.missingExpr),
     ], length: .zero, presence: presence))
     return ExpressionPatternSyntax(data)
   }
@@ -4918,7 +4960,7 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .valueBindingPattern,
       layout: [
       RawSyntax.missingToken(TokenKind.letKeyword),
-      RawSyntax.missing(SyntaxKind.pattern),
+      RawSyntax.missing(SyntaxKind.missingPattern),
     ], length: .zero, presence: presence))
     return ValueBindingPatternSyntax(data)
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
@@ -16,16 +16,17 @@
 internal enum SyntaxKind: CSyntaxKind {
   case token = 0
   case unknown = 1
-  case decl = 87
-  case expr = 88
-  case stmt = 89
-  case type = 90
-  case pattern = 91
   case unknownDecl = 2
   case unknownExpr = 24
   case unknownStmt = 71
   case unknownType = 211
   case unknownPattern = 201
+  case missing = 260
+  case missingDecl = 261
+  case missingExpr = 262
+  case missingStmt = 263
+  case missingType = 264
+  case missingPattern = 265
   case codeBlockItem = 92
   case codeBlockItemList = 163
   case codeBlock = 93

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -58,6 +58,48 @@ open class SyntaxRewriter {
     return PatternSyntax(visitChildren(node))
   }
 
+  /// Visit a `MissingSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: MissingSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
+  /// Visit a `MissingDeclSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: MissingDeclSyntax) -> DeclSyntax {
+    return DeclSyntax(visitChildren(node))
+  }
+
+  /// Visit a `MissingExprSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: MissingExprSyntax) -> ExprSyntax {
+    return ExprSyntax(visitChildren(node))
+  }
+
+  /// Visit a `MissingStmtSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: MissingStmtSyntax) -> StmtSyntax {
+    return StmtSyntax(visitChildren(node))
+  }
+
+  /// Visit a `MissingTypeSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: MissingTypeSyntax) -> TypeSyntax {
+    return TypeSyntax(visitChildren(node))
+  }
+
+  /// Visit a `MissingPatternSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: MissingPatternSyntax) -> PatternSyntax {
+    return PatternSyntax(visitChildren(node))
+  }
+
   /// Visit a `CodeBlockItemSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -1900,6 +1942,66 @@ open class SyntaxRewriter {
   /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplUnknownPatternSyntax(_ data: SyntaxData) -> Syntax {
       let node = UnknownPatternSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return Syntax(visit(node))
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplMissingSyntax(_ data: SyntaxData) -> Syntax {
+      let node = MissingSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplMissingDeclSyntax(_ data: SyntaxData) -> Syntax {
+      let node = MissingDeclSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return Syntax(visit(node))
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplMissingExprSyntax(_ data: SyntaxData) -> Syntax {
+      let node = MissingExprSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return Syntax(visit(node))
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplMissingStmtSyntax(_ data: SyntaxData) -> Syntax {
+      let node = MissingStmtSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return Syntax(visit(node))
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplMissingTypeSyntax(_ data: SyntaxData) -> Syntax {
+      let node = MissingTypeSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return Syntax(visit(node))
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplMissingPatternSyntax(_ data: SyntaxData) -> Syntax {
+      let node = MissingPatternSyntax(data)
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
       visitPre(node._syntaxNode)
       defer { visitPost(node._syntaxNode) }
@@ -4399,16 +4501,6 @@ open class SyntaxRewriter {
       return visitImplTokenSyntax
     case .unknown:
       return visitImplUnknownSyntax
-    case .decl:
-      return visitImplDeclSyntax
-    case .expr:
-      return visitImplExprSyntax
-    case .stmt:
-      return visitImplStmtSyntax
-    case .type:
-      return visitImplTypeSyntax
-    case .pattern:
-      return visitImplPatternSyntax
     case .unknownDecl:
       return visitImplUnknownDeclSyntax
     case .unknownExpr:
@@ -4419,6 +4511,18 @@ open class SyntaxRewriter {
       return visitImplUnknownTypeSyntax
     case .unknownPattern:
       return visitImplUnknownPatternSyntax
+    case .missing:
+      return visitImplMissingSyntax
+    case .missingDecl:
+      return visitImplMissingDeclSyntax
+    case .missingExpr:
+      return visitImplMissingExprSyntax
+    case .missingStmt:
+      return visitImplMissingStmtSyntax
+    case .missingType:
+      return visitImplMissingTypeSyntax
+    case .missingPattern:
+      return visitImplMissingPatternSyntax
     case .codeBlockItem:
       return visitImplCodeBlockItemSyntax
     case .codeBlockItemList:
@@ -4922,16 +5026,6 @@ open class SyntaxRewriter {
       return visitImplTokenSyntax(data)
     case .unknown:
       return visitImplUnknownSyntax(data)
-    case .decl:
-      return visitImplDeclSyntax(data)
-    case .expr:
-      return visitImplExprSyntax(data)
-    case .stmt:
-      return visitImplStmtSyntax(data)
-    case .type:
-      return visitImplTypeSyntax(data)
-    case .pattern:
-      return visitImplPatternSyntax(data)
     case .unknownDecl:
       return visitImplUnknownDeclSyntax(data)
     case .unknownExpr:
@@ -4942,6 +5036,18 @@ open class SyntaxRewriter {
       return visitImplUnknownTypeSyntax(data)
     case .unknownPattern:
       return visitImplUnknownPatternSyntax(data)
+    case .missing:
+      return visitImplMissingSyntax(data)
+    case .missingDecl:
+      return visitImplMissingDeclSyntax(data)
+    case .missingExpr:
+      return visitImplMissingExprSyntax(data)
+    case .missingStmt:
+      return visitImplMissingStmtSyntax(data)
+    case .missingType:
+      return visitImplMissingTypeSyntax(data)
+    case .missingPattern:
+      return visitImplMissingPatternSyntax(data)
     case .codeBlockItem:
       return visitImplCodeBlockItemSyntax(data)
     case .codeBlockItemList:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -91,6 +91,66 @@ open class SyntaxVisitor {
   /// The function called after visiting `UnknownPatternSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: UnknownPatternSyntax) {}
+  /// Visiting `MissingSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: MissingSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `MissingSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: MissingSyntax) {}
+  /// Visiting `MissingDeclSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: MissingDeclSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `MissingDeclSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: MissingDeclSyntax) {}
+  /// Visiting `MissingExprSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: MissingExprSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `MissingExprSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: MissingExprSyntax) {}
+  /// Visiting `MissingStmtSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: MissingStmtSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `MissingStmtSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: MissingStmtSyntax) {}
+  /// Visiting `MissingTypeSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: MissingTypeSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `MissingTypeSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: MissingTypeSyntax) {}
+  /// Visiting `MissingPatternSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: MissingPatternSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `MissingPatternSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: MissingPatternSyntax) {}
   /// Visiting `CodeBlockItemSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -2656,6 +2716,72 @@ open class SyntaxVisitor {
   /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplUnknownPatternSyntax(_ data: SyntaxData) {
       let node = UnknownPatternSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplMissingSyntax(_ data: SyntaxData) {
+      let node = MissingSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplMissingDeclSyntax(_ data: SyntaxData) {
+      let node = MissingDeclSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplMissingExprSyntax(_ data: SyntaxData) {
+      let node = MissingExprSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplMissingStmtSyntax(_ data: SyntaxData) {
+      let node = MissingStmtSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplMissingTypeSyntax(_ data: SyntaxData) {
+      let node = MissingTypeSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplMissingPatternSyntax(_ data: SyntaxData) {
+      let node = MissingPatternSyntax(data)
       let needsChildren = (visit(node) == .visitChildren)
       // Avoid calling into visitChildren if possible.
       if needsChildren && node.raw.numberOfChildren > 0 {
@@ -5368,16 +5494,6 @@ open class SyntaxVisitor {
     // circumvents an issue where the compiler allocates stack space for every
     // case statement next to each other in debug builds, causing it to allocate
     // ~50KB per call to this function. rdar://55929175
-    case .decl:
-      visitImplDeclSyntax(data)
-    case .expr:
-      visitImplExprSyntax(data)
-    case .stmt:
-      visitImplStmtSyntax(data)
-    case .type:
-      visitImplTypeSyntax(data)
-    case .pattern:
-      visitImplPatternSyntax(data)
     case .unknownDecl:
       visitImplUnknownDeclSyntax(data)
     case .unknownExpr:
@@ -5388,6 +5504,18 @@ open class SyntaxVisitor {
       visitImplUnknownTypeSyntax(data)
     case .unknownPattern:
       visitImplUnknownPatternSyntax(data)
+    case .missing:
+      visitImplMissingSyntax(data)
+    case .missingDecl:
+      visitImplMissingDeclSyntax(data)
+    case .missingExpr:
+      visitImplMissingExprSyntax(data)
+    case .missingStmt:
+      visitImplMissingStmtSyntax(data)
+    case .missingType:
+      visitImplMissingTypeSyntax(data)
+    case .missingPattern:
+      visitImplMissingPatternSyntax(data)
     case .codeBlockItem:
       visitImplCodeBlockItemSyntax(data)
     case .codeBlockItemList:

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -52,6 +52,45 @@ extension UnknownDeclSyntax: CustomReflectable {
   }
 }
 
+// MARK: - MissingDeclSyntax
+
+public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
+
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `MissingDeclSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .missingDecl else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `MissingDeclSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .missingDecl)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public var syntaxNodeType: SyntaxProtocol.Type {
+    return Swift.type(of: self)
+  }
+
+
+  public func _validateLayout() {
+    let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
+    assert(rawChildren.count == 0)
+  }
+}
+
+extension MissingDeclSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+    ])
+  }
+}
+
 // MARK: - TypealiasDeclSyntax
 
 public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
@@ -2782,7 +2821,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///                   current `extendedType`, if present.
   public func withExtendedType(
     _ newChild: TypeSyntax?) -> ExtensionDeclSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.extendedType)
     return ExtensionDeclSyntax(newData)
   }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -52,6 +52,45 @@ extension UnknownExprSyntax: CustomReflectable {
   }
 }
 
+// MARK: - MissingExprSyntax
+
+public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
+
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `MissingExprSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .missingExpr else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `MissingExprSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .missingExpr)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public var syntaxNodeType: SyntaxProtocol.Type {
+    return Swift.type(of: self)
+  }
+
+
+  public func _validateLayout() {
+    let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
+    assert(rawChildren.count == 0)
+  }
+}
+
+extension MissingExprSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+    ])
+  }
+}
+
 // MARK: - InOutExprSyntax
 
 public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
@@ -118,7 +157,7 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `expression`, if present.
   public func withExpression(
     _ newChild: ExprSyntax?) -> InOutExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.expression)
     return InOutExprSyntax(newData)
   }
@@ -319,7 +358,7 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `expression`, if present.
   public func withExpression(
     _ newChild: ExprSyntax?) -> TryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.expression)
     return TryExprSyntax(newData)
   }
@@ -433,7 +472,7 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `expression`, if present.
   public func withExpression(
     _ newChild: ExprSyntax?) -> AwaitExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.expression)
     return AwaitExprSyntax(newData)
   }
@@ -1571,7 +1610,7 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `postfixExpression`, if present.
   public func withPostfixExpression(
     _ newChild: ExprSyntax?) -> PrefixOperatorExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.postfixExpression)
     return PrefixOperatorExprSyntax(newData)
   }
@@ -2535,7 +2574,7 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `conditionExpression`, if present.
   public func withConditionExpression(
     _ newChild: ExprSyntax?) -> TernaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.conditionExpression)
     return TernaryExprSyntax(newData)
   }
@@ -2577,7 +2616,7 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `firstChoice`, if present.
   public func withFirstChoice(
     _ newChild: ExprSyntax?) -> TernaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.firstChoice)
     return TernaryExprSyntax(newData)
   }
@@ -2619,7 +2658,7 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `secondChoice`, if present.
   public func withSecondChoice(
     _ newChild: ExprSyntax?) -> TernaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.secondChoice)
     return TernaryExprSyntax(newData)
   }
@@ -2923,7 +2962,7 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `typeName`, if present.
   public func withTypeName(
     _ newChild: TypeSyntax?) -> IsExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.typeName)
     return IsExprSyntax(newData)
   }
@@ -3051,7 +3090,7 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `typeName`, if present.
   public func withTypeName(
     _ newChild: TypeSyntax?) -> AsExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.typeName)
     return AsExprSyntax(newData)
   }
@@ -3143,7 +3182,7 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `type`, if present.
   public func withType(
     _ newChild: TypeSyntax?) -> TypeExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.type)
     return TypeExprSyntax(newData)
   }
@@ -3404,7 +3443,7 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `pattern`, if present.
   public func withPattern(
     _ newChild: PatternSyntax?) -> UnresolvedPatternExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.pattern)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingPattern)
     let newData = data.replacingChild(raw, at: Cursor.pattern)
     return UnresolvedPatternExprSyntax(newData)
   }
@@ -3482,7 +3521,7 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `calledExpression`, if present.
   public func withCalledExpression(
     _ newChild: ExprSyntax?) -> FunctionCallExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.calledExpression)
     return FunctionCallExprSyntax(newData)
   }
@@ -3753,7 +3792,7 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `calledExpression`, if present.
   public func withCalledExpression(
     _ newChild: ExprSyntax?) -> SubscriptExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.calledExpression)
     return SubscriptExprSyntax(newData)
   }
@@ -4020,7 +4059,7 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `expression`, if present.
   public func withExpression(
     _ newChild: ExprSyntax?) -> OptionalChainingExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.expression)
     return OptionalChainingExprSyntax(newData)
   }
@@ -4125,7 +4164,7 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `expression`, if present.
   public func withExpression(
     _ newChild: ExprSyntax?) -> ForcedValueExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.expression)
     return ForcedValueExprSyntax(newData)
   }
@@ -4230,7 +4269,7 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `expression`, if present.
   public func withExpression(
     _ newChild: ExprSyntax?) -> PostfixUnaryExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.expression)
     return PostfixUnaryExprSyntax(newData)
   }
@@ -4335,7 +4374,7 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `expression`, if present.
   public func withExpression(
     _ newChild: ExprSyntax?) -> SpecializeExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.expression)
     return SpecializeExprSyntax(newData)
   }
@@ -4777,7 +4816,7 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `expression`, if present.
   public func withExpression(
     _ newChild: ExprSyntax?) -> KeyPathExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.expression)
     return KeyPathExprSyntax(newData)
   }
@@ -5221,7 +5260,7 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///                   current `name`, if present.
   public func withName(
     _ newChild: ExprSyntax?) -> ObjcSelectorExprSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.name)
     return ObjcSelectorExprSyntax(newData)
   }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -13,6 +13,45 @@
 //===----------------------------------------------------------------------===//
 
 
+// MARK: - MissingSyntax
+
+public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
+
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `MissingSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .missing else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `MissingSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .missing)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public var syntaxNodeType: SyntaxProtocol.Type {
+    return Swift.type(of: self)
+  }
+
+
+  public func _validateLayout() {
+    let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
+    assert(rawChildren.count == 0)
+  }
+}
+
+extension MissingSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+    ])
+  }
+}
+
 // MARK: - CodeBlockItemSyntax
 
 /// 
@@ -666,7 +705,7 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `expression`, if present.
   public func withExpression(
     _ newChild: ExprSyntax?) -> TupleExprElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.expression)
     return TupleExprElementSyntax(newData)
   }
@@ -789,7 +828,7 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `expression`, if present.
   public func withExpression(
     _ newChild: ExprSyntax?) -> ArrayElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.expression)
     return ArrayElementSyntax(newData)
   }
@@ -896,7 +935,7 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `keyExpression`, if present.
   public func withKeyExpression(
     _ newChild: ExprSyntax?) -> DictionaryElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.keyExpression)
     return DictionaryElementSyntax(newData)
   }
@@ -938,7 +977,7 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `valueExpression`, if present.
   public func withValueExpression(
     _ newChild: ExprSyntax?) -> DictionaryElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.valueExpression)
     return DictionaryElementSyntax(newData)
   }
@@ -1151,7 +1190,7 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `expression`, if present.
   public func withExpression(
     _ newChild: ExprSyntax?) -> ClosureCaptureItemSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.expression)
     return ClosureCaptureItemSyntax(newData)
   }
@@ -2384,7 +2423,7 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `value`, if present.
   public func withValue(
     _ newChild: TypeSyntax?) -> TypeInitializerClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.value)
     return TypeInitializerClauseSyntax(newData)
   }
@@ -2645,7 +2684,7 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `returnType`, if present.
   public func withReturnType(
     _ newChild: TypeSyntax?) -> ReturnClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.returnType)
     return ReturnClauseSyntax(newData)
   }
@@ -3542,7 +3581,7 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `typeName`, if present.
   public func withTypeName(
     _ newChild: TypeSyntax?) -> InheritedTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.typeName)
     return InheritedTypeSyntax(newData)
   }
@@ -3932,7 +3971,7 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `decl`, if present.
   public func withDecl(
     _ newChild: DeclSyntax?) -> MemberDeclListItemSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.decl)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingDecl)
     let newData = data.replacingChild(raw, at: Cursor.decl)
     return MemberDeclListItemSyntax(newData)
   }
@@ -4183,7 +4222,7 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `value`, if present.
   public func withValue(
     _ newChild: ExprSyntax?) -> InitializerClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.value)
     return InitializerClauseSyntax(newData)
   }
@@ -5089,7 +5128,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `pattern`, if present.
   public func withPattern(
     _ newChild: PatternSyntax?) -> PatternBindingSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.pattern)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingPattern)
     let newData = data.replacingChild(raw, at: Cursor.pattern)
     return PatternBindingSyntax(newData)
   }
@@ -6195,7 +6234,7 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `attributeName`, if present.
   public func withAttributeName(
     _ newChild: TypeSyntax?) -> CustomAttributeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.attributeName)
     return CustomAttributeSyntax(newData)
   }
@@ -9264,7 +9303,7 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `guardResult`, if present.
   public func withGuardResult(
     _ newChild: ExprSyntax?) -> WhereClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.guardResult)
     return WhereClauseSyntax(newData)
   }
@@ -9852,7 +9891,7 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `pattern`, if present.
   public func withPattern(
     _ newChild: PatternSyntax?) -> MatchingPatternConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.pattern)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingPattern)
     let newData = data.replacingChild(raw, at: Cursor.pattern)
     return MatchingPatternConditionSyntax(newData)
   }
@@ -10021,7 +10060,7 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `pattern`, if present.
   public func withPattern(
     _ newChild: PatternSyntax?) -> OptionalBindingConditionSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.pattern)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingPattern)
     let newData = data.replacingChild(raw, at: Cursor.pattern)
     return OptionalBindingConditionSyntax(newData)
   }
@@ -10795,7 +10834,7 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `pattern`, if present.
   public func withPattern(
     _ newChild: PatternSyntax?) -> CaseItemSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.pattern)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingPattern)
     let newData = data.replacingChild(raw, at: Cursor.pattern)
     return CaseItemSyntax(newData)
   }
@@ -11610,7 +11649,7 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `leftTypeIdentifier`, if present.
   public func withLeftTypeIdentifier(
     _ newChild: TypeSyntax?) -> SameTypeRequirementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.leftTypeIdentifier)
     return SameTypeRequirementSyntax(newData)
   }
@@ -11652,7 +11691,7 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `rightTypeIdentifier`, if present.
   public func withRightTypeIdentifier(
     _ newChild: TypeSyntax?) -> SameTypeRequirementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.rightTypeIdentifier)
     return SameTypeRequirementSyntax(newData)
   }
@@ -12228,7 +12267,7 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `leftTypeIdentifier`, if present.
   public func withLeftTypeIdentifier(
     _ newChild: TypeSyntax?) -> ConformanceRequirementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.leftTypeIdentifier)
     return ConformanceRequirementSyntax(newData)
   }
@@ -12270,7 +12309,7 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `rightTypeIdentifier`, if present.
   public func withRightTypeIdentifier(
     _ newChild: TypeSyntax?) -> ConformanceRequirementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.rightTypeIdentifier)
     return ConformanceRequirementSyntax(newData)
   }
@@ -12520,7 +12559,7 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `type`, if present.
   public func withType(
     _ newChild: TypeSyntax?) -> CompositionTypeElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.type)
     return CompositionTypeElementSyntax(newData)
   }
@@ -12719,7 +12758,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `type`, if present.
   public func withType(
     _ newChild: TypeSyntax?) -> TupleTypeElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.type)
     return TupleTypeElementSyntax(newData)
   }
@@ -12922,7 +12961,7 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `argumentType`, if present.
   public func withArgumentType(
     _ newChild: TypeSyntax?) -> GenericArgumentSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.argumentType)
     return GenericArgumentSyntax(newData)
   }
@@ -13204,7 +13243,7 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `type`, if present.
   public func withType(
     _ newChild: TypeSyntax?) -> TypeAnnotationSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.type)
     return TypeAnnotationSyntax(newData)
   }
@@ -13334,7 +13373,7 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `pattern`, if present.
   public func withPattern(
     _ newChild: PatternSyntax?) -> TuplePatternElementSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.pattern)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingPattern)
     let newData = data.replacingChild(raw, at: Cursor.pattern)
     return TuplePatternElementSyntax(newData)
   }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
@@ -52,6 +52,45 @@ extension UnknownPatternSyntax: CustomReflectable {
   }
 }
 
+// MARK: - MissingPatternSyntax
+
+public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
+
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `MissingPatternSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .missingPattern else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `MissingPatternSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .missingPattern)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public var syntaxNodeType: SyntaxProtocol.Type {
+    return Swift.type(of: self)
+  }
+
+
+  public func _validateLayout() {
+    let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
+    assert(rawChildren.count == 0)
+  }
+}
+
+extension MissingPatternSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+    ])
+  }
+}
+
 // MARK: - EnumCasePatternSyntax
 
 public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
@@ -287,7 +326,7 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   ///                   current `type`, if present.
   public func withType(
     _ newChild: TypeSyntax?) -> IsTypePatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.type)
     return IsTypePatternSyntax(newData)
   }
@@ -371,7 +410,7 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   ///                   current `subPattern`, if present.
   public func withSubPattern(
     _ newChild: PatternSyntax?) -> OptionalPatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.pattern)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingPattern)
     let newData = data.replacingChild(raw, at: Cursor.subPattern)
     return OptionalPatternSyntax(newData)
   }
@@ -550,7 +589,7 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   ///                   current `pattern`, if present.
   public func withPattern(
     _ newChild: PatternSyntax?) -> AsTypePatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.pattern)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingPattern)
     let newData = data.replacingChild(raw, at: Cursor.pattern)
     return AsTypePatternSyntax(newData)
   }
@@ -592,7 +631,7 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   ///                   current `type`, if present.
   public func withType(
     _ newChild: TypeSyntax?) -> AsTypePatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.type)
     return AsTypePatternSyntax(newData)
   }
@@ -946,7 +985,7 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   ///                   current `expression`, if present.
   public func withExpression(
     _ newChild: ExprSyntax?) -> ExpressionPatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.expression)
     return ExpressionPatternSyntax(newData)
   }
@@ -1041,7 +1080,7 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   ///                   current `valuePattern`, if present.
   public func withValuePattern(
     _ newChild: PatternSyntax?) -> ValueBindingPatternSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.pattern)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingPattern)
     let newData = data.replacingChild(raw, at: Cursor.valuePattern)
     return ValueBindingPatternSyntax(newData)
   }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -52,6 +52,45 @@ extension UnknownStmtSyntax: CustomReflectable {
   }
 }
 
+// MARK: - MissingStmtSyntax
+
+public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `MissingStmtSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .missingStmt else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `MissingStmtSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .missingStmt)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public var syntaxNodeType: SyntaxProtocol.Type {
+    return Swift.type(of: self)
+  }
+
+
+  public func _validateLayout() {
+    let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
+    assert(rawChildren.count == 0)
+  }
+}
+
+extension MissingStmtSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+    ])
+  }
+}
+
 // MARK: - ContinueStmtSyntax
 
 public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
@@ -526,7 +565,7 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///                   current `expression`, if present.
   public func withExpression(
     _ newChild: ExprSyntax?) -> ExpressionStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.expression)
     return ExpressionStmtSyntax(newData)
   }
@@ -711,7 +750,7 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///                   current `condition`, if present.
   public func withCondition(
     _ newChild: ExprSyntax?) -> RepeatWhileStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.condition)
     return RepeatWhileStmtSyntax(newData)
   }
@@ -1162,7 +1201,7 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///                   current `pattern`, if present.
   public func withPattern(
     _ newChild: PatternSyntax?) -> ForInStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.pattern)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingPattern)
     let newData = data.replacingChild(raw, at: Cursor.pattern)
     return ForInStmtSyntax(newData)
   }
@@ -1226,7 +1265,7 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///                   current `sequenceExpr`, if present.
   public func withSequenceExpr(
     _ newChild: ExprSyntax?) -> ForInStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.sequenceExpr)
     return ForInStmtSyntax(newData)
   }
@@ -1516,7 +1555,7 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///                   current `expression`, if present.
   public func withExpression(
     _ newChild: ExprSyntax?) -> SwitchStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.expression)
     return SwitchStmtSyntax(newData)
   }
@@ -2337,7 +2376,7 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///                   current `declaration`, if present.
   public func withDeclaration(
     _ newChild: DeclSyntax?) -> DeclarationStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.decl)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingDecl)
     let newData = data.replacingChild(raw, at: Cursor.declaration)
     return DeclarationStmtSyntax(newData)
   }
@@ -2432,7 +2471,7 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///                   current `expression`, if present.
   public func withExpression(
     _ newChild: ExprSyntax?) -> ThrowStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.expression)
     return ThrowStmtSyntax(newData)
   }
@@ -2847,7 +2886,7 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///                   current `condition`, if present.
   public func withCondition(
     _ newChild: ExprSyntax?) -> PoundAssertStmtSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.expr)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingExpr)
     let newData = data.replacingChild(raw, at: Cursor.condition)
     return PoundAssertStmtSyntax(newData)
   }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -52,6 +52,45 @@ extension UnknownTypeSyntax: CustomReflectable {
   }
 }
 
+// MARK: - MissingTypeSyntax
+
+public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
+
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `MissingTypeSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .missingType else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `MissingTypeSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .missingType)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public var syntaxNodeType: SyntaxProtocol.Type {
+    return Swift.type(of: self)
+  }
+
+
+  public func _validateLayout() {
+    let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
+    assert(rawChildren.count == 0)
+  }
+}
+
+extension MissingTypeSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+    ])
+  }
+}
+
 // MARK: - SimpleTypeIdentifierSyntax
 
 public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
@@ -204,7 +243,7 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///                   current `baseType`, if present.
   public func withBaseType(
     _ newChild: TypeSyntax?) -> MemberTypeIdentifierSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.baseType)
     return MemberTypeIdentifierSyntax(newData)
   }
@@ -466,7 +505,7 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///                   current `elementType`, if present.
   public func withElementType(
     _ newChild: TypeSyntax?) -> ArrayTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.elementType)
     return ArrayTypeSyntax(newData)
   }
@@ -605,7 +644,7 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///                   current `keyType`, if present.
   public func withKeyType(
     _ newChild: TypeSyntax?) -> DictionaryTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.keyType)
     return DictionaryTypeSyntax(newData)
   }
@@ -647,7 +686,7 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///                   current `valueType`, if present.
   public func withValueType(
     _ newChild: TypeSyntax?) -> DictionaryTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.valueType)
     return DictionaryTypeSyntax(newData)
   }
@@ -783,7 +822,7 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///                   current `baseType`, if present.
   public func withBaseType(
     _ newChild: TypeSyntax?) -> MetatypeTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.baseType)
     return MetatypeTypeSyntax(newData)
   }
@@ -919,7 +958,7 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///                   current `wrappedType`, if present.
   public func withWrappedType(
     _ newChild: TypeSyntax?) -> OptionalTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.wrappedType)
     return OptionalTypeSyntax(newData)
   }
@@ -1045,7 +1084,7 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///                   current `baseType`, if present.
   public func withBaseType(
     _ newChild: TypeSyntax?) -> ConstrainedSugarTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.baseType)
     return ConstrainedSugarTypeSyntax(newData)
   }
@@ -1129,7 +1168,7 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
   ///                   current `wrappedType`, if present.
   public func withWrappedType(
     _ newChild: TypeSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.wrappedType)
     return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
@@ -1634,7 +1673,7 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///                   current `returnType`, if present.
   public func withReturnType(
     _ newChild: TypeSyntax?) -> FunctionTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.returnType)
     return FunctionTypeSyntax(newData)
   }
@@ -1830,7 +1869,7 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///                   current `baseType`, if present.
   public func withBaseType(
     _ newChild: TypeSyntax?) -> AttributedTypeSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.type)
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingType)
     let newData = data.replacingChild(raw, at: Cursor.baseType)
     return AttributedTypeSyntax(newData)
   }

--- a/Sources/SwiftSyntaxBuilderGeneration/Node.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Node.swift
@@ -48,9 +48,14 @@ class Node {
     return syntaxKind.contains("Unknown")
   }
 
+  /// Returns `True` if this node is an `Unknown` syntax subclass.
+  var isMissing: Bool {
+    return syntaxKind.contains("Missing")
+  }
+
   /// Returns `True` if this node should have a builder associated.
   var isBuildable: Bool {
-    return !isBase && !isUnknown && !isSyntaxCollection
+    return !isBase && !isUnknown && !isMissing && !isSyntaxCollection
   }
 
   /// Returns 'True' if this node shall not be created while parsing if it has no children.

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/CommonNodes.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/CommonNodes.swift
@@ -43,6 +43,24 @@ let COMMON_NODES: [Node] = [
   Node(name: "UnknownPattern",
        kind: "Pattern"),
 
+  Node(name: "Missing",
+       kind: "Syntax"),
+
+  Node(name: "MissingDecl",
+       kind: "Decl"),
+
+  Node(name: "MissingExpr",
+       kind: "Expr"),
+
+  Node(name: "MissingStmt",
+       kind: "Stmt"),
+
+  Node(name: "MissingType",
+       kind: "Type"),
+
+  Node(name: "MissingPattern",
+       kind: "Pattern"),
+
   Node(name: "CodeBlockItem",
        description: "A CodeBlockItem is any Syntax node that appears on its own line insidea CodeBlock.",
        kind: "Syntax",

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/NodeSerializationCodes.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/NodeSerializationCodes.swift
@@ -269,4 +269,10 @@ public let SYNTAX_NODE_SERIALIZATION_CODES: [String: Int] = [
   "BackDeployAttributeSpecList": 257,
   "BackDeployVersionList": 258,
   "BackDeployVersionArgument": 259,
+  "Missing": 260,
+  "MissingDecl": 261,
+  "MissingExpr": 262,
+  "MissingStmt": 263,
+  "MissingType": 264,
+  "MissingPattern": 265,
 ]

--- a/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
@@ -17,6 +17,6 @@
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "99675ccdcfa965dd6fabc8af900e7545bce5df5d"
+      "2394a1c176c957b4cdf0fcd1a2454f28057ed3fd"
   }
 }

--- a/Tests/SwiftSyntaxTest/SyntaxChildrenTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxChildrenTests.swift
@@ -45,4 +45,14 @@ public class SyntaxChildrenTests: XCTestCase {
     try XCTAssertNext(&fixedUpIterator) { $0.as(TokenSyntax.self)?.tokenKind == .returnKeyword }
     XCTAssertNextIsNil(&fixedUpIterator)
   }
+
+  public func testMissingNodes() throws {
+    let node = SyntaxFactory.makeDeclarationStmt(declaration: DeclSyntax(SyntaxFactory.makeBlankMissingDecl()))
+
+    var sourceAccurateIt = node.children(viewMode: .sourceAccurate).makeIterator()
+    XCTAssertNextIsNil(&sourceAccurateIt)
+    
+    var fixedUpIt = node.children(viewMode: .fixedUp).makeIterator()
+    try XCTAssertNext(&fixedUpIt) { $0.is(MissingDeclSyntax.self) }
+  }
 }

--- a/Tests/SwiftSyntaxTest/VisitorTests.swift
+++ b/Tests/SwiftSyntaxTest/VisitorTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import SwiftSyntax
+
+public class VisitorTests: XCTestCase {
+  public func testVisitMissingNodes() throws {
+    let node = SyntaxFactory.makeDeclarationStmt(declaration: DeclSyntax(SyntaxFactory.makeBlankMissingDecl()))
+
+    class MissingDeclChecker: SyntaxVisitor {
+      var didSeeMissingDeclSyntax = false
+
+      override func visit(_ node: MissingDeclSyntax) -> SyntaxVisitorContinueKind {
+        didSeeMissingDeclSyntax = true
+        return .visitChildren
+      }
+
+      static func check(_ tree: SyntaxProtocol, viewMode: SyntaxTreeViewMode) -> Bool {
+        let visitor = MissingDeclChecker(viewMode: viewMode)
+        visitor.walk(tree)
+        return visitor.didSeeMissingDeclSyntax
+      }
+    }
+
+    XCTAssertFalse(MissingDeclChecker.check(node, viewMode: .sourceAccurate))
+    XCTAssertTrue(MissingDeclChecker.check(node, viewMode: .fixedUp))
+  }
+}


### PR DESCRIPTION
In the future, we only want to attach a source presence to tokens, not to nodes. All concreate nodes which are missing can be represented by creating the node and marking all tokens as missing, but if a syntax node carries a child, that has a base kind (like `Decl`), we can’t decide which concrete node to instantiate. Introduce `MissingDecl` etc. node for this purpose.

While at it, also remove the base kinds from `SyntaxKind` because we should never instantiate nodes of these base kinds.

rdar://97908258
rdar://97775360