### PR TITLE
Add methods for structurally comparing syntax trees

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -91,7 +91,7 @@ let package = Package(
     ),
     .target(
       name: "_SwiftSyntaxTestSupport",
-      dependencies: ["SwiftSyntax"]
+      dependencies: ["SwiftSyntax", "SwiftSyntaxParser"]
     ),
     .executableTarget(
       name: "lit-test-helper",

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -148,6 +148,15 @@ public struct Trivia {
 % end
 }
 
+extension Trivia: CustomDebugStringConvertible {
+   public var debugDescription: String {
+     if count == 1, let first {
+       return first.debugDescription
+     }
+     return "[" + map(\.debugDescription).joined(separator: ", ") + "]"
+   }
+ }
+
 extension Trivia: Equatable {}
 
 /// Conformance for Trivia to the Collection protocol.
@@ -168,7 +177,6 @@ extension Trivia: Collection {
     return pieces[index]
   }
 }
-
 
 extension Trivia: ExpressibleByArrayLiteral {
   /// Creates Trivia from the provided pieces.

--- a/Sources/SwiftSyntax/gyb_generated/Trivia.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Trivia.swift
@@ -274,6 +274,15 @@ public struct Trivia {
   }
 }
 
+extension Trivia: CustomDebugStringConvertible {
+   public var debugDescription: String {
+     if count == 1, let first {
+       return first.debugDescription
+     }
+     return "[" + map(\.debugDescription).joined(separator: ", ") + "]"
+   }
+ }
+
 extension Trivia: Equatable {}
 
 /// Conformance for Trivia to the Collection protocol.
@@ -294,7 +303,6 @@ extension Trivia: Collection {
     return pieces[index]
   }
 }
