### PR TITLE
Fix parser issues found by asserting that self-parsing should not produce diagnostics

### DIFF
--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -149,11 +149,9 @@ extension Parser.Lookahead {
       self.consumeIdentifier()
       if self.consume(if: .leftParen) != nil {
         while !self.at(.eof), !self.at(.rightParen), !self.at(.poundEndifKeyword) {
-          if self.consume(if: .rightParen) != nil {
-            break
-          }
           self.skipSingle()
         }
+        self.consume(if: .rightParen)
       }
     } while self.at(.atSign)
     return true

--- a/Sources/swift-parser-test/swift-parser-test.swift
+++ b/Sources/swift-parser-test/swift-parser-test.swift
@@ -269,7 +269,10 @@ class Reduce: ParsableCommand {
         printerr("Current source size \(reduced.count), reducing with chunk size \(chunkSize)")
       }
       reduced = try reduceImpl(source: reduced, chunkSize: chunkSize, testPasses: testPasses)
-      chunkSize = min(reduced.count / 2, chunkSize / 2)
+      chunkSize = min(
+        reduced.count / 2,
+        chunkSize / 2
+      )
     }
     return reduced
   }

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -51,7 +51,7 @@ func AssertEqualTokens(_ actual: [Lexer.Lexeme], _ expected: [Lexer.Lexeme], fil
 
 func AssertParse<Node: RawSyntaxNodeProtocol>(
   _ parseSyntax: (inout Parser) -> Node,
-  allowErrors: Bool = true,
+  allowErrors: Bool = false,
   file: StaticString = #file,
   line: UInt = #line,
   _ source: () -> String

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -139,7 +139,7 @@ final class DeclarationTests: XCTestCase {
       """
     }
 
-    try AssertParse({ $0.parseSourceFile() }) {
+    try AssertParse({ $0.parseSourceFile() }, allowErrors: true) {
       "_ = foo/* */?.description"
     }
     

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -164,11 +164,11 @@ final class ExpressionTests: XCTestCase {
       """
     }
 
-    try AssertParse({ $0.parseExpression() }) {
+    try AssertParse({ $0.parseExpression() }, allowErrors: true) {
       "[,"
     }
 
-    try AssertParse({ $0.parseExpression() }) {
+    try AssertParse({ $0.parseExpression() }, allowErrors: true) {
       """
       ([1:)
       """
@@ -197,7 +197,7 @@ final class ExpressionTests: XCTestCase {
       """#
     }
 
-    try AssertParse({ $0.parseExpression() }) {
+    try AssertParse({ $0.parseExpression() }, allowErrors: true) {
       #"" >> \( abc } ) << ""#
     }
 
@@ -213,7 +213,7 @@ final class ExpressionTests: XCTestCase {
       """##
     }
 
-    try AssertParse({ $0.parseExpression() }) {
+    try AssertParse({ $0.parseExpression() }, allowErrors: true) {
       #""\","#
     }
 
@@ -249,19 +249,19 @@ final class ExpressionTests: XCTestCase {
         """
     }
 
-    try AssertParse({ $0.parseExpression() }, allowErrors: false) {
+    try AssertParse({ $0.parseExpression() }) {
       ##"""
       #"""#
       """##
     }
 
-    try AssertParse({ $0.parseExpression() }, allowErrors: false) {
+    try AssertParse({ $0.parseExpression() }) {
       ##"""
       #"""""#
       """##
     }
 
-    try AssertParse({ $0.parseExpression() }, allowErrors: false) {
+    try AssertParse({ $0.parseExpression() }) {
       ##"""
       #"""
       multiline raw
@@ -269,7 +269,7 @@ final class ExpressionTests: XCTestCase {
       """##
     }
 
-    try AssertParse({ $0.parseExpression() }, allowErrors: false) {
+    try AssertParse({ $0.parseExpression() }) {
       #"""
       "\(x)"
       """#
@@ -277,7 +277,7 @@ final class ExpressionTests: XCTestCase {
   }
 
   func testRangeSubscript() throws {
-    try AssertParse({ $0.parseExpression() }, allowErrors: false) {
+    try AssertParse({ $0.parseExpression() }) {
       """
       text[...]
       """

--- a/Tests/SwiftParserTest/ParserTests.swift
+++ b/Tests/SwiftParserTest/ParserTests.swift
@@ -18,6 +18,20 @@ public class ParserTests: XCTestCase {
         let fileContents = try String(contentsOf: fileURL)
         let parsed = try Parser.parse(source: fileContents)
         AssertStringsEqualWithDiff("\(parsed)", fileContents)
+        let diagnostics = ParseDiagnosticsGenerator.diagnostics(for: parsed)
+        if !diagnostics.isEmpty {
+          var locationAndDiagnostics: [String] = []
+          let locationConverter = SourceLocationConverter(file: fileURL.lastPathComponent, tree: parsed)
+          for diag in diagnostics {
+            let location = diag.location(converter: locationConverter)
+            let message = diag.message
+            locationAndDiagnostics.append("\(location): \(message)")
+          }
+          XCTFail("""
+          Received the following diagnostics while parsing \(fileURL)
+          \(locationAndDiagnostics.joined(separator: "\n"))
+          """)
+        }
       }())
     }
   }

--- a/Tests/SwiftParserTest/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/RecoveryTests.swift
@@ -19,8 +19,8 @@ public class RecoveryTests: XCTestCase {
   }
 
   func testBogusKeypathBaseRecovery() throws {
-    try AssertParse({ $0.parseSourceFile() }) {
-      "func nestThoseIfs() {\\n    if false != true {\\n       print \"\\(i)\"\\n"
+    try AssertParse({ $0.parseSourceFile() }, allowErrors: true) {
+      #"func nestThoseIfs() {\n    if false != true {\n       print "\(i)\"\n"#
     }
   }
 
@@ -37,7 +37,7 @@ public class RecoveryTests: XCTestCase {
   }
 
   func testMissingSubscriptReturnClause() throws {
-    try AssertParse({ $0.parseSourceFile() }) {
+    try AssertParse({ $0.parseSourceFile() }, allowErrors: true) {
       """
       struct Foo {
         subscript(x: String) {}
@@ -55,7 +55,7 @@ public class RecoveryTests: XCTestCase {
   }
 
   func testClassWithLeadingNumber() throws {
-    try AssertParse({ $0.parseSourceFile() }) {
+    try AssertParse({ $0.parseSourceFile() }, allowErrors: true) {
       """
       class 23class {
         // expected-error@-1 {{class name can only start with a letter or underscore, not a number}}
@@ -82,7 +82,7 @@ public class RecoveryTests: XCTestCase {
   }
 
   func testMissingArrowInArrowExpr() throws {
-    try AssertParse({ $0.parseSourceFile() }) {
+    try AssertParse({ $0.parseSourceFile() }, allowErrors: true) {
       """
       [(Int) -> throws Int]()
       let _ = [Int throws Int]()
@@ -130,7 +130,7 @@ public class RecoveryTests: XCTestCase {
   }
 
   func testStringBogusClosingDelimiters() throws {
-    try AssertParse({ $0.parseSourceFile() }) {
+    try AssertParse({ $0.parseSourceFile() }, allowErrors: true) {
       #"\\("#
     }
 
@@ -140,13 +140,13 @@ public class RecoveryTests: XCTestCase {
       """##
     }
 
-    try AssertParse({ $0.parseStringLiteral() }) {
+    try AssertParse({ $0.parseStringLiteral() }, allowErrors: true) {
       #"""
       "
       """#
     }
 
-    try AssertParse({ $0.parseStringLiteral() }) {
+    try AssertParse({ $0.parseStringLiteral() }, allowErrors: true) {
       #"""
       "'
       """#
@@ -154,7 +154,7 @@ public class RecoveryTests: XCTestCase {
   }
 
   func testMissingArgumentToAttribute() throws {
-    try AssertParse({ $0.parseSourceFile() }) {
+    try AssertParse({ $0.parseSourceFile() }, allowErrors: true) {
       """
       @_dynamicReplacement(
       func test_dynamic_replacement_for2() {
@@ -193,7 +193,7 @@ public class RecoveryTests: XCTestCase {
   }
 
   func testExpressionMember() throws {
-    try AssertParse({ $0.parseSourceFile() }) {
+    try AssertParse({ $0.parseSourceFile() }, allowErrors: true) {
       """
       struct S {
         / ###line 25 "line-directive.swift"
@@ -213,7 +213,7 @@ public class RecoveryTests: XCTestCase {
   }
 
   func testExtraSyntaxInDirective() throws {
-    try AssertParse({ $0.parseDeclaration() }) {
+    try AssertParse({ $0.parseDeclaration() }, allowErrors: true) {
       """
       #if os(iOS)
         func foo() {}
@@ -343,7 +343,7 @@ public class RecoveryTests: XCTestCase {
   }
 
   func testTextRecovery() throws {
-    try AssertParse({ $0.parseSourceFile() }) {
+    try AssertParse({ $0.parseSourceFile() }, allowErrors: true) {
       """
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
       """

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -10,7 +10,7 @@ final class StatementTests: XCTestCase {
       """
     }
 
-    try AssertParse({ $0.parseIfStatement() }) {
+    try AssertParse({ $0.parseIfStatement() }, allowErrors: true) {
       """
       if case* ! = x {
         bar()


### PR DESCRIPTION
Flip the switch on `AssertParse` to check that no diagnostics are produced by default. Also check that no diagnostics are produced during the self-parse.

Making this change required two changes to:
- Fix an issue in attribute skipping, where we previously weren’t consuming `)` while skipping attributes
- Split a line in `swift-parser-test.swift` to disambiguate it as not being parsed as a regex literal (rdar://98736315)

In a follow-up PR, I will change the `AssertParse` statements that now `allowErrors` to check that the correct diagnostics are produced.

rdar://98575270