### PR TITLE
Add utility property for enclosing a string in backticks

### DIFF
--- a/Sources/SwiftSyntaxBuilderGeneration/String+Extensions.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/String+Extensions.swift
@@ -14,4 +14,5 @@ import Foundation
 
 extension StringProtocol {
     var withFirstCharacterLowercased: String { prefix(1).lowercased() + dropFirst() }
+    var backticked: String { "`\(self)`" }
 }

--- a/Sources/SwiftSyntaxBuilderGeneration/Templates/TokensFile.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Templates/TokensFile.swift
@@ -35,10 +35,10 @@ let tokensFile = SourceFile {
           // We need to use `CodeBlock` here to ensure there is braces around.
 
           let accessor = CodeBlock {
-            FunctionCallExpr(MemberAccessExpr(base: "TokenSyntax", name: "\(token.swiftKind)"))
+            FunctionCallExpr(MemberAccessExpr(base: "TokenSyntax", name: token.swiftKind))
           }
 
-          createTokenSyntaxPatternBinding("`\(token.name.withFirstCharacterLowercased)`", accessor: accessor)
+          createTokenSyntaxPatternBinding(token.name.withFirstCharacterLowercased.backticked, accessor: accessor)
         }
       } else if let text = token.text {
         VariableDecl(
@@ -51,7 +51,7 @@ let tokensFile = SourceFile {
             FunctionCallExpr(MemberAccessExpr(base: "TokenSyntax", name: "\(token.swiftKind)Token"))
           }
 
-          createTokenSyntaxPatternBinding("`\(token.name.withFirstCharacterLowercased)`", accessor: accessor)
+          createTokenSyntaxPatternBinding(token.name.withFirstCharacterLowercased.backticked, accessor: accessor)
         }
       }
       // TokenSyntax with custom text already has a static constructor function defined in SwiftSyntax.


### PR DESCRIPTION
A small convenience property in preparation of #555.