### PR TITLE
Introduce `RawSyntaxData.ParsedToken`

### DIFF
--- a/Sources/SwiftSyntax/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/RawSyntaxNodeProtocol.swift
@@ -86,6 +86,10 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
     return raw.rawTokenText
   }
 
+  public var byteLength: Int {
+    return raw.byteLength
+  }
+
   public var presence: SourcePresence {
     raw.presence
   }
@@ -94,7 +98,30 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
     presence == .missing
   }
 
-  /// Creates a `TokenSyntax`. `text` and trivia must be managed by the same
+  public var leadingTriviaPieces: [RawTriviaPiece] {
+    raw.tokenLeadingRawTriviaPieces
+  }
+
+  public var trailingTriviaPieces: [RawTriviaPiece] {
+    raw.tokenTrailingRawTriviaPieces
+  }
+
+  /// Creates a `RawTokenSyntax`. `wholeText` must be managed by the same
+  /// `arena`. `textRange` is a range of the token text in `wholeText`.
+  public init(
+    kind: RawTokenKind,
+    wholeText: SyntaxText,
+    textRange: Range<SyntaxText.Index>,
+    arena: SyntaxArena
+  ) {
+    assert(arena.contains(text: wholeText),
+           "token text must be managed by the arena")
+    let raw = RawSyntax.parsedToken(
+      kind: kind, wholeText: wholeText, textRange: textRange, arena: arena)
+    self = RawTokenSyntax(raw: raw)
+  }
+
+  /// Creates a `RawTokenSyntax`. `text` and trivia must be managed by the same
   /// `arena`.
   public init(
     kind: RawTokenKind,

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -118,13 +118,14 @@ public protocol SyntaxProtocol: CustomStringConvertible,
   var syntaxNodeType: SyntaxProtocol.Type { get }
 }
 
-internal extension SyntaxProtocol {
+extension SyntaxProtocol {
   var data: SyntaxData {
     return _syntaxNode.data
   }
 
   /// Access the raw syntax assuming the node is a Syntax.
-  var raw: RawSyntax {
+  @_spi(RawSyntax)
+  public var raw: RawSyntax {
     return _syntaxNode.data.raw
   }
 }

--- a/Sources/SwiftSyntax/SyntaxClassifier.swift
+++ b/Sources/SwiftSyntax/SyntaxClassifier.swift
@@ -276,9 +276,9 @@ fileprivate struct FastTokenSequence: Sequence {
 /// Provides a sequence of `SyntaxClassifiedRange`s for a token.
 fileprivate struct TokenClassificationIterator: IteratorProtocol {
   enum State {
-    case atLeadingTrivia(RawTriviaPieceBuffer, Int)
+    case atLeadingTrivia([RawTriviaPiece], Int)
     case atTokenText
-    case atTrailingTrivia(RawTriviaPieceBuffer, Int)
+    case atTrailingTrivia([RawTriviaPiece], Int)
   }
 
   let token: AbsoluteNode

--- a/Sources/SwiftSyntax/SyntaxOtherNodes.swift
+++ b/Sources/SwiftSyntax/SyntaxOtherNodes.swift
@@ -144,7 +144,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   /// The leading trivia (spaces, newlines, etc.) associated with this token.
   public var leadingTrivia: Trivia {
     get {
-      return raw.formTokenLeadingTrivia()!
+      return raw.formTokenLeadingTrivia()
     }
     set {
       self = withLeadingTrivia(newValue)
@@ -154,7 +154,7 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   /// The trailing trivia (spaces, newlines, etc.) associated with this token.
   public var trailingTrivia: Trivia {
     get {
-      return raw.formTokenTrailingTrivia()!
+      return raw.formTokenTrailingTrivia()
     }
     set {
       self = withTrailingTrivia(newValue)

--- a/Sources/SwiftSyntax/Trivia.swift.gyb
+++ b/Sources/SwiftSyntax/Trivia.swift.gyb
@@ -17,6 +17,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+public enum TriviaPosition {
+  case leading
+  case trailing
+}
+
 /// A contiguous stretch of a single kind of trivia. The constituent part of
 /// a `Trivia` collection.
 ///
@@ -70,7 +75,7 @@ extension TriviaPiece: CustomDebugStringConvertible {
       return "${trivia.lower_name}s(\(data))"
 %   else:
     case .${trivia.lower_name}(let name):
-      return "${trivia.lower_name}(\(name))"
+      return "${trivia.lower_name}(\(name.debugDescription))"
 %   end
 % end
     }
@@ -261,6 +266,11 @@ public enum RawTriviaPiece: Equatable {
 extension RawTriviaPiece: TextOutputStreamable {
   public func write<Target: TextOutputStream>(to target: inout Target) {
     TriviaPiece(raw: self).write(to: &target)
+  }
+}
+extension RawTriviaPiece: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    TriviaPiece(raw: self).debugDescription
   }
 }
 

--- a/Sources/SwiftSyntax/gyb_generated/Trivia.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Trivia.swift
@@ -12,6 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+public enum TriviaPosition {
+  case leading
+  case trailing
+}
+
 /// A contiguous stretch of a single kind of trivia. The constituent part of
 /// a `Trivia` collection.
 ///
@@ -108,17 +113,17 @@ extension TriviaPiece: CustomDebugStringConvertible {
     case .carriageReturnLineFeeds(let data):
       return "carriageReturnLineFeeds(\(data))"
     case .lineComment(let name):
-      return "lineComment(\(name))"
+      return "lineComment(\(name.debugDescription))"
     case .blockComment(let name):
-      return "blockComment(\(name))"
+      return "blockComment(\(name.debugDescription))"
     case .docLineComment(let name):
-      return "docLineComment(\(name))"
+      return "docLineComment(\(name.debugDescription))"
     case .docBlockComment(let name):
-      return "docBlockComment(\(name))"
+      return "docBlockComment(\(name.debugDescription))"
     case .unexpectedText(let name):
-      return "unexpectedText(\(name))"
+      return "unexpectedText(\(name.debugDescription))"
     case .shebang(let name):
-      return "shebang(\(name))"
+      return "shebang(\(name.debugDescription))"
     }
   }
 }
@@ -413,6 +418,11 @@ public enum RawTriviaPiece: Equatable {
 extension RawTriviaPiece: TextOutputStreamable {
   public func write<Target: TextOutputStream>(to target: inout Target) {
     TriviaPiece(raw: self).write(to: &target)
+  }
+}
+extension RawTriviaPiece: CustomDebugStringConvertible {
+  public var debugDescription: String {
+    TriviaPiece(raw: self).debugDescription
   }
 }
 


### PR DESCRIPTION
A new `RawSyntax` data variation. This is intended to be used for parsed token. Actual usage will be in follow-ups.

In this variation, unlike the existing `MaterializedToken`, leading/trailing trivia are stored in a `SyntaxText` form, and are lazily materialized by a function registered in `SyntaxArena`. Since the parser doesn't need to materialize them while parsing, it'd gain the "parsing" performance boost, in exchange for a performance reduction when accessing trivia.