### PR TITLE
Use SWIFTCI_USE_LOCAL_DEPS to check whether to clone swift-docc-plugin

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -143,6 +143,9 @@ let package = Package(
   ]
 )
 
-if ProcessInfo.processInfo.environment["SWIFT_BUILD_SCRIPT_ENVIRONMENT"] == nil {
+// If `SWIFTCI_USE_LOCAL_DEPS` is set, we are in a CI enviornment that might disallow 
+// internet access, so we can't load swift-docc-plugin. Simply don't load it in these
+// environments because we don't build docc in CI at the moment.
+if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
 }


### PR DESCRIPTION
Only SwiftSyntax’s build-script sets `SWIFT_BUILD_SCRIPT_ENVIRONMENT`. Once we migrate other projects into the unified SwiftPM build, the environment variable is not set and SwiftPM tries to download swift-docc-plugin in CI.

Use `SWIFTCI_USE_LOCAL_DEPS` as an indicator whether the remote plugin should be loaded.