### PR TITLE
Add two more diagnostics

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1061,7 +1061,9 @@ extension Parser {
   public mutating func parseParameterClause(isClosure: Bool = false) -> RawParameterClauseSyntax {
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
     var elements = [RawFunctionParameterSyntax]()
-    do {
+    // If we are missing the left parenthesis and the next token doesn't appear to be an argument label, don't parse any parameters.
+    let shouldSkipParameterParsing = lparen.isMissing && (!currentToken.canBeArgumentLabel || currentToken.isKeyword)
+    if !shouldSkipParameterParsing {
       var keepGoing = true
       while !self.at(.eof) && !self.at(.rightParen) && keepGoing {
         // Attributes.

--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -169,5 +169,16 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     }
     return .visitChildren
   }
+
+  public override func visit(_ node: UnresolvedTernaryExprSyntax) -> SyntaxVisitorContinueKind {
+    if shouldSkip(node) {
+      return .skipChildren
+    }
+    if node.colonMark.presence == .missing {
+      addDiagnostic(node.colonMark, .missingColonInTernaryExprDiagnostic)
+      markNodesAsHandled(node.colonMark.id)
+    }
+    return .visitChildren
+  }
 }
 

--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -158,5 +158,16 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     }
     return .visitChildren
   }
+
+  override public func visit(_ node: ParameterClauseSyntax) -> SyntaxVisitorContinueKind {
+    if shouldSkip(node) {
+      return .skipChildren
+    }
+    if node.leftParen.presence == .missing && node.parameterList.isEmpty && node.rightParen.presence == .missing {
+      addDiagnostic(node, .missingFunctionParameterClause)
+      markNodesAsHandled(node.leftParen.id, node.parameterList.id, node.rightParen.id)
+    }
+    return .visitChildren
+  }
 }
 

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -76,6 +76,7 @@ public extension ParserFixIt {
 /// Please order the cases in this enum alphabetically by case name.
 public enum StaticParserError: String, DiagnosticMessage {
   case cStyleForLoop = "C-style for statement has been removed in Swift 3"
+  case missingFunctionParameterClause = "Expected argument list in function declaration"
   case throwsInReturnPosition = "'throws' may only occur before '->'"
 
   public var message: String { self.rawValue }

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -76,6 +76,7 @@ public extension ParserFixIt {
 /// Please order the cases in this enum alphabetically by case name.
 public enum StaticParserError: String, DiagnosticMessage {
   case cStyleForLoop = "C-style for statement has been removed in Swift 3"
+  case missingColonInTernaryExprDiagnostic = "Expected ':' after '? ...' in ternary expression"
   case missingFunctionParameterClause = "Expected argument list in function declaration"
   case throwsInReturnPosition = "'throws' may only occur before '->'"
 

--- a/Tests/SwiftParserTest/DiagnosticTests.swift
+++ b/Tests/SwiftParserTest/DiagnosticTests.swift
@@ -93,4 +93,16 @@ public class DiagnosticTests: XCTestCase {
 
     XCTAssertSingleDiagnostic(in: classDecl, line: 2, column: 25, message: "Expected argument list in function declaration")
   }
+
+  func testMissingColonInTernary() throws {
+    let source = """
+      foo ? 1
+      """
+
+    let node = withParser(source: source) {
+      Syntax(raw: $0.parseExpression().raw)
+    }
+
+    XCTAssertSingleDiagnostic(in: node, line: 1, column: 8, message: "Expected ':' after '? ...' in ternary expression")
+  }
 }

--- a/Tests/SwiftParserTest/DiagnosticTests.swift
+++ b/Tests/SwiftParserTest/DiagnosticTests.swift
@@ -77,4 +77,20 @@ public class DiagnosticTests: XCTestCase {
       expectedFixedSource: "() throws -> Int"
     )
   }
+
+  public func testNoParamsForFunction() throws {
+    let source = """
+    class MyClass {
+      func withoutParameters
+
+      func withParameters() {}
+    }
+    """
+
+    let classDecl = withParser(source: source) {
+      Syntax(raw: $0.parseDeclaration().raw).as(ClassDeclSyntax.self)!
+    }
+
+    XCTAssertSingleDiagnostic(in: classDecl, line: 2, column: 25, message: "Expected argument list in function declaration")
+  }
 }

--- a/Tests/SwiftParserTest/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/RecoveryTests.swift
@@ -349,4 +349,40 @@ public class RecoveryTests: XCTestCase {
       """
     }
   }
+
+  public func testNoParamsForFunction() throws {
+    let source = """
+    class MyClass {
+      func withoutParameters
+
+      func withParameters() {}
+    }
+    """
+
+    let classDecl = withParser(source: source) {
+      Syntax(raw: $0.parseDeclaration().raw)
+    }
+    try XCTAssertHasSubstructure(
+      classDecl,
+      FunctionDeclSyntax(
+        attributes: nil,
+        modifiers: nil,
+        funcKeyword: .funcKeyword(),
+        identifier: .identifier("withoutParameters"),
+        genericParameterClause: nil,
+        signature: FunctionSignatureSyntax(
+          input: ParameterClauseSyntax(
+            leftParen: .leftParenToken(presence: .missing),
+            parameterList: FunctionParameterListSyntax([]),
+            rightParen: .rightParenToken(presence: .missing)
+          ),
+          asyncOrReasyncKeyword: nil,
+          throwsOrRethrowsKeyword: nil,
+          output: nil
+        ),
+        genericWhereClause: nil,
+        body: nil
+      )
+    )
+  }
 }


### PR DESCRIPTION
- Emit specialized diagnostic for functions without parameters
- Add contextual diagnostic message if colon is missing in ternary expression

rdar://98745337
rdar://98724207