### PR TITLE
Fix documentation for syntax collections in `SwiftSyntaxBuilderGeneration`

### DIFF
--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableNode.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableNode.swift
@@ -24,14 +24,12 @@ extension Node {
   }
 
   /// If documentation exists for this node, return it as a single-line string.
-  /// Otherwise return an empty string.
+  /// Otherwise return an empty string or a description of collection if this
+  /// node is a syntax collection.
   var documentation: String {
-    guard let description = description,
-          !description.isEmpty else {
-      return ""
-    }
-    if isSyntaxCollection {
-      return "`\(syntaxKind)` represents a collection of `\(description)`"
+    let description = self.description ?? ""
+    if description.isEmpty && isSyntaxCollection {
+      return "`\(syntaxKind)` represents a collection of `\(collectionElementType.buildableBaseName)`"
     } else {
       return flattened(indentedDocumentation: description)
     }


### PR DESCRIPTION
The Swift translation of`Node.documentation` (from [the Python version](https://github.com/apple/swift-syntax/blob/8875897090059060c6ea7846261187380b1f81dc/Sources/SwiftSyntaxBuilder/gyb_helpers/SyntaxBuildableWrappers.py#L102-L110)) generates empty documentations for syntax collections without a `documentation`, which previously generated the description of its element type as a fallback. This small patch fixes this slight mistranslation.