### PR TITLE
Fix build failure due to two PRs racing

### DIFF
--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -96,6 +96,7 @@ public enum SyntaxFactory {
     ], length: .zero, presence: presence))
     return MissingSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on MissingDeclSyntax")
   public static func makeMissingDecl(_ garbageBeforeAttributes: GarbageNodesSyntax? = nil, attributes: AttributeListSyntax?, _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil, modifiers: ModifierListSyntax?) -> MissingDeclSyntax {
     let layout: [RawSyntax?] = [
       garbageBeforeAttributes?.raw,

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -90,8 +90,16 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   }
 
   public init(
+    _ garbageBeforeAttributes: GarbageNodesSyntax? = nil,
+    attributes: AttributeListSyntax?,
+    _ garbageBetweenAttributesAndModifiers: GarbageNodesSyntax? = nil,
+    modifiers: ModifierListSyntax?
   ) {
     let layout: [RawSyntax?] = [
+      garbageBeforeAttributes?.raw,
+      attributes?.raw,
+      garbageBetweenAttributesAndModifiers?.raw,
+      modifiers?.raw,
     ]
     let raw = RawSyntax.createAndCalcLength(kind: SyntaxKind.missingDecl,
       layout: layout, presence: SourcePresence.present)

--- a/Tests/SwiftSyntaxTest/SyntaxChildrenTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxChildrenTests.swift
@@ -50,7 +50,10 @@ public class SyntaxChildrenTests: XCTestCase {
   }
 
   public func testMissingNodes() throws {
-    let node = DeclarationStmtSyntax(declaration: DeclSyntax(MissingDeclSyntax()))
+    let node = DeclarationStmtSyntax(declaration: DeclSyntax(MissingDeclSyntax(
+      attributes: nil,
+      modifiers: nil
+    )))
 
     var sourceAccurateIt = node.children(viewMode: .sourceAccurate).makeIterator()
     XCTAssertNextIsNil(&sourceAccurateIt)

--- a/Tests/SwiftSyntaxTest/VisitorTests.swift
+++ b/Tests/SwiftSyntaxTest/VisitorTests.swift
@@ -3,7 +3,10 @@ import SwiftSyntax
 
 public class VisitorTests: XCTestCase {
   public func testVisitMissingNodes() throws {
-    let node = DeclarationStmtSyntax(declaration: DeclSyntax(MissingDeclSyntax()))
+    let node = DeclarationStmtSyntax(declaration: DeclSyntax(MissingDeclSyntax(
+      attributes: nil,
+      modifiers: nil
+    )))
 
     class MissingDeclChecker: SyntaxVisitor {
       var didSeeMissingDeclSyntax = false


### PR DESCRIPTION
SwiftSyntax failed to build because https://github.com/apple/swift-syntax/pull/539 and https://github.com/apple/swift-syntax/pull/578 conflicted