### PR TITLE
Add convenience initializer for raw string literals

### DIFF
--- a/Sources/SwiftSyntaxBuilder/StringLiteralExprConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/StringLiteralExprConvenienceInitializers.swift
@@ -11,15 +11,58 @@
 //===----------------------------------------------------------------------===//
 
 import SwiftSyntax
+import Foundation
+
+/// A regular expression matching sequences of `#`s with an adjacent quote or
+/// interpolation. Used to determine the number of `#`s for a raw string literal.
+private let rawStringPotentialEscapesPattern = try! NSRegularExpression(
+  pattern: [
+    #""(#+)"#, // Match potential opening delimiters
+    #"(#+)""#, // Match potential closing delimiters
+    #"\\(#+)\("#, // Match potential interpolations
+  ].joined(separator: "|")
+)
 
 extension StringLiteralExpr {
-  public init(_ value: String, openQuote: TokenSyntax = .stringQuote, closeQuote: TokenSyntax = .stringQuote) {
+  /// Creates a string literal, optionally specifying quotes and delimiters.
+  public init(
+    openDelimiter: TokenSyntax? = nil,
+    openQuote: TokenSyntax = .stringQuote,
+    _ value: String,
+    closeQuote: TokenSyntax = .stringQuote,
+    closeDelimiter: TokenSyntax? = nil
+  ) {
     let content = TokenSyntax.stringSegment(value)
     let segment = StringSegment(content: content)
     let segments = StringLiteralSegments([segment])
 
-    self.init(openQuote: openQuote,
-              segments: segments,
-              closeQuote: closeQuote)
+    self.init(
+      openDelimiter: openDelimiter,
+      openQuote: openQuote,
+      segments: segments,
+      closeQuote: closeQuote,
+      closeDelimiter: closeDelimiter
+    )
+  }
+
+  /// Creates a raw string literal. Automatically determines
+  /// the number of `#`s needed to express the string as-is without any escapes.
+  public init(raw value: String) {
+    // Match potential escapes in the string
+    let matches = rawStringPotentialEscapesPattern.matches(in: value, range: NSRange(value.startIndex..., in: value))
+
+    // Find longest sequence of `#`s by taking the maximum length over all captures
+    let maxPoundCount = matches
+      .compactMap { match in (1..<match.numberOfRanges).map { match.range(at: $0).length }.max() }
+      .max() ?? 0
+
+    // Use a delimiter that is exactly one longer
+    let delimiter = TokenSyntax.rawStringDelimiter(String(repeating: "#", count: 1 + maxPoundCount))
+
+    self.init(
+      openDelimiter: delimiter,
+      value,
+      closeDelimiter: delimiter
+    )
   }
 }

--- a/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringLiteralTests.swift
@@ -33,6 +33,12 @@ final class StringLiteralTests: XCTestCase {
       #line: (StringLiteralExpr("asdf"), #"␣"asdf""#),
       #line: ("", #"␣"""#),
       #line: ("asdf", #"␣"asdf""#),
+      #line: (StringLiteralExpr(raw: "abc"), "␣#\"abc\"#"),
+      #line: (StringLiteralExpr(raw: #""quoted""#), ##"␣#""quoted""#"##),
+      #line: (StringLiteralExpr(raw: ##"#"rawquoted"#"##), ###"␣##"#"rawquoted"#"##"###),
+      #line: (StringLiteralExpr(raw: ####"###"unbalanced"####), #####"␣####"###"unbalanced"####"#####),
+      #line: (StringLiteralExpr(raw: ###"some "# string ##""###), ####"␣###"some "# string ##""###"####),
+      #line: (StringLiteralExpr(raw: ###"\##(abc) \(def)"###), ####"␣###"\##(abc) \(def)"###"####),
     ]
 
     for (line, testCase) in testCases {


### PR DESCRIPTION
This patch adds a small convenience initializer for raw string literals (in preparation of #575) and extends the existing convenience initializer to take custom delimiters.

```swift
StringLiteralExpr(raw: "abc")

// now generates

#"abc"#
```