### PR TITLE
Use `NilLiteralExpr` in `BuildableCollectionNodes`

### DIFF
--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableCollectionNodesFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/BuildableCollectionNodesFile.swift
@@ -200,7 +200,7 @@ private func createBuildFunction(node: Node) -> FunctionDecl {
                         BinaryOperatorExpr("+")
                         FunctionCallExpr(MemberAccessExpr(base: "format", name: "_makeIndent"))
                       }
-                    : "nil"
+                    : NilLiteralExpr()
                 )
               }
             })


### PR DESCRIPTION
A small patch that uses `NilLiteralExpr` in`BuildableCollectionNodes` instead of generating `nil` as an identifier.

One minor thing that we might want to figure out is why `nil` tokens generate a trailing space unlike identifier tokens.