### PR TITLE
Add a convenience initializer for `TernaryExpr`

### DIFF
--- a/Sources/SwiftSyntaxBuilder/TernaryExprConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/TernaryExprConvenienceInitializers.swift
@@ -1,0 +1,30 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+extension TernaryExpr {
+  public init(
+    if condition: ExpressibleAsExprBuildable,
+    then firstChoice: ExpressibleAsExprBuildable,
+    else secondChoice: ExpressibleAsExprBuildable
+  ) {
+    self.init(
+      conditionExpression: condition,
+      questionMark: .infixQuestionMarkToken(leadingTrivia: .space, trailingTrivia: .space),
+      firstChoice: firstChoice,
+      colonMark: .colonToken(leadingTrivia: .space),
+      secondChoice: secondChoice
+    )
+  }
+}
+

--- a/Sources/generate-swift-syntax-builder/Templates/BuildableNodesFile.swift
+++ b/Sources/generate-swift-syntax-builder/Templates/BuildableNodesFile.swift
@@ -355,11 +355,9 @@ private func createWithTrailingCommaFunction(node: Node) -> FunctionDecl {
           label: child.swiftName,
           expression: child.name == "TrailingComma" ? SequenceExpr {
             TernaryExpr(
-              conditionExpression: "withComma",
-              questionMark: .infixQuestionMark.withLeadingTrivia(.space).withTrailingTrivia(.space),
-              firstChoice: MemberAccessExpr(name: "comma"),
-              colonMark: .colon.withLeadingTrivia(.space).withTrailingTrivia(.space),
-              secondChoice: NilLiteralExpr()
+              if: "withComma",
+              then: MemberAccessExpr(name: "comma"),
+              else: NilLiteralExpr()
             )
           } : child.swiftName
         )

--- a/Tests/SwiftSyntaxBuilderTest/TernaryExprTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/TernaryExprTests.swift
@@ -1,0 +1,14 @@
+import XCTest
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+final class TernaryExprTests: XCTestCase {
+  func testTernaryExpr() {
+    let buildable = TernaryExpr(if: BooleanLiteralExpr(true), then: "a", else: "b")
+    let syntax = buildable.buildSyntax(format: Format())
+    XCTAssertEqual(syntax.description, """
+      true ? a : b
+      """)
+  }
+}
+


### PR DESCRIPTION
Generating ternary expressions using `SwiftSyntaxBuilder` with correct formatting is quite verbose currently:

```swift
TernaryExpr(
  conditionExpression: ...,
  questionMark: .infixQuestionMarkToken(leadingTrivia: .space, trailingTrivia: .space),
  firstChoice: ...,
  colonMark: .colonToken(leadingTrivia: .space),
  secondChoice: ...
)
```

This PR adds a convenience initializer that makes constructed `TernaryExpr`s in Swift almost as terse as their generated equivalents:

```swift
TernaryExpr(
  if: ...,
  then: ...,
  else: ...
)
```

I've used the `if-then-else` terminology for the labels since it is short, clear and easily disambiguable from the generated initializer, but feel free to suggest alternative spellings.