### PR TITLE
Use the builder-based `ParameterClause` initializer where possible

### DIFF
--- a/Sources/SwiftSyntaxBuilderGeneration/SyntaxUtilities.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/SyntaxUtilities.swift
@@ -65,20 +65,17 @@ func createTypeInheritanceClause(conformances: [String]) -> TypeInheritanceClaus
 /// Create a parameter clause of the form `format: .comma, leadingTrivia: Trivia = nil`
 /// where the presence of ` = nil` is controlled by `withDefaultTrivia`.
 func createFormatLeadingTriviaParameters(withDefaultTrivia: Bool = false) -> ParameterClause {
-  ParameterClause(
-    parameterList: [
-      FunctionParameter(
-        firstName: .identifier("format"),
-        colon: .colon,
-        type: "Format",
-        trailingComma: .comma
-      ),
-      FunctionParameter(
-        firstName: .identifier("leadingTrivia"),
-        colon: .colon,
-        type: OptionalType(wrappedType: "Trivia"),
-        defaultArgument: withDefaultTrivia ? InitializerClause(value: NilLiteralExpr()) : nil
-      ),
-    ]
-  )
+  ParameterClause {
+    FunctionParameter(
+      firstName: .identifier("format"),
+      colon: .colon,
+      type: "Format"
+    )
+    FunctionParameter(
+      firstName: .identifier("leadingTrivia"),
+      colon: .colon,
+      type: OptionalType(wrappedType: "Trivia"),
+      defaultArgument: withDefaultTrivia ? InitializerClause(value: NilLiteralExpr()) : nil
+    )
+  }
 }

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableCollectionNodesFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableCollectionNodesFile.swift
@@ -92,14 +92,14 @@ private func createArrayInitializer(node: Node) -> InitializerDecl {
     ].map { .docLineComment($0) + .newline }.reduce([], +),
     modifiers: [TokenSyntax.public],
     signature: FunctionSignature(
-      input: ParameterClause(
-        parameterList: FunctionParameter(
+      input: ParameterClause {
+        FunctionParameter(
           firstName: .wildcard,
           secondName: .identifier("elements"),
           colon: .colon,
           type: ArrayType(elementType: elementType.expressibleAs)
         )
-      )
+      }
     )
   ) {
     SequenceExpr {
@@ -123,14 +123,14 @@ private func createCombiningInitializer(node: Node) -> InitializerDecl {
     leadingTrivia: .docLineComment("/// Creates a new `\(type.buildableBaseName)` by flattening the elements in `lists`") + .newline,
     modifiers: [TokenSyntax.public],
     signature: FunctionSignature(
-      input: ParameterClause(
-        parameterList: FunctionParameter(
+      input: ParameterClause {
+        FunctionParameter(
           firstName: .identifier("combining").withTrailingTrivia(.space),
           secondName: .identifier("lists"),
           colon: .colon,
           type: ArrayType(elementType: type.expressibleAs)
         )
-      )
+      }
     )
   ) {
     SequenceExpr {
@@ -152,15 +152,15 @@ private func createArrayLiteralInitializer(node: Node) -> InitializerDecl {
   return InitializerDecl(
     modifiers: [TokenSyntax.public],
     signature: FunctionSignature(
-      input: ParameterClause(
-        parameterList: FunctionParameter(
+      input: ParameterClause {
+        FunctionParameter(
           firstName: .identifier("arrayLiteral").withTrailingTrivia(.space),
           secondName: .identifier("elements"),
           colon: .colon,
           type: elementType.expressibleAs,
           ellipsis: .ellipsis
         )
-      )
+      }
     )
   ) {
     FunctionCallExpr(MemberAccessExpr(base: "self", name: "init")) {

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/TokensFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/TokensFile.swift
@@ -55,15 +55,15 @@ let tokensFile = SourceFile {
         }
       } else {
         let signature = FunctionSignature(
-          input: ParameterClause(
-            parameterList: FunctionParameter(
+          input: ParameterClause {
+            FunctionParameter(
               attributes: nil,
               firstName: .wildcard,
               secondName: .identifier("text"),
               colon: .colon,
               type: "String"
             )
-          ),
+          },
           output: "TokenSyntax"
         )
 

--- a/Tests/SwiftSyntaxBuilderTest/ArrayExpressibleAsTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ArrayExpressibleAsTests.swift
@@ -30,17 +30,15 @@ final class ArrayExpressibleAsTests: XCTestCase {
 
   func testFunctionParameters() {
     let signature = FunctionSignature(
-      input: ParameterClause(
-        parameterList: [
-          FunctionParameter(
-            attributes: nil,
-            firstName: .wildcard,
-            secondName: .identifier("args"),
-            colon: .colon,
-            type: ArrayType(elementType: "String")
-          )
-        ]
-      ),
+      input: ParameterClause {
+        FunctionParameter(
+          attributes: nil,
+          firstName: .wildcard,
+          secondName: .identifier("args"),
+          colon: .colon,
+          type: ArrayType(elementType: "String")
+        )
+      },
       output: "Int"
     )
 

--- a/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/FunctionTests.swift
@@ -6,9 +6,9 @@ final class FunctionTests: XCTestCase {
   func testFibonacci() {
     let leadingTrivia = Trivia.garbageText("␣")
 
-    let input = ParameterClause(parameterList: [
+    let input = ParameterClause {
       FunctionParameter(firstName: .wildcard, secondName: .identifier("n"), colon: .colon, type: "Int")
-    ])
+    }
 
     let ifCodeBlock = ReturnStmt(expression: IntegerLiteralExpr(digits: "n"))
     


### PR DESCRIPTION
This looks both prettier and no longer requires us to worry about trailing commas thanks to #454.