### PR TITLE
Add convenience initializer for computed properties

### DIFF
--- a/Sources/SwiftSyntaxBuilder/VariableDeclConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/VariableDeclConvenienceInitializers.swift
@@ -13,6 +13,7 @@
 import SwiftSyntax
 
 extension VariableDecl {
+  /// Creates an optionally initialized property.
   public init(
     leadingTrivia: Trivia = [],
     _ letOrVarKeyword: TokenSyntax,
@@ -25,6 +26,23 @@ extension VariableDecl {
         pattern: name,
         typeAnnotation: type,
         initializer: initializer
+      )
+    }
+  }
+
+  /// Creates a computed property with the given accessor.
+  public init(
+    leadingTrivia: Trivia = [],
+    modifiers: ModifierList? = nil,
+    name: ExpressibleAsIdentifierPattern,
+    type: ExpressibleAsTypeAnnotation,
+    @CodeBlockItemListBuilder accessor: () -> ExpressibleAsCodeBlockItemList
+  ) {
+    self.init(leadingTrivia: leadingTrivia, modifiers: modifiers, letOrVarKeyword: .var) {
+      PatternBinding(
+        pattern: name,
+        typeAnnotation: type,
+        accessor: CodeBlock(statements: accessor())
       )
     }
   }

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -88,4 +88,21 @@ final class VariableTests: XCTestCase {
       XCTAssertEqual(syntax.description, expected, line: line)
     }
   }
+
+  func testComputedProperty() {
+    let buildable = VariableDecl(name: "test", type: "Int") {
+      SequenceExpr {
+        IntegerLiteralExpr(4)
+        BinaryOperatorExpr("+")
+        IntegerLiteralExpr(5)
+      }
+    }
+
+    let syntax = buildable.buildSyntax(format: Format())
+    XCTAssertEqual(syntax.description, """
+      var test: Int {
+          4 + 5
+      }
+      """)
+  }
 }


### PR DESCRIPTION
This PR adds a new convenience initializer for computed properties, making them as convenient to create as `FunctionDecl`s.