### PR TITLE
Make `TypeBuildable` expressible as `TypeAnnotation`

### DIFF
--- a/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
@@ -85,7 +85,7 @@ public extension ExpressibleAsSyntaxBuildable {
     return SwitchCaseList([self])
   }
 }
-public protocol ExpressibleAsTypeBuildable: ExpressibleAsReturnClause, ExpressibleAsTypeInitializerClause {
+public protocol ExpressibleAsTypeBuildable: ExpressibleAsReturnClause, ExpressibleAsTypeInitializerClause, ExpressibleAsTypeAnnotation {
   func createTypeBuildable() -> TypeBuildable
 }
 public extension ExpressibleAsTypeBuildable {
@@ -96,6 +96,10 @@ public extension ExpressibleAsTypeBuildable {
   /// Conformance to ExpressibleAsTypeInitializerClause
   func createTypeInitializerClause() -> TypeInitializerClause {
     return TypeInitializerClause(value: self)
+  }
+  /// Conformance to ExpressibleAsTypeAnnotation
+  func createTypeAnnotation() -> TypeAnnotation {
+    return TypeAnnotation(type: self)
   }
 }
 public protocol ExpressibleAsCodeBlockItem: ExpressibleAsCodeBlockItemList {
@@ -1737,14 +1741,10 @@ public extension ExpressibleAsPrimaryAssociatedTypeClause {
     return createPrimaryAssociatedTypeClause()
   }
 }
-public protocol ExpressibleAsSimpleTypeIdentifier: ExpressibleAsTypeAnnotation, ExpressibleAsTypeExpr, ExpressibleAsTypeBuildable {
+public protocol ExpressibleAsSimpleTypeIdentifier: ExpressibleAsTypeExpr, ExpressibleAsTypeBuildable {
   func createSimpleTypeIdentifier() -> SimpleTypeIdentifier
 }
 public extension ExpressibleAsSimpleTypeIdentifier {
-  /// Conformance to ExpressibleAsTypeAnnotation
-  func createTypeAnnotation() -> TypeAnnotation {
-    return TypeAnnotation(type: self)
-  }
   /// Conformance to ExpressibleAsTypeExpr
   func createTypeExpr() -> TypeExpr {
     return TypeExpr(type: self)
@@ -1769,26 +1769,18 @@ public extension ExpressibleAsClassRestrictionType {
     return createClassRestrictionType()
   }
 }
-public protocol ExpressibleAsArrayType: ExpressibleAsTypeAnnotation, ExpressibleAsTypeBuildable {
+public protocol ExpressibleAsArrayType: ExpressibleAsTypeBuildable {
   func createArrayType() -> ArrayType
 }
 public extension ExpressibleAsArrayType {
-  /// Conformance to ExpressibleAsTypeAnnotation
-  func createTypeAnnotation() -> TypeAnnotation {
-    return TypeAnnotation(type: self)
-  }
   func createTypeBuildable() -> TypeBuildable {
     return createArrayType()
   }
 }
-public protocol ExpressibleAsDictionaryType: ExpressibleAsTypeAnnotation, ExpressibleAsTypeBuildable {
+public protocol ExpressibleAsDictionaryType: ExpressibleAsTypeBuildable {
   func createDictionaryType() -> DictionaryType
 }
 public extension ExpressibleAsDictionaryType {
-  /// Conformance to ExpressibleAsTypeAnnotation
-  func createTypeAnnotation() -> TypeAnnotation {
-    return TypeAnnotation(type: self)
-  }
   func createTypeBuildable() -> TypeBuildable {
     return createDictionaryType()
   }

--- a/Sources/SwiftSyntaxBuilder/gyb_helpers/ExpressibleAsConformances.py
+++ b/Sources/SwiftSyntaxBuilder/gyb_helpers/ExpressibleAsConformances.py
@@ -5,18 +5,12 @@ SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES = {
     'ArrayElementList': [
         'ArrayExpr'
     ],
-    'ArrayType': [
-        'TypeAnnotation'
-    ],
     'CodeBlockItemList': [
         'CodeBlock'
     ],
     'DeclBuildable': [
         'CodeBlockItem',
         'MemberDeclListItem'
-    ],
-    'DictionaryType': [
-        'TypeAnnotation'
     ],
     'ExprBuildable': [
         'CodeBlockItem',
@@ -39,7 +33,6 @@ SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES = {
         'TupleExprElement'
     ],
     'SimpleTypeIdentifier': [
-        'TypeAnnotation',
         'TypeExpr'
     ],
     'StmtBuildable': [
@@ -52,7 +45,8 @@ SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES = {
     ],
     'TypeBuildable': [
         'ReturnClause',
-        'TypeInitializerClause'
+        'TypeInitializerClause',
+        'TypeAnnotation'
     ]
 }
 

--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableChild.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableChild.swift
@@ -47,7 +47,7 @@ extension Child {
               SequenceExpr {
                 MemberAccessExpr(base: varName, name: "leadingTrivia")
                 BinaryOperatorExpr("??")
-                ArrayExpr(elements: [])
+                ArrayExpr {}
               }
             }
           }

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/ExpressibleAsConformances.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/ExpressibleAsConformances.swift
@@ -19,18 +19,12 @@ let SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES: [String: [String]] = [
   "ArrayElementList": [
     "ArrayExpr",
   ],
-  "ArrayType": [
-    "TypeAnnotation",
-  ],
   "CodeBlockItemList": [
     "CodeBlock",
   ],
   "DeclBuildable": [
     "CodeBlockItem",
     "MemberDeclListItem",
-  ],
-  "DictionaryType": [
-    "TypeAnnotation",
   ],
   "ExprBuildable": [
     "CodeBlockItem",
@@ -53,7 +47,6 @@ let SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES: [String: [String]] = [
     "TupleExprElement",
   ],
   "SimpleTypeIdentifier": [
-    "TypeAnnotation",
     "TypeExpr",
   ],
   "StmtBuildable": [
@@ -67,5 +60,6 @@ let SYNTAX_BUILDABLE_EXPRESSIBLE_AS_CONFORMANCES: [String: [String]] = [
   "TypeBuildable": [
     "ReturnClause",
     "TypeInitializerClause",
+    "TypeAnnotation",
   ],
 ]


### PR DESCRIPTION
This simultaneously simplifies and generalizes the conformance tree since arbitrary type buildables can now be used wherever a type annotation is needed (previously `ArrayType`, `SimpleTypeIdentifier` and a few others were hardcoded).