### PR TITLE
Fix small typo in comment in Lexer

### DIFF
--- a/Sources/SwiftParser/Lexer.swift
+++ b/Sources/SwiftParser/Lexer.swift
@@ -865,7 +865,7 @@ extension Lexer.Cursor {
       let start = self
 
       switch self.advance() {
-      // 'continue' - the character is a part of the triivia.
+      // 'continue' - the character is a part of the trivia.
       // 'break' - the character should a part of token text.
       case nil:
         break


### PR DESCRIPTION
`triivia` seems to be typo of `trivia`