### PR TITLE
[WIP]Bump allocated RawSyntax

### DIFF
--- a/Sources/SwiftSyntax/CNodes.swift
+++ b/Sources/SwiftSyntax/CNodes.swift
@@ -25,6 +25,7 @@ typealias CTokenData = swiftparse_token_data_t
 typealias CLayoutData = swiftparse_layout_data_t
 typealias CTriviaPiecePtr = UnsafePointer<CTriviaPiece>
 typealias CTriviaPiece = swiftparse_trivia_piece_t
+typealias CRange = swiftparse_range_t
 
 /// Computes a hash value that describes the layout of all C nodes which are
 /// passed as opaque values between `SwiftSyntaxParser` and `SwiftSyntax`.

--- a/Sources/SwiftSyntax/RawSyntax+CSwiftSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax+CSwiftSyntax.swift
@@ -1,0 +1,113 @@
+//===------------------ RawSyntax.swift - Raw Syntax nodes ----------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_implementationOnly import _CSwiftSyntax
+
+extension RawSyntax {
+  static func createFromCSyntaxNode(
+    arena: SyntaxArena,
+    _ p: CSyntaxNodePtr,
+    in sourceBuffer: UnsafeBufferPointer<UInt8>
+  ) -> RawSyntax {
+    let cnode = p.pointee
+    if cnode.kind == 0 {
+      // Token.
+
+      func sliceSourceText(_ r: CRange) -> SyntaxText {
+        let sourceText = SyntaxText(
+          baseAddress: sourceBuffer.baseAddress, count: sourceBuffer.count)
+        let range = Int(r.offset) ..< Int(r.offset + r.length)
+        return SyntaxText(rebasing: sourceText[range])
+      }
+
+      let tokenKind: RawTokenKind = RawTokenKind.fromRawValue(cnode.token_data.kind)
+      /// Whole text of the token including leading/trailing trivia.
+      let wholeText: SyntaxText = sliceSourceText(cnode.token_data.range)
+
+      // These numbers are being adjusted while materializing trivia.
+      var tokenTextStart = 0
+      var tokenTextEnd = wholeText.count
+
+      // Prepare trivia.
+      let leadingTriviaInfo = UnsafeBufferPointer<swiftparse_trivia_piece_t>(
+        start: cnode.token_data.leading_trivia, count: numericCast(cnode.token_data.leading_trivia_count))
+      let trailingTriviaInfo = UnsafeBufferPointer<swiftparse_trivia_piece_t>(
+        start: cnode.token_data.trailing_trivia, count: numericCast(cnode.token_data.trailing_trivia_count))
+
+      let pieceBuffer = arena.allocateRawTriviaPieceBuffer(
+        count: leadingTriviaInfo.count + trailingTriviaInfo.count)
+      let numLeadingTrivia = leadingTriviaInfo.count
+
+      // Materialize the leading trivia, and advance 'tokenTextStart' to point
+      // the end of leading trivia.
+      for i in 0..<numLeadingTrivia {
+        let cPiece = leadingTriviaInfo[i]
+        let pieceStart = tokenTextStart
+        let pieceEnd = tokenTextStart + numericCast(cPiece.length)
+        let pieceText = SyntaxText(rebasing: wholeText[pieceStart ..< pieceEnd])
+        let piece = RawTriviaPiece.fromRawValue(kind: cPiece.kind, text: pieceText)
+        pieceBuffer.baseAddress!.advanced(by: i).initialize(to: piece)
+        tokenTextStart = pieceEnd
+      }
+      // Materialize the trailing trivia, and retreat 'tokenTextEnd' to point
+      // point the start of trailing trivia.
+      for i in (0..<trailingTriviaInfo.count).reversed() {
+        let cPiece = trailingTriviaInfo[i]
+        let pieceStart = tokenTextEnd - numericCast(cPiece.length)
+        let pieceEnd = tokenTextEnd
+        let pieceText = SyntaxText(rebasing: wholeText[pieceStart ..< pieceEnd])
+        let piece = RawTriviaPiece.fromRawValue(kind: cPiece.kind, text: pieceText)
+        pieceBuffer.baseAddress!.advanced(by: numLeadingTrivia + i).initialize(to: piece)
+        tokenTextEnd = pieceStart
+      }
+
+      // Slice the text
+      let tokenText = SyntaxText(rebasing: wholeText[tokenTextStart ..< tokenTextEnd])
+
+      // Total length of the pieces must match the whole text.
+      assert(tokenText.count + pieceBuffer.reduce(0, {$0 + $1.byteLength}) == wholeText.count)
+
+      return RawSyntax.materializedToken(
+        arena: arena, kind: tokenKind, text: tokenText,
+        triviaPieces: RawTriviaPieceBuffer(pieceBuffer),
+        numLeadingTrivia: numericCast(numLeadingTrivia),
+        byteLength: numericCast(wholeText.count))
+    } else {
+      // Layout.
+
+      let syntaxKind = SyntaxKind(rawValue: numericCast(cnode.kind))!
+
+      let count = Int(cnode.layout_data.nodes_count)
+      if count == 0 {
+        return makeEmptyLayout(arena: arena, kind: syntaxKind)
+      }
+
+      // '!' because we know 'count' is not 0.
+      let nodes: UnsafePointer<CClientNode?> = cnode.layout_data.nodes!
+      return makeLayout(
+        arena: arena,
+        kind: syntaxKind,
+        uninitializedCount: count
+      ) { buffer in
+        var ptr = buffer.baseAddress!
+        for i in 0 ..< count {
+          let element: RawSyntax? = nodes[i].map {
+            // 'CClinentNode' is a pointer to a 'RawSyntaxData'.
+            return RawSyntax.fromOpaque(UnsafeRawPointer($0))
+          }
+          ptr.initialize(to: element)
+          ptr += 1
+        }
+      }
+    }
+  }
+}

--- a/Sources/SwiftSyntax/RawSyntax+CSwiftSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax+CSwiftSyntax.swift
@@ -1,4 +1,4 @@
-//===------------------ RawSyntax.swift - Raw Syntax nodes ----------------===//
+//===------------------- RawSyntax+CSwiftSyntax.swift ---------------------===//
 //
 // This source file is part of the Swift.org open source project
 //

