### PR TITLE
Use explicit return type in Node initializer's flatMap

### DIFF
--- a/Sources/SwiftSyntaxBuilderGeneration/Node.swift
+++ b/Sources/SwiftSyntaxBuilderGeneration/Node.swift
@@ -92,7 +92,7 @@ class Node {
     } else {
       // Add implicitly generated GarbageNodes children between
       // any two defined children
-      self.children = children.enumerated().flatMap { (i, child) in
+      self.children = children.enumerated().flatMap { (i, child) -> [Child] in
         let garbageName: String
         if i == 0 {
           garbageName = "GarbageBefore\(child.name)"


### PR DESCRIPTION
This fixes a build issue with the latest Swift release since the improved multi-statement closure type inference is only available on recent nightly toolchains.