### PR TITLE
Add a recursive `hasError` flag to `RawSyntax`

### DIFF
--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -174,6 +174,11 @@ public extension SyntaxProtocol {
     return raw.kind.isUnknown
   }
 
+  /// Whether this tree contains a missing token or unexpected node.
+  var hasError: Bool {
+    return raw.recursiveFlags.contains(.hasError)
+  }
+
   /// The parent of this syntax node, or `nil` if this node is the root.
   var parent: Syntax? {
     return data.parent

--- a/Sources/SwiftSyntax/SyntaxKind.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxKind.swift.gyb
@@ -49,6 +49,18 @@ internal enum SyntaxKind: CSyntaxKind {
     default: return false
     }
   }
+
+  var isMissing: Bool {
+    switch self {
+% for name in SYNTAX_BASE_KINDS:
+%   if name not in ["Syntax", "SyntaxCollection"]:
+    case .missing${name}: return true
+%   end
+% end
+    case .missing: return true
+    default: return false
+    }
+  }
 }
 
 extension SyntaxKind {

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
@@ -339,6 +339,18 @@ internal enum SyntaxKind: CSyntaxKind {
     default: return false
     }
   }
+
+  var isMissing: Bool {
+    switch self {
+    case .missingDecl: return true
+    case .missingExpr: return true
+    case .missingPattern: return true
+    case .missingStmt: return true
+    case .missingType: return true
+    case .missing: return true
+    default: return false
+    }
+  }
 }
 
 extension SyntaxKind {

--- a/Tests/SwiftSyntaxTest/SyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/SyntaxTests.swift
@@ -1,0 +1,28 @@
+//===--- SyntaxTests.swift ------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+import SwiftSyntax
+
+public class SyntaxTests: XCTestCase {
+
+  public func testHasError() {
+    XCTAssertTrue(TokenSyntax.funcKeyword(presence: .missing).hasError)
+    XCTAssertFalse(TokenSyntax.funcKeyword(presence: .present).hasError)
+    XCTAssertTrue(UnexpectedNodesSyntax([]).hasError)
+    XCTAssertTrue(MissingExprSyntax().hasError)
+    XCTAssertFalse(CodeBlockItemListSyntax([]).hasError)
+
+    XCTAssertTrue(TokenListSyntax([TokenSyntax.funcKeyword(presence: .missing)]).hasError)
+    XCTAssertFalse(TokenListSyntax([TokenSyntax.funcKeyword(presence: .present)]).hasError)
+  }
+}


### PR DESCRIPTION
This allows us to check whether a subtree contains a syntax error in O(1).

rdar://98575249