### PR TITLE
Deprecate SyntaxFactory

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -67,6 +67,7 @@ let package = Package(
         "SyntaxTraits.swift.gyb",
         "SyntaxVisitor.swift.gyb",
         "TokenKind.swift.gyb",
+        "Tokens.swift.gyb",
         "Trivia.swift.gyb",
       ],
       swiftSettings: swiftSyntaxSwiftSettings

--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -20,7 +20,7 @@ internal struct RawSyntaxData {
     case layout(Layout)
   }
 
-  /// Token typically created with `SyntaxFactory.makeToken()`.
+  /// Token typically created with `TokenSyntax.<someToken>`.
   struct MaterializedToken {
     var tokenKind: RawTokenKind
     var tokenText: SyntaxText

--- a/Sources/SwiftSyntax/SyntaxAnyVisitor.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxAnyVisitor.swift.gyb
@@ -3,7 +3,7 @@
   # -*- mode: Swift -*-
   # Ignore the following admonition it applies to the resulting .swift file only
 }%
-//// Automatically Generated From SyntaxFactory.swift.gyb.
+//// Automatically Generated From SyntaxAnyVisitor.swift.gyb.
 //// Do Not Edit Directly!
 //===--------- SyntaxAnyVisitor.swift - Syntax any visitor class ----------===//
 //

--- a/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -55,6 +55,13 @@ public struct ${node.name}: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [${node.collection_element_type}]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.${node.swift_syntax_kind},
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }

--- a/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxFactory.swift.gyb
@@ -28,6 +28,7 @@
 //===----------------------------------------------------------------------===//
 
 public enum SyntaxFactory {
+  @available(*, deprecated, message: "Use initializer on TokenSyntax")
   public static func makeToken(_ kind: TokenKind, presence: SourcePresence,
                                leadingTrivia: Trivia = [],
                                trailingTrivia: Trivia = []) -> TokenSyntax {
@@ -37,6 +38,7 @@ public enum SyntaxFactory {
     return TokenSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on UnknownSyntax")
   public static func makeUnknownSyntax(tokens: [TokenSyntax]) -> UnknownSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: .unknown,
       layout: tokens.map { $0.raw }, presence: .present)
@@ -65,6 +67,7 @@ public enum SyntaxFactory {
 %       end
 %     end
 %     child_params = ', '.join(child_params)
+  @available(*, deprecated, message: "Use initializer on ${node.name}")
   public static func make${node.syntax_kind}(${child_params}) -> ${node.name} {
     let layout: [RawSyntax?] = [
 %     for child in node.children:
@@ -81,6 +84,7 @@ public enum SyntaxFactory {
     return ${node.name}(data)
   }
 %   elif node.is_syntax_collection():
+  @available(*, deprecated, message: "Use initializer on ${node.name}")
   public static func make${node.syntax_kind}(
     _ elements: [${node.collection_element_type}]) -> ${node.name} {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.${node.swift_syntax_kind},
@@ -92,6 +96,7 @@ public enum SyntaxFactory {
 
 %   if not node.is_base():
 %   default_presence = 'missing' if node.is_missing() else 'present'
+  @available(*, deprecated, message: "Use initializer on ${node.name}")
   public static func makeBlank${node.syntax_kind}(presence: SourcePresence = .${default_presence}) -> ${node.name} {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .${node.swift_syntax_kind},
       layout: [
@@ -119,6 +124,7 @@ public enum SyntaxFactory {
 %   leading_trivia = token_trivia(token.requires_leading_space)
 %   trailing_trivia = token_trivia(token.requires_trailing_space)
 %   if token.is_keyword:
+  @available(*, deprecated, message: "Use TokenSyntax.${token.swift_kind()}Keyword instead")
   public static func make${token.name}Keyword(
     leadingTrivia: Trivia = ${leading_trivia},
     trailingTrivia: Trivia = ${trailing_trivia}
@@ -128,6 +134,7 @@ public enum SyntaxFactory {
                      trailingTrivia: trailingTrivia)
   }
 %   elif token.text:
+  @available(*, deprecated, message: "Use TokenSyntax.${token.swift_kind()}Token instead")
   public static func make${token.name}Token(
     leadingTrivia: Trivia = ${leading_trivia},
     trailingTrivia: Trivia = ${trailing_trivia}
@@ -137,6 +144,7 @@ public enum SyntaxFactory {
                      trailingTrivia: trailingTrivia)
   }
 %   else:
+  @available(*, deprecated, message: "Use TokenSyntax.${token.swift_kind()} instead")
   public static func make${token.name}(
     _ text: String,
     leadingTrivia: Trivia = ${leading_trivia},
@@ -151,12 +159,14 @@ public enum SyntaxFactory {
 
 /// MARK: Convenience APIs
 
+  @available(*, deprecated, message: "Use initializer on TupleTypeSyntax")
   public static func makeVoidTupleType() -> TupleTypeSyntax {
     return makeTupleType(leftParen: makeLeftParenToken(),
                          elements: makeBlankTupleTypeElementList(),
                          rightParen: makeRightParenToken())
   }
 
+  @available(*, deprecated, message: "Use initializer on TupleTypeSyntax")
   public static func makeTupleTypeElement(name: TokenSyntax?,
     colon: TokenSyntax?, type: TypeSyntax,
     trailingComma: TokenSyntax?) -> TupleTypeElementSyntax {
@@ -165,12 +175,14 @@ public enum SyntaxFactory {
                                 initializer: nil, trailingComma: trailingComma)
   }
 
+  @available(*, deprecated, message: "Use initializer on TupleTypeSyntax")
   public static func makeTupleTypeElement(type: TypeSyntax,
     trailingComma: TokenSyntax?) -> TupleTypeElementSyntax  {
     return makeTupleTypeElement(name: nil, colon: nil, 
                                 type: type, trailingComma: trailingComma)
   }
 
+  @available(*, deprecated, message: "Use initializer on GenericParameterSyntax")
   public static func makeGenericParameter(name: TokenSyntax,
       trailingComma: TokenSyntax) -> GenericParameterSyntax {
     return makeGenericParameter(attributes: nil, name: name, colon: nil,
@@ -178,6 +190,7 @@ public enum SyntaxFactory {
                                 trailingComma: trailingComma)
   }
 
+  @available(*, deprecated, message: "Use initializer on SimpleTypeIdentifierSyntax")
   public static func makeTypeIdentifier(_ name: String,
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> TypeSyntax {
@@ -188,30 +201,35 @@ public enum SyntaxFactory {
     return TypeSyntax(typeIdentifier)
   }
 
+  @available(*, deprecated, message: "Use initializer on SimpleTypeIdentifierSyntax")
   public static func makeAnyTypeIdentifier(leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> TypeSyntax {
     return makeTypeIdentifier("Any", leadingTrivia: leadingTrivia, 
                               trailingTrivia: trailingTrivia)
   }
 
+  @available(*, deprecated, message: "Use initializer on SimpleTypeIdentifierSyntax")
   public static func makeSelfTypeIdentifier(leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> TypeSyntax {
     return makeTypeIdentifier("Self", leadingTrivia: leadingTrivia, 
                               trailingTrivia: trailingTrivia)
   }
 
+  @available(*, deprecated, message: "Use initializer on SimpleTypeIdentifierSyntax")
   public static func makeTypeToken(leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> TokenSyntax {
     return makeIdentifier("Type", leadingTrivia: leadingTrivia, 
                           trailingTrivia: trailingTrivia)
   }
 
+  @available(*, deprecated, message: "Use TokenSyntax.protocol")
   public static func makeProtocolToken(leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> TokenSyntax {
     return makeIdentifier("Protocol", leadingTrivia: leadingTrivia,
                           trailingTrivia: trailingTrivia)
   }
 
+  @available(*, deprecated, message: "Use TokenSyntax.spacedBinaryOperator")
   public static func makeBinaryOperator(_ name: String,
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> TokenSyntax {
@@ -221,6 +239,7 @@ public enum SyntaxFactory {
                      trailingTrivia: trailingTrivia)
   }
 
+  @available(*, deprecated, message: "Use initializer on StringLiteralExprSyntax")
   public static func makeStringLiteralExpr(_ text: String,
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> StringLiteralExprSyntax {
@@ -236,6 +255,7 @@ public enum SyntaxFactory {
                                  closeDelimiter: nil)
   }
 
+  @available(*, deprecated, message: "Use initializer on IdentifierExprSyntax")
   public static func makeVariableExpr(_ text: String,
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> IdentifierExprSyntax {

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
@@ -80,6 +80,34 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+%     for (index, child) in enumerate(node.children):
+%       comma = ',' if index != len(node.children) - 1 else ''
+%       param_type = child.type_name
+%       if child.is_optional:
+%         param_type = param_type + "?"
+%       if child.is_garbage_nodes():
+    _ ${child.swift_name}: ${param_type} = nil${comma}
+%       else:
+    ${child.swift_name}: ${param_type}${comma}
+%       end
+%     end 
+  ) {
+    let layout: [RawSyntax?] = [
+%     for child in node.children:
+%       if child.is_optional:
+      ${child.swift_name}?.raw,
+%       else:
+      ${child.swift_name}.raw,
+%       end
+%     end
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.${node.swift_syntax_kind},
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }

--- a/Sources/SwiftSyntax/SyntaxOtherNodes.swift
+++ b/Sources/SwiftSyntax/SyntaxOtherNodes.swift
@@ -41,6 +41,13 @@ public struct UnknownSyntax: SyntaxProtocol, SyntaxHashable {
     assert(data.raw.kind == .unknown)
     self._syntaxNode = Syntax(data)
   }
+
+  public init(tokens: [TokenSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: .unknown,
+      layout: tokens.map { $0.raw }, presence: .present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
 }
 
 extension UnknownSyntax: CustomReflectable {
@@ -68,6 +75,18 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .token)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ kind: TokenKind,
+    leadingTrivia: Trivia = [],
+    trailingTrivia: Trivia = [],
+    presence: SourcePresence
+  ) {
+    let raw = RawSyntax.createAndCalcLength(kind: kind, leadingTrivia: leadingTrivia,
+      trailingTrivia: trailingTrivia, presence: presence)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {

--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -3,7 +3,7 @@
   # -*- mode: Swift -*-
   # Ignore the following admonition it applies to the resulting .swift file only
 }%
-//// Automatically Generated From SyntaxFactory.swift.gyb.
+//// Automatically Generated From SyntaxRewriter.swift.gyb.
 //// Do Not Edit Directly!
 //===------------ SyntaxRewriter.swift - Syntax Rewriter class ------------===//
 //

--- a/Sources/SwiftSyntax/SyntaxVisitor.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxVisitor.swift.gyb
@@ -3,7 +3,7 @@
   # -*- mode: Swift -*-
   # Ignore the following admonition it applies to the resulting .swift file only
 }%
-//// Automatically Generated From SyntaxFactory.swift.gyb.
+//// Automatically Generated From SyntaxVisitor.swift.gyb.
 //// Do Not Edit Directly!
 //===------------- SyntaxVisitor.swift - Syntax Visitor class -------------===//
 //

--- a/Sources/SwiftSyntax/Tokens.swift.gyb
+++ b/Sources/SwiftSyntax/Tokens.swift.gyb
@@ -1,0 +1,86 @@
+%{
+  from gyb_syntax_support import *
+  # -*- mode: Swift -*-
+  # Ignore the following admonition it applies to the resulting .swift file only
+}%
+//// Automatically Generated From Tokens.swift.gyb.
+//// Do Not Edit Directly!
+//===--- Tokens.swift -----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+fileprivate func defaultTrivia(presence: SourcePresence, trivia: Trivia) -> Trivia {
+  switch presence {
+  case .present:
+    return trivia
+  case .missing:
+    return []
+  }
+}
+
+extension TokenSyntax {
+% for token in SYNTAX_TOKENS:
+%   leading_trivia = '.space' if token.requires_leading_space else '[]'
+%   trailing_trivia = '.space' if token.requires_trailing_space else '[]'
+%   if token.is_keyword:
+  public static func ${token.swift_kind()}(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .${token.swift_kind()},
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: ${leading_trivia}),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: ${trailing_trivia}),
+      presence: presence
+    )
+  }
+%   elif token.text:
+  public static func ${token.swift_kind()}Token(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .${token.swift_kind()},
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: ${leading_trivia}),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: ${trailing_trivia}),
+      presence: presence
+    )
+  }
+%   else:
+  public static func ${token.swift_kind()}(
+    _ text: String,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .${token.swift_kind()}(text),
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: ${leading_trivia}),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: ${trailing_trivia}),
+      presence: presence
+    )
+  }
+%   end
+% end
+  public static func eof(
+    leadingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .eof,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: ${leading_trivia}),
+      trailingTrivia: [],
+      presence: presence
+    )
+  }
+}

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
@@ -1,4 +1,4 @@
-//// Automatically Generated From SyntaxFactory.swift.gyb.
+//// Automatically Generated From SyntaxAnyVisitor.swift.gyb.
 //// Do Not Edit Directly!
 //===--------- SyntaxAnyVisitor.swift - Syntax any visitor class ----------===//
 //

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
@@ -40,6 +40,13 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [CodeBlockItemSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.codeBlockItemList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -287,6 +294,13 @@ public struct GarbageNodesSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .garbageNodes)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [Syntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.garbageNodes,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -538,6 +552,13 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [TupleExprElementSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.tupleExprElementList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -785,6 +806,13 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .arrayElementList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [ArrayElementSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.arrayElementList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1036,6 +1064,13 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [DictionaryElementSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.dictionaryElementList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1283,6 +1318,13 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .stringLiteralSegments)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [Syntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.stringLiteralSegments,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1534,6 +1576,13 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [DeclNameArgumentSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.declNameArgumentList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1781,6 +1830,13 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .exprList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [ExprSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.exprList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -2032,6 +2088,13 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [ClosureCaptureItemSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.closureCaptureItemList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -2279,6 +2342,13 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .closureParamList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [ClosureParamSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.closureParamList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -2530,6 +2600,13 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [MultipleTrailingClosureElementSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.multipleTrailingClosureElementList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -2777,6 +2854,13 @@ public struct ObjcNameSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .objcName)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [ObjcNamePieceSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.objcName,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -3028,6 +3112,13 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [FunctionParameterSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.functionParameterList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -3275,6 +3366,13 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .ifConfigClauseList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [IfConfigClauseSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.ifConfigClauseList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -3526,6 +3624,13 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [InheritedTypeSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.inheritedTypeList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -3773,6 +3878,13 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .memberDeclList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [MemberDeclListItemSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.memberDeclList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -4024,6 +4136,13 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [DeclModifierSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.modifierList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -4271,6 +4390,13 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .accessPath)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [AccessPathComponentSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.accessPath,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -4522,6 +4648,13 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [AccessorDeclSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.accessorList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -4771,6 +4904,13 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [PatternBindingSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.patternBindingList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -5015,6 +5155,13 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .enumCaseElementList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [EnumCaseElementSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.enumCaseElementList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -5266,6 +5413,13 @@ public struct IdentifierListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [TokenSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.identifierList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -5513,6 +5667,13 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .precedenceGroupAttributeList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [Syntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.precedenceGroupAttributeList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -5764,6 +5925,13 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [PrecedenceGroupNameElementSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.precedenceGroupNameList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -6011,6 +6179,13 @@ public struct TokenListSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .tokenList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [TokenSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.tokenList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -6262,6 +6437,13 @@ public struct NonEmptyTokenListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [TokenSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.nonEmptyTokenList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -6511,6 +6693,13 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [Syntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.attributeList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -6757,6 +6946,13 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .specializeAttributeSpecList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [Syntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.specializeAttributeSpecList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -7008,6 +7204,13 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [ObjCSelectorPieceSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.objCSelector,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -7255,6 +7458,13 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .differentiabilityParamList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [DifferentiabilityParamSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.differentiabilityParamList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -7506,6 +7716,13 @@ public struct BackDeployVersionListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [BackDeployVersionArgumentSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.backDeployVersionList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -7753,6 +7970,13 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .switchCaseList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [Syntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.switchCaseList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -8004,6 +8228,13 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [CatchClauseSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.catchClauseList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -8251,6 +8482,13 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .caseItemList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [CaseItemSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.caseItemList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -8502,6 +8740,13 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [CatchItemSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.catchItemList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -8749,6 +8994,13 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .conditionElementList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [ConditionElementSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.conditionElementList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -9000,6 +9252,13 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [GenericRequirementSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.genericRequirementList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -9247,6 +9506,13 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .genericParameterList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [GenericParameterSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.genericParameterList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -9498,6 +9764,13 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [PrimaryAssociatedTypeSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.primaryAssociatedTypeList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -9745,6 +10018,13 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .compositionTypeElementList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [CompositionTypeElementSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.compositionTypeElementList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -9996,6 +10276,13 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [TupleTypeElementSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.tupleTypeElementList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -10243,6 +10530,13 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .genericArgumentList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [GenericArgumentSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.genericArgumentList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -10494,6 +10788,13 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(_ children: [TuplePatternElementSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.tuplePatternElementList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -10741,6 +11042,13 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .availabilitySpecList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [AvailabilityArgumentSyntax]) {
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.availabilitySpecList,
+      layout: children.map { $0.raw }, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -23,6 +23,7 @@
 //===----------------------------------------------------------------------===//
 
 public enum SyntaxFactory {
+  @available(*, deprecated, message: "Use initializer on TokenSyntax")
   public static func makeToken(_ kind: TokenKind, presence: SourcePresence,
                                leadingTrivia: Trivia = [],
                                trailingTrivia: Trivia = []) -> TokenSyntax {
@@ -32,6 +33,7 @@ public enum SyntaxFactory {
     return TokenSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on UnknownSyntax")
   public static func makeUnknownSyntax(tokens: [TokenSyntax]) -> UnknownSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: .unknown,
       layout: tokens.map { $0.raw }, presence: .present)
@@ -47,6 +49,7 @@ public enum SyntaxFactory {
 
 
 
+  @available(*, deprecated, message: "Use initializer on UnknownDeclSyntax")
   public static func makeBlankUnknownDecl(presence: SourcePresence = .present) -> UnknownDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .unknownDecl,
       layout: [
@@ -54,6 +57,7 @@ public enum SyntaxFactory {
     return UnknownDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on UnknownExprSyntax")
   public static func makeBlankUnknownExpr(presence: SourcePresence = .present) -> UnknownExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .unknownExpr,
       layout: [
@@ -61,6 +65,7 @@ public enum SyntaxFactory {
     return UnknownExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on UnknownStmtSyntax")
   public static func makeBlankUnknownStmt(presence: SourcePresence = .present) -> UnknownStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .unknownStmt,
       layout: [
@@ -68,6 +73,7 @@ public enum SyntaxFactory {
     return UnknownStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on UnknownTypeSyntax")
   public static func makeBlankUnknownType(presence: SourcePresence = .present) -> UnknownTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .unknownType,
       layout: [
@@ -75,6 +81,7 @@ public enum SyntaxFactory {
     return UnknownTypeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on UnknownPatternSyntax")
   public static func makeBlankUnknownPattern(presence: SourcePresence = .present) -> UnknownPatternSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .unknownPattern,
       layout: [
@@ -82,6 +89,7 @@ public enum SyntaxFactory {
     return UnknownPatternSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MissingSyntax")
   public static func makeBlankMissing(presence: SourcePresence = .missing) -> MissingSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .missing,
       layout: [
@@ -89,6 +97,7 @@ public enum SyntaxFactory {
     return MissingSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MissingDeclSyntax")
   public static func makeBlankMissingDecl(presence: SourcePresence = .missing) -> MissingDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .missingDecl,
       layout: [
@@ -96,6 +105,7 @@ public enum SyntaxFactory {
     return MissingDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MissingExprSyntax")
   public static func makeBlankMissingExpr(presence: SourcePresence = .missing) -> MissingExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .missingExpr,
       layout: [
@@ -103,6 +113,7 @@ public enum SyntaxFactory {
     return MissingExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MissingStmtSyntax")
   public static func makeBlankMissingStmt(presence: SourcePresence = .missing) -> MissingStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .missingStmt,
       layout: [
@@ -110,6 +121,7 @@ public enum SyntaxFactory {
     return MissingStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MissingTypeSyntax")
   public static func makeBlankMissingType(presence: SourcePresence = .missing) -> MissingTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .missingType,
       layout: [
@@ -117,12 +129,14 @@ public enum SyntaxFactory {
     return MissingTypeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MissingPatternSyntax")
   public static func makeBlankMissingPattern(presence: SourcePresence = .missing) -> MissingPatternSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .missingPattern,
       layout: [
     ], length: .zero, presence: presence))
     return MissingPatternSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on CodeBlockItemSyntax")
   public static func makeCodeBlockItem(_ garbageBeforeItem: GarbageNodesSyntax? = nil, item: Syntax, _ garbageBetweenItemAndSemicolon: GarbageNodesSyntax? = nil, semicolon: TokenSyntax?, _ garbageBetweenSemicolonAndErrorTokens: GarbageNodesSyntax? = nil, errorTokens: Syntax?) -> CodeBlockItemSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeItem?.raw,
@@ -138,6 +152,7 @@ public enum SyntaxFactory {
     return CodeBlockItemSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on CodeBlockItemSyntax")
   public static func makeBlankCodeBlockItem(presence: SourcePresence = .present) -> CodeBlockItemSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .codeBlockItem,
       layout: [
@@ -150,6 +165,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return CodeBlockItemSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on CodeBlockItemListSyntax")
   public static func makeCodeBlockItemList(
     _ elements: [CodeBlockItemSyntax]) -> CodeBlockItemListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.codeBlockItemList,
@@ -158,12 +174,14 @@ public enum SyntaxFactory {
     return CodeBlockItemListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on CodeBlockItemListSyntax")
   public static func makeBlankCodeBlockItemList(presence: SourcePresence = .present) -> CodeBlockItemListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .codeBlockItemList,
       layout: [
     ], length: .zero, presence: presence))
     return CodeBlockItemListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on CodeBlockSyntax")
   public static func makeCodeBlock(_ garbageBeforeLeftBrace: GarbageNodesSyntax? = nil, leftBrace: TokenSyntax, _ garbageBetweenLeftBraceAndStatements: GarbageNodesSyntax? = nil, statements: CodeBlockItemListSyntax, _ garbageBetweenStatementsAndRightBrace: GarbageNodesSyntax? = nil, rightBrace: TokenSyntax) -> CodeBlockSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftBrace?.raw,
@@ -179,6 +197,7 @@ public enum SyntaxFactory {
     return CodeBlockSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on CodeBlockSyntax")
   public static func makeBlankCodeBlock(presence: SourcePresence = .present) -> CodeBlockSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .codeBlock,
       layout: [
@@ -191,6 +210,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return CodeBlockSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on GarbageNodesSyntax")
   public static func makeGarbageNodes(
     _ elements: [Syntax]) -> GarbageNodesSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.garbageNodes,
@@ -199,12 +219,14 @@ public enum SyntaxFactory {
     return GarbageNodesSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on GarbageNodesSyntax")
   public static func makeBlankGarbageNodes(presence: SourcePresence = .present) -> GarbageNodesSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .garbageNodes,
       layout: [
     ], length: .zero, presence: presence))
     return GarbageNodesSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on InOutExprSyntax")
   public static func makeInOutExpr(_ garbageBeforeAmpersand: GarbageNodesSyntax? = nil, ampersand: TokenSyntax, _ garbageBetweenAmpersandAndExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax) -> InOutExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAmpersand?.raw,
@@ -218,6 +240,7 @@ public enum SyntaxFactory {
     return InOutExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on InOutExprSyntax")
   public static func makeBlankInOutExpr(presence: SourcePresence = .present) -> InOutExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .inOutExpr,
       layout: [
@@ -228,6 +251,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return InOutExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PoundColumnExprSyntax")
   public static func makePoundColumnExpr(_ garbageBeforePoundColumn: GarbageNodesSyntax? = nil, poundColumn: TokenSyntax) -> PoundColumnExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePoundColumn?.raw,
@@ -239,6 +263,7 @@ public enum SyntaxFactory {
     return PoundColumnExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PoundColumnExprSyntax")
   public static func makeBlankPoundColumnExpr(presence: SourcePresence = .present) -> PoundColumnExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .poundColumnExpr,
       layout: [
@@ -247,6 +272,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PoundColumnExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TupleExprElementListSyntax")
   public static func makeTupleExprElementList(
     _ elements: [TupleExprElementSyntax]) -> TupleExprElementListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.tupleExprElementList,
@@ -255,12 +281,14 @@ public enum SyntaxFactory {
     return TupleExprElementListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TupleExprElementListSyntax")
   public static func makeBlankTupleExprElementList(presence: SourcePresence = .present) -> TupleExprElementListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .tupleExprElementList,
       layout: [
     ], length: .zero, presence: presence))
     return TupleExprElementListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ArrayElementListSyntax")
   public static func makeArrayElementList(
     _ elements: [ArrayElementSyntax]) -> ArrayElementListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.arrayElementList,
@@ -269,12 +297,14 @@ public enum SyntaxFactory {
     return ArrayElementListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ArrayElementListSyntax")
   public static func makeBlankArrayElementList(presence: SourcePresence = .present) -> ArrayElementListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .arrayElementList,
       layout: [
     ], length: .zero, presence: presence))
     return ArrayElementListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DictionaryElementListSyntax")
   public static func makeDictionaryElementList(
     _ elements: [DictionaryElementSyntax]) -> DictionaryElementListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.dictionaryElementList,
@@ -283,12 +313,14 @@ public enum SyntaxFactory {
     return DictionaryElementListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DictionaryElementListSyntax")
   public static func makeBlankDictionaryElementList(presence: SourcePresence = .present) -> DictionaryElementListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .dictionaryElementList,
       layout: [
     ], length: .zero, presence: presence))
     return DictionaryElementListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on StringLiteralSegmentsSyntax")
   public static func makeStringLiteralSegments(
     _ elements: [Syntax]) -> StringLiteralSegmentsSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.stringLiteralSegments,
@@ -297,12 +329,14 @@ public enum SyntaxFactory {
     return StringLiteralSegmentsSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on StringLiteralSegmentsSyntax")
   public static func makeBlankStringLiteralSegments(presence: SourcePresence = .present) -> StringLiteralSegmentsSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .stringLiteralSegments,
       layout: [
     ], length: .zero, presence: presence))
     return StringLiteralSegmentsSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TryExprSyntax")
   public static func makeTryExpr(_ garbageBeforeTryKeyword: GarbageNodesSyntax? = nil, tryKeyword: TokenSyntax, _ garbageBetweenTryKeywordAndQuestionOrExclamationMark: GarbageNodesSyntax? = nil, questionOrExclamationMark: TokenSyntax?, _ garbageBetweenQuestionOrExclamationMarkAndExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax) -> TryExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeTryKeyword?.raw,
@@ -318,6 +352,7 @@ public enum SyntaxFactory {
     return TryExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TryExprSyntax")
   public static func makeBlankTryExpr(presence: SourcePresence = .present) -> TryExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .tryExpr,
       layout: [
@@ -330,6 +365,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return TryExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AwaitExprSyntax")
   public static func makeAwaitExpr(_ garbageBeforeAwaitKeyword: GarbageNodesSyntax? = nil, awaitKeyword: TokenSyntax, _ garbageBetweenAwaitKeywordAndExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax) -> AwaitExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAwaitKeyword?.raw,
@@ -343,6 +379,7 @@ public enum SyntaxFactory {
     return AwaitExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AwaitExprSyntax")
   public static func makeBlankAwaitExpr(presence: SourcePresence = .present) -> AwaitExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .awaitExpr,
       layout: [
@@ -353,6 +390,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AwaitExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on MoveExprSyntax")
   public static func makeMoveExpr(_ garbageBeforeMoveKeyword: GarbageNodesSyntax? = nil, moveKeyword: TokenSyntax, _ garbageBetweenMoveKeywordAndExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax) -> MoveExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeMoveKeyword?.raw,
@@ -366,6 +404,7 @@ public enum SyntaxFactory {
     return MoveExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MoveExprSyntax")
   public static func makeBlankMoveExpr(presence: SourcePresence = .present) -> MoveExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .moveExpr,
       layout: [
@@ -376,6 +415,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return MoveExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DeclNameArgumentSyntax")
   public static func makeDeclNameArgument(_ garbageBeforeName: GarbageNodesSyntax? = nil, name: TokenSyntax, _ garbageBetweenNameAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax) -> DeclNameArgumentSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeName?.raw,
@@ -389,6 +429,7 @@ public enum SyntaxFactory {
     return DeclNameArgumentSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DeclNameArgumentSyntax")
   public static func makeBlankDeclNameArgument(presence: SourcePresence = .present) -> DeclNameArgumentSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .declNameArgument,
       layout: [
@@ -399,6 +440,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DeclNameArgumentSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DeclNameArgumentListSyntax")
   public static func makeDeclNameArgumentList(
     _ elements: [DeclNameArgumentSyntax]) -> DeclNameArgumentListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.declNameArgumentList,
@@ -407,12 +449,14 @@ public enum SyntaxFactory {
     return DeclNameArgumentListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DeclNameArgumentListSyntax")
   public static func makeBlankDeclNameArgumentList(presence: SourcePresence = .present) -> DeclNameArgumentListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .declNameArgumentList,
       layout: [
     ], length: .zero, presence: presence))
     return DeclNameArgumentListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DeclNameArgumentsSyntax")
   public static func makeDeclNameArguments(_ garbageBeforeLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndArguments: GarbageNodesSyntax? = nil, arguments: DeclNameArgumentListSyntax, _ garbageBetweenArgumentsAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> DeclNameArgumentsSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftParen?.raw,
@@ -428,6 +472,7 @@ public enum SyntaxFactory {
     return DeclNameArgumentsSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DeclNameArgumentsSyntax")
   public static func makeBlankDeclNameArguments(presence: SourcePresence = .present) -> DeclNameArgumentsSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .declNameArguments,
       layout: [
@@ -440,6 +485,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DeclNameArgumentsSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on IdentifierExprSyntax")
   public static func makeIdentifierExpr(_ garbageBeforeIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax, _ garbageBetweenIdentifierAndDeclNameArguments: GarbageNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?) -> IdentifierExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeIdentifier?.raw,
@@ -453,6 +499,7 @@ public enum SyntaxFactory {
     return IdentifierExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on IdentifierExprSyntax")
   public static func makeBlankIdentifierExpr(presence: SourcePresence = .present) -> IdentifierExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .identifierExpr,
       layout: [
@@ -463,6 +510,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return IdentifierExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on SuperRefExprSyntax")
   public static func makeSuperRefExpr(_ garbageBeforeSuperKeyword: GarbageNodesSyntax? = nil, superKeyword: TokenSyntax) -> SuperRefExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeSuperKeyword?.raw,
@@ -474,6 +522,7 @@ public enum SyntaxFactory {
     return SuperRefExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on SuperRefExprSyntax")
   public static func makeBlankSuperRefExpr(presence: SourcePresence = .present) -> SuperRefExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .superRefExpr,
       layout: [
@@ -482,6 +531,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return SuperRefExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on NilLiteralExprSyntax")
   public static func makeNilLiteralExpr(_ garbageBeforeNilKeyword: GarbageNodesSyntax? = nil, nilKeyword: TokenSyntax) -> NilLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeNilKeyword?.raw,
@@ -493,6 +543,7 @@ public enum SyntaxFactory {
     return NilLiteralExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on NilLiteralExprSyntax")
   public static func makeBlankNilLiteralExpr(presence: SourcePresence = .present) -> NilLiteralExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .nilLiteralExpr,
       layout: [
@@ -501,6 +552,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return NilLiteralExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DiscardAssignmentExprSyntax")
   public static func makeDiscardAssignmentExpr(_ garbageBeforeWildcard: GarbageNodesSyntax? = nil, wildcard: TokenSyntax) -> DiscardAssignmentExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeWildcard?.raw,
@@ -512,6 +564,7 @@ public enum SyntaxFactory {
     return DiscardAssignmentExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DiscardAssignmentExprSyntax")
   public static func makeBlankDiscardAssignmentExpr(presence: SourcePresence = .present) -> DiscardAssignmentExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .discardAssignmentExpr,
       layout: [
@@ -520,6 +573,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DiscardAssignmentExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AssignmentExprSyntax")
   public static func makeAssignmentExpr(_ garbageBeforeAssignToken: GarbageNodesSyntax? = nil, assignToken: TokenSyntax) -> AssignmentExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAssignToken?.raw,
@@ -531,6 +585,7 @@ public enum SyntaxFactory {
     return AssignmentExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AssignmentExprSyntax")
   public static func makeBlankAssignmentExpr(presence: SourcePresence = .present) -> AssignmentExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .assignmentExpr,
       layout: [
@@ -539,6 +594,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AssignmentExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on SequenceExprSyntax")
   public static func makeSequenceExpr(_ garbageBeforeElements: GarbageNodesSyntax? = nil, elements: ExprListSyntax) -> SequenceExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeElements?.raw,
@@ -550,6 +606,7 @@ public enum SyntaxFactory {
     return SequenceExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on SequenceExprSyntax")
   public static func makeBlankSequenceExpr(presence: SourcePresence = .present) -> SequenceExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .sequenceExpr,
       layout: [
@@ -558,6 +615,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return SequenceExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ExprListSyntax")
   public static func makeExprList(
     _ elements: [ExprSyntax]) -> ExprListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.exprList,
@@ -566,12 +624,14 @@ public enum SyntaxFactory {
     return ExprListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ExprListSyntax")
   public static func makeBlankExprList(presence: SourcePresence = .present) -> ExprListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .exprList,
       layout: [
     ], length: .zero, presence: presence))
     return ExprListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PoundLineExprSyntax")
   public static func makePoundLineExpr(_ garbageBeforePoundLine: GarbageNodesSyntax? = nil, poundLine: TokenSyntax) -> PoundLineExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePoundLine?.raw,
@@ -583,6 +643,7 @@ public enum SyntaxFactory {
     return PoundLineExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PoundLineExprSyntax")
   public static func makeBlankPoundLineExpr(presence: SourcePresence = .present) -> PoundLineExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .poundLineExpr,
       layout: [
@@ -591,6 +652,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PoundLineExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PoundFileExprSyntax")
   public static func makePoundFileExpr(_ garbageBeforePoundFile: GarbageNodesSyntax? = nil, poundFile: TokenSyntax) -> PoundFileExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePoundFile?.raw,
@@ -602,6 +664,7 @@ public enum SyntaxFactory {
     return PoundFileExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PoundFileExprSyntax")
   public static func makeBlankPoundFileExpr(presence: SourcePresence = .present) -> PoundFileExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .poundFileExpr,
       layout: [
@@ -610,6 +673,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PoundFileExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PoundFileIDExprSyntax")
   public static func makePoundFileIDExpr(_ garbageBeforePoundFileID: GarbageNodesSyntax? = nil, poundFileID: TokenSyntax) -> PoundFileIDExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePoundFileID?.raw,
@@ -621,6 +685,7 @@ public enum SyntaxFactory {
     return PoundFileIDExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PoundFileIDExprSyntax")
   public static func makeBlankPoundFileIDExpr(presence: SourcePresence = .present) -> PoundFileIDExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .poundFileIDExpr,
       layout: [
@@ -629,6 +694,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PoundFileIDExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PoundFilePathExprSyntax")
   public static func makePoundFilePathExpr(_ garbageBeforePoundFilePath: GarbageNodesSyntax? = nil, poundFilePath: TokenSyntax) -> PoundFilePathExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePoundFilePath?.raw,
@@ -640,6 +706,7 @@ public enum SyntaxFactory {
     return PoundFilePathExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PoundFilePathExprSyntax")
   public static func makeBlankPoundFilePathExpr(presence: SourcePresence = .present) -> PoundFilePathExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .poundFilePathExpr,
       layout: [
@@ -648,6 +715,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PoundFilePathExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PoundFunctionExprSyntax")
   public static func makePoundFunctionExpr(_ garbageBeforePoundFunction: GarbageNodesSyntax? = nil, poundFunction: TokenSyntax) -> PoundFunctionExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePoundFunction?.raw,
@@ -659,6 +727,7 @@ public enum SyntaxFactory {
     return PoundFunctionExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PoundFunctionExprSyntax")
   public static func makeBlankPoundFunctionExpr(presence: SourcePresence = .present) -> PoundFunctionExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .poundFunctionExpr,
       layout: [
@@ -667,6 +736,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PoundFunctionExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PoundDsohandleExprSyntax")
   public static func makePoundDsohandleExpr(_ garbageBeforePoundDsohandle: GarbageNodesSyntax? = nil, poundDsohandle: TokenSyntax) -> PoundDsohandleExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePoundDsohandle?.raw,
@@ -678,6 +748,7 @@ public enum SyntaxFactory {
     return PoundDsohandleExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PoundDsohandleExprSyntax")
   public static func makeBlankPoundDsohandleExpr(presence: SourcePresence = .present) -> PoundDsohandleExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .poundDsohandleExpr,
       layout: [
@@ -686,6 +757,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PoundDsohandleExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on SymbolicReferenceExprSyntax")
   public static func makeSymbolicReferenceExpr(_ garbageBeforeIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax, _ garbageBetweenIdentifierAndGenericArgumentClause: GarbageNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax?) -> SymbolicReferenceExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeIdentifier?.raw,
@@ -699,6 +771,7 @@ public enum SyntaxFactory {
     return SymbolicReferenceExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on SymbolicReferenceExprSyntax")
   public static func makeBlankSymbolicReferenceExpr(presence: SourcePresence = .present) -> SymbolicReferenceExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .symbolicReferenceExpr,
       layout: [
@@ -709,6 +782,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return SymbolicReferenceExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PrefixOperatorExprSyntax")
   public static func makePrefixOperatorExpr(_ garbageBeforeOperatorToken: GarbageNodesSyntax? = nil, operatorToken: TokenSyntax?, _ garbageBetweenOperatorTokenAndPostfixExpression: GarbageNodesSyntax? = nil, postfixExpression: ExprSyntax) -> PrefixOperatorExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeOperatorToken?.raw,
@@ -722,6 +796,7 @@ public enum SyntaxFactory {
     return PrefixOperatorExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PrefixOperatorExprSyntax")
   public static func makeBlankPrefixOperatorExpr(presence: SourcePresence = .present) -> PrefixOperatorExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .prefixOperatorExpr,
       layout: [
@@ -732,6 +807,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PrefixOperatorExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on BinaryOperatorExprSyntax")
   public static func makeBinaryOperatorExpr(_ garbageBeforeOperatorToken: GarbageNodesSyntax? = nil, operatorToken: TokenSyntax) -> BinaryOperatorExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeOperatorToken?.raw,
@@ -743,6 +819,7 @@ public enum SyntaxFactory {
     return BinaryOperatorExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on BinaryOperatorExprSyntax")
   public static func makeBlankBinaryOperatorExpr(presence: SourcePresence = .present) -> BinaryOperatorExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .binaryOperatorExpr,
       layout: [
@@ -751,6 +828,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return BinaryOperatorExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ArrowExprSyntax")
   public static func makeArrowExpr(_ garbageBeforeAsyncKeyword: GarbageNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ garbageBetweenAsyncKeywordAndThrowsToken: GarbageNodesSyntax? = nil, throwsToken: TokenSyntax?, _ garbageBetweenThrowsTokenAndArrowToken: GarbageNodesSyntax? = nil, arrowToken: TokenSyntax) -> ArrowExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAsyncKeyword?.raw,
@@ -766,6 +844,7 @@ public enum SyntaxFactory {
     return ArrowExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ArrowExprSyntax")
   public static func makeBlankArrowExpr(presence: SourcePresence = .present) -> ArrowExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .arrowExpr,
       layout: [
@@ -778,6 +857,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ArrowExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on InfixOperatorExprSyntax")
   public static func makeInfixOperatorExpr(_ garbageBeforeLeftOperand: GarbageNodesSyntax? = nil, leftOperand: ExprSyntax, _ garbageBetweenLeftOperandAndOperatorOperand: GarbageNodesSyntax? = nil, operatorOperand: ExprSyntax, _ garbageBetweenOperatorOperandAndRightOperand: GarbageNodesSyntax? = nil, rightOperand: ExprSyntax) -> InfixOperatorExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftOperand?.raw,
@@ -793,6 +873,7 @@ public enum SyntaxFactory {
     return InfixOperatorExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on InfixOperatorExprSyntax")
   public static func makeBlankInfixOperatorExpr(presence: SourcePresence = .present) -> InfixOperatorExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .infixOperatorExpr,
       layout: [
@@ -805,6 +886,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return InfixOperatorExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on FloatLiteralExprSyntax")
   public static func makeFloatLiteralExpr(_ garbageBeforeFloatingDigits: GarbageNodesSyntax? = nil, floatingDigits: TokenSyntax) -> FloatLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeFloatingDigits?.raw,
@@ -816,6 +898,7 @@ public enum SyntaxFactory {
     return FloatLiteralExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on FloatLiteralExprSyntax")
   public static func makeBlankFloatLiteralExpr(presence: SourcePresence = .present) -> FloatLiteralExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .floatLiteralExpr,
       layout: [
@@ -824,6 +907,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return FloatLiteralExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TupleExprSyntax")
   public static func makeTupleExpr(_ garbageBeforeLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndElementList: GarbageNodesSyntax? = nil, elementList: TupleExprElementListSyntax, _ garbageBetweenElementListAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> TupleExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftParen?.raw,
@@ -839,6 +923,7 @@ public enum SyntaxFactory {
     return TupleExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TupleExprSyntax")
   public static func makeBlankTupleExpr(presence: SourcePresence = .present) -> TupleExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .tupleExpr,
       layout: [
@@ -851,6 +936,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return TupleExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ArrayExprSyntax")
   public static func makeArrayExpr(_ garbageBeforeLeftSquare: GarbageNodesSyntax? = nil, leftSquare: TokenSyntax, _ garbageBetweenLeftSquareAndElements: GarbageNodesSyntax? = nil, elements: ArrayElementListSyntax, _ garbageBetweenElementsAndRightSquare: GarbageNodesSyntax? = nil, rightSquare: TokenSyntax) -> ArrayExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftSquare?.raw,
@@ -866,6 +952,7 @@ public enum SyntaxFactory {
     return ArrayExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ArrayExprSyntax")
   public static func makeBlankArrayExpr(presence: SourcePresence = .present) -> ArrayExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .arrayExpr,
       layout: [
@@ -878,6 +965,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ArrayExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DictionaryExprSyntax")
   public static func makeDictionaryExpr(_ garbageBeforeLeftSquare: GarbageNodesSyntax? = nil, leftSquare: TokenSyntax, _ garbageBetweenLeftSquareAndContent: GarbageNodesSyntax? = nil, content: Syntax, _ garbageBetweenContentAndRightSquare: GarbageNodesSyntax? = nil, rightSquare: TokenSyntax) -> DictionaryExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftSquare?.raw,
@@ -893,6 +981,7 @@ public enum SyntaxFactory {
     return DictionaryExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DictionaryExprSyntax")
   public static func makeBlankDictionaryExpr(presence: SourcePresence = .present) -> DictionaryExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .dictionaryExpr,
       layout: [
@@ -905,6 +994,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DictionaryExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TupleExprElementSyntax")
   public static func makeTupleExprElement(_ garbageBeforeLabel: GarbageNodesSyntax? = nil, label: TokenSyntax?, _ garbageBetweenLabelAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax?, _ garbageBetweenColonAndExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax, _ garbageBetweenExpressionAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> TupleExprElementSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLabel?.raw,
@@ -922,6 +1012,7 @@ public enum SyntaxFactory {
     return TupleExprElementSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TupleExprElementSyntax")
   public static func makeBlankTupleExprElement(presence: SourcePresence = .present) -> TupleExprElementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .tupleExprElement,
       layout: [
@@ -936,6 +1027,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return TupleExprElementSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ArrayElementSyntax")
   public static func makeArrayElement(_ garbageBeforeExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax, _ garbageBetweenExpressionAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> ArrayElementSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeExpression?.raw,
@@ -949,6 +1041,7 @@ public enum SyntaxFactory {
     return ArrayElementSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ArrayElementSyntax")
   public static func makeBlankArrayElement(presence: SourcePresence = .present) -> ArrayElementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .arrayElement,
       layout: [
@@ -959,6 +1052,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ArrayElementSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DictionaryElementSyntax")
   public static func makeDictionaryElement(_ garbageBeforeKeyExpression: GarbageNodesSyntax? = nil, keyExpression: ExprSyntax, _ garbageBetweenKeyExpressionAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndValueExpression: GarbageNodesSyntax? = nil, valueExpression: ExprSyntax, _ garbageBetweenValueExpressionAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> DictionaryElementSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeKeyExpression?.raw,
@@ -976,6 +1070,7 @@ public enum SyntaxFactory {
     return DictionaryElementSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DictionaryElementSyntax")
   public static func makeBlankDictionaryElement(presence: SourcePresence = .present) -> DictionaryElementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .dictionaryElement,
       layout: [
@@ -990,6 +1085,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DictionaryElementSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on IntegerLiteralExprSyntax")
   public static func makeIntegerLiteralExpr(_ garbageBeforeDigits: GarbageNodesSyntax? = nil, digits: TokenSyntax) -> IntegerLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeDigits?.raw,
@@ -1001,6 +1097,7 @@ public enum SyntaxFactory {
     return IntegerLiteralExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on IntegerLiteralExprSyntax")
   public static func makeBlankIntegerLiteralExpr(presence: SourcePresence = .present) -> IntegerLiteralExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .integerLiteralExpr,
       layout: [
@@ -1009,6 +1106,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return IntegerLiteralExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on BooleanLiteralExprSyntax")
   public static func makeBooleanLiteralExpr(_ garbageBeforeBooleanLiteral: GarbageNodesSyntax? = nil, booleanLiteral: TokenSyntax) -> BooleanLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeBooleanLiteral?.raw,
@@ -1020,6 +1118,7 @@ public enum SyntaxFactory {
     return BooleanLiteralExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on BooleanLiteralExprSyntax")
   public static func makeBlankBooleanLiteralExpr(presence: SourcePresence = .present) -> BooleanLiteralExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .booleanLiteralExpr,
       layout: [
@@ -1028,6 +1127,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return BooleanLiteralExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TernaryExprSyntax")
   public static func makeTernaryExpr(_ garbageBeforeConditionExpression: GarbageNodesSyntax? = nil, conditionExpression: ExprSyntax, _ garbageBetweenConditionExpressionAndQuestionMark: GarbageNodesSyntax? = nil, questionMark: TokenSyntax, _ garbageBetweenQuestionMarkAndFirstChoice: GarbageNodesSyntax? = nil, firstChoice: ExprSyntax, _ garbageBetweenFirstChoiceAndColonMark: GarbageNodesSyntax? = nil, colonMark: TokenSyntax, _ garbageBetweenColonMarkAndSecondChoice: GarbageNodesSyntax? = nil, secondChoice: ExprSyntax) -> TernaryExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeConditionExpression?.raw,
@@ -1047,6 +1147,7 @@ public enum SyntaxFactory {
     return TernaryExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TernaryExprSyntax")
   public static func makeBlankTernaryExpr(presence: SourcePresence = .present) -> TernaryExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .ternaryExpr,
       layout: [
@@ -1063,6 +1164,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return TernaryExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on MemberAccessExprSyntax")
   public static func makeMemberAccessExpr(_ garbageBeforeBase: GarbageNodesSyntax? = nil, base: ExprSyntax?, _ garbageBetweenBaseAndDot: GarbageNodesSyntax? = nil, dot: TokenSyntax, _ garbageBetweenDotAndName: GarbageNodesSyntax? = nil, name: TokenSyntax, _ garbageBetweenNameAndDeclNameArguments: GarbageNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?) -> MemberAccessExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeBase?.raw,
@@ -1080,6 +1182,7 @@ public enum SyntaxFactory {
     return MemberAccessExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MemberAccessExprSyntax")
   public static func makeBlankMemberAccessExpr(presence: SourcePresence = .present) -> MemberAccessExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .memberAccessExpr,
       layout: [
@@ -1094,6 +1197,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return MemberAccessExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on IsExprSyntax")
   public static func makeIsExpr(_ garbageBeforeIsTok: GarbageNodesSyntax? = nil, isTok: TokenSyntax, _ garbageBetweenIsTokAndTypeName: GarbageNodesSyntax? = nil, typeName: TypeSyntax) -> IsExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeIsTok?.raw,
@@ -1107,6 +1211,7 @@ public enum SyntaxFactory {
     return IsExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on IsExprSyntax")
   public static func makeBlankIsExpr(presence: SourcePresence = .present) -> IsExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .isExpr,
       layout: [
@@ -1117,6 +1222,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return IsExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AsExprSyntax")
   public static func makeAsExpr(_ garbageBeforeAsTok: GarbageNodesSyntax? = nil, asTok: TokenSyntax, _ garbageBetweenAsTokAndQuestionOrExclamationMark: GarbageNodesSyntax? = nil, questionOrExclamationMark: TokenSyntax?, _ garbageBetweenQuestionOrExclamationMarkAndTypeName: GarbageNodesSyntax? = nil, typeName: TypeSyntax) -> AsExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAsTok?.raw,
@@ -1132,6 +1238,7 @@ public enum SyntaxFactory {
     return AsExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AsExprSyntax")
   public static func makeBlankAsExpr(presence: SourcePresence = .present) -> AsExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .asExpr,
       layout: [
@@ -1144,6 +1251,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AsExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TypeExprSyntax")
   public static func makeTypeExpr(_ garbageBeforeType: GarbageNodesSyntax? = nil, type: TypeSyntax) -> TypeExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeType?.raw,
@@ -1155,6 +1263,7 @@ public enum SyntaxFactory {
     return TypeExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TypeExprSyntax")
   public static func makeBlankTypeExpr(presence: SourcePresence = .present) -> TypeExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .typeExpr,
       layout: [
@@ -1163,6 +1272,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return TypeExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ClosureCaptureItemSyntax")
   public static func makeClosureCaptureItem(_ garbageBeforeSpecifier: GarbageNodesSyntax? = nil, specifier: TokenListSyntax?, _ garbageBetweenSpecifierAndName: GarbageNodesSyntax? = nil, name: TokenSyntax?, _ garbageBetweenNameAndAssignToken: GarbageNodesSyntax? = nil, assignToken: TokenSyntax?, _ garbageBetweenAssignTokenAndExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax, _ garbageBetweenExpressionAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> ClosureCaptureItemSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeSpecifier?.raw,
@@ -1182,6 +1292,7 @@ public enum SyntaxFactory {
     return ClosureCaptureItemSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ClosureCaptureItemSyntax")
   public static func makeBlankClosureCaptureItem(presence: SourcePresence = .present) -> ClosureCaptureItemSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .closureCaptureItem,
       layout: [
@@ -1198,6 +1309,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ClosureCaptureItemSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ClosureCaptureItemListSyntax")
   public static func makeClosureCaptureItemList(
     _ elements: [ClosureCaptureItemSyntax]) -> ClosureCaptureItemListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.closureCaptureItemList,
@@ -1206,12 +1318,14 @@ public enum SyntaxFactory {
     return ClosureCaptureItemListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ClosureCaptureItemListSyntax")
   public static func makeBlankClosureCaptureItemList(presence: SourcePresence = .present) -> ClosureCaptureItemListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .closureCaptureItemList,
       layout: [
     ], length: .zero, presence: presence))
     return ClosureCaptureItemListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ClosureCaptureSignatureSyntax")
   public static func makeClosureCaptureSignature(_ garbageBeforeLeftSquare: GarbageNodesSyntax? = nil, leftSquare: TokenSyntax, _ garbageBetweenLeftSquareAndItems: GarbageNodesSyntax? = nil, items: ClosureCaptureItemListSyntax?, _ garbageBetweenItemsAndRightSquare: GarbageNodesSyntax? = nil, rightSquare: TokenSyntax) -> ClosureCaptureSignatureSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftSquare?.raw,
@@ -1227,6 +1341,7 @@ public enum SyntaxFactory {
     return ClosureCaptureSignatureSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ClosureCaptureSignatureSyntax")
   public static func makeBlankClosureCaptureSignature(presence: SourcePresence = .present) -> ClosureCaptureSignatureSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .closureCaptureSignature,
       layout: [
@@ -1239,6 +1354,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ClosureCaptureSignatureSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ClosureParamSyntax")
   public static func makeClosureParam(_ garbageBeforeName: GarbageNodesSyntax? = nil, name: TokenSyntax, _ garbageBetweenNameAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> ClosureParamSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeName?.raw,
@@ -1252,6 +1368,7 @@ public enum SyntaxFactory {
     return ClosureParamSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ClosureParamSyntax")
   public static func makeBlankClosureParam(presence: SourcePresence = .present) -> ClosureParamSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .closureParam,
       layout: [
@@ -1262,6 +1379,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ClosureParamSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ClosureParamListSyntax")
   public static func makeClosureParamList(
     _ elements: [ClosureParamSyntax]) -> ClosureParamListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.closureParamList,
@@ -1270,12 +1388,14 @@ public enum SyntaxFactory {
     return ClosureParamListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ClosureParamListSyntax")
   public static func makeBlankClosureParamList(presence: SourcePresence = .present) -> ClosureParamListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .closureParamList,
       layout: [
     ], length: .zero, presence: presence))
     return ClosureParamListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ClosureSignatureSyntax")
   public static func makeClosureSignature(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndCapture: GarbageNodesSyntax? = nil, capture: ClosureCaptureSignatureSyntax?, _ garbageBetweenCaptureAndInput: GarbageNodesSyntax? = nil, input: Syntax?, _ garbageBetweenInputAndAsyncKeyword: GarbageNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ garbageBetweenAsyncKeywordAndThrowsTok: GarbageNodesSyntax? = nil, throwsTok: TokenSyntax?, _ garbageBetweenThrowsTokAndOutput: GarbageNodesSyntax? = nil, output: ReturnClauseSyntax?, _ garbageBetweenOutputAndInTok: GarbageNodesSyntax? = nil, inTok: TokenSyntax) -> ClosureSignatureSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -1299,6 +1419,7 @@ public enum SyntaxFactory {
     return ClosureSignatureSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ClosureSignatureSyntax")
   public static func makeBlankClosureSignature(presence: SourcePresence = .present) -> ClosureSignatureSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .closureSignature,
       layout: [
@@ -1319,6 +1440,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ClosureSignatureSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ClosureExprSyntax")
   public static func makeClosureExpr(_ garbageBeforeLeftBrace: GarbageNodesSyntax? = nil, leftBrace: TokenSyntax, _ garbageBetweenLeftBraceAndSignature: GarbageNodesSyntax? = nil, signature: ClosureSignatureSyntax?, _ garbageBetweenSignatureAndStatements: GarbageNodesSyntax? = nil, statements: CodeBlockItemListSyntax, _ garbageBetweenStatementsAndRightBrace: GarbageNodesSyntax? = nil, rightBrace: TokenSyntax) -> ClosureExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftBrace?.raw,
@@ -1336,6 +1458,7 @@ public enum SyntaxFactory {
     return ClosureExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ClosureExprSyntax")
   public static func makeBlankClosureExpr(presence: SourcePresence = .present) -> ClosureExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .closureExpr,
       layout: [
@@ -1350,6 +1473,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ClosureExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on UnresolvedPatternExprSyntax")
   public static func makeUnresolvedPatternExpr(_ garbageBeforePattern: GarbageNodesSyntax? = nil, pattern: PatternSyntax) -> UnresolvedPatternExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePattern?.raw,
@@ -1361,6 +1485,7 @@ public enum SyntaxFactory {
     return UnresolvedPatternExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on UnresolvedPatternExprSyntax")
   public static func makeBlankUnresolvedPatternExpr(presence: SourcePresence = .present) -> UnresolvedPatternExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .unresolvedPatternExpr,
       layout: [
@@ -1369,6 +1494,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return UnresolvedPatternExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on MultipleTrailingClosureElementSyntax")
   public static func makeMultipleTrailingClosureElement(_ garbageBeforeLabel: GarbageNodesSyntax? = nil, label: TokenSyntax, _ garbageBetweenLabelAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndClosure: GarbageNodesSyntax? = nil, closure: ClosureExprSyntax) -> MultipleTrailingClosureElementSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLabel?.raw,
@@ -1384,6 +1510,7 @@ public enum SyntaxFactory {
     return MultipleTrailingClosureElementSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MultipleTrailingClosureElementSyntax")
   public static func makeBlankMultipleTrailingClosureElement(presence: SourcePresence = .present) -> MultipleTrailingClosureElementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .multipleTrailingClosureElement,
       layout: [
@@ -1396,6 +1523,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return MultipleTrailingClosureElementSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on MultipleTrailingClosureElementListSyntax")
   public static func makeMultipleTrailingClosureElementList(
     _ elements: [MultipleTrailingClosureElementSyntax]) -> MultipleTrailingClosureElementListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.multipleTrailingClosureElementList,
@@ -1404,12 +1532,14 @@ public enum SyntaxFactory {
     return MultipleTrailingClosureElementListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MultipleTrailingClosureElementListSyntax")
   public static func makeBlankMultipleTrailingClosureElementList(presence: SourcePresence = .present) -> MultipleTrailingClosureElementListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .multipleTrailingClosureElementList,
       layout: [
     ], length: .zero, presence: presence))
     return MultipleTrailingClosureElementListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on FunctionCallExprSyntax")
   public static func makeFunctionCallExpr(_ garbageBeforeCalledExpression: GarbageNodesSyntax? = nil, calledExpression: ExprSyntax, _ garbageBetweenCalledExpressionAndLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax?, _ garbageBetweenLeftParenAndArgumentList: GarbageNodesSyntax? = nil, argumentList: TupleExprElementListSyntax, _ garbageBetweenArgumentListAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax?, _ garbageBetweenRightParenAndTrailingClosure: GarbageNodesSyntax? = nil, trailingClosure: ClosureExprSyntax?, _ garbageBetweenTrailingClosureAndAdditionalTrailingClosures: GarbageNodesSyntax? = nil, additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?) -> FunctionCallExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeCalledExpression?.raw,
@@ -1431,6 +1561,7 @@ public enum SyntaxFactory {
     return FunctionCallExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on FunctionCallExprSyntax")
   public static func makeBlankFunctionCallExpr(presence: SourcePresence = .present) -> FunctionCallExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .functionCallExpr,
       layout: [
@@ -1449,6 +1580,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return FunctionCallExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on SubscriptExprSyntax")
   public static func makeSubscriptExpr(_ garbageBeforeCalledExpression: GarbageNodesSyntax? = nil, calledExpression: ExprSyntax, _ garbageBetweenCalledExpressionAndLeftBracket: GarbageNodesSyntax? = nil, leftBracket: TokenSyntax, _ garbageBetweenLeftBracketAndArgumentList: GarbageNodesSyntax? = nil, argumentList: TupleExprElementListSyntax, _ garbageBetweenArgumentListAndRightBracket: GarbageNodesSyntax? = nil, rightBracket: TokenSyntax, _ garbageBetweenRightBracketAndTrailingClosure: GarbageNodesSyntax? = nil, trailingClosure: ClosureExprSyntax?, _ garbageBetweenTrailingClosureAndAdditionalTrailingClosures: GarbageNodesSyntax? = nil, additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?) -> SubscriptExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeCalledExpression?.raw,
@@ -1470,6 +1602,7 @@ public enum SyntaxFactory {
     return SubscriptExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on SubscriptExprSyntax")
   public static func makeBlankSubscriptExpr(presence: SourcePresence = .present) -> SubscriptExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .subscriptExpr,
       layout: [
@@ -1488,6 +1621,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return SubscriptExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on OptionalChainingExprSyntax")
   public static func makeOptionalChainingExpr(_ garbageBeforeExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax, _ garbageBetweenExpressionAndQuestionMark: GarbageNodesSyntax? = nil, questionMark: TokenSyntax) -> OptionalChainingExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeExpression?.raw,
@@ -1501,6 +1635,7 @@ public enum SyntaxFactory {
     return OptionalChainingExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on OptionalChainingExprSyntax")
   public static func makeBlankOptionalChainingExpr(presence: SourcePresence = .present) -> OptionalChainingExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .optionalChainingExpr,
       layout: [
@@ -1511,6 +1646,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return OptionalChainingExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ForcedValueExprSyntax")
   public static func makeForcedValueExpr(_ garbageBeforeExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax, _ garbageBetweenExpressionAndExclamationMark: GarbageNodesSyntax? = nil, exclamationMark: TokenSyntax) -> ForcedValueExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeExpression?.raw,
@@ -1524,6 +1660,7 @@ public enum SyntaxFactory {
     return ForcedValueExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ForcedValueExprSyntax")
   public static func makeBlankForcedValueExpr(presence: SourcePresence = .present) -> ForcedValueExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .forcedValueExpr,
       layout: [
@@ -1534,6 +1671,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ForcedValueExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PostfixUnaryExprSyntax")
   public static func makePostfixUnaryExpr(_ garbageBeforeExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax, _ garbageBetweenExpressionAndOperatorToken: GarbageNodesSyntax? = nil, operatorToken: TokenSyntax) -> PostfixUnaryExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeExpression?.raw,
@@ -1547,6 +1685,7 @@ public enum SyntaxFactory {
     return PostfixUnaryExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PostfixUnaryExprSyntax")
   public static func makeBlankPostfixUnaryExpr(presence: SourcePresence = .present) -> PostfixUnaryExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .postfixUnaryExpr,
       layout: [
@@ -1557,6 +1696,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PostfixUnaryExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on SpecializeExprSyntax")
   public static func makeSpecializeExpr(_ garbageBeforeExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax, _ garbageBetweenExpressionAndGenericArgumentClause: GarbageNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax) -> SpecializeExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeExpression?.raw,
@@ -1570,6 +1710,7 @@ public enum SyntaxFactory {
     return SpecializeExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on SpecializeExprSyntax")
   public static func makeBlankSpecializeExpr(presence: SourcePresence = .present) -> SpecializeExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .specializeExpr,
       layout: [
@@ -1580,6 +1721,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return SpecializeExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on StringSegmentSyntax")
   public static func makeStringSegment(_ garbageBeforeContent: GarbageNodesSyntax? = nil, content: TokenSyntax) -> StringSegmentSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeContent?.raw,
@@ -1591,6 +1733,7 @@ public enum SyntaxFactory {
     return StringSegmentSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on StringSegmentSyntax")
   public static func makeBlankStringSegment(presence: SourcePresence = .present) -> StringSegmentSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .stringSegment,
       layout: [
@@ -1599,6 +1742,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return StringSegmentSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ExpressionSegmentSyntax")
   public static func makeExpressionSegment(_ garbageBeforeBackslash: GarbageNodesSyntax? = nil, backslash: TokenSyntax, _ garbageBetweenBackslashAndDelimiter: GarbageNodesSyntax? = nil, delimiter: TokenSyntax?, _ garbageBetweenDelimiterAndLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndExpressions: GarbageNodesSyntax? = nil, expressions: TupleExprElementListSyntax, _ garbageBetweenExpressionsAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> ExpressionSegmentSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeBackslash?.raw,
@@ -1618,6 +1762,7 @@ public enum SyntaxFactory {
     return ExpressionSegmentSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ExpressionSegmentSyntax")
   public static func makeBlankExpressionSegment(presence: SourcePresence = .present) -> ExpressionSegmentSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .expressionSegment,
       layout: [
@@ -1634,6 +1779,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ExpressionSegmentSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on StringLiteralExprSyntax")
   public static func makeStringLiteralExpr(_ garbageBeforeOpenDelimiter: GarbageNodesSyntax? = nil, openDelimiter: TokenSyntax?, _ garbageBetweenOpenDelimiterAndOpenQuote: GarbageNodesSyntax? = nil, openQuote: TokenSyntax, _ garbageBetweenOpenQuoteAndSegments: GarbageNodesSyntax? = nil, segments: StringLiteralSegmentsSyntax, _ garbageBetweenSegmentsAndCloseQuote: GarbageNodesSyntax? = nil, closeQuote: TokenSyntax, _ garbageBetweenCloseQuoteAndCloseDelimiter: GarbageNodesSyntax? = nil, closeDelimiter: TokenSyntax?) -> StringLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeOpenDelimiter?.raw,
@@ -1653,6 +1799,7 @@ public enum SyntaxFactory {
     return StringLiteralExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on StringLiteralExprSyntax")
   public static func makeBlankStringLiteralExpr(presence: SourcePresence = .present) -> StringLiteralExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .stringLiteralExpr,
       layout: [
@@ -1669,6 +1816,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return StringLiteralExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on RegexLiteralExprSyntax")
   public static func makeRegexLiteralExpr(_ garbageBeforeRegex: GarbageNodesSyntax? = nil, regex: TokenSyntax) -> RegexLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeRegex?.raw,
@@ -1680,6 +1828,7 @@ public enum SyntaxFactory {
     return RegexLiteralExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on RegexLiteralExprSyntax")
   public static func makeBlankRegexLiteralExpr(presence: SourcePresence = .present) -> RegexLiteralExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .regexLiteralExpr,
       layout: [
@@ -1688,6 +1837,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return RegexLiteralExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on KeyPathExprSyntax")
   public static func makeKeyPathExpr(_ garbageBeforeBackslash: GarbageNodesSyntax? = nil, backslash: TokenSyntax, _ garbageBetweenBackslashAndRootExpr: GarbageNodesSyntax? = nil, rootExpr: ExprSyntax?, _ garbageBetweenRootExprAndExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax) -> KeyPathExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeBackslash?.raw,
@@ -1703,6 +1853,7 @@ public enum SyntaxFactory {
     return KeyPathExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on KeyPathExprSyntax")
   public static func makeBlankKeyPathExpr(presence: SourcePresence = .present) -> KeyPathExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .keyPathExpr,
       layout: [
@@ -1715,6 +1866,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return KeyPathExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on KeyPathBaseExprSyntax")
   public static func makeKeyPathBaseExpr(_ garbageBeforePeriod: GarbageNodesSyntax? = nil, period: TokenSyntax) -> KeyPathBaseExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePeriod?.raw,
@@ -1726,6 +1878,7 @@ public enum SyntaxFactory {
     return KeyPathBaseExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on KeyPathBaseExprSyntax")
   public static func makeBlankKeyPathBaseExpr(presence: SourcePresence = .present) -> KeyPathBaseExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .keyPathBaseExpr,
       layout: [
@@ -1734,6 +1887,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return KeyPathBaseExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ObjcNamePieceSyntax")
   public static func makeObjcNamePiece(_ garbageBeforeName: GarbageNodesSyntax? = nil, name: TokenSyntax, _ garbageBetweenNameAndDot: GarbageNodesSyntax? = nil, dot: TokenSyntax?) -> ObjcNamePieceSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeName?.raw,
@@ -1747,6 +1901,7 @@ public enum SyntaxFactory {
     return ObjcNamePieceSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ObjcNamePieceSyntax")
   public static func makeBlankObjcNamePiece(presence: SourcePresence = .present) -> ObjcNamePieceSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .objcNamePiece,
       layout: [
@@ -1757,6 +1912,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ObjcNamePieceSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ObjcNameSyntax")
   public static func makeObjcName(
     _ elements: [ObjcNamePieceSyntax]) -> ObjcNameSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.objcName,
@@ -1765,12 +1921,14 @@ public enum SyntaxFactory {
     return ObjcNameSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ObjcNameSyntax")
   public static func makeBlankObjcName(presence: SourcePresence = .present) -> ObjcNameSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .objcName,
       layout: [
     ], length: .zero, presence: presence))
     return ObjcNameSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ObjcKeyPathExprSyntax")
   public static func makeObjcKeyPathExpr(_ garbageBeforeKeyPath: GarbageNodesSyntax? = nil, keyPath: TokenSyntax, _ garbageBetweenKeyPathAndLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndName: GarbageNodesSyntax? = nil, name: ObjcNameSyntax, _ garbageBetweenNameAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> ObjcKeyPathExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeKeyPath?.raw,
@@ -1788,6 +1946,7 @@ public enum SyntaxFactory {
     return ObjcKeyPathExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ObjcKeyPathExprSyntax")
   public static func makeBlankObjcKeyPathExpr(presence: SourcePresence = .present) -> ObjcKeyPathExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .objcKeyPathExpr,
       layout: [
@@ -1802,6 +1961,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ObjcKeyPathExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ObjcSelectorExprSyntax")
   public static func makeObjcSelectorExpr(_ garbageBeforePoundSelector: GarbageNodesSyntax? = nil, poundSelector: TokenSyntax, _ garbageBetweenPoundSelectorAndLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndKind: GarbageNodesSyntax? = nil, kind: TokenSyntax?, _ garbageBetweenKindAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax?, _ garbageBetweenColonAndName: GarbageNodesSyntax? = nil, name: ExprSyntax, _ garbageBetweenNameAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> ObjcSelectorExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePoundSelector?.raw,
@@ -1823,6 +1983,7 @@ public enum SyntaxFactory {
     return ObjcSelectorExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ObjcSelectorExprSyntax")
   public static func makeBlankObjcSelectorExpr(presence: SourcePresence = .present) -> ObjcSelectorExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .objcSelectorExpr,
       layout: [
@@ -1841,6 +2002,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ObjcSelectorExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PostfixIfConfigExprSyntax")
   public static func makePostfixIfConfigExpr(_ garbageBeforeBase: GarbageNodesSyntax? = nil, base: ExprSyntax?, _ garbageBetweenBaseAndConfig: GarbageNodesSyntax? = nil, config: IfConfigDeclSyntax) -> PostfixIfConfigExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeBase?.raw,
@@ -1854,6 +2016,7 @@ public enum SyntaxFactory {
     return PostfixIfConfigExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PostfixIfConfigExprSyntax")
   public static func makeBlankPostfixIfConfigExpr(presence: SourcePresence = .present) -> PostfixIfConfigExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .postfixIfConfigExpr,
       layout: [
@@ -1864,6 +2027,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PostfixIfConfigExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on EditorPlaceholderExprSyntax")
   public static func makeEditorPlaceholderExpr(_ garbageBeforeIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax) -> EditorPlaceholderExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeIdentifier?.raw,
@@ -1875,6 +2039,7 @@ public enum SyntaxFactory {
     return EditorPlaceholderExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on EditorPlaceholderExprSyntax")
   public static func makeBlankEditorPlaceholderExpr(presence: SourcePresence = .present) -> EditorPlaceholderExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .editorPlaceholderExpr,
       layout: [
@@ -1883,6 +2048,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return EditorPlaceholderExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ObjectLiteralExprSyntax")
   public static func makeObjectLiteralExpr(_ garbageBeforeIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax, _ garbageBetweenIdentifierAndLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndArguments: GarbageNodesSyntax? = nil, arguments: TupleExprElementListSyntax, _ garbageBetweenArgumentsAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> ObjectLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeIdentifier?.raw,
@@ -1900,6 +2066,7 @@ public enum SyntaxFactory {
     return ObjectLiteralExprSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ObjectLiteralExprSyntax")
   public static func makeBlankObjectLiteralExpr(presence: SourcePresence = .present) -> ObjectLiteralExprSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .objectLiteralExpr,
       layout: [
@@ -1914,6 +2081,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ObjectLiteralExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TypeInitializerClauseSyntax")
   public static func makeTypeInitializerClause(_ garbageBeforeEqual: GarbageNodesSyntax? = nil, equal: TokenSyntax, _ garbageBetweenEqualAndValue: GarbageNodesSyntax? = nil, value: TypeSyntax) -> TypeInitializerClauseSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeEqual?.raw,
@@ -1927,6 +2095,7 @@ public enum SyntaxFactory {
     return TypeInitializerClauseSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TypeInitializerClauseSyntax")
   public static func makeBlankTypeInitializerClause(presence: SourcePresence = .present) -> TypeInitializerClauseSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .typeInitializerClause,
       layout: [
@@ -1937,6 +2106,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return TypeInitializerClauseSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TypealiasDeclSyntax")
   public static func makeTypealiasDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndTypealiasKeyword: GarbageNodesSyntax? = nil, typealiasKeyword: TokenSyntax, _ garbageBetweenTypealiasKeywordAndIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax, _ garbageBetweenIdentifierAndGenericParameterClause: GarbageNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ garbageBetweenGenericParameterClauseAndInitializer: GarbageNodesSyntax? = nil, initializer: TypeInitializerClauseSyntax, _ garbageBetweenInitializerAndGenericWhereClause: GarbageNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?) -> TypealiasDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -1960,6 +2130,7 @@ public enum SyntaxFactory {
     return TypealiasDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TypealiasDeclSyntax")
   public static func makeBlankTypealiasDecl(presence: SourcePresence = .present) -> TypealiasDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .typealiasDecl,
       layout: [
@@ -1980,6 +2151,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return TypealiasDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AssociatedtypeDeclSyntax")
   public static func makeAssociatedtypeDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndAssociatedtypeKeyword: GarbageNodesSyntax? = nil, associatedtypeKeyword: TokenSyntax, _ garbageBetweenAssociatedtypeKeywordAndIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax, _ garbageBetweenIdentifierAndInheritanceClause: GarbageNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ garbageBetweenInheritanceClauseAndInitializer: GarbageNodesSyntax? = nil, initializer: TypeInitializerClauseSyntax?, _ garbageBetweenInitializerAndGenericWhereClause: GarbageNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?) -> AssociatedtypeDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -2003,6 +2175,7 @@ public enum SyntaxFactory {
     return AssociatedtypeDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AssociatedtypeDeclSyntax")
   public static func makeBlankAssociatedtypeDecl(presence: SourcePresence = .present) -> AssociatedtypeDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .associatedtypeDecl,
       layout: [
@@ -2023,6 +2196,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AssociatedtypeDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on FunctionParameterListSyntax")
   public static func makeFunctionParameterList(
     _ elements: [FunctionParameterSyntax]) -> FunctionParameterListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.functionParameterList,
@@ -2031,12 +2205,14 @@ public enum SyntaxFactory {
     return FunctionParameterListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on FunctionParameterListSyntax")
   public static func makeBlankFunctionParameterList(presence: SourcePresence = .present) -> FunctionParameterListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .functionParameterList,
       layout: [
     ], length: .zero, presence: presence))
     return FunctionParameterListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ParameterClauseSyntax")
   public static func makeParameterClause(_ garbageBeforeLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndParameterList: GarbageNodesSyntax? = nil, parameterList: FunctionParameterListSyntax, _ garbageBetweenParameterListAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> ParameterClauseSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftParen?.raw,
@@ -2052,6 +2228,7 @@ public enum SyntaxFactory {
     return ParameterClauseSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ParameterClauseSyntax")
   public static func makeBlankParameterClause(presence: SourcePresence = .present) -> ParameterClauseSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .parameterClause,
       layout: [
@@ -2064,6 +2241,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ParameterClauseSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ReturnClauseSyntax")
   public static func makeReturnClause(_ garbageBeforeArrow: GarbageNodesSyntax? = nil, arrow: TokenSyntax, _ garbageBetweenArrowAndReturnType: GarbageNodesSyntax? = nil, returnType: TypeSyntax) -> ReturnClauseSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeArrow?.raw,
@@ -2077,6 +2255,7 @@ public enum SyntaxFactory {
     return ReturnClauseSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ReturnClauseSyntax")
   public static func makeBlankReturnClause(presence: SourcePresence = .present) -> ReturnClauseSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .returnClause,
       layout: [
@@ -2087,6 +2266,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ReturnClauseSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on FunctionSignatureSyntax")
   public static func makeFunctionSignature(_ garbageBeforeInput: GarbageNodesSyntax? = nil, input: ParameterClauseSyntax, _ garbageBetweenInputAndAsyncOrReasyncKeyword: GarbageNodesSyntax? = nil, asyncOrReasyncKeyword: TokenSyntax?, _ garbageBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: GarbageNodesSyntax? = nil, throwsOrRethrowsKeyword: TokenSyntax?, _ garbageBetweenThrowsOrRethrowsKeywordAndOutput: GarbageNodesSyntax? = nil, output: ReturnClauseSyntax?) -> FunctionSignatureSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeInput?.raw,
@@ -2104,6 +2284,7 @@ public enum SyntaxFactory {
     return FunctionSignatureSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on FunctionSignatureSyntax")
   public static func makeBlankFunctionSignature(presence: SourcePresence = .present) -> FunctionSignatureSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .functionSignature,
       layout: [
@@ -2118,6 +2299,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return FunctionSignatureSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on IfConfigClauseSyntax")
   public static func makeIfConfigClause(_ garbageBeforePoundKeyword: GarbageNodesSyntax? = nil, poundKeyword: TokenSyntax, _ garbageBetweenPoundKeywordAndCondition: GarbageNodesSyntax? = nil, condition: ExprSyntax?, _ garbageBetweenConditionAndElements: GarbageNodesSyntax? = nil, elements: Syntax) -> IfConfigClauseSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePoundKeyword?.raw,
@@ -2133,6 +2315,7 @@ public enum SyntaxFactory {
     return IfConfigClauseSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on IfConfigClauseSyntax")
   public static func makeBlankIfConfigClause(presence: SourcePresence = .present) -> IfConfigClauseSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .ifConfigClause,
       layout: [
@@ -2145,6 +2328,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return IfConfigClauseSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on IfConfigClauseListSyntax")
   public static func makeIfConfigClauseList(
     _ elements: [IfConfigClauseSyntax]) -> IfConfigClauseListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.ifConfigClauseList,
@@ -2153,12 +2337,14 @@ public enum SyntaxFactory {
     return IfConfigClauseListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on IfConfigClauseListSyntax")
   public static func makeBlankIfConfigClauseList(presence: SourcePresence = .present) -> IfConfigClauseListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .ifConfigClauseList,
       layout: [
     ], length: .zero, presence: presence))
     return IfConfigClauseListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on IfConfigDeclSyntax")
   public static func makeIfConfigDecl(_ garbageBeforeClauses: GarbageNodesSyntax? = nil, clauses: IfConfigClauseListSyntax, _ garbageBetweenClausesAndPoundEndif: GarbageNodesSyntax? = nil, poundEndif: TokenSyntax) -> IfConfigDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeClauses?.raw,
@@ -2172,6 +2358,7 @@ public enum SyntaxFactory {
     return IfConfigDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on IfConfigDeclSyntax")
   public static func makeBlankIfConfigDecl(presence: SourcePresence = .present) -> IfConfigDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .ifConfigDecl,
       layout: [
@@ -2182,6 +2369,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return IfConfigDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PoundErrorDeclSyntax")
   public static func makePoundErrorDecl(_ garbageBeforePoundError: GarbageNodesSyntax? = nil, poundError: TokenSyntax, _ garbageBetweenPoundErrorAndLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndMessage: GarbageNodesSyntax? = nil, message: StringLiteralExprSyntax, _ garbageBetweenMessageAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> PoundErrorDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePoundError?.raw,
@@ -2199,6 +2387,7 @@ public enum SyntaxFactory {
     return PoundErrorDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PoundErrorDeclSyntax")
   public static func makeBlankPoundErrorDecl(presence: SourcePresence = .present) -> PoundErrorDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .poundErrorDecl,
       layout: [
@@ -2213,6 +2402,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PoundErrorDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PoundWarningDeclSyntax")
   public static func makePoundWarningDecl(_ garbageBeforePoundWarning: GarbageNodesSyntax? = nil, poundWarning: TokenSyntax, _ garbageBetweenPoundWarningAndLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndMessage: GarbageNodesSyntax? = nil, message: StringLiteralExprSyntax, _ garbageBetweenMessageAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> PoundWarningDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePoundWarning?.raw,
@@ -2230,6 +2420,7 @@ public enum SyntaxFactory {
     return PoundWarningDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PoundWarningDeclSyntax")
   public static func makeBlankPoundWarningDecl(presence: SourcePresence = .present) -> PoundWarningDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .poundWarningDecl,
       layout: [
@@ -2244,6 +2435,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PoundWarningDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PoundSourceLocationSyntax")
   public static func makePoundSourceLocation(_ garbageBeforePoundSourceLocation: GarbageNodesSyntax? = nil, poundSourceLocation: TokenSyntax, _ garbageBetweenPoundSourceLocationAndLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndArgs: GarbageNodesSyntax? = nil, args: PoundSourceLocationArgsSyntax?, _ garbageBetweenArgsAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> PoundSourceLocationSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePoundSourceLocation?.raw,
@@ -2261,6 +2453,7 @@ public enum SyntaxFactory {
     return PoundSourceLocationSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PoundSourceLocationSyntax")
   public static func makeBlankPoundSourceLocation(presence: SourcePresence = .present) -> PoundSourceLocationSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .poundSourceLocation,
       layout: [
@@ -2275,6 +2468,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PoundSourceLocationSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PoundSourceLocationArgsSyntax")
   public static func makePoundSourceLocationArgs(_ garbageBeforeFileArgLabel: GarbageNodesSyntax? = nil, fileArgLabel: TokenSyntax, _ garbageBetweenFileArgLabelAndFileArgColon: GarbageNodesSyntax? = nil, fileArgColon: TokenSyntax, _ garbageBetweenFileArgColonAndFileName: GarbageNodesSyntax? = nil, fileName: TokenSyntax, _ garbageBetweenFileNameAndComma: GarbageNodesSyntax? = nil, comma: TokenSyntax, _ garbageBetweenCommaAndLineArgLabel: GarbageNodesSyntax? = nil, lineArgLabel: TokenSyntax, _ garbageBetweenLineArgLabelAndLineArgColon: GarbageNodesSyntax? = nil, lineArgColon: TokenSyntax, _ garbageBetweenLineArgColonAndLineNumber: GarbageNodesSyntax? = nil, lineNumber: TokenSyntax) -> PoundSourceLocationArgsSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeFileArgLabel?.raw,
@@ -2298,6 +2492,7 @@ public enum SyntaxFactory {
     return PoundSourceLocationArgsSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PoundSourceLocationArgsSyntax")
   public static func makeBlankPoundSourceLocationArgs(presence: SourcePresence = .present) -> PoundSourceLocationArgsSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .poundSourceLocationArgs,
       layout: [
@@ -2318,6 +2513,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PoundSourceLocationArgsSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DeclModifierDetailSyntax")
   public static func makeDeclModifierDetail(_ garbageBeforeLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndDetail: GarbageNodesSyntax? = nil, detail: TokenSyntax, _ garbageBetweenDetailAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> DeclModifierDetailSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftParen?.raw,
@@ -2333,6 +2529,7 @@ public enum SyntaxFactory {
     return DeclModifierDetailSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DeclModifierDetailSyntax")
   public static func makeBlankDeclModifierDetail(presence: SourcePresence = .present) -> DeclModifierDetailSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .declModifierDetail,
       layout: [
@@ -2345,6 +2542,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DeclModifierDetailSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DeclModifierSyntax")
   public static func makeDeclModifier(_ garbageBeforeName: GarbageNodesSyntax? = nil, name: TokenSyntax, _ garbageBetweenNameAndDetail: GarbageNodesSyntax? = nil, detail: DeclModifierDetailSyntax?) -> DeclModifierSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeName?.raw,
@@ -2358,6 +2556,7 @@ public enum SyntaxFactory {
     return DeclModifierSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DeclModifierSyntax")
   public static func makeBlankDeclModifier(presence: SourcePresence = .present) -> DeclModifierSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .declModifier,
       layout: [
@@ -2368,6 +2567,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DeclModifierSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on InheritedTypeSyntax")
   public static func makeInheritedType(_ garbageBeforeTypeName: GarbageNodesSyntax? = nil, typeName: TypeSyntax, _ garbageBetweenTypeNameAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> InheritedTypeSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeTypeName?.raw,
@@ -2381,6 +2581,7 @@ public enum SyntaxFactory {
     return InheritedTypeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on InheritedTypeSyntax")
   public static func makeBlankInheritedType(presence: SourcePresence = .present) -> InheritedTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .inheritedType,
       layout: [
@@ -2391,6 +2592,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return InheritedTypeSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on InheritedTypeListSyntax")
   public static func makeInheritedTypeList(
     _ elements: [InheritedTypeSyntax]) -> InheritedTypeListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.inheritedTypeList,
@@ -2399,12 +2601,14 @@ public enum SyntaxFactory {
     return InheritedTypeListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on InheritedTypeListSyntax")
   public static func makeBlankInheritedTypeList(presence: SourcePresence = .present) -> InheritedTypeListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .inheritedTypeList,
       layout: [
     ], length: .zero, presence: presence))
     return InheritedTypeListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TypeInheritanceClauseSyntax")
   public static func makeTypeInheritanceClause(_ garbageBeforeColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndInheritedTypeCollection: GarbageNodesSyntax? = nil, inheritedTypeCollection: InheritedTypeListSyntax) -> TypeInheritanceClauseSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeColon?.raw,
@@ -2418,6 +2622,7 @@ public enum SyntaxFactory {
     return TypeInheritanceClauseSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TypeInheritanceClauseSyntax")
   public static func makeBlankTypeInheritanceClause(presence: SourcePresence = .present) -> TypeInheritanceClauseSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .typeInheritanceClause,
       layout: [
@@ -2428,6 +2633,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return TypeInheritanceClauseSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ClassDeclSyntax")
   public static func makeClassDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndClassKeyword: GarbageNodesSyntax? = nil, classKeyword: TokenSyntax, _ garbageBetweenClassKeywordAndIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax, _ garbageBetweenIdentifierAndGenericParameterClause: GarbageNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ garbageBetweenGenericParameterClauseAndInheritanceClause: GarbageNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ garbageBetweenInheritanceClauseAndGenericWhereClause: GarbageNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ garbageBetweenGenericWhereClauseAndMembers: GarbageNodesSyntax? = nil, members: MemberDeclBlockSyntax) -> ClassDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -2453,6 +2659,7 @@ public enum SyntaxFactory {
     return ClassDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ClassDeclSyntax")
   public static func makeBlankClassDecl(presence: SourcePresence = .present) -> ClassDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .classDecl,
       layout: [
@@ -2475,6 +2682,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ClassDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ActorDeclSyntax")
   public static func makeActorDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndActorKeyword: GarbageNodesSyntax? = nil, actorKeyword: TokenSyntax, _ garbageBetweenActorKeywordAndIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax, _ garbageBetweenIdentifierAndGenericParameterClause: GarbageNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ garbageBetweenGenericParameterClauseAndInheritanceClause: GarbageNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ garbageBetweenInheritanceClauseAndGenericWhereClause: GarbageNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ garbageBetweenGenericWhereClauseAndMembers: GarbageNodesSyntax? = nil, members: MemberDeclBlockSyntax) -> ActorDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -2500,6 +2708,7 @@ public enum SyntaxFactory {
     return ActorDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ActorDeclSyntax")
   public static func makeBlankActorDecl(presence: SourcePresence = .present) -> ActorDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .actorDecl,
       layout: [
@@ -2522,6 +2731,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ActorDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on StructDeclSyntax")
   public static func makeStructDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndStructKeyword: GarbageNodesSyntax? = nil, structKeyword: TokenSyntax, _ garbageBetweenStructKeywordAndIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax, _ garbageBetweenIdentifierAndGenericParameterClause: GarbageNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ garbageBetweenGenericParameterClauseAndInheritanceClause: GarbageNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ garbageBetweenInheritanceClauseAndGenericWhereClause: GarbageNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ garbageBetweenGenericWhereClauseAndMembers: GarbageNodesSyntax? = nil, members: MemberDeclBlockSyntax) -> StructDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -2547,6 +2757,7 @@ public enum SyntaxFactory {
     return StructDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on StructDeclSyntax")
   public static func makeBlankStructDecl(presence: SourcePresence = .present) -> StructDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .structDecl,
       layout: [
@@ -2569,6 +2780,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return StructDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ProtocolDeclSyntax")
   public static func makeProtocolDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndProtocolKeyword: GarbageNodesSyntax? = nil, protocolKeyword: TokenSyntax, _ garbageBetweenProtocolKeywordAndIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax, _ garbageBetweenIdentifierAndPrimaryAssociatedTypeClause: GarbageNodesSyntax? = nil, primaryAssociatedTypeClause: PrimaryAssociatedTypeClauseSyntax?, _ garbageBetweenPrimaryAssociatedTypeClauseAndInheritanceClause: GarbageNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ garbageBetweenInheritanceClauseAndGenericWhereClause: GarbageNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ garbageBetweenGenericWhereClauseAndMembers: GarbageNodesSyntax? = nil, members: MemberDeclBlockSyntax) -> ProtocolDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -2594,6 +2806,7 @@ public enum SyntaxFactory {
     return ProtocolDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ProtocolDeclSyntax")
   public static func makeBlankProtocolDecl(presence: SourcePresence = .present) -> ProtocolDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .protocolDecl,
       layout: [
@@ -2616,6 +2829,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ProtocolDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ExtensionDeclSyntax")
   public static func makeExtensionDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndExtensionKeyword: GarbageNodesSyntax? = nil, extensionKeyword: TokenSyntax, _ garbageBetweenExtensionKeywordAndExtendedType: GarbageNodesSyntax? = nil, extendedType: TypeSyntax, _ garbageBetweenExtendedTypeAndInheritanceClause: GarbageNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ garbageBetweenInheritanceClauseAndGenericWhereClause: GarbageNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ garbageBetweenGenericWhereClauseAndMembers: GarbageNodesSyntax? = nil, members: MemberDeclBlockSyntax) -> ExtensionDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -2639,6 +2853,7 @@ public enum SyntaxFactory {
     return ExtensionDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ExtensionDeclSyntax")
   public static func makeBlankExtensionDecl(presence: SourcePresence = .present) -> ExtensionDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .extensionDecl,
       layout: [
@@ -2659,6 +2874,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ExtensionDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on MemberDeclBlockSyntax")
   public static func makeMemberDeclBlock(_ garbageBeforeLeftBrace: GarbageNodesSyntax? = nil, leftBrace: TokenSyntax, _ garbageBetweenLeftBraceAndMembers: GarbageNodesSyntax? = nil, members: MemberDeclListSyntax, _ garbageBetweenMembersAndRightBrace: GarbageNodesSyntax? = nil, rightBrace: TokenSyntax) -> MemberDeclBlockSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftBrace?.raw,
@@ -2674,6 +2890,7 @@ public enum SyntaxFactory {
     return MemberDeclBlockSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MemberDeclBlockSyntax")
   public static func makeBlankMemberDeclBlock(presence: SourcePresence = .present) -> MemberDeclBlockSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .memberDeclBlock,
       layout: [
@@ -2686,6 +2903,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return MemberDeclBlockSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on MemberDeclListSyntax")
   public static func makeMemberDeclList(
     _ elements: [MemberDeclListItemSyntax]) -> MemberDeclListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.memberDeclList,
@@ -2694,12 +2912,14 @@ public enum SyntaxFactory {
     return MemberDeclListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MemberDeclListSyntax")
   public static func makeBlankMemberDeclList(presence: SourcePresence = .present) -> MemberDeclListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .memberDeclList,
       layout: [
     ], length: .zero, presence: presence))
     return MemberDeclListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on MemberDeclListItemSyntax")
   public static func makeMemberDeclListItem(_ garbageBeforeDecl: GarbageNodesSyntax? = nil, decl: DeclSyntax, _ garbageBetweenDeclAndSemicolon: GarbageNodesSyntax? = nil, semicolon: TokenSyntax?) -> MemberDeclListItemSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeDecl?.raw,
@@ -2713,6 +2933,7 @@ public enum SyntaxFactory {
     return MemberDeclListItemSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MemberDeclListItemSyntax")
   public static func makeBlankMemberDeclListItem(presence: SourcePresence = .present) -> MemberDeclListItemSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .memberDeclListItem,
       layout: [
@@ -2723,6 +2944,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return MemberDeclListItemSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on SourceFileSyntax")
   public static func makeSourceFile(_ garbageBeforeStatements: GarbageNodesSyntax? = nil, statements: CodeBlockItemListSyntax, _ garbageBetweenStatementsAndEOFToken: GarbageNodesSyntax? = nil, eofToken: TokenSyntax) -> SourceFileSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeStatements?.raw,
@@ -2736,6 +2958,7 @@ public enum SyntaxFactory {
     return SourceFileSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on SourceFileSyntax")
   public static func makeBlankSourceFile(presence: SourcePresence = .present) -> SourceFileSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .sourceFile,
       layout: [
@@ -2746,6 +2969,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return SourceFileSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on InitializerClauseSyntax")
   public static func makeInitializerClause(_ garbageBeforeEqual: GarbageNodesSyntax? = nil, equal: TokenSyntax, _ garbageBetweenEqualAndValue: GarbageNodesSyntax? = nil, value: ExprSyntax) -> InitializerClauseSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeEqual?.raw,
@@ -2759,6 +2983,7 @@ public enum SyntaxFactory {
     return InitializerClauseSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on InitializerClauseSyntax")
   public static func makeBlankInitializerClause(presence: SourcePresence = .present) -> InitializerClauseSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .initializerClause,
       layout: [
@@ -2769,6 +2994,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return InitializerClauseSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on FunctionParameterSyntax")
   public static func makeFunctionParameter(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndFirstName: GarbageNodesSyntax? = nil, firstName: TokenSyntax?, _ garbageBetweenFirstNameAndSecondName: GarbageNodesSyntax? = nil, secondName: TokenSyntax?, _ garbageBetweenSecondNameAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax?, _ garbageBetweenColonAndType: GarbageNodesSyntax? = nil, type: TypeSyntax?, _ garbageBetweenTypeAndEllipsis: GarbageNodesSyntax? = nil, ellipsis: TokenSyntax?, _ garbageBetweenEllipsisAndDefaultArgument: GarbageNodesSyntax? = nil, defaultArgument: InitializerClauseSyntax?, _ garbageBetweenDefaultArgumentAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> FunctionParameterSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -2794,6 +3020,7 @@ public enum SyntaxFactory {
     return FunctionParameterSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on FunctionParameterSyntax")
   public static func makeBlankFunctionParameter(presence: SourcePresence = .present) -> FunctionParameterSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .functionParameter,
       layout: [
@@ -2816,6 +3043,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return FunctionParameterSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ModifierListSyntax")
   public static func makeModifierList(
     _ elements: [DeclModifierSyntax]) -> ModifierListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.modifierList,
@@ -2824,12 +3052,14 @@ public enum SyntaxFactory {
     return ModifierListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ModifierListSyntax")
   public static func makeBlankModifierList(presence: SourcePresence = .present) -> ModifierListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .modifierList,
       layout: [
     ], length: .zero, presence: presence))
     return ModifierListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on FunctionDeclSyntax")
   public static func makeFunctionDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndFuncKeyword: GarbageNodesSyntax? = nil, funcKeyword: TokenSyntax, _ garbageBetweenFuncKeywordAndIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax, _ garbageBetweenIdentifierAndGenericParameterClause: GarbageNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ garbageBetweenGenericParameterClauseAndSignature: GarbageNodesSyntax? = nil, signature: FunctionSignatureSyntax, _ garbageBetweenSignatureAndGenericWhereClause: GarbageNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ garbageBetweenGenericWhereClauseAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax?) -> FunctionDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -2855,6 +3085,7 @@ public enum SyntaxFactory {
     return FunctionDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on FunctionDeclSyntax")
   public static func makeBlankFunctionDecl(presence: SourcePresence = .present) -> FunctionDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .functionDecl,
       layout: [
@@ -2877,6 +3108,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return FunctionDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on InitializerDeclSyntax")
   public static func makeInitializerDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndInitKeyword: GarbageNodesSyntax? = nil, initKeyword: TokenSyntax, _ garbageBetweenInitKeywordAndOptionalMark: GarbageNodesSyntax? = nil, optionalMark: TokenSyntax?, _ garbageBetweenOptionalMarkAndGenericParameterClause: GarbageNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ garbageBetweenGenericParameterClauseAndSignature: GarbageNodesSyntax? = nil, signature: FunctionSignatureSyntax, _ garbageBetweenSignatureAndGenericWhereClause: GarbageNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ garbageBetweenGenericWhereClauseAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax?) -> InitializerDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -2902,6 +3134,7 @@ public enum SyntaxFactory {
     return InitializerDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on InitializerDeclSyntax")
   public static func makeBlankInitializerDecl(presence: SourcePresence = .present) -> InitializerDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .initializerDecl,
       layout: [
@@ -2924,6 +3157,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return InitializerDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DeinitializerDeclSyntax")
   public static func makeDeinitializerDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndDeinitKeyword: GarbageNodesSyntax? = nil, deinitKeyword: TokenSyntax, _ garbageBetweenDeinitKeywordAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax?) -> DeinitializerDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -2941,6 +3175,7 @@ public enum SyntaxFactory {
     return DeinitializerDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DeinitializerDeclSyntax")
   public static func makeBlankDeinitializerDecl(presence: SourcePresence = .present) -> DeinitializerDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .deinitializerDecl,
       layout: [
@@ -2955,6 +3190,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DeinitializerDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on SubscriptDeclSyntax")
   public static func makeSubscriptDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndSubscriptKeyword: GarbageNodesSyntax? = nil, subscriptKeyword: TokenSyntax, _ garbageBetweenSubscriptKeywordAndGenericParameterClause: GarbageNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ garbageBetweenGenericParameterClauseAndIndices: GarbageNodesSyntax? = nil, indices: ParameterClauseSyntax, _ garbageBetweenIndicesAndResult: GarbageNodesSyntax? = nil, result: ReturnClauseSyntax, _ garbageBetweenResultAndGenericWhereClause: GarbageNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ garbageBetweenGenericWhereClauseAndAccessor: GarbageNodesSyntax? = nil, accessor: Syntax?) -> SubscriptDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -2980,6 +3216,7 @@ public enum SyntaxFactory {
     return SubscriptDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on SubscriptDeclSyntax")
   public static func makeBlankSubscriptDecl(presence: SourcePresence = .present) -> SubscriptDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .subscriptDecl,
       layout: [
@@ -3002,6 +3239,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return SubscriptDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AccessLevelModifierSyntax")
   public static func makeAccessLevelModifier(_ garbageBeforeName: GarbageNodesSyntax? = nil, name: TokenSyntax, _ garbageBetweenNameAndModifier: GarbageNodesSyntax? = nil, modifier: DeclModifierDetailSyntax?) -> AccessLevelModifierSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeName?.raw,
@@ -3015,6 +3253,7 @@ public enum SyntaxFactory {
     return AccessLevelModifierSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AccessLevelModifierSyntax")
   public static func makeBlankAccessLevelModifier(presence: SourcePresence = .present) -> AccessLevelModifierSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .accessLevelModifier,
       layout: [
@@ -3025,6 +3264,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AccessLevelModifierSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AccessPathComponentSyntax")
   public static func makeAccessPathComponent(_ garbageBeforeName: GarbageNodesSyntax? = nil, name: TokenSyntax, _ garbageBetweenNameAndTrailingDot: GarbageNodesSyntax? = nil, trailingDot: TokenSyntax?) -> AccessPathComponentSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeName?.raw,
@@ -3038,6 +3278,7 @@ public enum SyntaxFactory {
     return AccessPathComponentSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AccessPathComponentSyntax")
   public static func makeBlankAccessPathComponent(presence: SourcePresence = .present) -> AccessPathComponentSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .accessPathComponent,
       layout: [
@@ -3048,6 +3289,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AccessPathComponentSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AccessPathSyntax")
   public static func makeAccessPath(
     _ elements: [AccessPathComponentSyntax]) -> AccessPathSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.accessPath,
@@ -3056,12 +3298,14 @@ public enum SyntaxFactory {
     return AccessPathSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AccessPathSyntax")
   public static func makeBlankAccessPath(presence: SourcePresence = .present) -> AccessPathSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .accessPath,
       layout: [
     ], length: .zero, presence: presence))
     return AccessPathSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ImportDeclSyntax")
   public static func makeImportDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndImportTok: GarbageNodesSyntax? = nil, importTok: TokenSyntax, _ garbageBetweenImportTokAndImportKind: GarbageNodesSyntax? = nil, importKind: TokenSyntax?, _ garbageBetweenImportKindAndPath: GarbageNodesSyntax? = nil, path: AccessPathSyntax) -> ImportDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -3081,6 +3325,7 @@ public enum SyntaxFactory {
     return ImportDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ImportDeclSyntax")
   public static func makeBlankImportDecl(presence: SourcePresence = .present) -> ImportDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .importDecl,
       layout: [
@@ -3097,6 +3342,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ImportDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AccessorParameterSyntax")
   public static func makeAccessorParameter(_ garbageBeforeLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndName: GarbageNodesSyntax? = nil, name: TokenSyntax, _ garbageBetweenNameAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> AccessorParameterSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftParen?.raw,
@@ -3112,6 +3358,7 @@ public enum SyntaxFactory {
     return AccessorParameterSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AccessorParameterSyntax")
   public static func makeBlankAccessorParameter(presence: SourcePresence = .present) -> AccessorParameterSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .accessorParameter,
       layout: [
@@ -3124,6 +3371,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AccessorParameterSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AccessorDeclSyntax")
   public static func makeAccessorDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifier: GarbageNodesSyntax? = nil, modifier: DeclModifierSyntax?, _ garbageBetweenModifierAndAccessorKind: GarbageNodesSyntax? = nil, accessorKind: TokenSyntax, _ garbageBetweenAccessorKindAndParameter: GarbageNodesSyntax? = nil, parameter: AccessorParameterSyntax?, _ garbageBetweenParameterAndAsyncKeyword: GarbageNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ garbageBetweenAsyncKeywordAndThrowsKeyword: GarbageNodesSyntax? = nil, throwsKeyword: TokenSyntax?, _ garbageBetweenThrowsKeywordAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax?) -> AccessorDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -3147,6 +3395,7 @@ public enum SyntaxFactory {
     return AccessorDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AccessorDeclSyntax")
   public static func makeBlankAccessorDecl(presence: SourcePresence = .present) -> AccessorDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .accessorDecl,
       layout: [
@@ -3167,6 +3416,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AccessorDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AccessorListSyntax")
   public static func makeAccessorList(
     _ elements: [AccessorDeclSyntax]) -> AccessorListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.accessorList,
@@ -3175,12 +3425,14 @@ public enum SyntaxFactory {
     return AccessorListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AccessorListSyntax")
   public static func makeBlankAccessorList(presence: SourcePresence = .present) -> AccessorListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .accessorList,
       layout: [
     ], length: .zero, presence: presence))
     return AccessorListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AccessorBlockSyntax")
   public static func makeAccessorBlock(_ garbageBeforeLeftBrace: GarbageNodesSyntax? = nil, leftBrace: TokenSyntax, _ garbageBetweenLeftBraceAndAccessors: GarbageNodesSyntax? = nil, accessors: AccessorListSyntax, _ garbageBetweenAccessorsAndRightBrace: GarbageNodesSyntax? = nil, rightBrace: TokenSyntax) -> AccessorBlockSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftBrace?.raw,
@@ -3196,6 +3448,7 @@ public enum SyntaxFactory {
     return AccessorBlockSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AccessorBlockSyntax")
   public static func makeBlankAccessorBlock(presence: SourcePresence = .present) -> AccessorBlockSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .accessorBlock,
       layout: [
@@ -3208,6 +3461,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AccessorBlockSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PatternBindingSyntax")
   public static func makePatternBinding(_ garbageBeforePattern: GarbageNodesSyntax? = nil, pattern: PatternSyntax, _ garbageBetweenPatternAndTypeAnnotation: GarbageNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ garbageBetweenTypeAnnotationAndInitializer: GarbageNodesSyntax? = nil, initializer: InitializerClauseSyntax?, _ garbageBetweenInitializerAndAccessor: GarbageNodesSyntax? = nil, accessor: Syntax?, _ garbageBetweenAccessorAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> PatternBindingSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePattern?.raw,
@@ -3227,6 +3481,7 @@ public enum SyntaxFactory {
     return PatternBindingSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PatternBindingSyntax")
   public static func makeBlankPatternBinding(presence: SourcePresence = .present) -> PatternBindingSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .patternBinding,
       layout: [
@@ -3243,6 +3498,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PatternBindingSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PatternBindingListSyntax")
   public static func makePatternBindingList(
     _ elements: [PatternBindingSyntax]) -> PatternBindingListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.patternBindingList,
@@ -3251,12 +3507,14 @@ public enum SyntaxFactory {
     return PatternBindingListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PatternBindingListSyntax")
   public static func makeBlankPatternBindingList(presence: SourcePresence = .present) -> PatternBindingListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .patternBindingList,
       layout: [
     ], length: .zero, presence: presence))
     return PatternBindingListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on VariableDeclSyntax")
   public static func makeVariableDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndLetOrVarKeyword: GarbageNodesSyntax? = nil, letOrVarKeyword: TokenSyntax, _ garbageBetweenLetOrVarKeywordAndBindings: GarbageNodesSyntax? = nil, bindings: PatternBindingListSyntax) -> VariableDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -3274,6 +3532,7 @@ public enum SyntaxFactory {
     return VariableDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on VariableDeclSyntax")
   public static func makeBlankVariableDecl(presence: SourcePresence = .present) -> VariableDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .variableDecl,
       layout: [
@@ -3288,6 +3547,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return VariableDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on EnumCaseElementSyntax")
   public static func makeEnumCaseElement(_ garbageBeforeIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax, _ garbageBetweenIdentifierAndAssociatedValue: GarbageNodesSyntax? = nil, associatedValue: ParameterClauseSyntax?, _ garbageBetweenAssociatedValueAndRawValue: GarbageNodesSyntax? = nil, rawValue: InitializerClauseSyntax?, _ garbageBetweenRawValueAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> EnumCaseElementSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeIdentifier?.raw,
@@ -3305,6 +3565,7 @@ public enum SyntaxFactory {
     return EnumCaseElementSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on EnumCaseElementSyntax")
   public static func makeBlankEnumCaseElement(presence: SourcePresence = .present) -> EnumCaseElementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .enumCaseElement,
       layout: [
@@ -3319,6 +3580,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return EnumCaseElementSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on EnumCaseElementListSyntax")
   public static func makeEnumCaseElementList(
     _ elements: [EnumCaseElementSyntax]) -> EnumCaseElementListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.enumCaseElementList,
@@ -3327,12 +3589,14 @@ public enum SyntaxFactory {
     return EnumCaseElementListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on EnumCaseElementListSyntax")
   public static func makeBlankEnumCaseElementList(presence: SourcePresence = .present) -> EnumCaseElementListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .enumCaseElementList,
       layout: [
     ], length: .zero, presence: presence))
     return EnumCaseElementListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on EnumCaseDeclSyntax")
   public static func makeEnumCaseDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndCaseKeyword: GarbageNodesSyntax? = nil, caseKeyword: TokenSyntax, _ garbageBetweenCaseKeywordAndElements: GarbageNodesSyntax? = nil, elements: EnumCaseElementListSyntax) -> EnumCaseDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -3350,6 +3614,7 @@ public enum SyntaxFactory {
     return EnumCaseDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on EnumCaseDeclSyntax")
   public static func makeBlankEnumCaseDecl(presence: SourcePresence = .present) -> EnumCaseDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .enumCaseDecl,
       layout: [
@@ -3364,6 +3629,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return EnumCaseDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on EnumDeclSyntax")
   public static func makeEnumDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndEnumKeyword: GarbageNodesSyntax? = nil, enumKeyword: TokenSyntax, _ garbageBetweenEnumKeywordAndIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax, _ garbageBetweenIdentifierAndGenericParameters: GarbageNodesSyntax? = nil, genericParameters: GenericParameterClauseSyntax?, _ garbageBetweenGenericParametersAndInheritanceClause: GarbageNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ garbageBetweenInheritanceClauseAndGenericWhereClause: GarbageNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ garbageBetweenGenericWhereClauseAndMembers: GarbageNodesSyntax? = nil, members: MemberDeclBlockSyntax) -> EnumDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -3389,6 +3655,7 @@ public enum SyntaxFactory {
     return EnumDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on EnumDeclSyntax")
   public static func makeBlankEnumDecl(presence: SourcePresence = .present) -> EnumDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .enumDecl,
       layout: [
@@ -3411,6 +3678,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return EnumDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on OperatorDeclSyntax")
   public static func makeOperatorDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndOperatorKeyword: GarbageNodesSyntax? = nil, operatorKeyword: TokenSyntax, _ garbageBetweenOperatorKeywordAndIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax, _ garbageBetweenIdentifierAndOperatorPrecedenceAndTypes: GarbageNodesSyntax? = nil, operatorPrecedenceAndTypes: OperatorPrecedenceAndTypesSyntax?) -> OperatorDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -3430,6 +3698,7 @@ public enum SyntaxFactory {
     return OperatorDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on OperatorDeclSyntax")
   public static func makeBlankOperatorDecl(presence: SourcePresence = .present) -> OperatorDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .operatorDecl,
       layout: [
@@ -3446,6 +3715,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return OperatorDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on IdentifierListSyntax")
   public static func makeIdentifierList(
     _ elements: [TokenSyntax]) -> IdentifierListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.identifierList,
@@ -3454,12 +3724,14 @@ public enum SyntaxFactory {
     return IdentifierListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on IdentifierListSyntax")
   public static func makeBlankIdentifierList(presence: SourcePresence = .present) -> IdentifierListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .identifierList,
       layout: [
     ], length: .zero, presence: presence))
     return IdentifierListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on OperatorPrecedenceAndTypesSyntax")
   public static func makeOperatorPrecedenceAndTypes(_ garbageBeforeColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndPrecedenceGroupAndDesignatedTypes: GarbageNodesSyntax? = nil, precedenceGroupAndDesignatedTypes: IdentifierListSyntax) -> OperatorPrecedenceAndTypesSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeColon?.raw,
@@ -3473,6 +3745,7 @@ public enum SyntaxFactory {
     return OperatorPrecedenceAndTypesSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on OperatorPrecedenceAndTypesSyntax")
   public static func makeBlankOperatorPrecedenceAndTypes(presence: SourcePresence = .present) -> OperatorPrecedenceAndTypesSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .operatorPrecedenceAndTypes,
       layout: [
@@ -3483,6 +3756,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return OperatorPrecedenceAndTypesSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PrecedenceGroupDeclSyntax")
   public static func makePrecedenceGroupDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ garbageBetweenModifiersAndPrecedencegroupKeyword: GarbageNodesSyntax? = nil, precedencegroupKeyword: TokenSyntax, _ garbageBetweenPrecedencegroupKeywordAndIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax, _ garbageBetweenIdentifierAndLeftBrace: GarbageNodesSyntax? = nil, leftBrace: TokenSyntax, _ garbageBetweenLeftBraceAndGroupAttributes: GarbageNodesSyntax? = nil, groupAttributes: PrecedenceGroupAttributeListSyntax, _ garbageBetweenGroupAttributesAndRightBrace: GarbageNodesSyntax? = nil, rightBrace: TokenSyntax) -> PrecedenceGroupDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -3506,6 +3780,7 @@ public enum SyntaxFactory {
     return PrecedenceGroupDeclSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PrecedenceGroupDeclSyntax")
   public static func makeBlankPrecedenceGroupDecl(presence: SourcePresence = .present) -> PrecedenceGroupDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .precedenceGroupDecl,
       layout: [
@@ -3526,6 +3801,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PrecedenceGroupDeclSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PrecedenceGroupAttributeListSyntax")
   public static func makePrecedenceGroupAttributeList(
     _ elements: [Syntax]) -> PrecedenceGroupAttributeListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.precedenceGroupAttributeList,
@@ -3534,12 +3810,14 @@ public enum SyntaxFactory {
     return PrecedenceGroupAttributeListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PrecedenceGroupAttributeListSyntax")
   public static func makeBlankPrecedenceGroupAttributeList(presence: SourcePresence = .present) -> PrecedenceGroupAttributeListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .precedenceGroupAttributeList,
       layout: [
     ], length: .zero, presence: presence))
     return PrecedenceGroupAttributeListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PrecedenceGroupRelationSyntax")
   public static func makePrecedenceGroupRelation(_ garbageBeforeHigherThanOrLowerThan: GarbageNodesSyntax? = nil, higherThanOrLowerThan: TokenSyntax, _ garbageBetweenHigherThanOrLowerThanAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndOtherNames: GarbageNodesSyntax? = nil, otherNames: PrecedenceGroupNameListSyntax) -> PrecedenceGroupRelationSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeHigherThanOrLowerThan?.raw,
@@ -3555,6 +3833,7 @@ public enum SyntaxFactory {
     return PrecedenceGroupRelationSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PrecedenceGroupRelationSyntax")
   public static func makeBlankPrecedenceGroupRelation(presence: SourcePresence = .present) -> PrecedenceGroupRelationSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .precedenceGroupRelation,
       layout: [
@@ -3567,6 +3846,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PrecedenceGroupRelationSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PrecedenceGroupNameListSyntax")
   public static func makePrecedenceGroupNameList(
     _ elements: [PrecedenceGroupNameElementSyntax]) -> PrecedenceGroupNameListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.precedenceGroupNameList,
@@ -3575,12 +3855,14 @@ public enum SyntaxFactory {
     return PrecedenceGroupNameListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PrecedenceGroupNameListSyntax")
   public static func makeBlankPrecedenceGroupNameList(presence: SourcePresence = .present) -> PrecedenceGroupNameListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .precedenceGroupNameList,
       layout: [
     ], length: .zero, presence: presence))
     return PrecedenceGroupNameListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PrecedenceGroupNameElementSyntax")
   public static func makePrecedenceGroupNameElement(_ garbageBeforeName: GarbageNodesSyntax? = nil, name: TokenSyntax, _ garbageBetweenNameAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> PrecedenceGroupNameElementSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeName?.raw,
@@ -3594,6 +3876,7 @@ public enum SyntaxFactory {
     return PrecedenceGroupNameElementSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PrecedenceGroupNameElementSyntax")
   public static func makeBlankPrecedenceGroupNameElement(presence: SourcePresence = .present) -> PrecedenceGroupNameElementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .precedenceGroupNameElement,
       layout: [
@@ -3604,6 +3887,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PrecedenceGroupNameElementSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PrecedenceGroupAssignmentSyntax")
   public static func makePrecedenceGroupAssignment(_ garbageBeforeAssignmentKeyword: GarbageNodesSyntax? = nil, assignmentKeyword: TokenSyntax, _ garbageBetweenAssignmentKeywordAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndFlag: GarbageNodesSyntax? = nil, flag: TokenSyntax) -> PrecedenceGroupAssignmentSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAssignmentKeyword?.raw,
@@ -3619,6 +3903,7 @@ public enum SyntaxFactory {
     return PrecedenceGroupAssignmentSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PrecedenceGroupAssignmentSyntax")
   public static func makeBlankPrecedenceGroupAssignment(presence: SourcePresence = .present) -> PrecedenceGroupAssignmentSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .precedenceGroupAssignment,
       layout: [
@@ -3631,6 +3916,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PrecedenceGroupAssignmentSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PrecedenceGroupAssociativitySyntax")
   public static func makePrecedenceGroupAssociativity(_ garbageBeforeAssociativityKeyword: GarbageNodesSyntax? = nil, associativityKeyword: TokenSyntax, _ garbageBetweenAssociativityKeywordAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndValue: GarbageNodesSyntax? = nil, value: TokenSyntax) -> PrecedenceGroupAssociativitySyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAssociativityKeyword?.raw,
@@ -3646,6 +3932,7 @@ public enum SyntaxFactory {
     return PrecedenceGroupAssociativitySyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PrecedenceGroupAssociativitySyntax")
   public static func makeBlankPrecedenceGroupAssociativity(presence: SourcePresence = .present) -> PrecedenceGroupAssociativitySyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .precedenceGroupAssociativity,
       layout: [
@@ -3658,6 +3945,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PrecedenceGroupAssociativitySyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TokenListSyntax")
   public static func makeTokenList(
     _ elements: [TokenSyntax]) -> TokenListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.tokenList,
@@ -3666,12 +3954,14 @@ public enum SyntaxFactory {
     return TokenListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TokenListSyntax")
   public static func makeBlankTokenList(presence: SourcePresence = .present) -> TokenListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .tokenList,
       layout: [
     ], length: .zero, presence: presence))
     return TokenListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on NonEmptyTokenListSyntax")
   public static func makeNonEmptyTokenList(
     _ elements: [TokenSyntax]) -> NonEmptyTokenListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.nonEmptyTokenList,
@@ -3680,12 +3970,14 @@ public enum SyntaxFactory {
     return NonEmptyTokenListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on NonEmptyTokenListSyntax")
   public static func makeBlankNonEmptyTokenList(presence: SourcePresence = .present) -> NonEmptyTokenListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .nonEmptyTokenList,
       layout: [
     ], length: .zero, presence: presence))
     return NonEmptyTokenListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on CustomAttributeSyntax")
   public static func makeCustomAttribute(_ garbageBeforeAtSignToken: GarbageNodesSyntax? = nil, atSignToken: TokenSyntax, _ garbageBetweenAtSignTokenAndAttributeName: GarbageNodesSyntax? = nil, attributeName: TypeSyntax, _ garbageBetweenAttributeNameAndLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax?, _ garbageBetweenLeftParenAndArgumentList: GarbageNodesSyntax? = nil, argumentList: TupleExprElementListSyntax?, _ garbageBetweenArgumentListAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax?) -> CustomAttributeSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAtSignToken?.raw,
@@ -3705,6 +3997,7 @@ public enum SyntaxFactory {
     return CustomAttributeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on CustomAttributeSyntax")
   public static func makeBlankCustomAttribute(presence: SourcePresence = .present) -> CustomAttributeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .customAttribute,
       layout: [
@@ -3721,6 +4014,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return CustomAttributeSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AttributeSyntax")
   public static func makeAttribute(_ garbageBeforeAtSignToken: GarbageNodesSyntax? = nil, atSignToken: TokenSyntax, _ garbageBetweenAtSignTokenAndAttributeName: GarbageNodesSyntax? = nil, attributeName: TokenSyntax, _ garbageBetweenAttributeNameAndLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax?, _ garbageBetweenLeftParenAndArgument: GarbageNodesSyntax? = nil, argument: Syntax?, _ garbageBetweenArgumentAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax?, _ garbageBetweenRightParenAndTokenList: GarbageNodesSyntax? = nil, tokenList: TokenListSyntax?) -> AttributeSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAtSignToken?.raw,
@@ -3742,6 +4036,7 @@ public enum SyntaxFactory {
     return AttributeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AttributeSyntax")
   public static func makeBlankAttribute(presence: SourcePresence = .present) -> AttributeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .attribute,
       layout: [
@@ -3760,6 +4055,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AttributeSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AttributeListSyntax")
   public static func makeAttributeList(
     _ elements: [Syntax]) -> AttributeListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.attributeList,
@@ -3768,12 +4064,14 @@ public enum SyntaxFactory {
     return AttributeListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AttributeListSyntax")
   public static func makeBlankAttributeList(presence: SourcePresence = .present) -> AttributeListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .attributeList,
       layout: [
     ], length: .zero, presence: presence))
     return AttributeListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on SpecializeAttributeSpecListSyntax")
   public static func makeSpecializeAttributeSpecList(
     _ elements: [Syntax]) -> SpecializeAttributeSpecListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.specializeAttributeSpecList,
@@ -3782,12 +4080,14 @@ public enum SyntaxFactory {
     return SpecializeAttributeSpecListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on SpecializeAttributeSpecListSyntax")
   public static func makeBlankSpecializeAttributeSpecList(presence: SourcePresence = .present) -> SpecializeAttributeSpecListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .specializeAttributeSpecList,
       layout: [
     ], length: .zero, presence: presence))
     return SpecializeAttributeSpecListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AvailabilityEntrySyntax")
   public static func makeAvailabilityEntry(_ garbageBeforeLabel: GarbageNodesSyntax? = nil, label: TokenSyntax, _ garbageBetweenLabelAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndAvailabilityList: GarbageNodesSyntax? = nil, availabilityList: AvailabilitySpecListSyntax, _ garbageBetweenAvailabilityListAndSemicolon: GarbageNodesSyntax? = nil, semicolon: TokenSyntax) -> AvailabilityEntrySyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLabel?.raw,
@@ -3805,6 +4105,7 @@ public enum SyntaxFactory {
     return AvailabilityEntrySyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AvailabilityEntrySyntax")
   public static func makeBlankAvailabilityEntry(presence: SourcePresence = .present) -> AvailabilityEntrySyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .availabilityEntry,
       layout: [
@@ -3819,6 +4120,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AvailabilityEntrySyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on LabeledSpecializeEntrySyntax")
   public static func makeLabeledSpecializeEntry(_ garbageBeforeLabel: GarbageNodesSyntax? = nil, label: TokenSyntax, _ garbageBetweenLabelAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndValue: GarbageNodesSyntax? = nil, value: TokenSyntax, _ garbageBetweenValueAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLabel?.raw,
@@ -3836,6 +4138,7 @@ public enum SyntaxFactory {
     return LabeledSpecializeEntrySyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on LabeledSpecializeEntrySyntax")
   public static func makeBlankLabeledSpecializeEntry(presence: SourcePresence = .present) -> LabeledSpecializeEntrySyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .labeledSpecializeEntry,
       layout: [
@@ -3850,6 +4153,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return LabeledSpecializeEntrySyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TargetFunctionEntrySyntax")
   public static func makeTargetFunctionEntry(_ garbageBeforeLabel: GarbageNodesSyntax? = nil, label: TokenSyntax, _ garbageBetweenLabelAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndDeclname: GarbageNodesSyntax? = nil, declname: DeclNameSyntax, _ garbageBetweenDeclnameAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> TargetFunctionEntrySyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLabel?.raw,
@@ -3867,6 +4171,7 @@ public enum SyntaxFactory {
     return TargetFunctionEntrySyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TargetFunctionEntrySyntax")
   public static func makeBlankTargetFunctionEntry(presence: SourcePresence = .present) -> TargetFunctionEntrySyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .targetFunctionEntry,
       layout: [
@@ -3881,6 +4186,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return TargetFunctionEntrySyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on NamedAttributeStringArgumentSyntax")
   public static func makeNamedAttributeStringArgument(_ garbageBeforeNameTok: GarbageNodesSyntax? = nil, nameTok: TokenSyntax, _ garbageBetweenNameTokAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndStringOrDeclname: GarbageNodesSyntax? = nil, stringOrDeclname: Syntax) -> NamedAttributeStringArgumentSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeNameTok?.raw,
@@ -3896,6 +4202,7 @@ public enum SyntaxFactory {
     return NamedAttributeStringArgumentSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on NamedAttributeStringArgumentSyntax")
   public static func makeBlankNamedAttributeStringArgument(presence: SourcePresence = .present) -> NamedAttributeStringArgumentSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .namedAttributeStringArgument,
       layout: [
@@ -3908,6 +4215,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return NamedAttributeStringArgumentSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DeclNameSyntax")
   public static func makeDeclName(_ garbageBeforeDeclBaseName: GarbageNodesSyntax? = nil, declBaseName: Syntax, _ garbageBetweenDeclBaseNameAndDeclNameArguments: GarbageNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?) -> DeclNameSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeDeclBaseName?.raw,
@@ -3921,6 +4229,7 @@ public enum SyntaxFactory {
     return DeclNameSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DeclNameSyntax")
   public static func makeBlankDeclName(presence: SourcePresence = .present) -> DeclNameSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .declName,
       layout: [
@@ -3931,6 +4240,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DeclNameSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ImplementsAttributeArgumentsSyntax")
   public static func makeImplementsAttributeArguments(_ garbageBeforeType: GarbageNodesSyntax? = nil, type: SimpleTypeIdentifierSyntax, _ garbageBetweenTypeAndComma: GarbageNodesSyntax? = nil, comma: TokenSyntax, _ garbageBetweenCommaAndDeclBaseName: GarbageNodesSyntax? = nil, declBaseName: Syntax, _ garbageBetweenDeclBaseNameAndDeclNameArguments: GarbageNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?) -> ImplementsAttributeArgumentsSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeType?.raw,
@@ -3948,6 +4258,7 @@ public enum SyntaxFactory {
     return ImplementsAttributeArgumentsSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ImplementsAttributeArgumentsSyntax")
   public static func makeBlankImplementsAttributeArguments(presence: SourcePresence = .present) -> ImplementsAttributeArgumentsSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .implementsAttributeArguments,
       layout: [
@@ -3962,6 +4273,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ImplementsAttributeArgumentsSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ObjCSelectorPieceSyntax")
   public static func makeObjCSelectorPiece(_ garbageBeforeName: GarbageNodesSyntax? = nil, name: TokenSyntax?, _ garbageBetweenNameAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax?) -> ObjCSelectorPieceSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeName?.raw,
@@ -3975,6 +4287,7 @@ public enum SyntaxFactory {
     return ObjCSelectorPieceSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ObjCSelectorPieceSyntax")
   public static func makeBlankObjCSelectorPiece(presence: SourcePresence = .present) -> ObjCSelectorPieceSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .objCSelectorPiece,
       layout: [
@@ -3985,6 +4298,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ObjCSelectorPieceSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ObjCSelectorSyntax")
   public static func makeObjCSelector(
     _ elements: [ObjCSelectorPieceSyntax]) -> ObjCSelectorSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.objCSelector,
@@ -3993,12 +4307,14 @@ public enum SyntaxFactory {
     return ObjCSelectorSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ObjCSelectorSyntax")
   public static func makeBlankObjCSelector(presence: SourcePresence = .present) -> ObjCSelectorSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .objCSelector,
       layout: [
     ], length: .zero, presence: presence))
     return ObjCSelectorSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DifferentiableAttributeArgumentsSyntax")
   public static func makeDifferentiableAttributeArguments(_ garbageBeforeDiffKind: GarbageNodesSyntax? = nil, diffKind: TokenSyntax?, _ garbageBetweenDiffKindAndDiffKindComma: GarbageNodesSyntax? = nil, diffKindComma: TokenSyntax?, _ garbageBetweenDiffKindCommaAndDiffParams: GarbageNodesSyntax? = nil, diffParams: DifferentiabilityParamsClauseSyntax?, _ garbageBetweenDiffParamsAndDiffParamsComma: GarbageNodesSyntax? = nil, diffParamsComma: TokenSyntax?, _ garbageBetweenDiffParamsCommaAndWhereClause: GarbageNodesSyntax? = nil, whereClause: GenericWhereClauseSyntax?) -> DifferentiableAttributeArgumentsSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeDiffKind?.raw,
@@ -4018,6 +4334,7 @@ public enum SyntaxFactory {
     return DifferentiableAttributeArgumentsSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DifferentiableAttributeArgumentsSyntax")
   public static func makeBlankDifferentiableAttributeArguments(presence: SourcePresence = .present) -> DifferentiableAttributeArgumentsSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .differentiableAttributeArguments,
       layout: [
@@ -4034,6 +4351,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DifferentiableAttributeArgumentsSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DifferentiabilityParamsClauseSyntax")
   public static func makeDifferentiabilityParamsClause(_ garbageBeforeWrtLabel: GarbageNodesSyntax? = nil, wrtLabel: TokenSyntax, _ garbageBetweenWrtLabelAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndParameters: GarbageNodesSyntax? = nil, parameters: Syntax) -> DifferentiabilityParamsClauseSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeWrtLabel?.raw,
@@ -4049,6 +4367,7 @@ public enum SyntaxFactory {
     return DifferentiabilityParamsClauseSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DifferentiabilityParamsClauseSyntax")
   public static func makeBlankDifferentiabilityParamsClause(presence: SourcePresence = .present) -> DifferentiabilityParamsClauseSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .differentiabilityParamsClause,
       layout: [
@@ -4061,6 +4380,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DifferentiabilityParamsClauseSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DifferentiabilityParamsSyntax")
   public static func makeDifferentiabilityParams(_ garbageBeforeLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndDiffParams: GarbageNodesSyntax? = nil, diffParams: DifferentiabilityParamListSyntax, _ garbageBetweenDiffParamsAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> DifferentiabilityParamsSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftParen?.raw,
@@ -4076,6 +4396,7 @@ public enum SyntaxFactory {
     return DifferentiabilityParamsSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DifferentiabilityParamsSyntax")
   public static func makeBlankDifferentiabilityParams(presence: SourcePresence = .present) -> DifferentiabilityParamsSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .differentiabilityParams,
       layout: [
@@ -4088,6 +4409,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DifferentiabilityParamsSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DifferentiabilityParamListSyntax")
   public static func makeDifferentiabilityParamList(
     _ elements: [DifferentiabilityParamSyntax]) -> DifferentiabilityParamListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.differentiabilityParamList,
@@ -4096,12 +4418,14 @@ public enum SyntaxFactory {
     return DifferentiabilityParamListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DifferentiabilityParamListSyntax")
   public static func makeBlankDifferentiabilityParamList(presence: SourcePresence = .present) -> DifferentiabilityParamListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .differentiabilityParamList,
       layout: [
     ], length: .zero, presence: presence))
     return DifferentiabilityParamListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DifferentiabilityParamSyntax")
   public static func makeDifferentiabilityParam(_ garbageBeforeParameter: GarbageNodesSyntax? = nil, parameter: Syntax, _ garbageBetweenParameterAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> DifferentiabilityParamSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeParameter?.raw,
@@ -4115,6 +4439,7 @@ public enum SyntaxFactory {
     return DifferentiabilityParamSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DifferentiabilityParamSyntax")
   public static func makeBlankDifferentiabilityParam(presence: SourcePresence = .present) -> DifferentiabilityParamSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .differentiabilityParam,
       layout: [
@@ -4125,6 +4450,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DifferentiabilityParamSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DerivativeRegistrationAttributeArgumentsSyntax")
   public static func makeDerivativeRegistrationAttributeArguments(_ garbageBeforeOfLabel: GarbageNodesSyntax? = nil, ofLabel: TokenSyntax, _ garbageBetweenOfLabelAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndOriginalDeclName: GarbageNodesSyntax? = nil, originalDeclName: QualifiedDeclNameSyntax, _ garbageBetweenOriginalDeclNameAndPeriod: GarbageNodesSyntax? = nil, period: TokenSyntax?, _ garbageBetweenPeriodAndAccessorKind: GarbageNodesSyntax? = nil, accessorKind: TokenSyntax?, _ garbageBetweenAccessorKindAndComma: GarbageNodesSyntax? = nil, comma: TokenSyntax?, _ garbageBetweenCommaAndDiffParams: GarbageNodesSyntax? = nil, diffParams: DifferentiabilityParamsClauseSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeOfLabel?.raw,
@@ -4148,6 +4474,7 @@ public enum SyntaxFactory {
     return DerivativeRegistrationAttributeArgumentsSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DerivativeRegistrationAttributeArgumentsSyntax")
   public static func makeBlankDerivativeRegistrationAttributeArguments(presence: SourcePresence = .present) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .derivativeRegistrationAttributeArguments,
       layout: [
@@ -4168,6 +4495,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DerivativeRegistrationAttributeArgumentsSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on QualifiedDeclNameSyntax")
   public static func makeQualifiedDeclName(_ garbageBeforeBaseType: GarbageNodesSyntax? = nil, baseType: TypeSyntax?, _ garbageBetweenBaseTypeAndDot: GarbageNodesSyntax? = nil, dot: TokenSyntax?, _ garbageBetweenDotAndName: GarbageNodesSyntax? = nil, name: TokenSyntax, _ garbageBetweenNameAndArguments: GarbageNodesSyntax? = nil, arguments: DeclNameArgumentsSyntax?) -> QualifiedDeclNameSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeBaseType?.raw,
@@ -4185,6 +4513,7 @@ public enum SyntaxFactory {
     return QualifiedDeclNameSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on QualifiedDeclNameSyntax")
   public static func makeBlankQualifiedDeclName(presence: SourcePresence = .present) -> QualifiedDeclNameSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .qualifiedDeclName,
       layout: [
@@ -4199,6 +4528,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return QualifiedDeclNameSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on FunctionDeclNameSyntax")
   public static func makeFunctionDeclName(_ garbageBeforeName: GarbageNodesSyntax? = nil, name: Syntax, _ garbageBetweenNameAndArguments: GarbageNodesSyntax? = nil, arguments: DeclNameArgumentsSyntax?) -> FunctionDeclNameSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeName?.raw,
@@ -4212,6 +4542,7 @@ public enum SyntaxFactory {
     return FunctionDeclNameSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on FunctionDeclNameSyntax")
   public static func makeBlankFunctionDeclName(presence: SourcePresence = .present) -> FunctionDeclNameSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .functionDeclName,
       layout: [
@@ -4222,6 +4553,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return FunctionDeclNameSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on BackDeployAttributeSpecListSyntax")
   public static func makeBackDeployAttributeSpecList(_ garbageBeforeBeforeLabel: GarbageNodesSyntax? = nil, beforeLabel: TokenSyntax, _ garbageBetweenBeforeLabelAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndVersionList: GarbageNodesSyntax? = nil, versionList: BackDeployVersionListSyntax) -> BackDeployAttributeSpecListSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeBeforeLabel?.raw,
@@ -4237,6 +4569,7 @@ public enum SyntaxFactory {
     return BackDeployAttributeSpecListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on BackDeployAttributeSpecListSyntax")
   public static func makeBlankBackDeployAttributeSpecList(presence: SourcePresence = .present) -> BackDeployAttributeSpecListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .backDeployAttributeSpecList,
       layout: [
@@ -4249,6 +4582,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return BackDeployAttributeSpecListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on BackDeployVersionListSyntax")
   public static func makeBackDeployVersionList(
     _ elements: [BackDeployVersionArgumentSyntax]) -> BackDeployVersionListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.backDeployVersionList,
@@ -4257,12 +4591,14 @@ public enum SyntaxFactory {
     return BackDeployVersionListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on BackDeployVersionListSyntax")
   public static func makeBlankBackDeployVersionList(presence: SourcePresence = .present) -> BackDeployVersionListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .backDeployVersionList,
       layout: [
     ], length: .zero, presence: presence))
     return BackDeployVersionListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on BackDeployVersionArgumentSyntax")
   public static func makeBackDeployVersionArgument(_ garbageBeforeAvailabilityVersionRestriction: GarbageNodesSyntax? = nil, availabilityVersionRestriction: AvailabilityVersionRestrictionSyntax, _ garbageBetweenAvailabilityVersionRestrictionAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> BackDeployVersionArgumentSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAvailabilityVersionRestriction?.raw,
@@ -4276,6 +4612,7 @@ public enum SyntaxFactory {
     return BackDeployVersionArgumentSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on BackDeployVersionArgumentSyntax")
   public static func makeBlankBackDeployVersionArgument(presence: SourcePresence = .present) -> BackDeployVersionArgumentSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .backDeployVersionArgument,
       layout: [
@@ -4286,6 +4623,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return BackDeployVersionArgumentSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on LabeledStmtSyntax")
   public static func makeLabeledStmt(_ garbageBeforeLabelName: GarbageNodesSyntax? = nil, labelName: TokenSyntax, _ garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? = nil, labelColon: TokenSyntax, _ garbageBetweenLabelColonAndStatement: GarbageNodesSyntax? = nil, statement: StmtSyntax) -> LabeledStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLabelName?.raw,
@@ -4301,6 +4639,7 @@ public enum SyntaxFactory {
     return LabeledStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on LabeledStmtSyntax")
   public static func makeBlankLabeledStmt(presence: SourcePresence = .present) -> LabeledStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .labeledStmt,
       layout: [
@@ -4313,6 +4652,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return LabeledStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ContinueStmtSyntax")
   public static func makeContinueStmt(_ garbageBeforeContinueKeyword: GarbageNodesSyntax? = nil, continueKeyword: TokenSyntax, _ garbageBetweenContinueKeywordAndLabel: GarbageNodesSyntax? = nil, label: TokenSyntax?) -> ContinueStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeContinueKeyword?.raw,
@@ -4326,6 +4666,7 @@ public enum SyntaxFactory {
     return ContinueStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ContinueStmtSyntax")
   public static func makeBlankContinueStmt(presence: SourcePresence = .present) -> ContinueStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .continueStmt,
       layout: [
@@ -4336,6 +4677,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ContinueStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on WhileStmtSyntax")
   public static func makeWhileStmt(_ garbageBeforeWhileKeyword: GarbageNodesSyntax? = nil, whileKeyword: TokenSyntax, _ garbageBetweenWhileKeywordAndConditions: GarbageNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ garbageBetweenConditionsAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax) -> WhileStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeWhileKeyword?.raw,
@@ -4351,6 +4693,7 @@ public enum SyntaxFactory {
     return WhileStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on WhileStmtSyntax")
   public static func makeBlankWhileStmt(presence: SourcePresence = .present) -> WhileStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .whileStmt,
       layout: [
@@ -4363,6 +4706,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return WhileStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DeferStmtSyntax")
   public static func makeDeferStmt(_ garbageBeforeDeferKeyword: GarbageNodesSyntax? = nil, deferKeyword: TokenSyntax, _ garbageBetweenDeferKeywordAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax) -> DeferStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeDeferKeyword?.raw,
@@ -4376,6 +4720,7 @@ public enum SyntaxFactory {
     return DeferStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DeferStmtSyntax")
   public static func makeBlankDeferStmt(presence: SourcePresence = .present) -> DeferStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .deferStmt,
       layout: [
@@ -4386,6 +4731,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DeferStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ExpressionStmtSyntax")
   public static func makeExpressionStmt(_ garbageBeforeExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax) -> ExpressionStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeExpression?.raw,
@@ -4397,6 +4743,7 @@ public enum SyntaxFactory {
     return ExpressionStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ExpressionStmtSyntax")
   public static func makeBlankExpressionStmt(presence: SourcePresence = .present) -> ExpressionStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .expressionStmt,
       layout: [
@@ -4405,6 +4752,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ExpressionStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on SwitchCaseListSyntax")
   public static func makeSwitchCaseList(
     _ elements: [Syntax]) -> SwitchCaseListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.switchCaseList,
@@ -4413,12 +4761,14 @@ public enum SyntaxFactory {
     return SwitchCaseListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on SwitchCaseListSyntax")
   public static func makeBlankSwitchCaseList(presence: SourcePresence = .present) -> SwitchCaseListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .switchCaseList,
       layout: [
     ], length: .zero, presence: presence))
     return SwitchCaseListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on RepeatWhileStmtSyntax")
   public static func makeRepeatWhileStmt(_ garbageBeforeRepeatKeyword: GarbageNodesSyntax? = nil, repeatKeyword: TokenSyntax, _ garbageBetweenRepeatKeywordAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax, _ garbageBetweenBodyAndWhileKeyword: GarbageNodesSyntax? = nil, whileKeyword: TokenSyntax, _ garbageBetweenWhileKeywordAndCondition: GarbageNodesSyntax? = nil, condition: ExprSyntax) -> RepeatWhileStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeRepeatKeyword?.raw,
@@ -4436,6 +4786,7 @@ public enum SyntaxFactory {
     return RepeatWhileStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on RepeatWhileStmtSyntax")
   public static func makeBlankRepeatWhileStmt(presence: SourcePresence = .present) -> RepeatWhileStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .repeatWhileStmt,
       layout: [
@@ -4450,6 +4801,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return RepeatWhileStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on GuardStmtSyntax")
   public static func makeGuardStmt(_ garbageBeforeGuardKeyword: GarbageNodesSyntax? = nil, guardKeyword: TokenSyntax, _ garbageBetweenGuardKeywordAndConditions: GarbageNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ garbageBetweenConditionsAndElseKeyword: GarbageNodesSyntax? = nil, elseKeyword: TokenSyntax, _ garbageBetweenElseKeywordAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax) -> GuardStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeGuardKeyword?.raw,
@@ -4467,6 +4819,7 @@ public enum SyntaxFactory {
     return GuardStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on GuardStmtSyntax")
   public static func makeBlankGuardStmt(presence: SourcePresence = .present) -> GuardStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .guardStmt,
       layout: [
@@ -4481,6 +4834,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return GuardStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on WhereClauseSyntax")
   public static func makeWhereClause(_ garbageBeforeWhereKeyword: GarbageNodesSyntax? = nil, whereKeyword: TokenSyntax, _ garbageBetweenWhereKeywordAndGuardResult: GarbageNodesSyntax? = nil, guardResult: ExprSyntax) -> WhereClauseSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeWhereKeyword?.raw,
@@ -4494,6 +4848,7 @@ public enum SyntaxFactory {
     return WhereClauseSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on WhereClauseSyntax")
   public static func makeBlankWhereClause(presence: SourcePresence = .present) -> WhereClauseSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .whereClause,
       layout: [
@@ -4504,6 +4859,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return WhereClauseSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ForInStmtSyntax")
   public static func makeForInStmt(_ garbageBeforeForKeyword: GarbageNodesSyntax? = nil, forKeyword: TokenSyntax, _ garbageBetweenForKeywordAndTryKeyword: GarbageNodesSyntax? = nil, tryKeyword: TokenSyntax?, _ garbageBetweenTryKeywordAndAwaitKeyword: GarbageNodesSyntax? = nil, awaitKeyword: TokenSyntax?, _ garbageBetweenAwaitKeywordAndCaseKeyword: GarbageNodesSyntax? = nil, caseKeyword: TokenSyntax?, _ garbageBetweenCaseKeywordAndPattern: GarbageNodesSyntax? = nil, pattern: PatternSyntax, _ garbageBetweenPatternAndTypeAnnotation: GarbageNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ garbageBetweenTypeAnnotationAndInKeyword: GarbageNodesSyntax? = nil, inKeyword: TokenSyntax, _ garbageBetweenInKeywordAndSequenceExpr: GarbageNodesSyntax? = nil, sequenceExpr: ExprSyntax, _ garbageBetweenSequenceExprAndWhereClause: GarbageNodesSyntax? = nil, whereClause: WhereClauseSyntax?, _ garbageBetweenWhereClauseAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax) -> ForInStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeForKeyword?.raw,
@@ -4533,6 +4889,7 @@ public enum SyntaxFactory {
     return ForInStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ForInStmtSyntax")
   public static func makeBlankForInStmt(presence: SourcePresence = .present) -> ForInStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .forInStmt,
       layout: [
@@ -4559,6 +4916,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ForInStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on SwitchStmtSyntax")
   public static func makeSwitchStmt(_ garbageBeforeSwitchKeyword: GarbageNodesSyntax? = nil, switchKeyword: TokenSyntax, _ garbageBetweenSwitchKeywordAndExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax, _ garbageBetweenExpressionAndLeftBrace: GarbageNodesSyntax? = nil, leftBrace: TokenSyntax, _ garbageBetweenLeftBraceAndCases: GarbageNodesSyntax? = nil, cases: SwitchCaseListSyntax, _ garbageBetweenCasesAndRightBrace: GarbageNodesSyntax? = nil, rightBrace: TokenSyntax) -> SwitchStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeSwitchKeyword?.raw,
@@ -4578,6 +4936,7 @@ public enum SyntaxFactory {
     return SwitchStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on SwitchStmtSyntax")
   public static func makeBlankSwitchStmt(presence: SourcePresence = .present) -> SwitchStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .switchStmt,
       layout: [
@@ -4594,6 +4953,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return SwitchStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on CatchClauseListSyntax")
   public static func makeCatchClauseList(
     _ elements: [CatchClauseSyntax]) -> CatchClauseListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.catchClauseList,
@@ -4602,12 +4962,14 @@ public enum SyntaxFactory {
     return CatchClauseListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on CatchClauseListSyntax")
   public static func makeBlankCatchClauseList(presence: SourcePresence = .present) -> CatchClauseListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .catchClauseList,
       layout: [
     ], length: .zero, presence: presence))
     return CatchClauseListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DoStmtSyntax")
   public static func makeDoStmt(_ garbageBeforeDoKeyword: GarbageNodesSyntax? = nil, doKeyword: TokenSyntax, _ garbageBetweenDoKeywordAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax, _ garbageBetweenBodyAndCatchClauses: GarbageNodesSyntax? = nil, catchClauses: CatchClauseListSyntax?) -> DoStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeDoKeyword?.raw,
@@ -4623,6 +4985,7 @@ public enum SyntaxFactory {
     return DoStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DoStmtSyntax")
   public static func makeBlankDoStmt(presence: SourcePresence = .present) -> DoStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .doStmt,
       layout: [
@@ -4635,6 +4998,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DoStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ReturnStmtSyntax")
   public static func makeReturnStmt(_ garbageBeforeReturnKeyword: GarbageNodesSyntax? = nil, returnKeyword: TokenSyntax, _ garbageBetweenReturnKeywordAndExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax?) -> ReturnStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeReturnKeyword?.raw,
@@ -4648,6 +5012,7 @@ public enum SyntaxFactory {
     return ReturnStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ReturnStmtSyntax")
   public static func makeBlankReturnStmt(presence: SourcePresence = .present) -> ReturnStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .returnStmt,
       layout: [
@@ -4658,6 +5023,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ReturnStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on YieldStmtSyntax")
   public static func makeYieldStmt(_ garbageBeforeYieldKeyword: GarbageNodesSyntax? = nil, yieldKeyword: TokenSyntax, _ garbageBetweenYieldKeywordAndYields: GarbageNodesSyntax? = nil, yields: Syntax) -> YieldStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeYieldKeyword?.raw,
@@ -4671,6 +5037,7 @@ public enum SyntaxFactory {
     return YieldStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on YieldStmtSyntax")
   public static func makeBlankYieldStmt(presence: SourcePresence = .present) -> YieldStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .yieldStmt,
       layout: [
@@ -4681,6 +5048,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return YieldStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on YieldListSyntax")
   public static func makeYieldList(_ garbageBeforeLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndElementList: GarbageNodesSyntax? = nil, elementList: ExprListSyntax, _ garbageBetweenElementListAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?, _ garbageBetweenTrailingCommaAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> YieldListSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftParen?.raw,
@@ -4698,6 +5066,7 @@ public enum SyntaxFactory {
     return YieldListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on YieldListSyntax")
   public static func makeBlankYieldList(presence: SourcePresence = .present) -> YieldListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .yieldList,
       layout: [
@@ -4712,6 +5081,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return YieldListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on FallthroughStmtSyntax")
   public static func makeFallthroughStmt(_ garbageBeforeFallthroughKeyword: GarbageNodesSyntax? = nil, fallthroughKeyword: TokenSyntax) -> FallthroughStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeFallthroughKeyword?.raw,
@@ -4723,6 +5093,7 @@ public enum SyntaxFactory {
     return FallthroughStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on FallthroughStmtSyntax")
   public static func makeBlankFallthroughStmt(presence: SourcePresence = .present) -> FallthroughStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .fallthroughStmt,
       layout: [
@@ -4731,6 +5102,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return FallthroughStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on BreakStmtSyntax")
   public static func makeBreakStmt(_ garbageBeforeBreakKeyword: GarbageNodesSyntax? = nil, breakKeyword: TokenSyntax, _ garbageBetweenBreakKeywordAndLabel: GarbageNodesSyntax? = nil, label: TokenSyntax?) -> BreakStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeBreakKeyword?.raw,
@@ -4744,6 +5116,7 @@ public enum SyntaxFactory {
     return BreakStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on BreakStmtSyntax")
   public static func makeBlankBreakStmt(presence: SourcePresence = .present) -> BreakStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .breakStmt,
       layout: [
@@ -4754,6 +5127,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return BreakStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on CaseItemListSyntax")
   public static func makeCaseItemList(
     _ elements: [CaseItemSyntax]) -> CaseItemListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.caseItemList,
@@ -4762,12 +5136,14 @@ public enum SyntaxFactory {
     return CaseItemListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on CaseItemListSyntax")
   public static func makeBlankCaseItemList(presence: SourcePresence = .present) -> CaseItemListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .caseItemList,
       layout: [
     ], length: .zero, presence: presence))
     return CaseItemListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on CatchItemListSyntax")
   public static func makeCatchItemList(
     _ elements: [CatchItemSyntax]) -> CatchItemListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.catchItemList,
@@ -4776,12 +5152,14 @@ public enum SyntaxFactory {
     return CatchItemListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on CatchItemListSyntax")
   public static func makeBlankCatchItemList(presence: SourcePresence = .present) -> CatchItemListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .catchItemList,
       layout: [
     ], length: .zero, presence: presence))
     return CatchItemListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ConditionElementSyntax")
   public static func makeConditionElement(_ garbageBeforeCondition: GarbageNodesSyntax? = nil, condition: Syntax, _ garbageBetweenConditionAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> ConditionElementSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeCondition?.raw,
@@ -4795,6 +5173,7 @@ public enum SyntaxFactory {
     return ConditionElementSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ConditionElementSyntax")
   public static func makeBlankConditionElement(presence: SourcePresence = .present) -> ConditionElementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .conditionElement,
       layout: [
@@ -4805,6 +5184,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ConditionElementSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AvailabilityConditionSyntax")
   public static func makeAvailabilityCondition(_ garbageBeforePoundAvailableKeyword: GarbageNodesSyntax? = nil, poundAvailableKeyword: TokenSyntax, _ garbageBetweenPoundAvailableKeywordAndLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndAvailabilitySpec: GarbageNodesSyntax? = nil, availabilitySpec: AvailabilitySpecListSyntax, _ garbageBetweenAvailabilitySpecAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> AvailabilityConditionSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePoundAvailableKeyword?.raw,
@@ -4822,6 +5202,7 @@ public enum SyntaxFactory {
     return AvailabilityConditionSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AvailabilityConditionSyntax")
   public static func makeBlankAvailabilityCondition(presence: SourcePresence = .present) -> AvailabilityConditionSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .availabilityCondition,
       layout: [
@@ -4836,6 +5217,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AvailabilityConditionSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on MatchingPatternConditionSyntax")
   public static func makeMatchingPatternCondition(_ garbageBeforeCaseKeyword: GarbageNodesSyntax? = nil, caseKeyword: TokenSyntax, _ garbageBetweenCaseKeywordAndPattern: GarbageNodesSyntax? = nil, pattern: PatternSyntax, _ garbageBetweenPatternAndTypeAnnotation: GarbageNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ garbageBetweenTypeAnnotationAndInitializer: GarbageNodesSyntax? = nil, initializer: InitializerClauseSyntax) -> MatchingPatternConditionSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeCaseKeyword?.raw,
@@ -4853,6 +5235,7 @@ public enum SyntaxFactory {
     return MatchingPatternConditionSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MatchingPatternConditionSyntax")
   public static func makeBlankMatchingPatternCondition(presence: SourcePresence = .present) -> MatchingPatternConditionSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .matchingPatternCondition,
       layout: [
@@ -4867,6 +5250,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return MatchingPatternConditionSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on OptionalBindingConditionSyntax")
   public static func makeOptionalBindingCondition(_ garbageBeforeLetOrVarKeyword: GarbageNodesSyntax? = nil, letOrVarKeyword: TokenSyntax, _ garbageBetweenLetOrVarKeywordAndPattern: GarbageNodesSyntax? = nil, pattern: PatternSyntax, _ garbageBetweenPatternAndTypeAnnotation: GarbageNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ garbageBetweenTypeAnnotationAndInitializer: GarbageNodesSyntax? = nil, initializer: InitializerClauseSyntax?) -> OptionalBindingConditionSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLetOrVarKeyword?.raw,
@@ -4884,6 +5268,7 @@ public enum SyntaxFactory {
     return OptionalBindingConditionSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on OptionalBindingConditionSyntax")
   public static func makeBlankOptionalBindingCondition(presence: SourcePresence = .present) -> OptionalBindingConditionSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .optionalBindingCondition,
       layout: [
@@ -4898,6 +5283,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return OptionalBindingConditionSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on UnavailabilityConditionSyntax")
   public static func makeUnavailabilityCondition(_ garbageBeforePoundUnavailableKeyword: GarbageNodesSyntax? = nil, poundUnavailableKeyword: TokenSyntax, _ garbageBetweenPoundUnavailableKeywordAndLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndAvailabilitySpec: GarbageNodesSyntax? = nil, availabilitySpec: AvailabilitySpecListSyntax, _ garbageBetweenAvailabilitySpecAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> UnavailabilityConditionSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePoundUnavailableKeyword?.raw,
@@ -4915,6 +5301,7 @@ public enum SyntaxFactory {
     return UnavailabilityConditionSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on UnavailabilityConditionSyntax")
   public static func makeBlankUnavailabilityCondition(presence: SourcePresence = .present) -> UnavailabilityConditionSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .unavailabilityCondition,
       layout: [
@@ -4929,6 +5316,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return UnavailabilityConditionSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ConditionElementListSyntax")
   public static func makeConditionElementList(
     _ elements: [ConditionElementSyntax]) -> ConditionElementListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.conditionElementList,
@@ -4937,12 +5325,14 @@ public enum SyntaxFactory {
     return ConditionElementListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ConditionElementListSyntax")
   public static func makeBlankConditionElementList(presence: SourcePresence = .present) -> ConditionElementListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .conditionElementList,
       layout: [
     ], length: .zero, presence: presence))
     return ConditionElementListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DeclarationStmtSyntax")
   public static func makeDeclarationStmt(_ garbageBeforeDeclaration: GarbageNodesSyntax? = nil, declaration: DeclSyntax) -> DeclarationStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeDeclaration?.raw,
@@ -4954,6 +5344,7 @@ public enum SyntaxFactory {
     return DeclarationStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DeclarationStmtSyntax")
   public static func makeBlankDeclarationStmt(presence: SourcePresence = .present) -> DeclarationStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .declarationStmt,
       layout: [
@@ -4962,6 +5353,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DeclarationStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ThrowStmtSyntax")
   public static func makeThrowStmt(_ garbageBeforeThrowKeyword: GarbageNodesSyntax? = nil, throwKeyword: TokenSyntax, _ garbageBetweenThrowKeywordAndExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax) -> ThrowStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeThrowKeyword?.raw,
@@ -4975,6 +5367,7 @@ public enum SyntaxFactory {
     return ThrowStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ThrowStmtSyntax")
   public static func makeBlankThrowStmt(presence: SourcePresence = .present) -> ThrowStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .throwStmt,
       layout: [
@@ -4985,6 +5378,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ThrowStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on IfStmtSyntax")
   public static func makeIfStmt(_ garbageBeforeIfKeyword: GarbageNodesSyntax? = nil, ifKeyword: TokenSyntax, _ garbageBetweenIfKeywordAndConditions: GarbageNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ garbageBetweenConditionsAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax, _ garbageBetweenBodyAndElseKeyword: GarbageNodesSyntax? = nil, elseKeyword: TokenSyntax?, _ garbageBetweenElseKeywordAndElseBody: GarbageNodesSyntax? = nil, elseBody: Syntax?) -> IfStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeIfKeyword?.raw,
@@ -5004,6 +5398,7 @@ public enum SyntaxFactory {
     return IfStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on IfStmtSyntax")
   public static func makeBlankIfStmt(presence: SourcePresence = .present) -> IfStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .ifStmt,
       layout: [
@@ -5020,6 +5415,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return IfStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ElseIfContinuationSyntax")
   public static func makeElseIfContinuation(_ garbageBeforeIfStatement: GarbageNodesSyntax? = nil, ifStatement: IfStmtSyntax) -> ElseIfContinuationSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeIfStatement?.raw,
@@ -5031,6 +5427,7 @@ public enum SyntaxFactory {
     return ElseIfContinuationSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ElseIfContinuationSyntax")
   public static func makeBlankElseIfContinuation(presence: SourcePresence = .present) -> ElseIfContinuationSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .elseIfContinuation,
       layout: [
@@ -5039,6 +5436,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ElseIfContinuationSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ElseBlockSyntax")
   public static func makeElseBlock(_ garbageBeforeElseKeyword: GarbageNodesSyntax? = nil, elseKeyword: TokenSyntax, _ garbageBetweenElseKeywordAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax) -> ElseBlockSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeElseKeyword?.raw,
@@ -5052,6 +5450,7 @@ public enum SyntaxFactory {
     return ElseBlockSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ElseBlockSyntax")
   public static func makeBlankElseBlock(presence: SourcePresence = .present) -> ElseBlockSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .elseBlock,
       layout: [
@@ -5062,6 +5461,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ElseBlockSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on SwitchCaseSyntax")
   public static func makeSwitchCase(_ garbageBeforeUnknownAttr: GarbageNodesSyntax? = nil, unknownAttr: AttributeSyntax?, _ garbageBetweenUnknownAttrAndLabel: GarbageNodesSyntax? = nil, label: Syntax, _ garbageBetweenLabelAndStatements: GarbageNodesSyntax? = nil, statements: CodeBlockItemListSyntax) -> SwitchCaseSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeUnknownAttr?.raw,
@@ -5077,6 +5477,7 @@ public enum SyntaxFactory {
     return SwitchCaseSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on SwitchCaseSyntax")
   public static func makeBlankSwitchCase(presence: SourcePresence = .present) -> SwitchCaseSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .switchCase,
       layout: [
@@ -5089,6 +5490,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return SwitchCaseSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on SwitchDefaultLabelSyntax")
   public static func makeSwitchDefaultLabel(_ garbageBeforeDefaultKeyword: GarbageNodesSyntax? = nil, defaultKeyword: TokenSyntax, _ garbageBetweenDefaultKeywordAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax) -> SwitchDefaultLabelSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeDefaultKeyword?.raw,
@@ -5102,6 +5504,7 @@ public enum SyntaxFactory {
     return SwitchDefaultLabelSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on SwitchDefaultLabelSyntax")
   public static func makeBlankSwitchDefaultLabel(presence: SourcePresence = .present) -> SwitchDefaultLabelSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .switchDefaultLabel,
       layout: [
@@ -5112,6 +5515,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return SwitchDefaultLabelSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on CaseItemSyntax")
   public static func makeCaseItem(_ garbageBeforePattern: GarbageNodesSyntax? = nil, pattern: PatternSyntax, _ garbageBetweenPatternAndWhereClause: GarbageNodesSyntax? = nil, whereClause: WhereClauseSyntax?, _ garbageBetweenWhereClauseAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> CaseItemSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePattern?.raw,
@@ -5127,6 +5531,7 @@ public enum SyntaxFactory {
     return CaseItemSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on CaseItemSyntax")
   public static func makeBlankCaseItem(presence: SourcePresence = .present) -> CaseItemSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .caseItem,
       layout: [
@@ -5139,6 +5544,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return CaseItemSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on CatchItemSyntax")
   public static func makeCatchItem(_ garbageBeforePattern: GarbageNodesSyntax? = nil, pattern: PatternSyntax?, _ garbageBetweenPatternAndWhereClause: GarbageNodesSyntax? = nil, whereClause: WhereClauseSyntax?, _ garbageBetweenWhereClauseAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> CatchItemSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePattern?.raw,
@@ -5154,6 +5560,7 @@ public enum SyntaxFactory {
     return CatchItemSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on CatchItemSyntax")
   public static func makeBlankCatchItem(presence: SourcePresence = .present) -> CatchItemSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .catchItem,
       layout: [
@@ -5166,6 +5573,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return CatchItemSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on SwitchCaseLabelSyntax")
   public static func makeSwitchCaseLabel(_ garbageBeforeCaseKeyword: GarbageNodesSyntax? = nil, caseKeyword: TokenSyntax, _ garbageBetweenCaseKeywordAndCaseItems: GarbageNodesSyntax? = nil, caseItems: CaseItemListSyntax, _ garbageBetweenCaseItemsAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax) -> SwitchCaseLabelSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeCaseKeyword?.raw,
@@ -5181,6 +5589,7 @@ public enum SyntaxFactory {
     return SwitchCaseLabelSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on SwitchCaseLabelSyntax")
   public static func makeBlankSwitchCaseLabel(presence: SourcePresence = .present) -> SwitchCaseLabelSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .switchCaseLabel,
       layout: [
@@ -5193,6 +5602,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return SwitchCaseLabelSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on CatchClauseSyntax")
   public static func makeCatchClause(_ garbageBeforeCatchKeyword: GarbageNodesSyntax? = nil, catchKeyword: TokenSyntax, _ garbageBetweenCatchKeywordAndCatchItems: GarbageNodesSyntax? = nil, catchItems: CatchItemListSyntax?, _ garbageBetweenCatchItemsAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax) -> CatchClauseSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeCatchKeyword?.raw,
@@ -5208,6 +5618,7 @@ public enum SyntaxFactory {
     return CatchClauseSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on CatchClauseSyntax")
   public static func makeBlankCatchClause(presence: SourcePresence = .present) -> CatchClauseSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .catchClause,
       layout: [
@@ -5220,6 +5631,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return CatchClauseSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PoundAssertStmtSyntax")
   public static func makePoundAssertStmt(_ garbageBeforePoundAssert: GarbageNodesSyntax? = nil, poundAssert: TokenSyntax, _ garbageBetweenPoundAssertAndLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndCondition: GarbageNodesSyntax? = nil, condition: ExprSyntax, _ garbageBetweenConditionAndComma: GarbageNodesSyntax? = nil, comma: TokenSyntax?, _ garbageBetweenCommaAndMessage: GarbageNodesSyntax? = nil, message: TokenSyntax?, _ garbageBetweenMessageAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> PoundAssertStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePoundAssert?.raw,
@@ -5241,6 +5653,7 @@ public enum SyntaxFactory {
     return PoundAssertStmtSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PoundAssertStmtSyntax")
   public static func makeBlankPoundAssertStmt(presence: SourcePresence = .present) -> PoundAssertStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .poundAssertStmt,
       layout: [
@@ -5259,6 +5672,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PoundAssertStmtSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on GenericWhereClauseSyntax")
   public static func makeGenericWhereClause(_ garbageBeforeWhereKeyword: GarbageNodesSyntax? = nil, whereKeyword: TokenSyntax, _ garbageBetweenWhereKeywordAndRequirementList: GarbageNodesSyntax? = nil, requirementList: GenericRequirementListSyntax) -> GenericWhereClauseSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeWhereKeyword?.raw,
@@ -5272,6 +5686,7 @@ public enum SyntaxFactory {
     return GenericWhereClauseSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on GenericWhereClauseSyntax")
   public static func makeBlankGenericWhereClause(presence: SourcePresence = .present) -> GenericWhereClauseSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .genericWhereClause,
       layout: [
@@ -5282,6 +5697,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return GenericWhereClauseSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on GenericRequirementListSyntax")
   public static func makeGenericRequirementList(
     _ elements: [GenericRequirementSyntax]) -> GenericRequirementListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.genericRequirementList,
@@ -5290,12 +5706,14 @@ public enum SyntaxFactory {
     return GenericRequirementListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on GenericRequirementListSyntax")
   public static func makeBlankGenericRequirementList(presence: SourcePresence = .present) -> GenericRequirementListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .genericRequirementList,
       layout: [
     ], length: .zero, presence: presence))
     return GenericRequirementListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on GenericRequirementSyntax")
   public static func makeGenericRequirement(_ garbageBeforeBody: GarbageNodesSyntax? = nil, body: Syntax, _ garbageBetweenBodyAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> GenericRequirementSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeBody?.raw,
@@ -5309,6 +5727,7 @@ public enum SyntaxFactory {
     return GenericRequirementSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on GenericRequirementSyntax")
   public static func makeBlankGenericRequirement(presence: SourcePresence = .present) -> GenericRequirementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .genericRequirement,
       layout: [
@@ -5319,6 +5738,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return GenericRequirementSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on SameTypeRequirementSyntax")
   public static func makeSameTypeRequirement(_ garbageBeforeLeftTypeIdentifier: GarbageNodesSyntax? = nil, leftTypeIdentifier: TypeSyntax, _ garbageBetweenLeftTypeIdentifierAndEqualityToken: GarbageNodesSyntax? = nil, equalityToken: TokenSyntax, _ garbageBetweenEqualityTokenAndRightTypeIdentifier: GarbageNodesSyntax? = nil, rightTypeIdentifier: TypeSyntax) -> SameTypeRequirementSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftTypeIdentifier?.raw,
@@ -5334,6 +5754,7 @@ public enum SyntaxFactory {
     return SameTypeRequirementSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on SameTypeRequirementSyntax")
   public static func makeBlankSameTypeRequirement(presence: SourcePresence = .present) -> SameTypeRequirementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .sameTypeRequirement,
       layout: [
@@ -5346,6 +5767,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return SameTypeRequirementSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on LayoutRequirementSyntax")
   public static func makeLayoutRequirement(_ garbageBeforeTypeIdentifier: GarbageNodesSyntax? = nil, typeIdentifier: TypeSyntax, _ garbageBetweenTypeIdentifierAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndLayoutConstraint: GarbageNodesSyntax? = nil, layoutConstraint: TokenSyntax, _ garbageBetweenLayoutConstraintAndLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax?, _ garbageBetweenLeftParenAndSize: GarbageNodesSyntax? = nil, size: TokenSyntax?, _ garbageBetweenSizeAndComma: GarbageNodesSyntax? = nil, comma: TokenSyntax?, _ garbageBetweenCommaAndAlignment: GarbageNodesSyntax? = nil, alignment: TokenSyntax?, _ garbageBetweenAlignmentAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax?) -> LayoutRequirementSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeTypeIdentifier?.raw,
@@ -5371,6 +5793,7 @@ public enum SyntaxFactory {
     return LayoutRequirementSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on LayoutRequirementSyntax")
   public static func makeBlankLayoutRequirement(presence: SourcePresence = .present) -> LayoutRequirementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .layoutRequirement,
       layout: [
@@ -5393,6 +5816,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return LayoutRequirementSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on GenericParameterListSyntax")
   public static func makeGenericParameterList(
     _ elements: [GenericParameterSyntax]) -> GenericParameterListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.genericParameterList,
@@ -5401,12 +5825,14 @@ public enum SyntaxFactory {
     return GenericParameterListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on GenericParameterListSyntax")
   public static func makeBlankGenericParameterList(presence: SourcePresence = .present) -> GenericParameterListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .genericParameterList,
       layout: [
     ], length: .zero, presence: presence))
     return GenericParameterListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on GenericParameterSyntax")
   public static func makeGenericParameter(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndName: GarbageNodesSyntax? = nil, name: TokenSyntax, _ garbageBetweenNameAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax?, _ garbageBetweenColonAndInheritedType: GarbageNodesSyntax? = nil, inheritedType: TypeSyntax?, _ garbageBetweenInheritedTypeAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> GenericParameterSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,
@@ -5426,6 +5852,7 @@ public enum SyntaxFactory {
     return GenericParameterSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on GenericParameterSyntax")
   public static func makeBlankGenericParameter(presence: SourcePresence = .present) -> GenericParameterSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .genericParameter,
       layout: [
@@ -5442,6 +5869,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return GenericParameterSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PrimaryAssociatedTypeListSyntax")
   public static func makePrimaryAssociatedTypeList(
     _ elements: [PrimaryAssociatedTypeSyntax]) -> PrimaryAssociatedTypeListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.primaryAssociatedTypeList,
@@ -5450,12 +5878,14 @@ public enum SyntaxFactory {
     return PrimaryAssociatedTypeListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PrimaryAssociatedTypeListSyntax")
   public static func makeBlankPrimaryAssociatedTypeList(presence: SourcePresence = .present) -> PrimaryAssociatedTypeListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .primaryAssociatedTypeList,
       layout: [
     ], length: .zero, presence: presence))
     return PrimaryAssociatedTypeListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PrimaryAssociatedTypeSyntax")
   public static func makePrimaryAssociatedType(_ garbageBeforeName: GarbageNodesSyntax? = nil, name: TokenSyntax, _ garbageBetweenNameAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> PrimaryAssociatedTypeSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeName?.raw,
@@ -5469,6 +5899,7 @@ public enum SyntaxFactory {
     return PrimaryAssociatedTypeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PrimaryAssociatedTypeSyntax")
   public static func makeBlankPrimaryAssociatedType(presence: SourcePresence = .present) -> PrimaryAssociatedTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .primaryAssociatedType,
       layout: [
@@ -5479,6 +5910,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PrimaryAssociatedTypeSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on GenericParameterClauseSyntax")
   public static func makeGenericParameterClause(_ garbageBeforeLeftAngleBracket: GarbageNodesSyntax? = nil, leftAngleBracket: TokenSyntax, _ garbageBetweenLeftAngleBracketAndGenericParameterList: GarbageNodesSyntax? = nil, genericParameterList: GenericParameterListSyntax, _ garbageBetweenGenericParameterListAndRightAngleBracket: GarbageNodesSyntax? = nil, rightAngleBracket: TokenSyntax) -> GenericParameterClauseSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftAngleBracket?.raw,
@@ -5494,6 +5926,7 @@ public enum SyntaxFactory {
     return GenericParameterClauseSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on GenericParameterClauseSyntax")
   public static func makeBlankGenericParameterClause(presence: SourcePresence = .present) -> GenericParameterClauseSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .genericParameterClause,
       layout: [
@@ -5506,6 +5939,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return GenericParameterClauseSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ConformanceRequirementSyntax")
   public static func makeConformanceRequirement(_ garbageBeforeLeftTypeIdentifier: GarbageNodesSyntax? = nil, leftTypeIdentifier: TypeSyntax, _ garbageBetweenLeftTypeIdentifierAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndRightTypeIdentifier: GarbageNodesSyntax? = nil, rightTypeIdentifier: TypeSyntax) -> ConformanceRequirementSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftTypeIdentifier?.raw,
@@ -5521,6 +5955,7 @@ public enum SyntaxFactory {
     return ConformanceRequirementSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ConformanceRequirementSyntax")
   public static func makeBlankConformanceRequirement(presence: SourcePresence = .present) -> ConformanceRequirementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .conformanceRequirement,
       layout: [
@@ -5533,6 +5968,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ConformanceRequirementSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on PrimaryAssociatedTypeClauseSyntax")
   public static func makePrimaryAssociatedTypeClause(_ garbageBeforeLeftAngleBracket: GarbageNodesSyntax? = nil, leftAngleBracket: TokenSyntax, _ garbageBetweenLeftAngleBracketAndPrimaryAssociatedTypeList: GarbageNodesSyntax? = nil, primaryAssociatedTypeList: PrimaryAssociatedTypeListSyntax, _ garbageBetweenPrimaryAssociatedTypeListAndRightAngleBracket: GarbageNodesSyntax? = nil, rightAngleBracket: TokenSyntax) -> PrimaryAssociatedTypeClauseSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftAngleBracket?.raw,
@@ -5548,6 +5984,7 @@ public enum SyntaxFactory {
     return PrimaryAssociatedTypeClauseSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on PrimaryAssociatedTypeClauseSyntax")
   public static func makeBlankPrimaryAssociatedTypeClause(presence: SourcePresence = .present) -> PrimaryAssociatedTypeClauseSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .primaryAssociatedTypeClause,
       layout: [
@@ -5560,6 +5997,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return PrimaryAssociatedTypeClauseSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on SimpleTypeIdentifierSyntax")
   public static func makeSimpleTypeIdentifier(_ garbageBeforeName: GarbageNodesSyntax? = nil, name: TokenSyntax, _ garbageBetweenNameAndGenericArgumentClause: GarbageNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax?) -> SimpleTypeIdentifierSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeName?.raw,
@@ -5573,6 +6011,7 @@ public enum SyntaxFactory {
     return SimpleTypeIdentifierSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on SimpleTypeIdentifierSyntax")
   public static func makeBlankSimpleTypeIdentifier(presence: SourcePresence = .present) -> SimpleTypeIdentifierSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .simpleTypeIdentifier,
       layout: [
@@ -5583,6 +6022,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return SimpleTypeIdentifierSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on MemberTypeIdentifierSyntax")
   public static func makeMemberTypeIdentifier(_ garbageBeforeBaseType: GarbageNodesSyntax? = nil, baseType: TypeSyntax, _ garbageBetweenBaseTypeAndPeriod: GarbageNodesSyntax? = nil, period: TokenSyntax, _ garbageBetweenPeriodAndName: GarbageNodesSyntax? = nil, name: TokenSyntax, _ garbageBetweenNameAndGenericArgumentClause: GarbageNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax?) -> MemberTypeIdentifierSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeBaseType?.raw,
@@ -5600,6 +6040,7 @@ public enum SyntaxFactory {
     return MemberTypeIdentifierSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MemberTypeIdentifierSyntax")
   public static func makeBlankMemberTypeIdentifier(presence: SourcePresence = .present) -> MemberTypeIdentifierSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .memberTypeIdentifier,
       layout: [
@@ -5614,6 +6055,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return MemberTypeIdentifierSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ClassRestrictionTypeSyntax")
   public static func makeClassRestrictionType(_ garbageBeforeClassKeyword: GarbageNodesSyntax? = nil, classKeyword: TokenSyntax) -> ClassRestrictionTypeSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeClassKeyword?.raw,
@@ -5625,6 +6067,7 @@ public enum SyntaxFactory {
     return ClassRestrictionTypeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ClassRestrictionTypeSyntax")
   public static func makeBlankClassRestrictionType(presence: SourcePresence = .present) -> ClassRestrictionTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .classRestrictionType,
       layout: [
@@ -5633,6 +6076,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ClassRestrictionTypeSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ArrayTypeSyntax")
   public static func makeArrayType(_ garbageBeforeLeftSquareBracket: GarbageNodesSyntax? = nil, leftSquareBracket: TokenSyntax, _ garbageBetweenLeftSquareBracketAndElementType: GarbageNodesSyntax? = nil, elementType: TypeSyntax, _ garbageBetweenElementTypeAndRightSquareBracket: GarbageNodesSyntax? = nil, rightSquareBracket: TokenSyntax) -> ArrayTypeSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftSquareBracket?.raw,
@@ -5648,6 +6092,7 @@ public enum SyntaxFactory {
     return ArrayTypeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ArrayTypeSyntax")
   public static func makeBlankArrayType(presence: SourcePresence = .present) -> ArrayTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .arrayType,
       layout: [
@@ -5660,6 +6105,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ArrayTypeSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on DictionaryTypeSyntax")
   public static func makeDictionaryType(_ garbageBeforeLeftSquareBracket: GarbageNodesSyntax? = nil, leftSquareBracket: TokenSyntax, _ garbageBetweenLeftSquareBracketAndKeyType: GarbageNodesSyntax? = nil, keyType: TypeSyntax, _ garbageBetweenKeyTypeAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndValueType: GarbageNodesSyntax? = nil, valueType: TypeSyntax, _ garbageBetweenValueTypeAndRightSquareBracket: GarbageNodesSyntax? = nil, rightSquareBracket: TokenSyntax) -> DictionaryTypeSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftSquareBracket?.raw,
@@ -5679,6 +6125,7 @@ public enum SyntaxFactory {
     return DictionaryTypeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on DictionaryTypeSyntax")
   public static func makeBlankDictionaryType(presence: SourcePresence = .present) -> DictionaryTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .dictionaryType,
       layout: [
@@ -5695,6 +6142,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return DictionaryTypeSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on MetatypeTypeSyntax")
   public static func makeMetatypeType(_ garbageBeforeBaseType: GarbageNodesSyntax? = nil, baseType: TypeSyntax, _ garbageBetweenBaseTypeAndPeriod: GarbageNodesSyntax? = nil, period: TokenSyntax, _ garbageBetweenPeriodAndTypeOrProtocol: GarbageNodesSyntax? = nil, typeOrProtocol: TokenSyntax) -> MetatypeTypeSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeBaseType?.raw,
@@ -5710,6 +6158,7 @@ public enum SyntaxFactory {
     return MetatypeTypeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on MetatypeTypeSyntax")
   public static func makeBlankMetatypeType(presence: SourcePresence = .present) -> MetatypeTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .metatypeType,
       layout: [
@@ -5722,6 +6171,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return MetatypeTypeSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on OptionalTypeSyntax")
   public static func makeOptionalType(_ garbageBeforeWrappedType: GarbageNodesSyntax? = nil, wrappedType: TypeSyntax, _ garbageBetweenWrappedTypeAndQuestionMark: GarbageNodesSyntax? = nil, questionMark: TokenSyntax) -> OptionalTypeSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeWrappedType?.raw,
@@ -5735,6 +6185,7 @@ public enum SyntaxFactory {
     return OptionalTypeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on OptionalTypeSyntax")
   public static func makeBlankOptionalType(presence: SourcePresence = .present) -> OptionalTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .optionalType,
       layout: [
@@ -5745,6 +6196,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return OptionalTypeSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ConstrainedSugarTypeSyntax")
   public static func makeConstrainedSugarType(_ garbageBeforeSomeOrAnySpecifier: GarbageNodesSyntax? = nil, someOrAnySpecifier: TokenSyntax, _ garbageBetweenSomeOrAnySpecifierAndBaseType: GarbageNodesSyntax? = nil, baseType: TypeSyntax) -> ConstrainedSugarTypeSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeSomeOrAnySpecifier?.raw,
@@ -5758,6 +6210,7 @@ public enum SyntaxFactory {
     return ConstrainedSugarTypeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ConstrainedSugarTypeSyntax")
   public static func makeBlankConstrainedSugarType(presence: SourcePresence = .present) -> ConstrainedSugarTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .constrainedSugarType,
       layout: [
@@ -5768,6 +6221,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ConstrainedSugarTypeSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ImplicitlyUnwrappedOptionalTypeSyntax")
   public static func makeImplicitlyUnwrappedOptionalType(_ garbageBeforeWrappedType: GarbageNodesSyntax? = nil, wrappedType: TypeSyntax, _ garbageBetweenWrappedTypeAndExclamationMark: GarbageNodesSyntax? = nil, exclamationMark: TokenSyntax) -> ImplicitlyUnwrappedOptionalTypeSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeWrappedType?.raw,
@@ -5781,6 +6235,7 @@ public enum SyntaxFactory {
     return ImplicitlyUnwrappedOptionalTypeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ImplicitlyUnwrappedOptionalTypeSyntax")
   public static func makeBlankImplicitlyUnwrappedOptionalType(presence: SourcePresence = .present) -> ImplicitlyUnwrappedOptionalTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .implicitlyUnwrappedOptionalType,
       layout: [
@@ -5791,6 +6246,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ImplicitlyUnwrappedOptionalTypeSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on CompositionTypeElementSyntax")
   public static func makeCompositionTypeElement(_ garbageBeforeType: GarbageNodesSyntax? = nil, type: TypeSyntax, _ garbageBetweenTypeAndAmpersand: GarbageNodesSyntax? = nil, ampersand: TokenSyntax?) -> CompositionTypeElementSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeType?.raw,
@@ -5804,6 +6260,7 @@ public enum SyntaxFactory {
     return CompositionTypeElementSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on CompositionTypeElementSyntax")
   public static func makeBlankCompositionTypeElement(presence: SourcePresence = .present) -> CompositionTypeElementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .compositionTypeElement,
       layout: [
@@ -5814,6 +6271,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return CompositionTypeElementSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on CompositionTypeElementListSyntax")
   public static func makeCompositionTypeElementList(
     _ elements: [CompositionTypeElementSyntax]) -> CompositionTypeElementListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.compositionTypeElementList,
@@ -5822,12 +6280,14 @@ public enum SyntaxFactory {
     return CompositionTypeElementListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on CompositionTypeElementListSyntax")
   public static func makeBlankCompositionTypeElementList(presence: SourcePresence = .present) -> CompositionTypeElementListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .compositionTypeElementList,
       layout: [
     ], length: .zero, presence: presence))
     return CompositionTypeElementListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on CompositionTypeSyntax")
   public static func makeCompositionType(_ garbageBeforeElements: GarbageNodesSyntax? = nil, elements: CompositionTypeElementListSyntax) -> CompositionTypeSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeElements?.raw,
@@ -5839,6 +6299,7 @@ public enum SyntaxFactory {
     return CompositionTypeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on CompositionTypeSyntax")
   public static func makeBlankCompositionType(presence: SourcePresence = .present) -> CompositionTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .compositionType,
       layout: [
@@ -5847,6 +6308,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return CompositionTypeSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TupleTypeElementSyntax")
   public static func makeTupleTypeElement(_ garbageBeforeInOut: GarbageNodesSyntax? = nil, inOut: TokenSyntax?, _ garbageBetweenInOutAndName: GarbageNodesSyntax? = nil, name: TokenSyntax?, _ garbageBetweenNameAndSecondName: GarbageNodesSyntax? = nil, secondName: TokenSyntax?, _ garbageBetweenSecondNameAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax?, _ garbageBetweenColonAndType: GarbageNodesSyntax? = nil, type: TypeSyntax, _ garbageBetweenTypeAndEllipsis: GarbageNodesSyntax? = nil, ellipsis: TokenSyntax?, _ garbageBetweenEllipsisAndInitializer: GarbageNodesSyntax? = nil, initializer: InitializerClauseSyntax?, _ garbageBetweenInitializerAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> TupleTypeElementSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeInOut?.raw,
@@ -5872,6 +6334,7 @@ public enum SyntaxFactory {
     return TupleTypeElementSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TupleTypeElementSyntax")
   public static func makeBlankTupleTypeElement(presence: SourcePresence = .present) -> TupleTypeElementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .tupleTypeElement,
       layout: [
@@ -5894,6 +6357,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return TupleTypeElementSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TupleTypeElementListSyntax")
   public static func makeTupleTypeElementList(
     _ elements: [TupleTypeElementSyntax]) -> TupleTypeElementListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.tupleTypeElementList,
@@ -5902,12 +6366,14 @@ public enum SyntaxFactory {
     return TupleTypeElementListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TupleTypeElementListSyntax")
   public static func makeBlankTupleTypeElementList(presence: SourcePresence = .present) -> TupleTypeElementListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .tupleTypeElementList,
       layout: [
     ], length: .zero, presence: presence))
     return TupleTypeElementListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TupleTypeSyntax")
   public static func makeTupleType(_ garbageBeforeLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndElements: GarbageNodesSyntax? = nil, elements: TupleTypeElementListSyntax, _ garbageBetweenElementsAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> TupleTypeSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftParen?.raw,
@@ -5923,6 +6389,7 @@ public enum SyntaxFactory {
     return TupleTypeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TupleTypeSyntax")
   public static func makeBlankTupleType(presence: SourcePresence = .present) -> TupleTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .tupleType,
       layout: [
@@ -5935,6 +6402,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return TupleTypeSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on FunctionTypeSyntax")
   public static func makeFunctionType(_ garbageBeforeLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndArguments: GarbageNodesSyntax? = nil, arguments: TupleTypeElementListSyntax, _ garbageBetweenArgumentsAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax, _ garbageBetweenRightParenAndAsyncKeyword: GarbageNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ garbageBetweenAsyncKeywordAndThrowsOrRethrowsKeyword: GarbageNodesSyntax? = nil, throwsOrRethrowsKeyword: TokenSyntax?, _ garbageBetweenThrowsOrRethrowsKeywordAndArrow: GarbageNodesSyntax? = nil, arrow: TokenSyntax, _ garbageBetweenArrowAndReturnType: GarbageNodesSyntax? = nil, returnType: TypeSyntax) -> FunctionTypeSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftParen?.raw,
@@ -5958,6 +6426,7 @@ public enum SyntaxFactory {
     return FunctionTypeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on FunctionTypeSyntax")
   public static func makeBlankFunctionType(presence: SourcePresence = .present) -> FunctionTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .functionType,
       layout: [
@@ -5978,6 +6447,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return FunctionTypeSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AttributedTypeSyntax")
   public static func makeAttributedType(_ garbageBeforeSpecifier: GarbageNodesSyntax? = nil, specifier: TokenSyntax?, _ garbageBetweenSpecifierAndAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndBaseType: GarbageNodesSyntax? = nil, baseType: TypeSyntax) -> AttributedTypeSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeSpecifier?.raw,
@@ -5993,6 +6463,7 @@ public enum SyntaxFactory {
     return AttributedTypeSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AttributedTypeSyntax")
   public static func makeBlankAttributedType(presence: SourcePresence = .present) -> AttributedTypeSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .attributedType,
       layout: [
@@ -6005,6 +6476,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AttributedTypeSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on GenericArgumentListSyntax")
   public static func makeGenericArgumentList(
     _ elements: [GenericArgumentSyntax]) -> GenericArgumentListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.genericArgumentList,
@@ -6013,12 +6485,14 @@ public enum SyntaxFactory {
     return GenericArgumentListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on GenericArgumentListSyntax")
   public static func makeBlankGenericArgumentList(presence: SourcePresence = .present) -> GenericArgumentListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .genericArgumentList,
       layout: [
     ], length: .zero, presence: presence))
     return GenericArgumentListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on GenericArgumentSyntax")
   public static func makeGenericArgument(_ garbageBeforeArgumentType: GarbageNodesSyntax? = nil, argumentType: TypeSyntax, _ garbageBetweenArgumentTypeAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> GenericArgumentSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeArgumentType?.raw,
@@ -6032,6 +6506,7 @@ public enum SyntaxFactory {
     return GenericArgumentSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on GenericArgumentSyntax")
   public static func makeBlankGenericArgument(presence: SourcePresence = .present) -> GenericArgumentSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .genericArgument,
       layout: [
@@ -6042,6 +6517,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return GenericArgumentSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on GenericArgumentClauseSyntax")
   public static func makeGenericArgumentClause(_ garbageBeforeLeftAngleBracket: GarbageNodesSyntax? = nil, leftAngleBracket: TokenSyntax, _ garbageBetweenLeftAngleBracketAndArguments: GarbageNodesSyntax? = nil, arguments: GenericArgumentListSyntax, _ garbageBetweenArgumentsAndRightAngleBracket: GarbageNodesSyntax? = nil, rightAngleBracket: TokenSyntax) -> GenericArgumentClauseSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftAngleBracket?.raw,
@@ -6057,6 +6533,7 @@ public enum SyntaxFactory {
     return GenericArgumentClauseSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on GenericArgumentClauseSyntax")
   public static func makeBlankGenericArgumentClause(presence: SourcePresence = .present) -> GenericArgumentClauseSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .genericArgumentClause,
       layout: [
@@ -6069,6 +6546,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return GenericArgumentClauseSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TypeAnnotationSyntax")
   public static func makeTypeAnnotation(_ garbageBeforeColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndType: GarbageNodesSyntax? = nil, type: TypeSyntax) -> TypeAnnotationSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeColon?.raw,
@@ -6082,6 +6560,7 @@ public enum SyntaxFactory {
     return TypeAnnotationSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TypeAnnotationSyntax")
   public static func makeBlankTypeAnnotation(presence: SourcePresence = .present) -> TypeAnnotationSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .typeAnnotation,
       layout: [
@@ -6092,6 +6571,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return TypeAnnotationSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on EnumCasePatternSyntax")
   public static func makeEnumCasePattern(_ garbageBeforeType: GarbageNodesSyntax? = nil, type: TypeSyntax?, _ garbageBetweenTypeAndPeriod: GarbageNodesSyntax? = nil, period: TokenSyntax, _ garbageBetweenPeriodAndCaseName: GarbageNodesSyntax? = nil, caseName: TokenSyntax, _ garbageBetweenCaseNameAndAssociatedTuple: GarbageNodesSyntax? = nil, associatedTuple: TuplePatternSyntax?) -> EnumCasePatternSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeType?.raw,
@@ -6109,6 +6589,7 @@ public enum SyntaxFactory {
     return EnumCasePatternSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on EnumCasePatternSyntax")
   public static func makeBlankEnumCasePattern(presence: SourcePresence = .present) -> EnumCasePatternSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .enumCasePattern,
       layout: [
@@ -6123,6 +6604,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return EnumCasePatternSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on IsTypePatternSyntax")
   public static func makeIsTypePattern(_ garbageBeforeIsKeyword: GarbageNodesSyntax? = nil, isKeyword: TokenSyntax, _ garbageBetweenIsKeywordAndType: GarbageNodesSyntax? = nil, type: TypeSyntax) -> IsTypePatternSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeIsKeyword?.raw,
@@ -6136,6 +6618,7 @@ public enum SyntaxFactory {
     return IsTypePatternSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on IsTypePatternSyntax")
   public static func makeBlankIsTypePattern(presence: SourcePresence = .present) -> IsTypePatternSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .isTypePattern,
       layout: [
@@ -6146,6 +6629,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return IsTypePatternSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on OptionalPatternSyntax")
   public static func makeOptionalPattern(_ garbageBeforeSubPattern: GarbageNodesSyntax? = nil, subPattern: PatternSyntax, _ garbageBetweenSubPatternAndQuestionMark: GarbageNodesSyntax? = nil, questionMark: TokenSyntax) -> OptionalPatternSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeSubPattern?.raw,
@@ -6159,6 +6643,7 @@ public enum SyntaxFactory {
     return OptionalPatternSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on OptionalPatternSyntax")
   public static func makeBlankOptionalPattern(presence: SourcePresence = .present) -> OptionalPatternSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .optionalPattern,
       layout: [
@@ -6169,6 +6654,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return OptionalPatternSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on IdentifierPatternSyntax")
   public static func makeIdentifierPattern(_ garbageBeforeIdentifier: GarbageNodesSyntax? = nil, identifier: TokenSyntax) -> IdentifierPatternSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeIdentifier?.raw,
@@ -6180,6 +6666,7 @@ public enum SyntaxFactory {
     return IdentifierPatternSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on IdentifierPatternSyntax")
   public static func makeBlankIdentifierPattern(presence: SourcePresence = .present) -> IdentifierPatternSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .identifierPattern,
       layout: [
@@ -6188,6 +6675,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return IdentifierPatternSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AsTypePatternSyntax")
   public static func makeAsTypePattern(_ garbageBeforePattern: GarbageNodesSyntax? = nil, pattern: PatternSyntax, _ garbageBetweenPatternAndAsKeyword: GarbageNodesSyntax? = nil, asKeyword: TokenSyntax, _ garbageBetweenAsKeywordAndType: GarbageNodesSyntax? = nil, type: TypeSyntax) -> AsTypePatternSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePattern?.raw,
@@ -6203,6 +6691,7 @@ public enum SyntaxFactory {
     return AsTypePatternSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AsTypePatternSyntax")
   public static func makeBlankAsTypePattern(presence: SourcePresence = .present) -> AsTypePatternSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .asTypePattern,
       layout: [
@@ -6215,6 +6704,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AsTypePatternSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TuplePatternSyntax")
   public static func makeTuplePattern(_ garbageBeforeLeftParen: GarbageNodesSyntax? = nil, leftParen: TokenSyntax, _ garbageBetweenLeftParenAndElements: GarbageNodesSyntax? = nil, elements: TuplePatternElementListSyntax, _ garbageBetweenElementsAndRightParen: GarbageNodesSyntax? = nil, rightParen: TokenSyntax) -> TuplePatternSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLeftParen?.raw,
@@ -6230,6 +6720,7 @@ public enum SyntaxFactory {
     return TuplePatternSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TuplePatternSyntax")
   public static func makeBlankTuplePattern(presence: SourcePresence = .present) -> TuplePatternSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .tuplePattern,
       layout: [
@@ -6242,6 +6733,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return TuplePatternSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on WildcardPatternSyntax")
   public static func makeWildcardPattern(_ garbageBeforeWildcard: GarbageNodesSyntax? = nil, wildcard: TokenSyntax, _ garbageBetweenWildcardAndTypeAnnotation: GarbageNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?) -> WildcardPatternSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeWildcard?.raw,
@@ -6255,6 +6747,7 @@ public enum SyntaxFactory {
     return WildcardPatternSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on WildcardPatternSyntax")
   public static func makeBlankWildcardPattern(presence: SourcePresence = .present) -> WildcardPatternSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .wildcardPattern,
       layout: [
@@ -6265,6 +6758,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return WildcardPatternSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TuplePatternElementSyntax")
   public static func makeTuplePatternElement(_ garbageBeforeLabelName: GarbageNodesSyntax? = nil, labelName: TokenSyntax?, _ garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? = nil, labelColon: TokenSyntax?, _ garbageBetweenLabelColonAndPattern: GarbageNodesSyntax? = nil, pattern: PatternSyntax, _ garbageBetweenPatternAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> TuplePatternElementSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLabelName?.raw,
@@ -6282,6 +6776,7 @@ public enum SyntaxFactory {
     return TuplePatternElementSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TuplePatternElementSyntax")
   public static func makeBlankTuplePatternElement(presence: SourcePresence = .present) -> TuplePatternElementSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .tuplePatternElement,
       layout: [
@@ -6296,6 +6791,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return TuplePatternElementSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ExpressionPatternSyntax")
   public static func makeExpressionPattern(_ garbageBeforeExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax) -> ExpressionPatternSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeExpression?.raw,
@@ -6307,6 +6803,7 @@ public enum SyntaxFactory {
     return ExpressionPatternSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ExpressionPatternSyntax")
   public static func makeBlankExpressionPattern(presence: SourcePresence = .present) -> ExpressionPatternSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .expressionPattern,
       layout: [
@@ -6315,6 +6812,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ExpressionPatternSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on TuplePatternElementListSyntax")
   public static func makeTuplePatternElementList(
     _ elements: [TuplePatternElementSyntax]) -> TuplePatternElementListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.tuplePatternElementList,
@@ -6323,12 +6821,14 @@ public enum SyntaxFactory {
     return TuplePatternElementListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on TuplePatternElementListSyntax")
   public static func makeBlankTuplePatternElementList(presence: SourcePresence = .present) -> TuplePatternElementListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .tuplePatternElementList,
       layout: [
     ], length: .zero, presence: presence))
     return TuplePatternElementListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ValueBindingPatternSyntax")
   public static func makeValueBindingPattern(_ garbageBeforeLetOrVarKeyword: GarbageNodesSyntax? = nil, letOrVarKeyword: TokenSyntax, _ garbageBetweenLetOrVarKeywordAndValuePattern: GarbageNodesSyntax? = nil, valuePattern: PatternSyntax) -> ValueBindingPatternSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLetOrVarKeyword?.raw,
@@ -6342,6 +6842,7 @@ public enum SyntaxFactory {
     return ValueBindingPatternSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on ValueBindingPatternSyntax")
   public static func makeBlankValueBindingPattern(presence: SourcePresence = .present) -> ValueBindingPatternSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .valueBindingPattern,
       layout: [
@@ -6352,6 +6853,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ValueBindingPatternSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AvailabilitySpecListSyntax")
   public static func makeAvailabilitySpecList(
     _ elements: [AvailabilityArgumentSyntax]) -> AvailabilitySpecListSyntax {
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.availabilitySpecList,
@@ -6360,12 +6862,14 @@ public enum SyntaxFactory {
     return AvailabilitySpecListSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AvailabilitySpecListSyntax")
   public static func makeBlankAvailabilitySpecList(presence: SourcePresence = .present) -> AvailabilitySpecListSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .availabilitySpecList,
       layout: [
     ], length: .zero, presence: presence))
     return AvailabilitySpecListSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AvailabilityArgumentSyntax")
   public static func makeAvailabilityArgument(_ garbageBeforeEntry: GarbageNodesSyntax? = nil, entry: Syntax, _ garbageBetweenEntryAndTrailingComma: GarbageNodesSyntax? = nil, trailingComma: TokenSyntax?) -> AvailabilityArgumentSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeEntry?.raw,
@@ -6379,6 +6883,7 @@ public enum SyntaxFactory {
     return AvailabilityArgumentSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AvailabilityArgumentSyntax")
   public static func makeBlankAvailabilityArgument(presence: SourcePresence = .present) -> AvailabilityArgumentSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .availabilityArgument,
       layout: [
@@ -6389,6 +6894,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AvailabilityArgumentSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AvailabilityLabeledArgumentSyntax")
   public static func makeAvailabilityLabeledArgument(_ garbageBeforeLabel: GarbageNodesSyntax? = nil, label: TokenSyntax, _ garbageBetweenLabelAndColon: GarbageNodesSyntax? = nil, colon: TokenSyntax, _ garbageBetweenColonAndValue: GarbageNodesSyntax? = nil, value: Syntax) -> AvailabilityLabeledArgumentSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeLabel?.raw,
@@ -6404,6 +6910,7 @@ public enum SyntaxFactory {
     return AvailabilityLabeledArgumentSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AvailabilityLabeledArgumentSyntax")
   public static func makeBlankAvailabilityLabeledArgument(presence: SourcePresence = .present) -> AvailabilityLabeledArgumentSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .availabilityLabeledArgument,
       layout: [
@@ -6416,6 +6923,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AvailabilityLabeledArgumentSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on AvailabilityVersionRestrictionSyntax")
   public static func makeAvailabilityVersionRestriction(_ garbageBeforePlatform: GarbageNodesSyntax? = nil, platform: TokenSyntax, _ garbageBetweenPlatformAndVersion: GarbageNodesSyntax? = nil, version: VersionTupleSyntax?) -> AvailabilityVersionRestrictionSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforePlatform?.raw,
@@ -6429,6 +6937,7 @@ public enum SyntaxFactory {
     return AvailabilityVersionRestrictionSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on AvailabilityVersionRestrictionSyntax")
   public static func makeBlankAvailabilityVersionRestriction(presence: SourcePresence = .present) -> AvailabilityVersionRestrictionSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .availabilityVersionRestriction,
       layout: [
@@ -6439,6 +6948,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return AvailabilityVersionRestrictionSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on VersionTupleSyntax")
   public static func makeVersionTuple(_ garbageBeforeMajorMinor: GarbageNodesSyntax? = nil, majorMinor: Syntax, _ garbageBetweenMajorMinorAndPatchPeriod: GarbageNodesSyntax? = nil, patchPeriod: TokenSyntax?, _ garbageBetweenPatchPeriodAndPatchVersion: GarbageNodesSyntax? = nil, patchVersion: TokenSyntax?) -> VersionTupleSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeMajorMinor?.raw,
@@ -6454,6 +6964,7 @@ public enum SyntaxFactory {
     return VersionTupleSyntax(data)
   }
 
+  @available(*, deprecated, message: "Use initializer on VersionTupleSyntax")
   public static func makeBlankVersionTuple(presence: SourcePresence = .present) -> VersionTupleSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .versionTuple,
       layout: [
@@ -6470,6 +6981,7 @@ public enum SyntaxFactory {
 /// MARK: Token Creation APIs
 
 
+  @available(*, deprecated, message: "Use TokenSyntax.associatedtypeKeywordKeyword instead")
   public static func makeAssociatedtypeKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6478,6 +6990,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.classKeywordKeyword instead")
   public static func makeClassKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6486,6 +6999,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.deinitKeywordKeyword instead")
   public static func makeDeinitKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6494,6 +7008,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.enumKeywordKeyword instead")
   public static func makeEnumKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6502,6 +7017,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.extensionKeywordKeyword instead")
   public static func makeExtensionKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6510,6 +7026,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.funcKeywordKeyword instead")
   public static func makeFuncKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6518,6 +7035,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.importKeywordKeyword instead")
   public static func makeImportKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6526,6 +7044,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.initKeywordKeyword instead")
   public static func makeInitKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6534,6 +7053,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.inoutKeywordKeyword instead")
   public static func makeInoutKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6542,6 +7062,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.letKeywordKeyword instead")
   public static func makeLetKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6550,6 +7071,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.operatorKeywordKeyword instead")
   public static func makeOperatorKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6558,6 +7080,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.precedencegroupKeywordKeyword instead")
   public static func makePrecedencegroupKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6566,6 +7089,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.protocolKeywordKeyword instead")
   public static func makeProtocolKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6574,6 +7098,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.structKeywordKeyword instead")
   public static func makeStructKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6582,6 +7107,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.subscriptKeywordKeyword instead")
   public static func makeSubscriptKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6590,6 +7116,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.typealiasKeywordKeyword instead")
   public static func makeTypealiasKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6598,6 +7125,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.varKeywordKeyword instead")
   public static func makeVarKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6606,6 +7134,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.fileprivateKeywordKeyword instead")
   public static func makeFileprivateKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6614,6 +7143,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.internalKeywordKeyword instead")
   public static func makeInternalKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6622,6 +7152,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.privateKeywordKeyword instead")
   public static func makePrivateKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6630,6 +7161,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.publicKeywordKeyword instead")
   public static func makePublicKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6638,6 +7170,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.staticKeywordKeyword instead")
   public static func makeStaticKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6646,6 +7179,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.deferKeywordKeyword instead")
   public static func makeDeferKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6654,6 +7188,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.ifKeywordKeyword instead")
   public static func makeIfKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6662,6 +7197,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.guardKeywordKeyword instead")
   public static func makeGuardKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6670,6 +7206,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.doKeywordKeyword instead")
   public static func makeDoKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -6678,6 +7215,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.repeatKeywordKeyword instead")
   public static func makeRepeatKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6686,6 +7224,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.elseKeywordKeyword instead")
   public static func makeElseKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6694,6 +7233,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.forKeywordKeyword instead")
   public static func makeForKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6702,6 +7242,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.inKeywordKeyword instead")
   public static func makeInKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6710,6 +7251,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.whileKeywordKeyword instead")
   public static func makeWhileKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6718,6 +7260,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.returnKeywordKeyword instead")
   public static func makeReturnKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6726,6 +7269,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.breakKeywordKeyword instead")
   public static func makeBreakKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6734,6 +7278,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.continueKeywordKeyword instead")
   public static func makeContinueKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6742,6 +7287,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.fallthroughKeywordKeyword instead")
   public static func makeFallthroughKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6750,6 +7296,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.switchKeywordKeyword instead")
   public static func makeSwitchKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6758,6 +7305,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.caseKeywordKeyword instead")
   public static func makeCaseKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6766,6 +7314,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.defaultKeywordKeyword instead")
   public static func makeDefaultKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6774,6 +7323,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.whereKeywordKeyword instead")
   public static func makeWhereKeyword(
     leadingTrivia: Trivia = .space,
     trailingTrivia: Trivia = .space
@@ -6782,6 +7332,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.catchKeywordKeyword instead")
   public static func makeCatchKeyword(
     leadingTrivia: Trivia = .space,
     trailingTrivia: Trivia = []
@@ -6790,6 +7341,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.throwKeywordKeyword instead")
   public static func makeThrowKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6798,6 +7350,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.asKeywordKeyword instead")
   public static func makeAsKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6806,6 +7359,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.anyKeywordKeyword instead")
   public static func makeAnyKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6814,6 +7368,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.falseKeywordKeyword instead")
   public static func makeFalseKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6822,6 +7377,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.isKeywordKeyword instead")
   public static func makeIsKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6830,6 +7386,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.nilKeywordKeyword instead")
   public static func makeNilKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6838,6 +7395,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.rethrowsKeywordKeyword instead")
   public static func makeRethrowsKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6846,6 +7404,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.superKeywordKeyword instead")
   public static func makeSuperKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6854,6 +7413,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.selfKeywordKeyword instead")
   public static func makeSelfKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6862,6 +7422,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.capitalSelfKeywordKeyword instead")
   public static func makeCapitalSelfKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6870,6 +7431,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.trueKeywordKeyword instead")
   public static func makeTrueKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6878,6 +7440,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.tryKeywordKeyword instead")
   public static func makeTryKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6886,6 +7449,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.throwsKeywordKeyword instead")
   public static func makeThrowsKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6894,6 +7458,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.__file__KeywordKeyword instead")
   public static func make__FILE__Keyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6902,6 +7467,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.__line__KeywordKeyword instead")
   public static func make__LINE__Keyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6910,6 +7476,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.__column__KeywordKeyword instead")
   public static func make__COLUMN__Keyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6918,6 +7485,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.__function__KeywordKeyword instead")
   public static func make__FUNCTION__Keyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6926,6 +7494,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.__dso_handle__KeywordKeyword instead")
   public static func make__DSO_HANDLE__Keyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6934,6 +7503,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.wildcardKeywordKeyword instead")
   public static func makeWildcardKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -6942,6 +7512,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.leftParenToken instead")
   public static func makeLeftParenToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -6950,6 +7521,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.rightParenToken instead")
   public static func makeRightParenToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -6958,6 +7530,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.leftBraceToken instead")
   public static func makeLeftBraceToken(
     leadingTrivia: Trivia = .space,
     trailingTrivia: Trivia = []
@@ -6966,6 +7539,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.rightBraceToken instead")
   public static func makeRightBraceToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -6974,6 +7548,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.leftSquareBracketToken instead")
   public static func makeLeftSquareBracketToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -6982,6 +7557,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.rightSquareBracketToken instead")
   public static func makeRightSquareBracketToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -6990,6 +7566,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.leftAngleToken instead")
   public static func makeLeftAngleToken(
     leadingTrivia: Trivia = .space,
     trailingTrivia: Trivia = .space
@@ -6998,6 +7575,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.rightAngleToken instead")
   public static func makeRightAngleToken(
     leadingTrivia: Trivia = .space,
     trailingTrivia: Trivia = .space
@@ -7006,6 +7584,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.periodToken instead")
   public static func makePeriodToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7014,6 +7593,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.prefixPeriodToken instead")
   public static func makePrefixPeriodToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7022,6 +7602,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.commaToken instead")
   public static func makeCommaToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7030,6 +7611,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.ellipsisToken instead")
   public static func makeEllipsisToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7038,6 +7620,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.colonToken instead")
   public static func makeColonToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7046,6 +7629,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.semicolonToken instead")
   public static func makeSemicolonToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7054,6 +7638,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.equalToken instead")
   public static func makeEqualToken(
     leadingTrivia: Trivia = .space,
     trailingTrivia: Trivia = .space
@@ -7062,6 +7647,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.atSignToken instead")
   public static func makeAtSignToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7070,6 +7656,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundToken instead")
   public static func makePoundToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7078,6 +7665,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.prefixAmpersandToken instead")
   public static func makePrefixAmpersandToken(
     leadingTrivia: Trivia = .space,
     trailingTrivia: Trivia = .space
@@ -7086,6 +7674,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.arrowToken instead")
   public static func makeArrowToken(
     leadingTrivia: Trivia = .space,
     trailingTrivia: Trivia = .space
@@ -7094,6 +7683,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.backtickToken instead")
   public static func makeBacktickToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7102,6 +7692,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.backslashToken instead")
   public static func makeBackslashToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7110,6 +7701,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.exclamationMarkToken instead")
   public static func makeExclamationMarkToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7118,6 +7710,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.postfixQuestionMarkToken instead")
   public static func makePostfixQuestionMarkToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7126,6 +7719,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.infixQuestionMarkToken instead")
   public static func makeInfixQuestionMarkToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7134,6 +7728,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.stringQuoteToken instead")
   public static func makeStringQuoteToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7142,6 +7737,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.singleQuoteToken instead")
   public static func makeSingleQuoteToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7150,6 +7746,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.multilineStringQuoteToken instead")
   public static func makeMultilineStringQuoteToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7158,6 +7755,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundKeyPathKeywordKeyword instead")
   public static func makePoundKeyPathKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7166,6 +7764,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundLineKeywordKeyword instead")
   public static func makePoundLineKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7174,6 +7773,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundSelectorKeywordKeyword instead")
   public static func makePoundSelectorKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7182,6 +7782,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundFileKeywordKeyword instead")
   public static func makePoundFileKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7190,6 +7791,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundFileIDKeywordKeyword instead")
   public static func makePoundFileIDKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7198,6 +7800,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundFilePathKeywordKeyword instead")
   public static func makePoundFilePathKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7206,6 +7809,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundColumnKeywordKeyword instead")
   public static func makePoundColumnKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7214,6 +7818,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundFunctionKeywordKeyword instead")
   public static func makePoundFunctionKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7222,6 +7827,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundDsohandleKeywordKeyword instead")
   public static func makePoundDsohandleKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7230,6 +7836,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundAssertKeywordKeyword instead")
   public static func makePoundAssertKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7238,6 +7845,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundSourceLocationKeywordKeyword instead")
   public static func makePoundSourceLocationKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7246,6 +7854,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundWarningKeywordKeyword instead")
   public static func makePoundWarningKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7254,6 +7863,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundErrorKeywordKeyword instead")
   public static func makePoundErrorKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7262,6 +7872,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundIfKeywordKeyword instead")
   public static func makePoundIfKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7270,6 +7881,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundElseKeywordKeyword instead")
   public static func makePoundElseKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7278,6 +7890,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundElseifKeywordKeyword instead")
   public static func makePoundElseifKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7286,6 +7899,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundEndifKeywordKeyword instead")
   public static func makePoundEndifKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7294,6 +7908,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundAvailableKeywordKeyword instead")
   public static func makePoundAvailableKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7302,6 +7917,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundUnavailableKeywordKeyword instead")
   public static func makePoundUnavailableKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7310,6 +7926,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundFileLiteralKeywordKeyword instead")
   public static func makePoundFileLiteralKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7318,6 +7935,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundImageLiteralKeywordKeyword instead")
   public static func makePoundImageLiteralKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7326,6 +7944,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.poundColorLiteralKeywordKeyword instead")
   public static func makePoundColorLiteralKeyword(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = .space
@@ -7334,6 +7953,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.integerLiteral instead")
   public static func makeIntegerLiteral(
     _ text: String,
     leadingTrivia: Trivia = [],
@@ -7343,6 +7963,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.floatingLiteral instead")
   public static func makeFloatingLiteral(
     _ text: String,
     leadingTrivia: Trivia = [],
@@ -7352,6 +7973,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.stringLiteral instead")
   public static func makeStringLiteral(
     _ text: String,
     leadingTrivia: Trivia = [],
@@ -7361,6 +7983,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.regexLiteral instead")
   public static func makeRegexLiteral(
     _ text: String,
     leadingTrivia: Trivia = [],
@@ -7370,6 +7993,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.unknown instead")
   public static func makeUnknown(
     _ text: String,
     leadingTrivia: Trivia = [],
@@ -7379,6 +8003,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.identifier instead")
   public static func makeIdentifier(
     _ text: String,
     leadingTrivia: Trivia = [],
@@ -7388,6 +8013,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.unspacedBinaryOperator instead")
   public static func makeUnspacedBinaryOperator(
     _ text: String,
     leadingTrivia: Trivia = [],
@@ -7397,6 +8023,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.spacedBinaryOperator instead")
   public static func makeSpacedBinaryOperator(
     _ text: String,
     leadingTrivia: Trivia = .space,
@@ -7406,6 +8033,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.postfixOperator instead")
   public static func makePostfixOperator(
     _ text: String,
     leadingTrivia: Trivia = [],
@@ -7415,6 +8043,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.prefixOperator instead")
   public static func makePrefixOperator(
     _ text: String,
     leadingTrivia: Trivia = [],
@@ -7424,6 +8053,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.dollarIdentifier instead")
   public static func makeDollarIdentifier(
     _ text: String,
     leadingTrivia: Trivia = [],
@@ -7433,6 +8063,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.contextualKeyword instead")
   public static func makeContextualKeyword(
     _ text: String,
     leadingTrivia: Trivia = [],
@@ -7442,6 +8073,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.rawStringDelimiter instead")
   public static func makeRawStringDelimiter(
     _ text: String,
     leadingTrivia: Trivia = [],
@@ -7451,6 +8083,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.stringSegment instead")
   public static func makeStringSegment(
     _ text: String,
     leadingTrivia: Trivia = [],
@@ -7460,6 +8093,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.stringInterpolationAnchorToken instead")
   public static func makeStringInterpolationAnchorToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7468,6 +8102,7 @@ public enum SyntaxFactory {
                      leadingTrivia: leadingTrivia,
                      trailingTrivia: trailingTrivia)
   }
+  @available(*, deprecated, message: "Use TokenSyntax.yieldToken instead")
   public static func makeYieldToken(
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []
@@ -7479,12 +8114,14 @@ public enum SyntaxFactory {
 
 /// MARK: Convenience APIs
 
+  @available(*, deprecated, message: "Use initializer on TupleTypeSyntax")
   public static func makeVoidTupleType() -> TupleTypeSyntax {
     return makeTupleType(leftParen: makeLeftParenToken(),
                          elements: makeBlankTupleTypeElementList(),
                          rightParen: makeRightParenToken())
   }
 
+  @available(*, deprecated, message: "Use initializer on TupleTypeSyntax")
   public static func makeTupleTypeElement(name: TokenSyntax?,
     colon: TokenSyntax?, type: TypeSyntax,
     trailingComma: TokenSyntax?) -> TupleTypeElementSyntax {
@@ -7493,12 +8130,14 @@ public enum SyntaxFactory {
                                 initializer: nil, trailingComma: trailingComma)
   }
 
+  @available(*, deprecated, message: "Use initializer on TupleTypeSyntax")
   public static func makeTupleTypeElement(type: TypeSyntax,
     trailingComma: TokenSyntax?) -> TupleTypeElementSyntax  {
     return makeTupleTypeElement(name: nil, colon: nil, 
                                 type: type, trailingComma: trailingComma)
   }
 
+  @available(*, deprecated, message: "Use initializer on GenericParameterSyntax")
   public static func makeGenericParameter(name: TokenSyntax,
       trailingComma: TokenSyntax) -> GenericParameterSyntax {
     return makeGenericParameter(attributes: nil, name: name, colon: nil,
@@ -7506,6 +8145,7 @@ public enum SyntaxFactory {
                                 trailingComma: trailingComma)
   }
 
+  @available(*, deprecated, message: "Use initializer on SimpleTypeIdentifierSyntax")
   public static func makeTypeIdentifier(_ name: String,
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> TypeSyntax {
@@ -7516,30 +8156,35 @@ public enum SyntaxFactory {
     return TypeSyntax(typeIdentifier)
   }
 
+  @available(*, deprecated, message: "Use initializer on SimpleTypeIdentifierSyntax")
   public static func makeAnyTypeIdentifier(leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> TypeSyntax {
     return makeTypeIdentifier("Any", leadingTrivia: leadingTrivia, 
                               trailingTrivia: trailingTrivia)
   }
 
+  @available(*, deprecated, message: "Use initializer on SimpleTypeIdentifierSyntax")
   public static func makeSelfTypeIdentifier(leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> TypeSyntax {
     return makeTypeIdentifier("Self", leadingTrivia: leadingTrivia, 
                               trailingTrivia: trailingTrivia)
   }
 
+  @available(*, deprecated, message: "Use initializer on SimpleTypeIdentifierSyntax")
   public static func makeTypeToken(leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> TokenSyntax {
     return makeIdentifier("Type", leadingTrivia: leadingTrivia, 
                           trailingTrivia: trailingTrivia)
   }
 
+  @available(*, deprecated, message: "Use TokenSyntax.protocol")
   public static func makeProtocolToken(leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> TokenSyntax {
     return makeIdentifier("Protocol", leadingTrivia: leadingTrivia,
                           trailingTrivia: trailingTrivia)
   }
 
+  @available(*, deprecated, message: "Use TokenSyntax.spacedBinaryOperator")
   public static func makeBinaryOperator(_ name: String,
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> TokenSyntax {
@@ -7549,6 +8194,7 @@ public enum SyntaxFactory {
                      trailingTrivia: trailingTrivia)
   }
 
+  @available(*, deprecated, message: "Use initializer on StringLiteralExprSyntax")
   public static func makeStringLiteralExpr(_ text: String,
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> StringLiteralExprSyntax {
@@ -7564,6 +8210,7 @@ public enum SyntaxFactory {
                                  closeDelimiter: nil)
   }
 
+  @available(*, deprecated, message: "Use initializer on IdentifierExprSyntax")
   public static func makeVariableExpr(_ text: String,
     leadingTrivia: Trivia = [],
     trailingTrivia: Trivia = []) -> IdentifierExprSyntax {

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -1,4 +1,4 @@
-//// Automatically Generated From SyntaxFactory.swift.gyb.
+//// Automatically Generated From SyntaxRewriter.swift.gyb.
 //// Do Not Edit Directly!
 //===------------ SyntaxRewriter.swift - Syntax Rewriter class ------------===//
 //

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -1,4 +1,4 @@
-//// Automatically Generated From SyntaxFactory.swift.gyb.
+//// Automatically Generated From SyntaxVisitor.swift.gyb.
 //// Do Not Edit Directly!
 //===------------- SyntaxVisitor.swift - Syntax Visitor class -------------===//
 //

--- a/Sources/SwiftSyntax/gyb_generated/Tokens.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Tokens.swift
@@ -1,0 +1,1538 @@
+//// Automatically Generated From Tokens.swift.gyb.
+//// Do Not Edit Directly!
+//===--- Tokens.swift -----------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+fileprivate func defaultTrivia(presence: SourcePresence, trivia: Trivia) -> Trivia {
+  switch presence {
+  case .present:
+    return trivia
+  case .missing:
+    return []
+  }
+}
+
+extension TokenSyntax {
+  public static func associatedtypeKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .associatedtypeKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func classKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .classKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func deinitKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .deinitKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func enumKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .enumKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func extensionKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .extensionKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func funcKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .funcKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func importKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .importKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func initKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .initKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func inoutKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .inoutKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func letKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .letKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func operatorKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .operatorKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func precedencegroupKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .precedencegroupKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func protocolKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .protocolKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func structKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .structKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func subscriptKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .subscriptKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func typealiasKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .typealiasKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func varKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .varKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func fileprivateKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .fileprivateKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func internalKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .internalKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func privateKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .privateKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func publicKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .publicKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func staticKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .staticKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func deferKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .deferKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func ifKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .ifKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func guardKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .guardKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func doKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .doKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func repeatKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .repeatKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func elseKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .elseKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func forKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .forKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func inKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .inKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func whileKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .whileKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func returnKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .returnKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func breakKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .breakKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func continueKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .continueKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func fallthroughKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .fallthroughKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func switchKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .switchKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func caseKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .caseKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func defaultKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .defaultKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func whereKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .whereKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func catchKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .catchKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func throwKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .throwKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func asKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .asKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func anyKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .anyKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func falseKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .falseKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func isKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .isKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func nilKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .nilKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func rethrowsKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .rethrowsKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func superKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .superKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func selfKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .selfKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func capitalSelfKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .capitalSelfKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func trueKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .trueKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func tryKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .tryKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func throwsKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .throwsKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func __file__Keyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .__file__Keyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func __line__Keyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .__line__Keyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func __column__Keyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .__column__Keyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func __function__Keyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .__function__Keyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func __dso_handle__Keyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .__dso_handle__Keyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func wildcardKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .wildcardKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func leftParenToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .leftParen,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func rightParenToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .rightParen,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func leftBraceToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .leftBrace,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func rightBraceToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .rightBrace,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func leftSquareBracketToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .leftSquareBracket,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func rightSquareBracketToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .rightSquareBracket,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func leftAngleToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .leftAngle,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func rightAngleToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .rightAngle,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func periodToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .period,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func prefixPeriodToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .prefixPeriod,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func commaToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .comma,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func ellipsisToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .ellipsis,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func colonToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .colon,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func semicolonToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .semicolon,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func equalToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .equal,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func atSignToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .atSign,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func poundToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .pound,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func prefixAmpersandToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .prefixAmpersand,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func arrowToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .arrow,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func backtickToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .backtick,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func backslashToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .backslash,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func exclamationMarkToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .exclamationMark,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func postfixQuestionMarkToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .postfixQuestionMark,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func infixQuestionMarkToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .infixQuestionMark,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func stringQuoteToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .stringQuote,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func singleQuoteToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .singleQuote,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func multilineStringQuoteToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .multilineStringQuote,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func poundKeyPathKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundKeyPathKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundLineKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundLineKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundSelectorKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundSelectorKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundFileKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundFileKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundFileIDKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundFileIDKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundFilePathKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundFilePathKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundColumnKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundColumnKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundFunctionKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundFunctionKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundDsohandleKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundDsohandleKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundAssertKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundAssertKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundSourceLocationKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundSourceLocationKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundWarningKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundWarningKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundErrorKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundErrorKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundIfKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundIfKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundElseKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundElseKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundElseifKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundElseifKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundEndifKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundEndifKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundAvailableKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundAvailableKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundUnavailableKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundUnavailableKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundFileLiteralKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundFileLiteralKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundImageLiteralKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundImageLiteralKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func poundColorLiteralKeyword(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .poundColorLiteralKeyword,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func integerLiteral(
+    _ text: String,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .integerLiteral(text),
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func floatingLiteral(
+    _ text: String,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .floatingLiteral(text),
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func stringLiteral(
+    _ text: String,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .stringLiteral(text),
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func regexLiteral(
+    _ text: String,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .regexLiteral(text),
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func unknown(
+    _ text: String,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .unknown(text),
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func identifier(
+    _ text: String,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .identifier(text),
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func unspacedBinaryOperator(
+    _ text: String,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .unspacedBinaryOperator(text),
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func spacedBinaryOperator(
+    _ text: String,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .spacedBinaryOperator(text),
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: .space),
+      presence: presence
+    )
+  }
+  public static func postfixOperator(
+    _ text: String,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .postfixOperator(text),
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func prefixOperator(
+    _ text: String,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .prefixOperator(text),
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func dollarIdentifier(
+    _ text: String,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .dollarIdentifier(text),
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func contextualKeyword(
+    _ text: String,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .contextualKeyword(text),
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func rawStringDelimiter(
+    _ text: String,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .rawStringDelimiter(text),
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func stringSegment(
+    _ text: String,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .stringSegment(text),
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func stringInterpolationAnchorToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .stringInterpolationAnchor,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func yieldToken(
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .yield,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: trailingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      presence: presence
+    )
+  }
+  public static func eof(
+    leadingTrivia: Trivia? = nil,
+    presence: SourcePresence = .present
+  ) -> TokenSyntax {
+    return TokenSyntax(
+      .eof,
+      leadingTrivia: leadingTrivia ?? defaultTrivia(presence: presence, trivia: []),
+      trailingTrivia: [],
+      presence: presence
+    )
+  }
+}

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -34,6 +34,16 @@ public struct UnknownDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+  ) {
+    let layout: [RawSyntax?] = [
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.unknownDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -71,6 +81,16 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .missingDecl)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+  ) {
+    let layout: [RawSyntax?] = [
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.missingDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -126,6 +146,44 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .typealiasDecl)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndTypealiasKeyword: GarbageNodesSyntax? = nil,
+    typealiasKeyword: TokenSyntax,
+    _ garbageBetweenTypealiasKeywordAndIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ garbageBetweenIdentifierAndGenericParameterClause: GarbageNodesSyntax? = nil,
+    genericParameterClause: GenericParameterClauseSyntax?,
+    _ garbageBetweenGenericParameterClauseAndInitializer: GarbageNodesSyntax? = nil,
+    initializer: TypeInitializerClauseSyntax,
+    _ garbageBetweenInitializerAndGenericWhereClause: GarbageNodesSyntax? = nil,
+    genericWhereClause: GenericWhereClauseSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndTypealiasKeyword?.raw,
+      typealiasKeyword.raw,
+      garbageBetweenTypealiasKeywordAndIdentifier?.raw,
+      identifier.raw,
+      garbageBetweenIdentifierAndGenericParameterClause?.raw,
+      genericParameterClause?.raw,
+      garbageBetweenGenericParameterClauseAndInitializer?.raw,
+      initializer.raw,
+      garbageBetweenInitializerAndGenericWhereClause?.raw,
+      genericWhereClause?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.typealiasDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -655,6 +713,44 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndAssociatedtypeKeyword: GarbageNodesSyntax? = nil,
+    associatedtypeKeyword: TokenSyntax,
+    _ garbageBetweenAssociatedtypeKeywordAndIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ garbageBetweenIdentifierAndInheritanceClause: GarbageNodesSyntax? = nil,
+    inheritanceClause: TypeInheritanceClauseSyntax?,
+    _ garbageBetweenInheritanceClauseAndInitializer: GarbageNodesSyntax? = nil,
+    initializer: TypeInitializerClauseSyntax?,
+    _ garbageBetweenInitializerAndGenericWhereClause: GarbageNodesSyntax? = nil,
+    genericWhereClause: GenericWhereClauseSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndAssociatedtypeKeyword?.raw,
+      associatedtypeKeyword.raw,
+      garbageBetweenAssociatedtypeKeywordAndIdentifier?.raw,
+      identifier.raw,
+      garbageBetweenIdentifierAndInheritanceClause?.raw,
+      inheritanceClause?.raw,
+      garbageBetweenInheritanceClauseAndInitializer?.raw,
+      initializer?.raw,
+      garbageBetweenInitializerAndGenericWhereClause?.raw,
+      genericWhereClause?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.associatedtypeDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1172,6 +1268,24 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeClauses: GarbageNodesSyntax? = nil,
+    clauses: IfConfigClauseListSyntax,
+    _ garbageBetweenClausesAndPoundEndif: GarbageNodesSyntax? = nil,
+    poundEndif: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeClauses?.raw,
+      clauses.raw,
+      garbageBetweenClausesAndPoundEndif?.raw,
+      poundEndif.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.ifConfigDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1362,6 +1476,32 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .poundErrorDecl)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforePoundError: GarbageNodesSyntax? = nil,
+    poundError: TokenSyntax,
+    _ garbageBetweenPoundErrorAndLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndMessage: GarbageNodesSyntax? = nil,
+    message: StringLiteralExprSyntax,
+    _ garbageBetweenMessageAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePoundError?.raw,
+      poundError.raw,
+      garbageBetweenPoundErrorAndLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndMessage?.raw,
+      message.raw,
+      garbageBetweenMessageAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.poundErrorDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1661,6 +1801,32 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforePoundWarning: GarbageNodesSyntax? = nil,
+    poundWarning: TokenSyntax,
+    _ garbageBetweenPoundWarningAndLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndMessage: GarbageNodesSyntax? = nil,
+    message: StringLiteralExprSyntax,
+    _ garbageBetweenMessageAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePoundWarning?.raw,
+      poundWarning.raw,
+      garbageBetweenPoundWarningAndLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndMessage?.raw,
+      message.raw,
+      garbageBetweenMessageAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.poundWarningDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1956,6 +2122,32 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .poundSourceLocation)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforePoundSourceLocation: GarbageNodesSyntax? = nil,
+    poundSourceLocation: TokenSyntax,
+    _ garbageBetweenPoundSourceLocationAndLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndArgs: GarbageNodesSyntax? = nil,
+    args: PoundSourceLocationArgsSyntax?,
+    _ garbageBetweenArgsAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePoundSourceLocation?.raw,
+      poundSourceLocation.raw,
+      garbageBetweenPoundSourceLocationAndLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndArgs?.raw,
+      args?.raw,
+      garbageBetweenArgsAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.poundSourceLocation,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -2261,6 +2453,48 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .classDecl)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndClassKeyword: GarbageNodesSyntax? = nil,
+    classKeyword: TokenSyntax,
+    _ garbageBetweenClassKeywordAndIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ garbageBetweenIdentifierAndGenericParameterClause: GarbageNodesSyntax? = nil,
+    genericParameterClause: GenericParameterClauseSyntax?,
+    _ garbageBetweenGenericParameterClauseAndInheritanceClause: GarbageNodesSyntax? = nil,
+    inheritanceClause: TypeInheritanceClauseSyntax?,
+    _ garbageBetweenInheritanceClauseAndGenericWhereClause: GarbageNodesSyntax? = nil,
+    genericWhereClause: GenericWhereClauseSyntax?,
+    _ garbageBetweenGenericWhereClauseAndMembers: GarbageNodesSyntax? = nil,
+    members: MemberDeclBlockSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndClassKeyword?.raw,
+      classKeyword.raw,
+      garbageBetweenClassKeywordAndIdentifier?.raw,
+      identifier.raw,
+      garbageBetweenIdentifierAndGenericParameterClause?.raw,
+      genericParameterClause?.raw,
+      garbageBetweenGenericParameterClauseAndInheritanceClause?.raw,
+      inheritanceClause?.raw,
+      garbageBetweenInheritanceClauseAndGenericWhereClause?.raw,
+      genericWhereClause?.raw,
+      garbageBetweenGenericWhereClauseAndMembers?.raw,
+      members.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.classDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -2854,6 +3088,48 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndActorKeyword: GarbageNodesSyntax? = nil,
+    actorKeyword: TokenSyntax,
+    _ garbageBetweenActorKeywordAndIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ garbageBetweenIdentifierAndGenericParameterClause: GarbageNodesSyntax? = nil,
+    genericParameterClause: GenericParameterClauseSyntax?,
+    _ garbageBetweenGenericParameterClauseAndInheritanceClause: GarbageNodesSyntax? = nil,
+    inheritanceClause: TypeInheritanceClauseSyntax?,
+    _ garbageBetweenInheritanceClauseAndGenericWhereClause: GarbageNodesSyntax? = nil,
+    genericWhereClause: GenericWhereClauseSyntax?,
+    _ garbageBetweenGenericWhereClauseAndMembers: GarbageNodesSyntax? = nil,
+    members: MemberDeclBlockSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndActorKeyword?.raw,
+      actorKeyword.raw,
+      garbageBetweenActorKeywordAndIdentifier?.raw,
+      identifier.raw,
+      garbageBetweenIdentifierAndGenericParameterClause?.raw,
+      genericParameterClause?.raw,
+      garbageBetweenGenericParameterClauseAndInheritanceClause?.raw,
+      inheritanceClause?.raw,
+      garbageBetweenInheritanceClauseAndGenericWhereClause?.raw,
+      genericWhereClause?.raw,
+      garbageBetweenGenericWhereClauseAndMembers?.raw,
+      members.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.actorDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -3443,6 +3719,48 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .structDecl)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndStructKeyword: GarbageNodesSyntax? = nil,
+    structKeyword: TokenSyntax,
+    _ garbageBetweenStructKeywordAndIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ garbageBetweenIdentifierAndGenericParameterClause: GarbageNodesSyntax? = nil,
+    genericParameterClause: GenericParameterClauseSyntax?,
+    _ garbageBetweenGenericParameterClauseAndInheritanceClause: GarbageNodesSyntax? = nil,
+    inheritanceClause: TypeInheritanceClauseSyntax?,
+    _ garbageBetweenInheritanceClauseAndGenericWhereClause: GarbageNodesSyntax? = nil,
+    genericWhereClause: GenericWhereClauseSyntax?,
+    _ garbageBetweenGenericWhereClauseAndMembers: GarbageNodesSyntax? = nil,
+    members: MemberDeclBlockSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndStructKeyword?.raw,
+      structKeyword.raw,
+      garbageBetweenStructKeywordAndIdentifier?.raw,
+      identifier.raw,
+      garbageBetweenIdentifierAndGenericParameterClause?.raw,
+      genericParameterClause?.raw,
+      garbageBetweenGenericParameterClauseAndInheritanceClause?.raw,
+      inheritanceClause?.raw,
+      garbageBetweenInheritanceClauseAndGenericWhereClause?.raw,
+      genericWhereClause?.raw,
+      garbageBetweenGenericWhereClauseAndMembers?.raw,
+      members.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.structDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -4036,6 +4354,48 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndProtocolKeyword: GarbageNodesSyntax? = nil,
+    protocolKeyword: TokenSyntax,
+    _ garbageBetweenProtocolKeywordAndIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ garbageBetweenIdentifierAndPrimaryAssociatedTypeClause: GarbageNodesSyntax? = nil,
+    primaryAssociatedTypeClause: PrimaryAssociatedTypeClauseSyntax?,
+    _ garbageBetweenPrimaryAssociatedTypeClauseAndInheritanceClause: GarbageNodesSyntax? = nil,
+    inheritanceClause: TypeInheritanceClauseSyntax?,
+    _ garbageBetweenInheritanceClauseAndGenericWhereClause: GarbageNodesSyntax? = nil,
+    genericWhereClause: GenericWhereClauseSyntax?,
+    _ garbageBetweenGenericWhereClauseAndMembers: GarbageNodesSyntax? = nil,
+    members: MemberDeclBlockSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndProtocolKeyword?.raw,
+      protocolKeyword.raw,
+      garbageBetweenProtocolKeywordAndIdentifier?.raw,
+      identifier.raw,
+      garbageBetweenIdentifierAndPrimaryAssociatedTypeClause?.raw,
+      primaryAssociatedTypeClause?.raw,
+      garbageBetweenPrimaryAssociatedTypeClauseAndInheritanceClause?.raw,
+      inheritanceClause?.raw,
+      garbageBetweenInheritanceClauseAndGenericWhereClause?.raw,
+      genericWhereClause?.raw,
+      garbageBetweenGenericWhereClauseAndMembers?.raw,
+      members.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.protocolDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -4625,6 +4985,44 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndExtensionKeyword: GarbageNodesSyntax? = nil,
+    extensionKeyword: TokenSyntax,
+    _ garbageBetweenExtensionKeywordAndExtendedType: GarbageNodesSyntax? = nil,
+    extendedType: TypeSyntax,
+    _ garbageBetweenExtendedTypeAndInheritanceClause: GarbageNodesSyntax? = nil,
+    inheritanceClause: TypeInheritanceClauseSyntax?,
+    _ garbageBetweenInheritanceClauseAndGenericWhereClause: GarbageNodesSyntax? = nil,
+    genericWhereClause: GenericWhereClauseSyntax?,
+    _ garbageBetweenGenericWhereClauseAndMembers: GarbageNodesSyntax? = nil,
+    members: MemberDeclBlockSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndExtensionKeyword?.raw,
+      extensionKeyword.raw,
+      garbageBetweenExtensionKeywordAndExtendedType?.raw,
+      extendedType.raw,
+      garbageBetweenExtendedTypeAndInheritanceClause?.raw,
+      inheritanceClause?.raw,
+      garbageBetweenInheritanceClauseAndGenericWhereClause?.raw,
+      genericWhereClause?.raw,
+      garbageBetweenGenericWhereClauseAndMembers?.raw,
+      members.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.extensionDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -5152,6 +5550,48 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .functionDecl)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndFuncKeyword: GarbageNodesSyntax? = nil,
+    funcKeyword: TokenSyntax,
+    _ garbageBetweenFuncKeywordAndIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ garbageBetweenIdentifierAndGenericParameterClause: GarbageNodesSyntax? = nil,
+    genericParameterClause: GenericParameterClauseSyntax?,
+    _ garbageBetweenGenericParameterClauseAndSignature: GarbageNodesSyntax? = nil,
+    signature: FunctionSignatureSyntax,
+    _ garbageBetweenSignatureAndGenericWhereClause: GarbageNodesSyntax? = nil,
+    genericWhereClause: GenericWhereClauseSyntax?,
+    _ garbageBetweenGenericWhereClauseAndBody: GarbageNodesSyntax? = nil,
+    body: CodeBlockSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndFuncKeyword?.raw,
+      funcKeyword.raw,
+      garbageBetweenFuncKeywordAndIdentifier?.raw,
+      identifier.raw,
+      garbageBetweenIdentifierAndGenericParameterClause?.raw,
+      genericParameterClause?.raw,
+      garbageBetweenGenericParameterClauseAndSignature?.raw,
+      signature.raw,
+      garbageBetweenSignatureAndGenericWhereClause?.raw,
+      genericWhereClause?.raw,
+      garbageBetweenGenericWhereClauseAndBody?.raw,
+      body?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.functionDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -5745,6 +6185,48 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndInitKeyword: GarbageNodesSyntax? = nil,
+    initKeyword: TokenSyntax,
+    _ garbageBetweenInitKeywordAndOptionalMark: GarbageNodesSyntax? = nil,
+    optionalMark: TokenSyntax?,
+    _ garbageBetweenOptionalMarkAndGenericParameterClause: GarbageNodesSyntax? = nil,
+    genericParameterClause: GenericParameterClauseSyntax?,
+    _ garbageBetweenGenericParameterClauseAndSignature: GarbageNodesSyntax? = nil,
+    signature: FunctionSignatureSyntax,
+    _ garbageBetweenSignatureAndGenericWhereClause: GarbageNodesSyntax? = nil,
+    genericWhereClause: GenericWhereClauseSyntax?,
+    _ garbageBetweenGenericWhereClauseAndBody: GarbageNodesSyntax? = nil,
+    body: CodeBlockSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndInitKeyword?.raw,
+      initKeyword.raw,
+      garbageBetweenInitKeywordAndOptionalMark?.raw,
+      optionalMark?.raw,
+      garbageBetweenOptionalMarkAndGenericParameterClause?.raw,
+      genericParameterClause?.raw,
+      garbageBetweenGenericParameterClauseAndSignature?.raw,
+      signature.raw,
+      garbageBetweenSignatureAndGenericWhereClause?.raw,
+      genericWhereClause?.raw,
+      garbageBetweenGenericWhereClauseAndBody?.raw,
+      body?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.initializerDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -6328,6 +6810,32 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndDeinitKeyword: GarbageNodesSyntax? = nil,
+    deinitKeyword: TokenSyntax,
+    _ garbageBetweenDeinitKeywordAndBody: GarbageNodesSyntax? = nil,
+    body: CodeBlockSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndDeinitKeyword?.raw,
+      deinitKeyword.raw,
+      garbageBetweenDeinitKeywordAndBody?.raw,
+      body?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.deinitializerDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -6669,6 +7177,48 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .subscriptDecl)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndSubscriptKeyword: GarbageNodesSyntax? = nil,
+    subscriptKeyword: TokenSyntax,
+    _ garbageBetweenSubscriptKeywordAndGenericParameterClause: GarbageNodesSyntax? = nil,
+    genericParameterClause: GenericParameterClauseSyntax?,
+    _ garbageBetweenGenericParameterClauseAndIndices: GarbageNodesSyntax? = nil,
+    indices: ParameterClauseSyntax,
+    _ garbageBetweenIndicesAndResult: GarbageNodesSyntax? = nil,
+    result: ReturnClauseSyntax,
+    _ garbageBetweenResultAndGenericWhereClause: GarbageNodesSyntax? = nil,
+    genericWhereClause: GenericWhereClauseSyntax?,
+    _ garbageBetweenGenericWhereClauseAndAccessor: GarbageNodesSyntax? = nil,
+    accessor: Syntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndSubscriptKeyword?.raw,
+      subscriptKeyword.raw,
+      garbageBetweenSubscriptKeywordAndGenericParameterClause?.raw,
+      genericParameterClause?.raw,
+      garbageBetweenGenericParameterClauseAndIndices?.raw,
+      indices.raw,
+      garbageBetweenIndicesAndResult?.raw,
+      result.raw,
+      garbageBetweenResultAndGenericWhereClause?.raw,
+      genericWhereClause?.raw,
+      garbageBetweenGenericWhereClauseAndAccessor?.raw,
+      accessor?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.subscriptDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -7256,6 +7806,36 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndImportTok: GarbageNodesSyntax? = nil,
+    importTok: TokenSyntax,
+    _ garbageBetweenImportTokAndImportKind: GarbageNodesSyntax? = nil,
+    importKind: TokenSyntax?,
+    _ garbageBetweenImportKindAndPath: GarbageNodesSyntax? = nil,
+    path: AccessPathSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndImportTok?.raw,
+      importTok.raw,
+      garbageBetweenImportTokAndImportKind?.raw,
+      importKind?.raw,
+      garbageBetweenImportKindAndPath?.raw,
+      path.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.importDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -7676,6 +8256,44 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .accessorDecl)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifier: GarbageNodesSyntax? = nil,
+    modifier: DeclModifierSyntax?,
+    _ garbageBetweenModifierAndAccessorKind: GarbageNodesSyntax? = nil,
+    accessorKind: TokenSyntax,
+    _ garbageBetweenAccessorKindAndParameter: GarbageNodesSyntax? = nil,
+    parameter: AccessorParameterSyntax?,
+    _ garbageBetweenParameterAndAsyncKeyword: GarbageNodesSyntax? = nil,
+    asyncKeyword: TokenSyntax?,
+    _ garbageBetweenAsyncKeywordAndThrowsKeyword: GarbageNodesSyntax? = nil,
+    throwsKeyword: TokenSyntax?,
+    _ garbageBetweenThrowsKeywordAndBody: GarbageNodesSyntax? = nil,
+    body: CodeBlockSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifier?.raw,
+      modifier?.raw,
+      garbageBetweenModifierAndAccessorKind?.raw,
+      accessorKind.raw,
+      garbageBetweenAccessorKindAndParameter?.raw,
+      parameter?.raw,
+      garbageBetweenParameterAndAsyncKeyword?.raw,
+      asyncKeyword?.raw,
+      garbageBetweenAsyncKeywordAndThrowsKeyword?.raw,
+      throwsKeyword?.raw,
+      garbageBetweenThrowsKeywordAndBody?.raw,
+      body?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.accessorDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -8180,6 +8798,32 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndLetOrVarKeyword: GarbageNodesSyntax? = nil,
+    letOrVarKeyword: TokenSyntax,
+    _ garbageBetweenLetOrVarKeywordAndBindings: GarbageNodesSyntax? = nil,
+    bindings: PatternBindingListSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndLetOrVarKeyword?.raw,
+      letOrVarKeyword.raw,
+      garbageBetweenLetOrVarKeywordAndBindings?.raw,
+      bindings.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.variableDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -8537,6 +9181,32 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .enumCaseDecl)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndCaseKeyword: GarbageNodesSyntax? = nil,
+    caseKeyword: TokenSyntax,
+    _ garbageBetweenCaseKeywordAndElements: GarbageNodesSyntax? = nil,
+    elements: EnumCaseElementListSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndCaseKeyword?.raw,
+      caseKeyword.raw,
+      garbageBetweenCaseKeywordAndElements?.raw,
+      elements.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.enumCaseDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -8908,6 +9578,48 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .enumDecl)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndEnumKeyword: GarbageNodesSyntax? = nil,
+    enumKeyword: TokenSyntax,
+    _ garbageBetweenEnumKeywordAndIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ garbageBetweenIdentifierAndGenericParameters: GarbageNodesSyntax? = nil,
+    genericParameters: GenericParameterClauseSyntax?,
+    _ garbageBetweenGenericParametersAndInheritanceClause: GarbageNodesSyntax? = nil,
+    inheritanceClause: TypeInheritanceClauseSyntax?,
+    _ garbageBetweenInheritanceClauseAndGenericWhereClause: GarbageNodesSyntax? = nil,
+    genericWhereClause: GenericWhereClauseSyntax?,
+    _ garbageBetweenGenericWhereClauseAndMembers: GarbageNodesSyntax? = nil,
+    members: MemberDeclBlockSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndEnumKeyword?.raw,
+      enumKeyword.raw,
+      garbageBetweenEnumKeywordAndIdentifier?.raw,
+      identifier.raw,
+      garbageBetweenIdentifierAndGenericParameters?.raw,
+      genericParameters?.raw,
+      garbageBetweenGenericParametersAndInheritanceClause?.raw,
+      inheritanceClause?.raw,
+      garbageBetweenInheritanceClauseAndGenericWhereClause?.raw,
+      genericWhereClause?.raw,
+      garbageBetweenGenericWhereClauseAndMembers?.raw,
+      members.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.enumDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -9522,6 +10234,36 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndOperatorKeyword: GarbageNodesSyntax? = nil,
+    operatorKeyword: TokenSyntax,
+    _ garbageBetweenOperatorKeywordAndIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ garbageBetweenIdentifierAndOperatorPrecedenceAndTypes: GarbageNodesSyntax? = nil,
+    operatorPrecedenceAndTypes: OperatorPrecedenceAndTypesSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndOperatorKeyword?.raw,
+      operatorKeyword.raw,
+      garbageBetweenOperatorKeywordAndIdentifier?.raw,
+      identifier.raw,
+      garbageBetweenIdentifierAndOperatorPrecedenceAndTypes?.raw,
+      operatorPrecedenceAndTypes?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.operatorDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -9934,6 +10676,44 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .precedenceGroupDecl)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?,
+    _ garbageBetweenModifiersAndPrecedencegroupKeyword: GarbageNodesSyntax? = nil,
+    precedencegroupKeyword: TokenSyntax,
+    _ garbageBetweenPrecedencegroupKeywordAndIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ garbageBetweenIdentifierAndLeftBrace: GarbageNodesSyntax? = nil,
+    leftBrace: TokenSyntax,
+    _ garbageBetweenLeftBraceAndGroupAttributes: GarbageNodesSyntax? = nil,
+    groupAttributes: PrecedenceGroupAttributeListSyntax,
+    _ garbageBetweenGroupAttributesAndRightBrace: GarbageNodesSyntax? = nil,
+    rightBrace: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
+      garbageBetweenModifiersAndPrecedencegroupKeyword?.raw,
+      precedencegroupKeyword.raw,
+      garbageBetweenPrecedencegroupKeywordAndIdentifier?.raw,
+      identifier.raw,
+      garbageBetweenIdentifierAndLeftBrace?.raw,
+      leftBrace.raw,
+      garbageBetweenLeftBraceAndGroupAttributes?.raw,
+      groupAttributes.raw,
+      garbageBetweenGroupAttributesAndRightBrace?.raw,
+      rightBrace.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.precedenceGroupDecl,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -34,6 +34,16 @@ public struct UnknownExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+  ) {
+    let layout: [RawSyntax?] = [
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.unknownExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -71,6 +81,16 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .missingExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+  ) {
+    let layout: [RawSyntax?] = [
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.missingExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -116,6 +136,24 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .inOutExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAmpersand: GarbageNodesSyntax? = nil,
+    ampersand: TokenSyntax,
+    _ garbageBetweenAmpersandAndExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAmpersand?.raw,
+      ampersand.raw,
+      garbageBetweenAmpersandAndExpression?.raw,
+      expression.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.inOutExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -285,6 +323,20 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforePoundColumn: GarbageNodesSyntax? = nil,
+    poundColumn: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePoundColumn?.raw,
+      poundColumn.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.poundColumnExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -392,6 +444,28 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .tryExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeTryKeyword: GarbageNodesSyntax? = nil,
+    tryKeyword: TokenSyntax,
+    _ garbageBetweenTryKeywordAndQuestionOrExclamationMark: GarbageNodesSyntax? = nil,
+    questionOrExclamationMark: TokenSyntax?,
+    _ garbageBetweenQuestionOrExclamationMarkAndExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeTryKeyword?.raw,
+      tryKeyword.raw,
+      garbageBetweenTryKeywordAndQuestionOrExclamationMark?.raw,
+      questionOrExclamationMark?.raw,
+      garbageBetweenQuestionOrExclamationMarkAndExpression?.raw,
+      expression.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.tryExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -625,6 +699,24 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeAwaitKeyword: GarbageNodesSyntax? = nil,
+    awaitKeyword: TokenSyntax,
+    _ garbageBetweenAwaitKeywordAndExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAwaitKeyword?.raw,
+      awaitKeyword.raw,
+      garbageBetweenAwaitKeywordAndExpression?.raw,
+      expression.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.awaitExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -792,6 +884,24 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .moveExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeMoveKeyword: GarbageNodesSyntax? = nil,
+    moveKeyword: TokenSyntax,
+    _ garbageBetweenMoveKeywordAndExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeMoveKeyword?.raw,
+      moveKeyword.raw,
+      garbageBetweenMoveKeywordAndExpression?.raw,
+      expression.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.moveExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -963,6 +1073,24 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ garbageBetweenIdentifierAndDeclNameArguments: GarbageNodesSyntax? = nil,
+    declNameArguments: DeclNameArgumentsSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeIdentifier?.raw,
+      identifier.raw,
+      garbageBetweenIdentifierAndDeclNameArguments?.raw,
+      declNameArguments?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.identifierExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1130,6 +1258,20 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeSuperKeyword: GarbageNodesSyntax? = nil,
+    superKeyword: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeSuperKeyword?.raw,
+      superKeyword.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.superRefExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1233,6 +1375,20 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .nilLiteralExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeNilKeyword: GarbageNodesSyntax? = nil,
+    nilKeyword: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeNilKeyword?.raw,
+      nilKeyword.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.nilLiteralExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1340,6 +1496,20 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeWildcard: GarbageNodesSyntax? = nil,
+    wildcard: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeWildcard?.raw,
+      wildcard.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.discardAssignmentExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1445,6 +1615,20 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeAssignToken: GarbageNodesSyntax? = nil,
+    assignToken: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAssignToken?.raw,
+      assignToken.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.assignmentExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1548,6 +1732,20 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .sequenceExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeElements: GarbageNodesSyntax? = nil,
+    elements: ExprListSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeElements?.raw,
+      elements.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.sequenceExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1674,6 +1872,20 @@ public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforePoundLine: GarbageNodesSyntax? = nil,
+    poundLine: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePoundLine?.raw,
+      poundLine.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.poundLineExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1777,6 +1989,20 @@ public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .poundFileExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforePoundFile: GarbageNodesSyntax? = nil,
+    poundFile: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePoundFile?.raw,
+      poundFile.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.poundFileExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1884,6 +2110,20 @@ public struct PoundFileIDExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforePoundFileID: GarbageNodesSyntax? = nil,
+    poundFileID: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePoundFileID?.raw,
+      poundFileID.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.poundFileIDExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1987,6 +2227,20 @@ public struct PoundFilePathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .poundFilePathExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforePoundFilePath: GarbageNodesSyntax? = nil,
+    poundFilePath: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePoundFilePath?.raw,
+      poundFilePath.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.poundFilePathExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -2094,6 +2348,20 @@ public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforePoundFunction: GarbageNodesSyntax? = nil,
+    poundFunction: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePoundFunction?.raw,
+      poundFunction.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.poundFunctionExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -2197,6 +2465,20 @@ public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .poundDsohandleExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforePoundDsohandle: GarbageNodesSyntax? = nil,
+    poundDsohandle: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePoundDsohandle?.raw,
+      poundDsohandle.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.poundDsohandleExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -2304,6 +2586,24 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .symbolicReferenceExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ garbageBetweenIdentifierAndGenericArgumentClause: GarbageNodesSyntax? = nil,
+    genericArgumentClause: GenericArgumentClauseSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeIdentifier?.raw,
+      identifier.raw,
+      garbageBetweenIdentifierAndGenericArgumentClause?.raw,
+      genericArgumentClause?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.symbolicReferenceExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -2475,6 +2775,24 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeOperatorToken: GarbageNodesSyntax? = nil,
+    operatorToken: TokenSyntax?,
+    _ garbageBetweenOperatorTokenAndPostfixExpression: GarbageNodesSyntax? = nil,
+    postfixExpression: ExprSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeOperatorToken?.raw,
+      operatorToken?.raw,
+      garbageBetweenOperatorTokenAndPostfixExpression?.raw,
+      postfixExpression.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.prefixOperatorExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -2642,6 +2960,20 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeOperatorToken: GarbageNodesSyntax? = nil,
+    operatorToken: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeOperatorToken?.raw,
+      operatorToken.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.binaryOperatorExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -2749,6 +3081,28 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .arrowExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAsyncKeyword: GarbageNodesSyntax? = nil,
+    asyncKeyword: TokenSyntax?,
+    _ garbageBetweenAsyncKeywordAndThrowsToken: GarbageNodesSyntax? = nil,
+    throwsToken: TokenSyntax?,
+    _ garbageBetweenThrowsTokenAndArrowToken: GarbageNodesSyntax? = nil,
+    arrowToken: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAsyncKeyword?.raw,
+      asyncKeyword?.raw,
+      garbageBetweenAsyncKeywordAndThrowsToken?.raw,
+      throwsToken?.raw,
+      garbageBetweenThrowsTokenAndArrowToken?.raw,
+      arrowToken.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.arrowExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -2984,6 +3338,28 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeLeftOperand: GarbageNodesSyntax? = nil,
+    leftOperand: ExprSyntax,
+    _ garbageBetweenLeftOperandAndOperatorOperand: GarbageNodesSyntax? = nil,
+    operatorOperand: ExprSyntax,
+    _ garbageBetweenOperatorOperandAndRightOperand: GarbageNodesSyntax? = nil,
+    rightOperand: ExprSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftOperand?.raw,
+      leftOperand.raw,
+      garbageBetweenLeftOperandAndOperatorOperand?.raw,
+      operatorOperand.raw,
+      garbageBetweenOperatorOperandAndRightOperand?.raw,
+      rightOperand.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.infixOperatorExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -3213,6 +3589,20 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeFloatingDigits: GarbageNodesSyntax? = nil,
+    floatingDigits: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeFloatingDigits?.raw,
+      floatingDigits.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.floatLiteralExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -3320,6 +3710,28 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .tupleExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndElementList: GarbageNodesSyntax? = nil,
+    elementList: TupleExprElementListSyntax,
+    _ garbageBetweenElementListAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndElementList?.raw,
+      elementList.raw,
+      garbageBetweenElementListAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.tupleExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -3574,6 +3986,28 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeLeftSquare: GarbageNodesSyntax? = nil,
+    leftSquare: TokenSyntax,
+    _ garbageBetweenLeftSquareAndElements: GarbageNodesSyntax? = nil,
+    elements: ArrayElementListSyntax,
+    _ garbageBetweenElementsAndRightSquare: GarbageNodesSyntax? = nil,
+    rightSquare: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftSquare?.raw,
+      leftSquare.raw,
+      garbageBetweenLeftSquareAndElements?.raw,
+      elements.raw,
+      garbageBetweenElementsAndRightSquare?.raw,
+      rightSquare.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.arrayExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -3826,6 +4260,28 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeLeftSquare: GarbageNodesSyntax? = nil,
+    leftSquare: TokenSyntax,
+    _ garbageBetweenLeftSquareAndContent: GarbageNodesSyntax? = nil,
+    content: Syntax,
+    _ garbageBetweenContentAndRightSquare: GarbageNodesSyntax? = nil,
+    rightSquare: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftSquare?.raw,
+      leftSquare.raw,
+      garbageBetweenLeftSquareAndContent?.raw,
+      content.raw,
+      garbageBetweenContentAndRightSquare?.raw,
+      rightSquare.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.dictionaryExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -4055,6 +4511,20 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeDigits: GarbageNodesSyntax? = nil,
+    digits: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeDigits?.raw,
+      digits.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.integerLiteralExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -4158,6 +4628,20 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .booleanLiteralExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeBooleanLiteral: GarbageNodesSyntax? = nil,
+    booleanLiteral: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeBooleanLiteral?.raw,
+      booleanLiteral.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.booleanLiteralExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -4271,6 +4755,36 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .ternaryExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeConditionExpression: GarbageNodesSyntax? = nil,
+    conditionExpression: ExprSyntax,
+    _ garbageBetweenConditionExpressionAndQuestionMark: GarbageNodesSyntax? = nil,
+    questionMark: TokenSyntax,
+    _ garbageBetweenQuestionMarkAndFirstChoice: GarbageNodesSyntax? = nil,
+    firstChoice: ExprSyntax,
+    _ garbageBetweenFirstChoiceAndColonMark: GarbageNodesSyntax? = nil,
+    colonMark: TokenSyntax,
+    _ garbageBetweenColonMarkAndSecondChoice: GarbageNodesSyntax? = nil,
+    secondChoice: ExprSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeConditionExpression?.raw,
+      conditionExpression.raw,
+      garbageBetweenConditionExpressionAndQuestionMark?.raw,
+      questionMark.raw,
+      garbageBetweenQuestionMarkAndFirstChoice?.raw,
+      firstChoice.raw,
+      garbageBetweenFirstChoiceAndColonMark?.raw,
+      colonMark.raw,
+      garbageBetweenColonMarkAndSecondChoice?.raw,
+      secondChoice.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.ternaryExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -4632,6 +5146,32 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeBase: GarbageNodesSyntax? = nil,
+    base: ExprSyntax?,
+    _ garbageBetweenBaseAndDot: GarbageNodesSyntax? = nil,
+    dot: TokenSyntax,
+    _ garbageBetweenDotAndName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ garbageBetweenNameAndDeclNameArguments: GarbageNodesSyntax? = nil,
+    declNameArguments: DeclNameArgumentsSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeBase?.raw,
+      base?.raw,
+      garbageBetweenBaseAndDot?.raw,
+      dot.raw,
+      garbageBetweenDotAndName?.raw,
+      name.raw,
+      garbageBetweenNameAndDeclNameArguments?.raw,
+      declNameArguments?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.memberAccessExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -4925,6 +5465,24 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeIsTok: GarbageNodesSyntax? = nil,
+    isTok: TokenSyntax,
+    _ garbageBetweenIsTokAndTypeName: GarbageNodesSyntax? = nil,
+    typeName: TypeSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeIsTok?.raw,
+      isTok.raw,
+      garbageBetweenIsTokAndTypeName?.raw,
+      typeName.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.isExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -5094,6 +5652,28 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .asExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAsTok: GarbageNodesSyntax? = nil,
+    asTok: TokenSyntax,
+    _ garbageBetweenAsTokAndQuestionOrExclamationMark: GarbageNodesSyntax? = nil,
+    questionOrExclamationMark: TokenSyntax?,
+    _ garbageBetweenQuestionOrExclamationMarkAndTypeName: GarbageNodesSyntax? = nil,
+    typeName: TypeSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAsTok?.raw,
+      asTok.raw,
+      garbageBetweenAsTokAndQuestionOrExclamationMark?.raw,
+      questionOrExclamationMark?.raw,
+      garbageBetweenQuestionOrExclamationMarkAndTypeName?.raw,
+      typeName.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.asExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -5325,6 +5905,20 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeType: GarbageNodesSyntax? = nil,
+    type: TypeSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeType?.raw,
+      type.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.typeExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -5434,6 +6028,32 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .closureExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftBrace: GarbageNodesSyntax? = nil,
+    leftBrace: TokenSyntax,
+    _ garbageBetweenLeftBraceAndSignature: GarbageNodesSyntax? = nil,
+    signature: ClosureSignatureSyntax?,
+    _ garbageBetweenSignatureAndStatements: GarbageNodesSyntax? = nil,
+    statements: CodeBlockItemListSyntax,
+    _ garbageBetweenStatementsAndRightBrace: GarbageNodesSyntax? = nil,
+    rightBrace: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftBrace?.raw,
+      leftBrace.raw,
+      garbageBetweenLeftBraceAndSignature?.raw,
+      signature?.raw,
+      garbageBetweenSignatureAndStatements?.raw,
+      statements.raw,
+      garbageBetweenStatementsAndRightBrace?.raw,
+      rightBrace.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.closureExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -5746,6 +6366,20 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforePattern: GarbageNodesSyntax? = nil,
+    pattern: PatternSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePattern?.raw,
+      pattern.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.unresolvedPatternExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -5859,6 +6493,40 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .functionCallExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeCalledExpression: GarbageNodesSyntax? = nil,
+    calledExpression: ExprSyntax,
+    _ garbageBetweenCalledExpressionAndLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax?,
+    _ garbageBetweenLeftParenAndArgumentList: GarbageNodesSyntax? = nil,
+    argumentList: TupleExprElementListSyntax,
+    _ garbageBetweenArgumentListAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax?,
+    _ garbageBetweenRightParenAndTrailingClosure: GarbageNodesSyntax? = nil,
+    trailingClosure: ClosureExprSyntax?,
+    _ garbageBetweenTrailingClosureAndAdditionalTrailingClosures: GarbageNodesSyntax? = nil,
+    additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeCalledExpression?.raw,
+      calledExpression.raw,
+      garbageBetweenCalledExpressionAndLeftParen?.raw,
+      leftParen?.raw,
+      garbageBetweenLeftParenAndArgumentList?.raw,
+      argumentList.raw,
+      garbageBetweenArgumentListAndRightParen?.raw,
+      rightParen?.raw,
+      garbageBetweenRightParenAndTrailingClosure?.raw,
+      trailingClosure?.raw,
+      garbageBetweenTrailingClosureAndAdditionalTrailingClosures?.raw,
+      additionalTrailingClosures?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.functionCallExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -6324,6 +6992,40 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeCalledExpression: GarbageNodesSyntax? = nil,
+    calledExpression: ExprSyntax,
+    _ garbageBetweenCalledExpressionAndLeftBracket: GarbageNodesSyntax? = nil,
+    leftBracket: TokenSyntax,
+    _ garbageBetweenLeftBracketAndArgumentList: GarbageNodesSyntax? = nil,
+    argumentList: TupleExprElementListSyntax,
+    _ garbageBetweenArgumentListAndRightBracket: GarbageNodesSyntax? = nil,
+    rightBracket: TokenSyntax,
+    _ garbageBetweenRightBracketAndTrailingClosure: GarbageNodesSyntax? = nil,
+    trailingClosure: ClosureExprSyntax?,
+    _ garbageBetweenTrailingClosureAndAdditionalTrailingClosures: GarbageNodesSyntax? = nil,
+    additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeCalledExpression?.raw,
+      calledExpression.raw,
+      garbageBetweenCalledExpressionAndLeftBracket?.raw,
+      leftBracket.raw,
+      garbageBetweenLeftBracketAndArgumentList?.raw,
+      argumentList.raw,
+      garbageBetweenArgumentListAndRightBracket?.raw,
+      rightBracket.raw,
+      garbageBetweenRightBracketAndTrailingClosure?.raw,
+      trailingClosure?.raw,
+      garbageBetweenTrailingClosureAndAdditionalTrailingClosures?.raw,
+      additionalTrailingClosures?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.subscriptExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -6779,6 +7481,24 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax,
+    _ garbageBetweenExpressionAndQuestionMark: GarbageNodesSyntax? = nil,
+    questionMark: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeExpression?.raw,
+      expression.raw,
+      garbageBetweenExpressionAndQuestionMark?.raw,
+      questionMark.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.optionalChainingExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -6946,6 +7666,24 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .forcedValueExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax,
+    _ garbageBetweenExpressionAndExclamationMark: GarbageNodesSyntax? = nil,
+    exclamationMark: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeExpression?.raw,
+      expression.raw,
+      garbageBetweenExpressionAndExclamationMark?.raw,
+      exclamationMark.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.forcedValueExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -7117,6 +7855,24 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax,
+    _ garbageBetweenExpressionAndOperatorToken: GarbageNodesSyntax? = nil,
+    operatorToken: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeExpression?.raw,
+      expression.raw,
+      garbageBetweenExpressionAndOperatorToken?.raw,
+      operatorToken.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.postfixUnaryExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -7284,6 +8040,24 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .specializeExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax,
+    _ garbageBetweenExpressionAndGenericArgumentClause: GarbageNodesSyntax? = nil,
+    genericArgumentClause: GenericArgumentClauseSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeExpression?.raw,
+      expression.raw,
+      garbageBetweenExpressionAndGenericArgumentClause?.raw,
+      genericArgumentClause.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.specializeExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -7459,6 +8233,36 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .stringLiteralExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeOpenDelimiter: GarbageNodesSyntax? = nil,
+    openDelimiter: TokenSyntax?,
+    _ garbageBetweenOpenDelimiterAndOpenQuote: GarbageNodesSyntax? = nil,
+    openQuote: TokenSyntax,
+    _ garbageBetweenOpenQuoteAndSegments: GarbageNodesSyntax? = nil,
+    segments: StringLiteralSegmentsSyntax,
+    _ garbageBetweenSegmentsAndCloseQuote: GarbageNodesSyntax? = nil,
+    closeQuote: TokenSyntax,
+    _ garbageBetweenCloseQuoteAndCloseDelimiter: GarbageNodesSyntax? = nil,
+    closeDelimiter: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeOpenDelimiter?.raw,
+      openDelimiter?.raw,
+      garbageBetweenOpenDelimiterAndOpenQuote?.raw,
+      openQuote.raw,
+      garbageBetweenOpenQuoteAndSegments?.raw,
+      segments.raw,
+      garbageBetweenSegmentsAndCloseQuote?.raw,
+      closeQuote.raw,
+      garbageBetweenCloseQuoteAndCloseDelimiter?.raw,
+      closeDelimiter?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.stringLiteralExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -7833,6 +8637,20 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeRegex: GarbageNodesSyntax? = nil,
+    regex: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeRegex?.raw,
+      regex.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.regexLiteralExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -7940,6 +8758,28 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .keyPathExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeBackslash: GarbageNodesSyntax? = nil,
+    backslash: TokenSyntax,
+    _ garbageBetweenBackslashAndRootExpr: GarbageNodesSyntax? = nil,
+    rootExpr: ExprSyntax?,
+    _ garbageBetweenRootExprAndExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeBackslash?.raw,
+      backslash.raw,
+      garbageBetweenBackslashAndRootExpr?.raw,
+      rootExpr?.raw,
+      garbageBetweenRootExprAndExpression?.raw,
+      expression.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.keyPathExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -8171,6 +9011,20 @@ public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforePeriod: GarbageNodesSyntax? = nil,
+    period: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePeriod?.raw,
+      period.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.keyPathBaseExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -8280,6 +9134,32 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .objcKeyPathExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeKeyPath: GarbageNodesSyntax? = nil,
+    keyPath: TokenSyntax,
+    _ garbageBetweenKeyPathAndLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndName: GarbageNodesSyntax? = nil,
+    name: ObjcNameSyntax,
+    _ garbageBetweenNameAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeKeyPath?.raw,
+      keyPath.raw,
+      garbageBetweenKeyPathAndLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndName?.raw,
+      name.raw,
+      garbageBetweenNameAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.objcKeyPathExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -8600,6 +9480,40 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .objcSelectorExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforePoundSelector: GarbageNodesSyntax? = nil,
+    poundSelector: TokenSyntax,
+    _ garbageBetweenPoundSelectorAndLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndKind: GarbageNodesSyntax? = nil,
+    kind: TokenSyntax?,
+    _ garbageBetweenKindAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax?,
+    _ garbageBetweenColonAndName: GarbageNodesSyntax? = nil,
+    name: ExprSyntax,
+    _ garbageBetweenNameAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePoundSelector?.raw,
+      poundSelector.raw,
+      garbageBetweenPoundSelectorAndLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndKind?.raw,
+      kind?.raw,
+      garbageBetweenKindAndColon?.raw,
+      colon?.raw,
+      garbageBetweenColonAndName?.raw,
+      name.raw,
+      garbageBetweenNameAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.objcSelectorExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -9019,6 +9933,24 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeBase: GarbageNodesSyntax? = nil,
+    base: ExprSyntax?,
+    _ garbageBetweenBaseAndConfig: GarbageNodesSyntax? = nil,
+    config: IfConfigDeclSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeBase?.raw,
+      base?.raw,
+      garbageBetweenBaseAndConfig?.raw,
+      config.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.postfixIfConfigExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -9186,6 +10118,20 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeIdentifier?.raw,
+      identifier.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.editorPlaceholderExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -9295,6 +10241,32 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .objectLiteralExpr)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ garbageBetweenIdentifierAndLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndArguments: GarbageNodesSyntax? = nil,
+    arguments: TupleExprElementListSyntax,
+    _ garbageBetweenArgumentsAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeIdentifier?.raw,
+      identifier.raw,
+      garbageBetweenIdentifierAndLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndArguments?.raw,
+      arguments.raw,
+      garbageBetweenArgumentsAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.objectLiteralExpr,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -34,6 +34,16 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+  ) {
+    let layout: [RawSyntax?] = [
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.missing,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -83,6 +93,28 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .codeBlockItem)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeItem: GarbageNodesSyntax? = nil,
+    item: Syntax,
+    _ garbageBetweenItemAndSemicolon: GarbageNodesSyntax? = nil,
+    semicolon: TokenSyntax?,
+    _ garbageBetweenSemicolonAndErrorTokens: GarbageNodesSyntax? = nil,
+    errorTokens: Syntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeItem?.raw,
+      item.raw,
+      garbageBetweenItemAndSemicolon?.raw,
+      semicolon?.raw,
+      garbageBetweenSemicolonAndErrorTokens?.raw,
+      errorTokens?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.codeBlockItem,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -320,6 +352,28 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .codeBlock)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftBrace: GarbageNodesSyntax? = nil,
+    leftBrace: TokenSyntax,
+    _ garbageBetweenLeftBraceAndStatements: GarbageNodesSyntax? = nil,
+    statements: CodeBlockItemListSyntax,
+    _ garbageBetweenStatementsAndRightBrace: GarbageNodesSyntax? = nil,
+    rightBrace: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftBrace?.raw,
+      leftBrace.raw,
+      garbageBetweenLeftBraceAndStatements?.raw,
+      statements.raw,
+      garbageBetweenStatementsAndRightBrace?.raw,
+      rightBrace.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.codeBlock,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -572,6 +626,24 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ garbageBetweenNameAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeName?.raw,
+      name.raw,
+      garbageBetweenNameAndColon?.raw,
+      colon.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.declNameArgument,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -741,6 +813,28 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .declNameArguments)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndArguments: GarbageNodesSyntax? = nil,
+    arguments: DeclNameArgumentListSyntax,
+    _ garbageBetweenArgumentsAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndArguments?.raw,
+      arguments.raw,
+      garbageBetweenArgumentsAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.declNameArguments,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -995,6 +1089,32 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .tupleExprElement)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLabel: GarbageNodesSyntax? = nil,
+    label: TokenSyntax?,
+    _ garbageBetweenLabelAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax?,
+    _ garbageBetweenColonAndExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax,
+    _ garbageBetweenExpressionAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLabel?.raw,
+      label?.raw,
+      garbageBetweenLabelAndColon?.raw,
+      colon?.raw,
+      garbageBetweenColonAndExpression?.raw,
+      expression.raw,
+      garbageBetweenExpressionAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.tupleExprElement,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1290,6 +1410,24 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax,
+    _ garbageBetweenExpressionAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeExpression?.raw,
+      expression.raw,
+      garbageBetweenExpressionAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.arrayElement,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1461,6 +1599,32 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .dictionaryElement)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeKeyExpression: GarbageNodesSyntax? = nil,
+    keyExpression: ExprSyntax,
+    _ garbageBetweenKeyExpressionAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndValueExpression: GarbageNodesSyntax? = nil,
+    valueExpression: ExprSyntax,
+    _ garbageBetweenValueExpressionAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeKeyExpression?.raw,
+      keyExpression.raw,
+      garbageBetweenKeyExpressionAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndValueExpression?.raw,
+      valueExpression.raw,
+      garbageBetweenValueExpressionAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.dictionaryElement,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1760,6 +1924,36 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .closureCaptureItem)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeSpecifier: GarbageNodesSyntax? = nil,
+    specifier: TokenListSyntax?,
+    _ garbageBetweenSpecifierAndName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax?,
+    _ garbageBetweenNameAndAssignToken: GarbageNodesSyntax? = nil,
+    assignToken: TokenSyntax?,
+    _ garbageBetweenAssignTokenAndExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax,
+    _ garbageBetweenExpressionAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeSpecifier?.raw,
+      specifier?.raw,
+      garbageBetweenSpecifierAndName?.raw,
+      name?.raw,
+      garbageBetweenNameAndAssignToken?.raw,
+      assignToken?.raw,
+      garbageBetweenAssignTokenAndExpression?.raw,
+      expression.raw,
+      garbageBetweenExpressionAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.closureCaptureItem,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -2138,6 +2332,28 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeLeftSquare: GarbageNodesSyntax? = nil,
+    leftSquare: TokenSyntax,
+    _ garbageBetweenLeftSquareAndItems: GarbageNodesSyntax? = nil,
+    items: ClosureCaptureItemListSyntax?,
+    _ garbageBetweenItemsAndRightSquare: GarbageNodesSyntax? = nil,
+    rightSquare: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftSquare?.raw,
+      leftSquare.raw,
+      garbageBetweenLeftSquareAndItems?.raw,
+      items?.raw,
+      garbageBetweenItemsAndRightSquare?.raw,
+      rightSquare.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.closureCaptureSignature,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -2388,6 +2604,24 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ garbageBetweenNameAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeName?.raw,
+      name.raw,
+      garbageBetweenNameAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.closureParam,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -2565,6 +2799,44 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .closureSignature)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndCapture: GarbageNodesSyntax? = nil,
+    capture: ClosureCaptureSignatureSyntax?,
+    _ garbageBetweenCaptureAndInput: GarbageNodesSyntax? = nil,
+    input: Syntax?,
+    _ garbageBetweenInputAndAsyncKeyword: GarbageNodesSyntax? = nil,
+    asyncKeyword: TokenSyntax?,
+    _ garbageBetweenAsyncKeywordAndThrowsTok: GarbageNodesSyntax? = nil,
+    throwsTok: TokenSyntax?,
+    _ garbageBetweenThrowsTokAndOutput: GarbageNodesSyntax? = nil,
+    output: ReturnClauseSyntax?,
+    _ garbageBetweenOutputAndInTok: GarbageNodesSyntax? = nil,
+    inTok: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndCapture?.raw,
+      capture?.raw,
+      garbageBetweenCaptureAndInput?.raw,
+      input?.raw,
+      garbageBetweenInputAndAsyncKeyword?.raw,
+      asyncKeyword?.raw,
+      garbageBetweenAsyncKeywordAndThrowsTok?.raw,
+      throwsTok?.raw,
+      garbageBetweenThrowsTokAndOutput?.raw,
+      output?.raw,
+      garbageBetweenOutputAndInTok?.raw,
+      inTok.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.closureSignature,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -3067,6 +3339,28 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeLabel: GarbageNodesSyntax? = nil,
+    label: TokenSyntax,
+    _ garbageBetweenLabelAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndClosure: GarbageNodesSyntax? = nil,
+    closure: ClosureExprSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLabel?.raw,
+      label.raw,
+      garbageBetweenLabelAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndClosure?.raw,
+      closure.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.multipleTrailingClosureElement,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -3296,6 +3590,20 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeContent: GarbageNodesSyntax? = nil,
+    content: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeContent?.raw,
+      content.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.stringSegment,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -3407,6 +3715,36 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .expressionSegment)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeBackslash: GarbageNodesSyntax? = nil,
+    backslash: TokenSyntax,
+    _ garbageBetweenBackslashAndDelimiter: GarbageNodesSyntax? = nil,
+    delimiter: TokenSyntax?,
+    _ garbageBetweenDelimiterAndLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndExpressions: GarbageNodesSyntax? = nil,
+    expressions: TupleExprElementListSyntax,
+    _ garbageBetweenExpressionsAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeBackslash?.raw,
+      backslash.raw,
+      garbageBetweenBackslashAndDelimiter?.raw,
+      delimiter?.raw,
+      garbageBetweenDelimiterAndLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndExpressions?.raw,
+      expressions.raw,
+      garbageBetweenExpressionsAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.expressionSegment,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -3783,6 +4121,24 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ garbageBetweenNameAndDot: GarbageNodesSyntax? = nil,
+    dot: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeName?.raw,
+      name.raw,
+      garbageBetweenNameAndDot?.raw,
+      dot?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.objcNamePiece,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -3950,6 +4306,24 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .typeInitializerClause)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeEqual: GarbageNodesSyntax? = nil,
+    equal: TokenSyntax,
+    _ garbageBetweenEqualAndValue: GarbageNodesSyntax? = nil,
+    value: TypeSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeEqual?.raw,
+      equal.raw,
+      garbageBetweenEqualAndValue?.raw,
+      value.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.typeInitializerClause,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -4121,6 +4495,28 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .parameterClause)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndParameterList: GarbageNodesSyntax? = nil,
+    parameterList: FunctionParameterListSyntax,
+    _ garbageBetweenParameterListAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndParameterList?.raw,
+      parameterList.raw,
+      garbageBetweenParameterListAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.parameterClause,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -4373,6 +4769,24 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeArrow: GarbageNodesSyntax? = nil,
+    arrow: TokenSyntax,
+    _ garbageBetweenArrowAndReturnType: GarbageNodesSyntax? = nil,
+    returnType: TypeSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeArrow?.raw,
+      arrow.raw,
+      garbageBetweenArrowAndReturnType?.raw,
+      returnType.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.returnClause,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -4544,6 +4958,32 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .functionSignature)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeInput: GarbageNodesSyntax? = nil,
+    input: ParameterClauseSyntax,
+    _ garbageBetweenInputAndAsyncOrReasyncKeyword: GarbageNodesSyntax? = nil,
+    asyncOrReasyncKeyword: TokenSyntax?,
+    _ garbageBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: GarbageNodesSyntax? = nil,
+    throwsOrRethrowsKeyword: TokenSyntax?,
+    _ garbageBetweenThrowsOrRethrowsKeywordAndOutput: GarbageNodesSyntax? = nil,
+    output: ReturnClauseSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeInput?.raw,
+      input.raw,
+      garbageBetweenInputAndAsyncOrReasyncKeyword?.raw,
+      asyncOrReasyncKeyword?.raw,
+      garbageBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword?.raw,
+      throwsOrRethrowsKeyword?.raw,
+      garbageBetweenThrowsOrRethrowsKeywordAndOutput?.raw,
+      output?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.functionSignature,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -4841,6 +5281,28 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforePoundKeyword: GarbageNodesSyntax? = nil,
+    poundKeyword: TokenSyntax,
+    _ garbageBetweenPoundKeywordAndCondition: GarbageNodesSyntax? = nil,
+    condition: ExprSyntax?,
+    _ garbageBetweenConditionAndElements: GarbageNodesSyntax? = nil,
+    elements: Syntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePoundKeyword?.raw,
+      poundKeyword.raw,
+      garbageBetweenPoundKeywordAndCondition?.raw,
+      condition?.raw,
+      garbageBetweenConditionAndElements?.raw,
+      elements.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.ifConfigClause,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -5080,6 +5542,44 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .poundSourceLocationArgs)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeFileArgLabel: GarbageNodesSyntax? = nil,
+    fileArgLabel: TokenSyntax,
+    _ garbageBetweenFileArgLabelAndFileArgColon: GarbageNodesSyntax? = nil,
+    fileArgColon: TokenSyntax,
+    _ garbageBetweenFileArgColonAndFileName: GarbageNodesSyntax? = nil,
+    fileName: TokenSyntax,
+    _ garbageBetweenFileNameAndComma: GarbageNodesSyntax? = nil,
+    comma: TokenSyntax,
+    _ garbageBetweenCommaAndLineArgLabel: GarbageNodesSyntax? = nil,
+    lineArgLabel: TokenSyntax,
+    _ garbageBetweenLineArgLabelAndLineArgColon: GarbageNodesSyntax? = nil,
+    lineArgColon: TokenSyntax,
+    _ garbageBetweenLineArgColonAndLineNumber: GarbageNodesSyntax? = nil,
+    lineNumber: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeFileArgLabel?.raw,
+      fileArgLabel.raw,
+      garbageBetweenFileArgLabelAndFileArgColon?.raw,
+      fileArgColon.raw,
+      garbageBetweenFileArgColonAndFileName?.raw,
+      fileName.raw,
+      garbageBetweenFileNameAndComma?.raw,
+      comma.raw,
+      garbageBetweenCommaAndLineArgLabel?.raw,
+      lineArgLabel.raw,
+      garbageBetweenLineArgLabelAndLineArgColon?.raw,
+      lineArgColon.raw,
+      garbageBetweenLineArgColonAndLineNumber?.raw,
+      lineNumber.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.poundSourceLocationArgs,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -5563,6 +6063,28 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndDetail: GarbageNodesSyntax? = nil,
+    detail: TokenSyntax,
+    _ garbageBetweenDetailAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndDetail?.raw,
+      detail.raw,
+      garbageBetweenDetailAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.declModifierDetail,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -5794,6 +6316,24 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ garbageBetweenNameAndDetail: GarbageNodesSyntax? = nil,
+    detail: DeclModifierDetailSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeName?.raw,
+      name.raw,
+      garbageBetweenNameAndDetail?.raw,
+      detail?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.declModifier,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -5963,6 +6503,24 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeTypeName: GarbageNodesSyntax? = nil,
+    typeName: TypeSyntax,
+    _ garbageBetweenTypeNameAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeTypeName?.raw,
+      typeName.raw,
+      garbageBetweenTypeNameAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.inheritedType,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -6130,6 +6688,24 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .typeInheritanceClause)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndInheritedTypeCollection: GarbageNodesSyntax? = nil,
+    inheritedTypeCollection: InheritedTypeListSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndInheritedTypeCollection?.raw,
+      inheritedTypeCollection.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.typeInheritanceClause,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -6320,6 +6896,28 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .memberDeclBlock)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftBrace: GarbageNodesSyntax? = nil,
+    leftBrace: TokenSyntax,
+    _ garbageBetweenLeftBraceAndMembers: GarbageNodesSyntax? = nil,
+    members: MemberDeclListSyntax,
+    _ garbageBetweenMembersAndRightBrace: GarbageNodesSyntax? = nil,
+    rightBrace: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftBrace?.raw,
+      leftBrace.raw,
+      garbageBetweenLeftBraceAndMembers?.raw,
+      members.raw,
+      garbageBetweenMembersAndRightBrace?.raw,
+      rightBrace.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.memberDeclBlock,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -6576,6 +7174,24 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeDecl: GarbageNodesSyntax? = nil,
+    decl: DeclSyntax,
+    _ garbageBetweenDeclAndSemicolon: GarbageNodesSyntax? = nil,
+    semicolon: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeDecl?.raw,
+      decl.raw,
+      garbageBetweenDeclAndSemicolon?.raw,
+      semicolon?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.memberDeclListItem,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -6745,6 +7361,24 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .sourceFile)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeStatements: GarbageNodesSyntax? = nil,
+    statements: CodeBlockItemListSyntax,
+    _ garbageBetweenStatementsAndEOFToken: GarbageNodesSyntax? = nil,
+    eofToken: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeStatements?.raw,
+      statements.raw,
+      garbageBetweenStatementsAndEOFToken?.raw,
+      eofToken.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.sourceFile,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -6935,6 +7569,24 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeEqual: GarbageNodesSyntax? = nil,
+    equal: TokenSyntax,
+    _ garbageBetweenEqualAndValue: GarbageNodesSyntax? = nil,
+    value: ExprSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeEqual?.raw,
+      equal.raw,
+      garbageBetweenEqualAndValue?.raw,
+      value.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.initializerClause,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -7114,6 +7766,48 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .functionParameter)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndFirstName: GarbageNodesSyntax? = nil,
+    firstName: TokenSyntax?,
+    _ garbageBetweenFirstNameAndSecondName: GarbageNodesSyntax? = nil,
+    secondName: TokenSyntax?,
+    _ garbageBetweenSecondNameAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax?,
+    _ garbageBetweenColonAndType: GarbageNodesSyntax? = nil,
+    type: TypeSyntax?,
+    _ garbageBetweenTypeAndEllipsis: GarbageNodesSyntax? = nil,
+    ellipsis: TokenSyntax?,
+    _ garbageBetweenEllipsisAndDefaultArgument: GarbageNodesSyntax? = nil,
+    defaultArgument: InitializerClauseSyntax?,
+    _ garbageBetweenDefaultArgumentAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndFirstName?.raw,
+      firstName?.raw,
+      garbageBetweenFirstNameAndSecondName?.raw,
+      secondName?.raw,
+      garbageBetweenSecondNameAndColon?.raw,
+      colon?.raw,
+      garbageBetweenColonAndType?.raw,
+      type?.raw,
+      garbageBetweenTypeAndEllipsis?.raw,
+      ellipsis?.raw,
+      garbageBetweenEllipsisAndDefaultArgument?.raw,
+      defaultArgument?.raw,
+      garbageBetweenDefaultArgumentAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.functionParameter,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -7676,6 +8370,24 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ garbageBetweenNameAndModifier: GarbageNodesSyntax? = nil,
+    modifier: DeclModifierDetailSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeName?.raw,
+      name.raw,
+      garbageBetweenNameAndModifier?.raw,
+      modifier?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.accessLevelModifier,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -7843,6 +8555,24 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .accessPathComponent)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ garbageBetweenNameAndTrailingDot: GarbageNodesSyntax? = nil,
+    trailingDot: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeName?.raw,
+      name.raw,
+      garbageBetweenNameAndTrailingDot?.raw,
+      trailingDot?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.accessPathComponent,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -8014,6 +8744,28 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .accessorParameter)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ garbageBetweenNameAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndName?.raw,
+      name.raw,
+      garbageBetweenNameAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.accessorParameter,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -8247,6 +8999,28 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .accessorBlock)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftBrace: GarbageNodesSyntax? = nil,
+    leftBrace: TokenSyntax,
+    _ garbageBetweenLeftBraceAndAccessors: GarbageNodesSyntax? = nil,
+    accessors: AccessorListSyntax,
+    _ garbageBetweenAccessorsAndRightBrace: GarbageNodesSyntax? = nil,
+    rightBrace: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftBrace?.raw,
+      leftBrace.raw,
+      garbageBetweenLeftBraceAndAccessors?.raw,
+      accessors.raw,
+      garbageBetweenAccessorsAndRightBrace?.raw,
+      rightBrace.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.accessorBlock,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -8503,6 +9277,36 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .patternBinding)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforePattern: GarbageNodesSyntax? = nil,
+    pattern: PatternSyntax,
+    _ garbageBetweenPatternAndTypeAnnotation: GarbageNodesSyntax? = nil,
+    typeAnnotation: TypeAnnotationSyntax?,
+    _ garbageBetweenTypeAnnotationAndInitializer: GarbageNodesSyntax? = nil,
+    initializer: InitializerClauseSyntax?,
+    _ garbageBetweenInitializerAndAccessor: GarbageNodesSyntax? = nil,
+    accessor: Syntax?,
+    _ garbageBetweenAccessorAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePattern?.raw,
+      pattern.raw,
+      garbageBetweenPatternAndTypeAnnotation?.raw,
+      typeAnnotation?.raw,
+      garbageBetweenTypeAnnotationAndInitializer?.raw,
+      initializer?.raw,
+      garbageBetweenInitializerAndAccessor?.raw,
+      accessor?.raw,
+      garbageBetweenAccessorAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.patternBinding,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -8868,6 +9672,32 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax,
+    _ garbageBetweenIdentifierAndAssociatedValue: GarbageNodesSyntax? = nil,
+    associatedValue: ParameterClauseSyntax?,
+    _ garbageBetweenAssociatedValueAndRawValue: GarbageNodesSyntax? = nil,
+    rawValue: InitializerClauseSyntax?,
+    _ garbageBetweenRawValueAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeIdentifier?.raw,
+      identifier.raw,
+      garbageBetweenIdentifierAndAssociatedValue?.raw,
+      associatedValue?.raw,
+      garbageBetweenAssociatedValueAndRawValue?.raw,
+      rawValue?.raw,
+      garbageBetweenRawValueAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.enumCaseElement,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -9173,6 +10003,24 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndPrecedenceGroupAndDesignatedTypes: GarbageNodesSyntax? = nil,
+    precedenceGroupAndDesignatedTypes: IdentifierListSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndPrecedenceGroupAndDesignatedTypes?.raw,
+      precedenceGroupAndDesignatedTypes.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.operatorPrecedenceAndTypes,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -9368,6 +10216,28 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .precedenceGroupRelation)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeHigherThanOrLowerThan: GarbageNodesSyntax? = nil,
+    higherThanOrLowerThan: TokenSyntax,
+    _ garbageBetweenHigherThanOrLowerThanAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndOtherNames: GarbageNodesSyntax? = nil,
+    otherNames: PrecedenceGroupNameListSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeHigherThanOrLowerThan?.raw,
+      higherThanOrLowerThan.raw,
+      garbageBetweenHigherThanOrLowerThanAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndOtherNames?.raw,
+      otherNames.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.precedenceGroupRelation,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -9627,6 +10497,24 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ garbageBetweenNameAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeName?.raw,
+      name.raw,
+      garbageBetweenNameAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.precedenceGroupNameElement,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -9800,6 +10688,28 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .precedenceGroupAssignment)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAssignmentKeyword: GarbageNodesSyntax? = nil,
+    assignmentKeyword: TokenSyntax,
+    _ garbageBetweenAssignmentKeywordAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndFlag: GarbageNodesSyntax? = nil,
+    flag: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAssignmentKeyword?.raw,
+      assignmentKeyword.raw,
+      garbageBetweenAssignmentKeywordAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndFlag?.raw,
+      flag.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.precedenceGroupAssignment,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -10046,6 +10956,28 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeAssociativityKeyword: GarbageNodesSyntax? = nil,
+    associativityKeyword: TokenSyntax,
+    _ garbageBetweenAssociativityKeywordAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndValue: GarbageNodesSyntax? = nil,
+    value: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAssociativityKeyword?.raw,
+      associativityKeyword.raw,
+      garbageBetweenAssociativityKeywordAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndValue?.raw,
+      value.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.precedenceGroupAssociativity,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -10290,6 +11222,36 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .customAttribute)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAtSignToken: GarbageNodesSyntax? = nil,
+    atSignToken: TokenSyntax,
+    _ garbageBetweenAtSignTokenAndAttributeName: GarbageNodesSyntax? = nil,
+    attributeName: TypeSyntax,
+    _ garbageBetweenAttributeNameAndLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax?,
+    _ garbageBetweenLeftParenAndArgumentList: GarbageNodesSyntax? = nil,
+    argumentList: TupleExprElementListSyntax?,
+    _ garbageBetweenArgumentListAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAtSignToken?.raw,
+      atSignToken.raw,
+      garbageBetweenAtSignTokenAndAttributeName?.raw,
+      attributeName.raw,
+      garbageBetweenAttributeNameAndLeftParen?.raw,
+      leftParen?.raw,
+      garbageBetweenLeftParenAndArgumentList?.raw,
+      argumentList?.raw,
+      garbageBetweenArgumentListAndRightParen?.raw,
+      rightParen?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.customAttribute,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -10677,6 +11639,40 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .attribute)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeAtSignToken: GarbageNodesSyntax? = nil,
+    atSignToken: TokenSyntax,
+    _ garbageBetweenAtSignTokenAndAttributeName: GarbageNodesSyntax? = nil,
+    attributeName: TokenSyntax,
+    _ garbageBetweenAttributeNameAndLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax?,
+    _ garbageBetweenLeftParenAndArgument: GarbageNodesSyntax? = nil,
+    argument: Syntax?,
+    _ garbageBetweenArgumentAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax?,
+    _ garbageBetweenRightParenAndTokenList: GarbageNodesSyntax? = nil,
+    tokenList: TokenListSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAtSignToken?.raw,
+      atSignToken.raw,
+      garbageBetweenAtSignTokenAndAttributeName?.raw,
+      attributeName.raw,
+      garbageBetweenAttributeNameAndLeftParen?.raw,
+      leftParen?.raw,
+      garbageBetweenLeftParenAndArgument?.raw,
+      argument?.raw,
+      garbageBetweenArgumentAndRightParen?.raw,
+      rightParen?.raw,
+      garbageBetweenRightParenAndTokenList?.raw,
+      tokenList?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.attribute,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -11135,6 +12131,32 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeLabel: GarbageNodesSyntax? = nil,
+    label: TokenSyntax,
+    _ garbageBetweenLabelAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndAvailabilityList: GarbageNodesSyntax? = nil,
+    availabilityList: AvailabilitySpecListSyntax,
+    _ garbageBetweenAvailabilityListAndSemicolon: GarbageNodesSyntax? = nil,
+    semicolon: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLabel?.raw,
+      label.raw,
+      garbageBetweenLabelAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndAvailabilityList?.raw,
+      availabilityList.raw,
+      garbageBetweenAvailabilityListAndSemicolon?.raw,
+      semicolon.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.availabilityEntry,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -11457,6 +12479,32 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeLabel: GarbageNodesSyntax? = nil,
+    label: TokenSyntax,
+    _ garbageBetweenLabelAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndValue: GarbageNodesSyntax? = nil,
+    value: TokenSyntax,
+    _ garbageBetweenValueAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLabel?.raw,
+      label.raw,
+      garbageBetweenLabelAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndValue?.raw,
+      value.raw,
+      garbageBetweenValueAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.labeledSpecializeEntry,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -11765,6 +12813,32 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeLabel: GarbageNodesSyntax? = nil,
+    label: TokenSyntax,
+    _ garbageBetweenLabelAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndDeclname: GarbageNodesSyntax? = nil,
+    declname: DeclNameSyntax,
+    _ garbageBetweenDeclnameAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLabel?.raw,
+      label.raw,
+      garbageBetweenLabelAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndDeclname?.raw,
+      declname.raw,
+      garbageBetweenDeclnameAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.targetFunctionEntry,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -12071,6 +13145,28 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeNameTok: GarbageNodesSyntax? = nil,
+    nameTok: TokenSyntax,
+    _ garbageBetweenNameTokAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndStringOrDeclname: GarbageNodesSyntax? = nil,
+    stringOrDeclname: Syntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeNameTok?.raw,
+      nameTok.raw,
+      garbageBetweenNameTokAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndStringOrDeclname?.raw,
+      stringOrDeclname.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.namedAttributeStringArgument,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -12304,6 +13400,24 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeDeclBaseName: GarbageNodesSyntax? = nil,
+    declBaseName: Syntax,
+    _ garbageBetweenDeclBaseNameAndDeclNameArguments: GarbageNodesSyntax? = nil,
+    declNameArguments: DeclNameArgumentsSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeDeclBaseName?.raw,
+      declBaseName.raw,
+      garbageBetweenDeclBaseNameAndDeclNameArguments?.raw,
+      declNameArguments?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.declName,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -12486,6 +13600,32 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .implementsAttributeArguments)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeType: GarbageNodesSyntax? = nil,
+    type: SimpleTypeIdentifierSyntax,
+    _ garbageBetweenTypeAndComma: GarbageNodesSyntax? = nil,
+    comma: TokenSyntax,
+    _ garbageBetweenCommaAndDeclBaseName: GarbageNodesSyntax? = nil,
+    declBaseName: Syntax,
+    _ garbageBetweenDeclBaseNameAndDeclNameArguments: GarbageNodesSyntax? = nil,
+    declNameArguments: DeclNameArgumentsSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeType?.raw,
+      type.raw,
+      garbageBetweenTypeAndComma?.raw,
+      comma.raw,
+      garbageBetweenCommaAndDeclBaseName?.raw,
+      declBaseName.raw,
+      garbageBetweenDeclBaseNameAndDeclNameArguments?.raw,
+      declNameArguments?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.implementsAttributeArguments,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -12800,6 +13940,24 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax?,
+    _ garbageBetweenNameAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeName?.raw,
+      name?.raw,
+      garbageBetweenNameAndColon?.raw,
+      colon?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.objCSelectorPiece,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -12978,6 +14136,36 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .differentiableAttributeArguments)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeDiffKind: GarbageNodesSyntax? = nil,
+    diffKind: TokenSyntax?,
+    _ garbageBetweenDiffKindAndDiffKindComma: GarbageNodesSyntax? = nil,
+    diffKindComma: TokenSyntax?,
+    _ garbageBetweenDiffKindCommaAndDiffParams: GarbageNodesSyntax? = nil,
+    diffParams: DifferentiabilityParamsClauseSyntax?,
+    _ garbageBetweenDiffParamsAndDiffParamsComma: GarbageNodesSyntax? = nil,
+    diffParamsComma: TokenSyntax?,
+    _ garbageBetweenDiffParamsCommaAndWhereClause: GarbageNodesSyntax? = nil,
+    whereClause: GenericWhereClauseSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeDiffKind?.raw,
+      diffKind?.raw,
+      garbageBetweenDiffKindAndDiffKindComma?.raw,
+      diffKindComma?.raw,
+      garbageBetweenDiffKindCommaAndDiffParams?.raw,
+      diffParams?.raw,
+      garbageBetweenDiffParamsAndDiffParamsComma?.raw,
+      diffParamsComma?.raw,
+      garbageBetweenDiffParamsCommaAndWhereClause?.raw,
+      whereClause?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.differentiableAttributeArguments,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -13345,6 +14533,28 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeWrtLabel: GarbageNodesSyntax? = nil,
+    wrtLabel: TokenSyntax,
+    _ garbageBetweenWrtLabelAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndParameters: GarbageNodesSyntax? = nil,
+    parameters: Syntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeWrtLabel?.raw,
+      wrtLabel.raw,
+      garbageBetweenWrtLabelAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndParameters?.raw,
+      parameters.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.differentiabilityParamsClause,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -13581,6 +14791,28 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .differentiabilityParams)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndDiffParams: GarbageNodesSyntax? = nil,
+    diffParams: DifferentiabilityParamListSyntax,
+    _ garbageBetweenDiffParamsAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndDiffParams?.raw,
+      diffParams.raw,
+      garbageBetweenDiffParamsAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.differentiabilityParams,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -13838,6 +15070,24 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeParameter: GarbageNodesSyntax? = nil,
+    parameter: Syntax,
+    _ garbageBetweenParameterAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeParameter?.raw,
+      parameter.raw,
+      garbageBetweenParameterAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.differentiabilityParam,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -14020,6 +15270,44 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .derivativeRegistrationAttributeArguments)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeOfLabel: GarbageNodesSyntax? = nil,
+    ofLabel: TokenSyntax,
+    _ garbageBetweenOfLabelAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndOriginalDeclName: GarbageNodesSyntax? = nil,
+    originalDeclName: QualifiedDeclNameSyntax,
+    _ garbageBetweenOriginalDeclNameAndPeriod: GarbageNodesSyntax? = nil,
+    period: TokenSyntax?,
+    _ garbageBetweenPeriodAndAccessorKind: GarbageNodesSyntax? = nil,
+    accessorKind: TokenSyntax?,
+    _ garbageBetweenAccessorKindAndComma: GarbageNodesSyntax? = nil,
+    comma: TokenSyntax?,
+    _ garbageBetweenCommaAndDiffParams: GarbageNodesSyntax? = nil,
+    diffParams: DifferentiabilityParamsClauseSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeOfLabel?.raw,
+      ofLabel.raw,
+      garbageBetweenOfLabelAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndOriginalDeclName?.raw,
+      originalDeclName.raw,
+      garbageBetweenOriginalDeclNameAndPeriod?.raw,
+      period?.raw,
+      garbageBetweenPeriodAndAccessorKind?.raw,
+      accessorKind?.raw,
+      garbageBetweenAccessorKindAndComma?.raw,
+      comma?.raw,
+      garbageBetweenCommaAndDiffParams?.raw,
+      diffParams?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.derivativeRegistrationAttributeArguments,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -14520,6 +15808,32 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeBaseType: GarbageNodesSyntax? = nil,
+    baseType: TypeSyntax?,
+    _ garbageBetweenBaseTypeAndDot: GarbageNodesSyntax? = nil,
+    dot: TokenSyntax?,
+    _ garbageBetweenDotAndName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ garbageBetweenNameAndArguments: GarbageNodesSyntax? = nil,
+    arguments: DeclNameArgumentsSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeBaseType?.raw,
+      baseType?.raw,
+      garbageBetweenBaseTypeAndDot?.raw,
+      dot?.raw,
+      garbageBetweenDotAndName?.raw,
+      name.raw,
+      garbageBetweenNameAndArguments?.raw,
+      arguments?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.qualifiedDeclName,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -14824,6 +16138,24 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeName: GarbageNodesSyntax? = nil,
+    name: Syntax,
+    _ garbageBetweenNameAndArguments: GarbageNodesSyntax? = nil,
+    arguments: DeclNameArgumentsSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeName?.raw,
+      name.raw,
+      garbageBetweenNameAndArguments?.raw,
+      arguments?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.functionDeclName,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -15003,6 +16335,28 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .backDeployAttributeSpecList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeBeforeLabel: GarbageNodesSyntax? = nil,
+    beforeLabel: TokenSyntax,
+    _ garbageBetweenBeforeLabelAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndVersionList: GarbageNodesSyntax? = nil,
+    versionList: BackDeployVersionListSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeBeforeLabel?.raw,
+      beforeLabel.raw,
+      garbageBetweenBeforeLabelAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndVersionList?.raw,
+      versionList.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.backDeployAttributeSpecList,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -15267,6 +16621,24 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeAvailabilityVersionRestriction: GarbageNodesSyntax? = nil,
+    availabilityVersionRestriction: AvailabilityVersionRestrictionSyntax,
+    _ garbageBetweenAvailabilityVersionRestrictionAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAvailabilityVersionRestriction?.raw,
+      availabilityVersionRestriction.raw,
+      garbageBetweenAvailabilityVersionRestrictionAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.backDeployVersionArgument,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -15440,6 +16812,24 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeWhereKeyword: GarbageNodesSyntax? = nil,
+    whereKeyword: TokenSyntax,
+    _ garbageBetweenWhereKeywordAndGuardResult: GarbageNodesSyntax? = nil,
+    guardResult: ExprSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeWhereKeyword?.raw,
+      whereKeyword.raw,
+      garbageBetweenWhereKeywordAndGuardResult?.raw,
+      guardResult.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.whereClause,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -15611,6 +17001,32 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .yieldList)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndElementList: GarbageNodesSyntax? = nil,
+    elementList: ExprListSyntax,
+    _ garbageBetweenElementListAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?,
+    _ garbageBetweenTrailingCommaAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndElementList?.raw,
+      elementList.raw,
+      garbageBetweenElementListAndTrailingComma?.raw,
+      trailingComma?.raw,
+      garbageBetweenTrailingCommaAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.yieldList,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -15925,6 +17341,24 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeCondition: GarbageNodesSyntax? = nil,
+    condition: Syntax,
+    _ garbageBetweenConditionAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeCondition?.raw,
+      condition.raw,
+      garbageBetweenConditionAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.conditionElement,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -16096,6 +17530,32 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .availabilityCondition)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforePoundAvailableKeyword: GarbageNodesSyntax? = nil,
+    poundAvailableKeyword: TokenSyntax,
+    _ garbageBetweenPoundAvailableKeywordAndLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndAvailabilitySpec: GarbageNodesSyntax? = nil,
+    availabilitySpec: AvailabilitySpecListSyntax,
+    _ garbageBetweenAvailabilitySpecAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePoundAvailableKeyword?.raw,
+      poundAvailableKeyword.raw,
+      garbageBetweenPoundAvailableKeywordAndLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndAvailabilitySpec?.raw,
+      availabilitySpec.raw,
+      garbageBetweenAvailabilitySpecAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.availabilityCondition,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -16414,6 +17874,32 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeCaseKeyword: GarbageNodesSyntax? = nil,
+    caseKeyword: TokenSyntax,
+    _ garbageBetweenCaseKeywordAndPattern: GarbageNodesSyntax? = nil,
+    pattern: PatternSyntax,
+    _ garbageBetweenPatternAndTypeAnnotation: GarbageNodesSyntax? = nil,
+    typeAnnotation: TypeAnnotationSyntax?,
+    _ garbageBetweenTypeAnnotationAndInitializer: GarbageNodesSyntax? = nil,
+    initializer: InitializerClauseSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeCaseKeyword?.raw,
+      caseKeyword.raw,
+      garbageBetweenCaseKeywordAndPattern?.raw,
+      pattern.raw,
+      garbageBetweenPatternAndTypeAnnotation?.raw,
+      typeAnnotation?.raw,
+      garbageBetweenTypeAnnotationAndInitializer?.raw,
+      initializer.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.matchingPatternCondition,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -16711,6 +18197,32 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeLetOrVarKeyword: GarbageNodesSyntax? = nil,
+    letOrVarKeyword: TokenSyntax,
+    _ garbageBetweenLetOrVarKeywordAndPattern: GarbageNodesSyntax? = nil,
+    pattern: PatternSyntax,
+    _ garbageBetweenPatternAndTypeAnnotation: GarbageNodesSyntax? = nil,
+    typeAnnotation: TypeAnnotationSyntax?,
+    _ garbageBetweenTypeAnnotationAndInitializer: GarbageNodesSyntax? = nil,
+    initializer: InitializerClauseSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLetOrVarKeyword?.raw,
+      letOrVarKeyword.raw,
+      garbageBetweenLetOrVarKeywordAndPattern?.raw,
+      pattern.raw,
+      garbageBetweenPatternAndTypeAnnotation?.raw,
+      typeAnnotation?.raw,
+      garbageBetweenTypeAnnotationAndInitializer?.raw,
+      initializer?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.optionalBindingCondition,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -17006,6 +18518,32 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .unavailabilityCondition)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforePoundUnavailableKeyword: GarbageNodesSyntax? = nil,
+    poundUnavailableKeyword: TokenSyntax,
+    _ garbageBetweenPoundUnavailableKeywordAndLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndAvailabilitySpec: GarbageNodesSyntax? = nil,
+    availabilitySpec: AvailabilitySpecListSyntax,
+    _ garbageBetweenAvailabilitySpecAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePoundUnavailableKeyword?.raw,
+      poundUnavailableKeyword.raw,
+      garbageBetweenPoundUnavailableKeywordAndLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndAvailabilitySpec?.raw,
+      availabilitySpec.raw,
+      garbageBetweenAvailabilitySpecAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.unavailabilityCondition,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -17318,6 +18856,20 @@ public struct ElseIfContinuationSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeIfStatement: GarbageNodesSyntax? = nil,
+    ifStatement: IfStmtSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeIfStatement?.raw,
+      ifStatement.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.elseIfContinuation,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -17423,6 +18975,24 @@ public struct ElseBlockSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .elseBlock)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeElseKeyword: GarbageNodesSyntax? = nil,
+    elseKeyword: TokenSyntax,
+    _ garbageBetweenElseKeywordAndBody: GarbageNodesSyntax? = nil,
+    body: CodeBlockSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeElseKeyword?.raw,
+      elseKeyword.raw,
+      garbageBetweenElseKeywordAndBody?.raw,
+      body.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.elseBlock,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -17594,6 +19164,28 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .switchCase)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeUnknownAttr: GarbageNodesSyntax? = nil,
+    unknownAttr: AttributeSyntax?,
+    _ garbageBetweenUnknownAttrAndLabel: GarbageNodesSyntax? = nil,
+    label: Syntax,
+    _ garbageBetweenLabelAndStatements: GarbageNodesSyntax? = nil,
+    statements: CodeBlockItemListSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeUnknownAttr?.raw,
+      unknownAttr?.raw,
+      garbageBetweenUnknownAttrAndLabel?.raw,
+      label.raw,
+      garbageBetweenLabelAndStatements?.raw,
+      statements.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.switchCase,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -17846,6 +19438,24 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeDefaultKeyword: GarbageNodesSyntax? = nil,
+    defaultKeyword: TokenSyntax,
+    _ garbageBetweenDefaultKeywordAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeDefaultKeyword?.raw,
+      defaultKeyword.raw,
+      garbageBetweenDefaultKeywordAndColon?.raw,
+      colon.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.switchDefaultLabel,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -18015,6 +19625,28 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .caseItem)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforePattern: GarbageNodesSyntax? = nil,
+    pattern: PatternSyntax,
+    _ garbageBetweenPatternAndWhereClause: GarbageNodesSyntax? = nil,
+    whereClause: WhereClauseSyntax?,
+    _ garbageBetweenWhereClauseAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePattern?.raw,
+      pattern.raw,
+      garbageBetweenPatternAndWhereClause?.raw,
+      whereClause?.raw,
+      garbageBetweenWhereClauseAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.caseItem,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -18250,6 +19882,28 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforePattern: GarbageNodesSyntax? = nil,
+    pattern: PatternSyntax?,
+    _ garbageBetweenPatternAndWhereClause: GarbageNodesSyntax? = nil,
+    whereClause: WhereClauseSyntax?,
+    _ garbageBetweenWhereClauseAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePattern?.raw,
+      pattern?.raw,
+      garbageBetweenPatternAndWhereClause?.raw,
+      whereClause?.raw,
+      garbageBetweenWhereClauseAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.catchItem,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -18481,6 +20135,28 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .switchCaseLabel)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeCaseKeyword: GarbageNodesSyntax? = nil,
+    caseKeyword: TokenSyntax,
+    _ garbageBetweenCaseKeywordAndCaseItems: GarbageNodesSyntax? = nil,
+    caseItems: CaseItemListSyntax,
+    _ garbageBetweenCaseItemsAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeCaseKeyword?.raw,
+      caseKeyword.raw,
+      garbageBetweenCaseKeywordAndCaseItems?.raw,
+      caseItems.raw,
+      garbageBetweenCaseItemsAndColon?.raw,
+      colon.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.switchCaseLabel,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -18735,6 +20411,28 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeCatchKeyword: GarbageNodesSyntax? = nil,
+    catchKeyword: TokenSyntax,
+    _ garbageBetweenCatchKeywordAndCatchItems: GarbageNodesSyntax? = nil,
+    catchItems: CatchItemListSyntax?,
+    _ garbageBetweenCatchItemsAndBody: GarbageNodesSyntax? = nil,
+    body: CodeBlockSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeCatchKeyword?.raw,
+      catchKeyword.raw,
+      garbageBetweenCatchKeywordAndCatchItems?.raw,
+      catchItems?.raw,
+      garbageBetweenCatchItemsAndBody?.raw,
+      body.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.catchClause,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -18985,6 +20683,24 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeWhereKeyword: GarbageNodesSyntax? = nil,
+    whereKeyword: TokenSyntax,
+    _ garbageBetweenWhereKeywordAndRequirementList: GarbageNodesSyntax? = nil,
+    requirementList: GenericRequirementListSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeWhereKeyword?.raw,
+      whereKeyword.raw,
+      garbageBetweenWhereKeywordAndRequirementList?.raw,
+      requirementList.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.genericWhereClause,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -19173,6 +20889,24 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeBody: GarbageNodesSyntax? = nil,
+    body: Syntax,
+    _ garbageBetweenBodyAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeBody?.raw,
+      body.raw,
+      garbageBetweenBodyAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.genericRequirement,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -19342,6 +21076,28 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .sameTypeRequirement)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftTypeIdentifier: GarbageNodesSyntax? = nil,
+    leftTypeIdentifier: TypeSyntax,
+    _ garbageBetweenLeftTypeIdentifierAndEqualityToken: GarbageNodesSyntax? = nil,
+    equalityToken: TokenSyntax,
+    _ garbageBetweenEqualityTokenAndRightTypeIdentifier: GarbageNodesSyntax? = nil,
+    rightTypeIdentifier: TypeSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftTypeIdentifier?.raw,
+      leftTypeIdentifier.raw,
+      garbageBetweenLeftTypeIdentifierAndEqualityToken?.raw,
+      equalityToken.raw,
+      garbageBetweenEqualityTokenAndRightTypeIdentifier?.raw,
+      rightTypeIdentifier.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.sameTypeRequirement,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -19585,6 +21341,48 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .layoutRequirement)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeTypeIdentifier: GarbageNodesSyntax? = nil,
+    typeIdentifier: TypeSyntax,
+    _ garbageBetweenTypeIdentifierAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndLayoutConstraint: GarbageNodesSyntax? = nil,
+    layoutConstraint: TokenSyntax,
+    _ garbageBetweenLayoutConstraintAndLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax?,
+    _ garbageBetweenLeftParenAndSize: GarbageNodesSyntax? = nil,
+    size: TokenSyntax?,
+    _ garbageBetweenSizeAndComma: GarbageNodesSyntax? = nil,
+    comma: TokenSyntax?,
+    _ garbageBetweenCommaAndAlignment: GarbageNodesSyntax? = nil,
+    alignment: TokenSyntax?,
+    _ garbageBetweenAlignmentAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeTypeIdentifier?.raw,
+      typeIdentifier.raw,
+      garbageBetweenTypeIdentifierAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndLayoutConstraint?.raw,
+      layoutConstraint.raw,
+      garbageBetweenLayoutConstraintAndLeftParen?.raw,
+      leftParen?.raw,
+      garbageBetweenLeftParenAndSize?.raw,
+      size?.raw,
+      garbageBetweenSizeAndComma?.raw,
+      comma?.raw,
+      garbageBetweenCommaAndAlignment?.raw,
+      alignment?.raw,
+      garbageBetweenAlignmentAndRightParen?.raw,
+      rightParen?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.layoutRequirement,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -20134,6 +21932,36 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ garbageBetweenNameAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax?,
+    _ garbageBetweenColonAndInheritedType: GarbageNodesSyntax? = nil,
+    inheritedType: TypeSyntax?,
+    _ garbageBetweenInheritedTypeAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndName?.raw,
+      name.raw,
+      garbageBetweenNameAndColon?.raw,
+      colon?.raw,
+      garbageBetweenColonAndInheritedType?.raw,
+      inheritedType?.raw,
+      garbageBetweenInheritedTypeAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.genericParameter,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -20508,6 +22336,24 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ garbageBetweenNameAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeName?.raw,
+      name.raw,
+      garbageBetweenNameAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.primaryAssociatedType,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -20677,6 +22523,28 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .genericParameterClause)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftAngleBracket: GarbageNodesSyntax? = nil,
+    leftAngleBracket: TokenSyntax,
+    _ garbageBetweenLeftAngleBracketAndGenericParameterList: GarbageNodesSyntax? = nil,
+    genericParameterList: GenericParameterListSyntax,
+    _ garbageBetweenGenericParameterListAndRightAngleBracket: GarbageNodesSyntax? = nil,
+    rightAngleBracket: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftAngleBracket?.raw,
+      leftAngleBracket.raw,
+      garbageBetweenLeftAngleBracketAndGenericParameterList?.raw,
+      genericParameterList.raw,
+      garbageBetweenGenericParameterListAndRightAngleBracket?.raw,
+      rightAngleBracket.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.genericParameterClause,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -20931,6 +22799,28 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeLeftTypeIdentifier: GarbageNodesSyntax? = nil,
+    leftTypeIdentifier: TypeSyntax,
+    _ garbageBetweenLeftTypeIdentifierAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndRightTypeIdentifier: GarbageNodesSyntax? = nil,
+    rightTypeIdentifier: TypeSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftTypeIdentifier?.raw,
+      leftTypeIdentifier.raw,
+      garbageBetweenLeftTypeIdentifierAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndRightTypeIdentifier?.raw,
+      rightTypeIdentifier.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.conformanceRequirement,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -21162,6 +23052,28 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .primaryAssociatedTypeClause)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftAngleBracket: GarbageNodesSyntax? = nil,
+    leftAngleBracket: TokenSyntax,
+    _ garbageBetweenLeftAngleBracketAndPrimaryAssociatedTypeList: GarbageNodesSyntax? = nil,
+    primaryAssociatedTypeList: PrimaryAssociatedTypeListSyntax,
+    _ garbageBetweenPrimaryAssociatedTypeListAndRightAngleBracket: GarbageNodesSyntax? = nil,
+    rightAngleBracket: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftAngleBracket?.raw,
+      leftAngleBracket.raw,
+      garbageBetweenLeftAngleBracketAndPrimaryAssociatedTypeList?.raw,
+      primaryAssociatedTypeList.raw,
+      garbageBetweenPrimaryAssociatedTypeListAndRightAngleBracket?.raw,
+      rightAngleBracket.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.primaryAssociatedTypeClause,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -21414,6 +23326,24 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeType: GarbageNodesSyntax? = nil,
+    type: TypeSyntax,
+    _ garbageBetweenTypeAndAmpersand: GarbageNodesSyntax? = nil,
+    ampersand: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeType?.raw,
+      type.raw,
+      garbageBetweenTypeAndAmpersand?.raw,
+      ampersand?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.compositionTypeElement,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -21593,6 +23523,48 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .tupleTypeElement)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeInOut: GarbageNodesSyntax? = nil,
+    inOut: TokenSyntax?,
+    _ garbageBetweenInOutAndName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax?,
+    _ garbageBetweenNameAndSecondName: GarbageNodesSyntax? = nil,
+    secondName: TokenSyntax?,
+    _ garbageBetweenSecondNameAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax?,
+    _ garbageBetweenColonAndType: GarbageNodesSyntax? = nil,
+    type: TypeSyntax,
+    _ garbageBetweenTypeAndEllipsis: GarbageNodesSyntax? = nil,
+    ellipsis: TokenSyntax?,
+    _ garbageBetweenEllipsisAndInitializer: GarbageNodesSyntax? = nil,
+    initializer: InitializerClauseSyntax?,
+    _ garbageBetweenInitializerAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeInOut?.raw,
+      inOut?.raw,
+      garbageBetweenInOutAndName?.raw,
+      name?.raw,
+      garbageBetweenNameAndSecondName?.raw,
+      secondName?.raw,
+      garbageBetweenSecondNameAndColon?.raw,
+      colon?.raw,
+      garbageBetweenColonAndType?.raw,
+      type.raw,
+      garbageBetweenTypeAndEllipsis?.raw,
+      ellipsis?.raw,
+      garbageBetweenEllipsisAndInitializer?.raw,
+      initializer?.raw,
+      garbageBetweenInitializerAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.tupleTypeElement,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -22136,6 +24108,24 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeArgumentType: GarbageNodesSyntax? = nil,
+    argumentType: TypeSyntax,
+    _ garbageBetweenArgumentTypeAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeArgumentType?.raw,
+      argumentType.raw,
+      garbageBetweenArgumentTypeAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.genericArgument,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -22305,6 +24295,28 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .genericArgumentClause)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftAngleBracket: GarbageNodesSyntax? = nil,
+    leftAngleBracket: TokenSyntax,
+    _ garbageBetweenLeftAngleBracketAndArguments: GarbageNodesSyntax? = nil,
+    arguments: GenericArgumentListSyntax,
+    _ garbageBetweenArgumentsAndRightAngleBracket: GarbageNodesSyntax? = nil,
+    rightAngleBracket: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftAngleBracket?.raw,
+      leftAngleBracket.raw,
+      garbageBetweenLeftAngleBracketAndArguments?.raw,
+      arguments.raw,
+      garbageBetweenArgumentsAndRightAngleBracket?.raw,
+      rightAngleBracket.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.genericArgumentClause,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -22557,6 +24569,24 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndType: GarbageNodesSyntax? = nil,
+    type: TypeSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndType?.raw,
+      type.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.typeAnnotation,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -22728,6 +24758,32 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .tuplePatternElement)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLabelName: GarbageNodesSyntax? = nil,
+    labelName: TokenSyntax?,
+    _ garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? = nil,
+    labelColon: TokenSyntax?,
+    _ garbageBetweenLabelColonAndPattern: GarbageNodesSyntax? = nil,
+    pattern: PatternSyntax,
+    _ garbageBetweenPatternAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLabelName?.raw,
+      labelName?.raw,
+      garbageBetweenLabelNameAndLabelColon?.raw,
+      labelColon?.raw,
+      garbageBetweenLabelColonAndPattern?.raw,
+      pattern.raw,
+      garbageBetweenPatternAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.tuplePatternElement,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -23027,6 +25083,24 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeEntry: GarbageNodesSyntax? = nil,
+    entry: Syntax,
+    _ garbageBetweenEntryAndTrailingComma: GarbageNodesSyntax? = nil,
+    trailingComma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeEntry?.raw,
+      entry.raw,
+      garbageBetweenEntryAndTrailingComma?.raw,
+      trailingComma?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.availabilityArgument,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -23205,6 +25279,28 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .availabilityLabeledArgument)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLabel: GarbageNodesSyntax? = nil,
+    label: TokenSyntax,
+    _ garbageBetweenLabelAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndValue: GarbageNodesSyntax? = nil,
+    value: Syntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLabel?.raw,
+      label.raw,
+      garbageBetweenLabelAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndValue?.raw,
+      value.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.availabilityLabeledArgument,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -23445,6 +25541,24 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforePlatform: GarbageNodesSyntax? = nil,
+    platform: TokenSyntax,
+    _ garbageBetweenPlatformAndVersion: GarbageNodesSyntax? = nil,
+    version: VersionTupleSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePlatform?.raw,
+      platform.raw,
+      garbageBetweenPlatformAndVersion?.raw,
+      version?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.availabilityVersionRestriction,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -23623,6 +25737,28 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .versionTuple)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeMajorMinor: GarbageNodesSyntax? = nil,
+    majorMinor: Syntax,
+    _ garbageBetweenMajorMinorAndPatchPeriod: GarbageNodesSyntax? = nil,
+    patchPeriod: TokenSyntax?,
+    _ garbageBetweenPatchPeriodAndPatchVersion: GarbageNodesSyntax? = nil,
+    patchVersion: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeMajorMinor?.raw,
+      majorMinor.raw,
+      garbageBetweenMajorMinorAndPatchPeriod?.raw,
+      patchPeriod?.raw,
+      garbageBetweenPatchPeriodAndPatchVersion?.raw,
+      patchVersion?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.versionTuple,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
@@ -34,6 +34,16 @@ public struct UnknownPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+  ) {
+    let layout: [RawSyntax?] = [
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.unknownPattern,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -71,6 +81,16 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .missingPattern)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+  ) {
+    let layout: [RawSyntax?] = [
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.missingPattern,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -120,6 +140,32 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .enumCasePattern)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeType: GarbageNodesSyntax? = nil,
+    type: TypeSyntax?,
+    _ garbageBetweenTypeAndPeriod: GarbageNodesSyntax? = nil,
+    period: TokenSyntax,
+    _ garbageBetweenPeriodAndCaseName: GarbageNodesSyntax? = nil,
+    caseName: TokenSyntax,
+    _ garbageBetweenCaseNameAndAssociatedTuple: GarbageNodesSyntax? = nil,
+    associatedTuple: TuplePatternSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeType?.raw,
+      type?.raw,
+      garbageBetweenTypeAndPeriod?.raw,
+      period.raw,
+      garbageBetweenPeriodAndCaseName?.raw,
+      caseName.raw,
+      garbageBetweenCaseNameAndAssociatedTuple?.raw,
+      associatedTuple?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.enumCasePattern,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -415,6 +461,24 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeIsKeyword: GarbageNodesSyntax? = nil,
+    isKeyword: TokenSyntax,
+    _ garbageBetweenIsKeywordAndType: GarbageNodesSyntax? = nil,
+    type: TypeSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeIsKeyword?.raw,
+      isKeyword.raw,
+      garbageBetweenIsKeywordAndType?.raw,
+      type.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.isTypePattern,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -584,6 +648,24 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeSubPattern: GarbageNodesSyntax? = nil,
+    subPattern: PatternSyntax,
+    _ garbageBetweenSubPatternAndQuestionMark: GarbageNodesSyntax? = nil,
+    questionMark: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeSubPattern?.raw,
+      subPattern.raw,
+      garbageBetweenSubPatternAndQuestionMark?.raw,
+      questionMark.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.optionalPattern,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -751,6 +833,20 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeIdentifier: GarbageNodesSyntax? = nil,
+    identifier: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeIdentifier?.raw,
+      identifier.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.identifierPattern,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -858,6 +954,28 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .asTypePattern)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforePattern: GarbageNodesSyntax? = nil,
+    pattern: PatternSyntax,
+    _ garbageBetweenPatternAndAsKeyword: GarbageNodesSyntax? = nil,
+    asKeyword: TokenSyntax,
+    _ garbageBetweenAsKeywordAndType: GarbageNodesSyntax? = nil,
+    type: TypeSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePattern?.raw,
+      pattern.raw,
+      garbageBetweenPatternAndAsKeyword?.raw,
+      asKeyword.raw,
+      garbageBetweenAsKeywordAndType?.raw,
+      type.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.asTypePattern,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1091,6 +1209,28 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .tuplePattern)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndElements: GarbageNodesSyntax? = nil,
+    elements: TuplePatternElementListSyntax,
+    _ garbageBetweenElementsAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndElements?.raw,
+      elements.raw,
+      garbageBetweenElementsAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.tuplePattern,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1343,6 +1483,24 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeWildcard: GarbageNodesSyntax? = nil,
+    wildcard: TokenSyntax,
+    _ garbageBetweenWildcardAndTypeAnnotation: GarbageNodesSyntax? = nil,
+    typeAnnotation: TypeAnnotationSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeWildcard?.raw,
+      wildcard.raw,
+      garbageBetweenWildcardAndTypeAnnotation?.raw,
+      typeAnnotation?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.wildcardPattern,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1510,6 +1668,20 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeExpression?.raw,
+      expression.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.expressionPattern,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1615,6 +1787,24 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .valueBindingPattern)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLetOrVarKeyword: GarbageNodesSyntax? = nil,
+    letOrVarKeyword: TokenSyntax,
+    _ garbageBetweenLetOrVarKeywordAndValuePattern: GarbageNodesSyntax? = nil,
+    valuePattern: PatternSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLetOrVarKeyword?.raw,
+      letOrVarKeyword.raw,
+      garbageBetweenLetOrVarKeywordAndValuePattern?.raw,
+      valuePattern.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.valueBindingPattern,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -34,6 +34,16 @@ public struct UnknownStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+  ) {
+    let layout: [RawSyntax?] = [
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.unknownStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -71,6 +81,16 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .missingStmt)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+  ) {
+    let layout: [RawSyntax?] = [
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.missingStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -118,6 +138,28 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .labeledStmt)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLabelName: GarbageNodesSyntax? = nil,
+    labelName: TokenSyntax,
+    _ garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? = nil,
+    labelColon: TokenSyntax,
+    _ garbageBetweenLabelColonAndStatement: GarbageNodesSyntax? = nil,
+    statement: StmtSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLabelName?.raw,
+      labelName.raw,
+      garbageBetweenLabelNameAndLabelColon?.raw,
+      labelColon.raw,
+      garbageBetweenLabelColonAndStatement?.raw,
+      statement.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.labeledStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -351,6 +393,24 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeContinueKeyword: GarbageNodesSyntax? = nil,
+    continueKeyword: TokenSyntax,
+    _ garbageBetweenContinueKeywordAndLabel: GarbageNodesSyntax? = nil,
+    label: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeContinueKeyword?.raw,
+      continueKeyword.raw,
+      garbageBetweenContinueKeywordAndLabel?.raw,
+      label?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.continueStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -520,6 +580,28 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .whileStmt)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeWhileKeyword: GarbageNodesSyntax? = nil,
+    whileKeyword: TokenSyntax,
+    _ garbageBetweenWhileKeywordAndConditions: GarbageNodesSyntax? = nil,
+    conditions: ConditionElementListSyntax,
+    _ garbageBetweenConditionsAndBody: GarbageNodesSyntax? = nil,
+    body: CodeBlockSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeWhileKeyword?.raw,
+      whileKeyword.raw,
+      garbageBetweenWhileKeywordAndConditions?.raw,
+      conditions.raw,
+      garbageBetweenConditionsAndBody?.raw,
+      body.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.whileStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -772,6 +854,24 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeDeferKeyword: GarbageNodesSyntax? = nil,
+    deferKeyword: TokenSyntax,
+    _ garbageBetweenDeferKeywordAndBody: GarbageNodesSyntax? = nil,
+    body: CodeBlockSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeDeferKeyword?.raw,
+      deferKeyword.raw,
+      garbageBetweenDeferKeywordAndBody?.raw,
+      body.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.deferStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -939,6 +1039,20 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeExpression?.raw,
+      expression.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.expressionStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1048,6 +1162,32 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .repeatWhileStmt)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeRepeatKeyword: GarbageNodesSyntax? = nil,
+    repeatKeyword: TokenSyntax,
+    _ garbageBetweenRepeatKeywordAndBody: GarbageNodesSyntax? = nil,
+    body: CodeBlockSyntax,
+    _ garbageBetweenBodyAndWhileKeyword: GarbageNodesSyntax? = nil,
+    whileKeyword: TokenSyntax,
+    _ garbageBetweenWhileKeywordAndCondition: GarbageNodesSyntax? = nil,
+    condition: ExprSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeRepeatKeyword?.raw,
+      repeatKeyword.raw,
+      garbageBetweenRepeatKeywordAndBody?.raw,
+      body.raw,
+      garbageBetweenBodyAndWhileKeyword?.raw,
+      whileKeyword.raw,
+      garbageBetweenWhileKeywordAndCondition?.raw,
+      condition.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.repeatWhileStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1345,6 +1485,32 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .guardStmt)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeGuardKeyword: GarbageNodesSyntax? = nil,
+    guardKeyword: TokenSyntax,
+    _ garbageBetweenGuardKeywordAndConditions: GarbageNodesSyntax? = nil,
+    conditions: ConditionElementListSyntax,
+    _ garbageBetweenConditionsAndElseKeyword: GarbageNodesSyntax? = nil,
+    elseKeyword: TokenSyntax,
+    _ garbageBetweenElseKeywordAndBody: GarbageNodesSyntax? = nil,
+    body: CodeBlockSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeGuardKeyword?.raw,
+      guardKeyword.raw,
+      garbageBetweenGuardKeywordAndConditions?.raw,
+      conditions.raw,
+      garbageBetweenConditionsAndElseKeyword?.raw,
+      elseKeyword.raw,
+      garbageBetweenElseKeywordAndBody?.raw,
+      body.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.guardStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1673,6 +1839,56 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .forInStmt)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeForKeyword: GarbageNodesSyntax? = nil,
+    forKeyword: TokenSyntax,
+    _ garbageBetweenForKeywordAndTryKeyword: GarbageNodesSyntax? = nil,
+    tryKeyword: TokenSyntax?,
+    _ garbageBetweenTryKeywordAndAwaitKeyword: GarbageNodesSyntax? = nil,
+    awaitKeyword: TokenSyntax?,
+    _ garbageBetweenAwaitKeywordAndCaseKeyword: GarbageNodesSyntax? = nil,
+    caseKeyword: TokenSyntax?,
+    _ garbageBetweenCaseKeywordAndPattern: GarbageNodesSyntax? = nil,
+    pattern: PatternSyntax,
+    _ garbageBetweenPatternAndTypeAnnotation: GarbageNodesSyntax? = nil,
+    typeAnnotation: TypeAnnotationSyntax?,
+    _ garbageBetweenTypeAnnotationAndInKeyword: GarbageNodesSyntax? = nil,
+    inKeyword: TokenSyntax,
+    _ garbageBetweenInKeywordAndSequenceExpr: GarbageNodesSyntax? = nil,
+    sequenceExpr: ExprSyntax,
+    _ garbageBetweenSequenceExprAndWhereClause: GarbageNodesSyntax? = nil,
+    whereClause: WhereClauseSyntax?,
+    _ garbageBetweenWhereClauseAndBody: GarbageNodesSyntax? = nil,
+    body: CodeBlockSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeForKeyword?.raw,
+      forKeyword.raw,
+      garbageBetweenForKeywordAndTryKeyword?.raw,
+      tryKeyword?.raw,
+      garbageBetweenTryKeywordAndAwaitKeyword?.raw,
+      awaitKeyword?.raw,
+      garbageBetweenAwaitKeywordAndCaseKeyword?.raw,
+      caseKeyword?.raw,
+      garbageBetweenCaseKeywordAndPattern?.raw,
+      pattern.raw,
+      garbageBetweenPatternAndTypeAnnotation?.raw,
+      typeAnnotation?.raw,
+      garbageBetweenTypeAnnotationAndInKeyword?.raw,
+      inKeyword.raw,
+      garbageBetweenInKeywordAndSequenceExpr?.raw,
+      sequenceExpr.raw,
+      garbageBetweenSequenceExprAndWhereClause?.raw,
+      whereClause?.raw,
+      garbageBetweenWhereClauseAndBody?.raw,
+      body.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.forInStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -2346,6 +2562,36 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeSwitchKeyword: GarbageNodesSyntax? = nil,
+    switchKeyword: TokenSyntax,
+    _ garbageBetweenSwitchKeywordAndExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax,
+    _ garbageBetweenExpressionAndLeftBrace: GarbageNodesSyntax? = nil,
+    leftBrace: TokenSyntax,
+    _ garbageBetweenLeftBraceAndCases: GarbageNodesSyntax? = nil,
+    cases: SwitchCaseListSyntax,
+    _ garbageBetweenCasesAndRightBrace: GarbageNodesSyntax? = nil,
+    rightBrace: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeSwitchKeyword?.raw,
+      switchKeyword.raw,
+      garbageBetweenSwitchKeywordAndExpression?.raw,
+      expression.raw,
+      garbageBetweenExpressionAndLeftBrace?.raw,
+      leftBrace.raw,
+      garbageBetweenLeftBraceAndCases?.raw,
+      cases.raw,
+      garbageBetweenCasesAndRightBrace?.raw,
+      rightBrace.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.switchStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -2722,6 +2968,28 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeDoKeyword: GarbageNodesSyntax? = nil,
+    doKeyword: TokenSyntax,
+    _ garbageBetweenDoKeywordAndBody: GarbageNodesSyntax? = nil,
+    body: CodeBlockSyntax,
+    _ garbageBetweenBodyAndCatchClauses: GarbageNodesSyntax? = nil,
+    catchClauses: CatchClauseListSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeDoKeyword?.raw,
+      doKeyword.raw,
+      garbageBetweenDoKeywordAndBody?.raw,
+      body.raw,
+      garbageBetweenBodyAndCatchClauses?.raw,
+      catchClauses?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.doStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -2972,6 +3240,24 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeReturnKeyword: GarbageNodesSyntax? = nil,
+    returnKeyword: TokenSyntax,
+    _ garbageBetweenReturnKeywordAndExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeReturnKeyword?.raw,
+      returnKeyword.raw,
+      garbageBetweenReturnKeywordAndExpression?.raw,
+      expression?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.returnStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -3141,6 +3427,24 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeYieldKeyword: GarbageNodesSyntax? = nil,
+    yieldKeyword: TokenSyntax,
+    _ garbageBetweenYieldKeywordAndYields: GarbageNodesSyntax? = nil,
+    yields: Syntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeYieldKeyword?.raw,
+      yieldKeyword.raw,
+      garbageBetweenYieldKeywordAndYields?.raw,
+      yields.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.yieldStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -3308,6 +3612,20 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeFallthroughKeyword: GarbageNodesSyntax? = nil,
+    fallthroughKeyword: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeFallthroughKeyword?.raw,
+      fallthroughKeyword.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.fallthroughStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -3413,6 +3731,24 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .breakStmt)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeBreakKeyword: GarbageNodesSyntax? = nil,
+    breakKeyword: TokenSyntax,
+    _ garbageBetweenBreakKeywordAndLabel: GarbageNodesSyntax? = nil,
+    label: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeBreakKeyword?.raw,
+      breakKeyword.raw,
+      garbageBetweenBreakKeywordAndLabel?.raw,
+      label?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.breakStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -3582,6 +3918,20 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeDeclaration: GarbageNodesSyntax? = nil,
+    declaration: DeclSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeDeclaration?.raw,
+      declaration.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.declarationStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -3687,6 +4037,24 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .throwStmt)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeThrowKeyword: GarbageNodesSyntax? = nil,
+    throwKeyword: TokenSyntax,
+    _ garbageBetweenThrowKeywordAndExpression: GarbageNodesSyntax? = nil,
+    expression: ExprSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeThrowKeyword?.raw,
+      throwKeyword.raw,
+      garbageBetweenThrowKeywordAndExpression?.raw,
+      expression.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.throwStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -3862,6 +4230,36 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .ifStmt)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeIfKeyword: GarbageNodesSyntax? = nil,
+    ifKeyword: TokenSyntax,
+    _ garbageBetweenIfKeywordAndConditions: GarbageNodesSyntax? = nil,
+    conditions: ConditionElementListSyntax,
+    _ garbageBetweenConditionsAndBody: GarbageNodesSyntax? = nil,
+    body: CodeBlockSyntax,
+    _ garbageBetweenBodyAndElseKeyword: GarbageNodesSyntax? = nil,
+    elseKeyword: TokenSyntax?,
+    _ garbageBetweenElseKeywordAndElseBody: GarbageNodesSyntax? = nil,
+    elseBody: Syntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeIfKeyword?.raw,
+      ifKeyword.raw,
+      garbageBetweenIfKeywordAndConditions?.raw,
+      conditions.raw,
+      garbageBetweenConditionsAndBody?.raw,
+      body.raw,
+      garbageBetweenBodyAndElseKeyword?.raw,
+      elseKeyword?.raw,
+      garbageBetweenElseKeywordAndElseBody?.raw,
+      elseBody?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.ifStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -4244,6 +4642,40 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .poundAssertStmt)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforePoundAssert: GarbageNodesSyntax? = nil,
+    poundAssert: TokenSyntax,
+    _ garbageBetweenPoundAssertAndLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndCondition: GarbageNodesSyntax? = nil,
+    condition: ExprSyntax,
+    _ garbageBetweenConditionAndComma: GarbageNodesSyntax? = nil,
+    comma: TokenSyntax?,
+    _ garbageBetweenCommaAndMessage: GarbageNodesSyntax? = nil,
+    message: TokenSyntax?,
+    _ garbageBetweenMessageAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforePoundAssert?.raw,
+      poundAssert.raw,
+      garbageBetweenPoundAssertAndLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndCondition?.raw,
+      condition.raw,
+      garbageBetweenConditionAndComma?.raw,
+      comma?.raw,
+      garbageBetweenCommaAndMessage?.raw,
+      message?.raw,
+      garbageBetweenMessageAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.poundAssertStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -34,6 +34,16 @@ public struct UnknownTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+  ) {
+    let layout: [RawSyntax?] = [
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.unknownType,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -71,6 +81,16 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .missingType)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+  ) {
+    let layout: [RawSyntax?] = [
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.missingType,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -116,6 +136,24 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .simpleTypeIdentifier)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ garbageBetweenNameAndGenericArgumentClause: GarbageNodesSyntax? = nil,
+    genericArgumentClause: GenericArgumentClauseSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeName?.raw,
+      name.raw,
+      garbageBetweenNameAndGenericArgumentClause?.raw,
+      genericArgumentClause?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.simpleTypeIdentifier,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -289,6 +327,32 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .memberTypeIdentifier)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeBaseType: GarbageNodesSyntax? = nil,
+    baseType: TypeSyntax,
+    _ garbageBetweenBaseTypeAndPeriod: GarbageNodesSyntax? = nil,
+    period: TokenSyntax,
+    _ garbageBetweenPeriodAndName: GarbageNodesSyntax? = nil,
+    name: TokenSyntax,
+    _ garbageBetweenNameAndGenericArgumentClause: GarbageNodesSyntax? = nil,
+    genericArgumentClause: GenericArgumentClauseSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeBaseType?.raw,
+      baseType.raw,
+      garbageBetweenBaseTypeAndPeriod?.raw,
+      period.raw,
+      garbageBetweenPeriodAndName?.raw,
+      name.raw,
+      garbageBetweenNameAndGenericArgumentClause?.raw,
+      genericArgumentClause?.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.memberTypeIdentifier,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -582,6 +646,20 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeClassKeyword: GarbageNodesSyntax? = nil,
+    classKeyword: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeClassKeyword?.raw,
+      classKeyword.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.classRestrictionType,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -689,6 +767,28 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .arrayType)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftSquareBracket: GarbageNodesSyntax? = nil,
+    leftSquareBracket: TokenSyntax,
+    _ garbageBetweenLeftSquareBracketAndElementType: GarbageNodesSyntax? = nil,
+    elementType: TypeSyntax,
+    _ garbageBetweenElementTypeAndRightSquareBracket: GarbageNodesSyntax? = nil,
+    rightSquareBracket: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftSquareBracket?.raw,
+      leftSquareBracket.raw,
+      garbageBetweenLeftSquareBracketAndElementType?.raw,
+      elementType.raw,
+      garbageBetweenElementTypeAndRightSquareBracket?.raw,
+      rightSquareBracket.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.arrayType,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -926,6 +1026,36 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .dictionaryType)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftSquareBracket: GarbageNodesSyntax? = nil,
+    leftSquareBracket: TokenSyntax,
+    _ garbageBetweenLeftSquareBracketAndKeyType: GarbageNodesSyntax? = nil,
+    keyType: TypeSyntax,
+    _ garbageBetweenKeyTypeAndColon: GarbageNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ garbageBetweenColonAndValueType: GarbageNodesSyntax? = nil,
+    valueType: TypeSyntax,
+    _ garbageBetweenValueTypeAndRightSquareBracket: GarbageNodesSyntax? = nil,
+    rightSquareBracket: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftSquareBracket?.raw,
+      leftSquareBracket.raw,
+      garbageBetweenLeftSquareBracketAndKeyType?.raw,
+      keyType.raw,
+      garbageBetweenKeyTypeAndColon?.raw,
+      colon.raw,
+      garbageBetweenColonAndValueType?.raw,
+      valueType.raw,
+      garbageBetweenValueTypeAndRightSquareBracket?.raw,
+      rightSquareBracket.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.dictionaryType,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1285,6 +1415,28 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeBaseType: GarbageNodesSyntax? = nil,
+    baseType: TypeSyntax,
+    _ garbageBetweenBaseTypeAndPeriod: GarbageNodesSyntax? = nil,
+    period: TokenSyntax,
+    _ garbageBetweenPeriodAndTypeOrProtocol: GarbageNodesSyntax? = nil,
+    typeOrProtocol: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeBaseType?.raw,
+      baseType.raw,
+      garbageBetweenBaseTypeAndPeriod?.raw,
+      period.raw,
+      garbageBetweenPeriodAndTypeOrProtocol?.raw,
+      typeOrProtocol.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.metatypeType,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1516,6 +1668,24 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeWrappedType: GarbageNodesSyntax? = nil,
+    wrappedType: TypeSyntax,
+    _ garbageBetweenWrappedTypeAndQuestionMark: GarbageNodesSyntax? = nil,
+    questionMark: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeWrappedType?.raw,
+      wrappedType.raw,
+      garbageBetweenWrappedTypeAndQuestionMark?.raw,
+      questionMark.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.optionalType,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -1683,6 +1853,24 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .constrainedSugarType)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeSomeOrAnySpecifier: GarbageNodesSyntax? = nil,
+    someOrAnySpecifier: TokenSyntax,
+    _ garbageBetweenSomeOrAnySpecifierAndBaseType: GarbageNodesSyntax? = nil,
+    baseType: TypeSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeSomeOrAnySpecifier?.raw,
+      someOrAnySpecifier.raw,
+      garbageBetweenSomeOrAnySpecifierAndBaseType?.raw,
+      baseType.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.constrainedSugarType,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -1854,6 +2042,24 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeWrappedType: GarbageNodesSyntax? = nil,
+    wrappedType: TypeSyntax,
+    _ garbageBetweenWrappedTypeAndExclamationMark: GarbageNodesSyntax? = nil,
+    exclamationMark: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeWrappedType?.raw,
+      wrappedType.raw,
+      garbageBetweenWrappedTypeAndExclamationMark?.raw,
+      exclamationMark.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.implicitlyUnwrappedOptionalType,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -2021,6 +2227,20 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     self._syntaxNode = Syntax(data)
   }
 
+  public init(
+    _ garbageBeforeElements: GarbageNodesSyntax? = nil,
+    elements: CompositionTypeElementListSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeElements?.raw,
+      elements.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.compositionType,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
@@ -2147,6 +2367,28 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .tupleType)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndElements: GarbageNodesSyntax? = nil,
+    elements: TupleTypeElementListSyntax,
+    _ garbageBetweenElementsAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndElements?.raw,
+      elements.raw,
+      garbageBetweenElementsAndRightParen?.raw,
+      rightParen.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.tupleType,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -2407,6 +2649,44 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .functionType)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeLeftParen: GarbageNodesSyntax? = nil,
+    leftParen: TokenSyntax,
+    _ garbageBetweenLeftParenAndArguments: GarbageNodesSyntax? = nil,
+    arguments: TupleTypeElementListSyntax,
+    _ garbageBetweenArgumentsAndRightParen: GarbageNodesSyntax? = nil,
+    rightParen: TokenSyntax,
+    _ garbageBetweenRightParenAndAsyncKeyword: GarbageNodesSyntax? = nil,
+    asyncKeyword: TokenSyntax?,
+    _ garbageBetweenAsyncKeywordAndThrowsOrRethrowsKeyword: GarbageNodesSyntax? = nil,
+    throwsOrRethrowsKeyword: TokenSyntax?,
+    _ garbageBetweenThrowsOrRethrowsKeywordAndArrow: GarbageNodesSyntax? = nil,
+    arrow: TokenSyntax,
+    _ garbageBetweenArrowAndReturnType: GarbageNodesSyntax? = nil,
+    returnType: TypeSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLeftParen?.raw,
+      leftParen.raw,
+      garbageBetweenLeftParenAndArguments?.raw,
+      arguments.raw,
+      garbageBetweenArgumentsAndRightParen?.raw,
+      rightParen.raw,
+      garbageBetweenRightParenAndAsyncKeyword?.raw,
+      asyncKeyword?.raw,
+      garbageBetweenAsyncKeywordAndThrowsOrRethrowsKeyword?.raw,
+      throwsOrRethrowsKeyword?.raw,
+      garbageBetweenThrowsOrRethrowsKeywordAndArrow?.raw,
+      arrow.raw,
+      garbageBetweenArrowAndReturnType?.raw,
+      returnType.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.functionType,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {
@@ -2907,6 +3187,28 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   internal init(_ data: SyntaxData) {
     assert(data.raw.kind == .attributedType)
     self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ garbageBeforeSpecifier: GarbageNodesSyntax? = nil,
+    specifier: TokenSyntax?,
+    _ garbageBetweenSpecifierAndAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndBaseType: GarbageNodesSyntax? = nil,
+    baseType: TypeSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      garbageBeforeSpecifier?.raw,
+      specifier?.raw,
+      garbageBetweenSpecifierAndAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndBaseType?.raw,
+      baseType.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.attributedType,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
   }
 
   public var syntaxNodeType: SyntaxProtocol.Type {

--- a/Sources/SwiftSyntaxBuilder/BuildableNodes.swift.gyb
+++ b/Sources/SwiftSyntaxBuilder/BuildableNodes.swift.gyb
@@ -86,7 +86,7 @@ public struct ${type.buildable()}${conformance_clause(conformances)} {
         create_convenience_initializer = True
         if child.type().is_optional:
           param_type = 'String?'
-          produce_expr = '%s.map(TokenSyntax.%s)' % (child.name(), child.type().token().swift_kind())
+          produce_expr = '%s.map { TokenSyntax.%s($0) }' % (child.name(), child.type().token().swift_kind())
         else:
           param_type = 'String'
           produce_expr = 'TokenSyntax.%s(%s)' % (child.type().token().swift_kind(), child.name())
@@ -116,7 +116,7 @@ public struct ${type.buildable()}${conformance_clause(conformances)} {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `${type.syntax()}`.
   func build${type.base_name()}(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ${type.syntax()} {
-    let result = SyntaxFactory.make${type.base_name()}(
+    let result = ${type.syntax()}(
     % parameters = []
     % for (index, child) in enumerate(children):
     %   comma = ',' if index != len(children) - 1 else ''

--- a/Sources/SwiftSyntaxBuilder/CatchClauseConvenienceInitializer.swift
+++ b/Sources/SwiftSyntaxBuilder/CatchClauseConvenienceInitializer.swift
@@ -21,7 +21,7 @@ extension CatchClause {
   ) {
     self.init(
       leadingTrivia: leadingTrivia,
-      catchKeyword: SyntaxFactory.makeCatchKeyword(trailingTrivia: catchItems.elements.isEmpty ? [] : .space),
+      catchKeyword: .catchKeyword(trailingTrivia: catchItems.elements.isEmpty ? [] : .space),
       catchItems: catchItems,
       body: bodyBuilder()
     )

--- a/Sources/SwiftSyntaxBuilder/DictionaryExprConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/DictionaryExprConvenienceInitializers.swift
@@ -23,7 +23,7 @@ extension DictionaryExpr {
     let elementList = contentBuilder().createDictionaryElementList()
     self.init(
       leftSquare: leftSquare,
-      content: elementList.elements.isEmpty ? SyntaxFactory.makeColonToken(trailingTrivia: []) : elementList,
+      content: elementList.elements.isEmpty ? TokenSyntax.colonToken(trailingTrivia: []) : elementList,
       rightSquare: rightSquare
     )
   }

--- a/Sources/SwiftSyntaxBuilder/IfStmtConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/IfStmtConvenienceInitializers.swift
@@ -27,7 +27,7 @@ public extension IfStmt {
       leadingTrivia: leadingTrivia,
       conditions: conditions,
       body: body(),
-      elseKeyword: generatedElseBody == nil ? nil : SyntaxFactory.makeElseKeyword(leadingTrivia: .space, trailingTrivia: []),
+      elseKeyword: generatedElseBody == nil ? nil : TokenSyntax.elseKeyword(leadingTrivia: .space, trailingTrivia: []),
       elseBody: generatedElseBody.map { CodeBlock(statements: $0) }
     )
   }

--- a/Sources/SwiftSyntaxBuilder/MemberAccessExprConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/MemberAccessExprConvenienceInitializers.swift
@@ -20,6 +20,6 @@ extension MemberAccessExpr {
     name: String,
     declNameArguments: ExpressibleAsDeclNameArguments? = nil
   ) {
-    self.init(base: base, dot: dot, name: SyntaxFactory.makeIdentifier(name), declNameArguments: declNameArguments)
+    self.init(base: base, dot: dot, name: .identifier(name), declNameArguments: declNameArguments)
   }
 }

--- a/Sources/SwiftSyntaxBuilder/StringLiteralExprConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/StringLiteralExprConvenienceInitializers.swift
@@ -14,7 +14,7 @@ import SwiftSyntax
 
 extension StringLiteralExpr {
   public init(_ value: String, openQuote: TokenSyntax = .stringQuote, closeQuote: TokenSyntax = .stringQuote) {
-    let content = SyntaxFactory.makeToken(.stringSegment(value), presence: .present)
+    let content = TokenSyntax.stringSegment(value)
     let segment = StringSegment(content: content)
     let segments = StringLiteralSegments([segment])
 

--- a/Sources/SwiftSyntaxBuilder/TupleExprElementConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/TupleExprElementConvenienceInitializers.swift
@@ -17,6 +17,6 @@ public extension TupleExprElement {
   /// The presence of the colon will be inferred based on the presence of the label.
   init(label: String? = nil, expression: ExpressibleAsExprBuildable) {
     self.init(
-      label: label.map(TokenSyntax.identifier), colon: label == nil ? nil : .colon, expression: expression)
+      label: label.map { TokenSyntax.identifier($0) }, colon: label == nil ? nil : .colon, expression: expression)
   }
 }

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
@@ -35,7 +35,7 @@ public struct CodeBlockItemList: ExpressibleByArrayLiteral, SyntaxBuildable, Exp
     self.init(elements)
   }
   public func buildCodeBlockItemList(format: Format, leadingTrivia: Trivia? = nil ) -> CodeBlockItemListSyntax {
-    let result = SyntaxFactory.makeCodeBlockItemList(elements.map {
+    let result = CodeBlockItemListSyntax(elements.map {
       $0.buildCodeBlockItem(format: format, leadingTrivia: Trivia.newline + format._makeIndent())
     })
     if let leadingTrivia = leadingTrivia {
@@ -79,7 +79,7 @@ public struct GarbageNodes: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
     self.init(elements)
   }
   public func buildGarbageNodes(format: Format, leadingTrivia: Trivia? = nil ) -> GarbageNodesSyntax {
-    let result = SyntaxFactory.makeGarbageNodes(elements.map {
+    let result = GarbageNodesSyntax(elements.map {
       $0.buildSyntax(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -128,7 +128,7 @@ public struct TupleExprElementList: ExpressibleByArrayLiteral, SyntaxBuildable, 
     self.init(elements)
   }
   public func buildTupleExprElementList(format: Format, leadingTrivia: Trivia? = nil ) -> TupleExprElementListSyntax {
-    let result = SyntaxFactory.makeTupleExprElementList(elements.map {
+    let result = TupleExprElementListSyntax(elements.map {
       $0.buildTupleExprElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -177,7 +177,7 @@ public struct ArrayElementList: ExpressibleByArrayLiteral, SyntaxBuildable, Expr
     self.init(elements)
   }
   public func buildArrayElementList(format: Format, leadingTrivia: Trivia? = nil ) -> ArrayElementListSyntax {
-    let result = SyntaxFactory.makeArrayElementList(elements.map {
+    let result = ArrayElementListSyntax(elements.map {
       $0.buildArrayElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -221,7 +221,7 @@ public struct DictionaryElementList: ExpressibleByArrayLiteral, SyntaxBuildable,
     self.init(elements)
   }
   public func buildDictionaryElementList(format: Format, leadingTrivia: Trivia? = nil ) -> DictionaryElementListSyntax {
-    let result = SyntaxFactory.makeDictionaryElementList(elements.map {
+    let result = DictionaryElementListSyntax(elements.map {
       $0.buildDictionaryElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -270,7 +270,7 @@ public struct StringLiteralSegments: ExpressibleByArrayLiteral, SyntaxBuildable,
     self.init(elements)
   }
   public func buildStringLiteralSegments(format: Format, leadingTrivia: Trivia? = nil ) -> StringLiteralSegmentsSyntax {
-    let result = SyntaxFactory.makeStringLiteralSegments(elements.map {
+    let result = StringLiteralSegmentsSyntax(elements.map {
       $0.buildSyntax(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -319,7 +319,7 @@ public struct DeclNameArgumentList: ExpressibleByArrayLiteral, SyntaxBuildable, 
     self.init(elements)
   }
   public func buildDeclNameArgumentList(format: Format, leadingTrivia: Trivia? = nil ) -> DeclNameArgumentListSyntax {
-    let result = SyntaxFactory.makeDeclNameArgumentList(elements.map {
+    let result = DeclNameArgumentListSyntax(elements.map {
       $0.buildDeclNameArgument(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -368,7 +368,7 @@ public struct ExprList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleA
     self.init(elements)
   }
   public func buildExprList(format: Format, leadingTrivia: Trivia? = nil ) -> ExprListSyntax {
-    let result = SyntaxFactory.makeExprList(elements.map {
+    let result = ExprListSyntax(elements.map {
       $0.buildExpr(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -412,7 +412,7 @@ public struct ClosureCaptureItemList: ExpressibleByArrayLiteral, SyntaxBuildable
     self.init(elements)
   }
   public func buildClosureCaptureItemList(format: Format, leadingTrivia: Trivia? = nil ) -> ClosureCaptureItemListSyntax {
-    let result = SyntaxFactory.makeClosureCaptureItemList(elements.map {
+    let result = ClosureCaptureItemListSyntax(elements.map {
       $0.buildClosureCaptureItem(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -461,7 +461,7 @@ public struct ClosureParamList: ExpressibleByArrayLiteral, SyntaxBuildable, Expr
     self.init(elements)
   }
   public func buildClosureParamList(format: Format, leadingTrivia: Trivia? = nil ) -> ClosureParamListSyntax {
-    let result = SyntaxFactory.makeClosureParamList(elements.map {
+    let result = ClosureParamListSyntax(elements.map {
       $0.buildClosureParam(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -510,7 +510,7 @@ public struct MultipleTrailingClosureElementList: ExpressibleByArrayLiteral, Syn
     self.init(elements)
   }
   public func buildMultipleTrailingClosureElementList(format: Format, leadingTrivia: Trivia? = nil ) -> MultipleTrailingClosureElementListSyntax {
-    let result = SyntaxFactory.makeMultipleTrailingClosureElementList(elements.map {
+    let result = MultipleTrailingClosureElementListSyntax(elements.map {
       $0.buildMultipleTrailingClosureElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -559,7 +559,7 @@ public struct ObjcName: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleA
     self.init(elements)
   }
   public func buildObjcName(format: Format, leadingTrivia: Trivia? = nil ) -> ObjcNameSyntax {
-    let result = SyntaxFactory.makeObjcName(elements.map {
+    let result = ObjcNameSyntax(elements.map {
       $0.buildObjcNamePiece(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -608,7 +608,7 @@ public struct FunctionParameterList: ExpressibleByArrayLiteral, SyntaxBuildable,
     self.init(elements)
   }
   public func buildFunctionParameterList(format: Format, leadingTrivia: Trivia? = nil ) -> FunctionParameterListSyntax {
-    let result = SyntaxFactory.makeFunctionParameterList(elements.map {
+    let result = FunctionParameterListSyntax(elements.map {
       $0.buildFunctionParameter(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -657,7 +657,7 @@ public struct IfConfigClauseList: ExpressibleByArrayLiteral, SyntaxBuildable, Ex
     self.init(elements)
   }
   public func buildIfConfigClauseList(format: Format, leadingTrivia: Trivia? = nil ) -> IfConfigClauseListSyntax {
-    let result = SyntaxFactory.makeIfConfigClauseList(elements.map {
+    let result = IfConfigClauseListSyntax(elements.map {
       $0.buildIfConfigClause(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -706,7 +706,7 @@ public struct InheritedTypeList: ExpressibleByArrayLiteral, SyntaxBuildable, Exp
     self.init(elements)
   }
   public func buildInheritedTypeList(format: Format, leadingTrivia: Trivia? = nil ) -> InheritedTypeListSyntax {
-    let result = SyntaxFactory.makeInheritedTypeList(elements.map {
+    let result = InheritedTypeListSyntax(elements.map {
       $0.buildInheritedType(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -755,7 +755,7 @@ public struct MemberDeclList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
     self.init(elements)
   }
   public func buildMemberDeclList(format: Format, leadingTrivia: Trivia? = nil ) -> MemberDeclListSyntax {
-    let result = SyntaxFactory.makeMemberDeclList(elements.map {
+    let result = MemberDeclListSyntax(elements.map {
       $0.buildMemberDeclListItem(format: format, leadingTrivia: Trivia.newline + format._makeIndent())
     })
     if let leadingTrivia = leadingTrivia {
@@ -799,7 +799,7 @@ public struct ModifierList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
     self.init(elements)
   }
   public func buildModifierList(format: Format, leadingTrivia: Trivia? = nil ) -> ModifierListSyntax {
-    let result = SyntaxFactory.makeModifierList(elements.map {
+    let result = ModifierListSyntax(elements.map {
       $0.buildDeclModifier(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -848,7 +848,7 @@ public struct AccessPath: ExpressibleByArrayLiteral, SyntaxBuildable, Expressibl
     self.init(elements)
   }
   public func buildAccessPath(format: Format, leadingTrivia: Trivia? = nil ) -> AccessPathSyntax {
-    let result = SyntaxFactory.makeAccessPath(elements.map {
+    let result = AccessPathSyntax(elements.map {
       $0.buildAccessPathComponent(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -897,7 +897,7 @@ public struct AccessorList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
     self.init(elements)
   }
   public func buildAccessorList(format: Format, leadingTrivia: Trivia? = nil ) -> AccessorListSyntax {
-    let result = SyntaxFactory.makeAccessorList(elements.map {
+    let result = AccessorListSyntax(elements.map {
       $0.buildAccessorDecl(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -941,7 +941,7 @@ public struct PatternBindingList: ExpressibleByArrayLiteral, SyntaxBuildable, Ex
     self.init(elements)
   }
   public func buildPatternBindingList(format: Format, leadingTrivia: Trivia? = nil ) -> PatternBindingListSyntax {
-    let result = SyntaxFactory.makePatternBindingList(elements.map {
+    let result = PatternBindingListSyntax(elements.map {
       $0.buildPatternBinding(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -990,7 +990,7 @@ public struct EnumCaseElementList: ExpressibleByArrayLiteral, SyntaxBuildable, E
     self.init(elements)
   }
   public func buildEnumCaseElementList(format: Format, leadingTrivia: Trivia? = nil ) -> EnumCaseElementListSyntax {
-    let result = SyntaxFactory.makeEnumCaseElementList(elements.map {
+    let result = EnumCaseElementListSyntax(elements.map {
       $0.buildEnumCaseElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1037,7 +1037,7 @@ public struct IdentifierList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
     self.init(elements)
   }
   public func buildIdentifierList(format: Format, leadingTrivia: Trivia? = nil ) -> IdentifierListSyntax {
-    let result = SyntaxFactory.makeIdentifierList(elements)
+    let result = IdentifierListSyntax(elements)
     if let leadingTrivia = leadingTrivia {
       return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
@@ -1084,7 +1084,7 @@ public struct PrecedenceGroupAttributeList: ExpressibleByArrayLiteral, SyntaxBui
     self.init(elements)
   }
   public func buildPrecedenceGroupAttributeList(format: Format, leadingTrivia: Trivia? = nil ) -> PrecedenceGroupAttributeListSyntax {
-    let result = SyntaxFactory.makePrecedenceGroupAttributeList(elements.map {
+    let result = PrecedenceGroupAttributeListSyntax(elements.map {
       $0.buildSyntax(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1133,7 +1133,7 @@ public struct PrecedenceGroupNameList: ExpressibleByArrayLiteral, SyntaxBuildabl
     self.init(elements)
   }
   public func buildPrecedenceGroupNameList(format: Format, leadingTrivia: Trivia? = nil ) -> PrecedenceGroupNameListSyntax {
-    let result = SyntaxFactory.makePrecedenceGroupNameList(elements.map {
+    let result = PrecedenceGroupNameListSyntax(elements.map {
       $0.buildPrecedenceGroupNameElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1180,7 +1180,7 @@ public struct TokenList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressible
     self.init(elements)
   }
   public func buildTokenList(format: Format, leadingTrivia: Trivia? = nil ) -> TokenListSyntax {
-    let result = SyntaxFactory.makeTokenList(elements)
+    let result = TokenListSyntax(elements)
     if let leadingTrivia = leadingTrivia {
       return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
@@ -1225,7 +1225,7 @@ public struct NonEmptyTokenList: ExpressibleByArrayLiteral, SyntaxBuildable, Exp
     self.init(elements)
   }
   public func buildNonEmptyTokenList(format: Format, leadingTrivia: Trivia? = nil ) -> NonEmptyTokenListSyntax {
-    let result = SyntaxFactory.makeNonEmptyTokenList(elements)
+    let result = NonEmptyTokenListSyntax(elements)
     if let leadingTrivia = leadingTrivia {
       return result.withLeadingTrivia((leadingTrivia + (result.leadingTrivia ?? [])).addingSpacingAfterNewlinesIfNeeded())
     } else {
@@ -1272,7 +1272,7 @@ public struct AttributeList: ExpressibleByArrayLiteral, SyntaxBuildable, Express
     self.init(elements)
   }
   public func buildAttributeList(format: Format, leadingTrivia: Trivia? = nil ) -> AttributeListSyntax {
-    let result = SyntaxFactory.makeAttributeList(elements.map {
+    let result = AttributeListSyntax(elements.map {
       $0.buildSyntax(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1321,7 +1321,7 @@ public struct SpecializeAttributeSpecList: ExpressibleByArrayLiteral, SyntaxBuil
     self.init(elements)
   }
   public func buildSpecializeAttributeSpecList(format: Format, leadingTrivia: Trivia? = nil ) -> SpecializeAttributeSpecListSyntax {
-    let result = SyntaxFactory.makeSpecializeAttributeSpecList(elements.map {
+    let result = SpecializeAttributeSpecListSyntax(elements.map {
       $0.buildSyntax(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1370,7 +1370,7 @@ public struct ObjCSelector: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
     self.init(elements)
   }
   public func buildObjCSelector(format: Format, leadingTrivia: Trivia? = nil ) -> ObjCSelectorSyntax {
-    let result = SyntaxFactory.makeObjCSelector(elements.map {
+    let result = ObjCSelectorSyntax(elements.map {
       $0.buildObjCSelectorPiece(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1419,7 +1419,7 @@ public struct DifferentiabilityParamList: ExpressibleByArrayLiteral, SyntaxBuild
     self.init(elements)
   }
   public func buildDifferentiabilityParamList(format: Format, leadingTrivia: Trivia? = nil ) -> DifferentiabilityParamListSyntax {
-    let result = SyntaxFactory.makeDifferentiabilityParamList(elements.map {
+    let result = DifferentiabilityParamListSyntax(elements.map {
       $0.buildDifferentiabilityParam(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1468,7 +1468,7 @@ public struct BackDeployVersionList: ExpressibleByArrayLiteral, SyntaxBuildable,
     self.init(elements)
   }
   public func buildBackDeployVersionList(format: Format, leadingTrivia: Trivia? = nil ) -> BackDeployVersionListSyntax {
-    let result = SyntaxFactory.makeBackDeployVersionList(elements.map {
+    let result = BackDeployVersionListSyntax(elements.map {
       $0.buildBackDeployVersionArgument(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1517,7 +1517,7 @@ public struct SwitchCaseList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
     self.init(elements)
   }
   public func buildSwitchCaseList(format: Format, leadingTrivia: Trivia? = nil ) -> SwitchCaseListSyntax {
-    let result = SyntaxFactory.makeSwitchCaseList(elements.map {
+    let result = SwitchCaseListSyntax(elements.map {
       $0.buildSyntax(format: format, leadingTrivia: Trivia.newline + format._makeIndent())
     })
     if let leadingTrivia = leadingTrivia {
@@ -1566,7 +1566,7 @@ public struct CatchClauseList: ExpressibleByArrayLiteral, SyntaxBuildable, Expre
     self.init(elements)
   }
   public func buildCatchClauseList(format: Format, leadingTrivia: Trivia? = nil ) -> CatchClauseListSyntax {
-    let result = SyntaxFactory.makeCatchClauseList(elements.map {
+    let result = CatchClauseListSyntax(elements.map {
       $0.buildCatchClause(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1615,7 +1615,7 @@ public struct CaseItemList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
     self.init(elements)
   }
   public func buildCaseItemList(format: Format, leadingTrivia: Trivia? = nil ) -> CaseItemListSyntax {
-    let result = SyntaxFactory.makeCaseItemList(elements.map {
+    let result = CaseItemListSyntax(elements.map {
       $0.buildCaseItem(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1664,7 +1664,7 @@ public struct CatchItemList: ExpressibleByArrayLiteral, SyntaxBuildable, Express
     self.init(elements)
   }
   public func buildCatchItemList(format: Format, leadingTrivia: Trivia? = nil ) -> CatchItemListSyntax {
-    let result = SyntaxFactory.makeCatchItemList(elements.map {
+    let result = CatchItemListSyntax(elements.map {
       $0.buildCatchItem(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1713,7 +1713,7 @@ public struct ConditionElementList: ExpressibleByArrayLiteral, SyntaxBuildable, 
     self.init(elements)
   }
   public func buildConditionElementList(format: Format, leadingTrivia: Trivia? = nil ) -> ConditionElementListSyntax {
-    let result = SyntaxFactory.makeConditionElementList(elements.map {
+    let result = ConditionElementListSyntax(elements.map {
       $0.buildConditionElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1762,7 +1762,7 @@ public struct GenericRequirementList: ExpressibleByArrayLiteral, SyntaxBuildable
     self.init(elements)
   }
   public func buildGenericRequirementList(format: Format, leadingTrivia: Trivia? = nil ) -> GenericRequirementListSyntax {
-    let result = SyntaxFactory.makeGenericRequirementList(elements.map {
+    let result = GenericRequirementListSyntax(elements.map {
       $0.buildGenericRequirement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1811,7 +1811,7 @@ public struct GenericParameterList: ExpressibleByArrayLiteral, SyntaxBuildable, 
     self.init(elements)
   }
   public func buildGenericParameterList(format: Format, leadingTrivia: Trivia? = nil ) -> GenericParameterListSyntax {
-    let result = SyntaxFactory.makeGenericParameterList(elements.map {
+    let result = GenericParameterListSyntax(elements.map {
       $0.buildGenericParameter(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1860,7 +1860,7 @@ public struct PrimaryAssociatedTypeList: ExpressibleByArrayLiteral, SyntaxBuilda
     self.init(elements)
   }
   public func buildPrimaryAssociatedTypeList(format: Format, leadingTrivia: Trivia? = nil ) -> PrimaryAssociatedTypeListSyntax {
-    let result = SyntaxFactory.makePrimaryAssociatedTypeList(elements.map {
+    let result = PrimaryAssociatedTypeListSyntax(elements.map {
       $0.buildPrimaryAssociatedType(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1909,7 +1909,7 @@ public struct CompositionTypeElementList: ExpressibleByArrayLiteral, SyntaxBuild
     self.init(elements)
   }
   public func buildCompositionTypeElementList(format: Format, leadingTrivia: Trivia? = nil ) -> CompositionTypeElementListSyntax {
-    let result = SyntaxFactory.makeCompositionTypeElementList(elements.map {
+    let result = CompositionTypeElementListSyntax(elements.map {
       $0.buildCompositionTypeElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -1958,7 +1958,7 @@ public struct TupleTypeElementList: ExpressibleByArrayLiteral, SyntaxBuildable, 
     self.init(elements)
   }
   public func buildTupleTypeElementList(format: Format, leadingTrivia: Trivia? = nil ) -> TupleTypeElementListSyntax {
-    let result = SyntaxFactory.makeTupleTypeElementList(elements.map {
+    let result = TupleTypeElementListSyntax(elements.map {
       $0.buildTupleTypeElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -2007,7 +2007,7 @@ public struct GenericArgumentList: ExpressibleByArrayLiteral, SyntaxBuildable, E
     self.init(elements)
   }
   public func buildGenericArgumentList(format: Format, leadingTrivia: Trivia? = nil ) -> GenericArgumentListSyntax {
-    let result = SyntaxFactory.makeGenericArgumentList(elements.map {
+    let result = GenericArgumentListSyntax(elements.map {
       $0.buildGenericArgument(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -2056,7 +2056,7 @@ public struct TuplePatternElementList: ExpressibleByArrayLiteral, SyntaxBuildabl
     self.init(elements)
   }
   public func buildTuplePatternElementList(format: Format, leadingTrivia: Trivia? = nil ) -> TuplePatternElementListSyntax {
-    let result = SyntaxFactory.makeTuplePatternElementList(elements.map {
+    let result = TuplePatternElementListSyntax(elements.map {
       $0.buildTuplePatternElement(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {
@@ -2105,7 +2105,7 @@ public struct AvailabilitySpecList: ExpressibleByArrayLiteral, SyntaxBuildable, 
     self.init(elements)
   }
   public func buildAvailabilitySpecList(format: Format, leadingTrivia: Trivia? = nil ) -> AvailabilitySpecListSyntax {
-    let result = SyntaxFactory.makeAvailabilitySpecList(elements.map {
+    let result = AvailabilitySpecListSyntax(elements.map {
       $0.buildAvailabilityArgument(format: format, leadingTrivia: nil)
     })
     if let leadingTrivia = leadingTrivia {

--- a/Sources/SwiftSyntaxBuilder/generated/Tokens.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/Tokens.swift
@@ -20,604 +20,562 @@ public extension TokenSyntax {
   
   /// The `associatedtype` keyword
   static var `associatedtype`: TokenSyntax {
-    SyntaxFactory.makeAssociatedtypeKeyword()
+    TokenSyntax.associatedtypeKeyword()
   }
   
   /// The `class` keyword
   static var `class`: TokenSyntax {
-    SyntaxFactory.makeClassKeyword()
+    TokenSyntax.classKeyword()
   }
   
   /// The `deinit` keyword
   static var `deinit`: TokenSyntax {
-    SyntaxFactory.makeDeinitKeyword()
+    TokenSyntax.deinitKeyword()
   }
   
   /// The `enum` keyword
   static var `enum`: TokenSyntax {
-    SyntaxFactory.makeEnumKeyword()
+    TokenSyntax.enumKeyword()
   }
   
   /// The `extension` keyword
   static var `extension`: TokenSyntax {
-    SyntaxFactory.makeExtensionKeyword()
+    TokenSyntax.extensionKeyword()
   }
   
   /// The `func` keyword
   static var `func`: TokenSyntax {
-    SyntaxFactory.makeFuncKeyword()
+    TokenSyntax.funcKeyword()
   }
   
   /// The `import` keyword
   static var `import`: TokenSyntax {
-    SyntaxFactory.makeImportKeyword()
+    TokenSyntax.importKeyword()
   }
   
   /// The `init` keyword
   static var `init`: TokenSyntax {
-    SyntaxFactory.makeInitKeyword()
+    TokenSyntax.initKeyword()
   }
   
   /// The `inout` keyword
   static var `inout`: TokenSyntax {
-    SyntaxFactory.makeInoutKeyword()
+    TokenSyntax.inoutKeyword()
   }
   
   /// The `let` keyword
   static var `let`: TokenSyntax {
-    SyntaxFactory.makeLetKeyword()
+    TokenSyntax.letKeyword()
   }
   
   /// The `operator` keyword
   static var `operator`: TokenSyntax {
-    SyntaxFactory.makeOperatorKeyword()
+    TokenSyntax.operatorKeyword()
   }
   
   /// The `precedencegroup` keyword
   static var `precedencegroup`: TokenSyntax {
-    SyntaxFactory.makePrecedencegroupKeyword()
+    TokenSyntax.precedencegroupKeyword()
   }
   
   /// The `protocol` keyword
   static var `protocol`: TokenSyntax {
-    SyntaxFactory.makeProtocolKeyword()
+    TokenSyntax.protocolKeyword()
   }
   
   /// The `struct` keyword
   static var `struct`: TokenSyntax {
-    SyntaxFactory.makeStructKeyword()
+    TokenSyntax.structKeyword()
   }
   
   /// The `subscript` keyword
   static var `subscript`: TokenSyntax {
-    SyntaxFactory.makeSubscriptKeyword()
+    TokenSyntax.subscriptKeyword()
   }
   
   /// The `typealias` keyword
   static var `typealias`: TokenSyntax {
-    SyntaxFactory.makeTypealiasKeyword()
+    TokenSyntax.typealiasKeyword()
   }
   
   /// The `var` keyword
   static var `var`: TokenSyntax {
-    SyntaxFactory.makeVarKeyword()
+    TokenSyntax.varKeyword()
   }
   
   /// The `fileprivate` keyword
   static var `fileprivate`: TokenSyntax {
-    SyntaxFactory.makeFileprivateKeyword()
+    TokenSyntax.fileprivateKeyword()
   }
   
   /// The `internal` keyword
   static var `internal`: TokenSyntax {
-    SyntaxFactory.makeInternalKeyword()
+    TokenSyntax.internalKeyword()
   }
   
   /// The `private` keyword
   static var `private`: TokenSyntax {
-    SyntaxFactory.makePrivateKeyword()
+    TokenSyntax.privateKeyword()
   }
   
   /// The `public` keyword
   static var `public`: TokenSyntax {
-    SyntaxFactory.makePublicKeyword()
+    TokenSyntax.publicKeyword()
   }
   
   /// The `static` keyword
   static var `static`: TokenSyntax {
-    SyntaxFactory.makeStaticKeyword()
+    TokenSyntax.staticKeyword()
   }
   
   /// The `defer` keyword
   static var `defer`: TokenSyntax {
-    SyntaxFactory.makeDeferKeyword()
+    TokenSyntax.deferKeyword()
   }
   
   /// The `if` keyword
   static var `if`: TokenSyntax {
-    SyntaxFactory.makeIfKeyword()
+    TokenSyntax.ifKeyword()
   }
   
   /// The `guard` keyword
   static var `guard`: TokenSyntax {
-    SyntaxFactory.makeGuardKeyword()
+    TokenSyntax.guardKeyword()
   }
   
   /// The `do` keyword
   static var `do`: TokenSyntax {
-    SyntaxFactory.makeDoKeyword()
+    TokenSyntax.doKeyword()
   }
   
   /// The `repeat` keyword
   static var `repeat`: TokenSyntax {
-    SyntaxFactory.makeRepeatKeyword()
+    TokenSyntax.repeatKeyword()
   }
   
   /// The `else` keyword
   static var `else`: TokenSyntax {
-    SyntaxFactory.makeElseKeyword()
+    TokenSyntax.elseKeyword()
   }
   
   /// The `for` keyword
   static var `for`: TokenSyntax {
-    SyntaxFactory.makeForKeyword()
+    TokenSyntax.forKeyword()
   }
   
   /// The `in` keyword
   static var `in`: TokenSyntax {
-    SyntaxFactory.makeInKeyword()
+    TokenSyntax.inKeyword()
   }
   
   /// The `while` keyword
   static var `while`: TokenSyntax {
-    SyntaxFactory.makeWhileKeyword()
+    TokenSyntax.whileKeyword()
   }
   
   /// The `return` keyword
   static var `return`: TokenSyntax {
-    SyntaxFactory.makeReturnKeyword()
+    TokenSyntax.returnKeyword()
   }
   
   /// The `break` keyword
   static var `break`: TokenSyntax {
-    SyntaxFactory.makeBreakKeyword()
+    TokenSyntax.breakKeyword()
   }
   
   /// The `continue` keyword
   static var `continue`: TokenSyntax {
-    SyntaxFactory.makeContinueKeyword()
+    TokenSyntax.continueKeyword()
   }
   
   /// The `fallthrough` keyword
   static var `fallthrough`: TokenSyntax {
-    SyntaxFactory.makeFallthroughKeyword()
+    TokenSyntax.fallthroughKeyword()
   }
   
   /// The `switch` keyword
   static var `switch`: TokenSyntax {
-    SyntaxFactory.makeSwitchKeyword()
+    TokenSyntax.switchKeyword()
   }
   
   /// The `case` keyword
   static var `case`: TokenSyntax {
-    SyntaxFactory.makeCaseKeyword()
+    TokenSyntax.caseKeyword()
   }
   
   /// The `default` keyword
   static var `default`: TokenSyntax {
-    SyntaxFactory.makeDefaultKeyword()
+    TokenSyntax.defaultKeyword()
   }
   
   /// The `where` keyword
   static var `where`: TokenSyntax {
-    SyntaxFactory.makeWhereKeyword()
+    TokenSyntax.whereKeyword()
   }
   
   /// The `catch` keyword
   static var `catch`: TokenSyntax {
-    SyntaxFactory.makeCatchKeyword()
+    TokenSyntax.catchKeyword()
   }
   
   /// The `throw` keyword
   static var `throw`: TokenSyntax {
-    SyntaxFactory.makeThrowKeyword()
+    TokenSyntax.throwKeyword()
   }
   
   /// The `as` keyword
   static var `as`: TokenSyntax {
-    SyntaxFactory.makeAsKeyword()
+    TokenSyntax.asKeyword()
   }
   
   /// The `Any` keyword
   static var `any`: TokenSyntax {
-    SyntaxFactory.makeAnyKeyword()
+    TokenSyntax.anyKeyword()
   }
   
   /// The `false` keyword
   static var `false`: TokenSyntax {
-    SyntaxFactory.makeFalseKeyword()
+    TokenSyntax.falseKeyword()
   }
   
   /// The `is` keyword
   static var `is`: TokenSyntax {
-    SyntaxFactory.makeIsKeyword()
+    TokenSyntax.isKeyword()
   }
   
   /// The `nil` keyword
   static var `nil`: TokenSyntax {
-    SyntaxFactory.makeNilKeyword()
+    TokenSyntax.nilKeyword()
   }
   
   /// The `rethrows` keyword
   static var `rethrows`: TokenSyntax {
-    SyntaxFactory.makeRethrowsKeyword()
+    TokenSyntax.rethrowsKeyword()
   }
   
   /// The `super` keyword
   static var `super`: TokenSyntax {
-    SyntaxFactory.makeSuperKeyword()
+    TokenSyntax.superKeyword()
   }
   
   /// The `self` keyword
   static var `self`: TokenSyntax {
-    SyntaxFactory.makeSelfKeyword()
+    TokenSyntax.selfKeyword()
   }
   
   /// The `Self` keyword
   static var `capitalSelf`: TokenSyntax {
-    SyntaxFactory.makeCapitalSelfKeyword()
+    TokenSyntax.capitalSelfKeyword()
   }
   
   /// The `true` keyword
   static var `true`: TokenSyntax {
-    SyntaxFactory.makeTrueKeyword()
+    TokenSyntax.trueKeyword()
   }
   
   /// The `try` keyword
   static var `try`: TokenSyntax {
-    SyntaxFactory.makeTryKeyword()
+    TokenSyntax.tryKeyword()
   }
   
   /// The `throws` keyword
   static var `throws`: TokenSyntax {
-    SyntaxFactory.makeThrowsKeyword()
+    TokenSyntax.throwsKeyword()
   }
   
   /// The `__FILE__` keyword
   static var `__FILE__`: TokenSyntax {
-    SyntaxFactory.make__FILE__Keyword()
+    TokenSyntax.__file__Keyword()
   }
   
   /// The `__LINE__` keyword
   static var `__LINE__`: TokenSyntax {
-    SyntaxFactory.make__LINE__Keyword()
+    TokenSyntax.__line__Keyword()
   }
   
   /// The `__COLUMN__` keyword
   static var `__COLUMN__`: TokenSyntax {
-    SyntaxFactory.make__COLUMN__Keyword()
+    TokenSyntax.__column__Keyword()
   }
   
   /// The `__FUNCTION__` keyword
   static var `__FUNCTION__`: TokenSyntax {
-    SyntaxFactory.make__FUNCTION__Keyword()
+    TokenSyntax.__function__Keyword()
   }
   
   /// The `__DSO_HANDLE__` keyword
   static var `__DSO_HANDLE__`: TokenSyntax {
-    SyntaxFactory.make__DSO_HANDLE__Keyword()
+    TokenSyntax.__dso_handle__Keyword()
   }
   
   /// The `_` keyword
   static var `wildcard`: TokenSyntax {
-    SyntaxFactory.makeWildcardKeyword()
+    TokenSyntax.wildcardKeyword()
   }
   
   /// The `(` token
   static var `leftParen`: TokenSyntax {
-    SyntaxFactory.makeLeftParenToken()
+    TokenSyntax.leftParenToken()
   }
   
   /// The `)` token
   static var `rightParen`: TokenSyntax {
-    SyntaxFactory.makeRightParenToken()
+    TokenSyntax.rightParenToken()
   }
   
   /// The `{` token
   static var `leftBrace`: TokenSyntax {
-    SyntaxFactory.makeLeftBraceToken()
+    TokenSyntax.leftBraceToken()
   }
   
   /// The `}` token
   static var `rightBrace`: TokenSyntax {
-    SyntaxFactory.makeRightBraceToken()
+    TokenSyntax.rightBraceToken()
   }
   
   /// The `[` token
   static var `leftSquareBracket`: TokenSyntax {
-    SyntaxFactory.makeLeftSquareBracketToken()
+    TokenSyntax.leftSquareBracketToken()
   }
   
   /// The `]` token
   static var `rightSquareBracket`: TokenSyntax {
-    SyntaxFactory.makeRightSquareBracketToken()
+    TokenSyntax.rightSquareBracketToken()
   }
   
   /// The `<` token
   static var `leftAngle`: TokenSyntax {
-    SyntaxFactory.makeLeftAngleToken()
+    TokenSyntax.leftAngleToken()
   }
   
   /// The `>` token
   static var `rightAngle`: TokenSyntax {
-    SyntaxFactory.makeRightAngleToken()
+    TokenSyntax.rightAngleToken()
   }
   
   /// The `.` token
   static var `period`: TokenSyntax {
-    SyntaxFactory.makePeriodToken()
+    TokenSyntax.periodToken()
   }
   
   /// The `.` token
   static var `prefixPeriod`: TokenSyntax {
-    SyntaxFactory.makePrefixPeriodToken()
+    TokenSyntax.prefixPeriodToken()
   }
   
   /// The `,` token
   static var `comma`: TokenSyntax {
-    SyntaxFactory.makeCommaToken()
+    TokenSyntax.commaToken()
   }
   
   /// The `...` token
   static var `ellipsis`: TokenSyntax {
-    SyntaxFactory.makeEllipsisToken()
+    TokenSyntax.ellipsisToken()
   }
   
   /// The `:` token
   static var `colon`: TokenSyntax {
-    SyntaxFactory.makeColonToken()
+    TokenSyntax.colonToken()
   }
   
   /// The `;` token
   static var `semicolon`: TokenSyntax {
-    SyntaxFactory.makeSemicolonToken()
+    TokenSyntax.semicolonToken()
   }
   
   /// The `=` token
   static var `equal`: TokenSyntax {
-    SyntaxFactory.makeEqualToken()
+    TokenSyntax.equalToken()
   }
   
   /// The `@` token
   static var `atSign`: TokenSyntax {
-    SyntaxFactory.makeAtSignToken()
+    TokenSyntax.atSignToken()
   }
   
   /// The `#` token
   static var `pound`: TokenSyntax {
-    SyntaxFactory.makePoundToken()
+    TokenSyntax.poundToken()
   }
   
   /// The `&` token
   static var `prefixAmpersand`: TokenSyntax {
-    SyntaxFactory.makePrefixAmpersandToken()
+    TokenSyntax.prefixAmpersandToken()
   }
   
   /// The `->` token
   static var `arrow`: TokenSyntax {
-    SyntaxFactory.makeArrowToken()
+    TokenSyntax.arrowToken()
   }
   
   /// The ``` token
   static var `backtick`: TokenSyntax {
-    SyntaxFactory.makeBacktickToken()
+    TokenSyntax.backtickToken()
   }
   
   /// The `\` token
   static var `backslash`: TokenSyntax {
-    SyntaxFactory.makeBackslashToken()
+    TokenSyntax.backslashToken()
   }
   
   /// The `!` token
   static var `exclamationMark`: TokenSyntax {
-    SyntaxFactory.makeExclamationMarkToken()
+    TokenSyntax.exclamationMarkToken()
   }
   
   /// The `?` token
   static var `postfixQuestionMark`: TokenSyntax {
-    SyntaxFactory.makePostfixQuestionMarkToken()
+    TokenSyntax.postfixQuestionMarkToken()
   }
   
   /// The `?` token
   static var `infixQuestionMark`: TokenSyntax {
-    SyntaxFactory.makeInfixQuestionMarkToken()
+    TokenSyntax.infixQuestionMarkToken()
   }
   
   /// The `"` token
   static var `stringQuote`: TokenSyntax {
-    SyntaxFactory.makeStringQuoteToken()
+    TokenSyntax.stringQuoteToken()
   }
   
   /// The `'` token
   static var `singleQuote`: TokenSyntax {
-    SyntaxFactory.makeSingleQuoteToken()
+    TokenSyntax.singleQuoteToken()
   }
   
   /// The `"""` token
   static var `multilineStringQuote`: TokenSyntax {
-    SyntaxFactory.makeMultilineStringQuoteToken()
+    TokenSyntax.multilineStringQuoteToken()
   }
   
   /// The `#keyPath` keyword
   static var `poundKeyPath`: TokenSyntax {
-    SyntaxFactory.makePoundKeyPathKeyword()
+    TokenSyntax.poundKeyPathKeyword()
   }
   
   /// The `#line` keyword
   static var `poundLine`: TokenSyntax {
-    SyntaxFactory.makePoundLineKeyword()
+    TokenSyntax.poundLineKeyword()
   }
   
   /// The `#selector` keyword
   static var `poundSelector`: TokenSyntax {
-    SyntaxFactory.makePoundSelectorKeyword()
+    TokenSyntax.poundSelectorKeyword()
   }
   
   /// The `#file` keyword
   static var `poundFile`: TokenSyntax {
-    SyntaxFactory.makePoundFileKeyword()
+    TokenSyntax.poundFileKeyword()
   }
   
   /// The `#fileID` keyword
   static var `poundFileID`: TokenSyntax {
-    SyntaxFactory.makePoundFileIDKeyword()
+    TokenSyntax.poundFileIDKeyword()
   }
   
   /// The `#filePath` keyword
   static var `poundFilePath`: TokenSyntax {
-    SyntaxFactory.makePoundFilePathKeyword()
+    TokenSyntax.poundFilePathKeyword()
   }
   
   /// The `#column` keyword
   static var `poundColumn`: TokenSyntax {
-    SyntaxFactory.makePoundColumnKeyword()
+    TokenSyntax.poundColumnKeyword()
   }
   
   /// The `#function` keyword
   static var `poundFunction`: TokenSyntax {
-    SyntaxFactory.makePoundFunctionKeyword()
+    TokenSyntax.poundFunctionKeyword()
   }
   
   /// The `#dsohandle` keyword
   static var `poundDsohandle`: TokenSyntax {
-    SyntaxFactory.makePoundDsohandleKeyword()
+    TokenSyntax.poundDsohandleKeyword()
   }
   
   /// The `#assert` keyword
   static var `poundAssert`: TokenSyntax {
-    SyntaxFactory.makePoundAssertKeyword()
+    TokenSyntax.poundAssertKeyword()
   }
   
   /// The `#sourceLocation` keyword
   static var `poundSourceLocation`: TokenSyntax {
-    SyntaxFactory.makePoundSourceLocationKeyword()
+    TokenSyntax.poundSourceLocationKeyword()
   }
   
   /// The `#warning` keyword
   static var `poundWarning`: TokenSyntax {
-    SyntaxFactory.makePoundWarningKeyword()
+    TokenSyntax.poundWarningKeyword()
   }
   
   /// The `#error` keyword
   static var `poundError`: TokenSyntax {
-    SyntaxFactory.makePoundErrorKeyword()
+    TokenSyntax.poundErrorKeyword()
   }
   
   /// The `#if` keyword
   static var `poundIf`: TokenSyntax {
-    SyntaxFactory.makePoundIfKeyword()
+    TokenSyntax.poundIfKeyword()
   }
   
   /// The `#else` keyword
   static var `poundElse`: TokenSyntax {
-    SyntaxFactory.makePoundElseKeyword()
+    TokenSyntax.poundElseKeyword()
   }
   
   /// The `#elseif` keyword
   static var `poundElseif`: TokenSyntax {
-    SyntaxFactory.makePoundElseifKeyword()
+    TokenSyntax.poundElseifKeyword()
   }
   
   /// The `#endif` keyword
   static var `poundEndif`: TokenSyntax {
-    SyntaxFactory.makePoundEndifKeyword()
+    TokenSyntax.poundEndifKeyword()
   }
   
   /// The `#available` keyword
   static var `poundAvailable`: TokenSyntax {
-    SyntaxFactory.makePoundAvailableKeyword()
+    TokenSyntax.poundAvailableKeyword()
   }
   
   /// The `#unavailable` keyword
   static var `poundUnavailable`: TokenSyntax {
-    SyntaxFactory.makePoundUnavailableKeyword()
+    TokenSyntax.poundUnavailableKeyword()
   }
   
   /// The `#fileLiteral` keyword
   static var `poundFileLiteral`: TokenSyntax {
-    SyntaxFactory.makePoundFileLiteralKeyword()
+    TokenSyntax.poundFileLiteralKeyword()
   }
   
   /// The `#imageLiteral` keyword
   static var `poundImageLiteral`: TokenSyntax {
-    SyntaxFactory.makePoundImageLiteralKeyword()
+    TokenSyntax.poundImageLiteralKeyword()
   }
   
   /// The `#colorLiteral` keyword
   static var `poundColorLiteral`: TokenSyntax {
-    SyntaxFactory.makePoundColorLiteralKeyword()
-  }
-  static func `integerLiteral`(_ text: String) -> TokenSyntax {
-    SyntaxFactory.makeIntegerLiteral(text)
-  }
-  static func `floatingLiteral`(_ text: String) -> TokenSyntax {
-    SyntaxFactory.makeFloatingLiteral(text)
-  }
-  static func `stringLiteral`(_ text: String) -> TokenSyntax {
-    SyntaxFactory.makeStringLiteral(text)
-  }
-  static func `regexLiteral`(_ text: String) -> TokenSyntax {
-    SyntaxFactory.makeRegexLiteral(text)
-  }
-  static func `unknown`(_ text: String) -> TokenSyntax {
-    SyntaxFactory.makeUnknown(text)
-  }
-  static func `identifier`(_ text: String) -> TokenSyntax {
-    SyntaxFactory.makeIdentifier(text)
-  }
-  static func `unspacedBinaryOperator`(_ text: String) -> TokenSyntax {
-    SyntaxFactory.makeUnspacedBinaryOperator(text)
-  }
-  static func `spacedBinaryOperator`(_ text: String) -> TokenSyntax {
-    SyntaxFactory.makeSpacedBinaryOperator(text)
-  }
-  static func `postfixOperator`(_ text: String) -> TokenSyntax {
-    SyntaxFactory.makePostfixOperator(text)
-  }
-  static func `prefixOperator`(_ text: String) -> TokenSyntax {
-    SyntaxFactory.makePrefixOperator(text)
-  }
-  static func `dollarIdentifier`(_ text: String) -> TokenSyntax {
-    SyntaxFactory.makeDollarIdentifier(text)
-  }
-  static func `contextualKeyword`(_ text: String) -> TokenSyntax {
-    SyntaxFactory.makeContextualKeyword(text)
-  }
-  static func `rawStringDelimiter`(_ text: String) -> TokenSyntax {
-    SyntaxFactory.makeRawStringDelimiter(text)
-  }
-  static func `stringSegment`(_ text: String) -> TokenSyntax {
-    SyntaxFactory.makeStringSegment(text)
+    TokenSyntax.poundColorLiteralKeyword()
   }
   
   /// The `)` token
   static var `stringInterpolationAnchor`: TokenSyntax {
-    SyntaxFactory.makeStringInterpolationAnchorToken()
+    TokenSyntax.stringInterpolationAnchorToken()
   }
   
   /// The `yield` token
   static var `yield`: TokenSyntax {
-    SyntaxFactory.makeYieldToken()
+    TokenSyntax.yieldToken()
   }
   
   /// The `eof` token
   static var eof: TokenSyntax {
-    SyntaxFactory.makeToken(.eof, presence: .present)
+    TokenSyntax.eof()
   }
   
   /// The `open` contextual token
   static var open: TokenSyntax {
-    SyntaxFactory.makeContextualKeyword("open")
+    TokenSyntax.contextualKeyword("open")
     .withTrailingTrivia(.space)
   }
 }

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/BuildableNodes.swift
@@ -60,7 +60,7 @@ public struct CodeBlockItem: SyntaxBuildable, ExpressibleAsCodeBlockItem {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `CodeBlockItemSyntax`.
   func buildCodeBlockItem(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CodeBlockItemSyntax {
-    let result = SyntaxFactory.makeCodeBlockItem(
+    let result = CodeBlockItemSyntax(
       garbageBeforeItem?.buildGarbageNodes(format: format, leadingTrivia: nil),
       item: item.buildSyntax(format: format, leadingTrivia: nil),
       garbageBetweenItemAndSemicolon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -159,7 +159,7 @@ public struct CodeBlock: SyntaxBuildable, ExpressibleAsCodeBlock {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `CodeBlockSyntax`.
   func buildCodeBlock(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CodeBlockSyntax {
-    let result = SyntaxFactory.makeCodeBlock(
+    let result = CodeBlockSyntax(
       garbageBeforeLeftBrace?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftBrace: leftBrace,
       garbageBetweenLeftBraceAndStatements?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -227,7 +227,7 @@ public struct InOutExpr: ExprBuildable, ExpressibleAsInOutExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `InOutExprSyntax`.
   func buildInOutExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> InOutExprSyntax {
-    let result = SyntaxFactory.makeInOutExpr(
+    let result = InOutExprSyntax(
       garbageBeforeAmpersand?.buildGarbageNodes(format: format, leadingTrivia: nil),
       ampersand: ampersand,
       garbageBetweenAmpersandAndExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -291,7 +291,7 @@ public struct PoundColumnExpr: ExprBuildable, ExpressibleAsPoundColumnExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PoundColumnExprSyntax`.
   func buildPoundColumnExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundColumnExprSyntax {
-    let result = SyntaxFactory.makePoundColumnExpr(
+    let result = PoundColumnExprSyntax(
       garbageBeforePoundColumn?.buildGarbageNodes(format: format, leadingTrivia: nil),
       poundColumn: poundColumn
     )
@@ -370,7 +370,7 @@ public struct TryExpr: ExprBuildable, ExpressibleAsTryExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `TryExprSyntax`.
   func buildTryExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TryExprSyntax {
-    let result = SyntaxFactory.makeTryExpr(
+    let result = TryExprSyntax(
       garbageBeforeTryKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       tryKeyword: tryKeyword,
       garbageBetweenTryKeywordAndQuestionOrExclamationMark?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -462,7 +462,7 @@ public struct AwaitExpr: ExprBuildable, ExpressibleAsAwaitExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AwaitExprSyntax`.
   func buildAwaitExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AwaitExprSyntax {
-    let result = SyntaxFactory.makeAwaitExpr(
+    let result = AwaitExprSyntax(
       garbageBeforeAwaitKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       awaitKeyword: awaitKeyword,
       garbageBetweenAwaitKeywordAndExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -552,7 +552,7 @@ public struct MoveExpr: ExprBuildable, ExpressibleAsMoveExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `MoveExprSyntax`.
   func buildMoveExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MoveExprSyntax {
-    let result = SyntaxFactory.makeMoveExpr(
+    let result = MoveExprSyntax(
       garbageBeforeMoveKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       moveKeyword: moveKeyword,
       garbageBetweenMoveKeywordAndExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -624,7 +624,7 @@ public struct DeclNameArgument: SyntaxBuildable, ExpressibleAsDeclNameArgument {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DeclNameArgumentSyntax`.
   func buildDeclNameArgument(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclNameArgumentSyntax {
-    let result = SyntaxFactory.makeDeclNameArgument(
+    let result = DeclNameArgumentSyntax(
       garbageBeforeName?.buildGarbageNodes(format: format, leadingTrivia: nil),
       name: name,
       garbageBetweenNameAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -699,7 +699,7 @@ public struct DeclNameArguments: SyntaxBuildable, ExpressibleAsDeclNameArguments
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DeclNameArgumentsSyntax`.
   func buildDeclNameArguments(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclNameArgumentsSyntax {
-    let result = SyntaxFactory.makeDeclNameArguments(
+    let result = DeclNameArgumentsSyntax(
       garbageBeforeLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftParen: leftParen,
       garbageBetweenLeftParenAndArguments?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -766,7 +766,7 @@ public struct IdentifierExpr: ExprBuildable, ExpressibleAsIdentifierExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `IdentifierExprSyntax`.
   func buildIdentifierExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IdentifierExprSyntax {
-    let result = SyntaxFactory.makeIdentifierExpr(
+    let result = IdentifierExprSyntax(
       garbageBeforeIdentifier?.buildGarbageNodes(format: format, leadingTrivia: nil),
       identifier: identifier,
       garbageBetweenIdentifierAndDeclNameArguments?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -830,7 +830,7 @@ public struct SuperRefExpr: ExprBuildable, ExpressibleAsSuperRefExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `SuperRefExprSyntax`.
   func buildSuperRefExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SuperRefExprSyntax {
-    let result = SyntaxFactory.makeSuperRefExpr(
+    let result = SuperRefExprSyntax(
       garbageBeforeSuperKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       superKeyword: superKeyword
     )
@@ -892,7 +892,7 @@ public struct NilLiteralExpr: ExprBuildable, ExpressibleAsNilLiteralExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `NilLiteralExprSyntax`.
   func buildNilLiteralExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> NilLiteralExprSyntax {
-    let result = SyntaxFactory.makeNilLiteralExpr(
+    let result = NilLiteralExprSyntax(
       garbageBeforeNilKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       nilKeyword: nilKeyword
     )
@@ -954,7 +954,7 @@ public struct DiscardAssignmentExpr: ExprBuildable, ExpressibleAsDiscardAssignme
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DiscardAssignmentExprSyntax`.
   func buildDiscardAssignmentExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DiscardAssignmentExprSyntax {
-    let result = SyntaxFactory.makeDiscardAssignmentExpr(
+    let result = DiscardAssignmentExprSyntax(
       garbageBeforeWildcard?.buildGarbageNodes(format: format, leadingTrivia: nil),
       wildcard: wildcard
     )
@@ -1016,7 +1016,7 @@ public struct AssignmentExpr: ExprBuildable, ExpressibleAsAssignmentExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AssignmentExprSyntax`.
   func buildAssignmentExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AssignmentExprSyntax {
-    let result = SyntaxFactory.makeAssignmentExpr(
+    let result = AssignmentExprSyntax(
       garbageBeforeAssignToken?.buildGarbageNodes(format: format, leadingTrivia: nil),
       assignToken: assignToken
     )
@@ -1091,7 +1091,7 @@ public struct SequenceExpr: ExprBuildable, ExpressibleAsSequenceExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `SequenceExprSyntax`.
   func buildSequenceExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SequenceExprSyntax {
-    let result = SyntaxFactory.makeSequenceExpr(
+    let result = SequenceExprSyntax(
       garbageBeforeElements?.buildGarbageNodes(format: format, leadingTrivia: nil),
       elements: elements.buildExprList(format: format, leadingTrivia: nil)
     )
@@ -1153,7 +1153,7 @@ public struct PoundLineExpr: ExprBuildable, ExpressibleAsPoundLineExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PoundLineExprSyntax`.
   func buildPoundLineExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundLineExprSyntax {
-    let result = SyntaxFactory.makePoundLineExpr(
+    let result = PoundLineExprSyntax(
       garbageBeforePoundLine?.buildGarbageNodes(format: format, leadingTrivia: nil),
       poundLine: poundLine
     )
@@ -1215,7 +1215,7 @@ public struct PoundFileExpr: ExprBuildable, ExpressibleAsPoundFileExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PoundFileExprSyntax`.
   func buildPoundFileExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundFileExprSyntax {
-    let result = SyntaxFactory.makePoundFileExpr(
+    let result = PoundFileExprSyntax(
       garbageBeforePoundFile?.buildGarbageNodes(format: format, leadingTrivia: nil),
       poundFile: poundFile
     )
@@ -1277,7 +1277,7 @@ public struct PoundFileIDExpr: ExprBuildable, ExpressibleAsPoundFileIDExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PoundFileIDExprSyntax`.
   func buildPoundFileIDExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundFileIDExprSyntax {
-    let result = SyntaxFactory.makePoundFileIDExpr(
+    let result = PoundFileIDExprSyntax(
       garbageBeforePoundFileID?.buildGarbageNodes(format: format, leadingTrivia: nil),
       poundFileID: poundFileID
     )
@@ -1339,7 +1339,7 @@ public struct PoundFilePathExpr: ExprBuildable, ExpressibleAsPoundFilePathExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PoundFilePathExprSyntax`.
   func buildPoundFilePathExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundFilePathExprSyntax {
-    let result = SyntaxFactory.makePoundFilePathExpr(
+    let result = PoundFilePathExprSyntax(
       garbageBeforePoundFilePath?.buildGarbageNodes(format: format, leadingTrivia: nil),
       poundFilePath: poundFilePath
     )
@@ -1401,7 +1401,7 @@ public struct PoundFunctionExpr: ExprBuildable, ExpressibleAsPoundFunctionExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PoundFunctionExprSyntax`.
   func buildPoundFunctionExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundFunctionExprSyntax {
-    let result = SyntaxFactory.makePoundFunctionExpr(
+    let result = PoundFunctionExprSyntax(
       garbageBeforePoundFunction?.buildGarbageNodes(format: format, leadingTrivia: nil),
       poundFunction: poundFunction
     )
@@ -1463,7 +1463,7 @@ public struct PoundDsohandleExpr: ExprBuildable, ExpressibleAsPoundDsohandleExpr
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PoundDsohandleExprSyntax`.
   func buildPoundDsohandleExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundDsohandleExprSyntax {
-    let result = SyntaxFactory.makePoundDsohandleExpr(
+    let result = PoundDsohandleExprSyntax(
       garbageBeforePoundDsohandle?.buildGarbageNodes(format: format, leadingTrivia: nil),
       poundDsohandle: poundDsohandle
     )
@@ -1550,7 +1550,7 @@ public struct SymbolicReferenceExpr: ExprBuildable, ExpressibleAsSymbolicReferen
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `SymbolicReferenceExprSyntax`.
   func buildSymbolicReferenceExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SymbolicReferenceExprSyntax {
-    let result = SyntaxFactory.makeSymbolicReferenceExpr(
+    let result = SymbolicReferenceExprSyntax(
       garbageBeforeIdentifier?.buildGarbageNodes(format: format, leadingTrivia: nil),
       identifier: identifier,
       garbageBetweenIdentifierAndGenericArgumentClause?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -1628,7 +1628,7 @@ public struct PrefixOperatorExpr: ExprBuildable, ExpressibleAsPrefixOperatorExpr
     self.init(
       leadingTrivia: leadingTrivia,
       garbageBeforeOperatorToken: garbageBeforeOperatorToken,
-      operatorToken: operatorToken.map(TokenSyntax.prefixOperator),
+      operatorToken: operatorToken.map { TokenSyntax.prefixOperator($0) },
       garbageBetweenOperatorTokenAndPostfixExpression: garbageBetweenOperatorTokenAndPostfixExpression,
       postfixExpression: postfixExpression
     )
@@ -1639,7 +1639,7 @@ public struct PrefixOperatorExpr: ExprBuildable, ExpressibleAsPrefixOperatorExpr
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PrefixOperatorExprSyntax`.
   func buildPrefixOperatorExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrefixOperatorExprSyntax {
-    let result = SyntaxFactory.makePrefixOperatorExpr(
+    let result = PrefixOperatorExprSyntax(
       garbageBeforeOperatorToken?.buildGarbageNodes(format: format, leadingTrivia: nil),
       operatorToken: operatorToken,
       garbageBetweenOperatorTokenAndPostfixExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -1702,7 +1702,7 @@ public struct BinaryOperatorExpr: ExprBuildable, ExpressibleAsBinaryOperatorExpr
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `BinaryOperatorExprSyntax`.
   func buildBinaryOperatorExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> BinaryOperatorExprSyntax {
-    let result = SyntaxFactory.makeBinaryOperatorExpr(
+    let result = BinaryOperatorExprSyntax(
       garbageBeforeOperatorToken?.buildGarbageNodes(format: format, leadingTrivia: nil),
       operatorToken: operatorToken
     )
@@ -1791,7 +1791,7 @@ public struct ArrowExpr: ExprBuildable, ExpressibleAsArrowExpr {
     self.init(
       leadingTrivia: leadingTrivia,
       garbageBeforeAsyncKeyword: garbageBeforeAsyncKeyword,
-      asyncKeyword: asyncKeyword.map(TokenSyntax.contextualKeyword),
+      asyncKeyword: asyncKeyword.map { TokenSyntax.contextualKeyword($0) },
       garbageBetweenAsyncKeywordAndThrowsToken: garbageBetweenAsyncKeywordAndThrowsToken,
       throwsToken: throwsToken,
       garbageBetweenThrowsTokenAndArrowToken: garbageBetweenThrowsTokenAndArrowToken,
@@ -1804,7 +1804,7 @@ public struct ArrowExpr: ExprBuildable, ExpressibleAsArrowExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ArrowExprSyntax`.
   func buildArrowExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ArrowExprSyntax {
-    let result = SyntaxFactory.makeArrowExpr(
+    let result = ArrowExprSyntax(
       garbageBeforeAsyncKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       asyncKeyword: asyncKeyword,
       garbageBetweenAsyncKeywordAndThrowsToken?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -1885,7 +1885,7 @@ public struct InfixOperatorExpr: ExprBuildable, ExpressibleAsInfixOperatorExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `InfixOperatorExprSyntax`.
   func buildInfixOperatorExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> InfixOperatorExprSyntax {
-    let result = SyntaxFactory.makeInfixOperatorExpr(
+    let result = InfixOperatorExprSyntax(
       garbageBeforeLeftOperand?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftOperand: leftOperand.buildExpr(format: format, leadingTrivia: nil),
       garbageBetweenLeftOperandAndOperatorOperand?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -1964,7 +1964,7 @@ public struct FloatLiteralExpr: ExprBuildable, ExpressibleAsFloatLiteralExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `FloatLiteralExprSyntax`.
   func buildFloatLiteralExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FloatLiteralExprSyntax {
-    let result = SyntaxFactory.makeFloatLiteralExpr(
+    let result = FloatLiteralExprSyntax(
       garbageBeforeFloatingDigits?.buildGarbageNodes(format: format, leadingTrivia: nil),
       floatingDigits: floatingDigits
     )
@@ -2065,7 +2065,7 @@ public struct TupleExpr: ExprBuildable, ExpressibleAsTupleExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `TupleExprSyntax`.
   func buildTupleExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TupleExprSyntax {
-    let result = SyntaxFactory.makeTupleExpr(
+    let result = TupleExprSyntax(
       garbageBeforeLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftParen: leftParen,
       garbageBetweenLeftParenAndElementList?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -2170,7 +2170,7 @@ public struct ArrayExpr: ExprBuildable, ExpressibleAsArrayExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ArrayExprSyntax`.
   func buildArrayExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ArrayExprSyntax {
-    let result = SyntaxFactory.makeArrayExpr(
+    let result = ArrayExprSyntax(
       garbageBeforeLeftSquare?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftSquare: leftSquare,
       garbageBetweenLeftSquareAndElements?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -2253,7 +2253,7 @@ public struct DictionaryExpr: ExprBuildable, ExpressibleAsDictionaryExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DictionaryExprSyntax`.
   func buildDictionaryExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DictionaryExprSyntax {
-    let result = SyntaxFactory.makeDictionaryExpr(
+    let result = DictionaryExprSyntax(
       garbageBeforeLeftSquare?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftSquare: leftSquare,
       garbageBetweenLeftSquareAndContent?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -2344,7 +2344,7 @@ public struct TupleExprElement: SyntaxBuildable, ExpressibleAsTupleExprElement, 
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `TupleExprElementSyntax`.
   func buildTupleExprElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TupleExprElementSyntax {
-    let result = SyntaxFactory.makeTupleExprElement(
+    let result = TupleExprElementSyntax(
       garbageBeforeLabel?.buildGarbageNodes(format: format, leadingTrivia: nil),
       label: label,
       garbageBetweenLabelAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -2428,7 +2428,7 @@ public struct ArrayElement: SyntaxBuildable, ExpressibleAsArrayElement, HasTrail
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ArrayElementSyntax`.
   func buildArrayElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ArrayElementSyntax {
-    let result = SyntaxFactory.makeArrayElement(
+    let result = ArrayElementSyntax(
       garbageBeforeExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
       expression: expression.buildExpr(format: format, leadingTrivia: nil),
       garbageBetweenExpressionAndTrailingComma?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -2521,7 +2521,7 @@ public struct DictionaryElement: SyntaxBuildable, ExpressibleAsDictionaryElement
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DictionaryElementSyntax`.
   func buildDictionaryElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DictionaryElementSyntax {
-    let result = SyntaxFactory.makeDictionaryElement(
+    let result = DictionaryElementSyntax(
       garbageBeforeKeyExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
       keyExpression: keyExpression.buildExpr(format: format, leadingTrivia: nil),
       garbageBetweenKeyExpressionAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -2610,7 +2610,7 @@ public struct IntegerLiteralExpr: ExprBuildable, ExpressibleAsIntegerLiteralExpr
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `IntegerLiteralExprSyntax`.
   func buildIntegerLiteralExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IntegerLiteralExprSyntax {
-    let result = SyntaxFactory.makeIntegerLiteralExpr(
+    let result = IntegerLiteralExprSyntax(
       garbageBeforeDigits?.buildGarbageNodes(format: format, leadingTrivia: nil),
       digits: digits
     )
@@ -2672,7 +2672,7 @@ public struct BooleanLiteralExpr: ExprBuildable, ExpressibleAsBooleanLiteralExpr
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `BooleanLiteralExprSyntax`.
   func buildBooleanLiteralExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> BooleanLiteralExprSyntax {
-    let result = SyntaxFactory.makeBooleanLiteralExpr(
+    let result = BooleanLiteralExprSyntax(
       garbageBeforeBooleanLiteral?.buildGarbageNodes(format: format, leadingTrivia: nil),
       booleanLiteral: booleanLiteral
     )
@@ -2767,7 +2767,7 @@ public struct TernaryExpr: ExprBuildable, ExpressibleAsTernaryExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `TernaryExprSyntax`.
   func buildTernaryExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TernaryExprSyntax {
-    let result = SyntaxFactory.makeTernaryExpr(
+    let result = TernaryExprSyntax(
       garbageBeforeConditionExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
       conditionExpression: conditionExpression.buildExpr(format: format, leadingTrivia: nil),
       garbageBetweenConditionExpressionAndQuestionMark?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -2861,7 +2861,7 @@ public struct MemberAccessExpr: ExprBuildable, ExpressibleAsMemberAccessExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `MemberAccessExprSyntax`.
   func buildMemberAccessExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MemberAccessExprSyntax {
-    let result = SyntaxFactory.makeMemberAccessExpr(
+    let result = MemberAccessExprSyntax(
       garbageBeforeBase?.buildGarbageNodes(format: format, leadingTrivia: nil),
       base: base?.buildExpr(format: format, leadingTrivia: nil),
       garbageBetweenBaseAndDot?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -2937,7 +2937,7 @@ public struct IsExpr: ExprBuildable, ExpressibleAsIsExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `IsExprSyntax`.
   func buildIsExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IsExprSyntax {
-    let result = SyntaxFactory.makeIsExpr(
+    let result = IsExprSyntax(
       garbageBeforeIsTok?.buildGarbageNodes(format: format, leadingTrivia: nil),
       isTok: isTok,
       garbageBetweenIsTokAndTypeName?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -3018,7 +3018,7 @@ public struct AsExpr: ExprBuildable, ExpressibleAsAsExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AsExprSyntax`.
   func buildAsExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AsExprSyntax {
-    let result = SyntaxFactory.makeAsExpr(
+    let result = AsExprSyntax(
       garbageBeforeAsTok?.buildGarbageNodes(format: format, leadingTrivia: nil),
       asTok: asTok,
       garbageBetweenAsTokAndQuestionOrExclamationMark?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -3083,7 +3083,7 @@ public struct TypeExpr: ExprBuildable, ExpressibleAsTypeExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `TypeExprSyntax`.
   func buildTypeExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeExprSyntax {
-    let result = SyntaxFactory.makeTypeExpr(
+    let result = TypeExprSyntax(
       garbageBeforeType?.buildGarbageNodes(format: format, leadingTrivia: nil),
       type: type.buildType(format: format, leadingTrivia: nil)
     )
@@ -3193,7 +3193,7 @@ public struct ClosureCaptureItem: SyntaxBuildable, ExpressibleAsClosureCaptureIt
       garbageBeforeSpecifier: garbageBeforeSpecifier,
       specifier: specifier,
       garbageBetweenSpecifierAndName: garbageBetweenSpecifierAndName,
-      name: name.map(TokenSyntax.identifier),
+      name: name.map { TokenSyntax.identifier($0) },
       garbageBetweenNameAndAssignToken: garbageBetweenNameAndAssignToken,
       assignToken: assignToken,
       garbageBetweenAssignTokenAndExpression: garbageBetweenAssignTokenAndExpression,
@@ -3208,7 +3208,7 @@ public struct ClosureCaptureItem: SyntaxBuildable, ExpressibleAsClosureCaptureIt
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ClosureCaptureItemSyntax`.
   func buildClosureCaptureItem(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ClosureCaptureItemSyntax {
-    let result = SyntaxFactory.makeClosureCaptureItem(
+    let result = ClosureCaptureItemSyntax(
       garbageBeforeSpecifier?.buildGarbageNodes(format: format, leadingTrivia: nil),
       specifier: specifier?.buildTokenList(format: format, leadingTrivia: nil),
       garbageBetweenSpecifierAndName?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -3327,7 +3327,7 @@ public struct ClosureCaptureSignature: SyntaxBuildable, ExpressibleAsClosureCapt
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ClosureCaptureSignatureSyntax`.
   func buildClosureCaptureSignature(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ClosureCaptureSignatureSyntax {
-    let result = SyntaxFactory.makeClosureCaptureSignature(
+    let result = ClosureCaptureSignatureSyntax(
       garbageBeforeLeftSquare?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftSquare: leftSquare,
       garbageBetweenLeftSquareAndItems?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -3395,7 +3395,7 @@ public struct ClosureParam: SyntaxBuildable, ExpressibleAsClosureParam, HasTrail
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ClosureParamSyntax`.
   func buildClosureParam(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ClosureParamSyntax {
-    let result = SyntaxFactory.makeClosureParam(
+    let result = ClosureParamSyntax(
       garbageBeforeName?.buildGarbageNodes(format: format, leadingTrivia: nil),
       name: name,
       garbageBetweenNameAndTrailingComma?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -3536,7 +3536,7 @@ public struct ClosureSignature: SyntaxBuildable, ExpressibleAsClosureSignature {
       garbageBetweenCaptureAndInput: garbageBetweenCaptureAndInput,
       input: input,
       garbageBetweenInputAndAsyncKeyword: garbageBetweenInputAndAsyncKeyword,
-      asyncKeyword: asyncKeyword.map(TokenSyntax.contextualKeyword),
+      asyncKeyword: asyncKeyword.map { TokenSyntax.contextualKeyword($0) },
       garbageBetweenAsyncKeywordAndThrowsTok: garbageBetweenAsyncKeywordAndThrowsTok,
       throwsTok: throwsTok,
       garbageBetweenThrowsTokAndOutput: garbageBetweenThrowsTokAndOutput,
@@ -3551,7 +3551,7 @@ public struct ClosureSignature: SyntaxBuildable, ExpressibleAsClosureSignature {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ClosureSignatureSyntax`.
   func buildClosureSignature(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ClosureSignatureSyntax {
-    let result = SyntaxFactory.makeClosureSignature(
+    let result = ClosureSignatureSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndCapture?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -3670,7 +3670,7 @@ public struct ClosureExpr: ExprBuildable, ExpressibleAsClosureExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ClosureExprSyntax`.
   func buildClosureExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ClosureExprSyntax {
-    let result = SyntaxFactory.makeClosureExpr(
+    let result = ClosureExprSyntax(
       garbageBeforeLeftBrace?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftBrace: leftBrace,
       garbageBetweenLeftBraceAndSignature?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -3737,7 +3737,7 @@ public struct UnresolvedPatternExpr: ExprBuildable, ExpressibleAsUnresolvedPatte
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `UnresolvedPatternExprSyntax`.
   func buildUnresolvedPatternExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> UnresolvedPatternExprSyntax {
-    let result = SyntaxFactory.makeUnresolvedPatternExpr(
+    let result = UnresolvedPatternExprSyntax(
       garbageBeforePattern?.buildGarbageNodes(format: format, leadingTrivia: nil),
       pattern: pattern.buildPattern(format: format, leadingTrivia: nil)
     )
@@ -3815,7 +3815,7 @@ public struct MultipleTrailingClosureElement: SyntaxBuildable, ExpressibleAsMult
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `MultipleTrailingClosureElementSyntax`.
   func buildMultipleTrailingClosureElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MultipleTrailingClosureElementSyntax {
-    let result = SyntaxFactory.makeMultipleTrailingClosureElement(
+    let result = MultipleTrailingClosureElementSyntax(
       garbageBeforeLabel?.buildGarbageNodes(format: format, leadingTrivia: nil),
       label: label,
       garbageBetweenLabelAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -3950,7 +3950,7 @@ public struct FunctionCallExpr: ExprBuildable, ExpressibleAsFunctionCallExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `FunctionCallExprSyntax`.
   func buildFunctionCallExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FunctionCallExprSyntax {
-    let result = SyntaxFactory.makeFunctionCallExpr(
+    let result = FunctionCallExprSyntax(
       garbageBeforeCalledExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
       calledExpression: calledExpression.buildExpr(format: format, leadingTrivia: nil),
       garbageBetweenCalledExpressionAndLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -4097,7 +4097,7 @@ public struct SubscriptExpr: ExprBuildable, ExpressibleAsSubscriptExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `SubscriptExprSyntax`.
   func buildSubscriptExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SubscriptExprSyntax {
-    let result = SyntaxFactory.makeSubscriptExpr(
+    let result = SubscriptExprSyntax(
       garbageBeforeCalledExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
       calledExpression: calledExpression.buildExpr(format: format, leadingTrivia: nil),
       garbageBetweenCalledExpressionAndLeftBracket?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -4177,7 +4177,7 @@ public struct OptionalChainingExpr: ExprBuildable, ExpressibleAsOptionalChaining
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `OptionalChainingExprSyntax`.
   func buildOptionalChainingExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> OptionalChainingExprSyntax {
-    let result = SyntaxFactory.makeOptionalChainingExpr(
+    let result = OptionalChainingExprSyntax(
       garbageBeforeExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
       expression: expression.buildExpr(format: format, leadingTrivia: nil),
       garbageBetweenExpressionAndQuestionMark?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -4249,7 +4249,7 @@ public struct ForcedValueExpr: ExprBuildable, ExpressibleAsForcedValueExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ForcedValueExprSyntax`.
   func buildForcedValueExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ForcedValueExprSyntax {
-    let result = SyntaxFactory.makeForcedValueExpr(
+    let result = ForcedValueExprSyntax(
       garbageBeforeExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
       expression: expression.buildExpr(format: format, leadingTrivia: nil),
       garbageBetweenExpressionAndExclamationMark?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -4338,7 +4338,7 @@ public struct PostfixUnaryExpr: ExprBuildable, ExpressibleAsPostfixUnaryExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PostfixUnaryExprSyntax`.
   func buildPostfixUnaryExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PostfixUnaryExprSyntax {
-    let result = SyntaxFactory.makePostfixUnaryExpr(
+    let result = PostfixUnaryExprSyntax(
       garbageBeforeExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
       expression: expression.buildExpr(format: format, leadingTrivia: nil),
       garbageBetweenExpressionAndOperatorToken?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -4409,7 +4409,7 @@ public struct SpecializeExpr: ExprBuildable, ExpressibleAsSpecializeExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `SpecializeExprSyntax`.
   func buildSpecializeExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SpecializeExprSyntax {
-    let result = SyntaxFactory.makeSpecializeExpr(
+    let result = SpecializeExprSyntax(
       garbageBeforeExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
       expression: expression.buildExpr(format: format, leadingTrivia: nil),
       garbageBetweenExpressionAndGenericArgumentClause?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -4486,7 +4486,7 @@ public struct StringSegment: SyntaxBuildable, ExpressibleAsStringSegment {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `StringSegmentSyntax`.
   func buildStringSegment(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StringSegmentSyntax {
-    let result = SyntaxFactory.makeStringSegment(
+    let result = StringSegmentSyntax(
       garbageBeforeContent?.buildGarbageNodes(format: format, leadingTrivia: nil),
       content: content
     )
@@ -4591,7 +4591,7 @@ public struct ExpressionSegment: SyntaxBuildable, ExpressibleAsExpressionSegment
       garbageBeforeBackslash: garbageBeforeBackslash,
       backslash: backslash,
       garbageBetweenBackslashAndDelimiter: garbageBetweenBackslashAndDelimiter,
-      delimiter: delimiter.map(TokenSyntax.rawStringDelimiter),
+      delimiter: delimiter.map { TokenSyntax.rawStringDelimiter($0) },
       garbageBetweenDelimiterAndLeftParen: garbageBetweenDelimiterAndLeftParen,
       leftParen: leftParen,
       garbageBetweenLeftParenAndExpressions: garbageBetweenLeftParenAndExpressions,
@@ -4606,7 +4606,7 @@ public struct ExpressionSegment: SyntaxBuildable, ExpressibleAsExpressionSegment
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ExpressionSegmentSyntax`.
   func buildExpressionSegment(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExpressionSegmentSyntax {
-    let result = SyntaxFactory.makeExpressionSegment(
+    let result = ExpressionSegmentSyntax(
       garbageBeforeBackslash?.buildGarbageNodes(format: format, leadingTrivia: nil),
       backslash: backslash,
       garbageBetweenBackslashAndDelimiter?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -4716,7 +4716,7 @@ public struct StringLiteralExpr: ExprBuildable, ExpressibleAsStringLiteralExpr {
     self.init(
       leadingTrivia: leadingTrivia,
       garbageBeforeOpenDelimiter: garbageBeforeOpenDelimiter,
-      openDelimiter: openDelimiter.map(TokenSyntax.rawStringDelimiter),
+      openDelimiter: openDelimiter.map { TokenSyntax.rawStringDelimiter($0) },
       garbageBetweenOpenDelimiterAndOpenQuote: garbageBetweenOpenDelimiterAndOpenQuote,
       openQuote: openQuote,
       garbageBetweenOpenQuoteAndSegments: garbageBetweenOpenQuoteAndSegments,
@@ -4724,7 +4724,7 @@ public struct StringLiteralExpr: ExprBuildable, ExpressibleAsStringLiteralExpr {
       garbageBetweenSegmentsAndCloseQuote: garbageBetweenSegmentsAndCloseQuote,
       closeQuote: closeQuote,
       garbageBetweenCloseQuoteAndCloseDelimiter: garbageBetweenCloseQuoteAndCloseDelimiter,
-      closeDelimiter: closeDelimiter.map(TokenSyntax.rawStringDelimiter)
+      closeDelimiter: closeDelimiter.map { TokenSyntax.rawStringDelimiter($0) }
     )
   }
 
@@ -4733,7 +4733,7 @@ public struct StringLiteralExpr: ExprBuildable, ExpressibleAsStringLiteralExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `StringLiteralExprSyntax`.
   func buildStringLiteralExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StringLiteralExprSyntax {
-    let result = SyntaxFactory.makeStringLiteralExpr(
+    let result = StringLiteralExprSyntax(
       garbageBeforeOpenDelimiter?.buildGarbageNodes(format: format, leadingTrivia: nil),
       openDelimiter: openDelimiter,
       garbageBetweenOpenDelimiterAndOpenQuote?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -4816,7 +4816,7 @@ public struct RegexLiteralExpr: ExprBuildable, ExpressibleAsRegexLiteralExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `RegexLiteralExprSyntax`.
   func buildRegexLiteralExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> RegexLiteralExprSyntax {
-    let result = SyntaxFactory.makeRegexLiteralExpr(
+    let result = RegexLiteralExprSyntax(
       garbageBeforeRegex?.buildGarbageNodes(format: format, leadingTrivia: nil),
       regex: regex
     )
@@ -4894,7 +4894,7 @@ public struct KeyPathExpr: ExprBuildable, ExpressibleAsKeyPathExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `KeyPathExprSyntax`.
   func buildKeyPathExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> KeyPathExprSyntax {
-    let result = SyntaxFactory.makeKeyPathExpr(
+    let result = KeyPathExprSyntax(
       garbageBeforeBackslash?.buildGarbageNodes(format: format, leadingTrivia: nil),
       backslash: backslash,
       garbageBetweenBackslashAndRootExpr?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -4960,7 +4960,7 @@ public struct KeyPathBaseExpr: ExprBuildable, ExpressibleAsKeyPathBaseExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `KeyPathBaseExprSyntax`.
   func buildKeyPathBaseExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> KeyPathBaseExprSyntax {
-    let result = SyntaxFactory.makeKeyPathBaseExpr(
+    let result = KeyPathBaseExprSyntax(
       garbageBeforePeriod?.buildGarbageNodes(format: format, leadingTrivia: nil),
       period: period
     )
@@ -5048,7 +5048,7 @@ public struct ObjcNamePiece: SyntaxBuildable, ExpressibleAsObjcNamePiece {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ObjcNamePieceSyntax`.
   func buildObjcNamePiece(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ObjcNamePieceSyntax {
-    let result = SyntaxFactory.makeObjcNamePiece(
+    let result = ObjcNamePieceSyntax(
       garbageBeforeName?.buildGarbageNodes(format: format, leadingTrivia: nil),
       name: name,
       garbageBetweenNameAndDot?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -5132,7 +5132,7 @@ public struct ObjcKeyPathExpr: ExprBuildable, ExpressibleAsObjcKeyPathExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ObjcKeyPathExprSyntax`.
   func buildObjcKeyPathExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ObjcKeyPathExprSyntax {
-    let result = SyntaxFactory.makeObjcKeyPathExpr(
+    let result = ObjcKeyPathExprSyntax(
       garbageBeforeKeyPath?.buildGarbageNodes(format: format, leadingTrivia: nil),
       keyPath: keyPath,
       garbageBetweenKeyPathAndLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -5263,7 +5263,7 @@ public struct ObjcSelectorExpr: ExprBuildable, ExpressibleAsObjcSelectorExpr {
       garbageBetweenPoundSelectorAndLeftParen: garbageBetweenPoundSelectorAndLeftParen,
       leftParen: leftParen,
       garbageBetweenLeftParenAndKind: garbageBetweenLeftParenAndKind,
-      kind: kind.map(TokenSyntax.contextualKeyword),
+      kind: kind.map { TokenSyntax.contextualKeyword($0) },
       garbageBetweenKindAndColon: garbageBetweenKindAndColon,
       colon: colon,
       garbageBetweenColonAndName: garbageBetweenColonAndName,
@@ -5278,7 +5278,7 @@ public struct ObjcSelectorExpr: ExprBuildable, ExpressibleAsObjcSelectorExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ObjcSelectorExprSyntax`.
   func buildObjcSelectorExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ObjcSelectorExprSyntax {
-    let result = SyntaxFactory.makeObjcSelectorExpr(
+    let result = ObjcSelectorExprSyntax(
       garbageBeforePoundSelector?.buildGarbageNodes(format: format, leadingTrivia: nil),
       poundSelector: poundSelector,
       garbageBetweenPoundSelectorAndLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -5357,7 +5357,7 @@ public struct PostfixIfConfigExpr: ExprBuildable, ExpressibleAsPostfixIfConfigEx
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PostfixIfConfigExprSyntax`.
   func buildPostfixIfConfigExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PostfixIfConfigExprSyntax {
-    let result = SyntaxFactory.makePostfixIfConfigExpr(
+    let result = PostfixIfConfigExprSyntax(
       garbageBeforeBase?.buildGarbageNodes(format: format, leadingTrivia: nil),
       base: base?.buildExpr(format: format, leadingTrivia: nil),
       garbageBetweenBaseAndConfig?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -5434,7 +5434,7 @@ public struct EditorPlaceholderExpr: ExprBuildable, ExpressibleAsEditorPlacehold
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `EditorPlaceholderExprSyntax`.
   func buildEditorPlaceholderExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> EditorPlaceholderExprSyntax {
-    let result = SyntaxFactory.makeEditorPlaceholderExpr(
+    let result = EditorPlaceholderExprSyntax(
       garbageBeforeIdentifier?.buildGarbageNodes(format: format, leadingTrivia: nil),
       identifier: identifier
     )
@@ -5548,7 +5548,7 @@ public struct ObjectLiteralExpr: ExprBuildable, ExpressibleAsObjectLiteralExpr {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ObjectLiteralExprSyntax`.
   func buildObjectLiteralExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ObjectLiteralExprSyntax {
-    let result = SyntaxFactory.makeObjectLiteralExpr(
+    let result = ObjectLiteralExprSyntax(
       garbageBeforeIdentifier?.buildGarbageNodes(format: format, leadingTrivia: nil),
       identifier: identifier,
       garbageBetweenIdentifierAndLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -5624,7 +5624,7 @@ public struct TypeInitializerClause: SyntaxBuildable, ExpressibleAsTypeInitializ
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `TypeInitializerClauseSyntax`.
   func buildTypeInitializerClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeInitializerClauseSyntax {
-    let result = SyntaxFactory.makeTypeInitializerClause(
+    let result = TypeInitializerClauseSyntax(
       garbageBeforeEqual?.buildGarbageNodes(format: format, leadingTrivia: nil),
       equal: equal,
       garbageBetweenEqualAndValue?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -5768,7 +5768,7 @@ public struct TypealiasDecl: DeclBuildable, ExpressibleAsTypealiasDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `TypealiasDeclSyntax`.
   func buildTypealiasDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypealiasDeclSyntax {
-    let result = SyntaxFactory.makeTypealiasDecl(
+    let result = TypealiasDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -5928,7 +5928,7 @@ public struct AssociatedtypeDecl: DeclBuildable, ExpressibleAsAssociatedtypeDecl
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AssociatedtypeDeclSyntax`.
   func buildAssociatedtypeDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AssociatedtypeDeclSyntax {
-    let result = SyntaxFactory.makeAssociatedtypeDecl(
+    let result = AssociatedtypeDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -6041,7 +6041,7 @@ public struct ParameterClause: SyntaxBuildable, ExpressibleAsParameterClause {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ParameterClauseSyntax`.
   func buildParameterClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ParameterClauseSyntax {
-    let result = SyntaxFactory.makeParameterClause(
+    let result = ParameterClauseSyntax(
       garbageBeforeLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftParen: leftParen,
       garbageBetweenLeftParenAndParameterList?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -6109,7 +6109,7 @@ public struct ReturnClause: SyntaxBuildable, ExpressibleAsReturnClause {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ReturnClauseSyntax`.
   func buildReturnClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ReturnClauseSyntax {
-    let result = SyntaxFactory.makeReturnClause(
+    let result = ReturnClauseSyntax(
       garbageBeforeArrow?.buildGarbageNodes(format: format, leadingTrivia: nil),
       arrow: arrow,
       garbageBetweenArrowAndReturnType?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -6205,7 +6205,7 @@ public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature
       garbageBeforeInput: garbageBeforeInput,
       input: input,
       garbageBetweenInputAndAsyncOrReasyncKeyword: garbageBetweenInputAndAsyncOrReasyncKeyword,
-      asyncOrReasyncKeyword: asyncOrReasyncKeyword.map(TokenSyntax.contextualKeyword),
+      asyncOrReasyncKeyword: asyncOrReasyncKeyword.map { TokenSyntax.contextualKeyword($0) },
       garbageBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: garbageBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword,
       throwsOrRethrowsKeyword: throwsOrRethrowsKeyword,
       garbageBetweenThrowsOrRethrowsKeywordAndOutput: garbageBetweenThrowsOrRethrowsKeywordAndOutput,
@@ -6218,7 +6218,7 @@ public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `FunctionSignatureSyntax`.
   func buildFunctionSignature(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FunctionSignatureSyntax {
-    let result = SyntaxFactory.makeFunctionSignature(
+    let result = FunctionSignatureSyntax(
       garbageBeforeInput?.buildGarbageNodes(format: format, leadingTrivia: nil),
       input: input.buildParameterClause(format: format, leadingTrivia: nil),
       garbageBetweenInputAndAsyncOrReasyncKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -6296,7 +6296,7 @@ public struct IfConfigClause: SyntaxBuildable, ExpressibleAsIfConfigClause {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `IfConfigClauseSyntax`.
   func buildIfConfigClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IfConfigClauseSyntax {
-    let result = SyntaxFactory.makeIfConfigClause(
+    let result = IfConfigClauseSyntax(
       garbageBeforePoundKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       poundKeyword: poundKeyword,
       garbageBetweenPoundKeywordAndCondition?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -6364,7 +6364,7 @@ public struct IfConfigDecl: DeclBuildable, ExpressibleAsIfConfigDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `IfConfigDeclSyntax`.
   func buildIfConfigDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IfConfigDeclSyntax {
-    let result = SyntaxFactory.makeIfConfigDecl(
+    let result = IfConfigDeclSyntax(
       garbageBeforeClauses?.buildGarbageNodes(format: format, leadingTrivia: nil),
       clauses: clauses.buildIfConfigClauseList(format: format, leadingTrivia: nil),
       garbageBetweenClausesAndPoundEndif?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -6454,7 +6454,7 @@ public struct PoundErrorDecl: DeclBuildable, ExpressibleAsPoundErrorDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PoundErrorDeclSyntax`.
   func buildPoundErrorDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundErrorDeclSyntax {
-    let result = SyntaxFactory.makePoundErrorDecl(
+    let result = PoundErrorDeclSyntax(
       garbageBeforePoundError?.buildGarbageNodes(format: format, leadingTrivia: nil),
       poundError: poundError,
       garbageBetweenPoundErrorAndLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -6548,7 +6548,7 @@ public struct PoundWarningDecl: DeclBuildable, ExpressibleAsPoundWarningDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PoundWarningDeclSyntax`.
   func buildPoundWarningDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundWarningDeclSyntax {
-    let result = SyntaxFactory.makePoundWarningDecl(
+    let result = PoundWarningDeclSyntax(
       garbageBeforePoundWarning?.buildGarbageNodes(format: format, leadingTrivia: nil),
       poundWarning: poundWarning,
       garbageBetweenPoundWarningAndLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -6642,7 +6642,7 @@ public struct PoundSourceLocation: DeclBuildable, ExpressibleAsPoundSourceLocati
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PoundSourceLocationSyntax`.
   func buildPoundSourceLocation(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundSourceLocationSyntax {
-    let result = SyntaxFactory.makePoundSourceLocation(
+    let result = PoundSourceLocationSyntax(
       garbageBeforePoundSourceLocation?.buildGarbageNodes(format: format, leadingTrivia: nil),
       poundSourceLocation: poundSourceLocation,
       garbageBetweenPoundSourceLocationAndLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -6800,7 +6800,7 @@ public struct PoundSourceLocationArgs: SyntaxBuildable, ExpressibleAsPoundSource
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PoundSourceLocationArgsSyntax`.
   func buildPoundSourceLocationArgs(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundSourceLocationArgsSyntax {
-    let result = SyntaxFactory.makePoundSourceLocationArgs(
+    let result = PoundSourceLocationArgsSyntax(
       garbageBeforeFileArgLabel?.buildGarbageNodes(format: format, leadingTrivia: nil),
       fileArgLabel: fileArgLabel,
       garbageBetweenFileArgLabelAndFileArgColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -6907,7 +6907,7 @@ public struct DeclModifierDetail: SyntaxBuildable, ExpressibleAsDeclModifierDeta
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DeclModifierDetailSyntax`.
   func buildDeclModifierDetail(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclModifierDetailSyntax {
-    let result = SyntaxFactory.makeDeclModifierDetail(
+    let result = DeclModifierDetailSyntax(
       garbageBeforeLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftParen: leftParen,
       garbageBetweenLeftParenAndDetail?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -6975,7 +6975,7 @@ public struct DeclModifier: SyntaxBuildable, ExpressibleAsDeclModifier {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DeclModifierSyntax`.
   func buildDeclModifier(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclModifierSyntax {
-    let result = SyntaxFactory.makeDeclModifier(
+    let result = DeclModifierSyntax(
       garbageBeforeName?.buildGarbageNodes(format: format, leadingTrivia: nil),
       name: name,
       garbageBetweenNameAndDetail?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -7041,7 +7041,7 @@ public struct InheritedType: SyntaxBuildable, ExpressibleAsInheritedType, HasTra
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `InheritedTypeSyntax`.
   func buildInheritedType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> InheritedTypeSyntax {
-    let result = SyntaxFactory.makeInheritedType(
+    let result = InheritedTypeSyntax(
       garbageBeforeTypeName?.buildGarbageNodes(format: format, leadingTrivia: nil),
       typeName: typeName.buildType(format: format, leadingTrivia: nil),
       garbageBetweenTypeNameAndTrailingComma?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -7135,7 +7135,7 @@ public struct TypeInheritanceClause: SyntaxBuildable, ExpressibleAsTypeInheritan
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `TypeInheritanceClauseSyntax`.
   func buildTypeInheritanceClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeInheritanceClauseSyntax {
-    let result = SyntaxFactory.makeTypeInheritanceClause(
+    let result = TypeInheritanceClauseSyntax(
       garbageBeforeColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
       colon: colon,
       garbageBetweenColonAndInheritedTypeCollection?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -7291,7 +7291,7 @@ public struct ClassDecl: DeclBuildable, ExpressibleAsClassDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ClassDeclSyntax`.
   func buildClassDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ClassDeclSyntax {
-    let result = SyntaxFactory.makeClassDecl(
+    let result = ClassDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -7465,7 +7465,7 @@ public struct ActorDecl: DeclBuildable, ExpressibleAsActorDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ActorDeclSyntax`.
   func buildActorDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ActorDeclSyntax {
-    let result = SyntaxFactory.makeActorDecl(
+    let result = ActorDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -7639,7 +7639,7 @@ public struct StructDecl: DeclBuildable, ExpressibleAsStructDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `StructDeclSyntax`.
   func buildStructDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StructDeclSyntax {
-    let result = SyntaxFactory.makeStructDecl(
+    let result = StructDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -7813,7 +7813,7 @@ public struct ProtocolDecl: DeclBuildable, ExpressibleAsProtocolDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ProtocolDeclSyntax`.
   func buildProtocolDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ProtocolDeclSyntax {
-    let result = SyntaxFactory.makeProtocolDecl(
+    let result = ProtocolDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -7975,7 +7975,7 @@ public struct ExtensionDecl: DeclBuildable, ExpressibleAsExtensionDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ExtensionDeclSyntax`.
   func buildExtensionDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExtensionDeclSyntax {
-    let result = SyntaxFactory.makeExtensionDecl(
+    let result = ExtensionDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -8088,7 +8088,7 @@ public struct MemberDeclBlock: SyntaxBuildable, ExpressibleAsMemberDeclBlock {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `MemberDeclBlockSyntax`.
   func buildMemberDeclBlock(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MemberDeclBlockSyntax {
-    let result = SyntaxFactory.makeMemberDeclBlock(
+    let result = MemberDeclBlockSyntax(
       garbageBeforeLeftBrace?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftBrace: leftBrace,
       garbageBetweenLeftBraceAndMembers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -8157,7 +8157,7 @@ public struct MemberDeclListItem: SyntaxBuildable, ExpressibleAsMemberDeclListIt
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `MemberDeclListItemSyntax`.
   func buildMemberDeclListItem(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MemberDeclListItemSyntax {
-    let result = SyntaxFactory.makeMemberDeclListItem(
+    let result = MemberDeclListItemSyntax(
       garbageBeforeDecl?.buildGarbageNodes(format: format, leadingTrivia: nil),
       decl: decl.buildDecl(format: format, leadingTrivia: nil),
       garbageBetweenDeclAndSemicolon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -8240,7 +8240,7 @@ public struct SourceFile: SyntaxBuildable, ExpressibleAsSourceFile {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `SourceFileSyntax`.
   func buildSourceFile(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SourceFileSyntax {
-    let result = SyntaxFactory.makeSourceFile(
+    let result = SourceFileSyntax(
       garbageBeforeStatements?.buildGarbageNodes(format: format, leadingTrivia: nil),
       statements: statements.buildCodeBlockItemList(format: format, leadingTrivia: nil),
       garbageBetweenStatementsAndEOFToken?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -8306,7 +8306,7 @@ public struct InitializerClause: SyntaxBuildable, ExpressibleAsInitializerClause
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `InitializerClauseSyntax`.
   func buildInitializerClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> InitializerClauseSyntax {
-    let result = SyntaxFactory.makeInitializerClause(
+    let result = InitializerClauseSyntax(
       garbageBeforeEqual?.buildGarbageNodes(format: format, leadingTrivia: nil),
       equal: equal,
       garbageBetweenEqualAndValue?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -8422,7 +8422,7 @@ public struct FunctionParameter: SyntaxBuildable, ExpressibleAsFunctionParameter
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `FunctionParameterSyntax`.
   func buildFunctionParameter(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FunctionParameterSyntax {
-    let result = SyntaxFactory.makeFunctionParameter(
+    let result = FunctionParameterSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndFirstName?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -8612,7 +8612,7 @@ public struct FunctionDecl: DeclBuildable, ExpressibleAsFunctionDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `FunctionDeclSyntax`.
   func buildFunctionDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FunctionDeclSyntax {
-    let result = SyntaxFactory.makeFunctionDecl(
+    let result = FunctionDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -8787,7 +8787,7 @@ public struct InitializerDecl: DeclBuildable, ExpressibleAsInitializerDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `InitializerDeclSyntax`.
   func buildInitializerDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> InitializerDeclSyntax {
-    let result = SyntaxFactory.makeInitializerDecl(
+    let result = InitializerDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -8913,7 +8913,7 @@ public struct DeinitializerDecl: DeclBuildable, ExpressibleAsDeinitializerDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DeinitializerDeclSyntax`.
   func buildDeinitializerDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeinitializerDeclSyntax {
-    let result = SyntaxFactory.makeDeinitializerDecl(
+    let result = DeinitializerDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -9037,7 +9037,7 @@ public struct SubscriptDecl: DeclBuildable, ExpressibleAsSubscriptDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `SubscriptDeclSyntax`.
   func buildSubscriptDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SubscriptDeclSyntax {
-    let result = SyntaxFactory.makeSubscriptDecl(
+    let result = SubscriptDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -9138,7 +9138,7 @@ public struct AccessLevelModifier: SyntaxBuildable, ExpressibleAsAccessLevelModi
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AccessLevelModifierSyntax`.
   func buildAccessLevelModifier(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AccessLevelModifierSyntax {
-    let result = SyntaxFactory.makeAccessLevelModifier(
+    let result = AccessLevelModifierSyntax(
       garbageBeforeName?.buildGarbageNodes(format: format, leadingTrivia: nil),
       name: name,
       garbageBetweenNameAndModifier?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -9222,7 +9222,7 @@ public struct AccessPathComponent: SyntaxBuildable, ExpressibleAsAccessPathCompo
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AccessPathComponentSyntax`.
   func buildAccessPathComponent(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AccessPathComponentSyntax {
-    let result = SyntaxFactory.makeAccessPathComponent(
+    let result = AccessPathComponentSyntax(
       garbageBeforeName?.buildGarbageNodes(format: format, leadingTrivia: nil),
       name: name,
       garbageBetweenNameAndTrailingDot?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -9313,7 +9313,7 @@ public struct ImportDecl: DeclBuildable, ExpressibleAsImportDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ImportDeclSyntax`.
   func buildImportDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ImportDeclSyntax {
-    let result = SyntaxFactory.makeImportDecl(
+    let result = ImportDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -9422,7 +9422,7 @@ public struct AccessorParameter: SyntaxBuildable, ExpressibleAsAccessorParameter
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AccessorParameterSyntax`.
   func buildAccessorParameter(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AccessorParameterSyntax {
-    let result = SyntaxFactory.makeAccessorParameter(
+    let result = AccessorParameterSyntax(
       garbageBeforeLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftParen: leftParen,
       garbageBetweenLeftParenAndName?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -9557,7 +9557,7 @@ public struct AccessorDecl: DeclBuildable, ExpressibleAsAccessorDecl {
       garbageBetweenAccessorKindAndParameter: garbageBetweenAccessorKindAndParameter,
       parameter: parameter,
       garbageBetweenParameterAndAsyncKeyword: garbageBetweenParameterAndAsyncKeyword,
-      asyncKeyword: asyncKeyword.map(TokenSyntax.contextualKeyword),
+      asyncKeyword: asyncKeyword.map { TokenSyntax.contextualKeyword($0) },
       garbageBetweenAsyncKeywordAndThrowsKeyword: garbageBetweenAsyncKeywordAndThrowsKeyword,
       throwsKeyword: throwsKeyword,
       garbageBetweenThrowsKeywordAndBody: garbageBetweenThrowsKeywordAndBody,
@@ -9570,7 +9570,7 @@ public struct AccessorDecl: DeclBuildable, ExpressibleAsAccessorDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AccessorDeclSyntax`.
   func buildAccessorDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AccessorDeclSyntax {
-    let result = SyntaxFactory.makeAccessorDecl(
+    let result = AccessorDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifier?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -9661,7 +9661,7 @@ public struct AccessorBlock: SyntaxBuildable, ExpressibleAsAccessorBlock {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AccessorBlockSyntax`.
   func buildAccessorBlock(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AccessorBlockSyntax {
-    let result = SyntaxFactory.makeAccessorBlock(
+    let result = AccessorBlockSyntax(
       garbageBeforeLeftBrace?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftBrace: leftBrace,
       garbageBetweenLeftBraceAndAccessors?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -9753,7 +9753,7 @@ public struct PatternBinding: SyntaxBuildable, ExpressibleAsPatternBinding, HasT
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PatternBindingSyntax`.
   func buildPatternBinding(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PatternBindingSyntax {
-    let result = SyntaxFactory.makePatternBinding(
+    let result = PatternBindingSyntax(
       garbageBeforePattern?.buildGarbageNodes(format: format, leadingTrivia: nil),
       pattern: pattern.buildPattern(format: format, leadingTrivia: nil),
       garbageBetweenPatternAndTypeAnnotation?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -9883,7 +9883,7 @@ public struct VariableDecl: DeclBuildable, ExpressibleAsVariableDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `VariableDeclSyntax`.
   func buildVariableDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> VariableDeclSyntax {
-    let result = SyntaxFactory.makeVariableDecl(
+    let result = VariableDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -10002,7 +10002,7 @@ public struct EnumCaseElement: SyntaxBuildable, ExpressibleAsEnumCaseElement, Ha
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `EnumCaseElementSyntax`.
   func buildEnumCaseElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> EnumCaseElementSyntax {
-    let result = SyntaxFactory.makeEnumCaseElement(
+    let result = EnumCaseElementSyntax(
       garbageBeforeIdentifier?.buildGarbageNodes(format: format, leadingTrivia: nil),
       identifier: identifier,
       garbageBetweenIdentifierAndAssociatedValue?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -10129,7 +10129,7 @@ public struct EnumCaseDecl: DeclBuildable, ExpressibleAsEnumCaseDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `EnumCaseDeclSyntax`.
   func buildEnumCaseDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> EnumCaseDeclSyntax {
-    let result = SyntaxFactory.makeEnumCaseDecl(
+    let result = EnumCaseDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -10296,7 +10296,7 @@ public struct EnumDecl: DeclBuildable, ExpressibleAsEnumDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `EnumDeclSyntax`.
   func buildEnumDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> EnumDeclSyntax {
-    let result = SyntaxFactory.makeEnumDecl(
+    let result = EnumDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -10405,7 +10405,7 @@ public struct OperatorDecl: DeclBuildable, ExpressibleAsOperatorDecl {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `OperatorDeclSyntax`.
   func buildOperatorDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> OperatorDeclSyntax {
-    let result = SyntaxFactory.makeOperatorDecl(
+    let result = OperatorDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -10484,7 +10484,7 @@ public struct OperatorPrecedenceAndTypes: SyntaxBuildable, ExpressibleAsOperator
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `OperatorPrecedenceAndTypesSyntax`.
   func buildOperatorPrecedenceAndTypes(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> OperatorPrecedenceAndTypesSyntax {
-    let result = SyntaxFactory.makeOperatorPrecedenceAndTypes(
+    let result = OperatorPrecedenceAndTypesSyntax(
       garbageBeforeColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
       colon: colon,
       garbageBetweenColonAndPrecedenceGroupAndDesignatedTypes?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -10631,7 +10631,7 @@ public struct PrecedenceGroupDecl: DeclBuildable, ExpressibleAsPrecedenceGroupDe
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PrecedenceGroupDeclSyntax`.
   func buildPrecedenceGroupDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrecedenceGroupDeclSyntax {
-    let result = SyntaxFactory.makePrecedenceGroupDecl(
+    let result = PrecedenceGroupDeclSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndModifiers?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -10745,7 +10745,7 @@ public struct PrecedenceGroupRelation: SyntaxBuildable, ExpressibleAsPrecedenceG
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PrecedenceGroupRelationSyntax`.
   func buildPrecedenceGroupRelation(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrecedenceGroupRelationSyntax {
-    let result = SyntaxFactory.makePrecedenceGroupRelation(
+    let result = PrecedenceGroupRelationSyntax(
       garbageBeforeHigherThanOrLowerThan?.buildGarbageNodes(format: format, leadingTrivia: nil),
       higherThanOrLowerThan: higherThanOrLowerThan,
       garbageBetweenHigherThanOrLowerThanAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -10831,7 +10831,7 @@ public struct PrecedenceGroupNameElement: SyntaxBuildable, ExpressibleAsPreceden
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PrecedenceGroupNameElementSyntax`.
   func buildPrecedenceGroupNameElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrecedenceGroupNameElementSyntax {
-    let result = SyntaxFactory.makePrecedenceGroupNameElement(
+    let result = PrecedenceGroupNameElementSyntax(
       garbageBeforeName?.buildGarbageNodes(format: format, leadingTrivia: nil),
       name: name,
       garbageBetweenNameAndTrailingComma?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -10930,7 +10930,7 @@ public struct PrecedenceGroupAssignment: SyntaxBuildable, ExpressibleAsPrecedenc
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PrecedenceGroupAssignmentSyntax`.
   func buildPrecedenceGroupAssignment(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrecedenceGroupAssignmentSyntax {
-    let result = SyntaxFactory.makePrecedenceGroupAssignment(
+    let result = PrecedenceGroupAssignmentSyntax(
       garbageBeforeAssignmentKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       assignmentKeyword: assignmentKeyword,
       garbageBetweenAssignmentKeywordAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -11031,7 +11031,7 @@ public struct PrecedenceGroupAssociativity: SyntaxBuildable, ExpressibleAsPreced
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PrecedenceGroupAssociativitySyntax`.
   func buildPrecedenceGroupAssociativity(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrecedenceGroupAssociativitySyntax {
-    let result = SyntaxFactory.makePrecedenceGroupAssociativity(
+    let result = PrecedenceGroupAssociativitySyntax(
       garbageBeforeAssociativityKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       associativityKeyword: associativityKeyword,
       garbageBetweenAssociativityKeywordAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -11156,7 +11156,7 @@ public struct CustomAttribute: SyntaxBuildable, ExpressibleAsCustomAttribute {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `CustomAttributeSyntax`.
   func buildCustomAttribute(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CustomAttributeSyntax {
-    let result = SyntaxFactory.makeCustomAttribute(
+    let result = CustomAttributeSyntax(
       garbageBeforeAtSignToken?.buildGarbageNodes(format: format, leadingTrivia: nil),
       atSignToken: atSignToken,
       garbageBetweenAtSignTokenAndAttributeName?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -11263,7 +11263,7 @@ public struct Attribute: SyntaxBuildable, ExpressibleAsAttribute {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AttributeSyntax`.
   func buildAttribute(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AttributeSyntax {
-    let result = SyntaxFactory.makeAttribute(
+    let result = AttributeSyntax(
       garbageBeforeAtSignToken?.buildGarbageNodes(format: format, leadingTrivia: nil),
       atSignToken: atSignToken,
       garbageBetweenAtSignTokenAndAttributeName?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -11381,7 +11381,7 @@ public struct AvailabilityEntry: SyntaxBuildable, ExpressibleAsAvailabilityEntry
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AvailabilityEntrySyntax`.
   func buildAvailabilityEntry(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AvailabilityEntrySyntax {
-    let result = SyntaxFactory.makeAvailabilityEntry(
+    let result = AvailabilityEntrySyntax(
       garbageBeforeLabel?.buildGarbageNodes(format: format, leadingTrivia: nil),
       label: label,
       garbageBetweenLabelAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -11495,7 +11495,7 @@ public struct LabeledSpecializeEntry: SyntaxBuildable, ExpressibleAsLabeledSpeci
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `LabeledSpecializeEntrySyntax`.
   func buildLabeledSpecializeEntry(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> LabeledSpecializeEntrySyntax {
-    let result = SyntaxFactory.makeLabeledSpecializeEntry(
+    let result = LabeledSpecializeEntrySyntax(
       garbageBeforeLabel?.buildGarbageNodes(format: format, leadingTrivia: nil),
       label: label,
       garbageBetweenLabelAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -11623,7 +11623,7 @@ public struct TargetFunctionEntry: SyntaxBuildable, ExpressibleAsTargetFunctionE
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `TargetFunctionEntrySyntax`.
   func buildTargetFunctionEntry(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TargetFunctionEntrySyntax {
-    let result = SyntaxFactory.makeTargetFunctionEntry(
+    let result = TargetFunctionEntrySyntax(
       garbageBeforeLabel?.buildGarbageNodes(format: format, leadingTrivia: nil),
       label: label,
       garbageBetweenLabelAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -11716,7 +11716,7 @@ public struct NamedAttributeStringArgument: SyntaxBuildable, ExpressibleAsNamedA
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `NamedAttributeStringArgumentSyntax`.
   func buildNamedAttributeStringArgument(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> NamedAttributeStringArgumentSyntax {
-    let result = SyntaxFactory.makeNamedAttributeStringArgument(
+    let result = NamedAttributeStringArgumentSyntax(
       garbageBeforeNameTok?.buildGarbageNodes(format: format, leadingTrivia: nil),
       nameTok: nameTok,
       garbageBetweenNameTokAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -11783,7 +11783,7 @@ public struct DeclName: SyntaxBuildable, ExpressibleAsDeclName {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DeclNameSyntax`.
   func buildDeclName(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclNameSyntax {
-    let result = SyntaxFactory.makeDeclName(
+    let result = DeclNameSyntax(
       garbageBeforeDeclBaseName?.buildGarbageNodes(format: format, leadingTrivia: nil),
       declBaseName: declBaseName.buildSyntax(format: format, leadingTrivia: nil),
       garbageBetweenDeclBaseNameAndDeclNameArguments?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -11866,7 +11866,7 @@ public struct ImplementsAttributeArguments: SyntaxBuildable, ExpressibleAsImplem
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ImplementsAttributeArgumentsSyntax`.
   func buildImplementsAttributeArguments(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ImplementsAttributeArgumentsSyntax {
-    let result = SyntaxFactory.makeImplementsAttributeArguments(
+    let result = ImplementsAttributeArgumentsSyntax(
       garbageBeforeType?.buildGarbageNodes(format: format, leadingTrivia: nil),
       type: type.buildSimpleTypeIdentifier(format: format, leadingTrivia: nil),
       garbageBetweenTypeAndComma?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -11944,7 +11944,7 @@ public struct ObjCSelectorPiece: SyntaxBuildable, ExpressibleAsObjCSelectorPiece
     self.init(
       leadingTrivia: leadingTrivia,
       garbageBeforeName: garbageBeforeName,
-      name: name.map(TokenSyntax.identifier),
+      name: name.map { TokenSyntax.identifier($0) },
       garbageBetweenNameAndColon: garbageBetweenNameAndColon,
       colon: colon
     )
@@ -11955,7 +11955,7 @@ public struct ObjCSelectorPiece: SyntaxBuildable, ExpressibleAsObjCSelectorPiece
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ObjCSelectorPieceSyntax`.
   func buildObjCSelectorPiece(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ObjCSelectorPieceSyntax {
-    let result = SyntaxFactory.makeObjCSelectorPiece(
+    let result = ObjCSelectorPieceSyntax(
       garbageBeforeName?.buildGarbageNodes(format: format, leadingTrivia: nil),
       name: name,
       garbageBetweenNameAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -12061,7 +12061,7 @@ public struct DifferentiableAttributeArguments: SyntaxBuildable, ExpressibleAsDi
     self.init(
       leadingTrivia: leadingTrivia,
       garbageBeforeDiffKind: garbageBeforeDiffKind,
-      diffKind: diffKind.map(TokenSyntax.identifier),
+      diffKind: diffKind.map { TokenSyntax.identifier($0) },
       garbageBetweenDiffKindAndDiffKindComma: garbageBetweenDiffKindAndDiffKindComma,
       diffKindComma: diffKindComma,
       garbageBetweenDiffKindCommaAndDiffParams: garbageBetweenDiffKindCommaAndDiffParams,
@@ -12078,7 +12078,7 @@ public struct DifferentiableAttributeArguments: SyntaxBuildable, ExpressibleAsDi
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DifferentiableAttributeArgumentsSyntax`.
   func buildDifferentiableAttributeArguments(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DifferentiableAttributeArgumentsSyntax {
-    let result = SyntaxFactory.makeDifferentiableAttributeArguments(
+    let result = DifferentiableAttributeArgumentsSyntax(
       garbageBeforeDiffKind?.buildGarbageNodes(format: format, leadingTrivia: nil),
       diffKind: diffKind,
       garbageBetweenDiffKindAndDiffKindComma?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -12182,7 +12182,7 @@ public struct DifferentiabilityParamsClause: SyntaxBuildable, ExpressibleAsDiffe
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DifferentiabilityParamsClauseSyntax`.
   func buildDifferentiabilityParamsClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DifferentiabilityParamsClauseSyntax {
-    let result = SyntaxFactory.makeDifferentiabilityParamsClause(
+    let result = DifferentiabilityParamsClauseSyntax(
       garbageBeforeWrtLabel?.buildGarbageNodes(format: format, leadingTrivia: nil),
       wrtLabel: wrtLabel,
       garbageBetweenWrtLabelAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -12260,7 +12260,7 @@ public struct DifferentiabilityParams: SyntaxBuildable, ExpressibleAsDifferentia
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DifferentiabilityParamsSyntax`.
   func buildDifferentiabilityParams(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DifferentiabilityParamsSyntax {
-    let result = SyntaxFactory.makeDifferentiabilityParams(
+    let result = DifferentiabilityParamsSyntax(
       garbageBeforeLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftParen: leftParen,
       garbageBetweenLeftParenAndDiffParams?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -12329,7 +12329,7 @@ public struct DifferentiabilityParam: SyntaxBuildable, ExpressibleAsDifferentiab
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DifferentiabilityParamSyntax`.
   func buildDifferentiabilityParam(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DifferentiabilityParamSyntax {
-    let result = SyntaxFactory.makeDifferentiabilityParam(
+    let result = DifferentiabilityParamSyntax(
       garbageBeforeParameter?.buildGarbageNodes(format: format, leadingTrivia: nil),
       parameter: parameter.buildSyntax(format: format, leadingTrivia: nil),
       garbageBetweenParameterAndTrailingComma?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -12475,7 +12475,7 @@ public struct DerivativeRegistrationAttributeArguments: SyntaxBuildable, Express
       garbageBetweenOriginalDeclNameAndPeriod: garbageBetweenOriginalDeclNameAndPeriod,
       period: period,
       garbageBetweenPeriodAndAccessorKind: garbageBetweenPeriodAndAccessorKind,
-      accessorKind: accessorKind.map(TokenSyntax.identifier),
+      accessorKind: accessorKind.map { TokenSyntax.identifier($0) },
       garbageBetweenAccessorKindAndComma: garbageBetweenAccessorKindAndComma,
       comma: comma,
       garbageBetweenCommaAndDiffParams: garbageBetweenCommaAndDiffParams,
@@ -12488,7 +12488,7 @@ public struct DerivativeRegistrationAttributeArguments: SyntaxBuildable, Express
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DerivativeRegistrationAttributeArgumentsSyntax`.
   func buildDerivativeRegistrationAttributeArguments(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DerivativeRegistrationAttributeArgumentsSyntax {
-    let result = SyntaxFactory.makeDerivativeRegistrationAttributeArguments(
+    let result = DerivativeRegistrationAttributeArgumentsSyntax(
       garbageBeforeOfLabel?.buildGarbageNodes(format: format, leadingTrivia: nil),
       ofLabel: ofLabel,
       garbageBetweenOfLabelAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -12581,7 +12581,7 @@ public struct QualifiedDeclName: SyntaxBuildable, ExpressibleAsQualifiedDeclName
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `QualifiedDeclNameSyntax`.
   func buildQualifiedDeclName(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> QualifiedDeclNameSyntax {
-    let result = SyntaxFactory.makeQualifiedDeclName(
+    let result = QualifiedDeclNameSyntax(
       garbageBeforeBaseType?.buildGarbageNodes(format: format, leadingTrivia: nil),
       baseType: baseType?.buildType(format: format, leadingTrivia: nil),
       garbageBetweenBaseTypeAndDot?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -12651,7 +12651,7 @@ public struct FunctionDeclName: SyntaxBuildable, ExpressibleAsFunctionDeclName {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `FunctionDeclNameSyntax`.
   func buildFunctionDeclName(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FunctionDeclNameSyntax {
-    let result = SyntaxFactory.makeFunctionDeclName(
+    let result = FunctionDeclNameSyntax(
       garbageBeforeName?.buildGarbageNodes(format: format, leadingTrivia: nil),
       name: name.buildSyntax(format: format, leadingTrivia: nil),
       garbageBetweenNameAndArguments?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -12749,7 +12749,7 @@ public struct BackDeployAttributeSpecList: SyntaxBuildable, ExpressibleAsBackDep
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `BackDeployAttributeSpecListSyntax`.
   func buildBackDeployAttributeSpecList(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> BackDeployAttributeSpecListSyntax {
-    let result = SyntaxFactory.makeBackDeployAttributeSpecList(
+    let result = BackDeployAttributeSpecListSyntax(
       garbageBeforeBeforeLabel?.buildGarbageNodes(format: format, leadingTrivia: nil),
       beforeLabel: beforeLabel,
       garbageBetweenBeforeLabelAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -12818,7 +12818,7 @@ public struct BackDeployVersionArgument: SyntaxBuildable, ExpressibleAsBackDeplo
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `BackDeployVersionArgumentSyntax`.
   func buildBackDeployVersionArgument(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> BackDeployVersionArgumentSyntax {
-    let result = SyntaxFactory.makeBackDeployVersionArgument(
+    let result = BackDeployVersionArgumentSyntax(
       garbageBeforeAvailabilityVersionRestriction?.buildGarbageNodes(format: format, leadingTrivia: nil),
       availabilityVersionRestriction: availabilityVersionRestriction.buildAvailabilityVersionRestriction(format: format, leadingTrivia: nil),
       garbageBetweenAvailabilityVersionRestrictionAndTrailingComma?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -12914,7 +12914,7 @@ public struct LabeledStmt: StmtBuildable, ExpressibleAsLabeledStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `LabeledStmtSyntax`.
   func buildLabeledStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> LabeledStmtSyntax {
-    let result = SyntaxFactory.makeLabeledStmt(
+    let result = LabeledStmtSyntax(
       garbageBeforeLabelName?.buildGarbageNodes(format: format, leadingTrivia: nil),
       labelName: labelName,
       garbageBetweenLabelNameAndLabelColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -12997,7 +12997,7 @@ public struct ContinueStmt: StmtBuildable, ExpressibleAsContinueStmt {
       garbageBeforeContinueKeyword: garbageBeforeContinueKeyword,
       continueKeyword: continueKeyword,
       garbageBetweenContinueKeywordAndLabel: garbageBetweenContinueKeywordAndLabel,
-      label: label.map(TokenSyntax.identifier)
+      label: label.map { TokenSyntax.identifier($0) }
     )
   }
 
@@ -13006,7 +13006,7 @@ public struct ContinueStmt: StmtBuildable, ExpressibleAsContinueStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ContinueStmtSyntax`.
   func buildContinueStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ContinueStmtSyntax {
-    let result = SyntaxFactory.makeContinueStmt(
+    let result = ContinueStmtSyntax(
       garbageBeforeContinueKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       continueKeyword: continueKeyword,
       garbageBetweenContinueKeywordAndLabel?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -13108,7 +13108,7 @@ public struct WhileStmt: StmtBuildable, ExpressibleAsWhileStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `WhileStmtSyntax`.
   func buildWhileStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> WhileStmtSyntax {
-    let result = SyntaxFactory.makeWhileStmt(
+    let result = WhileStmtSyntax(
       garbageBeforeWhileKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       whileKeyword: whileKeyword,
       garbageBetweenWhileKeywordAndConditions?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -13200,7 +13200,7 @@ public struct DeferStmt: StmtBuildable, ExpressibleAsDeferStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DeferStmtSyntax`.
   func buildDeferStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeferStmtSyntax {
-    let result = SyntaxFactory.makeDeferStmt(
+    let result = DeferStmtSyntax(
       garbageBeforeDeferKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       deferKeyword: deferKeyword,
       garbageBetweenDeferKeywordAndBody?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -13263,7 +13263,7 @@ public struct ExpressionStmt: StmtBuildable, ExpressibleAsExpressionStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ExpressionStmtSyntax`.
   func buildExpressionStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExpressionStmtSyntax {
-    let result = SyntaxFactory.makeExpressionStmt(
+    let result = ExpressionStmtSyntax(
       garbageBeforeExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
       expression: expression.buildExpr(format: format, leadingTrivia: nil)
     )
@@ -13376,7 +13376,7 @@ public struct RepeatWhileStmt: StmtBuildable, ExpressibleAsRepeatWhileStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `RepeatWhileStmtSyntax`.
   func buildRepeatWhileStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> RepeatWhileStmtSyntax {
-    let result = SyntaxFactory.makeRepeatWhileStmt(
+    let result = RepeatWhileStmtSyntax(
       garbageBeforeRepeatKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       repeatKeyword: repeatKeyword,
       garbageBetweenRepeatKeywordAndBody?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -13495,7 +13495,7 @@ public struct GuardStmt: StmtBuildable, ExpressibleAsGuardStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `GuardStmtSyntax`.
   func buildGuardStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> GuardStmtSyntax {
-    let result = SyntaxFactory.makeGuardStmt(
+    let result = GuardStmtSyntax(
       garbageBeforeGuardKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       guardKeyword: guardKeyword,
       garbageBetweenGuardKeywordAndConditions?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -13571,7 +13571,7 @@ public struct WhereClause: SyntaxBuildable, ExpressibleAsWhereClause {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `WhereClauseSyntax`.
   func buildWhereClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> WhereClauseSyntax {
-    let result = SyntaxFactory.makeWhereClause(
+    let result = WhereClauseSyntax(
       garbageBeforeWhereKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       whereKeyword: whereKeyword,
       garbageBetweenWhereKeywordAndGuardResult?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -13732,7 +13732,7 @@ public struct ForInStmt: StmtBuildable, ExpressibleAsForInStmt {
       garbageBetweenForKeywordAndTryKeyword: garbageBetweenForKeywordAndTryKeyword,
       tryKeyword: tryKeyword,
       garbageBetweenTryKeywordAndAwaitKeyword: garbageBetweenTryKeywordAndAwaitKeyword,
-      awaitKeyword: awaitKeyword.map(TokenSyntax.identifier),
+      awaitKeyword: awaitKeyword.map { TokenSyntax.identifier($0) },
       garbageBetweenAwaitKeywordAndCaseKeyword: garbageBetweenAwaitKeywordAndCaseKeyword,
       caseKeyword: caseKeyword,
       garbageBetweenCaseKeywordAndPattern: garbageBetweenCaseKeywordAndPattern,
@@ -13755,7 +13755,7 @@ public struct ForInStmt: StmtBuildable, ExpressibleAsForInStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ForInStmtSyntax`.
   func buildForInStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ForInStmtSyntax {
-    let result = SyntaxFactory.makeForInStmt(
+    let result = ForInStmtSyntax(
       garbageBeforeForKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       forKeyword: forKeyword,
       garbageBetweenForKeywordAndTryKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -13899,7 +13899,7 @@ public struct SwitchStmt: StmtBuildable, ExpressibleAsSwitchStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `SwitchStmtSyntax`.
   func buildSwitchStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SwitchStmtSyntax {
-    let result = SyntaxFactory.makeSwitchStmt(
+    let result = SwitchStmtSyntax(
       garbageBeforeSwitchKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       switchKeyword: switchKeyword,
       garbageBetweenSwitchKeywordAndExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -14007,7 +14007,7 @@ public struct DoStmt: StmtBuildable, ExpressibleAsDoStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DoStmtSyntax`.
   func buildDoStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DoStmtSyntax {
-    let result = SyntaxFactory.makeDoStmt(
+    let result = DoStmtSyntax(
       garbageBeforeDoKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       doKeyword: doKeyword,
       garbageBetweenDoKeywordAndBody?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -14081,7 +14081,7 @@ public struct ReturnStmt: StmtBuildable, ExpressibleAsReturnStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ReturnStmtSyntax`.
   func buildReturnStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ReturnStmtSyntax {
-    let result = SyntaxFactory.makeReturnStmt(
+    let result = ReturnStmtSyntax(
       garbageBeforeReturnKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       returnKeyword: returnKeyword,
       garbageBetweenReturnKeywordAndExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -14153,7 +14153,7 @@ public struct YieldStmt: StmtBuildable, ExpressibleAsYieldStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `YieldStmtSyntax`.
   func buildYieldStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> YieldStmtSyntax {
-    let result = SyntaxFactory.makeYieldStmt(
+    let result = YieldStmtSyntax(
       garbageBeforeYieldKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       yieldKeyword: yieldKeyword,
       garbageBetweenYieldKeywordAndYields?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -14269,7 +14269,7 @@ public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `YieldListSyntax`.
   func buildYieldList(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> YieldListSyntax {
-    let result = SyntaxFactory.makeYieldList(
+    let result = YieldListSyntax(
       garbageBeforeLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftParen: leftParen,
       garbageBetweenLeftParenAndElementList?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -14331,7 +14331,7 @@ public struct FallthroughStmt: StmtBuildable, ExpressibleAsFallthroughStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `FallthroughStmtSyntax`.
   func buildFallthroughStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FallthroughStmtSyntax {
-    let result = SyntaxFactory.makeFallthroughStmt(
+    let result = FallthroughStmtSyntax(
       garbageBeforeFallthroughKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       fallthroughKeyword: fallthroughKeyword
     )
@@ -14410,7 +14410,7 @@ public struct BreakStmt: StmtBuildable, ExpressibleAsBreakStmt {
       garbageBeforeBreakKeyword: garbageBeforeBreakKeyword,
       breakKeyword: breakKeyword,
       garbageBetweenBreakKeywordAndLabel: garbageBetweenBreakKeywordAndLabel,
-      label: label.map(TokenSyntax.identifier)
+      label: label.map { TokenSyntax.identifier($0) }
     )
   }
 
@@ -14419,7 +14419,7 @@ public struct BreakStmt: StmtBuildable, ExpressibleAsBreakStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `BreakStmtSyntax`.
   func buildBreakStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> BreakStmtSyntax {
-    let result = SyntaxFactory.makeBreakStmt(
+    let result = BreakStmtSyntax(
       garbageBeforeBreakKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       breakKeyword: breakKeyword,
       garbageBetweenBreakKeywordAndLabel?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -14491,7 +14491,7 @@ public struct ConditionElement: SyntaxBuildable, ExpressibleAsConditionElement, 
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ConditionElementSyntax`.
   func buildConditionElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ConditionElementSyntax {
-    let result = SyntaxFactory.makeConditionElement(
+    let result = ConditionElementSyntax(
       garbageBeforeCondition?.buildGarbageNodes(format: format, leadingTrivia: nil),
       condition: condition.buildSyntax(format: format, leadingTrivia: nil),
       garbageBetweenConditionAndTrailingComma?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -14585,7 +14585,7 @@ public struct AvailabilityCondition: SyntaxBuildable, ExpressibleAsAvailabilityC
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AvailabilityConditionSyntax`.
   func buildAvailabilityCondition(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AvailabilityConditionSyntax {
-    let result = SyntaxFactory.makeAvailabilityCondition(
+    let result = AvailabilityConditionSyntax(
       garbageBeforePoundAvailableKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       poundAvailableKeyword: poundAvailableKeyword,
       garbageBetweenPoundAvailableKeywordAndLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -14671,7 +14671,7 @@ public struct MatchingPatternCondition: SyntaxBuildable, ExpressibleAsMatchingPa
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `MatchingPatternConditionSyntax`.
   func buildMatchingPatternCondition(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MatchingPatternConditionSyntax {
-    let result = SyntaxFactory.makeMatchingPatternCondition(
+    let result = MatchingPatternConditionSyntax(
       garbageBeforeCaseKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       caseKeyword: caseKeyword,
       garbageBetweenCaseKeywordAndPattern?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -14757,7 +14757,7 @@ public struct OptionalBindingCondition: SyntaxBuildable, ExpressibleAsOptionalBi
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `OptionalBindingConditionSyntax`.
   func buildOptionalBindingCondition(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> OptionalBindingConditionSyntax {
-    let result = SyntaxFactory.makeOptionalBindingCondition(
+    let result = OptionalBindingConditionSyntax(
       garbageBeforeLetOrVarKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       letOrVarKeyword: letOrVarKeyword,
       garbageBetweenLetOrVarKeywordAndPattern?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -14845,7 +14845,7 @@ public struct UnavailabilityCondition: SyntaxBuildable, ExpressibleAsUnavailabil
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `UnavailabilityConditionSyntax`.
   func buildUnavailabilityCondition(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> UnavailabilityConditionSyntax {
-    let result = SyntaxFactory.makeUnavailabilityCondition(
+    let result = UnavailabilityConditionSyntax(
       garbageBeforePoundUnavailableKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       poundUnavailableKeyword: poundUnavailableKeyword,
       garbageBetweenPoundUnavailableKeywordAndLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -14906,7 +14906,7 @@ public struct DeclarationStmt: StmtBuildable, ExpressibleAsDeclarationStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DeclarationStmtSyntax`.
   func buildDeclarationStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclarationStmtSyntax {
-    let result = SyntaxFactory.makeDeclarationStmt(
+    let result = DeclarationStmtSyntax(
       garbageBeforeDeclaration?.buildGarbageNodes(format: format, leadingTrivia: nil),
       declaration: declaration.buildDecl(format: format, leadingTrivia: nil)
     )
@@ -14976,7 +14976,7 @@ public struct ThrowStmt: StmtBuildable, ExpressibleAsThrowStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ThrowStmtSyntax`.
   func buildThrowStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ThrowStmtSyntax {
-    let result = SyntaxFactory.makeThrowStmt(
+    let result = ThrowStmtSyntax(
       garbageBeforeThrowKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       throwKeyword: throwKeyword,
       garbageBetweenThrowKeywordAndExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -15103,7 +15103,7 @@ public struct IfStmt: StmtBuildable, ExpressibleAsIfStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `IfStmtSyntax`.
   func buildIfStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IfStmtSyntax {
-    let result = SyntaxFactory.makeIfStmt(
+    let result = IfStmtSyntax(
       garbageBeforeIfKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       ifKeyword: ifKeyword,
       garbageBetweenIfKeywordAndConditions?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -15172,7 +15172,7 @@ public struct ElseIfContinuation: SyntaxBuildable, ExpressibleAsElseIfContinuati
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ElseIfContinuationSyntax`.
   func buildElseIfContinuation(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ElseIfContinuationSyntax {
-    let result = SyntaxFactory.makeElseIfContinuation(
+    let result = ElseIfContinuationSyntax(
       garbageBeforeIfStatement?.buildGarbageNodes(format: format, leadingTrivia: nil),
       ifStatement: ifStatement.buildIfStmt(format: format, leadingTrivia: nil)
     )
@@ -15254,7 +15254,7 @@ public struct ElseBlock: SyntaxBuildable, ExpressibleAsElseBlock {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ElseBlockSyntax`.
   func buildElseBlock(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ElseBlockSyntax {
-    let result = SyntaxFactory.makeElseBlock(
+    let result = ElseBlockSyntax(
       garbageBeforeElseKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       elseKeyword: elseKeyword,
       garbageBetweenElseKeywordAndBody?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -15349,7 +15349,7 @@ public struct SwitchCase: SyntaxBuildable, ExpressibleAsSwitchCase {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `SwitchCaseSyntax`.
   func buildSwitchCase(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SwitchCaseSyntax {
-    let result = SyntaxFactory.makeSwitchCase(
+    let result = SwitchCaseSyntax(
       garbageBeforeUnknownAttr?.buildGarbageNodes(format: format, leadingTrivia: nil),
       unknownAttr: unknownAttr?.buildAttribute(format: format, leadingTrivia: nil),
       garbageBetweenUnknownAttrAndLabel?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -15418,7 +15418,7 @@ public struct SwitchDefaultLabel: SyntaxBuildable, ExpressibleAsSwitchDefaultLab
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `SwitchDefaultLabelSyntax`.
   func buildSwitchDefaultLabel(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SwitchDefaultLabelSyntax {
-    let result = SyntaxFactory.makeSwitchDefaultLabel(
+    let result = SwitchDefaultLabelSyntax(
       garbageBeforeDefaultKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       defaultKeyword: defaultKeyword,
       garbageBetweenDefaultKeywordAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -15492,7 +15492,7 @@ public struct CaseItem: SyntaxBuildable, ExpressibleAsCaseItem, HasTrailingComma
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `CaseItemSyntax`.
   func buildCaseItem(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CaseItemSyntax {
-    let result = SyntaxFactory.makeCaseItem(
+    let result = CaseItemSyntax(
       garbageBeforePattern?.buildGarbageNodes(format: format, leadingTrivia: nil),
       pattern: pattern.buildPattern(format: format, leadingTrivia: nil),
       garbageBetweenPatternAndWhereClause?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -15580,7 +15580,7 @@ public struct CatchItem: SyntaxBuildable, ExpressibleAsCatchItem, HasTrailingCom
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `CatchItemSyntax`.
   func buildCatchItem(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CatchItemSyntax {
-    let result = SyntaxFactory.makeCatchItem(
+    let result = CatchItemSyntax(
       garbageBeforePattern?.buildGarbageNodes(format: format, leadingTrivia: nil),
       pattern: pattern?.buildPattern(format: format, leadingTrivia: nil),
       garbageBetweenPatternAndWhereClause?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -15691,7 +15691,7 @@ public struct SwitchCaseLabel: SyntaxBuildable, ExpressibleAsSwitchCaseLabel {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `SwitchCaseLabelSyntax`.
   func buildSwitchCaseLabel(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SwitchCaseLabelSyntax {
-    let result = SyntaxFactory.makeSwitchCaseLabel(
+    let result = SwitchCaseLabelSyntax(
       garbageBeforeCaseKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       caseKeyword: caseKeyword,
       garbageBetweenCaseKeywordAndCaseItems?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -15789,7 +15789,7 @@ public struct CatchClause: SyntaxBuildable, ExpressibleAsCatchClause {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `CatchClauseSyntax`.
   func buildCatchClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CatchClauseSyntax {
-    let result = SyntaxFactory.makeCatchClause(
+    let result = CatchClauseSyntax(
       garbageBeforeCatchKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       catchKeyword: catchKeyword,
       garbageBetweenCatchKeywordAndCatchItems?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -15915,7 +15915,7 @@ public struct PoundAssertStmt: StmtBuildable, ExpressibleAsPoundAssertStmt {
       garbageBetweenConditionAndComma: garbageBetweenConditionAndComma,
       comma: comma,
       garbageBetweenCommaAndMessage: garbageBetweenCommaAndMessage,
-      message: message.map(TokenSyntax.stringLiteral),
+      message: message.map { TokenSyntax.stringLiteral($0) },
       garbageBetweenMessageAndRightParen: garbageBetweenMessageAndRightParen,
       rightParen: rightParen
     )
@@ -15926,7 +15926,7 @@ public struct PoundAssertStmt: StmtBuildable, ExpressibleAsPoundAssertStmt {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PoundAssertStmtSyntax`.
   func buildPoundAssertStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundAssertStmtSyntax {
-    let result = SyntaxFactory.makePoundAssertStmt(
+    let result = PoundAssertStmtSyntax(
       garbageBeforePoundAssert?.buildGarbageNodes(format: format, leadingTrivia: nil),
       poundAssert: poundAssert,
       garbageBetweenPoundAssertAndLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -16024,7 +16024,7 @@ public struct GenericWhereClause: SyntaxBuildable, ExpressibleAsGenericWhereClau
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `GenericWhereClauseSyntax`.
   func buildGenericWhereClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> GenericWhereClauseSyntax {
-    let result = SyntaxFactory.makeGenericWhereClause(
+    let result = GenericWhereClauseSyntax(
       garbageBeforeWhereKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       whereKeyword: whereKeyword,
       garbageBetweenWhereKeywordAndRequirementList?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -16090,7 +16090,7 @@ public struct GenericRequirement: SyntaxBuildable, ExpressibleAsGenericRequireme
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `GenericRequirementSyntax`.
   func buildGenericRequirement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> GenericRequirementSyntax {
-    let result = SyntaxFactory.makeGenericRequirement(
+    let result = GenericRequirementSyntax(
       garbageBeforeBody?.buildGarbageNodes(format: format, leadingTrivia: nil),
       body: body.buildSyntax(format: format, leadingTrivia: nil),
       garbageBetweenBodyAndTrailingComma?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -16173,7 +16173,7 @@ public struct SameTypeRequirement: SyntaxBuildable, ExpressibleAsSameTypeRequire
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `SameTypeRequirementSyntax`.
   func buildSameTypeRequirement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SameTypeRequirementSyntax {
-    let result = SyntaxFactory.makeSameTypeRequirement(
+    let result = SameTypeRequirementSyntax(
       garbageBeforeLeftTypeIdentifier?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftTypeIdentifier: leftTypeIdentifier.buildType(format: format, leadingTrivia: nil),
       garbageBetweenLeftTypeIdentifierAndEqualityToken?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -16319,11 +16319,11 @@ public struct LayoutRequirement: SyntaxBuildable, ExpressibleAsLayoutRequirement
       garbageBetweenLayoutConstraintAndLeftParen: garbageBetweenLayoutConstraintAndLeftParen,
       leftParen: leftParen,
       garbageBetweenLeftParenAndSize: garbageBetweenLeftParenAndSize,
-      size: size.map(TokenSyntax.integerLiteral),
+      size: size.map { TokenSyntax.integerLiteral($0) },
       garbageBetweenSizeAndComma: garbageBetweenSizeAndComma,
       comma: comma,
       garbageBetweenCommaAndAlignment: garbageBetweenCommaAndAlignment,
-      alignment: alignment.map(TokenSyntax.integerLiteral),
+      alignment: alignment.map { TokenSyntax.integerLiteral($0) },
       garbageBetweenAlignmentAndRightParen: garbageBetweenAlignmentAndRightParen,
       rightParen: rightParen
     )
@@ -16334,7 +16334,7 @@ public struct LayoutRequirement: SyntaxBuildable, ExpressibleAsLayoutRequirement
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `LayoutRequirementSyntax`.
   func buildLayoutRequirement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> LayoutRequirementSyntax {
-    let result = SyntaxFactory.makeLayoutRequirement(
+    let result = LayoutRequirementSyntax(
       garbageBeforeTypeIdentifier?.buildGarbageNodes(format: format, leadingTrivia: nil),
       typeIdentifier: typeIdentifier.buildType(format: format, leadingTrivia: nil),
       garbageBetweenTypeIdentifierAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -16467,7 +16467,7 @@ public struct GenericParameter: SyntaxBuildable, ExpressibleAsGenericParameter, 
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `GenericParameterSyntax`.
   func buildGenericParameter(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> GenericParameterSyntax {
-    let result = SyntaxFactory.makeGenericParameter(
+    let result = GenericParameterSyntax(
       garbageBeforeAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
       attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil),
       garbageBetweenAttributesAndName?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -16573,7 +16573,7 @@ public struct PrimaryAssociatedType: SyntaxBuildable, ExpressibleAsPrimaryAssoci
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PrimaryAssociatedTypeSyntax`.
   func buildPrimaryAssociatedType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrimaryAssociatedTypeSyntax {
-    let result = SyntaxFactory.makePrimaryAssociatedType(
+    let result = PrimaryAssociatedTypeSyntax(
       garbageBeforeName?.buildGarbageNodes(format: format, leadingTrivia: nil),
       name: name,
       garbageBetweenNameAndTrailingComma?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -16680,7 +16680,7 @@ public struct GenericParameterClause: SyntaxBuildable, ExpressibleAsGenericParam
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `GenericParameterClauseSyntax`.
   func buildGenericParameterClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> GenericParameterClauseSyntax {
-    let result = SyntaxFactory.makeGenericParameterClause(
+    let result = GenericParameterClauseSyntax(
       garbageBeforeLeftAngleBracket?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftAngleBracket: leftAngleBracket,
       garbageBetweenLeftAngleBracketAndGenericParameterList?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -16756,7 +16756,7 @@ public struct ConformanceRequirement: SyntaxBuildable, ExpressibleAsConformanceR
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ConformanceRequirementSyntax`.
   func buildConformanceRequirement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ConformanceRequirementSyntax {
-    let result = SyntaxFactory.makeConformanceRequirement(
+    let result = ConformanceRequirementSyntax(
       garbageBeforeLeftTypeIdentifier?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftTypeIdentifier: leftTypeIdentifier.buildType(format: format, leadingTrivia: nil),
       garbageBetweenLeftTypeIdentifierAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -16833,7 +16833,7 @@ public struct PrimaryAssociatedTypeClause: SyntaxBuildable, ExpressibleAsPrimary
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `PrimaryAssociatedTypeClauseSyntax`.
   func buildPrimaryAssociatedTypeClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrimaryAssociatedTypeClauseSyntax {
-    let result = SyntaxFactory.makePrimaryAssociatedTypeClause(
+    let result = PrimaryAssociatedTypeClauseSyntax(
       garbageBeforeLeftAngleBracket?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftAngleBracket: leftAngleBracket,
       garbageBetweenLeftAngleBracketAndPrimaryAssociatedTypeList?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -16900,7 +16900,7 @@ public struct SimpleTypeIdentifier: TypeBuildable, ExpressibleAsSimpleTypeIdenti
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `SimpleTypeIdentifierSyntax`.
   func buildSimpleTypeIdentifier(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SimpleTypeIdentifierSyntax {
-    let result = SyntaxFactory.makeSimpleTypeIdentifier(
+    let result = SimpleTypeIdentifierSyntax(
       garbageBeforeName?.buildGarbageNodes(format: format, leadingTrivia: nil),
       name: name,
       garbageBetweenNameAndGenericArgumentClause?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -16988,7 +16988,7 @@ public struct MemberTypeIdentifier: TypeBuildable, ExpressibleAsMemberTypeIdenti
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `MemberTypeIdentifierSyntax`.
   func buildMemberTypeIdentifier(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MemberTypeIdentifierSyntax {
-    let result = SyntaxFactory.makeMemberTypeIdentifier(
+    let result = MemberTypeIdentifierSyntax(
       garbageBeforeBaseType?.buildGarbageNodes(format: format, leadingTrivia: nil),
       baseType: baseType.buildType(format: format, leadingTrivia: nil),
       garbageBetweenBaseTypeAndPeriod?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -17056,7 +17056,7 @@ public struct ClassRestrictionType: TypeBuildable, ExpressibleAsClassRestriction
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ClassRestrictionTypeSyntax`.
   func buildClassRestrictionType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ClassRestrictionTypeSyntax {
-    let result = SyntaxFactory.makeClassRestrictionType(
+    let result = ClassRestrictionTypeSyntax(
       garbageBeforeClassKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       classKeyword: classKeyword
     )
@@ -17135,7 +17135,7 @@ public struct ArrayType: TypeBuildable, ExpressibleAsArrayType {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ArrayTypeSyntax`.
   func buildArrayType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ArrayTypeSyntax {
-    let result = SyntaxFactory.makeArrayType(
+    let result = ArrayTypeSyntax(
       garbageBeforeLeftSquareBracket?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftSquareBracket: leftSquareBracket,
       garbageBetweenLeftSquareBracketAndElementType?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -17235,7 +17235,7 @@ public struct DictionaryType: TypeBuildable, ExpressibleAsDictionaryType {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `DictionaryTypeSyntax`.
   func buildDictionaryType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DictionaryTypeSyntax {
-    let result = SyntaxFactory.makeDictionaryType(
+    let result = DictionaryTypeSyntax(
       garbageBeforeLeftSquareBracket?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftSquareBracket: leftSquareBracket,
       garbageBetweenLeftSquareBracketAndKeyType?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -17344,7 +17344,7 @@ public struct MetatypeType: TypeBuildable, ExpressibleAsMetatypeType {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `MetatypeTypeSyntax`.
   func buildMetatypeType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MetatypeTypeSyntax {
-    let result = SyntaxFactory.makeMetatypeType(
+    let result = MetatypeTypeSyntax(
       garbageBeforeBaseType?.buildGarbageNodes(format: format, leadingTrivia: nil),
       baseType: baseType.buildType(format: format, leadingTrivia: nil),
       garbageBetweenBaseTypeAndPeriod?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -17418,7 +17418,7 @@ public struct OptionalType: TypeBuildable, ExpressibleAsOptionalType {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `OptionalTypeSyntax`.
   func buildOptionalType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> OptionalTypeSyntax {
-    let result = SyntaxFactory.makeOptionalType(
+    let result = OptionalTypeSyntax(
       garbageBeforeWrappedType?.buildGarbageNodes(format: format, leadingTrivia: nil),
       wrappedType: wrappedType.buildType(format: format, leadingTrivia: nil),
       garbageBetweenWrappedTypeAndQuestionMark?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -17508,7 +17508,7 @@ public struct ConstrainedSugarType: TypeBuildable, ExpressibleAsConstrainedSugar
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ConstrainedSugarTypeSyntax`.
   func buildConstrainedSugarType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ConstrainedSugarTypeSyntax {
-    let result = SyntaxFactory.makeConstrainedSugarType(
+    let result = ConstrainedSugarTypeSyntax(
       garbageBeforeSomeOrAnySpecifier?.buildGarbageNodes(format: format, leadingTrivia: nil),
       someOrAnySpecifier: someOrAnySpecifier,
       garbageBetweenSomeOrAnySpecifierAndBaseType?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -17580,7 +17580,7 @@ public struct ImplicitlyUnwrappedOptionalType: TypeBuildable, ExpressibleAsImpli
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ImplicitlyUnwrappedOptionalTypeSyntax`.
   func buildImplicitlyUnwrappedOptionalType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ImplicitlyUnwrappedOptionalTypeSyntax {
-    let result = SyntaxFactory.makeImplicitlyUnwrappedOptionalType(
+    let result = ImplicitlyUnwrappedOptionalTypeSyntax(
       garbageBeforeWrappedType?.buildGarbageNodes(format: format, leadingTrivia: nil),
       wrappedType: wrappedType.buildType(format: format, leadingTrivia: nil),
       garbageBetweenWrappedTypeAndExclamationMark?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -17652,7 +17652,7 @@ public struct CompositionTypeElement: SyntaxBuildable, ExpressibleAsCompositionT
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `CompositionTypeElementSyntax`.
   func buildCompositionTypeElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CompositionTypeElementSyntax {
-    let result = SyntaxFactory.makeCompositionTypeElement(
+    let result = CompositionTypeElementSyntax(
       garbageBeforeType?.buildGarbageNodes(format: format, leadingTrivia: nil),
       type: type.buildType(format: format, leadingTrivia: nil),
       garbageBetweenTypeAndAmpersand?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -17709,7 +17709,7 @@ public struct CompositionType: TypeBuildable, ExpressibleAsCompositionType {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `CompositionTypeSyntax`.
   func buildCompositionType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CompositionTypeSyntax {
-    let result = SyntaxFactory.makeCompositionType(
+    let result = CompositionTypeSyntax(
       garbageBeforeElements?.buildGarbageNodes(format: format, leadingTrivia: nil),
       elements: elements.buildCompositionTypeElementList(format: format, leadingTrivia: nil)
     )
@@ -17830,7 +17830,7 @@ public struct TupleTypeElement: SyntaxBuildable, ExpressibleAsTupleTypeElement, 
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `TupleTypeElementSyntax`.
   func buildTupleTypeElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TupleTypeElementSyntax {
-    let result = SyntaxFactory.makeTupleTypeElement(
+    let result = TupleTypeElementSyntax(
       garbageBeforeInOut?.buildGarbageNodes(format: format, leadingTrivia: nil),
       inOut: inOut,
       garbageBetweenInOutAndName?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -17939,7 +17939,7 @@ public struct TupleType: TypeBuildable, ExpressibleAsTupleType {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `TupleTypeSyntax`.
   func buildTupleType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TupleTypeSyntax {
-    let result = SyntaxFactory.makeTupleType(
+    let result = TupleTypeSyntax(
       garbageBeforeLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftParen: leftParen,
       garbageBetweenLeftParenAndElements?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -18057,7 +18057,7 @@ public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `FunctionTypeSyntax`.
   func buildFunctionType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FunctionTypeSyntax {
-    let result = SyntaxFactory.makeFunctionType(
+    let result = FunctionTypeSyntax(
       garbageBeforeLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftParen: leftParen,
       garbageBetweenLeftParenAndArguments?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -18147,7 +18147,7 @@ public struct AttributedType: TypeBuildable, ExpressibleAsAttributedType {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AttributedTypeSyntax`.
   func buildAttributedType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AttributedTypeSyntax {
-    let result = SyntaxFactory.makeAttributedType(
+    let result = AttributedTypeSyntax(
       garbageBeforeSpecifier?.buildGarbageNodes(format: format, leadingTrivia: nil),
       specifier: specifier,
       garbageBetweenSpecifierAndAttributes?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -18221,7 +18221,7 @@ public struct GenericArgument: SyntaxBuildable, ExpressibleAsGenericArgument, Ha
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `GenericArgumentSyntax`.
   func buildGenericArgument(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> GenericArgumentSyntax {
-    let result = SyntaxFactory.makeGenericArgument(
+    let result = GenericArgumentSyntax(
       garbageBeforeArgumentType?.buildGarbageNodes(format: format, leadingTrivia: nil),
       argumentType: argumentType.buildType(format: format, leadingTrivia: nil),
       garbageBetweenArgumentTypeAndTrailingComma?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -18328,7 +18328,7 @@ public struct GenericArgumentClause: SyntaxBuildable, ExpressibleAsGenericArgume
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `GenericArgumentClauseSyntax`.
   func buildGenericArgumentClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> GenericArgumentClauseSyntax {
-    let result = SyntaxFactory.makeGenericArgumentClause(
+    let result = GenericArgumentClauseSyntax(
       garbageBeforeLeftAngleBracket?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftAngleBracket: leftAngleBracket,
       garbageBetweenLeftAngleBracketAndArguments?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -18396,7 +18396,7 @@ public struct TypeAnnotation: SyntaxBuildable, ExpressibleAsTypeAnnotation {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `TypeAnnotationSyntax`.
   func buildTypeAnnotation(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeAnnotationSyntax {
-    let result = SyntaxFactory.makeTypeAnnotation(
+    let result = TypeAnnotationSyntax(
       garbageBeforeColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
       colon: colon,
       garbageBetweenColonAndType?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -18504,7 +18504,7 @@ public struct EnumCasePattern: PatternBuildable, ExpressibleAsEnumCasePattern {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `EnumCasePatternSyntax`.
   func buildEnumCasePattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> EnumCasePatternSyntax {
-    let result = SyntaxFactory.makeEnumCasePattern(
+    let result = EnumCasePatternSyntax(
       garbageBeforeType?.buildGarbageNodes(format: format, leadingTrivia: nil),
       type: type?.buildType(format: format, leadingTrivia: nil),
       garbageBetweenTypeAndPeriod?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -18580,7 +18580,7 @@ public struct IsTypePattern: PatternBuildable, ExpressibleAsIsTypePattern {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `IsTypePatternSyntax`.
   func buildIsTypePattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IsTypePatternSyntax {
-    let result = SyntaxFactory.makeIsTypePattern(
+    let result = IsTypePatternSyntax(
       garbageBeforeIsKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       isKeyword: isKeyword,
       garbageBetweenIsKeywordAndType?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -18652,7 +18652,7 @@ public struct OptionalPattern: PatternBuildable, ExpressibleAsOptionalPattern {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `OptionalPatternSyntax`.
   func buildOptionalPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> OptionalPatternSyntax {
-    let result = SyntaxFactory.makeOptionalPattern(
+    let result = OptionalPatternSyntax(
       garbageBeforeSubPattern?.buildGarbageNodes(format: format, leadingTrivia: nil),
       subPattern: subPattern.buildPattern(format: format, leadingTrivia: nil),
       garbageBetweenSubPatternAndQuestionMark?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -18715,7 +18715,7 @@ public struct IdentifierPattern: PatternBuildable, ExpressibleAsIdentifierPatter
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `IdentifierPatternSyntax`.
   func buildIdentifierPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IdentifierPatternSyntax {
-    let result = SyntaxFactory.makeIdentifierPattern(
+    let result = IdentifierPatternSyntax(
       garbageBeforeIdentifier?.buildGarbageNodes(format: format, leadingTrivia: nil),
       identifier: identifier
     )
@@ -18793,7 +18793,7 @@ public struct AsTypePattern: PatternBuildable, ExpressibleAsAsTypePattern {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AsTypePatternSyntax`.
   func buildAsTypePattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AsTypePatternSyntax {
-    let result = SyntaxFactory.makeAsTypePattern(
+    let result = AsTypePatternSyntax(
       garbageBeforePattern?.buildGarbageNodes(format: format, leadingTrivia: nil),
       pattern: pattern.buildPattern(format: format, leadingTrivia: nil),
       garbageBetweenPatternAndAsKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -18898,7 +18898,7 @@ public struct TuplePattern: PatternBuildable, ExpressibleAsTuplePattern {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `TuplePatternSyntax`.
   func buildTuplePattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TuplePatternSyntax {
-    let result = SyntaxFactory.makeTuplePattern(
+    let result = TuplePatternSyntax(
       garbageBeforeLeftParen?.buildGarbageNodes(format: format, leadingTrivia: nil),
       leftParen: leftParen,
       garbageBetweenLeftParenAndElements?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -18972,7 +18972,7 @@ public struct WildcardPattern: PatternBuildable, ExpressibleAsWildcardPattern {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `WildcardPatternSyntax`.
   func buildWildcardPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> WildcardPatternSyntax {
-    let result = SyntaxFactory.makeWildcardPattern(
+    let result = WildcardPatternSyntax(
       garbageBeforeWildcard?.buildGarbageNodes(format: format, leadingTrivia: nil),
       wildcard: wildcard,
       garbageBetweenWildcardAndTypeAnnotation?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -19072,7 +19072,7 @@ public struct TuplePatternElement: SyntaxBuildable, ExpressibleAsTuplePatternEle
     self.init(
       leadingTrivia: leadingTrivia,
       garbageBeforeLabelName: garbageBeforeLabelName,
-      labelName: labelName.map(TokenSyntax.identifier),
+      labelName: labelName.map { TokenSyntax.identifier($0) },
       garbageBetweenLabelNameAndLabelColon: garbageBetweenLabelNameAndLabelColon,
       labelColon: labelColon,
       garbageBetweenLabelColonAndPattern: garbageBetweenLabelColonAndPattern,
@@ -19087,7 +19087,7 @@ public struct TuplePatternElement: SyntaxBuildable, ExpressibleAsTuplePatternEle
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `TuplePatternElementSyntax`.
   func buildTuplePatternElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TuplePatternElementSyntax {
-    let result = SyntaxFactory.makeTuplePatternElement(
+    let result = TuplePatternElementSyntax(
       garbageBeforeLabelName?.buildGarbageNodes(format: format, leadingTrivia: nil),
       labelName: labelName,
       garbageBetweenLabelNameAndLabelColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -19162,7 +19162,7 @@ public struct ExpressionPattern: PatternBuildable, ExpressibleAsExpressionPatter
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ExpressionPatternSyntax`.
   func buildExpressionPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExpressionPatternSyntax {
-    let result = SyntaxFactory.makeExpressionPattern(
+    let result = ExpressionPatternSyntax(
       garbageBeforeExpression?.buildGarbageNodes(format: format, leadingTrivia: nil),
       expression: expression.buildExpr(format: format, leadingTrivia: nil)
     )
@@ -19232,7 +19232,7 @@ public struct ValueBindingPattern: PatternBuildable, ExpressibleAsValueBindingPa
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `ValueBindingPatternSyntax`.
   func buildValueBindingPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ValueBindingPatternSyntax {
-    let result = SyntaxFactory.makeValueBindingPattern(
+    let result = ValueBindingPatternSyntax(
       garbageBeforeLetOrVarKeyword?.buildGarbageNodes(format: format, leadingTrivia: nil),
       letOrVarKeyword: letOrVarKeyword,
       garbageBetweenLetOrVarKeywordAndValuePattern?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -19305,7 +19305,7 @@ public struct AvailabilityArgument: SyntaxBuildable, ExpressibleAsAvailabilityAr
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AvailabilityArgumentSyntax`.
   func buildAvailabilityArgument(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AvailabilityArgumentSyntax {
-    let result = SyntaxFactory.makeAvailabilityArgument(
+    let result = AvailabilityArgumentSyntax(
       garbageBeforeEntry?.buildGarbageNodes(format: format, leadingTrivia: nil),
       entry: entry.buildSyntax(format: format, leadingTrivia: nil),
       garbageBetweenEntryAndTrailingComma?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -19402,7 +19402,7 @@ public struct AvailabilityLabeledArgument: SyntaxBuildable, ExpressibleAsAvailab
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AvailabilityLabeledArgumentSyntax`.
   func buildAvailabilityLabeledArgument(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AvailabilityLabeledArgumentSyntax {
-    let result = SyntaxFactory.makeAvailabilityLabeledArgument(
+    let result = AvailabilityLabeledArgumentSyntax(
       garbageBeforeLabel?.buildGarbageNodes(format: format, leadingTrivia: nil),
       label: label,
       garbageBetweenLabelAndColon?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -19488,7 +19488,7 @@ public struct AvailabilityVersionRestriction: SyntaxBuildable, ExpressibleAsAvai
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `AvailabilityVersionRestrictionSyntax`.
   func buildAvailabilityVersionRestriction(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AvailabilityVersionRestrictionSyntax {
-    let result = SyntaxFactory.makeAvailabilityVersionRestriction(
+    let result = AvailabilityVersionRestrictionSyntax(
       garbageBeforePlatform?.buildGarbageNodes(format: format, leadingTrivia: nil),
       platform: platform,
       garbageBetweenPlatformAndVersion?.buildGarbageNodes(format: format, leadingTrivia: nil),
@@ -19576,7 +19576,7 @@ public struct VersionTuple: SyntaxBuildable, ExpressibleAsVersionTuple {
       garbageBetweenMajorMinorAndPatchPeriod: garbageBetweenMajorMinorAndPatchPeriod,
       patchPeriod: patchPeriod,
       garbageBetweenPatchPeriodAndPatchVersion: garbageBetweenPatchPeriodAndPatchVersion,
-      patchVersion: patchVersion.map(TokenSyntax.integerLiteral)
+      patchVersion: patchVersion.map { TokenSyntax.integerLiteral($0) }
     )
   }
 
@@ -19585,7 +19585,7 @@ public struct VersionTuple: SyntaxBuildable, ExpressibleAsVersionTuple {
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `VersionTupleSyntax`.
   func buildVersionTuple(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> VersionTupleSyntax {
-    let result = SyntaxFactory.makeVersionTuple(
+    let result = VersionTupleSyntax(
       garbageBeforeMajorMinor?.buildGarbageNodes(format: format, leadingTrivia: nil),
       majorMinor: majorMinor.buildSyntax(format: format, leadingTrivia: nil),
       garbageBetweenMajorMinorAndPatchPeriod?.buildGarbageNodes(format: format, leadingTrivia: nil),

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableCollectionNodesFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableCollectionNodesFile.swift
@@ -184,7 +184,7 @@ private func createBuildFunction(node: Node) -> FunctionDecl {
     VariableDecl(
       .let,
       name: "result",
-      initializer: FunctionCallExpr(MemberAccessExpr(base: "SyntaxFactory", name: "make\(type.baseName)")) {
+      initializer: FunctionCallExpr("\(type.syntaxBaseName)") {
         if elementType.isToken {
           TupleExprElement(expression: "elements")
         } else {

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/TokensFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/TokensFile.swift
@@ -35,7 +35,7 @@ let tokensFile = SourceFile {
           // We need to use `CodeBlock` here to ensure there is braces around.
 
           let accessor = CodeBlock {
-            FunctionCallExpr(MemberAccessExpr(base: "SyntaxFactory", name: "make\(token.name)Keyword"))
+            FunctionCallExpr(MemberAccessExpr(base: "TokenSyntax", name: "\(token.swiftKind)"))
           }
 
           createTokenSyntaxPatternBinding("`\(token.name.withFirstCharacterLowercased)`", accessor: accessor)
@@ -48,35 +48,13 @@ let tokensFile = SourceFile {
         ) {
           // We need to use `CodeBlock` here to ensure there is braces around.
           let accessor = CodeBlock {
-            FunctionCallExpr(MemberAccessExpr(base: "SyntaxFactory", name: "make\(token.name)Token"))
+            FunctionCallExpr(MemberAccessExpr(base: "TokenSyntax", name: "\(token.swiftKind)Token"))
           }
 
           createTokenSyntaxPatternBinding("`\(token.name.withFirstCharacterLowercased)`", accessor: accessor)
         }
-      } else {
-        let signature = FunctionSignature(
-          input: ParameterClause {
-            FunctionParameter(
-              attributes: nil,
-              firstName: .wildcard,
-              secondName: .identifier("text"),
-              colon: .colon,
-              type: "String"
-            )
-          },
-          output: "TokenSyntax"
-        )
-
-        FunctionDecl(
-          modifiers: [TokenSyntax.static],
-          identifier: .identifier("`\(token.name.withFirstCharacterLowercased)`"),
-          signature: signature
-        ) {
-          FunctionCallExpr(MemberAccessExpr(base: "SyntaxFactory", name: "make\(token.name)")) {
-            TupleExprElement(expression: IdentifierExpr("text"))
-          }
-        }
       }
+      // TokenSyntax with custom text already has a static constructor function defined in SwiftSyntax.
     }
     VariableDecl(
       leadingTrivia: .newline + .docLineComment("/// The `eof` token") + .newline,
@@ -85,9 +63,7 @@ let tokensFile = SourceFile {
     ) {
       // We need to use `CodeBlock` here to ensure there is braces around.
       let body = CodeBlock {
-        FunctionCallExpr(MemberAccessExpr(base: "SyntaxFactory", name: "makeToken")) {
-          TupleExprElement(expression: MemberAccessExpr(name: "eof"))
-          TupleExprElement(label: "presence", expression: MemberAccessExpr(name: "present"))
+        FunctionCallExpr(MemberAccessExpr(base: "TokenSyntax", name: "eof")) {
         }
       }
 
@@ -100,7 +76,7 @@ let tokensFile = SourceFile {
     ) {
       // We need to use `CodeBlock` here to ensure there is braces around.
       let body = CodeBlock {
-        FunctionCallExpr(MemberAccessExpr(base: "SyntaxFactory", name: "makeContextualKeyword")) {
+        FunctionCallExpr(MemberAccessExpr(base: "TokenSyntax", name: "contextualKeyword")) {
           TupleExprElement(expression: StringLiteralExpr("open"))
         }
 

--- a/Sources/SwiftSyntaxBuilderGeneration/Tokens.swift.gyb
+++ b/Sources/SwiftSyntaxBuilderGeneration/Tokens.swift.gyb
@@ -29,7 +29,7 @@ class Token {
   let isKeyword: Bool
 
   var swiftKind: String {
-    let name = self.name
+    let name = lowercaseFirstWord(name: self.name)
 
     if isKeyword {
       return name + "Keyword"

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/Tokens.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/Tokens.swift
@@ -23,7 +23,7 @@ class Token {
   let isKeyword: Bool
 
   var swiftKind: String {
-    let name = self.name
+    let name = lowercaseFirstWord(name: self.name)
 
     if isKeyword {
       return name + "Keyword"

--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -215,9 +215,11 @@ func getSwiftLanguageVersionInfo(args: CommandLineArguments) -> (languageVersion
 /// Rewrites a parsed tree with all constructed nodes.
 class TreeReconstructor : SyntaxRewriter {
   override func visit(_ token: TokenSyntax) -> Syntax {
-    let token = SyntaxFactory.makeToken(token.tokenKind, presence: token.presence,
-                                        leadingTrivia: token.leadingTrivia,
-                                        trailingTrivia: token.trailingTrivia)
+    let token = TokenSyntax(
+      token.tokenKind,
+      leadingTrivia: token.leadingTrivia,
+      trailingTrivia: token.trailingTrivia,
+      presence: token.presence)
     return Syntax(token)
   }
 }

--- a/Tests/SwiftSyntaxBuilderTest/ExtensionDeclTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ExtensionDeclTests.swift
@@ -7,7 +7,7 @@ final class ExtensionDeclTests: XCTestCase {
     let keywords = ["associatedtype", "class"].map { keyword -> VariableDecl in
       // We need to use `CodeBlock` here to ensure there is braces around.
       let body = CodeBlock {
-        FunctionCallExpr("SyntaxFactory.make\(keyword)Keyword")
+        FunctionCallExpr("TokenSyntax.\(keyword)Keyword")
       }
 
       return VariableDecl(
@@ -34,10 +34,10 @@ final class ExtensionDeclTests: XCTestCase {
     XCTAssertEqual(text, """
     extension TokenSyntax {
         public var `associatedtype`: TokenSyntax {
-            SyntaxFactory.makeassociatedtypeKeyword()
+            TokenSyntax.associatedtypeKeyword()
         }
         public var `class`: TokenSyntax {
-            SyntaxFactory.makeclassKeyword()
+            TokenSyntax.classKeyword()
         }
     }
     """)

--- a/Tests/SwiftSyntaxBuilderTest/ImportTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ImportTests.swift
@@ -5,7 +5,7 @@ import SwiftSyntaxBuilder
 final class ImportTests: XCTestCase {
   func testImport() {
     let leadingTrivia = Trivia.garbageText("␣")
-    let identifier = SyntaxFactory.makeIdentifier("SwiftSyntax")
+    let identifier = TokenSyntax.identifier("SwiftSyntax")
 
     let importDecl = ImportDecl(path: AccessPath([AccessPathComponent(name: identifier)]))
 

--- a/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
@@ -12,7 +12,7 @@ final class StringLiteralTests: XCTestCase {
 
     for (line, testCase) in testCases {
       let (value, expected) = testCase
-      let string = SyntaxFactory.makeStringSegment(value)
+      let string = TokenSyntax.stringSegment(value)
       let segment = StringSegment(content: string)
       let builder = StringLiteralExpr(openQuote: .stringQuote,
                                       segments: StringLiteralSegments([segment]),

--- a/Tests/SwiftSyntaxParserTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftSyntaxParserTest/AbsolutePositionTests.swift
@@ -7,7 +7,7 @@ fileprivate class FuncRenamer: SyntaxRewriter {
   override func visit(_ node: FunctionDeclSyntax) -> DeclSyntax {
     let rewritten = super.visit(node).as(FunctionDeclSyntax.self)!
     let modifiedFunctionDecl = rewritten.withIdentifier(
-      SyntaxFactory.makeIdentifier("anotherName"))
+      .identifier("anotherName"))
     return DeclSyntax(modifiedFunctionDecl)
   }
 }
@@ -67,11 +67,10 @@ public class AbsolutePositionTests: XCTestCase {
     var l = [CodeBlockItemSyntax]()
     let idx = 2000
     for _ in 0...idx {
-      l.append(SyntaxFactory.makeCodeBlockItem(
+      l.append(CodeBlockItemSyntax(
         item: Syntax(
-          SyntaxFactory.makeReturnStmt(
-            returnKeyword: SyntaxFactory.makeToken(.returnKeyword, presence: .present)
-                             .withTrailingTrivia(.newline),
+          ReturnStmtSyntax(
+            returnKeyword: .returnKeyword(trailingTrivia: .newline),
             expression: nil
           )
         ),
@@ -79,9 +78,9 @@ public class AbsolutePositionTests: XCTestCase {
         errorTokens: nil)
       )
     }
-    let root = SyntaxFactory.makeSourceFile(
-      statements: SyntaxFactory.makeCodeBlockItemList(l),
-      eofToken: SyntaxFactory.makeToken(.eof, presence: .present))
+    let root = SourceFileSyntax(
+      statements: CodeBlockItemListSyntax(l),
+      eofToken: .eof())
     _ = root.statements[idx].position
     _ = root.statements[idx].byteSize
     _ = root.statements[idx].positionAfterSkippingLeadingTrivia
@@ -100,9 +99,9 @@ public class AbsolutePositionTests: XCTestCase {
 
   func createSourceFile(_ count: Int) -> SourceFileSyntax {
     let items : [CodeBlockItemSyntax] =
-    [CodeBlockItemSyntax](repeating: SyntaxFactory.makeCodeBlockItem(
-      item: Syntax(SyntaxFactory.makeReturnStmt(
-        returnKeyword: SyntaxFactory.makeReturnKeyword(
+    [CodeBlockItemSyntax](repeating: CodeBlockItemSyntax(
+      item: Syntax(ReturnStmtSyntax(
+        returnKeyword: .returnKeyword(
           leadingTrivia: AbsolutePositionTests.leadingTrivia,
           trailingTrivia: AbsolutePositionTests.trailingTrivia
         ),
@@ -111,9 +110,9 @@ public class AbsolutePositionTests: XCTestCase {
       semicolon: nil,
       errorTokens: nil
     ), count: count)
-    return SyntaxFactory.makeSourceFile(
-      statements: SyntaxFactory.makeCodeBlockItemList(items),
-      eofToken: SyntaxFactory.makeToken(.eof, presence: .present))
+    return SourceFileSyntax(
+      statements: CodeBlockItemListSyntax(items),
+      eofToken: .eof())
   }
 
   public func testTrivias() {
@@ -170,12 +169,10 @@ public class AbsolutePositionTests: XCTestCase {
   }
 
   public func testWithoutSourceFileRoot() {
-    let item = SyntaxFactory.makeCodeBlockItem(
+    let item = CodeBlockItemSyntax(
       item: Syntax(
-        SyntaxFactory.makeReturnStmt(
-          returnKeyword: SyntaxFactory.makeToken(.returnKeyword, presence: .present)
-                           .withLeadingTrivia(.newline)
-                           .withTrailingTrivia(.newline),
+        ReturnStmtSyntax(
+          returnKeyword: .returnKeyword(leadingTrivia: .newline, trailingTrivia: .newline),
           expression: nil)
       ),
       semicolon: nil,

--- a/Tests/SwiftSyntaxParserTest/SyntaxTests.swift
+++ b/Tests/SwiftSyntaxParserTest/SyntaxTests.swift
@@ -89,15 +89,15 @@ public class SyntaxTests: XCTestCase {
     do {
       let leading = Trivia(pieces: [ .spaces(2) ])
       let trailing = Trivia(pieces: [ .spaces(1) ])
-      let funcKW = SyntaxFactory.makeFuncKeyword(
+      let funcKW = TokenSyntax.funcKeyword(
         leadingTrivia: leading, trailingTrivia: trailing)
       testFuncKw(funcKW)
     }
   }
 
   public func testCasting() {
-    let integerExpr = SyntaxFactory.makeIntegerLiteralExpr(
-      digits: SyntaxFactory.makeIntegerLiteral("1", trailingTrivia: .space)
+    let integerExpr = IntegerLiteralExprSyntax(
+      digits: .integerLiteral("1", trailingTrivia: .space)
     )
 
     let expr = ExprSyntax(integerExpr)
@@ -116,10 +116,10 @@ public class SyntaxTests: XCTestCase {
     XCTAssertFalse(expr.isProtocol(BracedSyntax.self))
     XCTAssertNil(expr.asProtocol(BracedSyntax.self))
 
-    let classDecl = SyntaxFactory.makeCodeBlock(
-      leftBrace: SyntaxFactory.makeToken(.leftBrace, presence: .present),
-      statements: SyntaxFactory.makeCodeBlockItemList([]),
-      rightBrace: SyntaxFactory.makeToken(.rightBrace, presence: .present)
+    let classDecl = CodeBlockSyntax(
+      leftBrace: TokenSyntax.leftBraceToken(),
+      statements: CodeBlockItemListSyntax([]),
+      rightBrace: TokenSyntax.rightBraceToken()
     )
 
     XCTAssertTrue(classDecl.isProtocol(BracedSyntax.self))
@@ -136,8 +136,8 @@ public class SyntaxTests: XCTestCase {
   }
 
   public func testNodeType() {
-    let integerExpr = SyntaxFactory.makeIntegerLiteralExpr(
-      digits: SyntaxFactory.makeIntegerLiteral("1", trailingTrivia: .space)
+    let integerExpr = IntegerLiteralExprSyntax(
+      digits: TokenSyntax.integerLiteral("1", trailingTrivia: .space)
     )
     let expr = ExprSyntax(integerExpr)
     let node = Syntax(expr)
@@ -148,8 +148,8 @@ public class SyntaxTests: XCTestCase {
   }
 
   public func testConstructFromSyntaxProtocol() {
-    let integerExpr = SyntaxFactory.makeIntegerLiteralExpr(
-      digits: SyntaxFactory.makeIntegerLiteral("1", trailingTrivia: .space)
+    let integerExpr = IntegerLiteralExprSyntax(
+      digits: .integerLiteral("1", trailingTrivia: .space)
     )
 
     XCTAssertEqual(Syntax(integerExpr), Syntax(fromProtocol: integerExpr as SyntaxProtocol))

--- a/Tests/SwiftSyntaxParserTest/SyntaxVisitorTests.swift
+++ b/Tests/SwiftSyntaxParserTest/SyntaxVisitorTests.swift
@@ -54,7 +54,7 @@ public class SyntaxVisitorTests: XCTestCase {
     XCTAssertNoThrow(try {
       let parsed = try SyntaxParser.parse(getTestInput("near-empty.swift"))
       let rewriter = VisitAnyRewriter(transform: { _ in
-         return SyntaxFactory.makeIdentifier("")
+        return TokenSyntax.identifier("")
       })
       let rewritten = rewriter.visit(parsed)
       XCTAssertEqual(rewritten.description, "")

--- a/Tests/SwiftSyntaxParserTest/TokenTest.swift
+++ b/Tests/SwiftSyntaxParserTest/TokenTest.swift
@@ -48,7 +48,7 @@ public class TokenTests: XCTestCase {
     XCTAssertTrue(tok.tokenKind == .multilineStringQuote)
     XCTAssertEqual(tok.contentLength.utf8Length, 3)
 
-    let tok2 = SyntaxFactory.makeMultilineStringQuoteToken()
+    let tok2 = TokenSyntax.multilineStringQuoteToken()
     XCTAssertTrue(tok2.tokenKind == .multilineStringQuote)
     XCTAssertEqual(tok2.contentLength.utf8Length, 3)
   }

--- a/Tests/SwiftSyntaxTest/CustomReflectableTests.swift
+++ b/Tests/SwiftSyntaxTest/CustomReflectableTests.swift
@@ -18,15 +18,12 @@ public class CustomReflectableTests: XCTestCase {
     }
 
     let testCases: [UInt: TestCase] = [
-      #line: .init(syntax: SyntaxFactory.makeUnknownSyntax(tokens: []),
+      #line: .init(syntax: UnknownSyntax(tokens: []),
                    expectedDumped: """
                                    - UnknownSyntax
 
                                    """),
-      #line: .init(syntax: SyntaxFactory.makeToken(.associatedtypeKeyword,
-                                                   presence: .present,
-                                                   leadingTrivia: [],
-                                                   trailingTrivia: []),
+      #line: .init(syntax: TokenSyntax.associatedtypeKeyword(leadingTrivia: [], trailingTrivia: []),
                    expectedDumped: """
                                    ▿ associatedtypeKeyword
                                      - text: "associatedtype"
@@ -38,18 +35,12 @@ public class CustomReflectableTests: XCTestCase {
 
                                    """),
       #line: {
-        let leftToken = SyntaxFactory.makeToken(.leftSquareBracket,
-                                                presence: .present,
-                                                leadingTrivia: [],
-                                                trailingTrivia: [])
-        let elements = SyntaxFactory.makeBlankArrayElementList()
-        let rightToken = SyntaxFactory.makeToken(.rightSquareBracket,
-                                                 presence: .present,
-                                                 leadingTrivia: [],
-                                                 trailingTrivia: [])
-        let expr = SyntaxFactory.makeArrayExpr(leftSquare: leftToken,
-                                               elements: elements,
-                                               rightSquare: rightToken)
+        let leftToken = TokenSyntax.leftSquareBracketToken()
+        let elements = ArrayElementListSyntax([])
+        let rightToken = TokenSyntax.rightSquareBracketToken()
+        let expr = ArrayExprSyntax(leftSquare: leftToken,
+                                   elements: elements,
+                                   rightSquare: rightToken)
         return .init(syntax: expr.tokens(viewMode: .sourceAccurate),
                      expectedDumped: """
                                      ▿ SwiftSyntax.TokenSequence
@@ -71,18 +62,12 @@ public class CustomReflectableTests: XCTestCase {
                                      """)
       }(),
       #line: {
-        let leftToken = SyntaxFactory.makeToken(.leftSquareBracket,
-                                                presence: .present,
-                                                leadingTrivia: [],
-                                                trailingTrivia: [])
-        let elements = SyntaxFactory.makeBlankArrayElementList()
-        let rightToken = SyntaxFactory.makeToken(.rightSquareBracket,
-                                                 presence: .present,
-                                                 leadingTrivia: [],
-                                                 trailingTrivia: [])
-        let expr = SyntaxFactory.makeArrayExpr(leftSquare: leftToken,
-                                               elements: elements,
-                                               rightSquare: rightToken)
+        let leftToken = TokenSyntax.leftSquareBracketToken()
+        let elements = ArrayElementListSyntax([])
+        let rightToken = TokenSyntax.rightSquareBracketToken()
+        let expr = ArrayExprSyntax(leftSquare: leftToken,
+                                   elements: elements,
+                                   rightSquare: rightToken)
         return .init(syntax: expr.tokens(viewMode: .sourceAccurate).reversed(),
                      expectedDumped: """
                                      ▿ SwiftSyntax.ReversedTokenSequence
@@ -104,25 +89,25 @@ public class CustomReflectableTests: XCTestCase {
                                      """)
       }(),
       #line: {
-        let token1 = SyntaxFactory.makeToken(.integerLiteral("1"),
-                                             presence: .present,
-                                             leadingTrivia: [],
-                                             trailingTrivia: [])
-        let expr1 = SyntaxFactory.makeIntegerLiteralExpr(digits: token1)
-        let token2 = SyntaxFactory.makeToken(.integerLiteral("2"),
-                                             presence: .present,
-                                             leadingTrivia: [],
-                                             trailingTrivia: [])
-        let expr2 = SyntaxFactory.makeIntegerLiteralExpr(digits: token2)
-        let elements = [SyntaxFactory.makeTupleExprElement(label: nil,
-                                                       colon: nil,
-                                                       expression: ExprSyntax(expr1),
-                                                       trailingComma: nil),
-                        SyntaxFactory.makeTupleExprElement(label: nil,
-                                                       colon: nil,
-                                                       expression: ExprSyntax(expr2),
-                                                       trailingComma: nil)]
-        let tuples = SyntaxFactory.makeTupleExprElementList(elements)
+        let token1 = TokenSyntax.integerLiteral("1")
+        let expr1 = IntegerLiteralExprSyntax(digits: token1)
+        let token2 = TokenSyntax.integerLiteral("2")
+        let expr2 = IntegerLiteralExprSyntax(digits: token2)
+        let elements = [
+          TupleExprElementSyntax(
+            label: nil,
+            colon: nil,
+            expression: ExprSyntax(expr1),
+            trailingComma: nil
+          ),
+          TupleExprElementSyntax(
+            label: nil,
+            colon: nil,
+            expression: ExprSyntax(expr2),
+            trailingComma: nil
+          )
+        ]
+        let tuples = TupleExprElementListSyntax(elements)
         return .init(syntax: tuples,
                      expectedDumped: """
                                      ▿ TupleExprElementListSyntax
@@ -166,25 +151,19 @@ public class CustomReflectableTests: XCTestCase {
                                      """)
       }(),
       #line: {
-        let token1 = SyntaxFactory.makeToken(.integerLiteral("1"),
-                                             presence: .present,
-                                             leadingTrivia: [],
-                                             trailingTrivia: [])
-        let expr1 = SyntaxFactory.makeIntegerLiteralExpr(digits: token1)
-        let token2 = SyntaxFactory.makeToken(.integerLiteral("2"),
-                                             presence: .present,
-                                             leadingTrivia: [],
-                                             trailingTrivia: [])
-        let expr2 = SyntaxFactory.makeIntegerLiteralExpr(digits: token2)
-        let elements = [SyntaxFactory.makeTupleExprElement(label: nil,
+        let token1 = TokenSyntax.integerLiteral("1")
+        let expr1 = IntegerLiteralExprSyntax(digits: token1)
+        let token2 = TokenSyntax.integerLiteral("2")
+        let expr2 = IntegerLiteralExprSyntax(digits: token2)
+        let elements = [TupleExprElementSyntax(label: nil,
                                                        colon: nil,
                                                        expression: ExprSyntax(expr1),
                                                        trailingComma: nil),
-          SyntaxFactory.makeTupleExprElement(label: nil,
+          TupleExprElementSyntax(label: nil,
                                          colon: nil,
                                          expression: ExprSyntax(expr2),
                                          trailingComma: nil)]
-        let tuples = SyntaxFactory.makeTupleExprElementList(elements)
+        let tuples = TupleExprElementListSyntax(elements)
         return .init(syntax: tuples.reversed(),
                      expectedDumped: """
                                      ▿ Swift.ReversedCollection<SwiftSyntax.TupleExprElementListSyntax>

--- a/Tests/SwiftSyntaxTest/MultithreadingTests.swift
+++ b/Tests/SwiftSyntaxTest/MultithreadingTests.swift
@@ -4,7 +4,11 @@ import SwiftSyntax
 public class MultithreadingTests: XCTestCase {
 
   public func testPathological() {
-    let tuple = SyntaxFactory.makeVoidTupleType()
+    let tuple = TupleTypeSyntax(
+      leftParen: .leftParenToken(),
+      elements: TupleTypeElementListSyntax([]),
+      rightParen: .rightParenToken()
+    )
 
     DispatchQueue.concurrentPerform(iterations: 100) { _ in
       XCTAssertEqual(tuple.leftParen, tuple.leftParen)
@@ -12,7 +16,11 @@ public class MultithreadingTests: XCTestCase {
   }
 
   public func testTwoAccesses() {
-    let tuple = SyntaxFactory.makeVoidTupleType()
+    let tuple = TupleTypeSyntax(
+      leftParen: .leftParenToken(),
+      elements: TupleTypeElementListSyntax([]),
+      rightParen: .rightParenToken()
+    )
 
     let queue1 = DispatchQueue(label: "queue1")
     let queue2 = DispatchQueue(label: "queue2")

--- a/Tests/SwiftSyntaxTest/SyntaxChildrenTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxChildrenTests.swift
@@ -5,9 +5,9 @@ import _SwiftSyntaxTestSupport
 public class SyntaxChildrenTests: XCTestCase {
 
   public func testIterateWithAllPresent() throws {
-    let returnStmt = SyntaxFactory.makeReturnStmt(
-      returnKeyword: SyntaxFactory.makeReturnKeyword(),
-      expression: ExprSyntax(SyntaxFactory.makeBlankUnknownExpr()))
+    let returnStmt = ReturnStmtSyntax(
+      returnKeyword: .returnKeyword(),
+      expression: ExprSyntax(UnknownExprSyntax()))
 
     var iterator = returnStmt.children(viewMode: .sourceAccurate).makeIterator()
     try XCTAssertNext(&iterator) { $0.as(TokenSyntax.self)?.tokenKind == .returnKeyword }
@@ -16,8 +16,8 @@ public class SyntaxChildrenTests: XCTestCase {
   }
 
   public func testIterateWithSomeMissing() throws {
-    let returnStmt = SyntaxFactory.makeReturnStmt(
-      returnKeyword: SyntaxFactory.makeReturnKeyword(),
+    let returnStmt = ReturnStmtSyntax(
+      returnKeyword: .returnKeyword(),
       expression: nil)
 
     var iterator = returnStmt.children(viewMode: .sourceAccurate).makeIterator()
@@ -26,15 +26,18 @@ public class SyntaxChildrenTests: XCTestCase {
   }
 
   public func testIterateWithAllMissing() {
-    let returnStmt = SyntaxFactory.makeBlankReturnStmt()
+    let returnStmt = ReturnStmtSyntax(
+      returnKeyword: TokenSyntax.returnKeyword(presence: .missing),
+      expression: nil
+    )
 
     var iterator = returnStmt.children(viewMode: .sourceAccurate).makeIterator()
     XCTAssertNextIsNil(&iterator)
   }
 
   public func testMissingTokens() throws {
-    let returnStmt = SyntaxFactory.makeReturnStmt(
-      returnKeyword: SyntaxFactory.makeToken(.returnKeyword, presence: .missing),
+    let returnStmt = ReturnStmtSyntax(
+      returnKeyword: .returnKeyword(presence: .missing),
       expression: nil
     )
 
@@ -47,7 +50,7 @@ public class SyntaxChildrenTests: XCTestCase {
   }
 
   public func testMissingNodes() throws {
-    let node = SyntaxFactory.makeDeclarationStmt(declaration: DeclSyntax(SyntaxFactory.makeBlankMissingDecl()))
+    let node = DeclarationStmtSyntax(declaration: DeclSyntax(MissingDeclSyntax()))
 
     var sourceAccurateIt = node.children(viewMode: .sourceAccurate).makeIterator()
     XCTAssertNextIsNil(&sourceAccurateIt)

--- a/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCollectionsTests.swift
@@ -3,16 +3,16 @@ import SwiftSyntax
 import _SwiftSyntaxTestSupport
 
 fileprivate func integerLiteralElement(_ int: Int) -> ArrayElementSyntax {
-    let literal = SyntaxFactory.makeIntegerLiteral("\(int)")
-    return SyntaxFactory.makeArrayElement(
-        expression: ExprSyntax(SyntaxFactory.makeIntegerLiteralExpr(digits: literal)),
+    let literal = TokenSyntax.integerLiteral("\(int)")
+    return ArrayElementSyntax(
+        expression: ExprSyntax(IntegerLiteralExprSyntax(digits: literal)),
         trailingComma: nil)
 }
 
 public class SyntaxCollectionsTests: XCTestCase {
 
   public func testAppendingElement() {
-      let arrayElementList = SyntaxFactory.makeArrayElementList([
+      let arrayElementList = ArrayElementListSyntax([
           integerLiteralElement(0)
       ])
 
@@ -25,7 +25,7 @@ public class SyntaxCollectionsTests: XCTestCase {
   }
 
   public func testInsertingElement() {
-      let arrayElementList = SyntaxFactory.makeArrayElementList([
+      let arrayElementList = ArrayElementListSyntax([
           integerLiteralElement(1)
       ])
 
@@ -43,7 +43,7 @@ public class SyntaxCollectionsTests: XCTestCase {
   }
 
   public func testPrependingElement() {
-      let arrayElementList = SyntaxFactory.makeArrayElementList([
+      let arrayElementList = ArrayElementListSyntax([
           integerLiteralElement(1)
       ])
 
@@ -55,7 +55,7 @@ public class SyntaxCollectionsTests: XCTestCase {
   }
 
   public func testRemovingFirstElement() {
-      let arrayElementList = SyntaxFactory.makeArrayElementList([
+      let arrayElementList = ArrayElementListSyntax([
           integerLiteralElement(0),
           integerLiteralElement(1)
       ])
@@ -68,7 +68,7 @@ public class SyntaxCollectionsTests: XCTestCase {
   }
 
   public func testRemovingLastElement() {
-      let arrayElementList = SyntaxFactory.makeArrayElementList([
+      let arrayElementList = ArrayElementListSyntax([
           integerLiteralElement(0),
           integerLiteralElement(1)
       ])
@@ -81,7 +81,7 @@ public class SyntaxCollectionsTests: XCTestCase {
   }
 
   public func testRemovingElement() {
-      let arrayElementList = SyntaxFactory.makeArrayElementList([
+      let arrayElementList = ArrayElementListSyntax([
           integerLiteralElement(0)
       ])
 
@@ -92,7 +92,7 @@ public class SyntaxCollectionsTests: XCTestCase {
   }
 
   public func testReplacingElement() {
-      let arrayElementList = SyntaxFactory.makeArrayElementList([
+      let arrayElementList = ArrayElementListSyntax([
           integerLiteralElement(0),
           integerLiteralElement(1),
           integerLiteralElement(2)
@@ -106,7 +106,7 @@ public class SyntaxCollectionsTests: XCTestCase {
   }
 
   public func testIteration() {
-    let arrayElementList = SyntaxFactory.makeArrayElementList([
+    let arrayElementList = ArrayElementListSyntax([
         integerLiteralElement(0),
         integerLiteralElement(1),
         integerLiteralElement(2)

--- a/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxCreationTests.swift
@@ -2,15 +2,15 @@ import XCTest
 import SwiftSyntax
 
 fileprivate func cannedStructDecl() -> StructDeclSyntax {
-  let structKW = SyntaxFactory.makeStructKeyword(trailingTrivia: .space)
-  let fooID = SyntaxFactory.makeIdentifier("Foo")
-  let rBrace = SyntaxFactory.makeRightBraceToken(leadingTrivia: .newline)
-  let members = SyntaxFactory.makeMemberDeclBlock(
-    leftBrace: SyntaxFactory.makeLeftBraceToken(),
-    members: SyntaxFactory.makeMemberDeclList([]),
+  let structKW = TokenSyntax.structKeyword(trailingTrivia: .space)
+  let fooID = TokenSyntax.identifier("Foo")
+  let rBrace = TokenSyntax.rightBraceToken(leadingTrivia: .newline)
+  let members = MemberDeclBlockSyntax(
+    leftBrace: .leftBraceToken(),
+    members: MemberDeclListSyntax([]),
     rightBrace: rBrace
   )
-  return SyntaxFactory.makeStructDecl(
+  return StructDeclSyntax(
     attributes: nil,
     modifiers: nil,
     structKeyword: structKW,
@@ -22,7 +22,7 @@ fileprivate func cannedStructDecl() -> StructDeclSyntax {
   )
 }
 
-public class SyntaxFactoryTests: XCTestCase {
+public class SyntaxCreationTests: XCTestCase {
 
   public func testGenerated() {
 
@@ -34,8 +34,8 @@ public class SyntaxFactoryTests: XCTestCase {
                    }
                    """)
 
-    let forType = SyntaxFactory.makeIdentifier("`for`")
-    let newBrace = SyntaxFactory.makeRightBraceToken(leadingTrivia: .newlines(2))
+    let forType = TokenSyntax.identifier("`for`")
+    let newBrace = TokenSyntax.rightBraceToken(leadingTrivia: .newlines(2))
 
     let renamed = structDecl.withIdentifier(forType)
                             .withMembers(structDecl.members
@@ -62,7 +62,7 @@ public class SyntaxFactoryTests: XCTestCase {
   }
 
   public func testTokenSyntax() {
-    let tok = SyntaxFactory.makeStructKeyword()
+    let tok = TokenSyntax.structKeyword()
     XCTAssertEqual("\(tok)", "struct ")
     XCTAssertEqual(tok.presence, .present)
 
@@ -87,35 +87,52 @@ public class SyntaxFactoryTests: XCTestCase {
     XCTAssertEqual("\(mutablePreSpacedTok)", "    struct  ")
   }
 
+//  private func makeStringLiteralExpr(_ text: String, leadingTrivia: Trivia = [], trailingTrivia: Trivia = []) -> StringLiteralExprSyntax {
+//    return
+//  }
+
   public func testFunctionCallSyntaxBuilder() {
-    let string = SyntaxFactory.makeStringLiteralExpr("Hello, world!")
-    let printID = SyntaxFactory.makeVariableExpr("print")
-    let arg = SyntaxFactory.makeTupleExprElement(
+    let string = StringLiteralExprSyntax(
+      openDelimiter: nil,
+      openQuote: .stringQuoteToken(),
+      segments: StringLiteralSegmentsSyntax([Syntax(StringSegmentSyntax(content: .stringSegment("Hello, world!")))]),
+      closeQuote: .stringQuoteToken(),
+      closeDelimiter: nil
+    )
+    let printID = ExprSyntax(IdentifierExprSyntax(identifier: .identifier("print"), declNameArguments: nil))
+    let arg = TupleExprElementSyntax(
       label: nil,
       colon: nil,
       expression: ExprSyntax(string),
       trailingComma: nil
     )
-    let call = SyntaxFactory.makeFunctionCallExpr(
+    let call = FunctionCallExprSyntax(
       calledExpression: ExprSyntax(printID),
-      leftParen: SyntaxFactory.makeLeftParenToken(),
-      argumentList: SyntaxFactory.makeTupleExprElementList([arg]),
-      rightParen: SyntaxFactory.makeRightParenToken(),
+      leftParen: .leftParenToken(),
+      argumentList: TupleExprElementListSyntax([arg]),
+      rightParen: .rightParenToken(),
       trailingClosure: nil,
       additionalTrailingClosures: nil
     )
     XCTAssertEqual("\(call)", "print(\"Hello, world!\")")
 
-    let terminatorArg = SyntaxFactory.makeTupleExprElement(
-      label: SyntaxFactory.makeIdentifier("terminator"),
-      colon: SyntaxFactory.makeColonToken(trailingTrivia: .space),
-      expression: ExprSyntax(SyntaxFactory.makeStringLiteralExpr(" ")),
+    let emptyString = StringLiteralExprSyntax(
+      openDelimiter: nil,
+      openQuote: .stringQuoteToken(),
+      segments: StringLiteralSegmentsSyntax([Syntax(StringSegmentSyntax(content: .stringSegment(" ")))]),
+      closeQuote: .stringQuoteToken(),
+      closeDelimiter: nil
+    )
+    let terminatorArg = TupleExprElementSyntax(
+      label: TokenSyntax.identifier("terminator"),
+      colon: TokenSyntax.colonToken(trailingTrivia: .space),
+      expression: ExprSyntax(emptyString),
       trailingComma: nil
     )
     let callWithTerminator = call.withArgumentList(
-      SyntaxFactory.makeTupleExprElementList([
+      TupleExprElementListSyntax([
         arg.withTrailingComma(
-          SyntaxFactory.makeCommaToken(trailingTrivia: .space)),
+          .commaToken(trailingTrivia: .space)),
         terminatorArg
       ])
     )
@@ -125,19 +142,25 @@ public class SyntaxFactoryTests: XCTestCase {
   }
 
   public func testWithOptionalChild() {
-    let string = SyntaxFactory.makeStringLiteralExpr("Hello, world!")
-    let printID = SyntaxFactory.makeVariableExpr("print")
-    let arg = SyntaxFactory.makeTupleExprElement(
+    let string = StringLiteralExprSyntax(
+      openDelimiter: nil,
+      openQuote: .stringQuoteToken(),
+      segments: StringLiteralSegmentsSyntax([Syntax(StringSegmentSyntax(content: .stringSegment("Hello, world!")))]),
+      closeQuote: .stringQuoteToken(),
+      closeDelimiter: nil
+    )
+    let printID = IdentifierExprSyntax(identifier: .identifier("print"), declNameArguments: nil)
+    let arg = TupleExprElementSyntax(
       label: nil,
       colon: nil,
       expression: ExprSyntax(string),
       trailingComma: nil
     )
-    let call1 = SyntaxFactory.makeFunctionCallExpr(
+    let call1 = FunctionCallExprSyntax(
       calledExpression: ExprSyntax(printID),
-      leftParen: SyntaxFactory.makeLeftParenToken(),
-      argumentList: SyntaxFactory.makeTupleExprElementList([arg]),
-      rightParen: SyntaxFactory.makeRightParenToken(),
+      leftParen: TokenSyntax.leftParenToken(),
+      argumentList: TupleExprElementListSyntax([arg]),
+      rightParen: TokenSyntax.rightParenToken(),
       trailingClosure: nil,
       additionalTrailingClosures: nil
     )
@@ -148,10 +171,10 @@ public class SyntaxFactoryTests: XCTestCase {
     XCTAssertNil(call2.leftParen)
     XCTAssertNil(call2.rightParen)
 
-    let call3 = SyntaxFactory.makeFunctionCallExpr(
+    let call3 = FunctionCallExprSyntax(
       calledExpression: ExprSyntax(printID),
       leftParen: nil,
-      argumentList: SyntaxFactory.makeTupleExprElementList([arg]),
+      argumentList: TupleExprElementListSyntax([arg]),
       rightParen: nil,
       trailingClosure: nil,
       additionalTrailingClosures: nil
@@ -161,19 +184,28 @@ public class SyntaxFactoryTests: XCTestCase {
   }
 
   public func testUnknownSyntax() {
-    let expr = SyntaxFactory.makeStringLiteralExpr("Hello, world!")
+    let expr = StringLiteralExprSyntax(
+      openDelimiter: nil,
+      openQuote: .stringQuoteToken(),
+      segments: StringLiteralSegmentsSyntax([Syntax(StringSegmentSyntax(content: .stringSegment("Hello, world!")))]),
+      closeQuote: .stringQuoteToken(),
+      closeDelimiter: nil
+    )
     XCTAssertFalse(expr.isUnknown)
-    let unknown = SyntaxFactory.makeUnknownSyntax(
-      tokens: [SyntaxFactory.makeLeftBraceToken()])
+    let unknown = UnknownSyntax(
+      tokens: [.leftBraceToken()])
     XCTAssertTrue(unknown.isUnknown)
     XCTAssertNoThrow(try SyntaxVerifier.verify(Syntax(expr)))
     XCTAssertThrowsError(try SyntaxVerifier.verify(Syntax(unknown)))
   }
 
   public func testMakeStringLiteralExpr() {
-    let expr = SyntaxFactory.makeStringLiteralExpr(
-      "Hello, world!",
-      leadingTrivia: .init(pieces: [.lineComment("// hello"), .newlines(1)])
+    let expr = StringLiteralExprSyntax(
+      openDelimiter: nil,
+      openQuote: .stringQuoteToken(leadingTrivia: [.lineComment("// hello"), .newlines(1)]),
+      segments: StringLiteralSegmentsSyntax([Syntax(StringSegmentSyntax(content: .stringSegment("Hello, world!")))]),
+      closeQuote: .stringQuoteToken(),
+      closeDelimiter: nil
     )
     let expected = """
 // hello
@@ -183,17 +215,17 @@ public class SyntaxFactoryTests: XCTestCase {
   }
     
   public func testMakeBinaryOperator() {
-    let first = SyntaxFactory.makeIntegerLiteralExpr(
-      digits: SyntaxFactory.makeIntegerLiteral("1", trailingTrivia: .space)
+    let first = IntegerLiteralExprSyntax(
+      digits: .integerLiteral("1")
     )
-    let second = SyntaxFactory.makeIntegerLiteralExpr(
-      digits: SyntaxFactory.makeIntegerLiteral("1")
+    let second = IntegerLiteralExprSyntax(
+      digits: .integerLiteral("1")
     )
     let operatorNames = ["==", "!=", "+", "-", "*", "/", "<", ">", "<=", ">="]
     operatorNames.forEach { operatorName in
-      let operatorToken = SyntaxFactory.makeBinaryOperator(operatorName, trailingTrivia: .space)
-      let operatorExpr = SyntaxFactory.makeBinaryOperatorExpr(operatorToken: operatorToken)
-      let exprList = SyntaxFactory.makeExprList([ExprSyntax(first),
+      let operatorToken = TokenSyntax.spacedBinaryOperator(operatorName, trailingTrivia: .space)
+      let operatorExpr = BinaryOperatorExprSyntax(operatorToken: operatorToken)
+      let exprList = ExprListSyntax([ExprSyntax(first),
                                                  ExprSyntax(operatorExpr),
                                                  ExprSyntax(second)])
 

--- a/Tests/SwiftSyntaxTest/SyntaxTreeModifierTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTreeModifierTests.swift
@@ -2,20 +2,20 @@ import XCTest
 import SwiftSyntax
 
 fileprivate func cannedVarDecl() -> VariableDeclSyntax {
-  let identifierPattern = SyntaxFactory.makeIdentifierPattern(
-    identifier: SyntaxFactory.makeIdentifier("a")
+  let identifierPattern = IdentifierPatternSyntax(
+    identifier: TokenSyntax.identifier("a")
   )
-  let pattern = SyntaxFactory.makePatternBinding(
+  let pattern = PatternBindingSyntax(
     pattern: PatternSyntax(identifierPattern),
-    typeAnnotation: SyntaxFactory.makeTypeAnnotation(
-      colon: SyntaxFactory.makeColonToken().withTrailingTrivia(.space),
-      type: SyntaxFactory.makeTypeIdentifier("Int")),
+    typeAnnotation: TypeAnnotationSyntax(
+      colon: TokenSyntax.colonToken(trailingTrivia: .space),
+      type: TypeSyntax(SimpleTypeIdentifierSyntax(name: .identifier("Int"), genericArgumentClause: nil))),
     initializer: nil, accessor: nil, trailingComma: nil)
-  return SyntaxFactory.makeVariableDecl(
+  return VariableDeclSyntax(
     attributes: nil,
     modifiers: nil,
-    letOrVarKeyword: SyntaxFactory.makeLetKeyword(),
-    bindings: SyntaxFactory.makePatternBindingList([pattern])
+    letOrVarKeyword: .letKeyword(),
+    bindings: PatternBindingListSyntax([pattern])
   )
 }
 
@@ -24,7 +24,7 @@ public class SyntaxTreeModifierTests: XCTestCase {
   public func testAccessorAsModifier() {
     var VD = cannedVarDecl()
     XCTAssertEqual("\(VD)", "let a: Int")
-    VD.letOrVarKeyword = SyntaxFactory.makeVarKeyword()
+    VD.letOrVarKeyword = .varKeyword()
     XCTAssertEqual("\(VD)", "var a: Int")
   }
 }

--- a/Tests/SwiftSyntaxTest/VisitorTests.swift
+++ b/Tests/SwiftSyntaxTest/VisitorTests.swift
@@ -3,7 +3,7 @@ import SwiftSyntax
 
 public class VisitorTests: XCTestCase {
   public func testVisitMissingNodes() throws {
-    let node = SyntaxFactory.makeDeclarationStmt(declaration: DeclSyntax(SyntaxFactory.makeBlankMissingDecl()))
+    let node = DeclarationStmtSyntax(declaration: DeclSyntax(MissingDeclSyntax()))
 
     class MissingDeclChecker: SyntaxVisitor {
       var didSeeMissingDeclSyntax = false
@@ -26,17 +26,20 @@ public class VisitorTests: XCTestCase {
 
   public func testVisitGarbage() throws {
     // This is just bunch of garbage
-    let garbageReturnStmt = SyntaxFactory.makeReturnStmt(
-      SyntaxFactory.makeGarbageNodes([Syntax(SyntaxFactory.makeToken(.identifier("starting"), presence: .present)), Syntax(SyntaxFactory.makeToken(.identifier("garbage"), presence: .present))]),
-      returnKeyword: SyntaxFactory.makeReturnKeyword(trailingTrivia: [.spaces(1)]),
-      SyntaxFactory.makeGarbageNodes([Syntax(SyntaxFactory.makeToken(.identifier("middle"), presence: .present))]),
-      expression: ExprSyntax(SyntaxFactory.makeNilLiteralExpr(SyntaxFactory.makeGarbageNodes([Syntax(SyntaxFactory.makeToken(.identifier("end"), presence: .present))]), nilKeyword: SyntaxFactory.makeToken(.nilKeyword, presence: .present)))
+    let garbageReturnStmt = ReturnStmtSyntax(
+      GarbageNodesSyntax([Syntax(TokenSyntax.identifier("starting")), Syntax(TokenSyntax.integerLiteral("garbage"))]),
+      returnKeyword: .returnKeyword(trailingTrivia: [.spaces(1)]),
+      GarbageNodesSyntax([Syntax(TokenSyntax.identifier("middle"))]),
+      expression: ExprSyntax(NilLiteralExprSyntax(GarbageNodesSyntax([Syntax(TokenSyntax.identifier("end"))]), nilKeyword: TokenSyntax.nilKeyword(trailingTrivia: [])))
     )
 
     // This is more real-world where the user wrote null instead of nil.
-    let misspelledNil = SyntaxFactory.makeReturnStmt(
-      returnKeyword: SyntaxFactory.makeReturnKeyword(trailingTrivia: [.spaces(1)]),
-      expression: ExprSyntax(SyntaxFactory.makeNilLiteralExpr(SyntaxFactory.makeGarbageNodes([Syntax(SyntaxFactory.makeToken(.identifier("null"), presence: .present))]), nilKeyword: SyntaxFactory.makeToken(.nilKeyword, presence: .missing)))
+    let misspelledNil = ReturnStmtSyntax(
+      returnKeyword: .returnKeyword(trailingTrivia: [.spaces(1)]),
+      expression: ExprSyntax(NilLiteralExprSyntax(
+        GarbageNodesSyntax([Syntax(TokenSyntax.identifier("null"))]),
+        nilKeyword: .nilKeyword(presence: .missing)
+      ))
     )
 
     // Test SyntaxVisitor

--- a/utils/group.json
+++ b/utils/group.json
@@ -11,6 +11,7 @@
     "TokenKind.swift",
     "SyntaxTreeViewMode.swift",
     "Trivia.swift",
+    "Tokens.swift",
   ],
   "Syntax nodes": [
     "Syntax.swift",


### PR DESCRIPTION
Instead of always writing `SyntaxFactory.make*` we can just use the initializers of the nodes that should be created, which leads to a lot nicer code IMO.

CC @akyrtzi @harlanhaskins in case you remember any compelling reasons why we decided to use `SyntaxFactory` instead of initializers when this was implemented.

rdar://97910890