### PR TITLE
Add SwiftParser's README to the exclude list

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -105,7 +105,10 @@ let package = Package(
     ),
     .target(
       name: "SwiftParser",
-      dependencies: ["SwiftSyntax"]
+      dependencies: ["SwiftSyntax"],
+      exclude: [
+        "README.md"
+      ]
     ),
     .executableTarget(
       name: "lit-test-helper",


### PR DESCRIPTION
Exclude SwiftParser's README from its target to resolve the `found 1
file(s) which are unhandled` warning.