-
 
 extension Trivia: ExpressibleByArrayLiteral {
   /// Creates Trivia from the provided pieces.

--- a/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
+++ b/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
@@ -15,6 +15,7 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import SwiftSyntaxParser
 import XCTest
 
 /// Verifies that there is a next item returned by the iterator and that it
@@ -31,4 +32,193 @@ public func XCTAssertNext<Iterator: IteratorProtocol>(
 /// Verifies that the iterator is exhausted.
 public func XCTAssertNextIsNil<Iterator: IteratorProtocol>(_ iterator: inout Iterator) {
   XCTAssertNil(iterator.next())
+}
+
+/// Verifies that the tree parsed from `actual` has the same structure as
+/// `expected`, ie. it has the same structure and optionally the same trivia
+/// (if `includeTrivia` is set).
+public func XCTAssertSameStructure(_ actual: String, _ expected: Syntax, includeTrivia: Bool = false,
+                                   file: StaticString = #filePath, line: UInt = #line) throws {
+  let actualTree = try Syntax(SyntaxParser.parse(source: actual))
+  XCTAssertSameStructure(actualTree, expected, includeTrivia: includeTrivia, file: file, line: line)
+}
+
+/// Verifies that two trees are equivalent, ie. they have the same structure
+/// and optionally the same trivia if `includeTrivia` is set.
+public func XCTAssertSameStructure(_ actual: Syntax, _ expected: Syntax, includeTrivia: Bool = false,
+                                   file: StaticString = #filePath, line: UInt = #line) {
+  let diff = actual.findFirstDifference(baseline: expected, includeTrivia: includeTrivia)
+  XCTAssertNil(diff, diff!.debugDescription, file: file, line: line)
+}
+
+/// Allows matching a subtrees of the given `markedText` against
+/// `baseline`/`expected` trees, where a combination of markers and the type
+/// of the `expected` tree is used to first find the subtree to match. Note
+/// any markers are removed before the source is parsed.
+///
+/// As an example, given some source with markers to parse:
+/// ```
+/// let subtreeMatcher = SubtreeMatcher("""
+///   func foo(#^FIRST^#x y: Double,
+///   #^SECOND^#first second third: Int) {}
+///   """
+/// ```
+///
+/// And then some asserts:
+/// ```
+/// let firstExpectedParam = ... // make the first expected parameter
+/// subtreeMatcher.assertSameStructure(from: "FIRST", firstExpectedParam)
+///
+/// let secondExpectedParam = ... // make the second expected parameter
+/// subtreeMatcher.assertSameStructure(from: "SECOND", secondExpectedParam)
+/// ```
+///
+/// Before parsing, `#^FIRST^#` and `#^SECOND^#` will first be removed from the
+/// source test.
+///
+/// The subtree matched in `FIRST` will start at the first node after
+/// `#^FIRST^#` that matches the root type of `firstExpectedParam`.
+///
+/// There's no *need* to specify a marker, eg. if we want to match on the first
+/// parameter only we could instead write:
+/// ```
+/// let subtreeMatcher = SubtreeMatcher("""
+///   func foo(first second third: Int) {}
+///   """
+/// let expectedParam = ... // make the first expected parameter
+/// subtreeMatcher.assertSameStructure(expectedParam)
+/// ```
+///
+/// Since no marker was given the matched subtree will just start at the first
+/// node matching `expectedParam`'s type.
+public struct SubtreeMatcher {
+  /// Maps marker names to the UTF-8 byte offset for the character at which
+  /// they occurred in the source *with markers removed*.
+  private let markers: [String: Int]
+  /// The syntax tree from parsing source *with markers removed*.
+  private var actualTree: Syntax
+
+  public init(_ markedText: String) throws {
+    var text = ""
+    var markers = [String: Int]()
+    var lastIndex = markedText.startIndex
+    for marker in findMarkedRanges(text: markedText) {
+      text += markedText[lastIndex ..< marker.range.lowerBound]
+      lastIndex = marker.range.upperBound
+
+      assert(markers[String(marker.name)] == nil, "Marker names must be unique")
+      markers[String(marker.name)] = text.utf8.count
+    }
+    text += markedText[lastIndex ..< markedText.endIndex]
+
+    self.markers = markers.isEmpty ? ["DEFAULT": 0] : markers
+    self.actualTree = try Syntax(SyntaxParser.parse(source: text))
+  }
+
+  /// Same as `Syntax.findFirstDifference(baseline:includeTrivia:)`, but
+  /// matches against the first subtree from parsing `markedText` that is after
+  /// `afterMarker` with the root matching the root type of `baseline`.
+  public func findFirstDifference(afterMarker: String? = nil, baseline: Syntax, includeTrivia: Bool = false) throws -> TreeDifference? {
+    let afterMarker = afterMarker ?? markers.first!.key
+    guard let subtreeStart = markers[afterMarker] else {
+      throw SubtreeError.invalidMarker(name: afterMarker)
+    }
+
+    guard let subtree = SyntaxTypeFinder.findFirstNode(in: actualTree, afterUTF8Offset: subtreeStart, ofType: baseline.syntaxNodeType) else {
+      throw SubtreeError.invalidSubtree(tree: actualTree, afterUTF8Offset: subtreeStart, type: String(describing: baseline.syntaxNodeType))
+    }
+
+    return subtree.findFirstDifference(baseline: baseline, includeTrivia: includeTrivia)
+  }
+
+  /// Same as `XCTAssertSameStructure`, but uses the subtree found from parsing
+  /// the text passed into `init(markedText:)` as the `actual` tree.
+  public func assertSameStructure(afterMarker: String? = nil, _ expected: Syntax, includeTrivia: Bool = false,
+                                  file: StaticString = #filePath, line: UInt = #line) throws {
+    let diff = try findFirstDifference(afterMarker: afterMarker, baseline: expected, includeTrivia: includeTrivia)
+    XCTAssertNil(diff, diff!.debugDescription, file: file, line: line)
+  }
+}
+
+public enum SubtreeError: Error, CustomStringConvertible {
+  case invalidMarker(name: String)
+  case invalidSubtree(tree: Syntax, afterUTF8Offset: Int, type: String)
+
+  public var description: String {
+    switch self {
+    case let .invalidMarker(name):
+      return "Could not find marker with name '\(name)'"
+    case let .invalidSubtree(tree, afterUTF8Offset, type):
+      return "Could not find subtree after UTF8 offset \(afterUTF8Offset) with type \(type) in:\n\(tree.debugDescription)"
+    }
+  }
+}
+
+/// Finds all marked ranges in the given text, see `Marker`.
+fileprivate func findMarkedRanges(text: String) -> [Marker] {
+  var markers = [Marker]()
+  while let marker = nextMarkedRange(text: text, from: markers.last?.range.upperBound ?? text.startIndex) {
+    markers.append(marker)
+  }
+  return markers
+}
+
+fileprivate func nextMarkedRange(text: String, from: String.Index) -> Marker? {
+  guard let start = text.range(of: "#^", range: from ..< text.endIndex),
+        let end = text.range(of: "^#", range: start.upperBound ..< text.endIndex) else {
+    return nil
+  }
+
+  let markerRange = start.lowerBound ..< end.upperBound
+  let name = text[start.upperBound ..< end.lowerBound]
+
+  // Expand to the whole line if the line only contains the marker
+  let lineRange = text.lineRange(for: start)
+  if text[lineRange].trimmingCharacters(in: .whitespacesAndNewlines) == text[markerRange] {
+    return Marker(name: name, range: lineRange)
+  }
+  return Marker(name: name, range: markerRange)
+}
+
+fileprivate struct Marker {
+  /// The name of the marker without the `#^` and `^#` markup.
+  let name: Substring
+  /// The range of the marker.
+  ///
+  /// If the marker contains all the the non-whitepace characters on the line,
+  /// this is the range of the entire line. Otherwise it's the range of the
+  /// marker itself, including the `#^` and `^#` markup.
+  let range: Range<String.Index>
+}
+
+fileprivate class SyntaxTypeFinder: SyntaxAnyVisitor {
+  private let offset: Int
+  private let type: SyntaxProtocol.Type
+  private var found: Syntax?
+
+  private init(offset: Int, type: SyntaxProtocol.Type) {
+    self.offset = offset
+    self.type = type
+    self.found = nil
+    super.init(viewMode: ._all)
+  }
+
+  fileprivate override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
+    if found != nil || node.endPosition.utf8Offset < offset {
+      return .skipChildren
+    }
+
+    if node.positionAfterSkippingLeadingTrivia.utf8Offset >= offset && node.syntaxNodeType == type {
+      found = node
+      return .skipChildren
+    }
+
+    return .visitChildren
+  }
+
+  public static func findFirstNode(in tree: Syntax, afterUTF8Offset offset: Int, ofType type: SyntaxProtocol.Type) -> Syntax? {
+    let finder = SyntaxTypeFinder(offset: offset, type: type)
+    finder.walk(tree)
+    return finder.found
+  }
 }

--- a/Tests/SwiftSyntaxTest/CustomReflectableTests.swift
+++ b/Tests/SwiftSyntaxTest/CustomReflectableTests.swift
@@ -20,7 +20,7 @@ public class CustomReflectableTests: XCTestCase {
     let testCases: [UInt: TestCase] = [
       #line: .init(syntax: SyntaxFactory.makeUnknownSyntax(tokens: []),
                    expectedDumped: """
-                                   - SwiftSyntax.UnknownSyntax
+                                   - UnknownSyntax
 
                                    """),
       #line: .init(syntax: SyntaxFactory.makeToken(.associatedtypeKeyword,
@@ -28,11 +28,11 @@ public class CustomReflectableTests: XCTestCase {
                                                    leadingTrivia: [],
                                                    trailingTrivia: []),
                    expectedDumped: """
-                                   ▿ SwiftSyntax.TokenSyntax
+                                   ▿ associatedtypeKeyword
                                      - text: "associatedtype"
-                                     ▿ leadingTrivia:
+                                     ▿ leadingTrivia: []
                                        - pieces: 0 elements
-                                     ▿ trailingTrivia:
+                                     ▿ trailingTrivia: []
                                        - pieces: 0 elements
                                      - tokenKind: SwiftSyntax.TokenKind.associatedtypeKeyword
 
@@ -53,18 +53,18 @@ public class CustomReflectableTests: XCTestCase {
         return .init(syntax: expr.tokens(viewMode: .sourceAccurate),
                      expectedDumped: """
                                      ▿ SwiftSyntax.TokenSequence
-                                       ▿ SwiftSyntax.TokenSyntax
+                                       ▿ leftSquareBracket
                                          - text: "["
-                                         ▿ leadingTrivia:
+                                         ▿ leadingTrivia: []
                                            - pieces: 0 elements
-                                         ▿ trailingTrivia:
+                                         ▿ trailingTrivia: []
                                            - pieces: 0 elements
                                          - tokenKind: SwiftSyntax.TokenKind.leftSquareBracket
-                                       ▿ SwiftSyntax.TokenSyntax
+                                       ▿ rightSquareBracket
                                          - text: "]"
-                                         ▿ leadingTrivia:
+                                         ▿ leadingTrivia: []
                                            - pieces: 0 elements
-                                         ▿ trailingTrivia:
+                                         ▿ trailingTrivia: []
                                            - pieces: 0 elements
                                          - tokenKind: SwiftSyntax.TokenKind.rightSquareBracket
 
@@ -86,18 +86,18 @@ public class CustomReflectableTests: XCTestCase {
         return .init(syntax: expr.tokens(viewMode: .sourceAccurate).reversed(),
                      expectedDumped: """
                                      ▿ SwiftSyntax.ReversedTokenSequence
-                                       ▿ SwiftSyntax.TokenSyntax
+                                       ▿ rightSquareBracket
                                          - text: "]"
-                                         ▿ leadingTrivia:
+                                         ▿ leadingTrivia: []
                                            - pieces: 0 elements
-                                         ▿ trailingTrivia:
+                                         ▿ trailingTrivia: []
                                            - pieces: 0 elements
                                          - tokenKind: SwiftSyntax.TokenKind.rightSquareBracket
-                                       ▿ SwiftSyntax.TokenSyntax
+                                       ▿ leftSquareBracket
                                          - text: "["
-                                         ▿ leadingTrivia:
+                                         ▿ leadingTrivia: []
                                            - pieces: 0 elements
-                                         ▿ trailingTrivia:
+                                         ▿ trailingTrivia: []
                                            - pieces: 0 elements
                                          - tokenKind: SwiftSyntax.TokenKind.leftSquareBracket
 
@@ -125,38 +125,38 @@ public class CustomReflectableTests: XCTestCase {
         let tuples = SyntaxFactory.makeTupleExprElementList(elements)
         return .init(syntax: tuples,
                      expectedDumped: """
-                                     ▿ SwiftSyntax.TupleExprElementListSyntax
-                                       ▿ SwiftSyntax.TupleExprElementSyntax
+                                     ▿ TupleExprElementListSyntax
+                                       ▿ TupleExprElementSyntax
                                          - garbageBeforeLabel: nil
                                          - label: nil
                                          - garbageBetweenLabelAndColon: nil
                                          - colon: nil
                                          - garbageBetweenColonAndExpression: nil
-                                         ▿ expression: SwiftSyntax.IntegerLiteralExprSyntax
+                                         ▿ expression: IntegerLiteralExprSyntax
                                            - garbageBeforeDigits: nil
-                                           ▿ digits: SwiftSyntax.TokenSyntax
+                                           ▿ digits: integerLiteral("1")
                                              - text: "1"
-                                             ▿ leadingTrivia:
+                                             ▿ leadingTrivia: []
                                                - pieces: 0 elements
-                                             ▿ trailingTrivia:
+                                             ▿ trailingTrivia: []
                                                - pieces: 0 elements
                                              ▿ tokenKind: SwiftSyntax.TokenKind.integerLiteral
                                                - integerLiteral: "1"
                                          - garbageBetweenExpressionAndTrailingComma: nil
                                          - trailingComma: nil
-                                       ▿ SwiftSyntax.TupleExprElementSyntax
+                                       ▿ TupleExprElementSyntax
                                          - garbageBeforeLabel: nil
                                          - label: nil
                                          - garbageBetweenLabelAndColon: nil
                                          - colon: nil
                                          - garbageBetweenColonAndExpression: nil
-                                         ▿ expression: SwiftSyntax.IntegerLiteralExprSyntax
+                                         ▿ expression: IntegerLiteralExprSyntax
                                            - garbageBeforeDigits: nil
-                                           ▿ digits: SwiftSyntax.TokenSyntax
+                                           ▿ digits: integerLiteral("2")
                                              - text: "2"
-                                             ▿ leadingTrivia:
+                                             ▿ leadingTrivia: []
                                                - pieces: 0 elements
-                                             ▿ trailingTrivia:
+                                             ▿ trailingTrivia: []
                                                - pieces: 0 elements
                                              ▿ tokenKind: SwiftSyntax.TokenKind.integerLiteral
                                                - integerLiteral: "2"
@@ -188,44 +188,44 @@ public class CustomReflectableTests: XCTestCase {
         return .init(syntax: tuples.reversed(),
                      expectedDumped: """
                                      ▿ Swift.ReversedCollection<SwiftSyntax.TupleExprElementListSyntax>
-                                       ▿ _base: SwiftSyntax.TupleExprElementListSyntax
-                                         ▿ SwiftSyntax.TupleExprElementSyntax
+                                       ▿ _base: TupleExprElementListSyntax
+                                         ▿ TupleExprElementSyntax
                                            - garbageBeforeLabel: nil
                                            - label: nil
                                            - garbageBetweenLabelAndColon: nil
                                            - colon: nil
                                            - garbageBetweenColonAndExpression: nil
-                                           ▿ expression: SwiftSyntax.IntegerLiteralExprSyntax
+                                           ▿ expression: IntegerLiteralExprSyntax
                                              - garbageBeforeDigits: nil
-                                             ▿ digits: SwiftSyntax.TokenSyntax
+                                             ▿ digits: integerLiteral("1")
                                                - text: "1"
-                                               ▿ leadingTrivia:
+                                               ▿ leadingTrivia: []
                                                  - pieces: 0 elements
-                                               ▿ trailingTrivia:
+                                               ▿ trailingTrivia: []
                                                  - pieces: 0 elements
                                                ▿ tokenKind: SwiftSyntax.TokenKind.integerLiteral
                                                  - integerLiteral: "1"
                                            - garbageBetweenExpressionAndTrailingComma: nil
                                            - trailingComma: nil
-                                         ▿ SwiftSyntax.TupleExprElementSyntax
+                                         ▿ TupleExprElementSyntax
                                            - garbageBeforeLabel: nil
                                            - label: nil
                                            - garbageBetweenLabelAndColon: nil
                                            - colon: nil
                                            - garbageBetweenColonAndExpression: nil
-                                           ▿ expression: SwiftSyntax.IntegerLiteralExprSyntax
+                                           ▿ expression: IntegerLiteralExprSyntax
                                              - garbageBeforeDigits: nil
-                                             ▿ digits: SwiftSyntax.TokenSyntax
+                                             ▿ digits: integerLiteral("2")
                                                - text: "2"
-                                               ▿ leadingTrivia:
+                                               ▿ leadingTrivia: []
                                                  - pieces: 0 elements
-                                               ▿ trailingTrivia:
+                                               ▿ trailingTrivia: []
                                                  - pieces: 0 elements
                                                ▿ tokenKind: SwiftSyntax.TokenKind.integerLiteral
                                                  - integerLiteral: "2"
                                            - garbageBetweenExpressionAndTrailingComma: nil
                                            - trailingComma: nil
-                                     
+
                                      """)
       }(),
     ]

--- a/Tests/SwiftSyntaxTest/SyntaxComparisonTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxComparisonTests.swift
@@ -1,0 +1,192 @@
+import SwiftSyntax
+import _SwiftSyntaxTestSupport
+import XCTest
+
+public class SyntaxComparisonTests: XCTestCase {
+  public func testSame() throws {
+    let expected = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f")))
+
+    let actual = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f")))
+    XCTAssertNil(actual.findFirstDifference(baseline: expected))
+
+    let matcher = try SubtreeMatcher("struct A { func f() { } }")
+    try XCTAssertNil(matcher.findFirstDifference(baseline: expected))
+  }
+
+  public func testDifferentType() throws {
+    let expected = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f")))
+    let actual = Syntax(makeBody())
+
+    let diff = try XCTUnwrap(actual.findFirstDifference(baseline: expected))
+    XCTAssertEqual(diff.reason, .nodeType)
+    XCTAssertTrue(Syntax(diff.baseline).is(FunctionDeclSyntax.self))
+    XCTAssertTrue(Syntax(diff.node).is(CodeBlockSyntax.self))
+  }
+
+  public func testDifferentTokenKind() throws {
+    let expected = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f"), keyword: SyntaxFactory.makeClassKeyword()))
+
+    func expectations(_ diff: TreeDifference?, file: StaticString = #filePath, line: UInt = #line) throws {
+      let diff = try XCTUnwrap(diff, file: file, line: line)
+      XCTAssertEqual(diff.reason, .token)
+      XCTAssertEqual(Syntax(diff.baseline).as(TokenSyntax.self)?.tokenKind, .classKeyword)
+      XCTAssertEqual(Syntax(diff.node).as(TokenSyntax.self)?.tokenKind, .funcKeyword)
+    }
+
+    let actual = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f")))
+    try expectations(actual.findFirstDifference(baseline: expected))
+
+    let matcher = try SubtreeMatcher("struct A { #^FUNC^#func f() { } }")
+    try expectations(matcher.findFirstDifference(baseline: expected))
+  }
+
+  public func testDifferentTokenText() throws {
+    let expected = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f")))
+    func expectations(_ diff: TreeDifference?, file: StaticString = #filePath, line: UInt = #line) throws {
+      let diff = try XCTUnwrap(diff, file: file, line: line)
+      XCTAssertEqual(diff.reason, .token)
+      XCTAssertEqual(Syntax(diff.baseline).as(TokenSyntax.self)?.tokenKind, .identifier("f"))
+      XCTAssertEqual(Syntax(diff.node).as(TokenSyntax.self)?.tokenKind, .identifier("g"))
+    }
+
+    let actual = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("g")))
+    try expectations(actual.findFirstDifference(baseline: expected))
+
+    let matcher = try SubtreeMatcher("struct A { #^FUNC^#func g() { } }")
+    try expectations(matcher.findFirstDifference(afterMarker: "FUNC", baseline: expected))
+  }
+
+  public func testDifferentTrivia() throws {
+    let expected = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f"), indent: 2))
+    func expectations(_ diff: TreeDifference?, file: StaticString = #filePath, line: UInt = #line) throws {
+      let diff = try XCTUnwrap(diff, file: file, line: line)
+      XCTAssertEqual(diff.reason, .trivia)
+      XCTAssertEqual(diff.baseline.leadingTrivia, .spaces(2))
+      XCTAssertEqual(diff.node.leadingTrivia, [])
+    }
+
+    let actual = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f")))
+    XCTAssertNil(actual.findFirstDifference(baseline: expected))
+    try expectations(actual.findFirstDifference(baseline: expected, includeTrivia: true))
+
+    let matcher = try SubtreeMatcher("struct A {func f() { }}")
+    try XCTAssertNil(matcher.findFirstDifference(baseline: expected))
+    try expectations(matcher.findFirstDifference(baseline: expected, includeTrivia: true))
+  }
+
+  public func testDifferentPresence() throws {
+    let expected = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f"), body: SyntaxFactory.makeBlankCodeBlock()))
+    func expectations(_ diff: TreeDifference?, file: StaticString = #filePath, line: UInt = #line) throws {
+      let diff = try XCTUnwrap(diff, file: file, line: line)
+      XCTAssertEqual(diff.reason, .presence)
+      XCTAssertTrue(diff.baseline.isMissing)
+      XCTAssertFalse(diff.node.isMissing)
+    }
+
+    let actual = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f")))
+    try expectations(actual.findFirstDifference(baseline: expected))
+
+    let matcher = try SubtreeMatcher("struct A { func f() { } }")
+    try expectations(matcher.findFirstDifference(baseline: expected))
+  }
+
+  public func testMissingNode() throws {
+    let expected = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f"), body: makeBody(statementCount: 1)))
+    func expectations(_ diff: TreeDifference?, file: StaticString = #filePath, line: UInt = #line) throws {
+      let diff = try XCTUnwrap(diff, file: file, line: line)
+      XCTAssertEqual(diff.reason, .missingNode)
+    }
+
+    let actual = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f")))
+    try expectations(actual.findFirstDifference(baseline: expected))
+
+    let matcher = try SubtreeMatcher("struct A { func f() { } }")
+    try expectations(matcher.findFirstDifference(baseline: expected))
+  }
+
+  public func testAdditionalNode() throws {
+    let expected = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f")))
+    func expectations(_ diff: TreeDifference?, file: StaticString = #filePath, line: UInt = #line) throws {
+      let diff = try XCTUnwrap(diff, file: file, line: line)
+      XCTAssertEqual(diff.reason, .additionalNode)
+    }
+
+    let actual = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f"), body: makeBody(statementCount: 1)))
+    try expectations(actual.findFirstDifference(baseline: expected))
+
+    let matcher = try SubtreeMatcher("""
+      struct A {
+        func f() {
+          0
+        }
+      }
+      """)
+    try expectations(matcher.findFirstDifference(baseline: expected))
+  }
+
+  public func testMultipleSubtreeMatches() throws {
+    let expectedFunc = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f")))
+    let expectedBody = Syntax(makeBody())
+
+    let matcher = try SubtreeMatcher("""
+      struct A {
+        #^FUNC^#
+        let member = 1
+
+        func f() #^BODY^#{
+          0
+        }
+      }
+      """)
+    let funcDiff = try XCTUnwrap(matcher.findFirstDifference(afterMarker: "FUNC", baseline: expectedFunc))
+    XCTAssertEqual(funcDiff.reason, .additionalNode)
+
+    let bodyDiff = try XCTUnwrap(matcher.findFirstDifference(afterMarker: "BODY", baseline: expectedBody))
+    XCTAssertEqual(bodyDiff.reason, .additionalNode)
+  }
+
+  /// Generates a `FunctionDeclSyntax` with the given `identifier`, `keyword`,
+  /// and `body` with some optional leading indentation (which applied only to
+  /// the start, not the entire body).
+  private func makeFunc(identifier: TokenSyntax, keyword: TokenSyntax = SyntaxFactory.makeFuncKeyword(),
+                        body: CodeBlockSyntax? = nil, indent: Int = 0) -> FunctionDeclSyntax {
+    let funcBody: CodeBlockSyntax
+    if let body {
+      funcBody = body
+    } else {
+      funcBody = makeBody()
+    }
+    let emptySignature = SyntaxFactory.makeFunctionSignature(input: SyntaxFactory.makeParameterClause(leftParen: SyntaxFactory.makeLeftParenToken(),
+                                                                                                      parameterList: SyntaxFactory.makeFunctionParameterList([]),
+                                                                                                      rightParen: SyntaxFactory.makeRightParenToken()),
+                                                             asyncOrReasyncKeyword: nil, throwsOrRethrowsKeyword: nil, output: nil)
+    let fd = SyntaxFactory.makeFunctionDecl(attributes: nil, modifiers: nil,
+                                            funcKeyword: keyword, identifier: identifier, genericParameterClause: nil,
+                                            signature: emptySignature, genericWhereClause: nil, body: funcBody)
+    if indent > 0 {
+      return fd.withLeadingTrivia(.spaces(indent))
+    }
+    return fd
+  }
+
+  /// Creates a `CodeBlockSyntax` that consists of `statementCount` integer
+  /// literals with increasing values. Ie. `makeBody(statementCount: 2)`
+  /// generates:
+  /// ```
+  /// {
+  ///   0
+  ///   1
+  /// }
+  /// ```
+  private func makeBody(statementCount: Int = 0) -> CodeBlockSyntax {
+    var items = [CodeBlockItemSyntax]()
+    for i in 0..<statementCount {
+      let literal = SyntaxFactory.makeIntegerLiteralExpr(digits: SyntaxFactory.makeIntegerLiteral(String(i)))
+      items.append(SyntaxFactory.makeCodeBlockItem(item: Syntax(literal), semicolon: nil, errorTokens: nil))
+    }
+    let block = SyntaxFactory.makeCodeBlockItemList(items)
+    return SyntaxFactory.makeCodeBlock(leftBrace: SyntaxFactory.makeLeftBraceToken(),
+                                       statements: block,
+                                       rightBrace: SyntaxFactory.makeRightBraceToken())
+  }
+}


### PR DESCRIPTION
Adds a `findFirstDifference` API to `Syntax`, `XCTAssertSameStructure`
assertions, and a `SubtreeMatch` to compare subtrees.