### PR TITLE
Re-enable `parser-diags.swift` test case

### DIFF
--- a/lit_tests/parser-diags.swift
+++ b/lit_tests/parser-diags.swift
@@ -1,7 +1,5 @@
 // RUN: %lit-test-helper -source-file %s -dump-diags 2>&1 | %FileCheck %s
 
-// REQUIRES: rdar71046813
-
 // CHECK: [[@LINE+2]]:11 error: consecutive statements on a line must be separated by ';'
 // CHECK-NEXT: Fixit: ([[@LINE+1]]:11,[[@LINE+1]]:11) Text: ";"
 let number⁚ Int


### PR DESCRIPTION
I don’t see this test failing locally, so let’s re-enable it.

rdar://71092878