### PR TITLE
Migrate from strings to typed buildable nodes in `SyntaxBuildableWrappers`

### DIFF
--- a/Sources/SwiftSyntaxBuilder/generated/BuildableBaseProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableBaseProtocols.swift
@@ -36,7 +36,7 @@ public extension DeclBuildable {
   /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
   ///
   /// Satisfies conformance to `DeclListBuildable`
-  func buildDeclList(format: Format, leadingTrivia: Trivia? = nil) -> [DeclSyntax] {
+  func buildDeclList(format: Format, leadingTrivia: Trivia? = nil ) -> [DeclSyntax] {
     return [buildDecl(format: format, leadingTrivia: leadingTrivia)]
   }
   /// Builds a `DeclSyntax`.
@@ -45,7 +45,7 @@ public extension DeclBuildable {
   /// - Returns: A new `Syntax` with the built `DeclSyntax`.
   ///
   /// Satisfies conformance to `SyntaxBuildable`.
-  func buildSyntax(format: Format, leadingTrivia: Trivia? = nil) -> Syntax {
+  func buildSyntax(format: Format, leadingTrivia: Trivia? = nil ) -> Syntax {
     return Syntax(buildDecl(format: format, leadingTrivia: leadingTrivia))
   }
 }
@@ -71,7 +71,7 @@ public extension ExprBuildable {
   /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
   ///
   /// Satisfies conformance to `ExprListBuildable`
-  func buildExprList(format: Format, leadingTrivia: Trivia? = nil) -> [ExprSyntax] {
+  func buildExprList(format: Format, leadingTrivia: Trivia? = nil ) -> [ExprSyntax] {
     return [buildExpr(format: format, leadingTrivia: leadingTrivia)]
   }
   /// Builds a `ExprSyntax`.
@@ -80,7 +80,7 @@ public extension ExprBuildable {
   /// - Returns: A new `Syntax` with the built `ExprSyntax`.
   ///
   /// Satisfies conformance to `SyntaxBuildable`.
-  func buildSyntax(format: Format, leadingTrivia: Trivia? = nil) -> Syntax {
+  func buildSyntax(format: Format, leadingTrivia: Trivia? = nil ) -> Syntax {
     return Syntax(buildExpr(format: format, leadingTrivia: leadingTrivia))
   }
 }
@@ -106,7 +106,7 @@ public extension PatternBuildable {
   /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
   ///
   /// Satisfies conformance to `PatternListBuildable`
-  func buildPatternList(format: Format, leadingTrivia: Trivia? = nil) -> [PatternSyntax] {
+  func buildPatternList(format: Format, leadingTrivia: Trivia? = nil ) -> [PatternSyntax] {
     return [buildPattern(format: format, leadingTrivia: leadingTrivia)]
   }
   /// Builds a `PatternSyntax`.
@@ -115,7 +115,7 @@ public extension PatternBuildable {
   /// - Returns: A new `Syntax` with the built `PatternSyntax`.
   ///
   /// Satisfies conformance to `SyntaxBuildable`.
-  func buildSyntax(format: Format, leadingTrivia: Trivia? = nil) -> Syntax {
+  func buildSyntax(format: Format, leadingTrivia: Trivia? = nil ) -> Syntax {
     return Syntax(buildPattern(format: format, leadingTrivia: leadingTrivia))
   }
 }
@@ -141,7 +141,7 @@ public extension StmtBuildable {
   /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
   ///
   /// Satisfies conformance to `StmtListBuildable`
-  func buildStmtList(format: Format, leadingTrivia: Trivia? = nil) -> [StmtSyntax] {
+  func buildStmtList(format: Format, leadingTrivia: Trivia? = nil ) -> [StmtSyntax] {
     return [buildStmt(format: format, leadingTrivia: leadingTrivia)]
   }
   /// Builds a `StmtSyntax`.
@@ -150,7 +150,7 @@ public extension StmtBuildable {
   /// - Returns: A new `Syntax` with the built `StmtSyntax`.
   ///
   /// Satisfies conformance to `SyntaxBuildable`.
-  func buildSyntax(format: Format, leadingTrivia: Trivia? = nil) -> Syntax {
+  func buildSyntax(format: Format, leadingTrivia: Trivia? = nil ) -> Syntax {
     return Syntax(buildStmt(format: format, leadingTrivia: leadingTrivia))
   }
 }
@@ -176,7 +176,7 @@ public extension SyntaxBuildable {
   /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
   ///
   /// Satisfies conformance to `SyntaxListBuildable`
-  func buildSyntaxList(format: Format, leadingTrivia: Trivia? = nil) -> [Syntax] {
+  func buildSyntaxList(format: Format, leadingTrivia: Trivia? = nil ) -> [Syntax] {
     return [buildSyntax(format: format, leadingTrivia: leadingTrivia)]
   }
 }
@@ -202,7 +202,7 @@ public extension TypeBuildable {
   /// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.
   ///
   /// Satisfies conformance to `TypeListBuildable`
-  func buildTypeList(format: Format, leadingTrivia: Trivia? = nil) -> [TypeSyntax] {
+  func buildTypeList(format: Format, leadingTrivia: Trivia? = nil ) -> [TypeSyntax] {
     return [buildType(format: format, leadingTrivia: leadingTrivia)]
   }
   /// Builds a `TypeSyntax`.
@@ -211,7 +211,7 @@ public extension TypeBuildable {
   /// - Returns: A new `Syntax` with the built `TypeSyntax`.
   ///
   /// Satisfies conformance to `SyntaxBuildable`.
-  func buildSyntax(format: Format, leadingTrivia: Trivia? = nil) -> Syntax {
+  func buildSyntax(format: Format, leadingTrivia: Trivia? = nil ) -> Syntax {
     return Syntax(buildType(format: format, leadingTrivia: leadingTrivia))
   }
 }

--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableChild.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableChild.swift
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
 /// Extension to the `Child` type to provide functionality specific to
 /// SwiftSyntaxBuilder.
 extension Child {
@@ -31,17 +34,37 @@ extension Child {
   /// Generate a Swift expression that creates a proper SwiftSyntax node of type
   /// `type.syntax` from a variable named `varName` of type `type.buildable` that
   /// represents this child node.
-  func generateExprBuildSyntaxNode(varName: String, formatName: String) -> String {
+  func generateExprBuildSyntaxNode(varName: String, formatName: String) -> ExpressibleAsExprBuildable {
     if type.isToken {
       if requiresLeadingNewline {
-        return "\(varName).withLeadingTrivia(.newline + \(formatName)._makeIndent() + (\(varName).leadingTrivia ?? []))"
+        return FunctionCallExpr(MemberAccessExpr(base: varName, name: "withLeadingTrivia")) {
+          SequenceExpr {
+            MemberAccessExpr(name: "newline")
+            BinaryOperatorExpr("+")
+            FunctionCallExpr(MemberAccessExpr(base: formatName, name: "_makeIndent"))
+            BinaryOperatorExpr("+")
+            TupleExpr {
+              SequenceExpr {
+                MemberAccessExpr(base: varName, name: "leadingTrivia")
+                BinaryOperatorExpr("??")
+                ArrayExpr(elements: [])
+              }
+            }
+          }
+        }
       } else {
         return varName
       }
     } else {
-      let format = formatName + (isIndented ? "._indented()" : "")
-      let expr = "\(varName)\(type.optionalQuestionMark)"
-      return "\(expr).build\(type.baseName)(format: \(format), leadingTrivia: nil)"
+      var format: ExpressibleAsExprBuildable = formatName
+      if isIndented {
+        format = FunctionCallExpr(MemberAccessExpr(base: format, name: "_indented"))
+      }
+      let expr = type.optionalChained(expr: varName)
+      return FunctionCallExpr(MemberAccessExpr(base: expr, name: "build\(type.baseName)")) {
+        TupleExprElement(label: "format", expression: format)
+        TupleExprElement(label: "leadingTrivia", expression: "nil")
+      }
     }
   }
 

--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableChild.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableChild.swift
@@ -63,7 +63,7 @@ extension Child {
       let expr = type.optionalChained(expr: varName)
       return FunctionCallExpr(MemberAccessExpr(base: expr, name: "build\(type.baseName)")) {
         TupleExprElement(label: "format", expression: format)
-        TupleExprElement(label: "leadingTrivia", expression: "nil")
+        TupleExprElement(label: "leadingTrivia", expression: NilLiteralExpr())
       }
     }
   }

--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableNode.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableNode.swift
@@ -45,7 +45,7 @@ extension Node {
 
   /// Assuming this node has a single child without a default value, that child.
   var singleNonDefaultedChild: Child {
-    let nonDefaultedParams = children.filter(\.type.defaultInitialization.isEmpty)
+    let nonDefaultedParams = children.filter { $0.type.defaultInitialization == nil }
     assert(nonDefaultedParams.count == 1)
     return nonDefaultedParams[0]
   }

--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableType.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableType.swift
@@ -22,11 +22,6 @@ struct SyntaxBuildableType: Hashable {
   let tokenKind: String?
   let isOptional: Bool
 
-  /// If optional `?`, otherwise the empty string.
-  var optionalQuestionMark: String {
-    isOptional ? "?" : ""
-  }
-
   /// Whether this is a token.
   var isToken: Bool {
     syntaxKind == "Token"
@@ -71,38 +66,30 @@ struct SyntaxBuildableType: Hashable {
     syntaxKind
   }
 
-  /// Return the name of the `Buildable` type that is the main entry point for building
+  /// Return the `Buildable` type that is the main entry point for building
   /// SwiftSyntax trees using `SwiftSyntaxBuilder`.
   ///
   /// These names look as follows:
   ///  - For nodes: The node name, e.g. `IdentifierExpr` (these are implemented as structs)
   ///  - For base kinds: `<BaseKind>Buildable`, e.g. `ExprBuildable` (these are implemented as protocols)
   ///  - For token: `TokenSyntax` (tokens don't have a dedicated type in SwiftSyntaxBuilder)
-  /// If the type is optional, this terminates with a '?'.
-  var buildable: String {
-    if isToken {
-      // Tokens don't have a dedicated buildable type.
-      return "TokenSyntax\(optionalQuestionMark)"
-    } else if SYNTAX_BASE_KINDS.contains(syntaxKind) {
-      return "\(syntaxKind)Buildable\(optionalQuestionMark)"
-    } else {
-      return "\(syntaxKind)\(optionalQuestionMark)"
-    }
+  /// If the type is optional, the type is wrapped in an `OptionalType`.
+  var buildable: ExpressibleAsTypeBuildable {
+    optionalWrapped(type: buildableBaseName)
   }
 
   /// Whether parameters of this type should be initializable by a result builder.
   /// Used for certain syntax collections and block-like structures (e.g. `CodeBlock`,
   /// `MemberDeclList`).
   var isBuilderInitializable: Bool {
-    BUILDER_INITIALIZABLE_TYPES.keys.contains(nonOptional.buildable)
+    BUILDER_INITIALIZABLE_TYPES.keys.contains(buildableBaseName)
   }
 
   /// A type suitable for initializing this type through a result builder (e.g.
   /// returns `CodeBlockItemList` for `CodeBlock`) and otherwise itself.
   var builderInitializableType: Self {
-    let buildable = nonOptional.buildable
-    return Self(
-      syntaxKind: BUILDER_INITIALIZABLE_TYPES[buildable].flatMap { $0 } ?? buildable,
+    Self(
+      syntaxKind: BUILDER_INITIALIZABLE_TYPES[buildableBaseName].flatMap { $0 } ?? buildableBaseName,
       isOptional: isOptional
     )
   }
@@ -110,42 +97,67 @@ struct SyntaxBuildableType: Hashable {
   /// The type from `buildable()` without any question marks attached.
   /// This is used for the `create*` methods defined in the `ExpressibleAs*` protocols.
   var buildableBaseName: String {
-    nonOptional.buildable
+    if isToken {
+      // Tokens don't have a dedicated buildable type.
+      return "TokenSyntax"
+    } else if SYNTAX_BASE_KINDS.contains(syntaxKind) {
+      return "\(syntaxKind)Buildable"
+    } else {
+      return syntaxKind
+    }
+  }
+
+  /// The `ExpressibleAs*` Swift type for this syntax kind without any
+  /// question marks attached.
+  var expressibleAsBaseName: String {
+    if isToken {
+      // Tokens don't have a dedicated ExpressibleAs type.
+      return buildableBaseName
+    } else {
+      return "ExpressibleAs\(buildableBaseName)"
+    }
   }
 
   /// The `ExpressibleAs*` Swift type for this syntax kind. Tokens don't
   /// have an `ExpressibleAs*` type, so for those this method just returns
   /// `TokenSyntax`. If the type is optional, this terminates with a `?`.
-  var expressibleAs: String {
-    if isToken {
-      // Tokens don't have a dedicated ExpressibleAs type.
-      return buildable
+  var expressibleAs: ExpressibleAsTypeBuildable {
+    optionalWrapped(type: expressibleAsBaseName)
+  }
+
+  /// The corresponding `*Syntax` type defined in the `SwiftSyntax` module,
+  /// without any question marks attached.
+  var syntaxBaseName: String {
+    if syntaxKind == "Syntax" {
+      return "Syntax"
     } else {
-      return "ExpressibleAs\(buildable)"
+      return "\(syntaxKind)Syntax"
     }
   }
 
   /// The corresponding `*Syntax` type defined in the `SwiftSyntax` module,
   /// which will eventually get built from `SwiftSyntaxBuilder`. If the type
   /// is optional, this terminates with a `?`.
-  var syntax: String {
-    if syntaxKind == "Syntax" {
-      return "Syntax\(optionalQuestionMark)"
-    } else {
-      return "\(syntaxKind)Syntax\(optionalQuestionMark)"
-    }
+  var syntax: ExpressibleAsTypeBuildable {
+    optionalWrapped(type: syntaxBaseName)
+  }
+
+  /// Assuming that this is a base kind, return the corresponding `*ListBuildable` type
+  /// without any question marks attached.
+  var listBuildableBaseName: String {
+    assert(SYNTAX_BASE_KINDS.contains(syntaxKind), "ListBuildable types only exist for syntax base kinds")
+    return "\(syntaxKind)ListBuildable"
   }
 
   /// Assuming that this is a base kind, return the corresponding `*ListBuildable` type.
-  var listBuildable: String {
-    assert(SYNTAX_BASE_KINDS.contains(syntaxKind), "ListBuildable types only exist for syntax base kinds")
-    return "\(syntaxKind)ListBuildable\(optionalQuestionMark)"
+  var listBuildable: ExpressibleAsTypeBuildable {
+    optionalWrapped(type: listBuildableBaseName)
   }
 
   /// Assuming that this is a collection type, the type of the result builder
   /// that can be used to build the collection.
-  var resultBuilder: String {
-    "\(syntaxKind)Builder\(optionalQuestionMark)"
+  var resultBuilder: ExpressibleAsTypeBuildable {
+    optionalWrapped(type: "\(syntaxKind)Builder")
   }
 
   /// The collection types in which this type occurs as an element.
@@ -167,7 +179,7 @@ struct SyntaxBuildableType: Hashable {
   /// make the `ExpressibleAs*` of this type conform to the `ExpressibleAs*`
   /// protocol of the convertible types.
   var convertibleToTypes: [Self] {
-    (SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES[buildable] ?? [])
+    (SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES[buildableBaseName] ?? [])
       .map { Self(syntaxKind: $0) }
   }
 
@@ -220,13 +232,31 @@ struct SyntaxBuildableType: Hashable {
     }
   }
 
+  /// Wraps a type in an optional depending on whether `isOptional` is true.
+  func optionalWrapped(type: ExpressibleAsTypeBuildable) -> ExpressibleAsTypeBuildable {
+    if isOptional {
+      return OptionalType(wrappedType: type)
+    } else {
+      return type
+    }
+  }
+
+  /// Wraps a type in an optional chaining depending on whether `isOptional` is true.
+  func optionalChained(expr: ExpressibleAsExprBuildable) -> ExpressibleAsExprBuildable {
+    if isOptional {
+      return OptionalChainingExpr(expression: expr)
+    } else {
+      return expr
+    }
+  }
+
   /// Generate an expression that converts a variable named `varName`
   /// which is of `expressibleAs` type to an object of type `buildable`.
-  func generateExprConvertParamTypeToStorageType(varName: String) -> String {
+  func generateExprConvertParamTypeToStorageType(varName: String) -> ExpressibleAsExprBuildable {
     if isToken {
       return varName
     } else {
-      return "\(varName)\(optionalQuestionMark).create\(buildableBaseName)()"
+      return FunctionCallExpr(MemberAccessExpr(base: optionalChained(expr: varName), name: "create\(buildableBaseName)"))
     }
   }
 }

--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableType.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableType.swift
@@ -43,7 +43,7 @@ struct SyntaxBuildableType: Hashable {
   /// Otherwise, return the empty string.
   var defaultInitialization: ExpressibleAsExprBuildable? {
     if isOptional {
-      return "nil"
+      return NilLiteralExpr()
     } else if isToken {
       if let token = token, token.text != nil {
         return MemberAccessExpr(base: "TokenSyntax", name: lowercaseFirstWord(name: token.name))

--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableType.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableType.swift
@@ -10,6 +10,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
 /// Wrapper around the syntax kind strings to provide functionality specific to
 /// SwiftSyntaxBuilder. In particular, this includes the functionality to create
 /// the `*Buildable`, `ExpressibleAs*` and `*Syntax` Swift types from the syntax
@@ -43,17 +46,17 @@ struct SyntaxBuildableType: Hashable {
   /// with fixed test), return an expression of the form ` = defaultValue`
   /// that can be used as the default value for a function parameter.
   /// Otherwise, return the empty string.
-  var defaultInitialization: String {
+  var defaultInitialization: ExpressibleAsExprBuildable? {
     if isOptional {
-      return " = nil"
+      return "nil"
     } else if isToken {
       if let token = token, token.text != nil {
-        return " = TokenSyntax.`\(lowercaseFirstWord(name: token.name))`"
+        return MemberAccessExpr(base: "TokenSyntax", name: lowercaseFirstWord(name: token.name))
       } else if tokenKind == "EOFToken" {
-        return " = TokenSyntax.eof"
+        return MemberAccessExpr(base: "TokenSyntax", name: "eof")
       }
     }
-    return ""
+    return nil
   }
 
   /// Whether the type is a syntax collection.

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableBaseProtocolsFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableBaseProtocolsFile.swift
@@ -153,7 +153,7 @@ private func formatLeadingTriviaParameters(withDefaultTrivia: Bool = false) -> P
         firstName: .identifier("leadingTrivia"),
         colon: .colon,
         type: OptionalType(wrappedType: "Trivia"),
-        defaultArgument: withDefaultTrivia ? InitializerClause(value: "nil") : nil
+        defaultArgument: withDefaultTrivia ? InitializerClause(value: NilLiteralExpr()) : nil
       ),
     ]
   )

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableBaseProtocolsFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableBaseProtocolsFile.swift
@@ -30,24 +30,24 @@ let buildableBaseProtocolsFile = SourceFile {
     let syntaxType = SyntaxBuildableType(syntaxKind: "Syntax")
     let isSyntax = type == syntaxType
     // Types that the `*Buildable` conforms to
-    let buildableConformances: [String] = [type.expressibleAs, type.listBuildable] + (isSyntax ? [] : [syntaxType.buildable])
-    let listConformances: [String] = isSyntax ? [] : [syntaxType.listBuildable]
+    let buildableConformances: [String] = [type.expressibleAsBaseName, type.listBuildableBaseName] + (isSyntax ? [] : [syntaxType.buildableBaseName])
+    let listConformances: [String] = isSyntax ? [] : [syntaxType.listBuildableBaseName]
 
     ProtocolDecl(
       modifiers: [TokenSyntax.public],
-      identifier: type.listBuildable,
+      identifier: type.listBuildableBaseName,
       inheritanceClause: createTypeInheritanceClause(conformances: listConformances)
     ) {
       FunctionDecl(
         leadingTrivia: [
-          "/// Builds list of `\(type.syntax)`s.",
+          "/// Builds list of `\(type.syntaxBaseName)`s.",
           "/// - Parameter format: The `Format` to use.",
           "/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.",
         ].map { .docLineComment($0) + .newline }.reduce([], +),
         identifier: .identifier("build\(type.baseName)List"),
         signature: FunctionSignature(
           input: formatLeadingTriviaParameters(),
-          output: ArrayType(elementType: type.syntax)
+          output: ArrayType(elementType: type.syntaxBaseName)
         ),
         body: nil
       )
@@ -55,19 +55,19 @@ let buildableBaseProtocolsFile = SourceFile {
 
     ProtocolDecl(
       modifiers: [TokenSyntax.public],
-      identifier: type.buildable,
+      identifier: type.buildableBaseName,
       inheritanceClause: createTypeInheritanceClause(conformances: buildableConformances)
     ) {
       FunctionDecl(
         leadingTrivia: [
-          "/// Builds list of `\(type.syntax)`s.",
+          "/// Builds list of `\(type.syntaxBaseName)`s.",
           "/// - Parameter format: The `Format` to use.",
           "/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.",
         ].map { .docLineComment($0) + .newline }.reduce([], +),
         identifier: .identifier("build\(type.baseName)"),
         signature: FunctionSignature(
           input: formatLeadingTriviaParameters(),
-          output: type.syntax
+          output: type.syntaxBaseName
         ),
         body: nil
       )
@@ -75,14 +75,14 @@ let buildableBaseProtocolsFile = SourceFile {
 
     ExtensionDecl(
       modifiers: [TokenSyntax.public],
-      extendedType: type.buildable
+      extendedType: type.buildableBaseName
     ) {
       FunctionDecl(
-        leadingTrivia: .docLineComment("/// Satisfies conformance to `\(type.expressibleAs)`.") + .newline,
+        leadingTrivia: .docLineComment("/// Satisfies conformance to `\(type.expressibleAsBaseName)`.") + .newline,
         identifier: .identifier("create\(type.buildableBaseName)"),
         signature: FunctionSignature(
           input: ParameterClause(),
-          output: type.buildable
+          output: type.buildableBaseName
         )
       ) {
         ReturnStmt(expression: "self")
@@ -90,7 +90,7 @@ let buildableBaseProtocolsFile = SourceFile {
 
       FunctionDecl(
         leadingTrivia: [
-          "/// Builds list of `\(type.syntax)`s.",
+          "/// Builds list of `\(type.syntaxBaseName)`s.",
           "/// - Parameter format: The `Format` to use.",
           "/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.",
           "///",
@@ -99,7 +99,7 @@ let buildableBaseProtocolsFile = SourceFile {
         identifier: .identifier("build\(type.baseName)List"),
         signature: FunctionSignature(
           input: formatLeadingTriviaParameters(withDefaultTrivia: true),
-          output: ArrayType(elementType: type.syntax)
+          output: ArrayType(elementType: type.syntaxBaseName)
         )
       ) {
         ReturnStmt(expression: ArrayExpr {
@@ -113,10 +113,10 @@ let buildableBaseProtocolsFile = SourceFile {
       if !isSyntax {
         FunctionDecl(
           leadingTrivia: [
-          "/// Builds a `\(type.syntax)`.",
+          "/// Builds a `\(type.syntaxBaseName)`.",
           "/// - Parameter format: The `Format` to use.",
           "/// - Parameter leadingTrivia: Replaces the last leading trivia if not nil.",
-          "/// - Returns: A new `Syntax` with the built `\(type.syntax)`.",
+          "/// - Returns: A new `Syntax` with the built `\(type.syntaxBaseName)`.",
           "///",
           "/// Satisfies conformance to `SyntaxBuildable`.",
         ].map { .docLineComment($0) + .newline }.reduce([], +),

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/ExpressibleAsProtocolsFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/ExpressibleAsProtocolsFile.swift
@@ -39,8 +39,8 @@ let expressibleAsProtocolsFile = SourceFile {
 
     ProtocolDecl(
       modifiers: [TokenSyntax.public],
-      identifier: type.expressibleAs,
-      inheritanceClause: createTypeInheritanceClause(conformances: declaredConformances.map(\.expressibleAs))
+      identifier: type.expressibleAsBaseName,
+      inheritanceClause: createTypeInheritanceClause(conformances: declaredConformances.map(\.expressibleAsBaseName))
     ) {
       FunctionDecl(
         identifier: .identifier("create\(type.buildableBaseName)"),
@@ -55,18 +55,18 @@ let expressibleAsProtocolsFile = SourceFile {
     if !conformances.isEmpty {
       ExtensionDecl(
         modifiers: [TokenSyntax.public],
-        extendedType: type.expressibleAs
+        extendedType: type.expressibleAsBaseName
       ) {
         for conformance in type.elementInCollections {
           FunctionDecl(
-            leadingTrivia: .docLineComment("/// Conformance to `\(conformance.expressibleAs)`") + .newline,
+            leadingTrivia: .docLineComment("/// Conformance to `\(conformance.expressibleAsBaseName)`") + .newline,
             identifier: .identifier("create\(conformance.buildableBaseName)"),
             signature: FunctionSignature(
               input: ParameterClause(),
               output: conformance.buildable
             )
           ) {
-            ReturnStmt(expression: FunctionCallExpr(conformance.buildable) {
+            ReturnStmt(expression: FunctionCallExpr(conformance.buildableBaseName) {
               TupleExprElement(expression: ArrayExpr {
                 ArrayElement(expression: "self")
               })
@@ -76,14 +76,14 @@ let expressibleAsProtocolsFile = SourceFile {
         for conformance in type.convertibleToTypes {
           let param = Node.from(type: conformance).singleNonDefaultedChild
           FunctionDecl(
-            leadingTrivia: .docLineComment("/// Conformance to \(conformance.expressibleAs)") + .newline,
+            leadingTrivia: .docLineComment("/// Conformance to \(conformance.expressibleAsBaseName)") + .newline,
             identifier: .identifier("create\(conformance.buildableBaseName)"),
             signature: FunctionSignature(
               input: ParameterClause(),
-              output: conformance.buildable
+              output: conformance.buildableBaseName
             )
           ) {
-            ReturnStmt(expression: FunctionCallExpr(conformance.buildable) {
+            ReturnStmt(expression: FunctionCallExpr(conformance.buildableBaseName) {
               TupleExprElement(label: param.swiftName, expression: "self")
             })
           }

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/TokenSyntaxFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/TokenSyntaxFile.swift
@@ -25,19 +25,19 @@ let tokenSyntaxFile = SourceFile {
 
   ExtensionDecl(
     extendedType: "TokenSyntax",
-    inheritanceClause: createTypeInheritanceClause(conformances: conformances.map(\.expressibleAs))
+    inheritanceClause: createTypeInheritanceClause(conformances: conformances.map(\.expressibleAsBaseName))
   ) {
     for conformance in tokenType.elementInCollections {
       FunctionDecl(
-        leadingTrivia: .docLineComment("/// Conformance to \(conformance.expressibleAs)") + .newline,
+        leadingTrivia: .docLineComment("/// Conformance to \(conformance.expressibleAsBaseName)") + .newline,
         modifiers: [TokenSyntax.public],
         identifier: .identifier("create\(conformance.buildableBaseName)"),
         signature: FunctionSignature(
           input: ParameterClause(),
-          output: conformance.buildable
+          output: conformance.buildableBaseName
         )
       ) {
-        ReturnStmt(expression: FunctionCallExpr(conformance.buildable) {
+        ReturnStmt(expression: FunctionCallExpr(conformance.buildableBaseName) {
           TupleExprElement(expression: ArrayExpr {
             ArrayElement(expression: "self")
           })
@@ -47,15 +47,15 @@ let tokenSyntaxFile = SourceFile {
     for conformance in tokenType.convertibleToTypes {
       let param = Node.from(type: conformance).singleNonDefaultedChild
       FunctionDecl(
-        leadingTrivia: .docLineComment("/// Conformance to \(conformance.expressibleAs)") + .newline,
+        leadingTrivia: .docLineComment("/// Conformance to \(conformance.expressibleAsBaseName)") + .newline,
         modifiers: [TokenSyntax.public],
         identifier: .identifier("create\(conformance.buildableBaseName)"),
         signature: FunctionSignature(
           input: ParameterClause(),
-          output: conformance.buildable
+          output: conformance.buildableBaseName
         )
       ) {
-        ReturnStmt(expression: FunctionCallExpr(conformance.buildable) {
+        ReturnStmt(expression: FunctionCallExpr(conformance.buildableBaseName) {
           TupleExprElement(label: param.swiftName, expression: "self")
         })
       }


### PR DESCRIPTION
As proposed in https://github.com/apple/swift-syntax/pull/485#pullrequestreview-1033905250, this PR migrates the generated snippets of Swift code in `SyntaxBuildableType` and `SyntaxBuildableChild` to `ExprBuildable`s and `TypeBuildable`s.

This will pave the way for a future PR porting `BuildableNodes.swift.gyb` to `SwiftSyntaxBuilderGeneration`.