--- a/Sources/SwiftSyntax/RawSyntax+CSwiftSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax+CSwiftSyntax.swift
@@ -14,9 +14,9 @@
 
 extension RawSyntax {
   static func createFromCSyntaxNode(
-    arena: SyntaxArena,
     _ p: CSyntaxNodePtr,
-    in sourceBuffer: UnsafeBufferPointer<UInt8>
+    in sourceBuffer: UnsafeBufferPointer<UInt8>,
+    arena: SyntaxArena
   ) -> RawSyntax {
     let cnode = p.pointee
     if cnode.kind == 0 {
@@ -77,10 +77,11 @@ extension RawSyntax {
       assert(tokenText.count + pieceBuffer.reduce(0, {$0 + $1.byteLength}) == wholeText.count)
 
       return RawSyntax.materializedToken(
-        arena: arena, kind: tokenKind, text: tokenText,
+        kind: tokenKind, text: tokenText,
         triviaPieces: RawTriviaPieceBuffer(pieceBuffer),
         numLeadingTrivia: numericCast(numLeadingTrivia),
-        byteLength: numericCast(wholeText.count))
+        byteLength: numericCast(wholeText.count),
+        arena: arena)
     } else {
       // Layout.
 
@@ -88,15 +89,15 @@ extension RawSyntax {
 
       let count = Int(cnode.layout_data.nodes_count)
       if count == 0 {
-        return makeEmptyLayout(arena: arena, kind: syntaxKind)
+        return makeEmptyLayout(kind: syntaxKind, arena: arena)
       }
 
       // '!' because we know 'count' is not 0.
       let nodes: UnsafePointer<CClientNode?> = cnode.layout_data.nodes!
       return makeLayout(
-        arena: arena,
         kind: syntaxKind,
-        uninitializedCount: count
+        uninitializedCount: count,
+        arena: arena
       ) { buffer in
         var ptr = buffer.baseAddress!
         for i in 0 ..< count {

--- a/Sources/SwiftSyntax/RawSyntax.swift
+++ b/Sources/SwiftSyntax/RawSyntax.swift
@@ -381,7 +381,7 @@ extension RawSyntax {
   // @available(*, deprecated, message: "use 'replacingLayout(with:arena:)'")
   func replacingLayout(_ layout: [RawSyntax?]) -> RawSyntax {
     if isToken { return self }
-    return self.replacingLayout(with: layout, arena: arena)
+    return self.replacingLayout(with: layout, arena: .default)
   }
 
   func insertingChild(

--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -475,24 +475,6 @@ fileprivate extension Trivia {
   }
 }
 
-fileprivate extension TokenKind {
-  /// Walks and passes to `body` the `SourceLength` for every detected line,
-  /// with the newline character included.
-  /// - Returns: The leftover `SourceLength` at the end of the walk.
-  func forEachLineLength(
-    prefix: SourceLength = .zero, body: (SourceLength) -> ()
-  ) -> SourceLength {
-    switch self {
-      case let .stringLiteral(text),
-           let .unknown(text),
-           let .stringSegment(text):
-        return text.forEachLineLength(prefix: prefix, body: body)
-      default:
-        return prefix + self.sourceLength
-    }
-  }
-}
-
 fileprivate extension TokenSyntax {
   /// Walks and passes to `body` the `SourceLength` for every detected line,
   /// with the newline character included.
@@ -502,7 +484,7 @@ fileprivate extension TokenSyntax {
   ) -> SourceLength {
     var curPrefix = prefix
     curPrefix = self.leadingTrivia.forEachLineLength(prefix: curPrefix, body: body)
-    curPrefix = self.tokenKind.forEachLineLength(prefix: curPrefix, body: body)
+    curPrefix = self.text.forEachLineLength(prefix: curPrefix, body: body)
     curPrefix = self.trailingTrivia.forEachLineLength(prefix: curPrefix, body: body)
     return curPrefix
   }

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -696,7 +696,11 @@ public struct SyntaxNode {
   /// `SyntaxData` objects. There's a cost associated with it that should be
   /// taken into account before used inside performance critical code.
   internal var asSyntaxData: SyntaxData {
-    return SyntaxData(absoluteRaw, parent: parent?.asSyntax)
+    if let parent = parent {
+      return SyntaxData(absoluteRaw, parent: parent.asSyntax)
+    } else {
+      return SyntaxData.forRoot(absoluteRaw.raw)
+    }
   }
 
   /// Converts this node to a `Syntax` object.

--- a/Sources/SwiftSyntax/SyntaxArena.swift
+++ b/Sources/SwiftSyntax/SyntaxArena.swift
@@ -121,7 +121,9 @@ public class SyntaxArena {
     precondition(
       !self.hasParent,
       "an arena can't have a new child once it's owned by other arenas")
-    // The precondition above should prevent cyclic references.
+    // `precondition(!self.hasParent)` should be sufficient to make sure we
+    // don’t add retain cycles between syntax arenas, but to be doubly sure,
+    // check the child arenas as well in debug builds.
     assert(!other.contains(arena: self), "cyclic arena hierarchy detected")
 
     other.hasParent = true

--- a/Sources/SwiftSyntax/SyntaxArena.swift
+++ b/Sources/SwiftSyntax/SyntaxArena.swift
@@ -1,0 +1,178 @@
+//===-------- SyntaxArena.swift - RawSyntaxData Memory Management  --------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public class SyntaxArena {
+  /// Bump-pointer allocator for all "intern" methods.
+  private var allocator: BumpPtrAllocator
+  /// Source file buffer the Syntax tree represents.
+  private var sourceBuffer: UnsafeBufferPointer<UInt8>
+
+  /// "children" arena.
+  private var children: Set<SyntaxArena>
+  /// Whether or not this arena has been added to other arenas as a child.
+  private var hasParent: Bool
+
+  public init() {
+    allocator = BumpPtrAllocator()
+    children = []
+    sourceBuffer = .init(start: nil, count: 0)
+    hasParent = false
+  }
+
+  /// Copies a source buffer in to the memory this arena manages, and returns
+  /// the interned buffer.
+  ///
+  /// The interned buffer is guaranteed to be null-terminated.
+  /// `contains(address _:)` is faster if the address is inside the memory
+  /// range this function returned.
+  public func internSourceBuffer(_ buffer: UnsafeBufferPointer<UInt8>) -> UnsafeBufferPointer<UInt8> {
+    precondition(sourceBuffer.baseAddress == nil, "SourceBuffer should only be set once.")
+    let allocated = allocator.allocate(UInt8.self, count: buffer.count + /* for NULL */1)
+    _ = allocated.initialize(from: buffer)
+
+    // NULL terminate.
+    allocated.baseAddress!.advanced(by: buffer.count).initialize(to: 0)
+
+    sourceBuffer = UnsafeBufferPointer(start: allocated.baseAddress!, count: buffer.count)
+    return sourceBuffer
+  }
+
+  /// Checks if the given memory address is inside the memory range returned
+  /// from `internSourceBuffer(_:)` method.
+  func sourceBufferContains(_ address: UnsafePointer<UInt8>) -> Bool {
+    guard let sourceStart = sourceBuffer.baseAddress else { return false }
+    return sourceStart <= address && address < sourceStart.advanced(by: sourceBuffer.count)
+  }
+
+  /// Allocates a buffer of `RawSyntax?` with the given count, then returns the
+  /// uninitlialized memory range as a `UnsafeMutableBufferPointer<RawSyntax?>`.
+  func allocateRawSyntaxBuffer(count: Int) -> UnsafeMutableBufferPointer<RawSyntax?> {
+    return allocator.allocate(RawSyntax?.self, count: count)
+  }
+
+  /// Allcates a buffer of `RawTriviaPiece` with the given count, then returns
+  /// the uninitialized memory range as a `UnsafeMutableBufferPointer<RawTriviaPiece>`.
+  public func allocateRawTriviaPieceBuffer(
+    count: Int) -> UnsafeMutableBufferPointer<RawTriviaPiece> {
+      return allocator.allocate(RawTriviaPiece.self, count: count)
+    }
+
+  /// Allcates a buffer of `UInt8` with the given count, then returns the
+  /// uninitialized memory range as a `UnsafeMutableBufferPointer<UInt8>`.
+  public func allocateTextBuffer(count: Int) -> UnsafeMutableBufferPointer<UInt8> {
+    return allocator.allocate(UInt8.self, count: count)
+  }
+
+  /// Copies the contents of a `SyntaxText` to the memory this arena manages,
+  /// and return the `SyntaxText` in the destiation.
+  func intern(_ value: SyntaxText) -> SyntaxText {
+    // Return the passed-in value if it's
+    // * empty,
+    // * a part of "source buffer", or
+    // * in the memory allocated by this arena
+    if (value.isEmpty || sourceBufferContains(value.baseAddress!) ||
+        allocator.contains(address: value.baseAddress!)) {
+      return value
+    }
+
+    let allocated = allocator.allocate(UInt8.self, count: value.count)
+    _ = allocated.initialize(from: value)
+    return SyntaxText(baseAddress: allocated.baseAddress, count: allocated.count)
+  }
+
+  /// Copies a UTF8 sequence of `String` to the memory this arena manages, and
+  /// returns the copied string as a `SyntaxText`
+  func intern(_ value: String) -> SyntaxText {
+    if value.isEmpty { return SyntaxText() }
+    var value = value
+    return value.withUTF8 { utf8 in
+      let allocated = allocator.allocate(UInt8.self, count: utf8.count)
+      _ = allocated.initialize(from: utf8)
+      return SyntaxText(baseAddress: allocated.baseAddress, count: utf8.count)
+    }
+  }
+
+  /// Copies a `RawSyntaxData` to the memory this arena manages, and retuns the
+  /// pointer to the destination.
+  func intern(_ value: RawSyntaxData) -> UnsafePointer<RawSyntaxData> {
+    let allocated = allocator.allocate(RawSyntaxData.self, count: 1).baseAddress!
+    allocated.initialize(to: value)
+    return UnsafePointer(allocated)
+  }
+
+  /// Adds an `SyntaxArena` to this arena as a "child". Do nothing if `arenaRef`
+  /// refers `self`.
+  ///
+  /// When an arena added to another arena, it's owned and is never released
+  /// until the parent arena is deinitialized. This can be used when the syntax
+  /// tree managed by this arena want to hold a subtree owned by other arena.
+  /// See also `RawSyntax.layout()`.
+  func addChild(_ arenaRef: SyntaxArenaRef) {
+    if SyntaxArenaRef(self) == arenaRef { return }
+
+    let other = arenaRef.value
+
+    precondition(
+      !self.hasParent,
+      "an arena can't have a new child once it's owned by other arenas")
+    // The precondition above should prevent cyclic references.
+    assert(!other.contains(arena: self), "cyclic arena hierarchy detected")
+
+    other.hasParent = true
+    children.insert(other)
+  }
+
+  /// Recursively checks if this arena contains given `arena` as a descendant.
+  func contains(arena: SyntaxArena) -> Bool {
+    return children.contains { child in
+      child === arena  || child.contains(arena: arena)
+    }
+  }
+}
+
+extension SyntaxArena: Hashable {
+  public func hash(into hasher: inout Hasher) {
+    hasher.combine(ObjectIdentifier(self))
+  }
+  public static func ==(lhs: SyntaxArena, rhs: SyntaxArena) -> Bool {
+    return lhs === rhs
+  }
+}
+
+/// Unsafely unowned reference to `SyntaxArena`. The user is responsible to
+/// maintain the lifetime of the `SyntaxArena`.
+///
+/// `RawSyntaxData` holds its `SyntaxArena` in this form to prevent their cyclic
+/// strong references. Also, passing around `SyntaxArena` in this form doesn't
+/// cause any ref-counting traffic.
+struct SyntaxArenaRef: Equatable {
+  private unowned(unsafe) var _value: SyntaxArena
+
+  init(_ value: __shared SyntaxArena) {
+    self._value = value
+  }
+
+  /// Returns the `SyntaxArena`
+  var value: SyntaxArena {
+    get { self._value }
+  }
+
+  static func ==(lhs: SyntaxArenaRef, rhs: SyntaxArenaRef) -> Bool {
+    return lhs._value === rhs._value
+  }
+}
+
+extension SyntaxArena {
+  // FIXME: This is only for migration. All clients should move to "arena" model.
+  @available(*, deprecated, message: ".default SyntaxArena is subject to remove soon")
+  public static let `default` = SyntaxArena()
+}

--- a/Sources/SwiftSyntax/SyntaxArena.swift
+++ b/Sources/SwiftSyntax/SyntaxArena.swift
@@ -33,18 +33,13 @@ public class SyntaxArena {
   /// Copies a source buffer in to the memory this arena manages, and returns
   /// the interned buffer.
   ///
-  /// The interned buffer is guaranteed to be null-terminated.
   /// `contains(address _:)` is faster if the address is inside the memory
   /// range this function returned.
   public func internSourceBuffer(_ buffer: UnsafeBufferPointer<UInt8>) -> UnsafeBufferPointer<UInt8> {
     precondition(sourceBuffer.baseAddress == nil, "SourceBuffer should only be set once.")
-    let allocated = allocator.allocate(UInt8.self, count: buffer.count + /* for NULL */1)
+    let allocated = allocator.allocate(UInt8.self, count: buffer.count)
     _ = allocated.initialize(from: buffer)
-
-    // NULL terminate.
-    allocated.baseAddress!.advanced(by: buffer.count).initialize(to: 0)
-
-    sourceBuffer = UnsafeBufferPointer(start: allocated.baseAddress!, count: buffer.count)
+    sourceBuffer = UnsafeBufferPointer(start: allocated.baseAddress, count: buffer.count)
     return sourceBuffer
   }
 

--- a/Sources/SwiftSyntax/SyntaxArena.swift
+++ b/Sources/SwiftSyntax/SyntaxArena.swift
@@ -33,13 +33,18 @@ public class SyntaxArena {
   /// Copies a source buffer in to the memory this arena manages, and returns
   /// the interned buffer.
   ///
+  /// The interned buffer is guaranteed to be null-terminated.
   /// `contains(address _:)` is faster if the address is inside the memory
   /// range this function returned.
   public func internSourceBuffer(_ buffer: UnsafeBufferPointer<UInt8>) -> UnsafeBufferPointer<UInt8> {
     precondition(sourceBuffer.baseAddress == nil, "SourceBuffer should only be set once.")
-    let allocated = allocator.allocate(UInt8.self, count: buffer.count)
+    let allocated = allocator.allocate(UInt8.self, count: buffer.count + /* for NULL */1)
     _ = allocated.initialize(from: buffer)
-    sourceBuffer = UnsafeBufferPointer(start: allocated.baseAddress, count: buffer.count)
+
+    // NULL terminate.
+    allocated.baseAddress!.advanced(by: buffer.count).initialize(to: 0)
+
+    sourceBuffer = UnsafeBufferPointer(start: allocated.baseAddress!, count: buffer.count)
     return sourceBuffer
   }
 

--- a/Sources/SwiftSyntax/SyntaxArena.swift
+++ b/Sources/SwiftSyntax/SyntaxArena.swift
@@ -61,14 +61,14 @@ public class SyntaxArena {
 
   /// Allcates a buffer of `RawTriviaPiece` with the given count, then returns
   /// the uninitialized memory range as a `UnsafeMutableBufferPointer<RawTriviaPiece>`.
-  public func allocateRawTriviaPieceBuffer(
+  func allocateRawTriviaPieceBuffer(
     count: Int) -> UnsafeMutableBufferPointer<RawTriviaPiece> {
       return allocator.allocate(RawTriviaPiece.self, count: count)
     }
 
   /// Allcates a buffer of `UInt8` with the given count, then returns the
   /// uninitialized memory range as a `UnsafeMutableBufferPointer<UInt8>`.
-  public func allocateTextBuffer(count: Int) -> UnsafeMutableBufferPointer<UInt8> {
+  func allocateTextBuffer(count: Int) -> UnsafeMutableBufferPointer<UInt8> {
     return allocator.allocate(UInt8.self, count: count)
   }
 

--- a/Sources/SwiftSyntax/SyntaxArena.swift
+++ b/Sources/SwiftSyntax/SyntaxArena.swift
@@ -170,6 +170,6 @@ struct SyntaxArenaRef: Equatable {
 
 extension SyntaxArena {
   // FIXME: This is only for migration. All clients should move to "arena" model.
-  @available(*, deprecated, message: ".default SyntaxArena is subject to remove soon")
+  //@available(*, deprecated, message: ".default SyntaxArena is subject to remove soon")
   public static let `default` = SyntaxArena()
 }

--- a/Sources/SwiftSyntax/SyntaxClassifier.swift
+++ b/Sources/SwiftSyntax/SyntaxClassifier.swift
@@ -48,7 +48,7 @@ extension RawTriviaPiece {
   }
 }
 
-struct TokenKindAndText {
+fileprivate struct TokenKindAndText {
   let kind: RawTokenKind
   let text: SyntaxText
 

--- a/Sources/SwiftSyntax/SyntaxClassifier.swift
+++ b/Sources/SwiftSyntax/SyntaxClassifier.swift
@@ -30,7 +30,7 @@ extension TokenSyntax {
     let contextualClassification = self.data.contextualClassification
     let relativeOffset = raw.tokenLeadingTriviaLength.utf8Length
     let absoluteOffset = position.utf8Offset + relativeOffset
-    return TokenKindAndText(kind: raw.rawTokenKind, text: raw.tokenText).classify(
+    return TokenKindAndText(kind: raw.rawTokenKind, text: raw.rawTokenText).classify(
       offset: absoluteOffset, contextualClassification: contextualClassification)
   }
 }
@@ -289,7 +289,7 @@ fileprivate struct TokenClassificationIterator: IteratorProtocol {
     assert(token.raw.isToken)
     self.token = token
     self.offset = Int(token.position.offset)
-    self.state = .atLeadingTrivia(token.raw.tokenLeadingTriviaPieces, 0)
+    self.state = .atLeadingTrivia(token.raw.tokenLeadingRawTriviaPieces, 0)
   }
 
   var relativeOffset: Int { return offset - Int(token.position.offset) }
@@ -310,11 +310,11 @@ fileprivate struct TokenClassificationIterator: IteratorProtocol {
 
       case .atTokenText:
         let classifiedRange = TokenKindAndText(
-          kind: token.raw.rawTokenKind, text: token.raw.tokenText)
+          kind: token.raw.rawTokenKind, text: token.raw.rawTokenText)
           .classify(offset: offset, contextualClassification: token.classification)
 
         // Move on to trailing trivia.
-        state = .atTrailingTrivia(token.raw.tokenTrailingTriviaPieces, 0)
+        state = .atTrailingTrivia(token.raw.tokenTrailingRawTriviaPieces, 0)
         offset = classifiedRange.endOffset
         guard classifiedRange.kind != .none else { break }
         return classifiedRange

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -228,14 +228,11 @@ struct SyntaxData {
     case .parent(let parentBox): return parentBox.value.data.arena
     }
   }
-  private var parentBox: SyntaxBox? {
+  var parent: Syntax? {
     switch parentOrArena {
-    case .parent(let parentBox): return parentBox
+    case .parent(let parentBox): return parentBox.value
     case .arena(_): return nil
     }
-  }
-  var parent: Syntax? {
-    return parentBox?.value
   }
   let absoluteRaw: AbsoluteRawSyntax
 

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -345,7 +345,7 @@ struct SyntaxData {
   ///            syntax data.
   /// - SeeAlso: replacingSelf(_:)
   func replacingChild(_ child: RawSyntax?, at index: Int) -> SyntaxData {
-    let newRaw = raw.replacingChild(at: index, with: child, arena: raw.arena)
+    let newRaw = raw.replacingChild(at: index, with: child, arena: .default)
     return replacingSelf(newRaw)
   }
 

--- a/Sources/SwiftSyntax/SyntaxOtherNodes.swift
+++ b/Sources/SwiftSyntax/SyntaxOtherNodes.swift
@@ -84,7 +84,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
 
   /// The text of the token as written in the source code.
   public var text: String {
-    return tokenKind.text
+    return String(syntaxText: raw.tokenText)
   }
 
   /// Returns a new TokenSyntax with its kind replaced
@@ -93,9 +93,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
     guard raw.kind == .token else {
       fatalError("TokenSyntax must have token as its raw")
     }
-    let newRaw = RawSyntax.createAndCalcLength(kind: tokenKind,
-      leadingTrivia: raw.formLeadingTrivia()!, trailingTrivia: raw.formTrailingTrivia()!,
-      presence: raw.presence)
+    let newRaw = raw.withTokenKind(tokenKind)
     let newData = data.replacingSelf(newRaw)
     return TokenSyntax(newData)
   }
@@ -136,7 +134,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   /// The leading trivia (spaces, newlines, etc.) associated with this token.
   public var leadingTrivia: Trivia {
     get {
-      return raw.formTokenLeadingTrivia()!
+      return raw.tokenLeadingTrivia
     }
     set {
       self = withLeadingTrivia(newValue)
@@ -146,7 +144,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   /// The trailing trivia (spaces, newlines, etc.) associated with this token.
   public var trailingTrivia: Trivia {
     get {
-      return raw.formTokenTrailingTrivia()!
+      return raw.tokenTrailingTrivia
     }
     set {
       self = withTrailingTrivia(newValue)
@@ -156,7 +154,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   /// The kind of token this node represents.
   public var tokenKind: TokenKind {
     get {
-      return raw.formTokenKind()!
+      return raw.tokenKind
     }
     set {
       self = withKind(newValue)

--- a/Sources/SwiftSyntax/SyntaxOtherNodes.swift
+++ b/Sources/SwiftSyntax/SyntaxOtherNodes.swift
@@ -84,7 +84,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
 
   /// The text of the token as written in the source code.
   public var text: String {
-    return String(syntaxText: raw.tokenText)
+    return String(syntaxText: raw.rawTokenText)
   }
 
   /// Returns a new TokenSyntax with its kind replaced
@@ -134,7 +134,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   /// The leading trivia (spaces, newlines, etc.) associated with this token.
   public var leadingTrivia: Trivia {
     get {
-      return raw.tokenLeadingTrivia
+      return raw.formTokenLeadingTrivia()!
     }
     set {
       self = withLeadingTrivia(newValue)
@@ -144,7 +144,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   /// The trailing trivia (spaces, newlines, etc.) associated with this token.
   public var trailingTrivia: Trivia {
     get {
-      return raw.tokenTrailingTrivia
+      return raw.formTokenTrailingTrivia()!
     }
     set {
       self = withTrailingTrivia(newValue)
@@ -154,7 +154,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   /// The kind of token this node represents.
   public var tokenKind: TokenKind {
     get {
-      return raw.tokenKind
+      return raw.formTokenKind()!
     }
     set {
       self = withKind(newValue)

--- a/Sources/SwiftSyntax/SyntaxOtherNodes.swift
+++ b/Sources/SwiftSyntax/SyntaxOtherNodes.swift
@@ -84,7 +84,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
 
   /// The text of the token as written in the source code.
   public var text: String {
-    return String(syntaxText: raw.rawTokenText)
+    return tokenKind.text
   }
 
   /// Returns a new TokenSyntax with its kind replaced

--- a/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxRewriter.swift.gyb
@@ -200,7 +200,6 @@ open class SyntaxRewriter {
     var newLayout: ContiguousArray<RawSyntax?>?
 
     let syntaxNode = node._syntaxNode
-    let parentBox = SyntaxBox(syntaxNode)
 
     // Incrementing i manually is faster than using .enumerated()
     var childIndex = 0
@@ -217,7 +216,7 @@ open class SyntaxRewriter {
 
       // Build the Syntax node to rewrite
       let absoluteRaw = AbsoluteRawSyntax(raw: child, info: info)
-      let data = SyntaxData(absoluteRaw, parentBox: parentBox)
+      let data = SyntaxData(absoluteRaw, parent: syntaxNode)
       
       let rewritten = visit(data)
       if rewritten.data.nodeId != info.nodeId {

--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -31,7 +31,6 @@ import Glibc
 /// buffer regardless of whether it is a valid UTF8. When creating
 /// `Swift.String`, ill-formed UTF8 sequences are replaced with the Unicode
 /// replacement character (`\u{FFFD}`).
-@_spi(Testing) // SPI name is subject to change
 public struct SyntaxText {
   var buffer: UnsafeBufferPointer<UInt8>
 

--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -31,6 +31,7 @@ import Glibc
 /// buffer regardless of whether it is a valid UTF8. When creating
 /// `Swift.String`, ill-formed UTF8 sequences are replaced with the Unicode
 /// replacement character (`\u{FFFD}`).
+@_spi(Testing) // SPI name is subject to change
 public struct SyntaxText {
   var buffer: UnsafeBufferPointer<UInt8>
 

--- a/Sources/SwiftSyntax/SyntaxVisitor.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxVisitor.swift.gyb
@@ -135,9 +135,8 @@ open class SyntaxVisitor {
 
   private func visitChildren<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) {
     let syntaxNode = Syntax(node)
-    let parentBox = SyntaxBox(syntaxNode)
     for childRaw in NonNilRawSyntaxChildren(syntaxNode, viewMode: viewMode) {
-      let childData = SyntaxData(childRaw, parentBox: parentBox)
+      let childData = SyntaxData(childRaw, parent: syntaxNode)
       visit(childData)
     }
   }

--- a/Sources/SwiftSyntax/TokenKind.swift.gyb
+++ b/Sources/SwiftSyntax/TokenKind.swift.gyb
@@ -173,6 +173,7 @@ public enum RawTokenKind {
 }
 
 extension TokenKind {
+  /// If the `rawKind` has a `defaultText`, `text` can be empty.
   static func fromRaw(kind rawKind: RawTokenKind, text: SyntaxText) -> TokenKind {
     switch rawKind {
     case .eof: return .eof
@@ -188,6 +189,8 @@ extension TokenKind {
     }
   }
 
+  /// Returns the `RawTokenKind` of this `TokenKind` and, if this `TokenKind`
+  /// has associated text, the associated text, otherwise `nil`.
   func decomposeToRaw() -> (rawKind: RawTokenKind, string: String?) {
     switch self {
     case .eof: return (.eof, nil)

--- a/Sources/SwiftSyntax/TokenKind.swift.gyb
+++ b/Sources/SwiftSyntax/TokenKind.swift.gyb
@@ -96,7 +96,7 @@ public enum TokenKind: Hashable {
 % end
     }
   }
-  
+
   var kind: String {
     switch self {
     case .eof: return "eof"
@@ -142,80 +142,60 @@ extension TokenKind: Equatable {
   }
 }
 
-extension TokenKind {
-  static func fromRawValue(kind: CTokenKind,
-                           textBuffer: UnsafeBufferPointer<UInt8>) -> TokenKind {
-    switch kind {
-    case 0: return .eof
-% for token in SYNTAX_TOKENS:
-    case ${token.serialization_code}:
-%   if token.text: # The token does not have text associated with it
-      return .${token.swift_kind()}
-%   else:
-      return .${token.swift_kind()}(.fromBuffer(textBuffer))
-%   end
-% end
-    default:
-      if !textBuffer.isEmpty {
-        // Default to an unknown token with the passed text if we don't know
-        // its kind.
-        return .unknown(.fromBuffer(textBuffer))
-      } else {
-        // If we were not passed the token's text, we cannot recover since we
-        // would lose roundtripness.
-        fatalError("unexpected token kind \(kind)")
-      }
-    }
-  }
-
-  static func hasText(kind: CTokenKind) -> Bool {
-    switch kind {
-    case 0: return false
-% for token in SYNTAX_TOKENS:
-    case ${token.serialization_code}:
-%   if token.text: # The token does not have text associated with it
-      return false
-%   else:
-      return true
-%   end
-% end
-    default:
-      fatalError("unexpected token kind \(kind)")
-    }
-  }
-}
-
 /// Plain token kind value, without an associated `String` value.
-internal enum RawTokenKind: CTokenKind {
-  case eof = 0
+public enum RawTokenKind {
+  case eof
 % for token in SYNTAX_TOKENS:
-  case ${token.swift_kind()} = ${token.serialization_code}
+  case ${token.swift_kind()}
 % end
 
   static func fromRawValue(_ rawValue: CTokenKind) -> RawTokenKind {
-    return RawTokenKind(rawValue: rawValue)!
+    switch rawValue {
+    case 0: return .eof
+% for token in SYNTAX_TOKENS:
+    case ${token.serialization_code}: return .${token.swift_kind()}
+% end
+    default: fatalError("unknown raw value")
+    }
+  }
+
+  var defaultText: SyntaxText? {
+    switch self {
+    case .eof: return ""
+% for token in SYNTAX_TOKENS:
+%   if token.text:
+    case .${token.swift_kind()}: return "${token.text}"
+%   end
+% end
+    default: return nil
+    }
   }
 }
 
 extension TokenKind {
-  internal func withUnsafeTokenText<Result>(
-    _ body: (UnsafeTokenText) -> Result
-  ) -> Result {
+  static func fromRaw(kind rawKind: RawTokenKind, text: SyntaxText) -> TokenKind {
+    switch rawKind {
+    case .eof: return .eof
+% for token in SYNTAX_TOKENS:
+    case .${token.swift_kind()}:
+%   if token.text:
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .${token.swift_kind()}
+%   else:
+      return .${token.swift_kind()}(String(syntaxText: text))
+%   end
+% end
+    }
+  }
+
+  func decomposeToRaw() -> (rawKind: RawTokenKind, string: String?) {
     switch self {
-    case .eof:
-      return body(.init(kind: .eof, length: 0))
+    case .eof: return (.eof, nil)
 % for token in SYNTAX_TOKENS:
 %   if token.text:
-    case .${token.swift_kind()}:
-      let length = ${len(token.text.encode('utf-8').decode('unicode-escape'))}
-      return body(.init(kind: .${token.swift_kind()}, length: length))
+    case .${token.swift_kind()}: return (.${token.swift_kind()}, nil)
 %   else:
-    case .${token.swift_kind()}(var text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .${token.swift_kind()}, length: length, customText: buf))
-      })!
+    case .${token.swift_kind()}(let str): return (.${token.swift_kind()}, str)
 %   end
 % end
     }

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -231,78 +231,82 @@ extension TriviaPiece {
   }
 }
 
-extension TriviaPiece {
-  static func fromRawValue(_ piece: CTriviaPiece,
-                           textBuffer: UnsafeBufferPointer<UInt8>) -> TriviaPiece {
-    switch piece.kind {
+/// Trivia piece for token RawSyntax.
+public enum RawTriviaPiece {
 % for trivia in TRIVIAS:
-    case ${trivia.serialization_code}:
 %   if trivia.is_collection():
-      return .${trivia.lower_name}s(Int(piece.length)/${trivia.characters_len()})
+    case ${trivia.lower_name}s(Int)
 %   else:
-      return .${trivia.lower_name}(.fromBuffer(textBuffer))
+    case ${trivia.lower_name}(SyntaxText)
 %   end
 % end
-    default:
-      fatalError("unexpected trivia piece kind \(piece.kind)")
-    }
-  }
 
-  static func hasText(kind: CTriviaKind) -> Bool {
-    switch kind {
+  static func make(arena: SyntaxArena, _ piece: TriviaPiece) -> RawTriviaPiece {
+    switch piece {
 % for trivia in TRIVIAS:
-    case ${trivia.serialization_code}:
 %   if trivia.is_collection():
-      return false
+    case let .${trivia.lower_name}s(count): return .${trivia.lower_name}s(count)
 %   else:
-      return true
+    case let .${trivia.lower_name}(text): return .${trivia.lower_name}(arena.intern(text))
 %   end
 % end
-    default:
-      fatalError("unexpected trivia piece kind \(kind)")
     }
   }
 }
 
-/// Plain trivia piece kind value, without an associated `String` value.
-internal enum TriviaPieceKind: CTriviaKind {
-% for trivia in TRIVIAS:
-    /// ${trivia.comment}
-%   if trivia.is_collection():
-    case ${trivia.lower_name}s = ${trivia.serialization_code}
-%   else:
-    case ${trivia.lower_name} = ${trivia.serialization_code}
-%   end
-% end
-
-  static func fromRawValue(_ rawValue: CTriviaKind) -> TriviaPieceKind {
-    return TriviaPieceKind(rawValue: rawValue)!
+extension RawTriviaPiece: TextOutputStreamable {
+  public func write<Target: TextOutputStream>(to target: inout Target) {
+    TriviaPiece(raw: self).write(to: &target)
   }
 }
 
 extension TriviaPiece {
-  internal func withUnsafeTriviaPiece<Result>(
-    _ body: (UnsafeTriviaPiece) -> Result
-  ) -> Result {
+  init(raw: RawTriviaPiece) {
+    switch raw {
+% for trivia in TRIVIAS:
+%   if trivia.is_collection():
+    case let .${trivia.lower_name}s(count): self = .${trivia.lower_name}s(count)
+%   else:
+    case let .${trivia.lower_name}(text): self = .${trivia.lower_name}(String(syntaxText: text))
+%   end
+% end
+    }
+  }
+}
+
+extension RawTriviaPiece {
+  public var byteLength: Int {
     switch self {
 % for trivia in TRIVIAS:
 %   if trivia.is_new_line:
     case let .${trivia.lower_name}s(count):
-      let length = count * ${trivia.characters_len()}
-      return body(.init(kind: .${trivia.lower_name}s, length: length))
+      return count * ${trivia.characters_len()}
 %   elif trivia.is_collection():
     case let .${trivia.lower_name}s(count):
-      let length = count
-      return body(.init(kind: .${trivia.lower_name}s, length: length))
+      return count
 %   else:
-    case var .${trivia.lower_name}(text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .${trivia.lower_name}, length: length, customText: buf))
-      })!
+    case let .${trivia.lower_name}(text):
+      return text.count
 %   end
 % end
+    }
+  }
+}
+
+
+extension RawTriviaPiece {
+  public static func fromRawValue(kind: UInt8, text: SyntaxText) -> RawTriviaPiece {
+    switch kind {
+% for trivia in TRIVIAS:
+    case ${trivia.serialization_code}:
+%   if trivia.is_collection():
+      return .${trivia.lower_name}s(text.count / ${trivia.characters_len()})
+%   else:
+      return .${trivia.lower_name}(text)
+%   end
+% end
+    default:
+      fatalError("unexpected trivia piece kind \(kind)")
     }
   }
 }

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -244,7 +244,7 @@ enum RawTriviaPiece {
 %   end
 % end
 
-  static func make(arena: SyntaxArena, _ piece: TriviaPiece) -> RawTriviaPiece {
+  static func make(_ piece: TriviaPiece, arena: SyntaxArena) -> RawTriviaPiece {
     switch piece {
 % for trivia in TRIVIAS:
 %   if trivia.is_collection():

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -300,7 +300,11 @@ extension RawTriviaPiece {
 % for trivia in TRIVIAS:
     case ${trivia.serialization_code}:
 %   if trivia.is_collection():
-      return .${trivia.lower_name}s(text.count / ${trivia.characters_len()})
+%     division = ""
+%     if not trivia.characters_len() == 1:
+%       division = " / %d" % (trivia.characters_len())
+%     end
+      return .${trivia.lower_name}s(text.count${division})
 %   else:
       return .${trivia.lower_name}(text)
 %   end

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -232,12 +232,15 @@ extension TriviaPiece {
 }
 
 /// Trivia piece for token RawSyntax.
+///
+/// In contrast to `TriviaPiece`, a `RawTriviaPiece` does not own the source
+/// text of a the trivia.
 enum RawTriviaPiece {
 % for trivia in TRIVIAS:
 %   if trivia.is_collection():
-    case ${trivia.lower_name}s(Int)
+  case ${trivia.lower_name}s(Int)
 %   else:
-    case ${trivia.lower_name}(SyntaxText)
+  case ${trivia.lower_name}(SyntaxText)
 %   end
 % end
 
@@ -292,7 +295,6 @@ extension RawTriviaPiece {
     }
   }
 }
-
 
 extension RawTriviaPiece {
   static func fromRawValue(kind: UInt8, text: SyntaxText) -> RawTriviaPiece {

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -232,7 +232,7 @@ extension TriviaPiece {
 }
 
 /// Trivia piece for token RawSyntax.
-public enum RawTriviaPiece {
+enum RawTriviaPiece {
 % for trivia in TRIVIAS:
 %   if trivia.is_collection():
     case ${trivia.lower_name}s(Int)
@@ -255,7 +255,7 @@ public enum RawTriviaPiece {
 }
 
 extension RawTriviaPiece: TextOutputStreamable {
-  public func write<Target: TextOutputStream>(to target: inout Target) {
+  func write<Target: TextOutputStream>(to target: inout Target) {
     TriviaPiece(raw: self).write(to: &target)
   }
 }
@@ -275,7 +275,7 @@ extension TriviaPiece {
 }
 
 extension RawTriviaPiece {
-  public var byteLength: Int {
+  var byteLength: Int {
     switch self {
 % for trivia in TRIVIAS:
 %   if trivia.is_new_line:
@@ -295,7 +295,7 @@ extension RawTriviaPiece {
 
 
 extension RawTriviaPiece {
-  public static func fromRawValue(kind: UInt8, text: SyntaxText) -> RawTriviaPiece {
+  static func fromRawValue(kind: UInt8, text: SyntaxText) -> RawTriviaPiece {
     switch kind {
 % for trivia in TRIVIAS:
     case ${trivia.serialization_code}:

--- a/Sources/SwiftSyntax/_SyntaxParserInterop.swift
+++ b/Sources/SwiftSyntax/_SyntaxParserInterop.swift
@@ -25,10 +25,10 @@ public enum _SyntaxParserInterop {
   /// `CClientNode` to `nodeFromRetainedOpaqueRawSyntax` transfers ownership
   /// back to `SwiftSyntax`.
   public static func getRetainedOpaqueRawSyntax(
-    arena: SyntaxArena, cnode: UnsafeRawPointer, sourceBuffer: UnsafeBufferPointer<UInt8>
+    cnode: UnsafeRawPointer, sourceBuffer: UnsafeBufferPointer<UInt8>, arena: SyntaxArena
   ) -> CClientNode {
     let cnode = cnode.assumingMemoryBound(to: CSyntaxNode.self)
-    let node = RawSyntax.createFromCSyntaxNode(arena: arena, cnode, in: sourceBuffer)
+    let node = RawSyntax.createFromCSyntaxNode(cnode, in: sourceBuffer, arena: arena)
     return CClientNode(mutating: node.toOpaque())
   }
 

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -5598,7 +5598,6 @@ open class SyntaxRewriter {
     var newLayout: ContiguousArray<RawSyntax?>?
 
     let syntaxNode = node._syntaxNode
-    let parentBox = SyntaxBox(syntaxNode)
 
     // Incrementing i manually is faster than using .enumerated()
     var childIndex = 0
@@ -5615,7 +5614,7 @@ open class SyntaxRewriter {
 
       // Build the Syntax node to rewrite
       let absoluteRaw = AbsoluteRawSyntax(raw: child, info: info)
-      let data = SyntaxData(absoluteRaw, parentBox: parentBox)
+      let data = SyntaxData(absoluteRaw, parent: syntaxNode)
       
       let rewritten = visit(data)
       if rewritten.data.nodeId != info.nodeId {

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -6055,9 +6055,8 @@ open class SyntaxVisitor {
 
   private func visitChildren<SyntaxType: SyntaxProtocol>(_ node: SyntaxType) {
     let syntaxNode = Syntax(node)
-    let parentBox = SyntaxBox(syntaxNode)
     for childRaw in NonNilRawSyntaxChildren(syntaxNode, viewMode: viewMode) {
-      let childData = SyntaxData(childRaw, parentBox: parentBox)
+      let childData = SyntaxData(childRaw, parent: syntaxNode)
       visit(childData)
     }
   }

--- a/Sources/SwiftSyntax/gyb_generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/TokenKind.swift
@@ -1499,6 +1499,7 @@ public enum RawTokenKind {
 }
 
 extension TokenKind {
+  /// If the `rawKind` has a `defaultText`, `text` can be empty.
   static func fromRaw(kind rawKind: RawTokenKind, text: SyntaxText) -> TokenKind {
     switch rawKind {
     case .eof: return .eof
@@ -1863,6 +1864,8 @@ extension TokenKind {
     }
   }
 
+  /// Returns the `RawTokenKind` of this `TokenKind` and, if this `TokenKind`
+  /// has associated text, the associated text, otherwise `nil`.
   func decomposeToRaw() -> (rawKind: RawTokenKind, string: String?) {
     switch self {
     case .eof: return (.eof, nil)

--- a/Sources/SwiftSyntax/gyb_generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/TokenKind.swift
@@ -712,7 +712,7 @@ public enum TokenKind: Hashable {
     case .yield: return false
     }
   }
-  
+
   var kind: String {
     switch self {
     case .eof: return "eof"
@@ -1121,1083 +1121,875 @@ extension TokenKind: Equatable {
   }
 }
 
-extension TokenKind {
-  static func fromRawValue(kind: CTokenKind,
-                           textBuffer: UnsafeBufferPointer<UInt8>) -> TokenKind {
-    switch kind {
-    case 0: return .eof
-    case 1:
-      return .associatedtypeKeyword
-    case 2:
-      return .classKeyword
-    case 3:
-      return .deinitKeyword
-    case 4:
-      return .enumKeyword
-    case 5:
-      return .extensionKeyword
-    case 6:
-      return .funcKeyword
-    case 7:
-      return .importKeyword
-    case 8:
-      return .initKeyword
-    case 9:
-      return .inoutKeyword
-    case 10:
-      return .letKeyword
-    case 11:
-      return .operatorKeyword
-    case 12:
-      return .precedencegroupKeyword
-    case 13:
-      return .protocolKeyword
-    case 14:
-      return .structKeyword
-    case 15:
-      return .subscriptKeyword
-    case 16:
-      return .typealiasKeyword
-    case 17:
-      return .varKeyword
-    case 18:
-      return .fileprivateKeyword
-    case 19:
-      return .internalKeyword
-    case 20:
-      return .privateKeyword
-    case 21:
-      return .publicKeyword
-    case 22:
-      return .staticKeyword
-    case 23:
-      return .deferKeyword
-    case 24:
-      return .ifKeyword
-    case 25:
-      return .guardKeyword
-    case 26:
-      return .doKeyword
-    case 27:
-      return .repeatKeyword
-    case 28:
-      return .elseKeyword
-    case 29:
-      return .forKeyword
-    case 30:
-      return .inKeyword
-    case 31:
-      return .whileKeyword
-    case 32:
-      return .returnKeyword
-    case 33:
-      return .breakKeyword
-    case 34:
-      return .continueKeyword
-    case 35:
-      return .fallthroughKeyword
-    case 36:
-      return .switchKeyword
-    case 37:
-      return .caseKeyword
-    case 38:
-      return .defaultKeyword
-    case 39:
-      return .whereKeyword
-    case 40:
-      return .catchKeyword
-    case 50:
-      return .throwKeyword
-    case 41:
-      return .asKeyword
-    case 42:
-      return .anyKeyword
-    case 43:
-      return .falseKeyword
-    case 44:
-      return .isKeyword
-    case 45:
-      return .nilKeyword
-    case 46:
-      return .rethrowsKeyword
-    case 47:
-      return .superKeyword
-    case 48:
-      return .selfKeyword
-    case 49:
-      return .capitalSelfKeyword
-    case 51:
-      return .trueKeyword
-    case 52:
-      return .tryKeyword
-    case 53:
-      return .throwsKeyword
-    case 54:
-      return .__file__Keyword
-    case 55:
-      return .__line__Keyword
-    case 56:
-      return .__column__Keyword
-    case 57:
-      return .__function__Keyword
-    case 58:
-      return .__dso_handle__Keyword
-    case 59:
-      return .wildcardKeyword
-    case 88:
-      return .leftParen
-    case 89:
-      return .rightParen
-    case 90:
-      return .leftBrace
-    case 91:
-      return .rightBrace
-    case 92:
-      return .leftSquareBracket
-    case 93:
-      return .rightSquareBracket
-    case 94:
-      return .leftAngle
-    case 95:
-      return .rightAngle
-    case 85:
-      return .period
-    case 87:
-      return .prefixPeriod
-    case 84:
-      return .comma
-    case 118:
-      return .ellipsis
-    case 82:
-      return .colon
-    case 83:
-      return .semicolon
-    case 86:
-      return .equal
-    case 80:
-      return .atSign
-    case 81:
-      return .pound
-    case 96:
-      return .prefixAmpersand
-    case 78:
-      return .arrow
-    case 79:
-      return .backtick
-    case 100:
-      return .backslash
-    case 99:
-      return .exclamationMark
-    case 97:
-      return .postfixQuestionMark
-    case 98:
-      return .infixQuestionMark
-    case 102:
-      return .stringQuote
-    case 120:
-      return .singleQuote
-    case 103:
-      return .multilineStringQuote
-    case 74:
-      return .poundKeyPathKeyword
-    case 69:
-      return .poundLineKeyword
-    case 73:
-      return .poundSelectorKeyword
-    case 68:
-      return .poundFileKeyword
-    case 122:
-      return .poundFileIDKeyword
-    case 121:
-      return .poundFilePathKeyword
-    case 70:
-      return .poundColumnKeyword
-    case 72:
-      return .poundFunctionKeyword
-    case 71:
-      return .poundDsohandleKeyword
-    case 117:
-      return .poundAssertKeyword
-    case 65:
-      return .poundSourceLocationKeyword
-    case 66:
-      return .poundWarningKeyword
-    case 67:
-      return .poundErrorKeyword
-    case 64:
-      return .poundIfKeyword
-    case 62:
-      return .poundElseKeyword
-    case 63:
-      return .poundElseifKeyword
-    case 61:
-      return .poundEndifKeyword
-    case 60:
-      return .poundAvailableKeyword
-    case 123:
-      return .poundUnavailableKeyword
-    case 76:
-      return .poundFileLiteralKeyword
-    case 77:
-      return .poundImageLiteralKeyword
-    case 75:
-      return .poundColorLiteralKeyword
-    case 111:
-      return .integerLiteral(.fromBuffer(textBuffer))
-    case 112:
-      return .floatingLiteral(.fromBuffer(textBuffer))
-    case 113:
-      return .stringLiteral(.fromBuffer(textBuffer))
-    case 124:
-      return .regexLiteral(.fromBuffer(textBuffer))
-    case 115:
-      return .unknown(.fromBuffer(textBuffer))
-    case 105:
-      return .identifier(.fromBuffer(textBuffer))
-    case 107:
-      return .unspacedBinaryOperator(.fromBuffer(textBuffer))
-    case 108:
-      return .spacedBinaryOperator(.fromBuffer(textBuffer))
-    case 110:
-      return .postfixOperator(.fromBuffer(textBuffer))
-    case 109:
-      return .prefixOperator(.fromBuffer(textBuffer))
-    case 106:
-      return .dollarIdentifier(.fromBuffer(textBuffer))
-    case 114:
-      return .contextualKeyword(.fromBuffer(textBuffer))
-    case 119:
-      return .rawStringDelimiter(.fromBuffer(textBuffer))
-    case 104:
-      return .stringSegment(.fromBuffer(textBuffer))
-    case 101:
-      return .stringInterpolationAnchor
-    case 116:
-      return .yield
-    default:
-      if !textBuffer.isEmpty {
-        // Default to an unknown token with the passed text if we don't know
-        // its kind.
-        return .unknown(.fromBuffer(textBuffer))
-      } else {
-        // If we were not passed the token's text, we cannot recover since we
-        // would lose roundtripness.
-        fatalError("unexpected token kind \(kind)")
-      }
-    }
-  }
-
-  static func hasText(kind: CTokenKind) -> Bool {
-    switch kind {
-    case 0: return false
-    case 1:
-      return false
-    case 2:
-      return false
-    case 3:
-      return false
-    case 4:
-      return false
-    case 5:
-      return false
-    case 6:
-      return false
-    case 7:
-      return false
-    case 8:
-      return false
-    case 9:
-      return false
-    case 10:
-      return false
-    case 11:
-      return false
-    case 12:
-      return false
-    case 13:
-      return false
-    case 14:
-      return false
-    case 15:
-      return false
-    case 16:
-      return false
-    case 17:
-      return false
-    case 18:
-      return false
-    case 19:
-      return false
-    case 20:
-      return false
-    case 21:
-      return false
-    case 22:
-      return false
-    case 23:
-      return false
-    case 24:
-      return false
-    case 25:
-      return false
-    case 26:
-      return false
-    case 27:
-      return false
-    case 28:
-      return false
-    case 29:
-      return false
-    case 30:
-      return false
-    case 31:
-      return false
-    case 32:
-      return false
-    case 33:
-      return false
-    case 34:
-      return false
-    case 35:
-      return false
-    case 36:
-      return false
-    case 37:
-      return false
-    case 38:
-      return false
-    case 39:
-      return false
-    case 40:
-      return false
-    case 50:
-      return false
-    case 41:
-      return false
-    case 42:
-      return false
-    case 43:
-      return false
-    case 44:
-      return false
-    case 45:
-      return false
-    case 46:
-      return false
-    case 47:
-      return false
-    case 48:
-      return false
-    case 49:
-      return false
-    case 51:
-      return false
-    case 52:
-      return false
-    case 53:
-      return false
-    case 54:
-      return false
-    case 55:
-      return false
-    case 56:
-      return false
-    case 57:
-      return false
-    case 58:
-      return false
-    case 59:
-      return false
-    case 88:
-      return false
-    case 89:
-      return false
-    case 90:
-      return false
-    case 91:
-      return false
-    case 92:
-      return false
-    case 93:
-      return false
-    case 94:
-      return false
-    case 95:
-      return false
-    case 85:
-      return false
-    case 87:
-      return false
-    case 84:
-      return false
-    case 118:
-      return false
-    case 82:
-      return false
-    case 83:
-      return false
-    case 86:
-      return false
-    case 80:
-      return false
-    case 81:
-      return false
-    case 96:
-      return false
-    case 78:
-      return false
-    case 79:
-      return false
-    case 100:
-      return false
-    case 99:
-      return false
-    case 97:
-      return false
-    case 98:
-      return false
-    case 102:
-      return false
-    case 120:
-      return false
-    case 103:
-      return false
-    case 74:
-      return false
-    case 69:
-      return false
-    case 73:
-      return false
-    case 68:
-      return false
-    case 122:
-      return false
-    case 121:
-      return false
-    case 70:
-      return false
-    case 72:
-      return false
-    case 71:
-      return false
-    case 117:
-      return false
-    case 65:
-      return false
-    case 66:
-      return false
-    case 67:
-      return false
-    case 64:
-      return false
-    case 62:
-      return false
-    case 63:
-      return false
-    case 61:
-      return false
-    case 60:
-      return false
-    case 123:
-      return false
-    case 76:
-      return false
-    case 77:
-      return false
-    case 75:
-      return false
-    case 111:
-      return true
-    case 112:
-      return true
-    case 113:
-      return true
-    case 124:
-      return true
-    case 115:
-      return true
-    case 105:
-      return true
-    case 107:
-      return true
-    case 108:
-      return true
-    case 110:
-      return true
-    case 109:
-      return true
-    case 106:
-      return true
-    case 114:
-      return true
-    case 119:
-      return true
-    case 104:
-      return true
-    case 101:
-      return false
-    case 116:
-      return false
-    default:
-      fatalError("unexpected token kind \(kind)")
-    }
-  }
-}
-
 /// Plain token kind value, without an associated `String` value.
-internal enum RawTokenKind: CTokenKind {
-  case eof = 0
-  case associatedtypeKeyword = 1
-  case classKeyword = 2
-  case deinitKeyword = 3
-  case enumKeyword = 4
-  case extensionKeyword = 5
-  case funcKeyword = 6
-  case importKeyword = 7
-  case initKeyword = 8
-  case inoutKeyword = 9
-  case letKeyword = 10
-  case operatorKeyword = 11
-  case precedencegroupKeyword = 12
-  case protocolKeyword = 13
-  case structKeyword = 14
-  case subscriptKeyword = 15
-  case typealiasKeyword = 16
-  case varKeyword = 17
-  case fileprivateKeyword = 18
-  case internalKeyword = 19
-  case privateKeyword = 20
-  case publicKeyword = 21
-  case staticKeyword = 22
-  case deferKeyword = 23
-  case ifKeyword = 24
-  case guardKeyword = 25
-  case doKeyword = 26
-  case repeatKeyword = 27
-  case elseKeyword = 28
-  case forKeyword = 29
-  case inKeyword = 30
-  case whileKeyword = 31
-  case returnKeyword = 32
-  case breakKeyword = 33
-  case continueKeyword = 34
-  case fallthroughKeyword = 35
-  case switchKeyword = 36
-  case caseKeyword = 37
-  case defaultKeyword = 38
-  case whereKeyword = 39
-  case catchKeyword = 40
-  case throwKeyword = 50
-  case asKeyword = 41
-  case anyKeyword = 42
-  case falseKeyword = 43
-  case isKeyword = 44
-  case nilKeyword = 45
-  case rethrowsKeyword = 46
-  case superKeyword = 47
-  case selfKeyword = 48
-  case capitalSelfKeyword = 49
-  case trueKeyword = 51
-  case tryKeyword = 52
-  case throwsKeyword = 53
-  case __file__Keyword = 54
-  case __line__Keyword = 55
-  case __column__Keyword = 56
-  case __function__Keyword = 57
-  case __dso_handle__Keyword = 58
-  case wildcardKeyword = 59
-  case leftParen = 88
-  case rightParen = 89
-  case leftBrace = 90
-  case rightBrace = 91
-  case leftSquareBracket = 92
-  case rightSquareBracket = 93
-  case leftAngle = 94
-  case rightAngle = 95
-  case period = 85
-  case prefixPeriod = 87
-  case comma = 84
-  case ellipsis = 118
-  case colon = 82
-  case semicolon = 83
-  case equal = 86
-  case atSign = 80
-  case pound = 81
-  case prefixAmpersand = 96
-  case arrow = 78
-  case backtick = 79
-  case backslash = 100
-  case exclamationMark = 99
-  case postfixQuestionMark = 97
-  case infixQuestionMark = 98
-  case stringQuote = 102
-  case singleQuote = 120
-  case multilineStringQuote = 103
-  case poundKeyPathKeyword = 74
-  case poundLineKeyword = 69
-  case poundSelectorKeyword = 73
-  case poundFileKeyword = 68
-  case poundFileIDKeyword = 122
-  case poundFilePathKeyword = 121
-  case poundColumnKeyword = 70
-  case poundFunctionKeyword = 72
-  case poundDsohandleKeyword = 71
-  case poundAssertKeyword = 117
-  case poundSourceLocationKeyword = 65
-  case poundWarningKeyword = 66
-  case poundErrorKeyword = 67
-  case poundIfKeyword = 64
-  case poundElseKeyword = 62
-  case poundElseifKeyword = 63
-  case poundEndifKeyword = 61
-  case poundAvailableKeyword = 60
-  case poundUnavailableKeyword = 123
-  case poundFileLiteralKeyword = 76
-  case poundImageLiteralKeyword = 77
-  case poundColorLiteralKeyword = 75
-  case integerLiteral = 111
-  case floatingLiteral = 112
-  case stringLiteral = 113
-  case regexLiteral = 124
-  case unknown = 115
-  case identifier = 105
-  case unspacedBinaryOperator = 107
-  case spacedBinaryOperator = 108
-  case postfixOperator = 110
-  case prefixOperator = 109
-  case dollarIdentifier = 106
-  case contextualKeyword = 114
-  case rawStringDelimiter = 119
-  case stringSegment = 104
-  case stringInterpolationAnchor = 101
-  case yield = 116
+public enum RawTokenKind {
+  case eof
+  case associatedtypeKeyword
+  case classKeyword
+  case deinitKeyword
+  case enumKeyword
+  case extensionKeyword
+  case funcKeyword
+  case importKeyword
+  case initKeyword
+  case inoutKeyword
+  case letKeyword
+  case operatorKeyword
+  case precedencegroupKeyword
+  case protocolKeyword
+  case structKeyword
+  case subscriptKeyword
+  case typealiasKeyword
+  case varKeyword
+  case fileprivateKeyword
+  case internalKeyword
+  case privateKeyword
+  case publicKeyword
+  case staticKeyword
+  case deferKeyword
+  case ifKeyword
+  case guardKeyword
+  case doKeyword
+  case repeatKeyword
+  case elseKeyword
+  case forKeyword
+  case inKeyword
+  case whileKeyword
+  case returnKeyword
+  case breakKeyword
+  case continueKeyword
+  case fallthroughKeyword
+  case switchKeyword
+  case caseKeyword
+  case defaultKeyword
+  case whereKeyword
+  case catchKeyword
+  case throwKeyword
+  case asKeyword
+  case anyKeyword
+  case falseKeyword
+  case isKeyword
+  case nilKeyword
+  case rethrowsKeyword
+  case superKeyword
+  case selfKeyword
+  case capitalSelfKeyword
+  case trueKeyword
+  case tryKeyword
+  case throwsKeyword
+  case __file__Keyword
+  case __line__Keyword
+  case __column__Keyword
+  case __function__Keyword
+  case __dso_handle__Keyword
+  case wildcardKeyword
+  case leftParen
+  case rightParen
+  case leftBrace
+  case rightBrace
+  case leftSquareBracket
+  case rightSquareBracket
+  case leftAngle
+  case rightAngle
+  case period
+  case prefixPeriod
+  case comma
+  case ellipsis
+  case colon
+  case semicolon
+  case equal
+  case atSign
+  case pound
+  case prefixAmpersand
+  case arrow
+  case backtick
+  case backslash
+  case exclamationMark
+  case postfixQuestionMark
+  case infixQuestionMark
+  case stringQuote
+  case singleQuote
+  case multilineStringQuote
+  case poundKeyPathKeyword
+  case poundLineKeyword
+  case poundSelectorKeyword
+  case poundFileKeyword
+  case poundFileIDKeyword
+  case poundFilePathKeyword
+  case poundColumnKeyword
+  case poundFunctionKeyword
+  case poundDsohandleKeyword
+  case poundAssertKeyword
+  case poundSourceLocationKeyword
+  case poundWarningKeyword
+  case poundErrorKeyword
+  case poundIfKeyword
+  case poundElseKeyword
+  case poundElseifKeyword
+  case poundEndifKeyword
+  case poundAvailableKeyword
+  case poundUnavailableKeyword
+  case poundFileLiteralKeyword
+  case poundImageLiteralKeyword
+  case poundColorLiteralKeyword
+  case integerLiteral
+  case floatingLiteral
+  case stringLiteral
+  case regexLiteral
+  case unknown
+  case identifier
+  case unspacedBinaryOperator
+  case spacedBinaryOperator
+  case postfixOperator
+  case prefixOperator
+  case dollarIdentifier
+  case contextualKeyword
+  case rawStringDelimiter
+  case stringSegment
+  case stringInterpolationAnchor
+  case yield
 
   static func fromRawValue(_ rawValue: CTokenKind) -> RawTokenKind {
-    return RawTokenKind(rawValue: rawValue)!
+    switch rawValue {
+    case 0: return .eof
+    case 1: return .associatedtypeKeyword
+    case 2: return .classKeyword
+    case 3: return .deinitKeyword
+    case 4: return .enumKeyword
+    case 5: return .extensionKeyword
+    case 6: return .funcKeyword
+    case 7: return .importKeyword
+    case 8: return .initKeyword
+    case 9: return .inoutKeyword
+    case 10: return .letKeyword
+    case 11: return .operatorKeyword
+    case 12: return .precedencegroupKeyword
+    case 13: return .protocolKeyword
+    case 14: return .structKeyword
+    case 15: return .subscriptKeyword
+    case 16: return .typealiasKeyword
+    case 17: return .varKeyword
+    case 18: return .fileprivateKeyword
+    case 19: return .internalKeyword
+    case 20: return .privateKeyword
+    case 21: return .publicKeyword
+    case 22: return .staticKeyword
+    case 23: return .deferKeyword
+    case 24: return .ifKeyword
+    case 25: return .guardKeyword
+    case 26: return .doKeyword
+    case 27: return .repeatKeyword
+    case 28: return .elseKeyword
+    case 29: return .forKeyword
+    case 30: return .inKeyword
+    case 31: return .whileKeyword
+    case 32: return .returnKeyword
+    case 33: return .breakKeyword
+    case 34: return .continueKeyword
+    case 35: return .fallthroughKeyword
+    case 36: return .switchKeyword
+    case 37: return .caseKeyword
+    case 38: return .defaultKeyword
+    case 39: return .whereKeyword
+    case 40: return .catchKeyword
+    case 50: return .throwKeyword
+    case 41: return .asKeyword
+    case 42: return .anyKeyword
+    case 43: return .falseKeyword
+    case 44: return .isKeyword
+    case 45: return .nilKeyword
+    case 46: return .rethrowsKeyword
+    case 47: return .superKeyword
+    case 48: return .selfKeyword
+    case 49: return .capitalSelfKeyword
+    case 51: return .trueKeyword
+    case 52: return .tryKeyword
+    case 53: return .throwsKeyword
+    case 54: return .__file__Keyword
+    case 55: return .__line__Keyword
+    case 56: return .__column__Keyword
+    case 57: return .__function__Keyword
+    case 58: return .__dso_handle__Keyword
+    case 59: return .wildcardKeyword
+    case 88: return .leftParen
+    case 89: return .rightParen
+    case 90: return .leftBrace
+    case 91: return .rightBrace
+    case 92: return .leftSquareBracket
+    case 93: return .rightSquareBracket
+    case 94: return .leftAngle
+    case 95: return .rightAngle
+    case 85: return .period
+    case 87: return .prefixPeriod
+    case 84: return .comma
+    case 118: return .ellipsis
+    case 82: return .colon
+    case 83: return .semicolon
+    case 86: return .equal
+    case 80: return .atSign
+    case 81: return .pound
+    case 96: return .prefixAmpersand
+    case 78: return .arrow
+    case 79: return .backtick
+    case 100: return .backslash
+    case 99: return .exclamationMark
+    case 97: return .postfixQuestionMark
+    case 98: return .infixQuestionMark
+    case 102: return .stringQuote
+    case 120: return .singleQuote
+    case 103: return .multilineStringQuote
+    case 74: return .poundKeyPathKeyword
+    case 69: return .poundLineKeyword
+    case 73: return .poundSelectorKeyword
+    case 68: return .poundFileKeyword
+    case 122: return .poundFileIDKeyword
+    case 121: return .poundFilePathKeyword
+    case 70: return .poundColumnKeyword
+    case 72: return .poundFunctionKeyword
+    case 71: return .poundDsohandleKeyword
+    case 117: return .poundAssertKeyword
+    case 65: return .poundSourceLocationKeyword
+    case 66: return .poundWarningKeyword
+    case 67: return .poundErrorKeyword
+    case 64: return .poundIfKeyword
+    case 62: return .poundElseKeyword
+    case 63: return .poundElseifKeyword
+    case 61: return .poundEndifKeyword
+    case 60: return .poundAvailableKeyword
+    case 123: return .poundUnavailableKeyword
+    case 76: return .poundFileLiteralKeyword
+    case 77: return .poundImageLiteralKeyword
+    case 75: return .poundColorLiteralKeyword
+    case 111: return .integerLiteral
+    case 112: return .floatingLiteral
+    case 113: return .stringLiteral
+    case 124: return .regexLiteral
+    case 115: return .unknown
+    case 105: return .identifier
+    case 107: return .unspacedBinaryOperator
+    case 108: return .spacedBinaryOperator
+    case 110: return .postfixOperator
+    case 109: return .prefixOperator
+    case 106: return .dollarIdentifier
+    case 114: return .contextualKeyword
+    case 119: return .rawStringDelimiter
+    case 104: return .stringSegment
+    case 101: return .stringInterpolationAnchor
+    case 116: return .yield
+    default: fatalError("unknown raw value")
+    }
+  }
+
+  var defaultText: SyntaxText? {
+    switch self {
+    case .eof: return ""
+    case .associatedtypeKeyword: return "associatedtype"
+    case .classKeyword: return "class"
+    case .deinitKeyword: return "deinit"
+    case .enumKeyword: return "enum"
+    case .extensionKeyword: return "extension"
+    case .funcKeyword: return "func"
+    case .importKeyword: return "import"
+    case .initKeyword: return "init"
+    case .inoutKeyword: return "inout"
+    case .letKeyword: return "let"
+    case .operatorKeyword: return "operator"
+    case .precedencegroupKeyword: return "precedencegroup"
+    case .protocolKeyword: return "protocol"
+    case .structKeyword: return "struct"
+    case .subscriptKeyword: return "subscript"
+    case .typealiasKeyword: return "typealias"
+    case .varKeyword: return "var"
+    case .fileprivateKeyword: return "fileprivate"
+    case .internalKeyword: return "internal"
+    case .privateKeyword: return "private"
+    case .publicKeyword: return "public"
+    case .staticKeyword: return "static"
+    case .deferKeyword: return "defer"
+    case .ifKeyword: return "if"
+    case .guardKeyword: return "guard"
+    case .doKeyword: return "do"
+    case .repeatKeyword: return "repeat"
+    case .elseKeyword: return "else"
+    case .forKeyword: return "for"
+    case .inKeyword: return "in"
+    case .whileKeyword: return "while"
+    case .returnKeyword: return "return"
+    case .breakKeyword: return "break"
+    case .continueKeyword: return "continue"
+    case .fallthroughKeyword: return "fallthrough"
+    case .switchKeyword: return "switch"
+    case .caseKeyword: return "case"
+    case .defaultKeyword: return "default"
+    case .whereKeyword: return "where"
+    case .catchKeyword: return "catch"
+    case .throwKeyword: return "throw"
+    case .asKeyword: return "as"
+    case .anyKeyword: return "Any"
+    case .falseKeyword: return "false"
+    case .isKeyword: return "is"
+    case .nilKeyword: return "nil"
+    case .rethrowsKeyword: return "rethrows"
+    case .superKeyword: return "super"
+    case .selfKeyword: return "self"
+    case .capitalSelfKeyword: return "Self"
+    case .trueKeyword: return "true"
+    case .tryKeyword: return "try"
+    case .throwsKeyword: return "throws"
+    case .__file__Keyword: return "__FILE__"
+    case .__line__Keyword: return "__LINE__"
+    case .__column__Keyword: return "__COLUMN__"
+    case .__function__Keyword: return "__FUNCTION__"
+    case .__dso_handle__Keyword: return "__DSO_HANDLE__"
+    case .wildcardKeyword: return "_"
+    case .leftParen: return "("
+    case .rightParen: return ")"
+    case .leftBrace: return "{"
+    case .rightBrace: return "}"
+    case .leftSquareBracket: return "["
+    case .rightSquareBracket: return "]"
+    case .leftAngle: return "<"
+    case .rightAngle: return ">"
+    case .period: return "."
+    case .prefixPeriod: return "."
+    case .comma: return ","
+    case .ellipsis: return "..."
+    case .colon: return ":"
+    case .semicolon: return ";"
+    case .equal: return "="
+    case .atSign: return "@"
+    case .pound: return "#"
+    case .prefixAmpersand: return "&"
+    case .arrow: return "->"
+    case .backtick: return "`"
+    case .backslash: return "\\"
+    case .exclamationMark: return "!"
+    case .postfixQuestionMark: return "?"
+    case .infixQuestionMark: return "?"
+    case .stringQuote: return "\""
+    case .singleQuote: return "\'"
+    case .multilineStringQuote: return "\"\"\""
+    case .poundKeyPathKeyword: return "#keyPath"
+    case .poundLineKeyword: return "#line"
+    case .poundSelectorKeyword: return "#selector"
+    case .poundFileKeyword: return "#file"
+    case .poundFileIDKeyword: return "#fileID"
+    case .poundFilePathKeyword: return "#filePath"
+    case .poundColumnKeyword: return "#column"
+    case .poundFunctionKeyword: return "#function"
+    case .poundDsohandleKeyword: return "#dsohandle"
+    case .poundAssertKeyword: return "#assert"
+    case .poundSourceLocationKeyword: return "#sourceLocation"
+    case .poundWarningKeyword: return "#warning"
+    case .poundErrorKeyword: return "#error"
+    case .poundIfKeyword: return "#if"
+    case .poundElseKeyword: return "#else"
+    case .poundElseifKeyword: return "#elseif"
+    case .poundEndifKeyword: return "#endif"
+    case .poundAvailableKeyword: return "#available"
+    case .poundUnavailableKeyword: return "#unavailable"
+    case .poundFileLiteralKeyword: return "#fileLiteral"
+    case .poundImageLiteralKeyword: return "#imageLiteral"
+    case .poundColorLiteralKeyword: return "#colorLiteral"
+    case .stringInterpolationAnchor: return ")"
+    case .yield: return "yield"
+    default: return nil
+    }
   }
 }
 
 extension TokenKind {
-  internal func withUnsafeTokenText<Result>(
-    _ body: (UnsafeTokenText) -> Result
-  ) -> Result {
-    switch self {
-    case .eof:
-      return body(.init(kind: .eof, length: 0))
+  static func fromRaw(kind rawKind: RawTokenKind, text: SyntaxText) -> TokenKind {
+    switch rawKind {
+    case .eof: return .eof
     case .associatedtypeKeyword:
-      let length = 14
-      return body(.init(kind: .associatedtypeKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .associatedtypeKeyword
     case .classKeyword:
-      let length = 5
-      return body(.init(kind: .classKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .classKeyword
     case .deinitKeyword:
-      let length = 6
-      return body(.init(kind: .deinitKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .deinitKeyword
     case .enumKeyword:
-      let length = 4
-      return body(.init(kind: .enumKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .enumKeyword
     case .extensionKeyword:
-      let length = 9
-      return body(.init(kind: .extensionKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .extensionKeyword
     case .funcKeyword:
-      let length = 4
-      return body(.init(kind: .funcKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .funcKeyword
     case .importKeyword:
-      let length = 6
-      return body(.init(kind: .importKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .importKeyword
     case .initKeyword:
-      let length = 4
-      return body(.init(kind: .initKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .initKeyword
     case .inoutKeyword:
-      let length = 5
-      return body(.init(kind: .inoutKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .inoutKeyword
     case .letKeyword:
-      let length = 3
-      return body(.init(kind: .letKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .letKeyword
     case .operatorKeyword:
-      let length = 8
-      return body(.init(kind: .operatorKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .operatorKeyword
     case .precedencegroupKeyword:
-      let length = 15
-      return body(.init(kind: .precedencegroupKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .precedencegroupKeyword
     case .protocolKeyword:
-      let length = 8
-      return body(.init(kind: .protocolKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .protocolKeyword
     case .structKeyword:
-      let length = 6
-      return body(.init(kind: .structKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .structKeyword
     case .subscriptKeyword:
-      let length = 9
-      return body(.init(kind: .subscriptKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .subscriptKeyword
     case .typealiasKeyword:
-      let length = 9
-      return body(.init(kind: .typealiasKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .typealiasKeyword
     case .varKeyword:
-      let length = 3
-      return body(.init(kind: .varKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .varKeyword
     case .fileprivateKeyword:
-      let length = 11
-      return body(.init(kind: .fileprivateKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .fileprivateKeyword
     case .internalKeyword:
-      let length = 8
-      return body(.init(kind: .internalKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .internalKeyword
     case .privateKeyword:
-      let length = 7
-      return body(.init(kind: .privateKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .privateKeyword
     case .publicKeyword:
-      let length = 6
-      return body(.init(kind: .publicKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .publicKeyword
     case .staticKeyword:
-      let length = 6
-      return body(.init(kind: .staticKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .staticKeyword
     case .deferKeyword:
-      let length = 5
-      return body(.init(kind: .deferKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .deferKeyword
     case .ifKeyword:
-      let length = 2
-      return body(.init(kind: .ifKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .ifKeyword
     case .guardKeyword:
-      let length = 5
-      return body(.init(kind: .guardKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .guardKeyword
     case .doKeyword:
-      let length = 2
-      return body(.init(kind: .doKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .doKeyword
     case .repeatKeyword:
-      let length = 6
-      return body(.init(kind: .repeatKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .repeatKeyword
     case .elseKeyword:
-      let length = 4
-      return body(.init(kind: .elseKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .elseKeyword
     case .forKeyword:
-      let length = 3
-      return body(.init(kind: .forKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .forKeyword
     case .inKeyword:
-      let length = 2
-      return body(.init(kind: .inKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .inKeyword
     case .whileKeyword:
-      let length = 5
-      return body(.init(kind: .whileKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .whileKeyword
     case .returnKeyword:
-      let length = 6
-      return body(.init(kind: .returnKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .returnKeyword
     case .breakKeyword:
-      let length = 5
-      return body(.init(kind: .breakKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .breakKeyword
     case .continueKeyword:
-      let length = 8
-      return body(.init(kind: .continueKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .continueKeyword
     case .fallthroughKeyword:
-      let length = 11
-      return body(.init(kind: .fallthroughKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .fallthroughKeyword
     case .switchKeyword:
-      let length = 6
-      return body(.init(kind: .switchKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .switchKeyword
     case .caseKeyword:
-      let length = 4
-      return body(.init(kind: .caseKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .caseKeyword
     case .defaultKeyword:
-      let length = 7
-      return body(.init(kind: .defaultKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .defaultKeyword
     case .whereKeyword:
-      let length = 5
-      return body(.init(kind: .whereKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .whereKeyword
     case .catchKeyword:
-      let length = 5
-      return body(.init(kind: .catchKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .catchKeyword
     case .throwKeyword:
-      let length = 5
-      return body(.init(kind: .throwKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .throwKeyword
     case .asKeyword:
-      let length = 2
-      return body(.init(kind: .asKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .asKeyword
     case .anyKeyword:
-      let length = 3
-      return body(.init(kind: .anyKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .anyKeyword
     case .falseKeyword:
-      let length = 5
-      return body(.init(kind: .falseKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .falseKeyword
     case .isKeyword:
-      let length = 2
-      return body(.init(kind: .isKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .isKeyword
     case .nilKeyword:
-      let length = 3
-      return body(.init(kind: .nilKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .nilKeyword
     case .rethrowsKeyword:
-      let length = 8
-      return body(.init(kind: .rethrowsKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .rethrowsKeyword
     case .superKeyword:
-      let length = 5
-      return body(.init(kind: .superKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .superKeyword
     case .selfKeyword:
-      let length = 4
-      return body(.init(kind: .selfKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .selfKeyword
     case .capitalSelfKeyword:
-      let length = 4
-      return body(.init(kind: .capitalSelfKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .capitalSelfKeyword
     case .trueKeyword:
-      let length = 4
-      return body(.init(kind: .trueKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .trueKeyword
     case .tryKeyword:
-      let length = 3
-      return body(.init(kind: .tryKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .tryKeyword
     case .throwsKeyword:
-      let length = 6
-      return body(.init(kind: .throwsKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .throwsKeyword
     case .__file__Keyword:
-      let length = 8
-      return body(.init(kind: .__file__Keyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .__file__Keyword
     case .__line__Keyword:
-      let length = 8
-      return body(.init(kind: .__line__Keyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .__line__Keyword
     case .__column__Keyword:
-      let length = 10
-      return body(.init(kind: .__column__Keyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .__column__Keyword
     case .__function__Keyword:
-      let length = 12
-      return body(.init(kind: .__function__Keyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .__function__Keyword
     case .__dso_handle__Keyword:
-      let length = 14
-      return body(.init(kind: .__dso_handle__Keyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .__dso_handle__Keyword
     case .wildcardKeyword:
-      let length = 1
-      return body(.init(kind: .wildcardKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .wildcardKeyword
     case .leftParen:
-      let length = 1
-      return body(.init(kind: .leftParen, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .leftParen
     case .rightParen:
-      let length = 1
-      return body(.init(kind: .rightParen, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .rightParen
     case .leftBrace:
-      let length = 1
-      return body(.init(kind: .leftBrace, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .leftBrace
     case .rightBrace:
-      let length = 1
-      return body(.init(kind: .rightBrace, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .rightBrace
     case .leftSquareBracket:
-      let length = 1
-      return body(.init(kind: .leftSquareBracket, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .leftSquareBracket
     case .rightSquareBracket:
-      let length = 1
-      return body(.init(kind: .rightSquareBracket, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .rightSquareBracket
     case .leftAngle:
-      let length = 1
-      return body(.init(kind: .leftAngle, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .leftAngle
     case .rightAngle:
-      let length = 1
-      return body(.init(kind: .rightAngle, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .rightAngle
     case .period:
-      let length = 1
-      return body(.init(kind: .period, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .period
     case .prefixPeriod:
-      let length = 1
-      return body(.init(kind: .prefixPeriod, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .prefixPeriod
     case .comma:
-      let length = 1
-      return body(.init(kind: .comma, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .comma
     case .ellipsis:
-      let length = 3
-      return body(.init(kind: .ellipsis, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .ellipsis
     case .colon:
-      let length = 1
-      return body(.init(kind: .colon, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .colon
     case .semicolon:
-      let length = 1
-      return body(.init(kind: .semicolon, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .semicolon
     case .equal:
-      let length = 1
-      return body(.init(kind: .equal, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .equal
     case .atSign:
-      let length = 1
-      return body(.init(kind: .atSign, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .atSign
     case .pound:
-      let length = 1
-      return body(.init(kind: .pound, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .pound
     case .prefixAmpersand:
-      let length = 1
-      return body(.init(kind: .prefixAmpersand, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .prefixAmpersand
     case .arrow:
-      let length = 2
-      return body(.init(kind: .arrow, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .arrow
     case .backtick:
-      let length = 1
-      return body(.init(kind: .backtick, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .backtick
     case .backslash:
-      let length = 1
-      return body(.init(kind: .backslash, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .backslash
     case .exclamationMark:
-      let length = 1
-      return body(.init(kind: .exclamationMark, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .exclamationMark
     case .postfixQuestionMark:
-      let length = 1
-      return body(.init(kind: .postfixQuestionMark, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .postfixQuestionMark
     case .infixQuestionMark:
-      let length = 1
-      return body(.init(kind: .infixQuestionMark, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .infixQuestionMark
     case .stringQuote:
-      let length = 1
-      return body(.init(kind: .stringQuote, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .stringQuote
     case .singleQuote:
-      let length = 1
-      return body(.init(kind: .singleQuote, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .singleQuote
     case .multilineStringQuote:
-      let length = 3
-      return body(.init(kind: .multilineStringQuote, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .multilineStringQuote
     case .poundKeyPathKeyword:
-      let length = 8
-      return body(.init(kind: .poundKeyPathKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundKeyPathKeyword
     case .poundLineKeyword:
-      let length = 5
-      return body(.init(kind: .poundLineKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundLineKeyword
     case .poundSelectorKeyword:
-      let length = 9
-      return body(.init(kind: .poundSelectorKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundSelectorKeyword
     case .poundFileKeyword:
-      let length = 5
-      return body(.init(kind: .poundFileKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundFileKeyword
     case .poundFileIDKeyword:
-      let length = 7
-      return body(.init(kind: .poundFileIDKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundFileIDKeyword
     case .poundFilePathKeyword:
-      let length = 9
-      return body(.init(kind: .poundFilePathKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundFilePathKeyword
     case .poundColumnKeyword:
-      let length = 7
-      return body(.init(kind: .poundColumnKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundColumnKeyword
     case .poundFunctionKeyword:
-      let length = 9
-      return body(.init(kind: .poundFunctionKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundFunctionKeyword
     case .poundDsohandleKeyword:
-      let length = 10
-      return body(.init(kind: .poundDsohandleKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundDsohandleKeyword
     case .poundAssertKeyword:
-      let length = 7
-      return body(.init(kind: .poundAssertKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundAssertKeyword
     case .poundSourceLocationKeyword:
-      let length = 15
-      return body(.init(kind: .poundSourceLocationKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundSourceLocationKeyword
     case .poundWarningKeyword:
-      let length = 8
-      return body(.init(kind: .poundWarningKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundWarningKeyword
     case .poundErrorKeyword:
-      let length = 6
-      return body(.init(kind: .poundErrorKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundErrorKeyword
     case .poundIfKeyword:
-      let length = 3
-      return body(.init(kind: .poundIfKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundIfKeyword
     case .poundElseKeyword:
-      let length = 5
-      return body(.init(kind: .poundElseKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundElseKeyword
     case .poundElseifKeyword:
-      let length = 7
-      return body(.init(kind: .poundElseifKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundElseifKeyword
     case .poundEndifKeyword:
-      let length = 6
-      return body(.init(kind: .poundEndifKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundEndifKeyword
     case .poundAvailableKeyword:
-      let length = 10
-      return body(.init(kind: .poundAvailableKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundAvailableKeyword
     case .poundUnavailableKeyword:
-      let length = 12
-      return body(.init(kind: .poundUnavailableKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundUnavailableKeyword
     case .poundFileLiteralKeyword:
-      let length = 12
-      return body(.init(kind: .poundFileLiteralKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundFileLiteralKeyword
     case .poundImageLiteralKeyword:
-      let length = 13
-      return body(.init(kind: .poundImageLiteralKeyword, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundImageLiteralKeyword
     case .poundColorLiteralKeyword:
-      let length = 13
-      return body(.init(kind: .poundColorLiteralKeyword, length: length))
-    case .integerLiteral(var text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .integerLiteral, length: length, customText: buf))
-      })!
-    case .floatingLiteral(var text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .floatingLiteral, length: length, customText: buf))
-      })!
-    case .stringLiteral(var text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .stringLiteral, length: length, customText: buf))
-      })!
-    case .regexLiteral(var text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .regexLiteral, length: length, customText: buf))
-      })!
-    case .unknown(var text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .unknown, length: length, customText: buf))
-      })!
-    case .identifier(var text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .identifier, length: length, customText: buf))
-      })!
-    case .unspacedBinaryOperator(var text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .unspacedBinaryOperator, length: length, customText: buf))
-      })!
-    case .spacedBinaryOperator(var text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .spacedBinaryOperator, length: length, customText: buf))
-      })!
-    case .postfixOperator(var text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .postfixOperator, length: length, customText: buf))
-      })!
-    case .prefixOperator(var text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .prefixOperator, length: length, customText: buf))
-      })!
-    case .dollarIdentifier(var text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .dollarIdentifier, length: length, customText: buf))
-      })!
-    case .contextualKeyword(var text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .contextualKeyword, length: length, customText: buf))
-      })!
-    case .rawStringDelimiter(var text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .rawStringDelimiter, length: length, customText: buf))
-      })!
-    case .stringSegment(var text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .stringSegment, length: length, customText: buf))
-      })!
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .poundColorLiteralKeyword
+    case .integerLiteral:
+      return .integerLiteral(String(syntaxText: text))
+    case .floatingLiteral:
+      return .floatingLiteral(String(syntaxText: text))
+    case .stringLiteral:
+      return .stringLiteral(String(syntaxText: text))
+    case .regexLiteral:
+      return .regexLiteral(String(syntaxText: text))
+    case .unknown:
+      return .unknown(String(syntaxText: text))
+    case .identifier:
+      return .identifier(String(syntaxText: text))
+    case .unspacedBinaryOperator:
+      return .unspacedBinaryOperator(String(syntaxText: text))
+    case .spacedBinaryOperator:
+      return .spacedBinaryOperator(String(syntaxText: text))
+    case .postfixOperator:
+      return .postfixOperator(String(syntaxText: text))
+    case .prefixOperator:
+      return .prefixOperator(String(syntaxText: text))
+    case .dollarIdentifier:
+      return .dollarIdentifier(String(syntaxText: text))
+    case .contextualKeyword:
+      return .contextualKeyword(String(syntaxText: text))
+    case .rawStringDelimiter:
+      return .rawStringDelimiter(String(syntaxText: text))
+    case .stringSegment:
+      return .stringSegment(String(syntaxText: text))
     case .stringInterpolationAnchor:
-      let length = 1
-      return body(.init(kind: .stringInterpolationAnchor, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .stringInterpolationAnchor
     case .yield:
-      let length = 5
-      return body(.init(kind: .yield, length: length))
+      assert(text.isEmpty || rawKind.defaultText == text)
+      return .yield
+    }
+  }
+
+  func decomposeToRaw() -> (rawKind: RawTokenKind, string: String?) {
+    switch self {
+    case .eof: return (.eof, nil)
+    case .associatedtypeKeyword: return (.associatedtypeKeyword, nil)
+    case .classKeyword: return (.classKeyword, nil)
+    case .deinitKeyword: return (.deinitKeyword, nil)
+    case .enumKeyword: return (.enumKeyword, nil)
+    case .extensionKeyword: return (.extensionKeyword, nil)
+    case .funcKeyword: return (.funcKeyword, nil)
+    case .importKeyword: return (.importKeyword, nil)
+    case .initKeyword: return (.initKeyword, nil)
+    case .inoutKeyword: return (.inoutKeyword, nil)
+    case .letKeyword: return (.letKeyword, nil)
+    case .operatorKeyword: return (.operatorKeyword, nil)
+    case .precedencegroupKeyword: return (.precedencegroupKeyword, nil)
+    case .protocolKeyword: return (.protocolKeyword, nil)
+    case .structKeyword: return (.structKeyword, nil)
+    case .subscriptKeyword: return (.subscriptKeyword, nil)
+    case .typealiasKeyword: return (.typealiasKeyword, nil)
+    case .varKeyword: return (.varKeyword, nil)
+    case .fileprivateKeyword: return (.fileprivateKeyword, nil)
+    case .internalKeyword: return (.internalKeyword, nil)
+    case .privateKeyword: return (.privateKeyword, nil)
+    case .publicKeyword: return (.publicKeyword, nil)
+    case .staticKeyword: return (.staticKeyword, nil)
+    case .deferKeyword: return (.deferKeyword, nil)
+    case .ifKeyword: return (.ifKeyword, nil)
+    case .guardKeyword: return (.guardKeyword, nil)
+    case .doKeyword: return (.doKeyword, nil)
+    case .repeatKeyword: return (.repeatKeyword, nil)
+    case .elseKeyword: return (.elseKeyword, nil)
+    case .forKeyword: return (.forKeyword, nil)
+    case .inKeyword: return (.inKeyword, nil)
+    case .whileKeyword: return (.whileKeyword, nil)
+    case .returnKeyword: return (.returnKeyword, nil)
+    case .breakKeyword: return (.breakKeyword, nil)
+    case .continueKeyword: return (.continueKeyword, nil)
+    case .fallthroughKeyword: return (.fallthroughKeyword, nil)
+    case .switchKeyword: return (.switchKeyword, nil)
+    case .caseKeyword: return (.caseKeyword, nil)
+    case .defaultKeyword: return (.defaultKeyword, nil)
+    case .whereKeyword: return (.whereKeyword, nil)
+    case .catchKeyword: return (.catchKeyword, nil)
+    case .throwKeyword: return (.throwKeyword, nil)
+    case .asKeyword: return (.asKeyword, nil)
+    case .anyKeyword: return (.anyKeyword, nil)
+    case .falseKeyword: return (.falseKeyword, nil)
+    case .isKeyword: return (.isKeyword, nil)
+    case .nilKeyword: return (.nilKeyword, nil)
+    case .rethrowsKeyword: return (.rethrowsKeyword, nil)
+    case .superKeyword: return (.superKeyword, nil)
+    case .selfKeyword: return (.selfKeyword, nil)
+    case .capitalSelfKeyword: return (.capitalSelfKeyword, nil)
+    case .trueKeyword: return (.trueKeyword, nil)
+    case .tryKeyword: return (.tryKeyword, nil)
+    case .throwsKeyword: return (.throwsKeyword, nil)
+    case .__file__Keyword: return (.__file__Keyword, nil)
+    case .__line__Keyword: return (.__line__Keyword, nil)
+    case .__column__Keyword: return (.__column__Keyword, nil)
+    case .__function__Keyword: return (.__function__Keyword, nil)
+    case .__dso_handle__Keyword: return (.__dso_handle__Keyword, nil)
+    case .wildcardKeyword: return (.wildcardKeyword, nil)
+    case .leftParen: return (.leftParen, nil)
+    case .rightParen: return (.rightParen, nil)
+    case .leftBrace: return (.leftBrace, nil)
+    case .rightBrace: return (.rightBrace, nil)
+    case .leftSquareBracket: return (.leftSquareBracket, nil)
+    case .rightSquareBracket: return (.rightSquareBracket, nil)
+    case .leftAngle: return (.leftAngle, nil)
+    case .rightAngle: return (.rightAngle, nil)
+    case .period: return (.period, nil)
+    case .prefixPeriod: return (.prefixPeriod, nil)
+    case .comma: return (.comma, nil)
+    case .ellipsis: return (.ellipsis, nil)
+    case .colon: return (.colon, nil)
+    case .semicolon: return (.semicolon, nil)
+    case .equal: return (.equal, nil)
+    case .atSign: return (.atSign, nil)
+    case .pound: return (.pound, nil)
+    case .prefixAmpersand: return (.prefixAmpersand, nil)
+    case .arrow: return (.arrow, nil)
+    case .backtick: return (.backtick, nil)
+    case .backslash: return (.backslash, nil)
+    case .exclamationMark: return (.exclamationMark, nil)
+    case .postfixQuestionMark: return (.postfixQuestionMark, nil)
+    case .infixQuestionMark: return (.infixQuestionMark, nil)
+    case .stringQuote: return (.stringQuote, nil)
+    case .singleQuote: return (.singleQuote, nil)
+    case .multilineStringQuote: return (.multilineStringQuote, nil)
+    case .poundKeyPathKeyword: return (.poundKeyPathKeyword, nil)
+    case .poundLineKeyword: return (.poundLineKeyword, nil)
+    case .poundSelectorKeyword: return (.poundSelectorKeyword, nil)
+    case .poundFileKeyword: return (.poundFileKeyword, nil)
+    case .poundFileIDKeyword: return (.poundFileIDKeyword, nil)
+    case .poundFilePathKeyword: return (.poundFilePathKeyword, nil)
+    case .poundColumnKeyword: return (.poundColumnKeyword, nil)
+    case .poundFunctionKeyword: return (.poundFunctionKeyword, nil)
+    case .poundDsohandleKeyword: return (.poundDsohandleKeyword, nil)
+    case .poundAssertKeyword: return (.poundAssertKeyword, nil)
+    case .poundSourceLocationKeyword: return (.poundSourceLocationKeyword, nil)
+    case .poundWarningKeyword: return (.poundWarningKeyword, nil)
+    case .poundErrorKeyword: return (.poundErrorKeyword, nil)
+    case .poundIfKeyword: return (.poundIfKeyword, nil)
+    case .poundElseKeyword: return (.poundElseKeyword, nil)
+    case .poundElseifKeyword: return (.poundElseifKeyword, nil)
+    case .poundEndifKeyword: return (.poundEndifKeyword, nil)
+    case .poundAvailableKeyword: return (.poundAvailableKeyword, nil)
+    case .poundUnavailableKeyword: return (.poundUnavailableKeyword, nil)
+    case .poundFileLiteralKeyword: return (.poundFileLiteralKeyword, nil)
+    case .poundImageLiteralKeyword: return (.poundImageLiteralKeyword, nil)
+    case .poundColorLiteralKeyword: return (.poundColorLiteralKeyword, nil)
+    case .integerLiteral(let str): return (.integerLiteral, str)
+    case .floatingLiteral(let str): return (.floatingLiteral, str)
+    case .stringLiteral(let str): return (.stringLiteral, str)
+    case .regexLiteral(let str): return (.regexLiteral, str)
+    case .unknown(let str): return (.unknown, str)
+    case .identifier(let str): return (.identifier, str)
+    case .unspacedBinaryOperator(let str): return (.unspacedBinaryOperator, str)
+    case .spacedBinaryOperator(let str): return (.spacedBinaryOperator, str)
+    case .postfixOperator(let str): return (.postfixOperator, str)
+    case .prefixOperator(let str): return (.prefixOperator, str)
+    case .dollarIdentifier(let str): return (.dollarIdentifier, str)
+    case .contextualKeyword(let str): return (.contextualKeyword, str)
+    case .rawStringDelimiter(let str): return (.rawStringDelimiter, str)
+    case .stringSegment(let str): return (.stringSegment, str)
+    case .stringInterpolationAnchor: return (.stringInterpolationAnchor, nil)
+    case .yield: return (.yield, nil)
     }
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/Trivia.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Trivia.swift
@@ -372,7 +372,7 @@ extension TriviaPiece {
 }
 
 /// Trivia piece for token RawSyntax.
-public enum RawTriviaPiece {
+enum RawTriviaPiece {
     case spaces(Int)
     case tabs(Int)
     case verticalTabs(Int)
@@ -407,7 +407,7 @@ public enum RawTriviaPiece {
 }
 
 extension RawTriviaPiece: TextOutputStreamable {
-  public func write<Target: TextOutputStream>(to target: inout Target) {
+  func write<Target: TextOutputStream>(to target: inout Target) {
     TriviaPiece(raw: self).write(to: &target)
   }
 }
@@ -433,7 +433,7 @@ extension TriviaPiece {
 }
 
 extension RawTriviaPiece {
-  public var byteLength: Int {
+  var byteLength: Int {
     switch self {
     case let .spaces(count):
       return count
@@ -467,7 +467,7 @@ extension RawTriviaPiece {
 
 
 extension RawTriviaPiece {
-  public static func fromRawValue(kind: UInt8, text: SyntaxText) -> RawTriviaPiece {
+  static func fromRawValue(kind: UInt8, text: SyntaxText) -> RawTriviaPiece {
     switch kind {
     case 0:
       return .spaces(text.count)

--- a/Sources/SwiftSyntax/gyb_generated/Trivia.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Trivia.swift
@@ -470,17 +470,17 @@ extension RawTriviaPiece {
   public static func fromRawValue(kind: UInt8, text: SyntaxText) -> RawTriviaPiece {
     switch kind {
     case 0:
-      return .spaces(text.count / 1)
+      return .spaces(text.count)
     case 1:
-      return .tabs(text.count / 1)
+      return .tabs(text.count)
     case 2:
-      return .verticalTabs(text.count / 1)
+      return .verticalTabs(text.count)
     case 3:
-      return .formfeeds(text.count / 1)
+      return .formfeeds(text.count)
     case 4:
-      return .newlines(text.count / 1)
+      return .newlines(text.count)
     case 5:
-      return .carriageReturns(text.count / 1)
+      return .carriageReturns(text.count)
     case 6:
       return .carriageReturnLineFeeds(text.count / 2)
     case 8:

--- a/Sources/SwiftSyntax/gyb_generated/Trivia.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Trivia.swift
@@ -371,171 +371,132 @@ extension TriviaPiece {
   }
 }
 
-extension TriviaPiece {
-  static func fromRawValue(_ piece: CTriviaPiece,
-                           textBuffer: UnsafeBufferPointer<UInt8>) -> TriviaPiece {
-    switch piece.kind {
-    case 0:
-      return .spaces(Int(piece.length)/1)
-    case 1:
-      return .tabs(Int(piece.length)/1)
-    case 2:
-      return .verticalTabs(Int(piece.length)/1)
-    case 3:
-      return .formfeeds(Int(piece.length)/1)
-    case 4:
-      return .newlines(Int(piece.length)/1)
-    case 5:
-      return .carriageReturns(Int(piece.length)/1)
-    case 6:
-      return .carriageReturnLineFeeds(Int(piece.length)/2)
-    case 8:
-      return .lineComment(.fromBuffer(textBuffer))
-    case 9:
-      return .blockComment(.fromBuffer(textBuffer))
-    case 10:
-      return .docLineComment(.fromBuffer(textBuffer))
-    case 11:
-      return .docBlockComment(.fromBuffer(textBuffer))
-    case 12:
-      return .garbageText(.fromBuffer(textBuffer))
-    case 13:
-      return .shebang(.fromBuffer(textBuffer))
-    default:
-      fatalError("unexpected trivia piece kind \(piece.kind)")
-    }
-  }
+/// Trivia piece for token RawSyntax.
+public enum RawTriviaPiece {
+    case spaces(Int)
+    case tabs(Int)
+    case verticalTabs(Int)
+    case formfeeds(Int)
+    case newlines(Int)
+    case carriageReturns(Int)
+    case carriageReturnLineFeeds(Int)
+    case lineComment(SyntaxText)
+    case blockComment(SyntaxText)
+    case docLineComment(SyntaxText)
+    case docBlockComment(SyntaxText)
+    case garbageText(SyntaxText)
+    case shebang(SyntaxText)
 
-  static func hasText(kind: CTriviaKind) -> Bool {
-    switch kind {
-    case 0:
-      return false
-    case 1:
-      return false
-    case 2:
-      return false
-    case 3:
-      return false
-    case 4:
-      return false
-    case 5:
-      return false
-    case 6:
-      return false
-    case 8:
-      return true
-    case 9:
-      return true
-    case 10:
-      return true
-    case 11:
-      return true
-    case 12:
-      return true
-    case 13:
-      return true
-    default:
-      fatalError("unexpected trivia piece kind \(kind)")
+  static func make(arena: SyntaxArena, _ piece: TriviaPiece) -> RawTriviaPiece {
+    switch piece {
+    case let .spaces(count): return .spaces(count)
+    case let .tabs(count): return .tabs(count)
+    case let .verticalTabs(count): return .verticalTabs(count)
+    case let .formfeeds(count): return .formfeeds(count)
+    case let .newlines(count): return .newlines(count)
+    case let .carriageReturns(count): return .carriageReturns(count)
+    case let .carriageReturnLineFeeds(count): return .carriageReturnLineFeeds(count)
+    case let .lineComment(text): return .lineComment(arena.intern(text))
+    case let .blockComment(text): return .blockComment(arena.intern(text))
+    case let .docLineComment(text): return .docLineComment(arena.intern(text))
+    case let .docBlockComment(text): return .docBlockComment(arena.intern(text))
+    case let .garbageText(text): return .garbageText(arena.intern(text))
+    case let .shebang(text): return .shebang(arena.intern(text))
     }
   }
 }
 
-/// Plain trivia piece kind value, without an associated `String` value.
-internal enum TriviaPieceKind: CTriviaKind {
-    /// A space ' ' character.
-    case spaces = 0
-    /// A tab '\t' character.
-    case tabs = 1
-    /// A vertical tab '\v' character.
-    case verticalTabs = 2
-    /// A form-feed 'f' character.
-    case formfeeds = 3
-    /// A newline '\n' character.
-    case newlines = 4
-    /// A newline '\r' character.
-    case carriageReturns = 5
-    /// A newline consists of contiguous '\r' and '\n' characters.
-    case carriageReturnLineFeeds = 6
-    /// A developer line comment, starting with '//'
-    case lineComment = 8
-    /// A developer block comment, starting with '/*' and ending with '*/'.
-    case blockComment = 9
-    /// A documentation line comment, starting with '///'.
-    case docLineComment = 10
-    /// A documentation block comment, starting with '/**' and ending with '*/'.
-    case docBlockComment = 11
-    /// Any skipped garbage text.
-    case garbageText = 12
-    /// A script command, starting with '#!'.
-    case shebang = 13
-
-  static func fromRawValue(_ rawValue: CTriviaKind) -> TriviaPieceKind {
-    return TriviaPieceKind(rawValue: rawValue)!
+extension RawTriviaPiece: TextOutputStreamable {
+  public func write<Target: TextOutputStream>(to target: inout Target) {
+    TriviaPiece(raw: self).write(to: &target)
   }
 }
 
 extension TriviaPiece {
-  internal func withUnsafeTriviaPiece<Result>(
-    _ body: (UnsafeTriviaPiece) -> Result
-  ) -> Result {
+  init(raw: RawTriviaPiece) {
+    switch raw {
+    case let .spaces(count): self = .spaces(count)
+    case let .tabs(count): self = .tabs(count)
+    case let .verticalTabs(count): self = .verticalTabs(count)
+    case let .formfeeds(count): self = .formfeeds(count)
+    case let .newlines(count): self = .newlines(count)
+    case let .carriageReturns(count): self = .carriageReturns(count)
+    case let .carriageReturnLineFeeds(count): self = .carriageReturnLineFeeds(count)
+    case let .lineComment(text): self = .lineComment(String(syntaxText: text))
+    case let .blockComment(text): self = .blockComment(String(syntaxText: text))
+    case let .docLineComment(text): self = .docLineComment(String(syntaxText: text))
+    case let .docBlockComment(text): self = .docBlockComment(String(syntaxText: text))
+    case let .garbageText(text): self = .garbageText(String(syntaxText: text))
+    case let .shebang(text): self = .shebang(String(syntaxText: text))
+    }
+  }
+}
+
+extension RawTriviaPiece {
+  public var byteLength: Int {
     switch self {
     case let .spaces(count):
-      let length = count
-      return body(.init(kind: .spaces, length: length))
+      return count
     case let .tabs(count):
-      let length = count
-      return body(.init(kind: .tabs, length: length))
+      return count
     case let .verticalTabs(count):
-      let length = count
-      return body(.init(kind: .verticalTabs, length: length))
+      return count
     case let .formfeeds(count):
-      let length = count
-      return body(.init(kind: .formfeeds, length: length))
+      return count
     case let .newlines(count):
-      let length = count * 1
-      return body(.init(kind: .newlines, length: length))
+      return count * 1
     case let .carriageReturns(count):
-      let length = count * 1
-      return body(.init(kind: .carriageReturns, length: length))
+      return count * 1
     case let .carriageReturnLineFeeds(count):
-      let length = count * 2
-      return body(.init(kind: .carriageReturnLineFeeds, length: length))
-    case var .lineComment(text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .lineComment, length: length, customText: buf))
-      })!
-    case var .blockComment(text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .blockComment, length: length, customText: buf))
-      })!
-    case var .docLineComment(text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .docLineComment, length: length, customText: buf))
-      })!
-    case var .docBlockComment(text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .docBlockComment, length: length, customText: buf))
-      })!
-    case var .garbageText(text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .garbageText, length: length, customText: buf))
-      })!
-    case var .shebang(text):
-      text.makeContiguousUTF8()
-      let length = text.utf8.count
-      return text.utf8.withContiguousStorageIfAvailable({ (buf: UnsafeBufferPointer<UInt8>) in
-        return body(.init(kind: .shebang, length: length, customText: buf))
-      })!
+      return count * 2
+    case let .lineComment(text):
+      return text.count
+    case let .blockComment(text):
+      return text.count
+    case let .docLineComment(text):
+      return text.count
+    case let .docBlockComment(text):
+      return text.count
+    case let .garbageText(text):
+      return text.count
+    case let .shebang(text):
+      return text.count
+    }
+  }
+}
+
+
+extension RawTriviaPiece {
+  public static func fromRawValue(kind: UInt8, text: SyntaxText) -> RawTriviaPiece {
+    switch kind {
+    case 0:
+      return .spaces(text.count / 1)
+    case 1:
+      return .tabs(text.count / 1)
+    case 2:
+      return .verticalTabs(text.count / 1)
+    case 3:
+      return .formfeeds(text.count / 1)
+    case 4:
+      return .newlines(text.count / 1)
+    case 5:
+      return .carriageReturns(text.count / 1)
+    case 6:
+      return .carriageReturnLineFeeds(text.count / 2)
+    case 8:
+      return .lineComment(text)
+    case 9:
+      return .blockComment(text)
+    case 10:
+      return .docLineComment(text)
+    case 11:
+      return .docBlockComment(text)
+    case 12:
+      return .garbageText(text)
+    case 13:
+      return .shebang(text)
+    default:
+      fatalError("unexpected trivia piece kind \(kind)")
     }
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/Trivia.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Trivia.swift
@@ -372,22 +372,25 @@ extension TriviaPiece {
 }
 
 /// Trivia piece for token RawSyntax.
+///
+/// In contrast to `TriviaPiece`, a `RawTriviaPiece` does not own the source
+/// text of a the trivia.
 enum RawTriviaPiece {
-    case spaces(Int)
-    case tabs(Int)
-    case verticalTabs(Int)
-    case formfeeds(Int)
-    case newlines(Int)
-    case carriageReturns(Int)
-    case carriageReturnLineFeeds(Int)
-    case lineComment(SyntaxText)
-    case blockComment(SyntaxText)
-    case docLineComment(SyntaxText)
-    case docBlockComment(SyntaxText)
-    case garbageText(SyntaxText)
-    case shebang(SyntaxText)
+  case spaces(Int)
+  case tabs(Int)
+  case verticalTabs(Int)
+  case formfeeds(Int)
+  case newlines(Int)
+  case carriageReturns(Int)
+  case carriageReturnLineFeeds(Int)
+  case lineComment(SyntaxText)
+  case blockComment(SyntaxText)
+  case docLineComment(SyntaxText)
+  case docBlockComment(SyntaxText)
+  case garbageText(SyntaxText)
+  case shebang(SyntaxText)
 
-  static func make(arena: SyntaxArena, _ piece: TriviaPiece) -> RawTriviaPiece {
+  static func make(_ piece: TriviaPiece, arena: SyntaxArena) -> RawTriviaPiece {
     switch piece {
     case let .spaces(count): return .spaces(count)
     case let .tabs(count): return .tabs(count)
@@ -464,7 +467,6 @@ extension RawTriviaPiece {
     }
   }
 }
-
 
 extension RawTriviaPiece {
   static func fromRawValue(kind: UInt8, text: SyntaxText) -> RawTriviaPiece {

--- a/Sources/SwiftSyntaxParser/SyntaxParser.swift
+++ b/Sources/SwiftSyntaxParser/SyntaxParser.swift
@@ -86,18 +86,12 @@ public enum SyntaxParser {
     var utf8Source = source
     utf8Source.makeContiguousUTF8()
 
-    let rawSyntax = parseRaw(source: utf8Source,
-                             parseTransition: parseTransition,
-                             filenameForDiagnostics: filenameForDiagnostics,
-                             languageVersion: languageVersion,
-                             enableBareSlashRegexLiteral: enableBareSlashRegexLiteral,
-                             diagnosticHandler: diagnosticHandler)
-
-    let base = _SyntaxParserInterop.nodeFromRetainedOpaqueRawSyntax(rawSyntax)
-    guard let file = base.as(SourceFileSyntax.self) else {
-      throw ParserError.invalidSyntaxData
-    }
-    return file
+    return try parseImpl(source: utf8Source,
+                         parseTransition: parseTransition,
+                         filenameForDiagnostics: filenameForDiagnostics,
+                         languageVersion: languageVersion,
+                         enableBareSlashRegexLiteral: enableBareSlashRegexLiteral,
+                         diagnosticHandler: diagnosticHandler)
   }
 
   /// Parses the file `URL` into a full-fidelity Syntax tree.
@@ -132,19 +126,23 @@ public enum SyntaxParser {
                      diagnosticHandler: diagnosticHandler)
   }
 
-  private static func parseRaw(
+  private static func parseImpl(
     source: String,
     parseTransition: IncrementalParseTransition?,
     filenameForDiagnostics: String,
     languageVersion: String?,
     enableBareSlashRegexLiteral: Bool?,
     diagnosticHandler: ((Diagnostic) -> Void)?
-  ) -> CClientNode {
+  ) throws -> SourceFileSyntax {
     precondition(source.isContiguousUTF8)
     let c_parser = swiftparse_parser_create()
     defer {
       swiftparse_parser_dispose(c_parser)
     }
+    var source = source
+    let arena = SyntaxArena()
+    let sourceBuffer = source.withUTF8 { arena.internSourceBuffer($0) }
+
     if let languageVersion = languageVersion {
       languageVersion.withCString { languageVersionCString in
         swiftparse_parser_set_language_version(c_parser, languageVersionCString)
@@ -155,7 +153,8 @@ public enum SyntaxParser {
     }
 
     let nodeHandler = { (cnode: CSyntaxNodePtr!) -> UnsafeMutableRawPointer in
-      return _SyntaxParserInterop.getRetainedOpaqueRawSyntax(cnode: cnode, source: source)
+      return _SyntaxParserInterop.getRetainedOpaqueRawSyntax(
+        arena: arena, cnode: cnode, sourceBuffer: sourceBuffer)
     }
     swiftparse_parser_set_node_handler(c_parser, nodeHandler);
 
@@ -206,11 +205,12 @@ public enum SyntaxParser {
       swiftparse_parser_set_diagnostic_handler(c_parser, diagHandler)
     }
 
-    let c_top = source.withCString { buf in
-      swiftparse_parse_string(c_parser, buf, source.utf8.count)
+    let c_top = swiftparse_parse_string(c_parser, sourceBuffer.baseAddress, sourceBuffer.count)
+    let base = _SyntaxParserInterop.nodeFromRetainedOpaqueRawSyntax(c_top!)
+    guard let file = base.as(SourceFileSyntax.self) else {
+      throw ParserError.invalidSyntaxData
     }
-
-    return c_top!
+    return file
   }
 }
 

--- a/Sources/SwiftSyntaxParser/SyntaxParser.swift
+++ b/Sources/SwiftSyntaxParser/SyntaxParser.swift
@@ -154,7 +154,7 @@ public enum SyntaxParser {
 
     let nodeHandler = { (cnode: CSyntaxNodePtr!) -> UnsafeMutableRawPointer in
       return _SyntaxParserInterop.getRetainedOpaqueRawSyntax(
-        arena: arena, cnode: cnode, sourceBuffer: sourceBuffer)
+        cnode: cnode, sourceBuffer: sourceBuffer, arena: arena)
     }
     swiftparse_parser_set_node_handler(c_parser, nodeHandler);
 

--- a/Tests/PerformanceTest/ParsingPerformanceTests.swift
+++ b/Tests/PerformanceTest/ParsingPerformanceTests.swift
@@ -14,9 +14,7 @@ public class ParsingPerformanceTests: XCTestCase {
   func testParsingPerformance() {
     measure {
       do {
-        for _ in 0 ..< 500 {
         _ = try SyntaxParser.parse(inputFile)
-        }
       } catch {
         XCTFail(error.localizedDescription)
       }

--- a/Tests/PerformanceTest/ParsingPerformanceTests.swift
+++ b/Tests/PerformanceTest/ParsingPerformanceTests.swift
@@ -14,7 +14,9 @@ public class ParsingPerformanceTests: XCTestCase {
   func testParsingPerformance() {
     measure {
       do {
+        for _ in 0 ..< 500 {
         _ = try SyntaxParser.parse(inputFile)
+        }
       } catch {
         XCTFail(error.localizedDescription)
       }

--- a/lit_tests/coloring.swift
+++ b/lit_tests/coloring.swift
@@ -232,7 +232,7 @@ func f(x: Int) -> Int {
    )
    """
 
-  // CHECK: <str>"</str>\<anchor>(</anchor><int>1</int><anchor>)</anchor><str></str>\<anchor>(</anchor><int>1</int><anchor>)</anchor><str>"</str>
+  // CHECK: <str>"</str>\<anchor>(</anchor><int>1</int><anchor>)</anchor>\<anchor>(</anchor><int>1</int><anchor>)</anchor><str>"</str>
   "\(1)\(1)"
 }
 

--- a/utils/group.json
+++ b/utils/group.json
@@ -1,6 +1,7 @@
 {
   "Syntax": [
     "RawSyntax.swift",
+    "RawSyntax+CSwiftSyntax.swift",
     "SyntaxChildren.swift",
     "SyntaxData.swift",
     "SyntaxEnum.swift",
@@ -45,6 +46,7 @@
   ],
   "Internal": [
     "_SyntaxParserInterop.swift",
+    "SyntaxArena.swift",
     "CNodes.swift",
     "AtomicCounter.swift",
     "SyntaxVerifier.swift",


### PR DESCRIPTION
* Introduce `SyntaxArena` that manages the memory of `RawSyntax`
* `RawSyntaxData` is the "data" of raw syntax managed by `SyntaxArena`, and it has
  - Unowned pointer to the `SyntaxArena`
  - Tagged union of "token" or "layout" data where all data are managed by the `SyntaxArena`
* `RawSyntax` is now just a pointer wrapper of `RawSyntaxData` and APIs.
* Root `SyntaxData` now owns the `SyntaxArena` of the root `RawSyntax`.

For intermediate solution `SyntaxArena` has `static var default` which is used by Factory methods. This cannot be a permanent solution because it's never deallocate the memory. In future all factory methods will require explicit `arena` to use.