### PR TITLE
Remove underscore from SyntaxViewingMode._all

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -540,7 +540,7 @@ public extension SyntaxProtocol {
       target.write(String(describing: syntaxNodeType))
     }
 
-    let allChildren = children(viewMode: ._all)
+    let allChildren = children(viewMode: .all)
     if includeChildren {
       if !allChildren.isEmpty {
         target.write(" children=\(allChildren.count)")

--- a/Sources/SwiftSyntax/SyntaxTreeViewMode.swift
+++ b/Sources/SwiftSyntax/SyntaxTreeViewMode.swift
@@ -25,9 +25,7 @@ public enum SyntaxTreeViewMode {
   case fixedUp
 
   /// Both missing and garbage nodes will be traversed.
-  /// Mostly useful for SwiftSyntax internal verifiers that verify the integrity
-  /// of the entire tree
-  case _all
+  case all
 
   /// Returns whether this traversal node should visit `node` or ignore it.
   func shouldTraverse(node: RawSyntax) -> Bool {
@@ -36,7 +34,7 @@ public enum SyntaxTreeViewMode {
       return node.presence == .present
     case .fixedUp:
       return node.kind != .garbageNodes
-    case ._all:
+    case .all:
       return true
     }
   }

--- a/Sources/SwiftSyntax/SyntaxVerifier.swift
+++ b/Sources/SwiftSyntax/SyntaxVerifier.swift
@@ -31,7 +31,7 @@ public class SyntaxVerifier: SyntaxAnyVisitor {
   var unknownNodes: [Syntax] = []
 
   init() {
-    super.init(viewMode: ._all)
+    super.init(viewMode: .all)
   }
 
   public override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {

--- a/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
+++ b/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
@@ -237,7 +237,7 @@ fileprivate class SyntaxTypeFinder: SyntaxAnyVisitor {
     self.offset = offset
     self.type = type
     self.found = nil
-    super.init(viewMode: ._all)
+    super.init(viewMode: .all)
   }
 
   fileprivate override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxComparison.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxComparison.swift
@@ -94,8 +94,8 @@ public extension SyntaxProtocol {
       return TreeDifference(node: self, baseline: baseline, reason: reason)
     }
 
-    var iterator = children(viewMode: ._all).makeIterator()
-    var baseIterator = baseline.children(viewMode: ._all).makeIterator()
+    var iterator = children(viewMode: .all).makeIterator()
+    var baseIterator = baseline.children(viewMode: .all).makeIterator()
     while let child = iterator.next() {
       guard let baselineChild = baseIterator.next() else {
         return TreeDifference(node: child, baseline: baseline, reason: .additionalNode)

--- a/Sources/lit-test-helper/main.swift
+++ b/Sources/lit-test-helper/main.swift
@@ -505,7 +505,7 @@ func diagnose(args: CommandLineArguments) throws {
     init(diagnosticHandler: @escaping ((Diagnostic) -> Void), _ converter: SourceLocationConverter) {
       self.diagnosticHandler = diagnosticHandler
       self.converter = converter
-      super.init(viewMode: ._all)
+      super.init(viewMode: .all)
     }
     override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
       if node.isUnknown {


### PR DESCRIPTION
I believe this syntax viewing mode can be useful in general and there’s no need to make it semi-private with an underscore.

rdar://98368959