### PR TITLE
Add `leadingTrivia` parameter to the `VariableDecl` convenience initializer

### DIFF
--- a/Sources/SwiftSyntaxBuilder/VariableDeclConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/VariableDeclConvenienceInitializers.swift
@@ -14,12 +14,13 @@ import SwiftSyntax
 
 extension VariableDecl {
   public init(
+    leadingTrivia: Trivia = [],
     _ letOrVarKeyword: TokenSyntax,
     name: ExpressibleAsIdentifierPattern,
     type: ExpressibleAsTypeAnnotation? = nil,
     initializer: ExpressibleAsInitializerClause? = nil
   ) {
-    self.init(letOrVarKeyword: letOrVarKeyword) {
+    self.init(leadingTrivia: leadingTrivia, letOrVarKeyword: letOrVarKeyword) {
       PatternBinding(
         pattern: name,
         typeAnnotation: type,


### PR DESCRIPTION
A small addition to the `VariableDecl` convenience initializer adding an optional `leadingTrivia` parameter e.g. for adding doc comments to generated variable declarations.