### PR TITLE
Get rid of shorthand `if let` syntax to fix compilation with Swift 5.6

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -529,10 +529,10 @@ public extension SyntaxProtocol {
     if let token = Syntax(self).as(TokenSyntax.self) {
       target.write(String(describing: token.tokenKind))
       if includeTrivia {
-        if let leadingTrivia, !leadingTrivia.isEmpty {
+        if let leadingTrivia = leadingTrivia, !leadingTrivia.isEmpty {
           target.write(" leadingTrivia=\(leadingTrivia.debugDescription)")
         }
-        if let trailingTrivia, !trailingTrivia.isEmpty {
+        if let trailingTrivia = trailingTrivia, !trailingTrivia.isEmpty {
           target.write(" trailingTrivia=\(trailingTrivia.debugDescription)")
         }
       }

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -150,7 +150,7 @@ public struct Trivia {
 
 extension Trivia: CustomDebugStringConvertible {
    public var debugDescription: String {
-     if count == 1, let first {
+     if count == 1, let first = first {
        return first.debugDescription
      }
      return "[" + map(\.debugDescription).joined(separator: ", ") + "]"

--- a/Sources/SwiftSyntax/gyb_generated/Trivia.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Trivia.swift
@@ -276,7 +276,7 @@ public struct Trivia {
 
 extension Trivia: CustomDebugStringConvertible {
    public var debugDescription: String {
-     if count == 1, let first {
+     if count == 1, let first = first {
        return first.debugDescription
      }
      return "[" + map(\.debugDescription).joined(separator: ", ") + "]"


### PR DESCRIPTION
Similar issue as [here](https://github.com/apple/swift-syntax/pull/538#discussion_r935207895)
There is also usage of the new APIs (like [`UnsafeMutableRawPointer.alignedUp(toMultipleOf:)`](https://developer.apple.com/documentation/swift/unsafemutablerawpointer/alignedup(tomultipleof:)?changes=latest_minor)) in the [`BumpPtrAllocator.swift`](https://github.com/apple/swift-syntax/blob/2380374d1ed52d89674adad21d98b8dd1d1be14c/Sources/SwiftSyntax/BumpPtrAllocator.swift#L83), but I'm not sure how to fix that properly