### PR TITLE
Make SyntaxArena.allocator immutable

### DIFF
--- a/Sources/SwiftSyntax/SyntaxArena.swift
+++ b/Sources/SwiftSyntax/SyntaxArena.swift
@@ -16,7 +16,7 @@ public class SyntaxArena {
   public typealias ParseTriviaFunction = (_ source: SyntaxText, _ position: TriviaPosition) -> [RawTriviaPiece]
 
   /// Bump-pointer allocator for all "intern" methods.
-  private var allocator: BumpPtrAllocator
+  private let allocator: BumpPtrAllocator
   /// Source file buffer the Syntax tree represents.
   private var sourceBuffer: UnsafeBufferPointer<UInt8>
 


### PR DESCRIPTION
`var` -> `let`. `SyntaxAnena` and `BumpPtrAllocator` lifetime should be 1:1.
Furthermore, if it's `var`, the arena needs to `retain`/`release` the allocator everytime calling it.