### PR TITLE
Restore the Ability to Build with 5.6/5.5

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.5
 
 import PackageDescription
 import Foundation
@@ -142,9 +142,11 @@ let package = Package(
   ]
 )
 
-// If `SWIFTCI_USE_LOCAL_DEPS` is set, we are in a CI enviornment that might disallow 
+#if swift(>=5.6)
+// If `SWIFTCI_USE_LOCAL_DEPS` is set, we are in a CI enviornment that might disallow
 // internet access, so we can't load swift-docc-plugin. Simply don't load it in these
 // environments because we don't build docc in CI at the moment.
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
     package.dependencies.append(.package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"))
 }
+#endif


### PR DESCRIPTION
We still support building with tools from Xcode 13, so we cannot adopt
features after Swift 5.5. Recreate UMRP.alignedUp(toMultipleOf:) for
this environment and conditionalize docc support in the build script
on the newer language features being around.