### PR TITLE
Allow starting a SourceLocationConverter on a node thats's not Source FileSyntax

### DIFF
--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -122,7 +122,8 @@ public final class SourceLocationConverter {
   /// - Parameters:
   ///   - file: The file path associated with the syntax tree.
   ///   - tree: The syntax tree to convert positions to line/columns for.
-  public init(file: String, tree: SourceFileSyntax) {
+  public init(file: String, tree: Syntax) {
+    assert(tree.id.indexInTree == .zero, "SourceLocationConverter should be a syntax tree's root")
     self.file = file
     (self.lines, endOfFile) = computeLines(tree: tree)
     assert(tree.byteSize == endOfFile.utf8Offset)
@@ -335,7 +336,7 @@ public extension SyntaxProtocol {
 /// Returns array of lines with the position at the start of the line and
 /// the end-of-file position.
 fileprivate func computeLines(
-  tree: SourceFileSyntax
+  tree: Syntax
 ) -> ([AbsolutePosition], AbsolutePosition) {
   var lines: [AbsolutePosition] = []
   // First line starts from the beginning.

--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -520,7 +520,7 @@ func diagnose(args: CommandLineArguments) throws {
   }
   let visitor = DiagnoseUnknown(
     diagnosticHandler: printDiagnostic,
-    SourceLocationConverter(file: treeURL.path, tree: tree)
+    SourceLocationConverter(file: treeURL.path, tree: Syntax(tree))
   )
   visitor.walk(tree)
 }

--- a/Tests/SwiftSyntaxParserTest/AbsolutePositionTests.swift
+++ b/Tests/SwiftSyntaxParserTest/AbsolutePositionTests.swift
@@ -184,7 +184,7 @@ public class AbsolutePositionTests: XCTestCase {
   public func testSourceLocation() {
     let filePath = "/tmp/test.swift"
     let root = self.createSourceFile(2)
-    let converter = SourceLocationConverter(file: filePath, tree: root)
+    let converter = SourceLocationConverter(file: filePath, tree: Syntax(root))
     let secondReturnStmt = root.statements[1]
     let startLoc = secondReturnStmt.startLocation(converter: converter)
     XCTAssertEqual(startLoc.line, 8)


### PR DESCRIPTION
For test cases, it’s useful to work on syntax subtrees that don’t have a `SourceFileSyntax` as their root. In these cases it’s also useful to start a `SourceLocationConverter` on any syntax node.