### PR TITLE
Add `Child.isGarbageNodes`

### DIFF
--- a/Sources/SwiftSyntaxBuilderGeneration/Child.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Child.swift
@@ -63,6 +63,11 @@ class Child {
     return tokenChoices.first
   }
 
+  /// Whether this child has syntax kind `GarbageNodes`.
+  var isGarbageNodes: Bool {
+    syntaxKind == "GarbageNodes"
+  }
+
   /// If a classification is passed, it specifies the color identifiers in
   /// that subtree should inherit for syntax coloring. Must be a member of
   /// SyntaxClassification in SyntaxClassifier.h.gyb


### PR DESCRIPTION
This PR ports [`Child.is_garbage_nodes`](https://github.com/apple/swift/blob/df2d938604ca19427aeed52d741674013403e645/utils/gyb_syntax_support/Child.py#L87-L88) to Swift as needed to port `BuildableNodes.swift.gyb` to `SwiftSyntaxBuilderGeneration`.