### PR TITLE
Mark `TokenKind` as `Hashable`

### DIFF
--- a/Sources/SwiftSyntax/TokenKind.swift.gyb
+++ b/Sources/SwiftSyntax/TokenKind.swift.gyb
@@ -18,7 +18,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Enumerates the kinds of tokens in the Swift language.
-public enum TokenKind {
+public enum TokenKind: Hashable {
   case eof
 % for token in SYNTAX_TOKENS:
 %   kind = token.swift_kind()

--- a/Sources/SwiftSyntax/gyb_generated/TokenKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/TokenKind.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Enumerates the kinds of tokens in the Swift language.
-public enum TokenKind {
+public enum TokenKind: Hashable {
   case eof
   case associatedtypeKeyword
   case classKeyword


### PR DESCRIPTION
Useful so we can create a `Set<TokenKind>`, which clients can use to check if a token has one of a set of expected kinds.