### PR TITLE
Several improvements to diagnostics in the new parser

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -59,6 +59,10 @@ let package = Package(
       ]
     ),
     .target(
+      name: "SwiftDiagnostics",
+      dependencies: ["SwiftSyntax"]
+    ),
+    .target(
       name: "SwiftSyntax",
       dependencies: ["_CSwiftSyntax"],
       exclude: [
@@ -105,7 +109,7 @@ let package = Package(
     ),
     .target(
       name: "SwiftParser",
-      dependencies: ["SwiftSyntax"],
+      dependencies: ["SwiftDiagnostics", "SwiftSyntax"],
       exclude: [
         "README.md"
       ]
@@ -116,7 +120,7 @@ let package = Package(
     ),
     .executableTarget(
       name: "swift-parser-test",
-      dependencies: ["SwiftSyntax", "SwiftParser", .product(name: "ArgumentParser", package: "swift-argument-parser")]
+      dependencies: ["SwiftDiagnostics", "SwiftSyntax", "SwiftParser", .product(name: "ArgumentParser", package: "swift-argument-parser")]
     ),
     .executableTarget(
         name: "generate-swift-syntax-builder",
@@ -162,7 +166,7 @@ let package = Package(
     ),
     .testTarget(
       name: "SwiftParserTest",
-      dependencies: ["SwiftParser", "_SwiftSyntaxTestSupport"]
+      dependencies: ["SwiftDiagnostics", "SwiftParser", "_SwiftSyntaxTestSupport"]
     ),
   ]
 )

--- a/Sources/SwiftDiagnostics/Diagnostic.swift
+++ b/Sources/SwiftDiagnostics/Diagnostic.swift
@@ -19,7 +19,7 @@ public struct Diagnostic {
   /// The node at whose start location the message should be displayed.
   public let node: Syntax
 
-  init(node: Syntax, message: DiagnosticMessage) {
+  public init(node: Syntax, message: DiagnosticMessage) {
     self.diagMessage = message
     self.node = node
   }

--- a/Sources/SwiftDiagnostics/Diagnostic.swift
+++ b/Sources/SwiftDiagnostics/Diagnostic.swift
@@ -19,13 +19,17 @@ public struct Diagnostic: CustomDebugStringConvertible {
   /// The node at whose start location the message should be displayed.
   public let node: Syntax
 
+  /// Nodes that should be highlighted in the source code.
+  public let highlights: [Syntax]
+
   /// Fix-Its that can be applied to resolve this diagnostic.
   /// Each Fix-It offers a different way to resolve the diagnostic. Usually, there's only one.
   public let fixIts: [FixIt]
 
-  public init(node: Syntax, message: DiagnosticMessage, fixIts: [FixIt] = []) {
+  public init(node: Syntax, message: DiagnosticMessage, highlights: [Syntax] = [], fixIts: [FixIt] = []) {
     self.diagMessage = message
     self.node = node
+    self.highlights = highlights
     self.fixIts = fixIts
   }
 

--- a/Sources/SwiftDiagnostics/Diagnostic.swift
+++ b/Sources/SwiftDiagnostics/Diagnostic.swift
@@ -12,7 +12,7 @@
 
 import SwiftSyntax
 
-public struct Diagnostic {
+public struct Diagnostic: CustomDebugStringConvertible {
   /// The message that should be displayed to the user
   public let diagMessage: DiagnosticMessage
 
@@ -38,6 +38,16 @@ public struct Diagnostic {
   /// The location at which the diagnostic should be displayed.
   public func location(converter: SourceLocationConverter) -> SourceLocation {
     return node.startLocation(converter: converter)
+  }
+
+  public var debugDescription: String {
+    if let root = node.root.as(SourceFileSyntax.self) {
+      let locationConverter = SourceLocationConverter(file: "", tree: root)
+      let location = location(converter: locationConverter)
+      return "\(location): \(message)"
+    } else {
+      return "<unknown>: \(message)"
+    }
   }
 }
 

--- a/Sources/SwiftDiagnostics/Diagnostic.swift
+++ b/Sources/SwiftDiagnostics/Diagnostic.swift
@@ -30,8 +30,8 @@ public struct Diagnostic {
   }
 
   /// An ID that identifies the diagnostic's message.
-  /// See ``DiagnosticMessageID``.
-  public var diagnosticID: DiagnosticMessageID {
+  /// See ``MessageID``.
+  public var diagnosticID: MessageID {
     return diagMessage.diagnosticID
   }
 

--- a/Sources/SwiftDiagnostics/Diagnostic.swift
+++ b/Sources/SwiftDiagnostics/Diagnostic.swift
@@ -19,9 +19,14 @@ public struct Diagnostic: CustomDebugStringConvertible {
   /// The node at whose start location the message should be displayed.
   public let node: Syntax
 
-  public init(node: Syntax, message: DiagnosticMessage) {
+  /// Fix-Its that can be applied to resolve this diagnostic.
+  /// Each Fix-It offers a different way to resolve the diagnostic. Usually, there's only one.
+  public let fixIts: [FixIt]
+
+  public init(node: Syntax, message: DiagnosticMessage, fixIts: [FixIt] = []) {
     self.diagMessage = message
     self.node = node
+    self.fixIts = fixIts
   }
 
   /// The message that should be displayed to the user.

--- a/Sources/SwiftDiagnostics/DiagnosticMessage.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticMessage.swift
@@ -34,18 +34,3 @@ public protocol DiagnosticMessage {
   /// See ``DiagnosticMessageID``.
   var diagnosticID: DiagnosticMessageID { get }
 }
-
-/// A diagnostic how's ID is determined by the diagnostic's type.
-public protocol TypedDiagnosticMessage: DiagnosticMessage {
-  var diagnosticID: DiagnosticMessageID { get }
-}
-
-public extension TypedDiagnosticMessage {
-  static var diagnosticID: DiagnosticMessageID {
-    return DiagnosticMessageID("\(self)")
-  }
-
-  var diagnosticID: DiagnosticMessageID {
-    return Self.diagnosticID
-  }
-}

--- a/Sources/SwiftDiagnostics/FixIt.swift
+++ b/Sources/SwiftDiagnostics/FixIt.swift
@@ -1,0 +1,46 @@
+//===--- FixIt.swift ------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+/// Types conforming to this protocol represent Fix-It messages that can be
+/// shown to the client.
+/// The messages should describe the change that the Fix-It will perform
+public protocol FixItMessage {
+  /// The diagnostic message that should be displayed in the client.
+  var message: String { get }
+
+  /// See ``MessageID``.
+  var fixItID: MessageID { get }
+}
+
+
+/// A Fix-It that can be applied to resolve a diagnostic.
+public struct FixIt {
+  public enum Change {
+    /// Replace `oldNode` by `newNode`.
+    case replace(oldNode: Syntax, newNode: Syntax)
+  }
+
+  /// A description of what this Fix-It performs.
+  public let message: FixItMessage
+
+  /// The changes that need to be performed when the Fix-It is applied.
+  public let changes: [Change]
+
+  public init(message: FixItMessage, changes: [Change]) {
+    assert(!changes.isEmpty, "A Fix-It must have at least one diagnostic associated with it")
+    self.message = message
+    self.changes = changes
+  }
+}
+

--- a/Sources/SwiftDiagnostics/Message.swift
+++ b/Sources/SwiftDiagnostics/Message.swift
@@ -18,10 +18,12 @@
 /// same wording. Eg. it’s possible that the message contains more context when
 /// available.
 public struct MessageID: Hashable {
-  private let value: String
+  private let domain: String
+  private let id: String
 
-  public init(_ value: String) {
-    self.value = value
+  public init(domain: String, id: String) {
+    self.domain = domain
+    self.id = id
   }
 }
 

--- a/Sources/SwiftDiagnostics/Message.swift
+++ b/Sources/SwiftDiagnostics/Message.swift
@@ -25,6 +25,12 @@ public struct MessageID: Hashable {
   }
 }
 
+public enum DiagnosticSeverity {
+  case error
+  case warning
+  case note
+}
+
 /// Types conforming to this protocol represent diagnostic messages that can be
 /// shown to the client.
 public protocol DiagnosticMessage {
@@ -33,4 +39,6 @@ public protocol DiagnosticMessage {
 
   /// See ``MessageID``.
   var diagnosticID: MessageID { get }
+
+  var severity: DiagnosticSeverity { get }
 }

--- a/Sources/SwiftDiagnostics/Message.swift
+++ b/Sources/SwiftDiagnostics/Message.swift
@@ -1,4 +1,4 @@
-//===--- DiagnosticMessage.swift ------------------------------------------===//
+//===--- Message.swift ----------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -17,7 +17,7 @@
 /// Two diagnostics with the same ID don’t need to necessarily have the exact
 /// same wording. Eg. it’s possible that the message contains more context when
 /// available.
-public struct DiagnosticMessageID: Hashable {
+public struct MessageID: Hashable {
   private let value: String
 
   public init(_ value: String) {
@@ -31,6 +31,6 @@ public protocol DiagnosticMessage {
   /// The diagnostic message that should be displayed in the client.
   var message: String { get }
 
-  /// See ``DiagnosticMessageID``.
-  var diagnosticID: DiagnosticMessageID { get }
+  /// See ``MessageID``.
+  var diagnosticID: MessageID { get }
 }

--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -96,13 +96,12 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     if shouldSkip(node) {
       return .skipChildren
     }
+    // Detect C-style for loops based on two semicolons which could not be parsed between the 'for' keyword and the '{'
     // This is mostly a proof-of-concept implementation to produce more complex diagnostics.
-    if let unexpectedCondition = node.body.unexpectedBeforeLeftBrace {
-      // Detect C-style for loops based on two semicolons which could not be parsed between the 'for' keyword and the '{'
-      if unexpectedCondition.tokens(withKind: .semicolon).count == 2 {
-        addDiagnostic(node, .cStyleForLoop)
-        markNodesAsHandled(node.inKeyword.id, unexpectedCondition.id)
-      }
+    if let unexpectedCondition = node.body.unexpectedBeforeLeftBrace,
+       unexpectedCondition.tokens(withKind: .semicolon).count == 2 {
+      addDiagnostic(node, .cStyleForLoop)
+      markNodesAsHandled(node.inKeyword.id, unexpectedCondition.id)
     }
     return .visitChildren
   }
@@ -111,12 +110,12 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     if shouldSkip(node) {
       return .skipChildren
     }
-    if let output = node.output, let unexpectedBeforeReturnType = output.unexpectedBetweenArrowAndReturnType {
-      if let throwsInReturnPosition = unexpectedBeforeReturnType.tokens(withKind: .throwsKeyword).first {
+    if let output = node.output,
+       let unexpectedBeforeReturnType = output.unexpectedBetweenArrowAndReturnType,
+       let throwsInReturnPosition = unexpectedBeforeReturnType.tokens(withKind: .throwsKeyword).first {
         addDiagnostic(throwsInReturnPosition, .throwsInReturnPosition)
         markNodesAsHandled(unexpectedBeforeReturnType.id, throwsInReturnPosition.id)
         return .visitChildren
-      }
     }
     return .visitChildren
   }

--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftDiagnostics
 import SwiftSyntax
 
 extension UnexpectedNodesSyntax {

--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -47,6 +47,11 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     diagnostics.append(Diagnostic(node: Syntax(node), message: message))
   }
 
+  /// Produce a diagnostic.
+  private func addDiagnostic<T: SyntaxProtocol>(_ node: T, _ message: StaticParserError) {
+    addDiagnostic(node, message as DiagnosticMessage)
+  }
+
   /// If a diagnostic is generated that covers multiple syntax nodes, mark them as handles so they don't produce the generic diagnostics anymore.
   private func markNodesAsHandled(_ nodes: SyntaxIdentifier...) {
     handledNodes.append(contentsOf: nodes)
@@ -95,7 +100,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     if let unexpectedCondition = node.body.unexpectedBeforeLeftBrace {
       // Detect C-style for loops based on two semicolons which could not be parsed between the 'for' keyword and the '{'
       if unexpectedCondition.tokens(withKind: .semicolon).count == 2 {
-        addDiagnostic(node, CStyleForLoopError())
+        addDiagnostic(node, .cStyleForLoop)
         markNodesAsHandled(node.inKeyword.id, unexpectedCondition.id)
       }
     }
@@ -108,7 +113,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     }
     if let output = node.output, let unexpectedBeforeReturnType = output.unexpectedBetweenArrowAndReturnType {
       if let throwsInReturnPosition = unexpectedBeforeReturnType.tokens(withKind: .throwsKeyword).first {
-        addDiagnostic(throwsInReturnPosition, ThrowsInReturnPositionError())
+        addDiagnostic(throwsInReturnPosition, .throwsInReturnPosition)
         markNodesAsHandled(unexpectedBeforeReturnType.id, throwsInReturnPosition.id)
         return .visitChildren
       }

--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -71,7 +71,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     if shouldSkip(node) {
       return .skipChildren
     }
-    addDiagnostic(node, UnexpectedNodesDiagnostic(unexpectedNodes: node))
+    addDiagnostic(node, UnexpectedNodesError(unexpectedNodes: node))
     return .skipChildren
   }
 
@@ -80,7 +80,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
       return .skipChildren
     }
     if node.presence == .missing {
-      addDiagnostic(node, MissingTokenDiagnostic(missingToken: node))
+      addDiagnostic(node, MissingTokenError(missingToken: node))
     }
     return .skipChildren
   }
@@ -95,7 +95,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     if let unexpectedCondition = node.body.unexpectedBeforeLeftBrace {
       // Detect C-style for loops based on two semicolons which could not be parsed between the 'for' keyword and the '{'
       if unexpectedCondition.tokens(withKind: .semicolon).count == 2 {
-        addDiagnostic(node, CStyleForLoopDiagnostic())
+        addDiagnostic(node, CStyleForLoopError())
         markNodesAsHandled(node.inKeyword.id, unexpectedCondition.id)
       }
     }
@@ -108,7 +108,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     }
     if let output = node.output, let unexpectedBeforeReturnType = output.unexpectedBetweenArrowAndReturnType {
       if let throwsInReturnPosition = unexpectedBeforeReturnType.tokens(withKind: .throwsKeyword).first {
-        addDiagnostic(throwsInReturnPosition, ThrowsInReturnPositionDiagnostic())
+        addDiagnostic(throwsInReturnPosition, ThrowsInReturnPositionError())
         markNodesAsHandled(unexpectedBeforeReturnType.id, throwsInReturnPosition.id)
         return .visitChildren
       }

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -36,30 +36,28 @@ extension Syntax {
   }
 }
 
-
-/// A diagnostic how's ID is determined by the diagnostic's type.
-public protocol TypedDiagnosticMessage: DiagnosticMessage {
-  var diagnosticID: DiagnosticMessageID { get }
+/// A diagnostic whose ID is determined by the diagnostic's type.
+public protocol DiagnosticMessageType: DiagnosticMessage {
+  var diagnosticID: MessageID { get }
 }
 
-public extension TypedDiagnosticMessage {
-  static var diagnosticID: DiagnosticMessageID {
-    return DiagnosticMessageID("\(self)")
+public extension DiagnosticMessageType {
+  static var diagnosticID: MessageID {
+    return MessageID("\(self)")
   }
 
-  var diagnosticID: DiagnosticMessageID {
+  var diagnosticID: MessageID {
     return Self.diagnosticID
   }
 }
 
-
 // MARK: - Diagnostics (please sort alphabetically)
 
-public struct CStyleForLoopDiagnostic: TypedDiagnosticMessage {
+public struct CStyleForLoopDiagnostic: DiagnosticMessageType {
   public var message = "C-style for statement has been removed in Swift 3"
 }
 
-public struct MissingTokenDiagnostic: TypedDiagnosticMessage {
+public struct MissingTokenDiagnostic: DiagnosticMessageType {
   public let missingToken: TokenSyntax
 
   public var message: String {
@@ -82,11 +80,11 @@ public struct MissingTokenDiagnostic: TypedDiagnosticMessage {
   }
 }
 
-public struct ThrowsInReturnPositionDiagnostic: TypedDiagnosticMessage {
+public struct ThrowsInReturnPositionDiagnostic: DiagnosticMessageType {
   public let message = "'throws' may only occur before '->'"
 }
 
-public struct UnexpectedNodesDiagnostic: TypedDiagnosticMessage {
+public struct UnexpectedNodesDiagnostic: DiagnosticMessageType {
   public let unexpectedNodes: UnexpectedNodesSyntax
 
   public var message: String {

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -36,12 +36,12 @@ extension Syntax {
   }
 }
 
-/// A diagnostic whose ID is determined by the diagnostic's type.
-public protocol DiagnosticMessageType: DiagnosticMessage {
+/// A error diagnostic whose ID is determined by the diagnostic's type.
+public protocol ParserError: DiagnosticMessage {
   var diagnosticID: MessageID { get }
 }
 
-public extension DiagnosticMessageType {
+public extension ParserError {
   static var diagnosticID: MessageID {
     return MessageID("\(self)")
   }
@@ -49,15 +49,19 @@ public extension DiagnosticMessageType {
   var diagnosticID: MessageID {
     return Self.diagnosticID
   }
+
+  var severity: DiagnosticSeverity {
+    return .error
+  }
 }
 
 // MARK: - Diagnostics (please sort alphabetically)
 
-public struct CStyleForLoopDiagnostic: DiagnosticMessageType {
+public struct CStyleForLoopError: ParserError {
   public var message = "C-style for statement has been removed in Swift 3"
 }
 
-public struct MissingTokenDiagnostic: DiagnosticMessageType {
+public struct MissingTokenError: ParserError {
   public let missingToken: TokenSyntax
 
   public var message: String {
@@ -80,11 +84,11 @@ public struct MissingTokenDiagnostic: DiagnosticMessageType {
   }
 }
 
-public struct ThrowsInReturnPositionDiagnostic: DiagnosticMessageType {
+public struct ThrowsInReturnPositionError: ParserError {
   public let message = "'throws' may only occur before '->'"
 }
 
-public struct UnexpectedNodesDiagnostic: DiagnosticMessageType {
+public struct UnexpectedNodesError: ParserError {
   public let unexpectedNodes: UnexpectedNodesSyntax
 
   public var message: String {

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -57,6 +57,20 @@ public extension ParserError {
   }
 }
 
+public protocol ParserFixIt: FixItMessage {
+  var fixItID: MessageID { get }
+}
+
+public extension ParserFixIt {
+  static var fixItID: MessageID {
+    return MessageID(domain: diagnosticDomain, id: "\(self)")
+  }
+
+  var fixItID: MessageID {
+    return Self.fixItID
+  }
+}
+
 // MARK: - Static diagnostics
 
 /// Please order the cases in this enum alphabetically by case name.
@@ -71,6 +85,16 @@ public enum StaticParserError: String, DiagnosticMessage {
   }
 
   public var severity: DiagnosticSeverity { .error }
+}
+
+public enum StaticParserFixIt: String, FixItMessage {
+  case moveThrowBeforeArrow = "Move 'throws' in before of '->'"
+
+  public var message: String { self.rawValue }
+
+  public var fixItID: MessageID {
+    MessageID(domain: diagnosticDomain, id: "\(type(of: self)).\(self)")
+  }
 }
 
 // MARK: - Diagnostics (please sort alphabetically)

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -55,11 +55,23 @@ public extension ParserError {
   }
 }
 
-// MARK: - Diagnostics (please sort alphabetically)
+// MARK: - Static diagnostics
 
-public struct CStyleForLoopError: ParserError {
-  public var message = "C-style for statement has been removed in Swift 3"
+/// Please order the cases in this enum alphabetically by case name.
+public enum StaticParserError: String, DiagnosticMessage {
+  case cStyleForLoop = "C-style for statement has been removed in Swift 3"
+  case throwsInReturnPosition = "'throws' may only occur before '->'"
+
+  public var message: String { self.rawValue }
+
+  public var diagnosticID: MessageID {
+    MessageID("\(type(of: self)).\(self)")
+  }
+
+  public var severity: DiagnosticSeverity { .error }
 }
+
+// MARK: - Diagnostics (please sort alphabetically)
 
 public struct MissingTokenError: ParserError {
   public let missingToken: TokenSyntax
@@ -82,10 +94,6 @@ public struct MissingTokenError: ParserError {
     }
     return "Expected '\(missingToken.text)' in \(parentTypeName)"
   }
-}
-
-public struct ThrowsInReturnPositionError: ParserError {
-  public let message = "'throws' may only occur before '->'"
 }
 
 public struct UnexpectedNodesError: ParserError {

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -10,6 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import SwiftDiagnostics
 import SwiftSyntax
 
 extension Syntax {
@@ -34,6 +35,23 @@ extension Syntax {
     }
   }
 }
+
+
+/// A diagnostic how's ID is determined by the diagnostic's type.
+public protocol TypedDiagnosticMessage: DiagnosticMessage {
+  var diagnosticID: DiagnosticMessageID { get }
+}
+
+public extension TypedDiagnosticMessage {
+  static var diagnosticID: DiagnosticMessageID {
+    return DiagnosticMessageID("\(self)")
+  }
+
+  var diagnosticID: DiagnosticMessageID {
+    return Self.diagnosticID
+  }
+}
+
 
 // MARK: - Diagnostics (please sort alphabetically)
 

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -13,6 +13,8 @@
 import SwiftDiagnostics
 import SwiftSyntax
 
+let diagnosticDomain: String = "SwiftParser"
+
 extension Syntax {
   // FIXME: These should be defined in gyb_syntax_support.
   var nodeTypeNameForDiagnostics: String? {
@@ -43,7 +45,7 @@ public protocol ParserError: DiagnosticMessage {
 
 public extension ParserError {
   static var diagnosticID: MessageID {
-    return MessageID("\(self)")
+    return MessageID(domain: diagnosticDomain, id: "\(self)")
   }
 
   var diagnosticID: MessageID {
@@ -65,7 +67,7 @@ public enum StaticParserError: String, DiagnosticMessage {
   public var message: String { self.rawValue }
 
   public var diagnosticID: MessageID {
-    MessageID("\(type(of: self)).\(self)")
+    MessageID(domain: diagnosticDomain, id: "\(type(of: self)).\(self)")
   }
 
   public var severity: DiagnosticSeverity { .error }

--- a/Sources/swift-parser-test/swift-parser-test.swift
+++ b/Sources/swift-parser-test/swift-parser-test.swift
@@ -11,6 +11,7 @@
 //===----------------------------------------------------------------------===//
 
 
+import SwiftDiagnostics
 import SwiftSyntax
 import SwiftParser
 import Foundation

--- a/Sources/swift-parser-test/swift-parser-test.swift
+++ b/Sources/swift-parser-test/swift-parser-test.swift
@@ -132,14 +132,11 @@ class PrintDiags: ParsableCommand {
       enableBareSlashRegexLiteral: enableBareSlashRegex
     )
     let diags = ParseDiagnosticsGenerator.diagnostics(for: tree)
-    let locationConverter = SourceLocationConverter(file: sourceFile, tree: tree)
     if diags.isEmpty {
       print("No diagnostics produced")
     }
     for diag in diags {
-      let location = diag.location(converter: locationConverter)
-      let message = diag.message
-      print("\(location): \(message)")
+      print("\(diag.debugDescription)")
     }
   }
 }

--- a/Tests/SwiftParserTest/DiagnosticAssertions.swift
+++ b/Tests/SwiftParserTest/DiagnosticAssertions.swift
@@ -1,3 +1,4 @@
+import SwiftDiagnostics
 import SwiftSyntax
 import SwiftParser
 import XCTest

--- a/Tests/SwiftParserTest/DiagnosticAssertions.swift
+++ b/Tests/SwiftParserTest/DiagnosticAssertions.swift
@@ -32,8 +32,9 @@ public class FixItApplier: SyntaxRewriter {
 
 /// Asserts that the diagnostics `diag` inside `tree` occurs at `line` and
 /// `column`.
-/// If `message` is not `nil`, assert that the diagnostic has the given message.
 /// If `id` is not `nil`, assert that the diagnostic has the given message.
+/// If `message` is not `nil`, assert that the diagnostic has the given message.
+/// If `highlight` is not `nil`, assert that the highlighted range has this content.
 func XCTAssertDiagnostic<T: SyntaxProtocol>(
   _ diag: Diagnostic,
   in tree: T,
@@ -41,6 +42,7 @@ func XCTAssertDiagnostic<T: SyntaxProtocol>(
   column: Int,
   id: MessageID? = nil,
   message: String? = nil,
+  highlight: String? = nil,
   testFile: StaticString = #filePath,
   testLine: UInt = #line
 ) {
@@ -53,6 +55,9 @@ func XCTAssertDiagnostic<T: SyntaxProtocol>(
   }
   if let message = message {
     XCTAssertEqual(diag.message, message, file: testFile, line: testLine)
+  }
+  if let highlight = highlight {
+    AssertStringsEqualWithDiff(diag.highlights.map(\.description).joined(), highlight, file: testFile, line: testLine)
   }
 }
 
@@ -67,6 +72,7 @@ func XCTAssertSingleDiagnostic<T: SyntaxProtocol>(
   column: Int,
   id: MessageID? = nil,
   message: String? = nil,
+  highlight: String? = nil,
   expectedFixedSource: String? = nil,
   testFile: StaticString = #filePath,
   testLine: UInt = #line
@@ -76,7 +82,7 @@ func XCTAssertSingleDiagnostic<T: SyntaxProtocol>(
     XCTFail("Received \(diags.count) diagnostics but expected excatly one: \(diags)", file: testFile, line: testLine)
     return
   }
-  XCTAssertDiagnostic(diags.first!, in: tree, line: line, column: column, id: id, message: message, testFile: testFile, testLine: testLine)
+  XCTAssertDiagnostic(diags.first!, in: tree, line: line, column: column, id: id, message: message, highlight: highlight, testFile: testFile, testLine: testLine)
   if let expectedFixedSource = expectedFixedSource {
     let fixedSource = FixItApplier.applyFixes(in: diags, to: tree).description
     AssertStringsEqualWithDiff(fixedSource, expectedFixedSource, file: testFile, line: testLine)

--- a/Tests/SwiftParserTest/DiagnosticAssertions.swift
+++ b/Tests/SwiftParserTest/DiagnosticAssertions.swift
@@ -13,7 +13,7 @@ func XCTAssertDiagnostic<T: SyntaxProtocol>(
   in tree: T,
   line: Int,
   column: Int,
-  id: DiagnosticMessageID? = nil,
+  id: MessageID? = nil,
   message: String? = nil,
   testFile: StaticString = #filePath,
   testLine: UInt = #line
@@ -38,7 +38,7 @@ func XCTAssertSingleDiagnostic<T: SyntaxProtocol>(
   in tree: T,
   line: Int,
   column: Int,
-  id: DiagnosticMessageID? = nil,
+  id: MessageID? = nil,
   message: String? = nil,
   testFile: StaticString = #filePath,
   testLine: UInt = #line

--- a/Tests/SwiftParserTest/DiagnosticInfrastructureTests.swift
+++ b/Tests/SwiftParserTest/DiagnosticInfrastructureTests.swift
@@ -4,12 +4,13 @@ import SwiftParser
 
 public class DiagnosticInfrastructureTests: XCTestCase {
   public func testDiagnosticID() throws {
-    struct TestDiagnostic: DiagnosticMessageType {
+    struct TestDiagnostic: ParserError {
       let message: String = "My test diagnostic"
     }
 
     let diag = TestDiagnostic()
     XCTAssertEqual(diag.diagnosticID, MessageID("TestDiagnostic"))
     XCTAssertEqual(diag.message, "My test diagnostic")
+    XCTAssertEqual(diag.severity, .error)
   }
 }

--- a/Tests/SwiftParserTest/DiagnosticInfrastructureTests.swift
+++ b/Tests/SwiftParserTest/DiagnosticInfrastructureTests.swift
@@ -9,11 +9,11 @@ public class DiagnosticInfrastructureTests: XCTestCase {
     }
 
     let diag = TestDiagnostic()
-    XCTAssertEqual(diag.diagnosticID, MessageID("TestDiagnostic"))
+    XCTAssertEqual(diag.diagnosticID, MessageID(domain: "SwiftParser", id: "TestDiagnostic"))
     XCTAssertEqual(diag.message, "My test diagnostic")
     XCTAssertEqual(diag.severity, .error)
 
-    XCTAssertEqual(StaticParserError.throwsInReturnPosition.diagnosticID, MessageID("StaticParserError.throwsInReturnPosition"))
+    XCTAssertEqual(StaticParserError.throwsInReturnPosition.diagnosticID, MessageID(domain: "SwiftParser", id: "StaticParserError.throwsInReturnPosition"))
     XCTAssertEqual(StaticParserError.throwsInReturnPosition.severity, .error)
   }
 }

--- a/Tests/SwiftParserTest/DiagnosticInfrastructureTests.swift
+++ b/Tests/SwiftParserTest/DiagnosticInfrastructureTests.swift
@@ -12,5 +12,8 @@ public class DiagnosticInfrastructureTests: XCTestCase {
     XCTAssertEqual(diag.diagnosticID, MessageID("TestDiagnostic"))
     XCTAssertEqual(diag.message, "My test diagnostic")
     XCTAssertEqual(diag.severity, .error)
+
+    XCTAssertEqual(StaticParserError.throwsInReturnPosition.diagnosticID, MessageID("StaticParserError.throwsInReturnPosition"))
+    XCTAssertEqual(StaticParserError.throwsInReturnPosition.severity, .error)
   }
 }

--- a/Tests/SwiftParserTest/DiagnosticInfrastructureTests.swift
+++ b/Tests/SwiftParserTest/DiagnosticInfrastructureTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import SwiftDiagnostics
 import SwiftParser
 
 public class DiagnosticInfrastructureTests: XCTestCase {

--- a/Tests/SwiftParserTest/DiagnosticInfrastructureTests.swift
+++ b/Tests/SwiftParserTest/DiagnosticInfrastructureTests.swift
@@ -4,12 +4,12 @@ import SwiftParser
 
 public class DiagnosticInfrastructureTests: XCTestCase {
   public func testDiagnosticID() throws {
-    struct TestDiagnostic: TypedDiagnosticMessage {
+    struct TestDiagnostic: DiagnosticMessageType {
       let message: String = "My test diagnostic"
     }
 
     let diag = TestDiagnostic()
-    XCTAssertEqual(diag.diagnosticID, DiagnosticMessageID("TestDiagnostic"))
+    XCTAssertEqual(diag.diagnosticID, MessageID("TestDiagnostic"))
     XCTAssertEqual(diag.message, "My test diagnostic")
   }
 }

--- a/Tests/SwiftParserTest/DiagnosticTests.swift
+++ b/Tests/SwiftParserTest/DiagnosticTests.swift
@@ -10,7 +10,7 @@ public class DiagnosticTests: XCTestCase {
     """
     let signature = withParser(source: source) { Syntax(raw: $0.parseFunctionSignature().raw) }
 
-    XCTAssertSingleDiagnostic(in: signature, line: 1, column: 15, id: MissingTokenDiagnostic.diagnosticID, message: "Expected ':' in function parameter")
+    XCTAssertSingleDiagnostic(in: signature, line: 1, column: 15, id: MissingTokenError.diagnosticID, message: "Expected ':' in function parameter")
   }
 
   public func testUnexpectedDiags() throws {

--- a/Tests/SwiftParserTest/DiagnosticTests.swift
+++ b/Tests/SwiftParserTest/DiagnosticTests.swift
@@ -31,7 +31,12 @@ public class DiagnosticTests: XCTestCase {
       Syntax(raw: $0.parseForEachStatement().raw).as(ForInStmtSyntax.self)!
     }
 
-    XCTAssertSingleDiagnostic(in: loop, line: 1, column: 1, message: "C-style for statement has been removed in Swift 3")
+    XCTAssertSingleDiagnostic(
+      in: loop,
+      line: 1, column: 1,
+      message: "C-style for statement has been removed in Swift 3",
+      highlight: "let x = 0; x < 10; x += 1, y += 1 "
+    )
   }
 
   public func testMissingClosingParen() throws {

--- a/Tests/SwiftParserTest/DiagnosticTests.swift
+++ b/Tests/SwiftParserTest/DiagnosticTests.swift
@@ -65,6 +65,11 @@ public class DiagnosticTests: XCTestCase {
       Syntax(raw: $0.parseFunctionSignature().raw).as(FunctionSignatureSyntax.self)!
     }
 
-    XCTAssertSingleDiagnostic(in: signature, line: 1, column: 7, message: "'throws' may only occur before '->'")
+    XCTAssertSingleDiagnostic(
+      in: signature,
+      line: 1, column: 7,
+      message: "'throws' may only occur before '->'",
+      expectedFixedSource: "() throws -> Int"
+    )
   }
 }


### PR DESCRIPTION
- Move diagnostic types to their own modules (this will make it easier to use these diagnostics e.g. from the operator precedence library https://github.com/apple/swift-syntax/pull/619)
- Add severity, Fix-It and highlight range support
- Add a domain to `DiagnosticID`

The goal of this PR is to provide the mentioned functionality above. At this point, the goal is not to review ParseDiagnosticsGenerator.swift. I know that the generator has super rough edges at the moment but before optimizing it for better ergonomics, I would like to implement a few more diagnostics to see what the common patterns are.