### PR TITLE
Fix RawTokenSyntax initializer

### DIFF
--- a/Sources/SwiftSyntax/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/RawSyntaxNodeProtocol.swift
@@ -13,7 +13,7 @@
 /// All typed raw syntax nodes conform to this protocol.
 /// `RawXXXSyntax` is a typed wrappeer of `RawSyntax`.
 @_spi(RawSyntax)
-public protocol RawSyntaxNodeProtocol {
+public protocol RawSyntaxNodeProtocol: CustomStringConvertible, TextOutputStreamable {
   /// Returns `true` if `raw` can be cast to this concrete raw syntax type.
   static func isKindOf(_ raw: RawSyntax) -> Bool
 
@@ -33,6 +33,14 @@ public extension RawSyntaxNodeProtocol {
   /// Check if this instance can be cast to the specified syntax type.
   func `is`<Node: RawSyntaxNodeProtocol>(_: Node.Type) -> Bool {
     Node.isKindOf(self.raw)
+  }
+
+  var description: String {
+    raw.description
+  }
+
+  func write<Target>(to target: inout Target) where Target : TextOutputStream {
+    raw.write(to: &target)
   }
 }
 
@@ -98,7 +106,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
     assert(arena.contains(text: text), "token text must be managed by the arena")
     let totalTriviaCount = leadingTriviaPieces.count + trailingTriviaPieces.count
     let buffer = arena.allocateRawTriviaPieceBuffer(count: totalTriviaCount)
-    var byteLength = 0
+    var byteLength = text.count
     if totalTriviaCount != 0 {
       var ptr = buffer.baseAddress!
       for piece in leadingTriviaPieces + trailingTriviaPieces {

--- a/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
@@ -36,30 +36,49 @@ fileprivate func cannedStructDecl(arena: SyntaxArena) -> RawStructDeclSyntax {
 
 final class RawSyntaxTests: XCTestCase {
 
-    func testFactory() throws {
-      withExtendedLifetime(SyntaxArena()) { arena in
-        let structDecl = cannedStructDecl(arena: arena)
-        XCTAssertEqual("\(structDecl.raw)",
+  func testFactory() throws {
+    withExtendedLifetime(SyntaxArena()) { arena in
+      let structDecl = cannedStructDecl(arena: arena)
+      XCTAssertEqual("\(structDecl.raw)",
                        """
                        struct Foo {
                        }
                        """)
-      }
     }
+  }
 
-    func testAccessor() throws {
-      withExtendedLifetime(SyntaxArena()) { arena in
-        let structDecl = cannedStructDecl(arena: arena)
-        XCTAssertEqual(structDecl.identifier.tokenKind, .identifier)
-        XCTAssertEqual(structDecl.structKeyword.tokenText, "struct")
-        XCTAssertEqual(structDecl.members.leftBrace.tokenText, "{")
-        XCTAssertEqual(structDecl.members.members.elements.count, 0)
+  func testAccessor() throws {
+    withExtendedLifetime(SyntaxArena()) { arena in
+      let structDecl = cannedStructDecl(arena: arena)
+      XCTAssertEqual(structDecl.identifier.tokenKind, .identifier)
+      XCTAssertEqual(structDecl.structKeyword.tokenText, "struct")
+      XCTAssertEqual(structDecl.members.leftBrace.tokenText, "{")
+      XCTAssertEqual(structDecl.members.members.elements.count, 0)
 
-        XCTAssert(structDecl.is(RawDeclSyntax.self))
-        XCTAssertNotNil(structDecl.as(RawDeclSyntax.self))
-        XCTAssertNil(structDecl.as(RawClassDeclSyntax.self))
-        XCTAssertFalse(structDecl.is(RawTypeSyntax.self))
-      }
+      XCTAssert(structDecl.is(RawDeclSyntax.self))
+      XCTAssertNotNil(structDecl.as(RawDeclSyntax.self))
+      XCTAssertNil(structDecl.as(RawClassDeclSyntax.self))
+      XCTAssertFalse(structDecl.is(RawTypeSyntax.self))
     }
+  }
+
+  func testMaterializedToken() throws {
+    withExtendedLifetime(SyntaxArena()) { arena in
+      let ident = RawTokenSyntax(
+        kind: .identifier, text: arena.intern("foo"),
+        leadingTriviaPieces: [], trailingTriviaPieces: [],
+        arena: arena)
+      XCTAssertEqual(ident.tokenKind, .identifier)
+      XCTAssertEqual(ident.tokenText, "foo")
+      XCTAssertEqual(ident.presence, .present)
+      XCTAssertEqual(ident.description, "foo")
+
+      let missingIdent = RawTokenSyntax(missing: .identifier, arena: arena)
+      XCTAssertEqual(missingIdent.presence, .missing)
+      XCTAssertEqual(missingIdent.tokenText, "")
+      XCTAssertEqual(missingIdent.description, "")
+    }
+  }
+
 
 }


### PR DESCRIPTION
Token text was not taken into account in the byteLength calcuration.