### PR TITLE
Multiple improvements to SwiftSyntaxComparison

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -91,7 +91,7 @@ let package = Package(
     ),
     .target(
       name: "_SwiftSyntaxTestSupport",
-      dependencies: ["SwiftSyntax", "SwiftSyntaxParser"]
+      dependencies: ["SwiftSyntax"]
     ),
     .executableTarget(
       name: "lit-test-helper",

--- a/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
+++ b/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
@@ -15,7 +15,6 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
-import SwiftSyntaxParser
 import XCTest
 
 /// Verifies that there is a next item returned by the iterator and that it
@@ -35,18 +34,27 @@ public func XCTAssertNextIsNil<Iterator: IteratorProtocol>(_ iterator: inout Ite
 }
 
 /// Verifies that the tree parsed from `actual` has the same structure as
-/// `expected`, ie. it has the same structure and optionally the same trivia
-/// (if `includeTrivia` is set).
-public func XCTAssertSameStructure(_ actual: String, _ expected: Syntax, includeTrivia: Bool = false,
-                                   file: StaticString = #filePath, line: UInt = #line) throws {
-  let actualTree = try Syntax(SyntaxParser.parse(source: actual))
+/// `expected` when parsed with `parse`, ie. it has the same structure and
+/// optionally the same trivia (if `includeTrivia` is set).
+public func XCTAssertSameStructure(
+  _ actual: String,
+  parse: (String) throws -> Syntax,
+  _ expected: Syntax,
+  includeTrivia: Bool = false,
+  file: StaticString = #filePath, line: UInt = #line
+) throws {
+  let actualTree = try parse(actual)
   XCTAssertSameStructure(actualTree, expected, includeTrivia: includeTrivia, file: file, line: line)
 }
 
 /// Verifies that two trees are equivalent, ie. they have the same structure
 /// and optionally the same trivia if `includeTrivia` is set.
-public func XCTAssertSameStructure(_ actual: Syntax, _ expected: Syntax, includeTrivia: Bool = false,
-                                   file: StaticString = #filePath, line: UInt = #line) {
+public func XCTAssertSameStructure(
+  _ actual: SyntaxProtocol,
+  _ expected: SyntaxProtocol,
+  includeTrivia: Bool = false,
+  file: StaticString = #filePath, line: UInt = #line
+) {
   let diff = actual.findFirstDifference(baseline: expected, includeTrivia: includeTrivia)
   XCTAssertNil(diff, diff!.debugDescription, file: file, line: line)
 }
@@ -98,7 +106,7 @@ public struct SubtreeMatcher {
   /// The syntax tree from parsing source *with markers removed*.
   private var actualTree: Syntax
 
-  public init(_ markedText: String) throws {
+  public init(_ markedText: String, parse: (String) throws -> Syntax) throws {
     var text = ""
     var markers = [String: Int]()
     var lastIndex = markedText.startIndex
@@ -112,7 +120,7 @@ public struct SubtreeMatcher {
     text += markedText[lastIndex ..< markedText.endIndex]
 
     self.markers = markers.isEmpty ? ["DEFAULT": 0] : markers
-    self.actualTree = try Syntax(SyntaxParser.parse(source: text))
+    self.actualTree = try parse(text)
   }
 
   /// Same as `Syntax.findFirstDifference(baseline:includeTrivia:)`, but

--- a/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
+++ b/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
@@ -186,7 +186,7 @@ public enum SubtreeError: Error, CustomStringConvertible {
     case let .invalidMarker(name):
       return "Could not find marker with name '\(name)'"
     case let .invalidSubtree(tree, afterUTF8Offset, type):
-      return "Could not find subtree after UTF8 offset \(afterUTF8Offset) with type \(type) in:\n\(tree.debugDescription)"
+      return "Could not find subtree after UTF8 offset \(afterUTF8Offset) with type \(type) in:\n\(tree.debugDescription(includeChildren: true))"
     }
   }
 }

--- a/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
+++ b/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
@@ -59,6 +59,30 @@ public func XCTAssertSameStructure(
   XCTAssertNil(diff, diff!.debugDescription, file: file, line: line)
 }
 
+/// See `SubtreeMatcher.assertSameStructure`.
+public func XCTAssertHasSubstructure(
+  _ markedText: String,
+  parse: (String) throws -> Syntax,
+  afterMarker: String? = nil,
+  _ expected: SyntaxProtocol,
+  includeTrivia: Bool = false,
+  file: StaticString = #filePath, line: UInt = #line
+) throws {
+  let subtreeMatcher = try SubtreeMatcher(markedText, parse: parse)
+  try subtreeMatcher.assertSameStructure(afterMarker: afterMarker, Syntax(expected), file: file, line: line)
+}
+
+/// See `SubtreeMatcher.assertSameStructure`.
+public func XCTAssertHasSubstructure(
+  _ actualTree: SyntaxProtocol,
+  _ expected: SyntaxProtocol,
+  includeTrivia: Bool = false,
+  file: StaticString = #filePath, line: UInt = #line
+) throws {
+  let subtreeMatcher = SubtreeMatcher(Syntax(actualTree))
+  try subtreeMatcher.assertSameStructure(Syntax(expected), file: file, line: line)
+}
+
 /// Allows matching a subtrees of the given `markedText` against
 /// `baseline`/`expected` trees, where a combination of markers and the type
 /// of the `expected` tree is used to first find the subtree to match. Note
@@ -121,6 +145,11 @@ public struct SubtreeMatcher {
 
     self.markers = markers.isEmpty ? ["DEFAULT": 0] : markers
     self.actualTree = try parse(text)
+  }
+
+  public init(_ actualTree: Syntax) {
+    self.markers = ["DEFAULT": 0]
+    self.actualTree = actualTree
   }
 
   /// Same as `Syntax.findFirstDifference(baseline:includeTrivia:)`, but

--- a/Tests/SwiftSyntaxParserTest/SyntaxComparisonTests.swift
+++ b/Tests/SwiftSyntaxParserTest/SyntaxComparisonTests.swift
@@ -1,6 +1,11 @@
 import SwiftSyntax
 import _SwiftSyntaxTestSupport
+import SwiftSyntaxParser
 import XCTest
+
+private func parse(source: String) throws -> Syntax {
+  return try Syntax(SyntaxParser.parse(source: source))
+}
 
 public class SyntaxComparisonTests: XCTestCase {
   public func testSame() throws {
@@ -9,7 +14,7 @@ public class SyntaxComparisonTests: XCTestCase {
     let actual = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f")))
     XCTAssertNil(actual.findFirstDifference(baseline: expected))
 
-    let matcher = try SubtreeMatcher("struct A { func f() { } }")
+    let matcher = try SubtreeMatcher("struct A { func f() { } }", parse: parse)
     try XCTAssertNil(matcher.findFirstDifference(baseline: expected))
   }
 
@@ -36,7 +41,7 @@ public class SyntaxComparisonTests: XCTestCase {
     let actual = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f")))
     try expectations(actual.findFirstDifference(baseline: expected))
 
-    let matcher = try SubtreeMatcher("struct A { #^FUNC^#func f() { } }")
+    let matcher = try SubtreeMatcher("struct A { #^FUNC^#func f() { } }", parse: parse)
     try expectations(matcher.findFirstDifference(baseline: expected))
   }
 
@@ -52,7 +57,7 @@ public class SyntaxComparisonTests: XCTestCase {
     let actual = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("g")))
     try expectations(actual.findFirstDifference(baseline: expected))
 
-    let matcher = try SubtreeMatcher("struct A { #^FUNC^#func g() { } }")
+    let matcher = try SubtreeMatcher("struct A { #^FUNC^#func g() { } }", parse: parse)
     try expectations(matcher.findFirstDifference(afterMarker: "FUNC", baseline: expected))
   }
 
@@ -69,7 +74,7 @@ public class SyntaxComparisonTests: XCTestCase {
     XCTAssertNil(actual.findFirstDifference(baseline: expected))
     try expectations(actual.findFirstDifference(baseline: expected, includeTrivia: true))
 
-    let matcher = try SubtreeMatcher("struct A {func f() { }}")
+    let matcher = try SubtreeMatcher("struct A {func f() { }}", parse: parse)
     try XCTAssertNil(matcher.findFirstDifference(baseline: expected))
     try expectations(matcher.findFirstDifference(baseline: expected, includeTrivia: true))
   }
@@ -86,7 +91,7 @@ public class SyntaxComparisonTests: XCTestCase {
     let actual = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f")))
     try expectations(actual.findFirstDifference(baseline: expected))
 
-    let matcher = try SubtreeMatcher("struct A { func f() { } }")
+    let matcher = try SubtreeMatcher("struct A { func f() { } }", parse: parse)
     try expectations(matcher.findFirstDifference(baseline: expected))
   }
 
@@ -100,7 +105,7 @@ public class SyntaxComparisonTests: XCTestCase {
     let actual = Syntax(makeFunc(identifier: SyntaxFactory.makeIdentifier("f")))
     try expectations(actual.findFirstDifference(baseline: expected))
 
-    let matcher = try SubtreeMatcher("struct A { func f() { } }")
+    let matcher = try SubtreeMatcher("struct A { func f() { } }", parse: parse)
     try expectations(matcher.findFirstDifference(baseline: expected))
   }
 
@@ -120,7 +125,7 @@ public class SyntaxComparisonTests: XCTestCase {
           0
         }
       }
-      """)
+      """, parse: parse)
     try expectations(matcher.findFirstDifference(baseline: expected))
   }
 
@@ -137,7 +142,7 @@ public class SyntaxComparisonTests: XCTestCase {
           0
         }
       }
-      """)
+      """, parse: parse)
     let funcDiff = try XCTUnwrap(matcher.findFirstDifference(afterMarker: "FUNC", baseline: expectedFunc))
     XCTAssertEqual(funcDiff.reason, .additionalNode)
 


### PR DESCRIPTION
- Remove dependency from `_SwiftSyntaxTestSupport` on `SyntaxParser.parse`
  - This required moving SyntaxComparisonTests.swift from SwiftSyntaxTest to SwiftSyntaxParserTest because SwiftSyntaxTest no longer has a dependency on the parser (which it shouldn’t have IMO)
- Print children for "Could not find subtree after UTF8 offset" syntax comparison error message
- Add `XCTAssert*` methods to make sure a tree has a certain subtree