### PR TITLE
Formalize Labeled Syntax

### DIFF
--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -1045,6 +1045,12 @@ extension SyntaxNode {
     return BackDeployVersionArgumentSyntax(asSyntaxData)
   }
 
+  public var isLabeledStmt: Bool { return raw.kind == .labeledStmt }
+  public var asLabeledStmt: LabeledStmtSyntax? {
+    guard isLabeledStmt else { return nil }
+    return LabeledStmtSyntax(asSyntaxData)
+  }
+
   public var isContinueStmt: Bool { return raw.kind == .continueStmt }
   public var asContinueStmt: ContinueStmtSyntax? {
     guard isContinueStmt else { return nil }
@@ -1920,6 +1926,8 @@ extension Syntax {
     case .backDeployVersionList(let node):
       return node
     case .backDeployVersionArgument(let node):
+      return node
+    case .labeledStmt(let node):
       return node
     case .continueStmt(let node):
       return node

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
@@ -1258,6 +1258,13 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   override open func visitPost(_ node: BackDeployVersionArgumentSyntax) {
     visitAnyPost(node._syntaxNode)
   }
+  override open func visit(_ node: LabeledStmtSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: LabeledStmtSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
   override open func visit(_ node: ContinueStmtSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
@@ -272,7 +272,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   /// `nil` if the conversion is not possible.
   public init?(_ syntax: Syntax) {
     switch syntax.raw.kind {
-    case .unknownStmt, .missingStmt, .continueStmt, .whileStmt, .deferStmt, .expressionStmt, .repeatWhileStmt, .guardStmt, .forInStmt, .switchStmt, .doStmt, .returnStmt, .yieldStmt, .fallthroughStmt, .breakStmt, .declarationStmt, .throwStmt, .ifStmt, .poundAssertStmt:
+    case .unknownStmt, .missingStmt, .labeledStmt, .continueStmt, .whileStmt, .deferStmt, .expressionStmt, .repeatWhileStmt, .guardStmt, .forInStmt, .switchStmt, .doStmt, .returnStmt, .yieldStmt, .fallthroughStmt, .breakStmt, .declarationStmt, .throwStmt, .ifStmt, .poundAssertStmt:
       self._syntaxNode = syntax
     default:
       return nil
@@ -286,7 +286,7 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     // Assert that the kind of the given data matches in debug builds.
 #if DEBUG
     switch data.raw.kind {
-    case .unknownStmt, .missingStmt, .continueStmt, .whileStmt, .deferStmt, .expressionStmt, .repeatWhileStmt, .guardStmt, .forInStmt, .switchStmt, .doStmt, .returnStmt, .yieldStmt, .fallthroughStmt, .breakStmt, .declarationStmt, .throwStmt, .ifStmt, .poundAssertStmt:
+    case .unknownStmt, .missingStmt, .labeledStmt, .continueStmt, .whileStmt, .deferStmt, .expressionStmt, .repeatWhileStmt, .guardStmt, .forInStmt, .switchStmt, .doStmt, .returnStmt, .yieldStmt, .fallthroughStmt, .breakStmt, .declarationStmt, .throwStmt, .ifStmt, .poundAssertStmt:
       break
     default:
       fatalError("Unable to create StmtSyntax from \(data.raw.kind)")

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBuilders.swift
@@ -7275,6 +7275,60 @@ extension BackDeployVersionArgumentSyntax {
   }
 }
 
+public struct LabeledStmtSyntaxBuilder {
+  private var layout =
+    Array<RawSyntax?>(repeating: nil, count: 6)
+
+  internal init() {}
+
+  public mutating func useLabelName(_ node: TokenSyntax) {
+    let idx = LabeledStmtSyntax.Cursor.labelName.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func useLabelColon(_ node: TokenSyntax) {
+    let idx = LabeledStmtSyntax.Cursor.labelColon.rawValue
+    layout[idx] = node.raw
+  }
+
+  public mutating func useStatement(_ node: StmtSyntax) {
+    let idx = LabeledStmtSyntax.Cursor.statement.rawValue
+    layout[idx] = node.raw
+  }
+
+  internal mutating func buildData() -> SyntaxData {
+    if (layout[1] == nil) {
+      layout[1] = RawSyntax.missingToken(TokenKind.identifier(""))
+    }
+    if (layout[3] == nil) {
+      layout[3] = RawSyntax.missingToken(TokenKind.colon)
+    }
+    if (layout[5] == nil) {
+      layout[5] = RawSyntax.missing(SyntaxKind.missingStmt)
+    }
+
+    return .forRoot(RawSyntax.createAndCalcLength(kind: .labeledStmt,
+      layout: layout, presence: .present))
+  }
+}
+
+extension LabeledStmtSyntax {
+  /// Creates a `LabeledStmtSyntax` using the provided build function.
+  /// - Parameter:
+  ///   - build: A closure that will be invoked in order to initialize
+  ///            the fields of the syntax node.
+  ///            This closure is passed a `LabeledStmtSyntaxBuilder` which you can use to
+  ///            incrementally build the structure of the node.
+  /// - Returns: A `LabeledStmtSyntax` with all the fields populated in the builder
+  ///            closure.
+  public init(_ build: (inout LabeledStmtSyntaxBuilder) -> Void) {
+    var builder = LabeledStmtSyntaxBuilder()
+    build(&builder)
+    let data = builder.buildData()
+    self.init(data)
+  }
+}
+
 public struct ContinueStmtSyntaxBuilder {
   private var layout =
     Array<RawSyntax?>(repeating: nil, count: 4)
@@ -7320,19 +7374,9 @@ extension ContinueStmtSyntax {
 
 public struct WhileStmtSyntaxBuilder {
   private var layout =
-    Array<RawSyntax?>(repeating: nil, count: 10)
+    Array<RawSyntax?>(repeating: nil, count: 6)
 
   internal init() {}
-
-  public mutating func useLabelName(_ node: TokenSyntax) {
-    let idx = WhileStmtSyntax.Cursor.labelName.rawValue
-    layout[idx] = node.raw
-  }
-
-  public mutating func useLabelColon(_ node: TokenSyntax) {
-    let idx = WhileStmtSyntax.Cursor.labelColon.rawValue
-    layout[idx] = node.raw
-  }
 
   public mutating func useWhileKeyword(_ node: TokenSyntax) {
     let idx = WhileStmtSyntax.Cursor.whileKeyword.rawValue
@@ -7356,14 +7400,14 @@ public struct WhileStmtSyntaxBuilder {
   }
 
   internal mutating func buildData() -> SyntaxData {
+    if (layout[1] == nil) {
+      layout[1] = RawSyntax.missingToken(TokenKind.whileKeyword)
+    }
+    if (layout[3] == nil) {
+      layout[3] = RawSyntax.missing(SyntaxKind.conditionElementList)
+    }
     if (layout[5] == nil) {
-      layout[5] = RawSyntax.missingToken(TokenKind.whileKeyword)
-    }
-    if (layout[7] == nil) {
-      layout[7] = RawSyntax.missing(SyntaxKind.conditionElementList)
-    }
-    if (layout[9] == nil) {
-      layout[9] = RawSyntax.missing(SyntaxKind.codeBlock)
+      layout[5] = RawSyntax.missing(SyntaxKind.codeBlock)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .whileStmt,
@@ -7474,19 +7518,9 @@ extension ExpressionStmtSyntax {
 
 public struct RepeatWhileStmtSyntaxBuilder {
   private var layout =
-    Array<RawSyntax?>(repeating: nil, count: 12)
+    Array<RawSyntax?>(repeating: nil, count: 8)
 
   internal init() {}
-
-  public mutating func useLabelName(_ node: TokenSyntax) {
-    let idx = RepeatWhileStmtSyntax.Cursor.labelName.rawValue
-    layout[idx] = node.raw
-  }
-
-  public mutating func useLabelColon(_ node: TokenSyntax) {
-    let idx = RepeatWhileStmtSyntax.Cursor.labelColon.rawValue
-    layout[idx] = node.raw
-  }
 
   public mutating func useRepeatKeyword(_ node: TokenSyntax) {
     let idx = RepeatWhileStmtSyntax.Cursor.repeatKeyword.rawValue
@@ -7509,17 +7543,17 @@ public struct RepeatWhileStmtSyntaxBuilder {
   }
 
   internal mutating func buildData() -> SyntaxData {
+    if (layout[1] == nil) {
+      layout[1] = RawSyntax.missingToken(TokenKind.repeatKeyword)
+    }
+    if (layout[3] == nil) {
+      layout[3] = RawSyntax.missing(SyntaxKind.codeBlock)
+    }
     if (layout[5] == nil) {
-      layout[5] = RawSyntax.missingToken(TokenKind.repeatKeyword)
+      layout[5] = RawSyntax.missingToken(TokenKind.whileKeyword)
     }
     if (layout[7] == nil) {
-      layout[7] = RawSyntax.missing(SyntaxKind.codeBlock)
-    }
-    if (layout[9] == nil) {
-      layout[9] = RawSyntax.missingToken(TokenKind.whileKeyword)
-    }
-    if (layout[11] == nil) {
-      layout[11] = RawSyntax.missing(SyntaxKind.missingExpr)
+      layout[7] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .repeatWhileStmt,
@@ -7660,19 +7694,9 @@ extension WhereClauseSyntax {
 
 public struct ForInStmtSyntaxBuilder {
   private var layout =
-    Array<RawSyntax?>(repeating: nil, count: 24)
+    Array<RawSyntax?>(repeating: nil, count: 20)
 
   internal init() {}
-
-  public mutating func useLabelName(_ node: TokenSyntax) {
-    let idx = ForInStmtSyntax.Cursor.labelName.rawValue
-    layout[idx] = node.raw
-  }
-
-  public mutating func useLabelColon(_ node: TokenSyntax) {
-    let idx = ForInStmtSyntax.Cursor.labelColon.rawValue
-    layout[idx] = node.raw
-  }
 
   public mutating func useForKeyword(_ node: TokenSyntax) {
     let idx = ForInStmtSyntax.Cursor.forKeyword.rawValue
@@ -7725,20 +7749,20 @@ public struct ForInStmtSyntaxBuilder {
   }
 
   internal mutating func buildData() -> SyntaxData {
-    if (layout[5] == nil) {
-      layout[5] = RawSyntax.missingToken(TokenKind.forKeyword)
+    if (layout[1] == nil) {
+      layout[1] = RawSyntax.missingToken(TokenKind.forKeyword)
+    }
+    if (layout[9] == nil) {
+      layout[9] = RawSyntax.missing(SyntaxKind.missingPattern)
     }
     if (layout[13] == nil) {
-      layout[13] = RawSyntax.missing(SyntaxKind.missingPattern)
+      layout[13] = RawSyntax.missingToken(TokenKind.inKeyword)
     }
-    if (layout[17] == nil) {
-      layout[17] = RawSyntax.missingToken(TokenKind.inKeyword)
+    if (layout[15] == nil) {
+      layout[15] = RawSyntax.missing(SyntaxKind.missingExpr)
     }
     if (layout[19] == nil) {
-      layout[19] = RawSyntax.missing(SyntaxKind.missingExpr)
-    }
-    if (layout[23] == nil) {
-      layout[23] = RawSyntax.missing(SyntaxKind.codeBlock)
+      layout[19] = RawSyntax.missing(SyntaxKind.codeBlock)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .forInStmt,
@@ -7765,19 +7789,9 @@ extension ForInStmtSyntax {
 
 public struct SwitchStmtSyntaxBuilder {
   private var layout =
-    Array<RawSyntax?>(repeating: nil, count: 14)
+    Array<RawSyntax?>(repeating: nil, count: 10)
 
   internal init() {}
-
-  public mutating func useLabelName(_ node: TokenSyntax) {
-    let idx = SwitchStmtSyntax.Cursor.labelName.rawValue
-    layout[idx] = node.raw
-  }
-
-  public mutating func useLabelColon(_ node: TokenSyntax) {
-    let idx = SwitchStmtSyntax.Cursor.labelColon.rawValue
-    layout[idx] = node.raw
-  }
 
   public mutating func useSwitchKeyword(_ node: TokenSyntax) {
     let idx = SwitchStmtSyntax.Cursor.switchKeyword.rawValue
@@ -7811,20 +7825,20 @@ public struct SwitchStmtSyntaxBuilder {
   }
 
   internal mutating func buildData() -> SyntaxData {
+    if (layout[1] == nil) {
+      layout[1] = RawSyntax.missingToken(TokenKind.switchKeyword)
+    }
+    if (layout[3] == nil) {
+      layout[3] = RawSyntax.missing(SyntaxKind.missingExpr)
+    }
     if (layout[5] == nil) {
-      layout[5] = RawSyntax.missingToken(TokenKind.switchKeyword)
+      layout[5] = RawSyntax.missingToken(TokenKind.leftBrace)
     }
     if (layout[7] == nil) {
-      layout[7] = RawSyntax.missing(SyntaxKind.missingExpr)
+      layout[7] = RawSyntax.missing(SyntaxKind.switchCaseList)
     }
     if (layout[9] == nil) {
-      layout[9] = RawSyntax.missingToken(TokenKind.leftBrace)
-    }
-    if (layout[11] == nil) {
-      layout[11] = RawSyntax.missing(SyntaxKind.switchCaseList)
-    }
-    if (layout[13] == nil) {
-      layout[13] = RawSyntax.missingToken(TokenKind.rightBrace)
+      layout[9] = RawSyntax.missingToken(TokenKind.rightBrace)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .switchStmt,
@@ -7851,19 +7865,9 @@ extension SwitchStmtSyntax {
 
 public struct DoStmtSyntaxBuilder {
   private var layout =
-    Array<RawSyntax?>(repeating: nil, count: 10)
+    Array<RawSyntax?>(repeating: nil, count: 6)
 
   internal init() {}
-
-  public mutating func useLabelName(_ node: TokenSyntax) {
-    let idx = DoStmtSyntax.Cursor.labelName.rawValue
-    layout[idx] = node.raw
-  }
-
-  public mutating func useLabelColon(_ node: TokenSyntax) {
-    let idx = DoStmtSyntax.Cursor.labelColon.rawValue
-    layout[idx] = node.raw
-  }
 
   public mutating func useDoKeyword(_ node: TokenSyntax) {
     let idx = DoStmtSyntax.Cursor.doKeyword.rawValue
@@ -7887,11 +7891,11 @@ public struct DoStmtSyntaxBuilder {
   }
 
   internal mutating func buildData() -> SyntaxData {
-    if (layout[5] == nil) {
-      layout[5] = RawSyntax.missingToken(TokenKind.doKeyword)
+    if (layout[1] == nil) {
+      layout[1] = RawSyntax.missingToken(TokenKind.doKeyword)
     }
-    if (layout[7] == nil) {
-      layout[7] = RawSyntax.missing(SyntaxKind.codeBlock)
+    if (layout[3] == nil) {
+      layout[3] = RawSyntax.missing(SyntaxKind.codeBlock)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .doStmt,
@@ -8531,19 +8535,9 @@ extension ThrowStmtSyntax {
 
 public struct IfStmtSyntaxBuilder {
   private var layout =
-    Array<RawSyntax?>(repeating: nil, count: 14)
+    Array<RawSyntax?>(repeating: nil, count: 10)
 
   internal init() {}
-
-  public mutating func useLabelName(_ node: TokenSyntax) {
-    let idx = IfStmtSyntax.Cursor.labelName.rawValue
-    layout[idx] = node.raw
-  }
-
-  public mutating func useLabelColon(_ node: TokenSyntax) {
-    let idx = IfStmtSyntax.Cursor.labelColon.rawValue
-    layout[idx] = node.raw
-  }
 
   public mutating func useIfKeyword(_ node: TokenSyntax) {
     let idx = IfStmtSyntax.Cursor.ifKeyword.rawValue
@@ -8577,14 +8571,14 @@ public struct IfStmtSyntaxBuilder {
   }
 
   internal mutating func buildData() -> SyntaxData {
+    if (layout[1] == nil) {
+      layout[1] = RawSyntax.missingToken(TokenKind.ifKeyword)
+    }
+    if (layout[3] == nil) {
+      layout[3] = RawSyntax.missing(SyntaxKind.conditionElementList)
+    }
     if (layout[5] == nil) {
-      layout[5] = RawSyntax.missingToken(TokenKind.ifKeyword)
-    }
-    if (layout[7] == nil) {
-      layout[7] = RawSyntax.missing(SyntaxKind.conditionElementList)
-    }
-    if (layout[9] == nil) {
-      layout[9] = RawSyntax.missing(SyntaxKind.codeBlock)
+      layout[5] = RawSyntax.missing(SyntaxKind.codeBlock)
     }
 
     return .forRoot(RawSyntax.createAndCalcLength(kind: .ifStmt,

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxClassification.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxClassification.swift
@@ -79,7 +79,7 @@ extension SyntaxClassification {
         return (.keyword, false)
       case (.attribute, 3):
         return (.attribute, false)
-      case (.forInStmt, 9):
+      case (.forInStmt, 5):
         return (.keyword, false)
       case (.simpleTypeIdentifier, 1):
         return (.typeIdentifier, false)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -187,6 +187,7 @@ public enum SyntaxEnum {
   case backDeployAttributeSpecList(BackDeployAttributeSpecListSyntax)
   case backDeployVersionList(BackDeployVersionListSyntax)
   case backDeployVersionArgument(BackDeployVersionArgumentSyntax)
+  case labeledStmt(LabeledStmtSyntax)
   case continueStmt(ContinueStmtSyntax)
   case whileStmt(WhileStmtSyntax)
   case deferStmt(DeferStmtSyntax)
@@ -625,6 +626,8 @@ public extension Syntax {
       return .backDeployVersionList(BackDeployVersionListSyntax(self)!)
     case .backDeployVersionArgument:
       return .backDeployVersionArgument(BackDeployVersionArgumentSyntax(self)!)
+    case .labeledStmt:
+      return .labeledStmt(LabeledStmtSyntax(self)!)
     case .continueStmt:
       return .continueStmt(ContinueStmtSyntax(self)!)
     case .whileStmt:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -4236,6 +4236,33 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return BackDeployVersionArgumentSyntax(data)
   }
+  public static func makeLabeledStmt(_ garbageBeforeLabelName: GarbageNodesSyntax? = nil, labelName: TokenSyntax, _ garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? = nil, labelColon: TokenSyntax, _ garbageBetweenLabelColonAndStatement: GarbageNodesSyntax? = nil, statement: StmtSyntax) -> LabeledStmtSyntax {
+    let layout: [RawSyntax?] = [
+      garbageBeforeLabelName?.raw,
+      labelName.raw,
+      garbageBetweenLabelNameAndLabelColon?.raw,
+      labelColon.raw,
+      garbageBetweenLabelColonAndStatement?.raw,
+      statement.raw,
+    ]
+    let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.labeledStmt,
+      layout: layout, presence: SourcePresence.present)
+    let data = SyntaxData.forRoot(raw)
+    return LabeledStmtSyntax(data)
+  }
+
+  public static func makeBlankLabeledStmt(presence: SourcePresence = .present) -> LabeledStmtSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.create(kind: .labeledStmt,
+      layout: [
+      nil,
+      RawSyntax.missingToken(TokenKind.identifier("")),
+      nil,
+      RawSyntax.missingToken(TokenKind.colon),
+      nil,
+      RawSyntax.missing(SyntaxKind.missingStmt),
+    ], length: .zero, presence: presence))
+    return LabeledStmtSyntax(data)
+  }
   public static func makeContinueStmt(_ garbageBeforeContinueKeyword: GarbageNodesSyntax? = nil, continueKeyword: TokenSyntax, _ garbageBetweenContinueKeywordAndLabel: GarbageNodesSyntax? = nil, label: TokenSyntax?) -> ContinueStmtSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeContinueKeyword?.raw,
@@ -4259,13 +4286,9 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ContinueStmtSyntax(data)
   }
-  public static func makeWhileStmt(_ garbageBeforeLabelName: GarbageNodesSyntax? = nil, labelName: TokenSyntax?, _ garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? = nil, labelColon: TokenSyntax?, _ garbageBetweenLabelColonAndWhileKeyword: GarbageNodesSyntax? = nil, whileKeyword: TokenSyntax, _ garbageBetweenWhileKeywordAndConditions: GarbageNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ garbageBetweenConditionsAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax) -> WhileStmtSyntax {
+  public static func makeWhileStmt(_ garbageBeforeWhileKeyword: GarbageNodesSyntax? = nil, whileKeyword: TokenSyntax, _ garbageBetweenWhileKeywordAndConditions: GarbageNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ garbageBetweenConditionsAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax) -> WhileStmtSyntax {
     let layout: [RawSyntax?] = [
-      garbageBeforeLabelName?.raw,
-      labelName?.raw,
-      garbageBetweenLabelNameAndLabelColon?.raw,
-      labelColon?.raw,
-      garbageBetweenLabelColonAndWhileKeyword?.raw,
+      garbageBeforeWhileKeyword?.raw,
       whileKeyword.raw,
       garbageBetweenWhileKeywordAndConditions?.raw,
       conditions.raw,
@@ -4281,10 +4304,6 @@ public enum SyntaxFactory {
   public static func makeBlankWhileStmt(presence: SourcePresence = .present) -> WhileStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .whileStmt,
       layout: [
-      nil,
-      nil,
-      nil,
-      nil,
       nil,
       RawSyntax.missingToken(TokenKind.whileKeyword),
       nil,
@@ -4350,13 +4369,9 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return SwitchCaseListSyntax(data)
   }
-  public static func makeRepeatWhileStmt(_ garbageBeforeLabelName: GarbageNodesSyntax? = nil, labelName: TokenSyntax?, _ garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? = nil, labelColon: TokenSyntax?, _ garbageBetweenLabelColonAndRepeatKeyword: GarbageNodesSyntax? = nil, repeatKeyword: TokenSyntax, _ garbageBetweenRepeatKeywordAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax, _ garbageBetweenBodyAndWhileKeyword: GarbageNodesSyntax? = nil, whileKeyword: TokenSyntax, _ garbageBetweenWhileKeywordAndCondition: GarbageNodesSyntax? = nil, condition: ExprSyntax) -> RepeatWhileStmtSyntax {
+  public static func makeRepeatWhileStmt(_ garbageBeforeRepeatKeyword: GarbageNodesSyntax? = nil, repeatKeyword: TokenSyntax, _ garbageBetweenRepeatKeywordAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax, _ garbageBetweenBodyAndWhileKeyword: GarbageNodesSyntax? = nil, whileKeyword: TokenSyntax, _ garbageBetweenWhileKeywordAndCondition: GarbageNodesSyntax? = nil, condition: ExprSyntax) -> RepeatWhileStmtSyntax {
     let layout: [RawSyntax?] = [
-      garbageBeforeLabelName?.raw,
-      labelName?.raw,
-      garbageBetweenLabelNameAndLabelColon?.raw,
-      labelColon?.raw,
-      garbageBetweenLabelColonAndRepeatKeyword?.raw,
+      garbageBeforeRepeatKeyword?.raw,
       repeatKeyword.raw,
       garbageBetweenRepeatKeywordAndBody?.raw,
       body.raw,
@@ -4374,10 +4389,6 @@ public enum SyntaxFactory {
   public static func makeBlankRepeatWhileStmt(presence: SourcePresence = .present) -> RepeatWhileStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .repeatWhileStmt,
       layout: [
-      nil,
-      nil,
-      nil,
-      nil,
       nil,
       RawSyntax.missingToken(TokenKind.repeatKeyword),
       nil,
@@ -4443,13 +4454,9 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return WhereClauseSyntax(data)
   }
-  public static func makeForInStmt(_ garbageBeforeLabelName: GarbageNodesSyntax? = nil, labelName: TokenSyntax?, _ garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? = nil, labelColon: TokenSyntax?, _ garbageBetweenLabelColonAndForKeyword: GarbageNodesSyntax? = nil, forKeyword: TokenSyntax, _ garbageBetweenForKeywordAndTryKeyword: GarbageNodesSyntax? = nil, tryKeyword: TokenSyntax?, _ garbageBetweenTryKeywordAndAwaitKeyword: GarbageNodesSyntax? = nil, awaitKeyword: TokenSyntax?, _ garbageBetweenAwaitKeywordAndCaseKeyword: GarbageNodesSyntax? = nil, caseKeyword: TokenSyntax?, _ garbageBetweenCaseKeywordAndPattern: GarbageNodesSyntax? = nil, pattern: PatternSyntax, _ garbageBetweenPatternAndTypeAnnotation: GarbageNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ garbageBetweenTypeAnnotationAndInKeyword: GarbageNodesSyntax? = nil, inKeyword: TokenSyntax, _ garbageBetweenInKeywordAndSequenceExpr: GarbageNodesSyntax? = nil, sequenceExpr: ExprSyntax, _ garbageBetweenSequenceExprAndWhereClause: GarbageNodesSyntax? = nil, whereClause: WhereClauseSyntax?, _ garbageBetweenWhereClauseAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax) -> ForInStmtSyntax {
+  public static func makeForInStmt(_ garbageBeforeForKeyword: GarbageNodesSyntax? = nil, forKeyword: TokenSyntax, _ garbageBetweenForKeywordAndTryKeyword: GarbageNodesSyntax? = nil, tryKeyword: TokenSyntax?, _ garbageBetweenTryKeywordAndAwaitKeyword: GarbageNodesSyntax? = nil, awaitKeyword: TokenSyntax?, _ garbageBetweenAwaitKeywordAndCaseKeyword: GarbageNodesSyntax? = nil, caseKeyword: TokenSyntax?, _ garbageBetweenCaseKeywordAndPattern: GarbageNodesSyntax? = nil, pattern: PatternSyntax, _ garbageBetweenPatternAndTypeAnnotation: GarbageNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ garbageBetweenTypeAnnotationAndInKeyword: GarbageNodesSyntax? = nil, inKeyword: TokenSyntax, _ garbageBetweenInKeywordAndSequenceExpr: GarbageNodesSyntax? = nil, sequenceExpr: ExprSyntax, _ garbageBetweenSequenceExprAndWhereClause: GarbageNodesSyntax? = nil, whereClause: WhereClauseSyntax?, _ garbageBetweenWhereClauseAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax) -> ForInStmtSyntax {
     let layout: [RawSyntax?] = [
-      garbageBeforeLabelName?.raw,
-      labelName?.raw,
-      garbageBetweenLabelNameAndLabelColon?.raw,
-      labelColon?.raw,
-      garbageBetweenLabelColonAndForKeyword?.raw,
+      garbageBeforeForKeyword?.raw,
       forKeyword.raw,
       garbageBetweenForKeywordAndTryKeyword?.raw,
       tryKeyword?.raw,
@@ -4480,10 +4487,6 @@ public enum SyntaxFactory {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .forInStmt,
       layout: [
       nil,
-      nil,
-      nil,
-      nil,
-      nil,
       RawSyntax.missingToken(TokenKind.forKeyword),
       nil,
       nil,
@@ -4506,13 +4509,9 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ForInStmtSyntax(data)
   }
-  public static func makeSwitchStmt(_ garbageBeforeLabelName: GarbageNodesSyntax? = nil, labelName: TokenSyntax?, _ garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? = nil, labelColon: TokenSyntax?, _ garbageBetweenLabelColonAndSwitchKeyword: GarbageNodesSyntax? = nil, switchKeyword: TokenSyntax, _ garbageBetweenSwitchKeywordAndExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax, _ garbageBetweenExpressionAndLeftBrace: GarbageNodesSyntax? = nil, leftBrace: TokenSyntax, _ garbageBetweenLeftBraceAndCases: GarbageNodesSyntax? = nil, cases: SwitchCaseListSyntax, _ garbageBetweenCasesAndRightBrace: GarbageNodesSyntax? = nil, rightBrace: TokenSyntax) -> SwitchStmtSyntax {
+  public static func makeSwitchStmt(_ garbageBeforeSwitchKeyword: GarbageNodesSyntax? = nil, switchKeyword: TokenSyntax, _ garbageBetweenSwitchKeywordAndExpression: GarbageNodesSyntax? = nil, expression: ExprSyntax, _ garbageBetweenExpressionAndLeftBrace: GarbageNodesSyntax? = nil, leftBrace: TokenSyntax, _ garbageBetweenLeftBraceAndCases: GarbageNodesSyntax? = nil, cases: SwitchCaseListSyntax, _ garbageBetweenCasesAndRightBrace: GarbageNodesSyntax? = nil, rightBrace: TokenSyntax) -> SwitchStmtSyntax {
     let layout: [RawSyntax?] = [
-      garbageBeforeLabelName?.raw,
-      labelName?.raw,
-      garbageBetweenLabelNameAndLabelColon?.raw,
-      labelColon?.raw,
-      garbageBetweenLabelColonAndSwitchKeyword?.raw,
+      garbageBeforeSwitchKeyword?.raw,
       switchKeyword.raw,
       garbageBetweenSwitchKeywordAndExpression?.raw,
       expression.raw,
@@ -4532,10 +4531,6 @@ public enum SyntaxFactory {
   public static func makeBlankSwitchStmt(presence: SourcePresence = .present) -> SwitchStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .switchStmt,
       layout: [
-      nil,
-      nil,
-      nil,
-      nil,
       nil,
       RawSyntax.missingToken(TokenKind.switchKeyword),
       nil,
@@ -4563,13 +4558,9 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return CatchClauseListSyntax(data)
   }
-  public static func makeDoStmt(_ garbageBeforeLabelName: GarbageNodesSyntax? = nil, labelName: TokenSyntax?, _ garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? = nil, labelColon: TokenSyntax?, _ garbageBetweenLabelColonAndDoKeyword: GarbageNodesSyntax? = nil, doKeyword: TokenSyntax, _ garbageBetweenDoKeywordAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax, _ garbageBetweenBodyAndCatchClauses: GarbageNodesSyntax? = nil, catchClauses: CatchClauseListSyntax?) -> DoStmtSyntax {
+  public static func makeDoStmt(_ garbageBeforeDoKeyword: GarbageNodesSyntax? = nil, doKeyword: TokenSyntax, _ garbageBetweenDoKeywordAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax, _ garbageBetweenBodyAndCatchClauses: GarbageNodesSyntax? = nil, catchClauses: CatchClauseListSyntax?) -> DoStmtSyntax {
     let layout: [RawSyntax?] = [
-      garbageBeforeLabelName?.raw,
-      labelName?.raw,
-      garbageBetweenLabelNameAndLabelColon?.raw,
-      labelColon?.raw,
-      garbageBetweenLabelColonAndDoKeyword?.raw,
+      garbageBeforeDoKeyword?.raw,
       doKeyword.raw,
       garbageBetweenDoKeywordAndBody?.raw,
       body.raw,
@@ -4585,10 +4576,6 @@ public enum SyntaxFactory {
   public static func makeBlankDoStmt(presence: SourcePresence = .present) -> DoStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .doStmt,
       layout: [
-      nil,
-      nil,
-      nil,
-      nil,
       nil,
       RawSyntax.missingToken(TokenKind.doKeyword),
       nil,
@@ -4948,13 +4935,9 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return ThrowStmtSyntax(data)
   }
-  public static func makeIfStmt(_ garbageBeforeLabelName: GarbageNodesSyntax? = nil, labelName: TokenSyntax?, _ garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? = nil, labelColon: TokenSyntax?, _ garbageBetweenLabelColonAndIfKeyword: GarbageNodesSyntax? = nil, ifKeyword: TokenSyntax, _ garbageBetweenIfKeywordAndConditions: GarbageNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ garbageBetweenConditionsAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax, _ garbageBetweenBodyAndElseKeyword: GarbageNodesSyntax? = nil, elseKeyword: TokenSyntax?, _ garbageBetweenElseKeywordAndElseBody: GarbageNodesSyntax? = nil, elseBody: Syntax?) -> IfStmtSyntax {
+  public static func makeIfStmt(_ garbageBeforeIfKeyword: GarbageNodesSyntax? = nil, ifKeyword: TokenSyntax, _ garbageBetweenIfKeywordAndConditions: GarbageNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ garbageBetweenConditionsAndBody: GarbageNodesSyntax? = nil, body: CodeBlockSyntax, _ garbageBetweenBodyAndElseKeyword: GarbageNodesSyntax? = nil, elseKeyword: TokenSyntax?, _ garbageBetweenElseKeywordAndElseBody: GarbageNodesSyntax? = nil, elseBody: Syntax?) -> IfStmtSyntax {
     let layout: [RawSyntax?] = [
-      garbageBeforeLabelName?.raw,
-      labelName?.raw,
-      garbageBetweenLabelNameAndLabelColon?.raw,
-      labelColon?.raw,
-      garbageBetweenLabelColonAndIfKeyword?.raw,
+      garbageBeforeIfKeyword?.raw,
       ifKeyword.raw,
       garbageBetweenIfKeywordAndConditions?.raw,
       conditions.raw,
@@ -4974,10 +4957,6 @@ public enum SyntaxFactory {
   public static func makeBlankIfStmt(presence: SourcePresence = .present) -> IfStmtSyntax {
     let data = SyntaxData.forRoot(RawSyntax.create(kind: .ifStmt,
       layout: [
-      nil,
-      nil,
-      nil,
-      nil,
       nil,
       RawSyntax.missingToken(TokenKind.ifKeyword),
       nil,

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
@@ -187,6 +187,7 @@ internal enum SyntaxKind: CSyntaxKind {
   case backDeployAttributeSpecList = 257
   case backDeployVersionList = 258
   case backDeployVersionArgument = 259
+  case labeledStmt = 267
   case continueStmt = 72
   case whileStmt = 73
   case deferStmt = 74

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -1220,6 +1220,13 @@ open class SyntaxRewriter {
     return Syntax(visitChildren(node))
   }
 
+  /// Visit a `LabeledStmtSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: LabeledStmtSyntax) -> StmtSyntax {
+    return StmtSyntax(visitChildren(node))
+  }
+
   /// Visit a `ContinueStmtSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -3624,6 +3631,16 @@ open class SyntaxRewriter {
   }
 
   /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplLabeledStmtSyntax(_ data: SyntaxData) -> Syntax {
+      let node = LabeledStmtSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return Syntax(visit(node))
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplContinueStmtSyntax(_ data: SyntaxData) -> Syntax {
       let node = ContinueStmtSyntax(data)
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
@@ -4877,6 +4894,8 @@ open class SyntaxRewriter {
       return visitImplBackDeployVersionListSyntax
     case .backDeployVersionArgument:
       return visitImplBackDeployVersionArgumentSyntax
+    case .labeledStmt:
+      return visitImplLabeledStmtSyntax
     case .continueStmt:
       return visitImplContinueStmtSyntax
     case .whileStmt:
@@ -5406,6 +5425,8 @@ open class SyntaxRewriter {
       return visitImplBackDeployVersionListSyntax(data)
     case .backDeployVersionArgument:
       return visitImplBackDeployVersionArgumentSyntax(data)
+    case .labeledStmt:
+      return visitImplLabeledStmtSyntax(data)
     case .continueStmt:
       return visitImplContinueStmtSyntax(data)
     case .whileStmt:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxTraits.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxTraits.swift
@@ -158,31 +158,6 @@ public extension SyntaxProtocol {
   }
 }
 
-// MARK: - LabeledSyntax
-
-public protocol LabeledSyntax: SyntaxProtocol {
-  var labelName: TokenSyntax? { get }
-  func withLabelName(_ newChild: TokenSyntax?) -> Self
-  var labelColon: TokenSyntax? { get }
-  func withLabelColon(_ newChild: TokenSyntax?) -> Self
-}
-
-public extension SyntaxProtocol {
-  /// Check whether the non-type erased version of this syntax node conforms to 
-  /// `LabeledSyntax`. 
-  /// Note that this will incur an existential conversion.
-  func isProtocol(_: LabeledSyntax.Protocol) -> Bool {
-    return self.asProtocol(LabeledSyntax.self) != nil
-  }
-
-  /// Return the non-type erased version of this syntax node if it conforms to 
-  /// `LabeledSyntax`. Otherwise return `nil`.
-  /// Note that this will incur an existential conversion.
-  func asProtocol(_: LabeledSyntax.Protocol) -> LabeledSyntax? {
-    return Syntax(self).asProtocol(SyntaxProtocol.self) as? LabeledSyntax
-  }
-}
-
 // MARK: - WithStatementsSyntax
 
 public protocol WithStatementsSyntax: SyntaxProtocol {
@@ -247,15 +222,15 @@ extension PrecedenceGroupDeclSyntax: IdentifiedDeclSyntax {}
 extension LabeledSpecializeEntrySyntax: WithTrailingCommaSyntax {}
 extension TargetFunctionEntrySyntax: WithTrailingCommaSyntax {}
 extension DifferentiabilityParamSyntax: WithTrailingCommaSyntax {}
-extension WhileStmtSyntax: WithCodeBlockSyntax, LabeledSyntax {}
+extension WhileStmtSyntax: WithCodeBlockSyntax {}
 extension DeferStmtSyntax: WithCodeBlockSyntax {}
-extension RepeatWhileStmtSyntax: WithCodeBlockSyntax, LabeledSyntax {}
+extension RepeatWhileStmtSyntax: WithCodeBlockSyntax {}
 extension GuardStmtSyntax: WithCodeBlockSyntax {}
-extension ForInStmtSyntax: WithCodeBlockSyntax, LabeledSyntax {}
-extension SwitchStmtSyntax: BracedSyntax, LabeledSyntax {}
-extension DoStmtSyntax: WithCodeBlockSyntax, LabeledSyntax {}
+extension ForInStmtSyntax: WithCodeBlockSyntax {}
+extension SwitchStmtSyntax: BracedSyntax {}
+extension DoStmtSyntax: WithCodeBlockSyntax {}
 extension ConditionElementSyntax: WithTrailingCommaSyntax {}
-extension IfStmtSyntax: WithCodeBlockSyntax, LabeledSyntax {}
+extension IfStmtSyntax: WithCodeBlockSyntax {}
 extension ElseBlockSyntax: WithCodeBlockSyntax {}
 extension SwitchCaseSyntax: WithStatementsSyntax {}
 extension CaseItemSyntax: WithTrailingCommaSyntax {}
@@ -269,4 +244,4 @@ extension TupleTypeSyntax: ParenthesizedSyntax {}
 extension FunctionTypeSyntax: ParenthesizedSyntax {}
 extension GenericArgumentSyntax: WithTrailingCommaSyntax {}
 extension TuplePatternSyntax: ParenthesizedSyntax {}
-extension TuplePatternElementSyntax: WithTrailingCommaSyntax, LabeledSyntax {}
+extension TuplePatternElementSyntax: WithTrailingCommaSyntax {}

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -1751,6 +1751,16 @@ open class SyntaxVisitor {
   /// The function called after visiting `BackDeployVersionArgumentSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: BackDeployVersionArgumentSyntax) {}
+  /// Visiting `LabeledStmtSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: LabeledStmtSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `LabeledStmtSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: LabeledStmtSyntax) {}
   /// Visiting `ContinueStmtSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -4571,6 +4581,17 @@ open class SyntaxVisitor {
   }
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplLabeledStmtSyntax(_ data: SyntaxData) {
+      let node = LabeledStmtSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && node.raw.numberOfChildren > 0 {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplContinueStmtSyntax(_ data: SyntaxData) {
       let node = ContinueStmtSyntax(data)
       let needsChildren = (visit(node) == .visitChildren)
@@ -5878,6 +5899,8 @@ open class SyntaxVisitor {
       visitImplBackDeployVersionListSyntax(data)
     case .backDeployVersionArgument:
       visitImplBackDeployVersionArgumentSyntax(data)
+    case .labeledStmt:
+      visitImplLabeledStmtSyntax(data)
     case .continueStmt:
       visitImplContinueStmtSyntax(data)
     case .whileStmt:

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -91,6 +91,239 @@ extension MissingStmtSyntax: CustomReflectable {
   }
 }
 
+// MARK: - LabeledStmtSyntax
+
+public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
+  enum Cursor: Int {
+    case garbageBeforeLabelName
+    case labelName
+    case garbageBetweenLabelNameAndLabelColon
+    case labelColon
+    case garbageBetweenLabelColonAndStatement
+    case statement
+  }
+
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `LabeledStmtSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .labeledStmt else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `LabeledStmtSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .labeledStmt)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public var syntaxNodeType: SyntaxProtocol.Type {
+    return Swift.type(of: self)
+  }
+
+  public var garbageBeforeLabelName: GarbageNodesSyntax? {
+    get {
+      let childData = data.child(at: Cursor.garbageBeforeLabelName,
+                                 parent: Syntax(self))
+      if childData == nil { return nil }
+      return GarbageNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withGarbageBeforeLabelName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `garbageBeforeLabelName` replaced.
+  /// - param newChild: The new `garbageBeforeLabelName` to replace the node's
+  ///                   current `garbageBeforeLabelName`, if present.
+  public func withGarbageBeforeLabelName(
+    _ newChild: GarbageNodesSyntax?) -> LabeledStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: Cursor.garbageBeforeLabelName)
+    return LabeledStmtSyntax(newData)
+  }
+
+  public var labelName: TokenSyntax {
+    get {
+      let childData = data.child(at: Cursor.labelName,
+                                 parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withLabelName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `labelName` replaced.
+  /// - param newChild: The new `labelName` to replace the node's
+  ///                   current `labelName`, if present.
+  public func withLabelName(
+    _ newChild: TokenSyntax?) -> LabeledStmtSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.identifier(""))
+    let newData = data.replacingChild(raw, at: Cursor.labelName)
+    return LabeledStmtSyntax(newData)
+  }
+
+  public var garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? {
+    get {
+      let childData = data.child(at: Cursor.garbageBetweenLabelNameAndLabelColon,
+                                 parent: Syntax(self))
+      if childData == nil { return nil }
+      return GarbageNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withGarbageBetweenLabelNameAndLabelColon(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `garbageBetweenLabelNameAndLabelColon` replaced.
+  /// - param newChild: The new `garbageBetweenLabelNameAndLabelColon` to replace the node's
+  ///                   current `garbageBetweenLabelNameAndLabelColon`, if present.
+  public func withGarbageBetweenLabelNameAndLabelColon(
+    _ newChild: GarbageNodesSyntax?) -> LabeledStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: Cursor.garbageBetweenLabelNameAndLabelColon)
+    return LabeledStmtSyntax(newData)
+  }
+
+  public var labelColon: TokenSyntax {
+    get {
+      let childData = data.child(at: Cursor.labelColon,
+                                 parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withLabelColon(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `labelColon` replaced.
+  /// - param newChild: The new `labelColon` to replace the node's
+  ///                   current `labelColon`, if present.
+  public func withLabelColon(
+    _ newChild: TokenSyntax?) -> LabeledStmtSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missingToken(TokenKind.colon)
+    let newData = data.replacingChild(raw, at: Cursor.labelColon)
+    return LabeledStmtSyntax(newData)
+  }
+
+  public var garbageBetweenLabelColonAndStatement: GarbageNodesSyntax? {
+    get {
+      let childData = data.child(at: Cursor.garbageBetweenLabelColonAndStatement,
+                                 parent: Syntax(self))
+      if childData == nil { return nil }
+      return GarbageNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withGarbageBetweenLabelColonAndStatement(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `garbageBetweenLabelColonAndStatement` replaced.
+  /// - param newChild: The new `garbageBetweenLabelColonAndStatement` to replace the node's
+  ///                   current `garbageBetweenLabelColonAndStatement`, if present.
+  public func withGarbageBetweenLabelColonAndStatement(
+    _ newChild: GarbageNodesSyntax?) -> LabeledStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: Cursor.garbageBetweenLabelColonAndStatement)
+    return LabeledStmtSyntax(newData)
+  }
+
+  public var statement: StmtSyntax {
+    get {
+      let childData = data.child(at: Cursor.statement,
+                                 parent: Syntax(self))
+      return StmtSyntax(childData!)
+    }
+    set(value) {
+      self = withStatement(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `statement` replaced.
+  /// - param newChild: The new `statement` to replace the node's
+  ///                   current `statement`, if present.
+  public func withStatement(
+    _ newChild: StmtSyntax?) -> LabeledStmtSyntax {
+    let raw = newChild?.raw ?? RawSyntax.missing(SyntaxKind.missingStmt)
+    let newData = data.replacingChild(raw, at: Cursor.statement)
+    return LabeledStmtSyntax(newData)
+  }
+
+
+  public func _validateLayout() {
+    let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
+    assert(rawChildren.count == 6)
+    // Check child #0 child is GarbageNodesSyntax or missing
+    if let raw = rawChildren[0].raw {
+      let info = rawChildren[0].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(GarbageNodesSyntax.self))
+    }
+    // Check child #1 child is TokenSyntax 
+    assert(rawChildren[1].raw != nil)
+    if let raw = rawChildren[1].raw {
+      let info = rawChildren[1].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(TokenSyntax.self))
+    }
+    // Check child #2 child is GarbageNodesSyntax or missing
+    if let raw = rawChildren[2].raw {
+      let info = rawChildren[2].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(GarbageNodesSyntax.self))
+    }
+    // Check child #3 child is TokenSyntax 
+    assert(rawChildren[3].raw != nil)
+    if let raw = rawChildren[3].raw {
+      let info = rawChildren[3].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(TokenSyntax.self))
+    }
+    // Check child #4 child is GarbageNodesSyntax or missing
+    if let raw = rawChildren[4].raw {
+      let info = rawChildren[4].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(GarbageNodesSyntax.self))
+    }
+    // Check child #5 child is StmtSyntax 
+    assert(rawChildren[5].raw != nil)
+    if let raw = rawChildren[5].raw {
+      let info = rawChildren[5].syntaxInfo
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
+      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
+      let syntaxChild = Syntax(syntaxData)
+      assert(syntaxChild.is(StmtSyntax.self))
+    }
+  }
+}
+
+extension LabeledStmtSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "garbageBeforeLabelName": garbageBeforeLabelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "labelName": Syntax(labelName).asProtocol(SyntaxProtocol.self),
+      "garbageBetweenLabelNameAndLabelColon": garbageBetweenLabelNameAndLabelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "labelColon": Syntax(labelColon).asProtocol(SyntaxProtocol.self),
+      "garbageBetweenLabelColonAndStatement": garbageBetweenLabelColonAndStatement.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "statement": Syntax(statement).asProtocol(SyntaxProtocol.self),
+    ])
+  }
+}
+
 // MARK: - ContinueStmtSyntax
 
 public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
@@ -264,11 +497,7 @@ extension ContinueStmtSyntax: CustomReflectable {
 
 public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
-    case garbageBeforeLabelName
-    case labelName
-    case garbageBetweenLabelNameAndLabelColon
-    case labelColon
-    case garbageBetweenLabelColonAndWhileKeyword
+    case garbageBeforeWhileKeyword
     case whileKeyword
     case garbageBetweenWhileKeywordAndConditions
     case conditions
@@ -297,113 +526,25 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return Swift.type(of: self)
   }
 
-  public var garbageBeforeLabelName: GarbageNodesSyntax? {
+  public var garbageBeforeWhileKeyword: GarbageNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.garbageBeforeLabelName,
+      let childData = data.child(at: Cursor.garbageBeforeWhileKeyword,
                                  parent: Syntax(self))
       if childData == nil { return nil }
       return GarbageNodesSyntax(childData!)
     }
     set(value) {
-      self = withGarbageBeforeLabelName(value)
+      self = withGarbageBeforeWhileKeyword(value)
     }
   }
 
-  /// Returns a copy of the receiver with its `garbageBeforeLabelName` replaced.
-  /// - param newChild: The new `garbageBeforeLabelName` to replace the node's
-  ///                   current `garbageBeforeLabelName`, if present.
-  public func withGarbageBeforeLabelName(
+  /// Returns a copy of the receiver with its `garbageBeforeWhileKeyword` replaced.
+  /// - param newChild: The new `garbageBeforeWhileKeyword` to replace the node's
+  ///                   current `garbageBeforeWhileKeyword`, if present.
+  public func withGarbageBeforeWhileKeyword(
     _ newChild: GarbageNodesSyntax?) -> WhileStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBeforeLabelName)
-    return WhileStmtSyntax(newData)
-  }
-
-  public var labelName: TokenSyntax? {
-    get {
-      let childData = data.child(at: Cursor.labelName,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withLabelName(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `labelName` replaced.
-  /// - param newChild: The new `labelName` to replace the node's
-  ///                   current `labelName`, if present.
-  public func withLabelName(
-    _ newChild: TokenSyntax?) -> WhileStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.labelName)
-    return WhileStmtSyntax(newData)
-  }
-
-  public var garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? {
-    get {
-      let childData = data.child(at: Cursor.garbageBetweenLabelNameAndLabelColon,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return GarbageNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withGarbageBetweenLabelNameAndLabelColon(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `garbageBetweenLabelNameAndLabelColon` replaced.
-  /// - param newChild: The new `garbageBetweenLabelNameAndLabelColon` to replace the node's
-  ///                   current `garbageBetweenLabelNameAndLabelColon`, if present.
-  public func withGarbageBetweenLabelNameAndLabelColon(
-    _ newChild: GarbageNodesSyntax?) -> WhileStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBetweenLabelNameAndLabelColon)
-    return WhileStmtSyntax(newData)
-  }
-
-  public var labelColon: TokenSyntax? {
-    get {
-      let childData = data.child(at: Cursor.labelColon,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withLabelColon(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `labelColon` replaced.
-  /// - param newChild: The new `labelColon` to replace the node's
-  ///                   current `labelColon`, if present.
-  public func withLabelColon(
-    _ newChild: TokenSyntax?) -> WhileStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.labelColon)
-    return WhileStmtSyntax(newData)
-  }
-
-  public var garbageBetweenLabelColonAndWhileKeyword: GarbageNodesSyntax? {
-    get {
-      let childData = data.child(at: Cursor.garbageBetweenLabelColonAndWhileKeyword,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return GarbageNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withGarbageBetweenLabelColonAndWhileKeyword(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `garbageBetweenLabelColonAndWhileKeyword` replaced.
-  /// - param newChild: The new `garbageBetweenLabelColonAndWhileKeyword` to replace the node's
-  ///                   current `garbageBetweenLabelColonAndWhileKeyword`, if present.
-  public func withGarbageBetweenLabelColonAndWhileKeyword(
-    _ newChild: GarbageNodesSyntax?) -> WhileStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBetweenLabelColonAndWhileKeyword)
+    let newData = data.replacingChild(raw, at: Cursor.garbageBeforeWhileKeyword)
     return WhileStmtSyntax(newData)
   }
 
@@ -536,7 +677,7 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public func _validateLayout() {
     let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
-    assert(rawChildren.count == 10)
+    assert(rawChildren.count == 6)
     // Check child #0 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[0].raw {
       let info = rawChildren[0].syntaxInfo
@@ -545,7 +686,8 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #1 child is TokenSyntax or missing
+    // Check child #1 child is TokenSyntax 
+    assert(rawChildren[1].raw != nil)
     if let raw = rawChildren[1].raw {
       let info = rawChildren[1].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
@@ -561,13 +703,14 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #3 child is TokenSyntax or missing
+    // Check child #3 child is ConditionElementListSyntax 
+    assert(rawChildren[3].raw != nil)
     if let raw = rawChildren[3].raw {
       let info = rawChildren[3].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TokenSyntax.self))
+      assert(syntaxChild.is(ConditionElementListSyntax.self))
     }
     // Check child #4 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[4].raw {
@@ -577,44 +720,10 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #5 child is TokenSyntax 
+    // Check child #5 child is CodeBlockSyntax 
     assert(rawChildren[5].raw != nil)
     if let raw = rawChildren[5].raw {
       let info = rawChildren[5].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TokenSyntax.self))
-    }
-    // Check child #6 child is GarbageNodesSyntax or missing
-    if let raw = rawChildren[6].raw {
-      let info = rawChildren[6].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(GarbageNodesSyntax.self))
-    }
-    // Check child #7 child is ConditionElementListSyntax 
-    assert(rawChildren[7].raw != nil)
-    if let raw = rawChildren[7].raw {
-      let info = rawChildren[7].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(ConditionElementListSyntax.self))
-    }
-    // Check child #8 child is GarbageNodesSyntax or missing
-    if let raw = rawChildren[8].raw {
-      let info = rawChildren[8].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(GarbageNodesSyntax.self))
-    }
-    // Check child #9 child is CodeBlockSyntax 
-    assert(rawChildren[9].raw != nil)
-    if let raw = rawChildren[9].raw {
-      let info = rawChildren[9].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
@@ -626,11 +735,7 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension WhileStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "garbageBeforeLabelName": garbageBeforeLabelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "labelName": labelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "garbageBetweenLabelNameAndLabelColon": garbageBetweenLabelNameAndLabelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "labelColon": labelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "garbageBetweenLabelColonAndWhileKeyword": garbageBetweenLabelColonAndWhileKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "garbageBeforeWhileKeyword": garbageBeforeWhileKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "whileKeyword": Syntax(whileKeyword).asProtocol(SyntaxProtocol.self),
       "garbageBetweenWhileKeywordAndConditions": garbageBetweenWhileKeywordAndConditions.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "conditions": Syntax(conditions).asProtocol(SyntaxProtocol.self),
@@ -918,11 +1023,7 @@ extension ExpressionStmtSyntax: CustomReflectable {
 
 public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
-    case garbageBeforeLabelName
-    case labelName
-    case garbageBetweenLabelNameAndLabelColon
-    case labelColon
-    case garbageBetweenLabelColonAndRepeatKeyword
+    case garbageBeforeRepeatKeyword
     case repeatKeyword
     case garbageBetweenRepeatKeywordAndBody
     case body
@@ -953,113 +1054,25 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return Swift.type(of: self)
   }
 
-  public var garbageBeforeLabelName: GarbageNodesSyntax? {
+  public var garbageBeforeRepeatKeyword: GarbageNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.garbageBeforeLabelName,
+      let childData = data.child(at: Cursor.garbageBeforeRepeatKeyword,
                                  parent: Syntax(self))
       if childData == nil { return nil }
       return GarbageNodesSyntax(childData!)
     }
     set(value) {
-      self = withGarbageBeforeLabelName(value)
+      self = withGarbageBeforeRepeatKeyword(value)
     }
   }
 
-  /// Returns a copy of the receiver with its `garbageBeforeLabelName` replaced.
-  /// - param newChild: The new `garbageBeforeLabelName` to replace the node's
-  ///                   current `garbageBeforeLabelName`, if present.
-  public func withGarbageBeforeLabelName(
+  /// Returns a copy of the receiver with its `garbageBeforeRepeatKeyword` replaced.
+  /// - param newChild: The new `garbageBeforeRepeatKeyword` to replace the node's
+  ///                   current `garbageBeforeRepeatKeyword`, if present.
+  public func withGarbageBeforeRepeatKeyword(
     _ newChild: GarbageNodesSyntax?) -> RepeatWhileStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBeforeLabelName)
-    return RepeatWhileStmtSyntax(newData)
-  }
-
-  public var labelName: TokenSyntax? {
-    get {
-      let childData = data.child(at: Cursor.labelName,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withLabelName(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `labelName` replaced.
-  /// - param newChild: The new `labelName` to replace the node's
-  ///                   current `labelName`, if present.
-  public func withLabelName(
-    _ newChild: TokenSyntax?) -> RepeatWhileStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.labelName)
-    return RepeatWhileStmtSyntax(newData)
-  }
-
-  public var garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? {
-    get {
-      let childData = data.child(at: Cursor.garbageBetweenLabelNameAndLabelColon,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return GarbageNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withGarbageBetweenLabelNameAndLabelColon(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `garbageBetweenLabelNameAndLabelColon` replaced.
-  /// - param newChild: The new `garbageBetweenLabelNameAndLabelColon` to replace the node's
-  ///                   current `garbageBetweenLabelNameAndLabelColon`, if present.
-  public func withGarbageBetweenLabelNameAndLabelColon(
-    _ newChild: GarbageNodesSyntax?) -> RepeatWhileStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBetweenLabelNameAndLabelColon)
-    return RepeatWhileStmtSyntax(newData)
-  }
-
-  public var labelColon: TokenSyntax? {
-    get {
-      let childData = data.child(at: Cursor.labelColon,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withLabelColon(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `labelColon` replaced.
-  /// - param newChild: The new `labelColon` to replace the node's
-  ///                   current `labelColon`, if present.
-  public func withLabelColon(
-    _ newChild: TokenSyntax?) -> RepeatWhileStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.labelColon)
-    return RepeatWhileStmtSyntax(newData)
-  }
-
-  public var garbageBetweenLabelColonAndRepeatKeyword: GarbageNodesSyntax? {
-    get {
-      let childData = data.child(at: Cursor.garbageBetweenLabelColonAndRepeatKeyword,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return GarbageNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withGarbageBetweenLabelColonAndRepeatKeyword(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `garbageBetweenLabelColonAndRepeatKeyword` replaced.
-  /// - param newChild: The new `garbageBetweenLabelColonAndRepeatKeyword` to replace the node's
-  ///                   current `garbageBetweenLabelColonAndRepeatKeyword`, if present.
-  public func withGarbageBetweenLabelColonAndRepeatKeyword(
-    _ newChild: GarbageNodesSyntax?) -> RepeatWhileStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBetweenLabelColonAndRepeatKeyword)
+    let newData = data.replacingChild(raw, at: Cursor.garbageBeforeRepeatKeyword)
     return RepeatWhileStmtSyntax(newData)
   }
 
@@ -1216,7 +1229,7 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public func _validateLayout() {
     let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
-    assert(rawChildren.count == 12)
+    assert(rawChildren.count == 8)
     // Check child #0 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[0].raw {
       let info = rawChildren[0].syntaxInfo
@@ -1225,7 +1238,8 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #1 child is TokenSyntax or missing
+    // Check child #1 child is TokenSyntax 
+    assert(rawChildren[1].raw != nil)
     if let raw = rawChildren[1].raw {
       let info = rawChildren[1].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
@@ -1241,13 +1255,14 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #3 child is TokenSyntax or missing
+    // Check child #3 child is CodeBlockSyntax 
+    assert(rawChildren[3].raw != nil)
     if let raw = rawChildren[3].raw {
       let info = rawChildren[3].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TokenSyntax.self))
+      assert(syntaxChild.is(CodeBlockSyntax.self))
     }
     // Check child #4 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[4].raw {
@@ -1274,44 +1289,10 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #7 child is CodeBlockSyntax 
+    // Check child #7 child is ExprSyntax 
     assert(rawChildren[7].raw != nil)
     if let raw = rawChildren[7].raw {
       let info = rawChildren[7].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(CodeBlockSyntax.self))
-    }
-    // Check child #8 child is GarbageNodesSyntax or missing
-    if let raw = rawChildren[8].raw {
-      let info = rawChildren[8].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(GarbageNodesSyntax.self))
-    }
-    // Check child #9 child is TokenSyntax 
-    assert(rawChildren[9].raw != nil)
-    if let raw = rawChildren[9].raw {
-      let info = rawChildren[9].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TokenSyntax.self))
-    }
-    // Check child #10 child is GarbageNodesSyntax or missing
-    if let raw = rawChildren[10].raw {
-      let info = rawChildren[10].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(GarbageNodesSyntax.self))
-    }
-    // Check child #11 child is ExprSyntax 
-    assert(rawChildren[11].raw != nil)
-    if let raw = rawChildren[11].raw {
-      let info = rawChildren[11].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
@@ -1323,11 +1304,7 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension RepeatWhileStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "garbageBeforeLabelName": garbageBeforeLabelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "labelName": labelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "garbageBetweenLabelNameAndLabelColon": garbageBetweenLabelNameAndLabelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "labelColon": labelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "garbageBetweenLabelColonAndRepeatKeyword": garbageBetweenLabelColonAndRepeatKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "garbageBeforeRepeatKeyword": garbageBeforeRepeatKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "repeatKeyword": Syntax(repeatKeyword).asProtocol(SyntaxProtocol.self),
       "garbageBetweenRepeatKeywordAndBody": garbageBetweenRepeatKeywordAndBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "body": Syntax(body).asProtocol(SyntaxProtocol.self),
@@ -1659,11 +1636,7 @@ extension GuardStmtSyntax: CustomReflectable {
 
 public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
-    case garbageBeforeLabelName
-    case labelName
-    case garbageBetweenLabelNameAndLabelColon
-    case labelColon
-    case garbageBetweenLabelColonAndForKeyword
+    case garbageBeforeForKeyword
     case forKeyword
     case garbageBetweenForKeywordAndTryKeyword
     case tryKeyword
@@ -1706,113 +1679,25 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return Swift.type(of: self)
   }
 
-  public var garbageBeforeLabelName: GarbageNodesSyntax? {
+  public var garbageBeforeForKeyword: GarbageNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.garbageBeforeLabelName,
+      let childData = data.child(at: Cursor.garbageBeforeForKeyword,
                                  parent: Syntax(self))
       if childData == nil { return nil }
       return GarbageNodesSyntax(childData!)
     }
     set(value) {
-      self = withGarbageBeforeLabelName(value)
+      self = withGarbageBeforeForKeyword(value)
     }
   }
 
-  /// Returns a copy of the receiver with its `garbageBeforeLabelName` replaced.
-  /// - param newChild: The new `garbageBeforeLabelName` to replace the node's
-  ///                   current `garbageBeforeLabelName`, if present.
-  public func withGarbageBeforeLabelName(
+  /// Returns a copy of the receiver with its `garbageBeforeForKeyword` replaced.
+  /// - param newChild: The new `garbageBeforeForKeyword` to replace the node's
+  ///                   current `garbageBeforeForKeyword`, if present.
+  public func withGarbageBeforeForKeyword(
     _ newChild: GarbageNodesSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBeforeLabelName)
-    return ForInStmtSyntax(newData)
-  }
-
-  public var labelName: TokenSyntax? {
-    get {
-      let childData = data.child(at: Cursor.labelName,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withLabelName(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `labelName` replaced.
-  /// - param newChild: The new `labelName` to replace the node's
-  ///                   current `labelName`, if present.
-  public func withLabelName(
-    _ newChild: TokenSyntax?) -> ForInStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.labelName)
-    return ForInStmtSyntax(newData)
-  }
-
-  public var garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? {
-    get {
-      let childData = data.child(at: Cursor.garbageBetweenLabelNameAndLabelColon,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return GarbageNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withGarbageBetweenLabelNameAndLabelColon(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `garbageBetweenLabelNameAndLabelColon` replaced.
-  /// - param newChild: The new `garbageBetweenLabelNameAndLabelColon` to replace the node's
-  ///                   current `garbageBetweenLabelNameAndLabelColon`, if present.
-  public func withGarbageBetweenLabelNameAndLabelColon(
-    _ newChild: GarbageNodesSyntax?) -> ForInStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBetweenLabelNameAndLabelColon)
-    return ForInStmtSyntax(newData)
-  }
-
-  public var labelColon: TokenSyntax? {
-    get {
-      let childData = data.child(at: Cursor.labelColon,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withLabelColon(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `labelColon` replaced.
-  /// - param newChild: The new `labelColon` to replace the node's
-  ///                   current `labelColon`, if present.
-  public func withLabelColon(
-    _ newChild: TokenSyntax?) -> ForInStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.labelColon)
-    return ForInStmtSyntax(newData)
-  }
-
-  public var garbageBetweenLabelColonAndForKeyword: GarbageNodesSyntax? {
-    get {
-      let childData = data.child(at: Cursor.garbageBetweenLabelColonAndForKeyword,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return GarbageNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withGarbageBetweenLabelColonAndForKeyword(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `garbageBetweenLabelColonAndForKeyword` replaced.
-  /// - param newChild: The new `garbageBetweenLabelColonAndForKeyword` to replace the node's
-  ///                   current `garbageBetweenLabelColonAndForKeyword`, if present.
-  public func withGarbageBetweenLabelColonAndForKeyword(
-    _ newChild: GarbageNodesSyntax?) -> ForInStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBetweenLabelColonAndForKeyword)
+    let newData = data.replacingChild(raw, at: Cursor.garbageBeforeForKeyword)
     return ForInStmtSyntax(newData)
   }
 
@@ -2232,7 +2117,7 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public func _validateLayout() {
     let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
-    assert(rawChildren.count == 24)
+    assert(rawChildren.count == 20)
     // Check child #0 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[0].raw {
       let info = rawChildren[0].syntaxInfo
@@ -2241,7 +2126,8 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #1 child is TokenSyntax or missing
+    // Check child #1 child is TokenSyntax 
+    assert(rawChildren[1].raw != nil)
     if let raw = rawChildren[1].raw {
       let info = rawChildren[1].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
@@ -2273,8 +2159,7 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #5 child is TokenSyntax 
-    assert(rawChildren[5].raw != nil)
+    // Check child #5 child is TokenSyntax or missing
     if let raw = rawChildren[5].raw {
       let info = rawChildren[5].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
@@ -2306,13 +2191,14 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #9 child is TokenSyntax or missing
+    // Check child #9 child is PatternSyntax 
+    assert(rawChildren[9].raw != nil)
     if let raw = rawChildren[9].raw {
       let info = rawChildren[9].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TokenSyntax.self))
+      assert(syntaxChild.is(PatternSyntax.self))
     }
     // Check child #10 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[10].raw {
@@ -2322,13 +2208,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #11 child is TokenSyntax or missing
+    // Check child #11 child is TypeAnnotationSyntax or missing
     if let raw = rawChildren[11].raw {
       let info = rawChildren[11].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TokenSyntax.self))
+      assert(syntaxChild.is(TypeAnnotationSyntax.self))
     }
     // Check child #12 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[12].raw {
@@ -2338,14 +2224,14 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #13 child is PatternSyntax 
+    // Check child #13 child is TokenSyntax 
     assert(rawChildren[13].raw != nil)
     if let raw = rawChildren[13].raw {
       let info = rawChildren[13].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(PatternSyntax.self))
+      assert(syntaxChild.is(TokenSyntax.self))
     }
     // Check child #14 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[14].raw {
@@ -2355,13 +2241,14 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #15 child is TypeAnnotationSyntax or missing
+    // Check child #15 child is ExprSyntax 
+    assert(rawChildren[15].raw != nil)
     if let raw = rawChildren[15].raw {
       let info = rawChildren[15].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TypeAnnotationSyntax.self))
+      assert(syntaxChild.is(ExprSyntax.self))
     }
     // Check child #16 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[16].raw {
@@ -2371,14 +2258,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #17 child is TokenSyntax 
-    assert(rawChildren[17].raw != nil)
+    // Check child #17 child is WhereClauseSyntax or missing
     if let raw = rawChildren[17].raw {
       let info = rawChildren[17].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TokenSyntax.self))
+      assert(syntaxChild.is(WhereClauseSyntax.self))
     }
     // Check child #18 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[18].raw {
@@ -2388,43 +2274,10 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #19 child is ExprSyntax 
+    // Check child #19 child is CodeBlockSyntax 
     assert(rawChildren[19].raw != nil)
     if let raw = rawChildren[19].raw {
       let info = rawChildren[19].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(ExprSyntax.self))
-    }
-    // Check child #20 child is GarbageNodesSyntax or missing
-    if let raw = rawChildren[20].raw {
-      let info = rawChildren[20].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(GarbageNodesSyntax.self))
-    }
-    // Check child #21 child is WhereClauseSyntax or missing
-    if let raw = rawChildren[21].raw {
-      let info = rawChildren[21].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(WhereClauseSyntax.self))
-    }
-    // Check child #22 child is GarbageNodesSyntax or missing
-    if let raw = rawChildren[22].raw {
-      let info = rawChildren[22].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(GarbageNodesSyntax.self))
-    }
-    // Check child #23 child is CodeBlockSyntax 
-    assert(rawChildren[23].raw != nil)
-    if let raw = rawChildren[23].raw {
-      let info = rawChildren[23].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
@@ -2436,11 +2289,7 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension ForInStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "garbageBeforeLabelName": garbageBeforeLabelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "labelName": labelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "garbageBetweenLabelNameAndLabelColon": garbageBetweenLabelNameAndLabelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "labelColon": labelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "garbageBetweenLabelColonAndForKeyword": garbageBetweenLabelColonAndForKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "garbageBeforeForKeyword": garbageBeforeForKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "forKeyword": Syntax(forKeyword).asProtocol(SyntaxProtocol.self),
       "garbageBetweenForKeywordAndTryKeyword": garbageBetweenForKeywordAndTryKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "tryKeyword": tryKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
@@ -2468,11 +2317,7 @@ extension ForInStmtSyntax: CustomReflectable {
 
 public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
-    case garbageBeforeLabelName
-    case labelName
-    case garbageBetweenLabelNameAndLabelColon
-    case labelColon
-    case garbageBetweenLabelColonAndSwitchKeyword
+    case garbageBeforeSwitchKeyword
     case switchKeyword
     case garbageBetweenSwitchKeywordAndExpression
     case expression
@@ -2505,113 +2350,25 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return Swift.type(of: self)
   }
 
-  public var garbageBeforeLabelName: GarbageNodesSyntax? {
+  public var garbageBeforeSwitchKeyword: GarbageNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.garbageBeforeLabelName,
+      let childData = data.child(at: Cursor.garbageBeforeSwitchKeyword,
                                  parent: Syntax(self))
       if childData == nil { return nil }
       return GarbageNodesSyntax(childData!)
     }
     set(value) {
-      self = withGarbageBeforeLabelName(value)
+      self = withGarbageBeforeSwitchKeyword(value)
     }
   }
 
-  /// Returns a copy of the receiver with its `garbageBeforeLabelName` replaced.
-  /// - param newChild: The new `garbageBeforeLabelName` to replace the node's
-  ///                   current `garbageBeforeLabelName`, if present.
-  public func withGarbageBeforeLabelName(
+  /// Returns a copy of the receiver with its `garbageBeforeSwitchKeyword` replaced.
+  /// - param newChild: The new `garbageBeforeSwitchKeyword` to replace the node's
+  ///                   current `garbageBeforeSwitchKeyword`, if present.
+  public func withGarbageBeforeSwitchKeyword(
     _ newChild: GarbageNodesSyntax?) -> SwitchStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBeforeLabelName)
-    return SwitchStmtSyntax(newData)
-  }
-
-  public var labelName: TokenSyntax? {
-    get {
-      let childData = data.child(at: Cursor.labelName,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withLabelName(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `labelName` replaced.
-  /// - param newChild: The new `labelName` to replace the node's
-  ///                   current `labelName`, if present.
-  public func withLabelName(
-    _ newChild: TokenSyntax?) -> SwitchStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.labelName)
-    return SwitchStmtSyntax(newData)
-  }
-
-  public var garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? {
-    get {
-      let childData = data.child(at: Cursor.garbageBetweenLabelNameAndLabelColon,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return GarbageNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withGarbageBetweenLabelNameAndLabelColon(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `garbageBetweenLabelNameAndLabelColon` replaced.
-  /// - param newChild: The new `garbageBetweenLabelNameAndLabelColon` to replace the node's
-  ///                   current `garbageBetweenLabelNameAndLabelColon`, if present.
-  public func withGarbageBetweenLabelNameAndLabelColon(
-    _ newChild: GarbageNodesSyntax?) -> SwitchStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBetweenLabelNameAndLabelColon)
-    return SwitchStmtSyntax(newData)
-  }
-
-  public var labelColon: TokenSyntax? {
-    get {
-      let childData = data.child(at: Cursor.labelColon,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withLabelColon(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `labelColon` replaced.
-  /// - param newChild: The new `labelColon` to replace the node's
-  ///                   current `labelColon`, if present.
-  public func withLabelColon(
-    _ newChild: TokenSyntax?) -> SwitchStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.labelColon)
-    return SwitchStmtSyntax(newData)
-  }
-
-  public var garbageBetweenLabelColonAndSwitchKeyword: GarbageNodesSyntax? {
-    get {
-      let childData = data.child(at: Cursor.garbageBetweenLabelColonAndSwitchKeyword,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return GarbageNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withGarbageBetweenLabelColonAndSwitchKeyword(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `garbageBetweenLabelColonAndSwitchKeyword` replaced.
-  /// - param newChild: The new `garbageBetweenLabelColonAndSwitchKeyword` to replace the node's
-  ///                   current `garbageBetweenLabelColonAndSwitchKeyword`, if present.
-  public func withGarbageBetweenLabelColonAndSwitchKeyword(
-    _ newChild: GarbageNodesSyntax?) -> SwitchStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBetweenLabelColonAndSwitchKeyword)
+    let newData = data.replacingChild(raw, at: Cursor.garbageBeforeSwitchKeyword)
     return SwitchStmtSyntax(newData)
   }
 
@@ -2830,7 +2587,7 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public func _validateLayout() {
     let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
-    assert(rawChildren.count == 14)
+    assert(rawChildren.count == 10)
     // Check child #0 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[0].raw {
       let info = rawChildren[0].syntaxInfo
@@ -2839,7 +2596,8 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #1 child is TokenSyntax or missing
+    // Check child #1 child is TokenSyntax 
+    assert(rawChildren[1].raw != nil)
     if let raw = rawChildren[1].raw {
       let info = rawChildren[1].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
@@ -2855,13 +2613,14 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #3 child is TokenSyntax or missing
+    // Check child #3 child is ExprSyntax 
+    assert(rawChildren[3].raw != nil)
     if let raw = rawChildren[3].raw {
       let info = rawChildren[3].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TokenSyntax.self))
+      assert(syntaxChild.is(ExprSyntax.self))
     }
     // Check child #4 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[4].raw {
@@ -2888,14 +2647,14 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #7 child is ExprSyntax 
+    // Check child #7 child is SwitchCaseListSyntax 
     assert(rawChildren[7].raw != nil)
     if let raw = rawChildren[7].raw {
       let info = rawChildren[7].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(ExprSyntax.self))
+      assert(syntaxChild.is(SwitchCaseListSyntax.self))
     }
     // Check child #8 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[8].raw {
@@ -2914,51 +2673,13 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(TokenSyntax.self))
     }
-    // Check child #10 child is GarbageNodesSyntax or missing
-    if let raw = rawChildren[10].raw {
-      let info = rawChildren[10].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(GarbageNodesSyntax.self))
-    }
-    // Check child #11 child is SwitchCaseListSyntax 
-    assert(rawChildren[11].raw != nil)
-    if let raw = rawChildren[11].raw {
-      let info = rawChildren[11].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(SwitchCaseListSyntax.self))
-    }
-    // Check child #12 child is GarbageNodesSyntax or missing
-    if let raw = rawChildren[12].raw {
-      let info = rawChildren[12].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(GarbageNodesSyntax.self))
-    }
-    // Check child #13 child is TokenSyntax 
-    assert(rawChildren[13].raw != nil)
-    if let raw = rawChildren[13].raw {
-      let info = rawChildren[13].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TokenSyntax.self))
-    }
   }
 }
 
 extension SwitchStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "garbageBeforeLabelName": garbageBeforeLabelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "labelName": labelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "garbageBetweenLabelNameAndLabelColon": garbageBetweenLabelNameAndLabelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "labelColon": labelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "garbageBetweenLabelColonAndSwitchKeyword": garbageBetweenLabelColonAndSwitchKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "garbageBeforeSwitchKeyword": garbageBeforeSwitchKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "switchKeyword": Syntax(switchKeyword).asProtocol(SyntaxProtocol.self),
       "garbageBetweenSwitchKeywordAndExpression": garbageBetweenSwitchKeywordAndExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
@@ -2976,11 +2697,7 @@ extension SwitchStmtSyntax: CustomReflectable {
 
 public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
-    case garbageBeforeLabelName
-    case labelName
-    case garbageBetweenLabelNameAndLabelColon
-    case labelColon
-    case garbageBetweenLabelColonAndDoKeyword
+    case garbageBeforeDoKeyword
     case doKeyword
     case garbageBetweenDoKeywordAndBody
     case body
@@ -3009,113 +2726,25 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return Swift.type(of: self)
   }
 
-  public var garbageBeforeLabelName: GarbageNodesSyntax? {
+  public var garbageBeforeDoKeyword: GarbageNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.garbageBeforeLabelName,
+      let childData = data.child(at: Cursor.garbageBeforeDoKeyword,
                                  parent: Syntax(self))
       if childData == nil { return nil }
       return GarbageNodesSyntax(childData!)
     }
     set(value) {
-      self = withGarbageBeforeLabelName(value)
+      self = withGarbageBeforeDoKeyword(value)
     }
   }
 
-  /// Returns a copy of the receiver with its `garbageBeforeLabelName` replaced.
-  /// - param newChild: The new `garbageBeforeLabelName` to replace the node's
-  ///                   current `garbageBeforeLabelName`, if present.
-  public func withGarbageBeforeLabelName(
+  /// Returns a copy of the receiver with its `garbageBeforeDoKeyword` replaced.
+  /// - param newChild: The new `garbageBeforeDoKeyword` to replace the node's
+  ///                   current `garbageBeforeDoKeyword`, if present.
+  public func withGarbageBeforeDoKeyword(
     _ newChild: GarbageNodesSyntax?) -> DoStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBeforeLabelName)
-    return DoStmtSyntax(newData)
-  }
-
-  public var labelName: TokenSyntax? {
-    get {
-      let childData = data.child(at: Cursor.labelName,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withLabelName(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `labelName` replaced.
-  /// - param newChild: The new `labelName` to replace the node's
-  ///                   current `labelName`, if present.
-  public func withLabelName(
-    _ newChild: TokenSyntax?) -> DoStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.labelName)
-    return DoStmtSyntax(newData)
-  }
-
-  public var garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? {
-    get {
-      let childData = data.child(at: Cursor.garbageBetweenLabelNameAndLabelColon,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return GarbageNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withGarbageBetweenLabelNameAndLabelColon(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `garbageBetweenLabelNameAndLabelColon` replaced.
-  /// - param newChild: The new `garbageBetweenLabelNameAndLabelColon` to replace the node's
-  ///                   current `garbageBetweenLabelNameAndLabelColon`, if present.
-  public func withGarbageBetweenLabelNameAndLabelColon(
-    _ newChild: GarbageNodesSyntax?) -> DoStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBetweenLabelNameAndLabelColon)
-    return DoStmtSyntax(newData)
-  }
-
-  public var labelColon: TokenSyntax? {
-    get {
-      let childData = data.child(at: Cursor.labelColon,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withLabelColon(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `labelColon` replaced.
-  /// - param newChild: The new `labelColon` to replace the node's
-  ///                   current `labelColon`, if present.
-  public func withLabelColon(
-    _ newChild: TokenSyntax?) -> DoStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.labelColon)
-    return DoStmtSyntax(newData)
-  }
-
-  public var garbageBetweenLabelColonAndDoKeyword: GarbageNodesSyntax? {
-    get {
-      let childData = data.child(at: Cursor.garbageBetweenLabelColonAndDoKeyword,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return GarbageNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withGarbageBetweenLabelColonAndDoKeyword(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `garbageBetweenLabelColonAndDoKeyword` replaced.
-  /// - param newChild: The new `garbageBetweenLabelColonAndDoKeyword` to replace the node's
-  ///                   current `garbageBetweenLabelColonAndDoKeyword`, if present.
-  public func withGarbageBetweenLabelColonAndDoKeyword(
-    _ newChild: GarbageNodesSyntax?) -> DoStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBetweenLabelColonAndDoKeyword)
+    let newData = data.replacingChild(raw, at: Cursor.garbageBeforeDoKeyword)
     return DoStmtSyntax(newData)
   }
 
@@ -3249,7 +2878,7 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public func _validateLayout() {
     let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
-    assert(rawChildren.count == 10)
+    assert(rawChildren.count == 6)
     // Check child #0 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[0].raw {
       let info = rawChildren[0].syntaxInfo
@@ -3258,7 +2887,8 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #1 child is TokenSyntax or missing
+    // Check child #1 child is TokenSyntax 
+    assert(rawChildren[1].raw != nil)
     if let raw = rawChildren[1].raw {
       let info = rawChildren[1].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
@@ -3274,13 +2904,14 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #3 child is TokenSyntax or missing
+    // Check child #3 child is CodeBlockSyntax 
+    assert(rawChildren[3].raw != nil)
     if let raw = rawChildren[3].raw {
       let info = rawChildren[3].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TokenSyntax.self))
+      assert(syntaxChild.is(CodeBlockSyntax.self))
     }
     // Check child #4 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[4].raw {
@@ -3290,43 +2921,9 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #5 child is TokenSyntax 
-    assert(rawChildren[5].raw != nil)
+    // Check child #5 child is CatchClauseListSyntax or missing
     if let raw = rawChildren[5].raw {
       let info = rawChildren[5].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TokenSyntax.self))
-    }
-    // Check child #6 child is GarbageNodesSyntax or missing
-    if let raw = rawChildren[6].raw {
-      let info = rawChildren[6].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(GarbageNodesSyntax.self))
-    }
-    // Check child #7 child is CodeBlockSyntax 
-    assert(rawChildren[7].raw != nil)
-    if let raw = rawChildren[7].raw {
-      let info = rawChildren[7].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(CodeBlockSyntax.self))
-    }
-    // Check child #8 child is GarbageNodesSyntax or missing
-    if let raw = rawChildren[8].raw {
-      let info = rawChildren[8].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(GarbageNodesSyntax.self))
-    }
-    // Check child #9 child is CatchClauseListSyntax or missing
-    if let raw = rawChildren[9].raw {
-      let info = rawChildren[9].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
@@ -3338,11 +2935,7 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension DoStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "garbageBeforeLabelName": garbageBeforeLabelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "labelName": labelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "garbageBetweenLabelNameAndLabelColon": garbageBetweenLabelNameAndLabelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "labelColon": labelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "garbageBetweenLabelColonAndDoKeyword": garbageBetweenLabelColonAndDoKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "garbageBeforeDoKeyword": garbageBeforeDoKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "doKeyword": Syntax(doKeyword).asProtocol(SyntaxProtocol.self),
       "garbageBetweenDoKeywordAndBody": garbageBetweenDoKeywordAndBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "body": Syntax(body).asProtocol(SyntaxProtocol.self),
@@ -4242,11 +3835,7 @@ extension ThrowStmtSyntax: CustomReflectable {
 
 public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   enum Cursor: Int {
-    case garbageBeforeLabelName
-    case labelName
-    case garbageBetweenLabelNameAndLabelColon
-    case labelColon
-    case garbageBetweenLabelColonAndIfKeyword
+    case garbageBeforeIfKeyword
     case ifKeyword
     case garbageBetweenIfKeywordAndConditions
     case conditions
@@ -4279,113 +3868,25 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return Swift.type(of: self)
   }
 
-  public var garbageBeforeLabelName: GarbageNodesSyntax? {
+  public var garbageBeforeIfKeyword: GarbageNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.garbageBeforeLabelName,
+      let childData = data.child(at: Cursor.garbageBeforeIfKeyword,
                                  parent: Syntax(self))
       if childData == nil { return nil }
       return GarbageNodesSyntax(childData!)
     }
     set(value) {
-      self = withGarbageBeforeLabelName(value)
+      self = withGarbageBeforeIfKeyword(value)
     }
   }
 
-  /// Returns a copy of the receiver with its `garbageBeforeLabelName` replaced.
-  /// - param newChild: The new `garbageBeforeLabelName` to replace the node's
-  ///                   current `garbageBeforeLabelName`, if present.
-  public func withGarbageBeforeLabelName(
+  /// Returns a copy of the receiver with its `garbageBeforeIfKeyword` replaced.
+  /// - param newChild: The new `garbageBeforeIfKeyword` to replace the node's
+  ///                   current `garbageBeforeIfKeyword`, if present.
+  public func withGarbageBeforeIfKeyword(
     _ newChild: GarbageNodesSyntax?) -> IfStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBeforeLabelName)
-    return IfStmtSyntax(newData)
-  }
-
-  public var labelName: TokenSyntax? {
-    get {
-      let childData = data.child(at: Cursor.labelName,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withLabelName(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `labelName` replaced.
-  /// - param newChild: The new `labelName` to replace the node's
-  ///                   current `labelName`, if present.
-  public func withLabelName(
-    _ newChild: TokenSyntax?) -> IfStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.labelName)
-    return IfStmtSyntax(newData)
-  }
-
-  public var garbageBetweenLabelNameAndLabelColon: GarbageNodesSyntax? {
-    get {
-      let childData = data.child(at: Cursor.garbageBetweenLabelNameAndLabelColon,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return GarbageNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withGarbageBetweenLabelNameAndLabelColon(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `garbageBetweenLabelNameAndLabelColon` replaced.
-  /// - param newChild: The new `garbageBetweenLabelNameAndLabelColon` to replace the node's
-  ///                   current `garbageBetweenLabelNameAndLabelColon`, if present.
-  public func withGarbageBetweenLabelNameAndLabelColon(
-    _ newChild: GarbageNodesSyntax?) -> IfStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBetweenLabelNameAndLabelColon)
-    return IfStmtSyntax(newData)
-  }
-
-  public var labelColon: TokenSyntax? {
-    get {
-      let childData = data.child(at: Cursor.labelColon,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withLabelColon(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `labelColon` replaced.
-  /// - param newChild: The new `labelColon` to replace the node's
-  ///                   current `labelColon`, if present.
-  public func withLabelColon(
-    _ newChild: TokenSyntax?) -> IfStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.labelColon)
-    return IfStmtSyntax(newData)
-  }
-
-  public var garbageBetweenLabelColonAndIfKeyword: GarbageNodesSyntax? {
-    get {
-      let childData = data.child(at: Cursor.garbageBetweenLabelColonAndIfKeyword,
-                                 parent: Syntax(self))
-      if childData == nil { return nil }
-      return GarbageNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withGarbageBetweenLabelColonAndIfKeyword(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `garbageBetweenLabelColonAndIfKeyword` replaced.
-  /// - param newChild: The new `garbageBetweenLabelColonAndIfKeyword` to replace the node's
-  ///                   current `garbageBetweenLabelColonAndIfKeyword`, if present.
-  public func withGarbageBetweenLabelColonAndIfKeyword(
-    _ newChild: GarbageNodesSyntax?) -> IfStmtSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.garbageBetweenLabelColonAndIfKeyword)
+    let newData = data.replacingChild(raw, at: Cursor.garbageBeforeIfKeyword)
     return IfStmtSyntax(newData)
   }
 
@@ -4606,7 +4107,7 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public func _validateLayout() {
     let rawChildren = Array(RawSyntaxChildren(Syntax(self)))
-    assert(rawChildren.count == 14)
+    assert(rawChildren.count == 10)
     // Check child #0 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[0].raw {
       let info = rawChildren[0].syntaxInfo
@@ -4615,7 +4116,8 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #1 child is TokenSyntax or missing
+    // Check child #1 child is TokenSyntax 
+    assert(rawChildren[1].raw != nil)
     if let raw = rawChildren[1].raw {
       let info = rawChildren[1].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
@@ -4631,13 +4133,14 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #3 child is TokenSyntax or missing
+    // Check child #3 child is ConditionElementListSyntax 
+    assert(rawChildren[3].raw != nil)
     if let raw = rawChildren[3].raw {
       let info = rawChildren[3].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TokenSyntax.self))
+      assert(syntaxChild.is(ConditionElementListSyntax.self))
     }
     // Check child #4 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[4].raw {
@@ -4647,14 +4150,14 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #5 child is TokenSyntax 
+    // Check child #5 child is CodeBlockSyntax 
     assert(rawChildren[5].raw != nil)
     if let raw = rawChildren[5].raw {
       let info = rawChildren[5].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TokenSyntax.self))
+      assert(syntaxChild.is(CodeBlockSyntax.self))
     }
     // Check child #6 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[6].raw {
@@ -4664,14 +4167,13 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #7 child is ConditionElementListSyntax 
-    assert(rawChildren[7].raw != nil)
+    // Check child #7 child is TokenSyntax or missing
     if let raw = rawChildren[7].raw {
       let info = rawChildren[7].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(ConditionElementListSyntax.self))
+      assert(syntaxChild.is(TokenSyntax.self))
     }
     // Check child #8 child is GarbageNodesSyntax or missing
     if let raw = rawChildren[8].raw {
@@ -4681,42 +4183,9 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       let syntaxChild = Syntax(syntaxData)
       assert(syntaxChild.is(GarbageNodesSyntax.self))
     }
-    // Check child #9 child is CodeBlockSyntax 
-    assert(rawChildren[9].raw != nil)
+    // Check child #9 child is Syntax or missing
     if let raw = rawChildren[9].raw {
       let info = rawChildren[9].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(CodeBlockSyntax.self))
-    }
-    // Check child #10 child is GarbageNodesSyntax or missing
-    if let raw = rawChildren[10].raw {
-      let info = rawChildren[10].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(GarbageNodesSyntax.self))
-    }
-    // Check child #11 child is TokenSyntax or missing
-    if let raw = rawChildren[11].raw {
-      let info = rawChildren[11].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(TokenSyntax.self))
-    }
-    // Check child #12 child is GarbageNodesSyntax or missing
-    if let raw = rawChildren[12].raw {
-      let info = rawChildren[12].syntaxInfo
-      let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
-      let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
-      let syntaxChild = Syntax(syntaxData)
-      assert(syntaxChild.is(GarbageNodesSyntax.self))
-    }
-    // Check child #13 child is Syntax or missing
-    if let raw = rawChildren[13].raw {
-      let info = rawChildren[13].syntaxInfo
       let absoluteRaw = AbsoluteRawSyntax(raw: raw, info: info)
       let syntaxData = SyntaxData(absoluteRaw, parent: Syntax(self))
       let syntaxChild = Syntax(syntaxData)
@@ -4728,11 +4197,7 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 extension IfStmtSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, children: [
-      "garbageBeforeLabelName": garbageBeforeLabelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "labelName": labelName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "garbageBetweenLabelNameAndLabelColon": garbageBetweenLabelNameAndLabelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "labelColon": labelColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "garbageBetweenLabelColonAndIfKeyword": garbageBetweenLabelColonAndIfKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "garbageBeforeIfKeyword": garbageBeforeIfKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "ifKeyword": Syntax(ifKeyword).asProtocol(SyntaxProtocol.self),
       "garbageBetweenIfKeywordAndConditions": garbageBetweenIfKeywordAndConditions.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "conditions": Syntax(conditions).asProtocol(SyntaxProtocol.self),

--- a/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
@@ -1353,6 +1353,14 @@ public extension ExpressibleAsBackDeployVersionArgument {
     return createBackDeployVersionArgument()
   }
 }
+public protocol ExpressibleAsLabeledStmt: ExpressibleAsStmtBuildable {
+  func createLabeledStmt() -> LabeledStmt
+}
+public extension ExpressibleAsLabeledStmt {
+  func createStmtBuildable() -> StmtBuildable {
+    return createLabeledStmt()
+  }
+}
 public protocol ExpressibleAsContinueStmt: ExpressibleAsStmtBuildable {
   func createContinueStmt() -> ContinueStmt
 }

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/NodeSerializationCodes.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/NodeSerializationCodes.swift
@@ -277,4 +277,5 @@ public let SYNTAX_NODE_SERIALIZATION_CODES: [String: Int] = [
   "MissingType": 264,
   "MissingPattern": 265,
   "GarbageNodes": 266,
+  "LabeledStmt": 267,
 ]

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/PatternNodes.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/PatternNodes.swift
@@ -105,8 +105,7 @@ let PATTERN_NODES: [Node] = [
   Node(name: "TuplePatternElement",
        kind: "Syntax",
        traits: [
-         "WithTrailingComma",
-         "Labeled"
+         "WithTrailingComma"
        ],
        children: [
          Child(name: "LabelName",

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/StmtNodes.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/StmtNodes.swift
@@ -13,6 +13,17 @@
 //===----------------------------------------------------------------------===//
 
 let STMT_NODES: [Node] = [
+  Node(name: "LabeledStmt",
+       kind: "Stmt",
+       children: [
+         Child(name: "LabelName",
+               kind: "IdentifierToken"),
+         Child(name: "LabelColon",
+               kind: "ColonToken"),
+         Child(name: "Statement",
+               kind: "Stmt")
+       ]),
+
   Node(name: "ContinueStmt",
        kind: "Stmt",
        children: [
@@ -26,16 +37,9 @@ let STMT_NODES: [Node] = [
   Node(name: "WhileStmt",
        kind: "Stmt",
        traits: [
-         "WithCodeBlock",
-         "Labeled"
+         "WithCodeBlock"
        ],
        children: [
-         Child(name: "LabelName",
-               kind: "IdentifierToken",
-               isOptional: true),
-         Child(name: "LabelColon",
-               kind: "ColonToken",
-               isOptional: true),
          Child(name: "WhileKeyword",
                kind: "WhileToken"),
          Child(name: "Conditions",
@@ -74,16 +78,9 @@ let STMT_NODES: [Node] = [
   Node(name: "RepeatWhileStmt",
        kind: "Stmt",
        traits: [
-         "WithCodeBlock",
-         "Labeled"
+         "WithCodeBlock"
        ],
        children: [
-         Child(name: "LabelName",
-               kind: "IdentifierToken",
-               isOptional: true),
-         Child(name: "LabelColon",
-               kind: "ColonToken",
-               isOptional: true),
          Child(name: "RepeatKeyword",
                kind: "RepeatToken"),
          Child(name: "Body",
@@ -123,16 +120,9 @@ let STMT_NODES: [Node] = [
   Node(name: "ForInStmt",
        kind: "Stmt",
        traits: [
-         "WithCodeBlock",
-         "Labeled"
+         "WithCodeBlock"
        ],
        children: [
-         Child(name: "LabelName",
-               kind: "IdentifierToken",
-               isOptional: true),
-         Child(name: "LabelColon",
-               kind: "ColonToken",
-               isOptional: true),
          Child(name: "ForKeyword",
                kind: "ForToken"),
          Child(name: "TryKeyword",
@@ -167,16 +157,9 @@ let STMT_NODES: [Node] = [
   Node(name: "SwitchStmt",
        kind: "Stmt",
        traits: [
-         "Braced",
-         "Labeled"
+         "Braced"
        ],
        children: [
-         Child(name: "LabelName",
-               kind: "IdentifierToken",
-               isOptional: true),
-         Child(name: "LabelColon",
-               kind: "ColonToken",
-               isOptional: true),
          Child(name: "SwitchKeyword",
                kind: "SwitchToken"),
          Child(name: "Expression",
@@ -198,16 +181,9 @@ let STMT_NODES: [Node] = [
   Node(name: "DoStmt",
        kind: "Stmt",
        traits: [
-         "WithCodeBlock",
-         "Labeled"
+         "WithCodeBlock"
        ],
        children: [
-         Child(name: "LabelName",
-               kind: "IdentifierToken",
-               isOptional: true),
-         Child(name: "LabelColon",
-               kind: "ColonToken",
-               isOptional: true),
          Child(name: "DoKeyword",
                kind: "DoToken"),
          Child(name: "Body",
@@ -392,16 +368,9 @@ let STMT_NODES: [Node] = [
   Node(name: "IfStmt",
        kind: "Stmt",
        traits: [
-         "WithCodeBlock",
-         "Labeled"
+         "WithCodeBlock"
        ],
        children: [
-         Child(name: "LabelName",
-               kind: "IdentifierToken",
-               isOptional: true),
-         Child(name: "LabelColon",
-               kind: "ColonToken",
-               isOptional: true),
          Child(name: "IfKeyword",
                kind: "IfToken"),
          Child(name: "Conditions",

--- a/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/Traits.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/gyb_generated/Traits.swift
@@ -59,12 +59,6 @@ let TRAITS: [Trait] = [
           Child(name: "TrailingComma", kind: "CommaToken", isOptional: true),
         ]
   ),
-  Trait(traitName: "Labeled",
-        children: [
-          Child(name: "LabelName", kind: "IdentifierToken", isOptional: true),
-          Child(name: "LabelColon", kind: "ColonToken", isOptional: true),
-        ]
-  ),
   Trait(traitName: "WithStatements",
         children: [
           Child(name: "Statements", kind: "CodeBlockItemList"),

--- a/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
@@ -17,6 +17,6 @@
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "76189e10177bf095e1fce1c3e38313bd9a8e0a8b"
+      "796dd4cb2500877043f3a280f4822afca6a822ee"
   }
 }

--- a/Tests/SwiftSyntaxBuilderTest/DoStmtTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/DoStmtTests.swift
@@ -4,7 +4,6 @@ import SwiftSyntaxBuilder
 final class DoStmtTests: XCTestCase {
   func testDoStmt() {
     let buildable = DoStmt(
-      labelName: nil,
       body: CodeBlock(statementsBuilder: {
         CodeBlockItem(item: TryExpr(expression: FunctionCallExpr(MemberAccessExpr(base: "a", name: "b"))))
       }),

--- a/Tests/SwiftSyntaxBuilderTest/ExpressibleBuildablesTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/ExpressibleBuildablesTests.swift
@@ -65,7 +65,6 @@ final class ExpressibleBuildablesTests: XCTestCase {
     let expression = IdentifierExpr("version")
 
     let switchStmt = SwitchStmt(
-      labelName: nil,
       expression: expression
     ) {
       for (version, semVer) in versions {


### PR DESCRIPTION
This represents labeled statements as an explicit kind of statement and removes the Labeled trait. Any kind of statement is allowed to be labeled in the tree, but we specifically diagnose the syntax elements that aren't allowed to have labels. This homogenizes the way clients deal with statement labels and also makes parser recovery quite a bit easier in the case where we have a label but no actual statement following it.