### PR TITLE
Fix `ArrayExpr` in `SyntaxBuildableChild`

### DIFF
--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableChild.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxBuildableChild.swift
@@ -47,7 +47,7 @@ extension Child {
               SequenceExpr {
                 MemberAccessExpr(base: varName, name: "leadingTrivia")
                 BinaryOperatorExpr("??")
-                ArrayExpr(elements: [])
+                ArrayExpr {}
               }
             }
           }


### PR DESCRIPTION
This is a small patch that fixes the (currently broken) `SwiftSyntaxBuilderGeneration` due to the now missing `Array: ExpressibleAsArrayElementList` conformance (see https://github.com/apple/swift-syntax/pull/483#discussion_r937747605).