### PR TITLE
Make IfConfigClause Elements Optional

### DIFF
--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
@@ -3531,9 +3531,6 @@ public struct IfConfigClauseSyntaxBuilder {
     if (layout[0] == nil) {
       layout[0] = RawSyntax.missingToken(TokenKind.poundIfKeyword)
     }
-    if (layout[2] == nil) {
-      layout[2] = RawSyntax.missing(SyntaxKind.unknown)
-    }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .ifConfigClause,
       layout: layout, presence: .present))

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -1648,11 +1648,11 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return FunctionSignatureSyntax(data)
   }
-  public static func makeIfConfigClause(poundKeyword: TokenSyntax, condition: ExprSyntax?, elements: Syntax) -> IfConfigClauseSyntax {
+  public static func makeIfConfigClause(poundKeyword: TokenSyntax, condition: ExprSyntax?, elements: Syntax?) -> IfConfigClauseSyntax {
     let layout: [RawSyntax?] = [
       poundKeyword.raw,
       condition?.raw,
-      elements.raw,
+      elements?.raw,
     ]
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.ifConfigClause,
       layout: layout, presence: SourcePresence.present)
@@ -1665,7 +1665,7 @@ public enum SyntaxFactory {
       layout: [
       RawSyntax.missingToken(TokenKind.poundIfKeyword),
       nil,
-      RawSyntax.missing(SyntaxKind.unknown),
+      nil,
     ], length: .zero, presence: presence))
     return IfConfigClauseSyntax(data)
   }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -2926,10 +2926,11 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return IfConfigClauseSyntax(newData)
   }
 
-  public var elements: Syntax {
+  public var elements: Syntax? {
     get {
       let childData = data.child(at: Cursor.elements,
                                  parent: Syntax(self))
+      if childData == nil { return nil }
       return Syntax(childData!)
     }
     set(value) {
@@ -2942,7 +2943,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///                   current `elements`, if present.
   public func withElements(
     _ newChild: Syntax?) -> IfConfigClauseSyntax {
-    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.unknown)
+    let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: Cursor.elements)
     return IfConfigClauseSyntax(newData)
   }
@@ -2968,8 +2969,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(ExprSyntax.self))
     }
-    // Check child #2 child is Syntax 
-    assert(rawChildren[2].raw != nil)
+    // Check child #2 child is Syntax or missing
     if let raw = rawChildren[2].raw {
       let info = rawChildren[2].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
@@ -2985,7 +2985,7 @@ extension IfConfigClauseSyntax: CustomReflectable {
     return Mirror(self, children: [
       "poundKeyword": Syntax(poundKeyword).asProtocol(SyntaxProtocol.self),
       "condition": condition.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "elements": Syntax(elements).asProtocol(SyntaxProtocol.self),
+      "elements": elements.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/BuildableNodes.swift
@@ -4956,7 +4956,7 @@ public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature
 public struct IfConfigClause: SyntaxBuildable, ExpressibleAsIfConfigClause {
   let poundKeyword: TokenSyntax
   let condition: ExprBuildable?
-  let elements: SyntaxBuildable
+  let elements: SyntaxBuildable?
 
   /// The leading trivia attached to this syntax node once built.
   /// This is typically used to add comments (e.g. for documentation).
@@ -4971,13 +4971,13 @@ public struct IfConfigClause: SyntaxBuildable, ExpressibleAsIfConfigClause {
     leadingTrivia: Trivia = [],
     poundKeyword: TokenSyntax,
     condition: ExpressibleAsExprBuildable? = nil,
-    elements: ExpressibleAsSyntaxBuildable
+    elements: ExpressibleAsSyntaxBuildable? = nil
   ) {
     self.leadingTrivia = leadingTrivia
     self.poundKeyword = poundKeyword
     assert(poundKeyword.text == "#if" || poundKeyword.text == "#elseif" || poundKeyword.text == "#else")
     self.condition = condition?.createExprBuildable()
-    self.elements = elements.createSyntaxBuildable()
+    self.elements = elements?.createSyntaxBuildable()
   }
 
 
@@ -4989,7 +4989,7 @@ public struct IfConfigClause: SyntaxBuildable, ExpressibleAsIfConfigClause {
     let result = SyntaxFactory.makeIfConfigClause(
       poundKeyword: poundKeyword,
       condition: condition?.buildExpr(format: format, leadingTrivia: nil),
-      elements: elements.buildSyntax(format: format, leadingTrivia: nil)
+      elements: elements?.buildSyntax(format: format, leadingTrivia: nil)
     )
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
     return result.withLeadingTrivia(combinedLeadingTrivia)

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/DeclNodes.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/DeclNodes.swift
@@ -148,6 +148,7 @@ let DECL_NODES: [Node] = [
                classification: "BuildConfigId"),
          Child(name: "Elements",
                kind: "Syntax",
+               isOptional: true,
                nodeChoices: [
                  Child(name: "Statements",
                        kind: "CodeBlockItemList"),

--- a/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
@@ -17,6 +17,6 @@
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "99675ccdcfa965dd6fabc8af900e7545bce5df5d"
+      "cc504c14e79e2c639d9668e88a76506ef60b8479"
   }
 }


### PR DESCRIPTION
A #if clause need not actually contain any elements. Consider

```
#if !FEATURE_ENABLED
#else
class Foo {

}
#endif
```