### PR TITLE
Remove redundant assertion for cyclic SyntaxArenas

### DIFF
--- a/Sources/SwiftSyntax/SyntaxArena.swift
+++ b/Sources/SwiftSyntax/SyntaxArena.swift
@@ -126,11 +126,7 @@ public class SyntaxArena {
     precondition(
       !self.hasParent,
       "an arena can't have a new child once it's owned by other arenas")
-    // `precondition(!self.hasParent)` should be sufficient to make sure we
-    // don’t add retain cycles between syntax arenas, but to be doubly sure,
-    // check the child arenas as well in debug builds.
-    assert(!other.contains(arena: self), "cyclic arena hierarchy detected")
-
+    
     other.hasParent = true
     children.insert(other)
   }


### PR DESCRIPTION
When running the stress tester locally, the SwiftSyntax parser was significantly slowed down by this (we spent multiple seconds in this check).