### PR TITLE
Get rid of `XXXSyntax.Cursor` type

### DIFF
--- a/Sources/SwiftSyntax/Raw/RawSyntaxLayoutView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxLayoutView.swift
@@ -149,14 +149,6 @@ struct RawSyntaxLayoutView {
     }
   }
 
-  /// Returns the child at the provided cursor in the layout.
-  /// - Parameter index: The index of the child you're accessing.
-  /// - Returns: The child at the provided index.
-  subscript<CursorType: RawRepresentable>(_ index: CursorType) -> RawSyntax?
-    where CursorType.RawValue == Int {
-    return children[index.rawValue]
-  }
-
   /// The number of children, `present` or `missing`, in this node.
   var numberOfChildren: Int {
     return children.count

--- a/Sources/SwiftSyntax/SyntaxData.swift
+++ b/Sources/SwiftSyntax/SyntaxData.swift
@@ -298,22 +298,6 @@ struct SyntaxData {
     return SyntaxData(AbsoluteRawSyntax(raw: raw!, info: info), parent: parent)
   }
 
-  /// Returns the child data at the provided cursor in this data's layout.
-  /// - Note: This has O(n) performance, prefer using a proper Sequence type
-  ///         if applicable, instead of this.
-  /// - Note: This function traps if the cursor is out of the bounds of the
-  ///         data's layout.
-  ///
-  /// - Parameter cursor: The cursor to create and cache.
-  /// - Parameter parent: The parent to associate the child with. This is
-  ///             normally the Syntax node that this `SyntaxData` belongs to.
-  /// - Returns: The child's data at the provided cursor.
-  func child<CursorType: RawRepresentable>(
-    at cursor: CursorType, parent: Syntax) -> SyntaxData?
-    where CursorType.RawValue == Int {
-    return child(at: cursor.rawValue, parent: parent)
-  }
-
   /// Creates a copy of `self` and recursively creates `SyntaxData` nodes up to
   /// the root.
   /// - parameter newRaw: The new RawSyntax that will back the new `Data`
@@ -346,22 +330,6 @@ struct SyntaxData {
   func replacingChild(_ child: RawSyntax?, at index: Int) -> SyntaxData {
     let newRaw = raw.layoutView!.replacingChild(at: index, with: child, arena: .default)
     return replacingSelf(newRaw)
-  }
-
-  /// Creates a copy of `self` with the child at the provided cursor replaced
-  /// with a new SyntaxData containing the raw syntax provided.
-  ///
-  /// - Parameters:
-  ///   - child: The raw syntax for the new child to replace.
-  ///   - cursor: A cursor that points to the index of the child you wish to
-  ///             replace
-  /// - Returns: The new root node created by this operation, and the new child
-  ///            syntax data.
-  /// - SeeAlso: replacingSelf(_:)
-  func replacingChild<CursorType: RawRepresentable>(_ child: RawSyntax?,
-    at cursor: CursorType) -> SyntaxData
-    where CursorType.RawValue == Int {
-    return replacingChild(child, at: cursor.rawValue)
   }
 
   func withLeadingTrivia(_ leadingTrivia: Trivia) -> SyntaxData {

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
@@ -47,18 +47,6 @@ nodes whose base kind are that specified kind.
 /// ${line}
 %     end
 public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
-%     # ======
-%     # Cursor
-%     # ======
-%
-%     if node.children:
-  enum Cursor: Int {
-%       for child in node.children:
-    case ${child.swift_name}
-%       end
-  }
-%     end
-
 %     # ==============
 %     # Initialization
 %     # ==============
@@ -111,7 +99,7 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
   public var syntaxNodeType: SyntaxProtocol.Type {
     return Swift.type(of: self)
   }
-%     for child in node.children:
+%     for (idx, child) in enumerate(node.children):
 %       child_node = NODE_MAP.get(child.syntax_kind)
 %
 %       # ===================
@@ -128,8 +116,7 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
 %       end
   public var ${child.swift_name}: ${ret_type} {
     get {
-      let childData = data.child(at: Cursor.${child.swift_name},
-                                 parent: Syntax(self))
+      let childData = data.child(at: ${idx}, parent: Syntax(self))
 %       if child.is_optional:
       if childData == nil { return nil }
 %       end
@@ -160,14 +147,13 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
   ///            appended to its `${child.swift_name}` collection.
   public func add${child_elt}(_ element: ${child_elt_type}) -> ${node.name} {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.${child.swift_name}] {
+    if let col = raw.layoutView!.children[${idx}] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.${child_node.swift_syntax_kind},
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.${child.swift_name})
+    let newData = data.replacingChild(collection, at: ${idx})
     return ${node.name}(newData)
   }
 %       end
@@ -185,7 +171,7 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
 %       else:
     let raw = newChild?.raw ?? ${make_missing_swift_child(child)}
 %       end
-    let newData = data.replacingChild(raw, at: Cursor.${child.swift_name})
+    let newData = data.replacingChild(raw, at: ${idx})
     return ${node.name}(newData)
   }
 %     end

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -16,7 +16,6 @@
 // MARK: - UnknownDeclSyntax
 
 public struct UnknownDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `UnknownDeclSyntax` if possible. Returns
@@ -59,13 +58,6 @@ extension UnknownDeclSyntax: CustomReflectable {
 // MARK: - MissingDeclSyntax
 
 public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `MissingDeclSyntax` if possible. Returns
@@ -107,8 +99,7 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -123,14 +114,13 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> MissingDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return MissingDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -147,14 +137,13 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> MissingDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return MissingDeclSyntax(newData)
   }
 
@@ -164,14 +153,13 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> MissingDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return MissingDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -186,14 +174,13 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> MissingDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return MissingDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -210,14 +197,13 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> MissingDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return MissingDeclSyntax(newData)
   }
 
@@ -227,7 +213,7 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> MissingDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return MissingDeclSyntax(newData)
   }
 }
@@ -246,23 +232,6 @@ extension MissingDeclSyntax: CustomReflectable {
 // MARK: - TypealiasDeclSyntax
 
 public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndTypealiasKeyword
-    case typealiasKeyword
-    case unexpectedBetweenTypealiasKeywordAndIdentifier
-    case identifier
-    case unexpectedBetweenIdentifierAndGenericParameterClause
-    case genericParameterClause
-    case unexpectedBetweenGenericParameterClauseAndInitializer
-    case initializer
-    case unexpectedBetweenInitializerAndGenericWhereClause
-    case genericWhereClause
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TypealiasDeclSyntax` if possible. Returns
@@ -324,8 +293,7 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -340,14 +308,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return TypealiasDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -364,14 +331,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> TypealiasDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -381,14 +347,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> TypealiasDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return TypealiasDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -403,14 +368,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return TypealiasDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -427,14 +391,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> TypealiasDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return TypealiasDeclSyntax(newData)
   }
 
@@ -444,14 +407,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> TypealiasDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return TypealiasDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndTypealiasKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndTypealiasKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -466,14 +428,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndTypealiasKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndTypealiasKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return TypealiasDeclSyntax(newData)
   }
 
   public var typealiasKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.typealiasKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -487,14 +448,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withTypealiasKeyword(
     _ newChild: TokenSyntax?) -> TypealiasDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.typealiasKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.typealiasKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return TypealiasDeclSyntax(newData)
   }
 
   public var unexpectedBetweenTypealiasKeywordAndIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTypealiasKeywordAndIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -509,14 +469,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTypealiasKeywordAndIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTypealiasKeywordAndIdentifier)
+    let newData = data.replacingChild(raw, at: 6)
     return TypealiasDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -530,14 +489,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> TypealiasDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 7)
     return TypealiasDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIdentifierAndGenericParameterClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -552,14 +510,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIdentifierAndGenericParameterClause(
     _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIdentifierAndGenericParameterClause)
+    let newData = data.replacingChild(raw, at: 8)
     return TypealiasDeclSyntax(newData)
   }
 
   public var genericParameterClause: GenericParameterClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericParameterClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericParameterClauseSyntax(childData!)
     }
@@ -574,14 +531,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericParameterClause(
     _ newChild: GenericParameterClauseSyntax?) -> TypealiasDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericParameterClause)
+    let newData = data.replacingChild(raw, at: 9)
     return TypealiasDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterClauseAndInitializer: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericParameterClauseAndInitializer,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -596,14 +552,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericParameterClauseAndInitializer(
     _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericParameterClauseAndInitializer)
+    let newData = data.replacingChild(raw, at: 10)
     return TypealiasDeclSyntax(newData)
   }
 
   public var initializer: TypeInitializerClauseSyntax {
     get {
-      let childData = data.child(at: Cursor.initializer,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       return TypeInitializerClauseSyntax(childData!)
     }
     set(value) {
@@ -617,14 +572,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withInitializer(
     _ newChild: TypeInitializerClauseSyntax?) -> TypealiasDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.typeInitializerClause, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.initializer)
+    let newData = data.replacingChild(raw, at: 11)
     return TypealiasDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInitializerAndGenericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -639,14 +593,13 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInitializerAndGenericWhereClause(
     _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInitializerAndGenericWhereClause)
+    let newData = data.replacingChild(raw, at: 12)
     return TypealiasDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericWhereClauseSyntax(childData!)
     }
@@ -661,7 +614,7 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericWhereClause(
     _ newChild: GenericWhereClauseSyntax?) -> TypealiasDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericWhereClause)
+    let newData = data.replacingChild(raw, at: 13)
     return TypealiasDeclSyntax(newData)
   }
 }
@@ -690,23 +643,6 @@ extension TypealiasDeclSyntax: CustomReflectable {
 // MARK: - AssociatedtypeDeclSyntax
 
 public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndAssociatedtypeKeyword
-    case associatedtypeKeyword
-    case unexpectedBetweenAssociatedtypeKeywordAndIdentifier
-    case identifier
-    case unexpectedBetweenIdentifierAndInheritanceClause
-    case inheritanceClause
-    case unexpectedBetweenInheritanceClauseAndInitializer
-    case initializer
-    case unexpectedBetweenInitializerAndGenericWhereClause
-    case genericWhereClause
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AssociatedtypeDeclSyntax` if possible. Returns
@@ -768,8 +704,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -784,14 +719,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return AssociatedtypeDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -808,14 +742,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> AssociatedtypeDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -825,14 +758,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> AssociatedtypeDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return AssociatedtypeDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -847,14 +779,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return AssociatedtypeDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -871,14 +802,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> AssociatedtypeDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return AssociatedtypeDeclSyntax(newData)
   }
 
@@ -888,14 +818,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> AssociatedtypeDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return AssociatedtypeDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndAssociatedtypeKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndAssociatedtypeKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -910,14 +839,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndAssociatedtypeKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndAssociatedtypeKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return AssociatedtypeDeclSyntax(newData)
   }
 
   public var associatedtypeKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.associatedtypeKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -931,14 +859,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAssociatedtypeKeyword(
     _ newChild: TokenSyntax?) -> AssociatedtypeDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.associatedtypeKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.associatedtypeKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return AssociatedtypeDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAssociatedtypeKeywordAndIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAssociatedtypeKeywordAndIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -953,14 +880,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAssociatedtypeKeywordAndIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAssociatedtypeKeywordAndIdentifier)
+    let newData = data.replacingChild(raw, at: 6)
     return AssociatedtypeDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -974,14 +900,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> AssociatedtypeDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 7)
     return AssociatedtypeDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndInheritanceClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIdentifierAndInheritanceClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -996,14 +921,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIdentifierAndInheritanceClause(
     _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIdentifierAndInheritanceClause)
+    let newData = data.replacingChild(raw, at: 8)
     return AssociatedtypeDeclSyntax(newData)
   }
 
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.inheritanceClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeInheritanceClauseSyntax(childData!)
     }
@@ -1018,14 +942,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withInheritanceClause(
     _ newChild: TypeInheritanceClauseSyntax?) -> AssociatedtypeDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.inheritanceClause)
+    let newData = data.replacingChild(raw, at: 9)
     return AssociatedtypeDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInheritanceClauseAndInitializer: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInheritanceClauseAndInitializer,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1040,14 +963,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInheritanceClauseAndInitializer(
     _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInheritanceClauseAndInitializer)
+    let newData = data.replacingChild(raw, at: 10)
     return AssociatedtypeDeclSyntax(newData)
   }
 
   public var initializer: TypeInitializerClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.initializer,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeInitializerClauseSyntax(childData!)
     }
@@ -1062,14 +984,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withInitializer(
     _ newChild: TypeInitializerClauseSyntax?) -> AssociatedtypeDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.initializer)
+    let newData = data.replacingChild(raw, at: 11)
     return AssociatedtypeDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInitializerAndGenericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1084,14 +1005,13 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInitializerAndGenericWhereClause(
     _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInitializerAndGenericWhereClause)
+    let newData = data.replacingChild(raw, at: 12)
     return AssociatedtypeDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericWhereClauseSyntax(childData!)
     }
@@ -1106,7 +1026,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericWhereClause(
     _ newChild: GenericWhereClauseSyntax?) -> AssociatedtypeDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericWhereClause)
+    let newData = data.replacingChild(raw, at: 13)
     return AssociatedtypeDeclSyntax(newData)
   }
 }
@@ -1135,13 +1055,6 @@ extension AssociatedtypeDeclSyntax: CustomReflectable {
 // MARK: - IfConfigDeclSyntax
 
 public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeClauses
-    case clauses
-    case unexpectedBetweenClausesAndPoundEndif
-    case poundEndif
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `IfConfigDeclSyntax` if possible. Returns
@@ -1183,8 +1096,7 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeClauses: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeClauses,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1199,14 +1111,13 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeClauses(
     _ newChild: UnexpectedNodesSyntax?) -> IfConfigDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeClauses)
+    let newData = data.replacingChild(raw, at: 0)
     return IfConfigDeclSyntax(newData)
   }
 
   public var clauses: IfConfigClauseListSyntax {
     get {
-      let childData = data.child(at: Cursor.clauses,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return IfConfigClauseListSyntax(childData!)
     }
     set(value) {
@@ -1222,14 +1133,13 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `clauses` collection.
   public func addClause(_ element: IfConfigClauseSyntax) -> IfConfigDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.clauses] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClauseList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.clauses)
+    let newData = data.replacingChild(collection, at: 1)
     return IfConfigDeclSyntax(newData)
   }
 
@@ -1239,14 +1149,13 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withClauses(
     _ newChild: IfConfigClauseListSyntax?) -> IfConfigDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifConfigClauseList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.clauses)
+    let newData = data.replacingChild(raw, at: 1)
     return IfConfigDeclSyntax(newData)
   }
 
   public var unexpectedBetweenClausesAndPoundEndif: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenClausesAndPoundEndif,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1261,14 +1170,13 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenClausesAndPoundEndif(
     _ newChild: UnexpectedNodesSyntax?) -> IfConfigDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenClausesAndPoundEndif)
+    let newData = data.replacingChild(raw, at: 2)
     return IfConfigDeclSyntax(newData)
   }
 
   public var poundEndif: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundEndif,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1282,7 +1190,7 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withPoundEndif(
     _ newChild: TokenSyntax?) -> IfConfigDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundEndifKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundEndif)
+    let newData = data.replacingChild(raw, at: 3)
     return IfConfigDeclSyntax(newData)
   }
 }
@@ -1301,17 +1209,6 @@ extension IfConfigDeclSyntax: CustomReflectable {
 // MARK: - PoundErrorDeclSyntax
 
 public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePoundError
-    case poundError
-    case unexpectedBetweenPoundErrorAndLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndMessage
-    case message
-    case unexpectedBetweenMessageAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PoundErrorDeclSyntax` if possible. Returns
@@ -1361,8 +1258,7 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePoundError: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePoundError,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1377,14 +1273,13 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePoundError(
     _ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePoundError)
+    let newData = data.replacingChild(raw, at: 0)
     return PoundErrorDeclSyntax(newData)
   }
 
   public var poundError: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundError,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1398,14 +1293,13 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withPoundError(
     _ newChild: TokenSyntax?) -> PoundErrorDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundErrorKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundError)
+    let newData = data.replacingChild(raw, at: 1)
     return PoundErrorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenPoundErrorAndLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPoundErrorAndLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1420,14 +1314,13 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPoundErrorAndLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPoundErrorAndLeftParen)
+    let newData = data.replacingChild(raw, at: 2)
     return PoundErrorDeclSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1441,14 +1334,13 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> PoundErrorDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 3)
     return PoundErrorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndMessage: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndMessage,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1463,14 +1355,13 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndMessage(
     _ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndMessage)
+    let newData = data.replacingChild(raw, at: 4)
     return PoundErrorDeclSyntax(newData)
   }
 
   public var message: StringLiteralExprSyntax {
     get {
-      let childData = data.child(at: Cursor.message,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return StringLiteralExprSyntax(childData!)
     }
     set(value) {
@@ -1484,14 +1375,13 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withMessage(
     _ newChild: StringLiteralExprSyntax?) -> PoundErrorDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.message)
+    let newData = data.replacingChild(raw, at: 5)
     return PoundErrorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenMessageAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1506,14 +1396,13 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenMessageAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenMessageAndRightParen)
+    let newData = data.replacingChild(raw, at: 6)
     return PoundErrorDeclSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1527,7 +1416,7 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> PoundErrorDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 7)
     return PoundErrorDeclSyntax(newData)
   }
 }
@@ -1550,17 +1439,6 @@ extension PoundErrorDeclSyntax: CustomReflectable {
 // MARK: - PoundWarningDeclSyntax
 
 public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePoundWarning
-    case poundWarning
-    case unexpectedBetweenPoundWarningAndLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndMessage
-    case message
-    case unexpectedBetweenMessageAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PoundWarningDeclSyntax` if possible. Returns
@@ -1610,8 +1488,7 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePoundWarning: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePoundWarning,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1626,14 +1503,13 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePoundWarning(
     _ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePoundWarning)
+    let newData = data.replacingChild(raw, at: 0)
     return PoundWarningDeclSyntax(newData)
   }
 
   public var poundWarning: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundWarning,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1647,14 +1523,13 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withPoundWarning(
     _ newChild: TokenSyntax?) -> PoundWarningDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundWarningKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundWarning)
+    let newData = data.replacingChild(raw, at: 1)
     return PoundWarningDeclSyntax(newData)
   }
 
   public var unexpectedBetweenPoundWarningAndLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPoundWarningAndLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1669,14 +1544,13 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPoundWarningAndLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPoundWarningAndLeftParen)
+    let newData = data.replacingChild(raw, at: 2)
     return PoundWarningDeclSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1690,14 +1564,13 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> PoundWarningDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 3)
     return PoundWarningDeclSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndMessage: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndMessage,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1712,14 +1585,13 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndMessage(
     _ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndMessage)
+    let newData = data.replacingChild(raw, at: 4)
     return PoundWarningDeclSyntax(newData)
   }
 
   public var message: StringLiteralExprSyntax {
     get {
-      let childData = data.child(at: Cursor.message,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return StringLiteralExprSyntax(childData!)
     }
     set(value) {
@@ -1733,14 +1605,13 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withMessage(
     _ newChild: StringLiteralExprSyntax?) -> PoundWarningDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.message)
+    let newData = data.replacingChild(raw, at: 5)
     return PoundWarningDeclSyntax(newData)
   }
 
   public var unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenMessageAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1755,14 +1626,13 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenMessageAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenMessageAndRightParen)
+    let newData = data.replacingChild(raw, at: 6)
     return PoundWarningDeclSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1776,7 +1646,7 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> PoundWarningDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 7)
     return PoundWarningDeclSyntax(newData)
   }
 }
@@ -1799,17 +1669,6 @@ extension PoundWarningDeclSyntax: CustomReflectable {
 // MARK: - PoundSourceLocationSyntax
 
 public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePoundSourceLocation
-    case poundSourceLocation
-    case unexpectedBetweenPoundSourceLocationAndLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndArgs
-    case args
-    case unexpectedBetweenArgsAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PoundSourceLocationSyntax` if possible. Returns
@@ -1859,8 +1718,7 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePoundSourceLocation: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePoundSourceLocation,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1875,14 +1733,13 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePoundSourceLocation(
     _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePoundSourceLocation)
+    let newData = data.replacingChild(raw, at: 0)
     return PoundSourceLocationSyntax(newData)
   }
 
   public var poundSourceLocation: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundSourceLocation,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1896,14 +1753,13 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withPoundSourceLocation(
     _ newChild: TokenSyntax?) -> PoundSourceLocationSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundSourceLocationKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundSourceLocation)
+    let newData = data.replacingChild(raw, at: 1)
     return PoundSourceLocationSyntax(newData)
   }
 
   public var unexpectedBetweenPoundSourceLocationAndLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPoundSourceLocationAndLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1918,14 +1774,13 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPoundSourceLocationAndLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPoundSourceLocationAndLeftParen)
+    let newData = data.replacingChild(raw, at: 2)
     return PoundSourceLocationSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1939,14 +1794,13 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> PoundSourceLocationSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 3)
     return PoundSourceLocationSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndArgs: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndArgs,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1961,14 +1815,13 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndArgs(
     _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndArgs)
+    let newData = data.replacingChild(raw, at: 4)
     return PoundSourceLocationSyntax(newData)
   }
 
   public var args: PoundSourceLocationArgsSyntax? {
     get {
-      let childData = data.child(at: Cursor.args,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return PoundSourceLocationArgsSyntax(childData!)
     }
@@ -1983,14 +1836,13 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withArgs(
     _ newChild: PoundSourceLocationArgsSyntax?) -> PoundSourceLocationSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.args)
+    let newData = data.replacingChild(raw, at: 5)
     return PoundSourceLocationSyntax(newData)
   }
 
   public var unexpectedBetweenArgsAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenArgsAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2005,14 +1857,13 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenArgsAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenArgsAndRightParen)
+    let newData = data.replacingChild(raw, at: 6)
     return PoundSourceLocationSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2026,7 +1877,7 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> PoundSourceLocationSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 7)
     return PoundSourceLocationSyntax(newData)
   }
 }
@@ -2049,25 +1900,6 @@ extension PoundSourceLocationSyntax: CustomReflectable {
 // MARK: - ClassDeclSyntax
 
 public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndClassKeyword
-    case classKeyword
-    case unexpectedBetweenClassKeywordAndIdentifier
-    case identifier
-    case unexpectedBetweenIdentifierAndGenericParameterClause
-    case genericParameterClause
-    case unexpectedBetweenGenericParameterClauseAndInheritanceClause
-    case inheritanceClause
-    case unexpectedBetweenInheritanceClauseAndGenericWhereClause
-    case genericWhereClause
-    case unexpectedBetweenGenericWhereClauseAndMembers
-    case members
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ClassDeclSyntax` if possible. Returns
@@ -2133,8 +1965,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2149,14 +1980,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return ClassDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -2173,14 +2003,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> ClassDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return ClassDeclSyntax(newData)
   }
 
@@ -2190,14 +2019,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return ClassDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2212,14 +2040,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return ClassDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -2236,14 +2063,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> ClassDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return ClassDeclSyntax(newData)
   }
 
@@ -2253,14 +2079,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return ClassDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndClassKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndClassKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2275,14 +2100,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndClassKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndClassKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return ClassDeclSyntax(newData)
   }
 
   public var classKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.classKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2296,14 +2120,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withClassKeyword(
     _ newChild: TokenSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.classKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.classKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return ClassDeclSyntax(newData)
   }
 
   public var unexpectedBetweenClassKeywordAndIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenClassKeywordAndIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2318,14 +2141,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenClassKeywordAndIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenClassKeywordAndIdentifier)
+    let newData = data.replacingChild(raw, at: 6)
     return ClassDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2339,14 +2161,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 7)
     return ClassDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIdentifierAndGenericParameterClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2361,14 +2182,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIdentifierAndGenericParameterClause(
     _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIdentifierAndGenericParameterClause)
+    let newData = data.replacingChild(raw, at: 8)
     return ClassDeclSyntax(newData)
   }
 
   public var genericParameterClause: GenericParameterClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericParameterClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericParameterClauseSyntax(childData!)
     }
@@ -2383,14 +2203,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericParameterClause(
     _ newChild: GenericParameterClauseSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericParameterClause)
+    let newData = data.replacingChild(raw, at: 9)
     return ClassDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericParameterClauseAndInheritanceClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2405,14 +2224,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericParameterClauseAndInheritanceClause(
     _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericParameterClauseAndInheritanceClause)
+    let newData = data.replacingChild(raw, at: 10)
     return ClassDeclSyntax(newData)
   }
 
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.inheritanceClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeInheritanceClauseSyntax(childData!)
     }
@@ -2427,14 +2245,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withInheritanceClause(
     _ newChild: TypeInheritanceClauseSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.inheritanceClause)
+    let newData = data.replacingChild(raw, at: 11)
     return ClassDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInheritanceClauseAndGenericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2449,14 +2266,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(
     _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInheritanceClauseAndGenericWhereClause)
+    let newData = data.replacingChild(raw, at: 12)
     return ClassDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericWhereClauseSyntax(childData!)
     }
@@ -2471,14 +2287,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericWhereClause(
     _ newChild: GenericWhereClauseSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericWhereClause)
+    let newData = data.replacingChild(raw, at: 13)
     return ClassDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericWhereClauseAndMembers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 14, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2493,14 +2308,13 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericWhereClauseAndMembers(
     _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericWhereClauseAndMembers)
+    let newData = data.replacingChild(raw, at: 14)
     return ClassDeclSyntax(newData)
   }
 
   public var members: MemberDeclBlockSyntax {
     get {
-      let childData = data.child(at: Cursor.members,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 15, parent: Syntax(self))
       return MemberDeclBlockSyntax(childData!)
     }
     set(value) {
@@ -2514,7 +2328,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withMembers(
     _ newChild: MemberDeclBlockSyntax?) -> ClassDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.members)
+    let newData = data.replacingChild(raw, at: 15)
     return ClassDeclSyntax(newData)
   }
 }
@@ -2545,25 +2359,6 @@ extension ClassDeclSyntax: CustomReflectable {
 // MARK: - ActorDeclSyntax
 
 public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndActorKeyword
-    case actorKeyword
-    case unexpectedBetweenActorKeywordAndIdentifier
-    case identifier
-    case unexpectedBetweenIdentifierAndGenericParameterClause
-    case genericParameterClause
-    case unexpectedBetweenGenericParameterClauseAndInheritanceClause
-    case inheritanceClause
-    case unexpectedBetweenInheritanceClauseAndGenericWhereClause
-    case genericWhereClause
-    case unexpectedBetweenGenericWhereClauseAndMembers
-    case members
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ActorDeclSyntax` if possible. Returns
@@ -2629,8 +2424,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2645,14 +2439,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return ActorDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -2669,14 +2462,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> ActorDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return ActorDeclSyntax(newData)
   }
 
@@ -2686,14 +2478,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return ActorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2708,14 +2499,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return ActorDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -2732,14 +2522,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> ActorDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return ActorDeclSyntax(newData)
   }
 
@@ -2749,14 +2538,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return ActorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndActorKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndActorKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2771,14 +2559,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndActorKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndActorKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return ActorDeclSyntax(newData)
   }
 
   public var actorKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.actorKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2792,14 +2579,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withActorKeyword(
     _ newChild: TokenSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.actorKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return ActorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenActorKeywordAndIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenActorKeywordAndIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2814,14 +2600,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenActorKeywordAndIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenActorKeywordAndIdentifier)
+    let newData = data.replacingChild(raw, at: 6)
     return ActorDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2835,14 +2620,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 7)
     return ActorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIdentifierAndGenericParameterClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2857,14 +2641,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIdentifierAndGenericParameterClause(
     _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIdentifierAndGenericParameterClause)
+    let newData = data.replacingChild(raw, at: 8)
     return ActorDeclSyntax(newData)
   }
 
   public var genericParameterClause: GenericParameterClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericParameterClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericParameterClauseSyntax(childData!)
     }
@@ -2879,14 +2662,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericParameterClause(
     _ newChild: GenericParameterClauseSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericParameterClause)
+    let newData = data.replacingChild(raw, at: 9)
     return ActorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericParameterClauseAndInheritanceClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2901,14 +2683,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericParameterClauseAndInheritanceClause(
     _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericParameterClauseAndInheritanceClause)
+    let newData = data.replacingChild(raw, at: 10)
     return ActorDeclSyntax(newData)
   }
 
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.inheritanceClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeInheritanceClauseSyntax(childData!)
     }
@@ -2923,14 +2704,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withInheritanceClause(
     _ newChild: TypeInheritanceClauseSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.inheritanceClause)
+    let newData = data.replacingChild(raw, at: 11)
     return ActorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInheritanceClauseAndGenericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2945,14 +2725,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(
     _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInheritanceClauseAndGenericWhereClause)
+    let newData = data.replacingChild(raw, at: 12)
     return ActorDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericWhereClauseSyntax(childData!)
     }
@@ -2967,14 +2746,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericWhereClause(
     _ newChild: GenericWhereClauseSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericWhereClause)
+    let newData = data.replacingChild(raw, at: 13)
     return ActorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericWhereClauseAndMembers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 14, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2989,14 +2767,13 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericWhereClauseAndMembers(
     _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericWhereClauseAndMembers)
+    let newData = data.replacingChild(raw, at: 14)
     return ActorDeclSyntax(newData)
   }
 
   public var members: MemberDeclBlockSyntax {
     get {
-      let childData = data.child(at: Cursor.members,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 15, parent: Syntax(self))
       return MemberDeclBlockSyntax(childData!)
     }
     set(value) {
@@ -3010,7 +2787,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withMembers(
     _ newChild: MemberDeclBlockSyntax?) -> ActorDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.members)
+    let newData = data.replacingChild(raw, at: 15)
     return ActorDeclSyntax(newData)
   }
 }
@@ -3041,25 +2818,6 @@ extension ActorDeclSyntax: CustomReflectable {
 // MARK: - StructDeclSyntax
 
 public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndStructKeyword
-    case structKeyword
-    case unexpectedBetweenStructKeywordAndIdentifier
-    case identifier
-    case unexpectedBetweenIdentifierAndGenericParameterClause
-    case genericParameterClause
-    case unexpectedBetweenGenericParameterClauseAndInheritanceClause
-    case inheritanceClause
-    case unexpectedBetweenInheritanceClauseAndGenericWhereClause
-    case genericWhereClause
-    case unexpectedBetweenGenericWhereClauseAndMembers
-    case members
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `StructDeclSyntax` if possible. Returns
@@ -3125,8 +2883,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3141,14 +2898,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return StructDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -3165,14 +2921,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> StructDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return StructDeclSyntax(newData)
   }
 
@@ -3182,14 +2937,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return StructDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3204,14 +2958,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return StructDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -3228,14 +2981,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> StructDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return StructDeclSyntax(newData)
   }
 
@@ -3245,14 +2997,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return StructDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndStructKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndStructKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3267,14 +3018,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndStructKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndStructKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return StructDeclSyntax(newData)
   }
 
   public var structKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.structKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3288,14 +3038,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withStructKeyword(
     _ newChild: TokenSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.structKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.structKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return StructDeclSyntax(newData)
   }
 
   public var unexpectedBetweenStructKeywordAndIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenStructKeywordAndIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3310,14 +3059,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenStructKeywordAndIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenStructKeywordAndIdentifier)
+    let newData = data.replacingChild(raw, at: 6)
     return StructDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3331,14 +3079,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 7)
     return StructDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIdentifierAndGenericParameterClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3353,14 +3100,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIdentifierAndGenericParameterClause(
     _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIdentifierAndGenericParameterClause)
+    let newData = data.replacingChild(raw, at: 8)
     return StructDeclSyntax(newData)
   }
 
   public var genericParameterClause: GenericParameterClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericParameterClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericParameterClauseSyntax(childData!)
     }
@@ -3375,14 +3121,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericParameterClause(
     _ newChild: GenericParameterClauseSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericParameterClause)
+    let newData = data.replacingChild(raw, at: 9)
     return StructDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericParameterClauseAndInheritanceClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3397,14 +3142,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericParameterClauseAndInheritanceClause(
     _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericParameterClauseAndInheritanceClause)
+    let newData = data.replacingChild(raw, at: 10)
     return StructDeclSyntax(newData)
   }
 
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.inheritanceClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeInheritanceClauseSyntax(childData!)
     }
@@ -3419,14 +3163,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withInheritanceClause(
     _ newChild: TypeInheritanceClauseSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.inheritanceClause)
+    let newData = data.replacingChild(raw, at: 11)
     return StructDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInheritanceClauseAndGenericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3441,14 +3184,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(
     _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInheritanceClauseAndGenericWhereClause)
+    let newData = data.replacingChild(raw, at: 12)
     return StructDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericWhereClauseSyntax(childData!)
     }
@@ -3463,14 +3205,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericWhereClause(
     _ newChild: GenericWhereClauseSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericWhereClause)
+    let newData = data.replacingChild(raw, at: 13)
     return StructDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericWhereClauseAndMembers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 14, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3485,14 +3226,13 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericWhereClauseAndMembers(
     _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericWhereClauseAndMembers)
+    let newData = data.replacingChild(raw, at: 14)
     return StructDeclSyntax(newData)
   }
 
   public var members: MemberDeclBlockSyntax {
     get {
-      let childData = data.child(at: Cursor.members,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 15, parent: Syntax(self))
       return MemberDeclBlockSyntax(childData!)
     }
     set(value) {
@@ -3506,7 +3246,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withMembers(
     _ newChild: MemberDeclBlockSyntax?) -> StructDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.members)
+    let newData = data.replacingChild(raw, at: 15)
     return StructDeclSyntax(newData)
   }
 }
@@ -3537,25 +3277,6 @@ extension StructDeclSyntax: CustomReflectable {
 // MARK: - ProtocolDeclSyntax
 
 public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndProtocolKeyword
-    case protocolKeyword
-    case unexpectedBetweenProtocolKeywordAndIdentifier
-    case identifier
-    case unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause
-    case primaryAssociatedTypeClause
-    case unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause
-    case inheritanceClause
-    case unexpectedBetweenInheritanceClauseAndGenericWhereClause
-    case genericWhereClause
-    case unexpectedBetweenGenericWhereClauseAndMembers
-    case members
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ProtocolDeclSyntax` if possible. Returns
@@ -3621,8 +3342,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3637,14 +3357,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return ProtocolDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -3661,14 +3380,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> ProtocolDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -3678,14 +3396,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return ProtocolDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3700,14 +3417,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return ProtocolDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -3724,14 +3440,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> ProtocolDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return ProtocolDeclSyntax(newData)
   }
 
@@ -3741,14 +3456,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return ProtocolDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndProtocolKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndProtocolKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3763,14 +3477,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndProtocolKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndProtocolKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return ProtocolDeclSyntax(newData)
   }
 
   public var protocolKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.protocolKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3784,14 +3497,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withProtocolKeyword(
     _ newChild: TokenSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.protocolKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.protocolKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return ProtocolDeclSyntax(newData)
   }
 
   public var unexpectedBetweenProtocolKeywordAndIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenProtocolKeywordAndIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3806,14 +3518,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenProtocolKeywordAndIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenProtocolKeywordAndIdentifier)
+    let newData = data.replacingChild(raw, at: 6)
     return ProtocolDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3827,14 +3538,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 7)
     return ProtocolDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3849,14 +3559,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause(
     _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause)
+    let newData = data.replacingChild(raw, at: 8)
     return ProtocolDeclSyntax(newData)
   }
 
   public var primaryAssociatedTypeClause: PrimaryAssociatedTypeClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.primaryAssociatedTypeClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return PrimaryAssociatedTypeClauseSyntax(childData!)
     }
@@ -3871,14 +3580,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withPrimaryAssociatedTypeClause(
     _ newChild: PrimaryAssociatedTypeClauseSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.primaryAssociatedTypeClause)
+    let newData = data.replacingChild(raw, at: 9)
     return ProtocolDeclSyntax(newData)
   }
 
   public var unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3893,14 +3601,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause(
     _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause)
+    let newData = data.replacingChild(raw, at: 10)
     return ProtocolDeclSyntax(newData)
   }
 
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.inheritanceClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeInheritanceClauseSyntax(childData!)
     }
@@ -3915,14 +3622,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withInheritanceClause(
     _ newChild: TypeInheritanceClauseSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.inheritanceClause)
+    let newData = data.replacingChild(raw, at: 11)
     return ProtocolDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInheritanceClauseAndGenericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3937,14 +3643,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(
     _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInheritanceClauseAndGenericWhereClause)
+    let newData = data.replacingChild(raw, at: 12)
     return ProtocolDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericWhereClauseSyntax(childData!)
     }
@@ -3959,14 +3664,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericWhereClause(
     _ newChild: GenericWhereClauseSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericWhereClause)
+    let newData = data.replacingChild(raw, at: 13)
     return ProtocolDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericWhereClauseAndMembers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 14, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3981,14 +3685,13 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericWhereClauseAndMembers(
     _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericWhereClauseAndMembers)
+    let newData = data.replacingChild(raw, at: 14)
     return ProtocolDeclSyntax(newData)
   }
 
   public var members: MemberDeclBlockSyntax {
     get {
-      let childData = data.child(at: Cursor.members,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 15, parent: Syntax(self))
       return MemberDeclBlockSyntax(childData!)
     }
     set(value) {
@@ -4002,7 +3705,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withMembers(
     _ newChild: MemberDeclBlockSyntax?) -> ProtocolDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.members)
+    let newData = data.replacingChild(raw, at: 15)
     return ProtocolDeclSyntax(newData)
   }
 }
@@ -4033,23 +3736,6 @@ extension ProtocolDeclSyntax: CustomReflectable {
 // MARK: - ExtensionDeclSyntax
 
 public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndExtensionKeyword
-    case extensionKeyword
-    case unexpectedBetweenExtensionKeywordAndExtendedType
-    case extendedType
-    case unexpectedBetweenExtendedTypeAndInheritanceClause
-    case inheritanceClause
-    case unexpectedBetweenInheritanceClauseAndGenericWhereClause
-    case genericWhereClause
-    case unexpectedBetweenGenericWhereClauseAndMembers
-    case members
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ExtensionDeclSyntax` if possible. Returns
@@ -4111,8 +3797,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4127,14 +3812,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return ExtensionDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -4151,14 +3835,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> ExtensionDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4168,14 +3851,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> ExtensionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return ExtensionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4190,14 +3872,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return ExtensionDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -4214,14 +3895,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> ExtensionDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return ExtensionDeclSyntax(newData)
   }
 
@@ -4231,14 +3911,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> ExtensionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return ExtensionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndExtensionKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndExtensionKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4253,14 +3932,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndExtensionKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndExtensionKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return ExtensionDeclSyntax(newData)
   }
 
   public var extensionKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.extensionKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4274,14 +3952,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withExtensionKeyword(
     _ newChild: TokenSyntax?) -> ExtensionDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.extensionKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.extensionKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return ExtensionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenExtensionKeywordAndExtendedType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenExtensionKeywordAndExtendedType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4296,14 +3973,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenExtensionKeywordAndExtendedType(
     _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenExtensionKeywordAndExtendedType)
+    let newData = data.replacingChild(raw, at: 6)
     return ExtensionDeclSyntax(newData)
   }
 
   public var extendedType: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.extendedType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -4317,14 +3993,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withExtendedType(
     _ newChild: TypeSyntax?) -> ExtensionDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.extendedType)
+    let newData = data.replacingChild(raw, at: 7)
     return ExtensionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenExtendedTypeAndInheritanceClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenExtendedTypeAndInheritanceClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4339,14 +4014,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenExtendedTypeAndInheritanceClause(
     _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenExtendedTypeAndInheritanceClause)
+    let newData = data.replacingChild(raw, at: 8)
     return ExtensionDeclSyntax(newData)
   }
 
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.inheritanceClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeInheritanceClauseSyntax(childData!)
     }
@@ -4361,14 +4035,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withInheritanceClause(
     _ newChild: TypeInheritanceClauseSyntax?) -> ExtensionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.inheritanceClause)
+    let newData = data.replacingChild(raw, at: 9)
     return ExtensionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInheritanceClauseAndGenericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4383,14 +4056,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(
     _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInheritanceClauseAndGenericWhereClause)
+    let newData = data.replacingChild(raw, at: 10)
     return ExtensionDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericWhereClauseSyntax(childData!)
     }
@@ -4405,14 +4077,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericWhereClause(
     _ newChild: GenericWhereClauseSyntax?) -> ExtensionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericWhereClause)
+    let newData = data.replacingChild(raw, at: 11)
     return ExtensionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericWhereClauseAndMembers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4427,14 +4098,13 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericWhereClauseAndMembers(
     _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericWhereClauseAndMembers)
+    let newData = data.replacingChild(raw, at: 12)
     return ExtensionDeclSyntax(newData)
   }
 
   public var members: MemberDeclBlockSyntax {
     get {
-      let childData = data.child(at: Cursor.members,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       return MemberDeclBlockSyntax(childData!)
     }
     set(value) {
@@ -4448,7 +4118,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withMembers(
     _ newChild: MemberDeclBlockSyntax?) -> ExtensionDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.members)
+    let newData = data.replacingChild(raw, at: 13)
     return ExtensionDeclSyntax(newData)
   }
 }
@@ -4477,25 +4147,6 @@ extension ExtensionDeclSyntax: CustomReflectable {
 // MARK: - FunctionDeclSyntax
 
 public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndFuncKeyword
-    case funcKeyword
-    case unexpectedBetweenFuncKeywordAndIdentifier
-    case identifier
-    case unexpectedBetweenIdentifierAndGenericParameterClause
-    case genericParameterClause
-    case unexpectedBetweenGenericParameterClauseAndSignature
-    case signature
-    case unexpectedBetweenSignatureAndGenericWhereClause
-    case genericWhereClause
-    case unexpectedBetweenGenericWhereClauseAndBody
-    case body
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `FunctionDeclSyntax` if possible. Returns
@@ -4561,8 +4212,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4577,14 +4227,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return FunctionDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -4601,14 +4250,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> FunctionDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return FunctionDeclSyntax(newData)
   }
 
@@ -4618,14 +4266,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return FunctionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4640,14 +4287,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return FunctionDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -4664,14 +4310,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> FunctionDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return FunctionDeclSyntax(newData)
   }
 
@@ -4681,14 +4326,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return FunctionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndFuncKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndFuncKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4703,14 +4347,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndFuncKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndFuncKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return FunctionDeclSyntax(newData)
   }
 
   public var funcKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.funcKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4724,14 +4367,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withFuncKeyword(
     _ newChild: TokenSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.funcKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.funcKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return FunctionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenFuncKeywordAndIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenFuncKeywordAndIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4746,14 +4388,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenFuncKeywordAndIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenFuncKeywordAndIdentifier)
+    let newData = data.replacingChild(raw, at: 6)
     return FunctionDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4767,14 +4408,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 7)
     return FunctionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIdentifierAndGenericParameterClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4789,14 +4429,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIdentifierAndGenericParameterClause(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIdentifierAndGenericParameterClause)
+    let newData = data.replacingChild(raw, at: 8)
     return FunctionDeclSyntax(newData)
   }
 
   public var genericParameterClause: GenericParameterClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericParameterClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericParameterClauseSyntax(childData!)
     }
@@ -4811,14 +4450,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericParameterClause(
     _ newChild: GenericParameterClauseSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericParameterClause)
+    let newData = data.replacingChild(raw, at: 9)
     return FunctionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericParameterClauseAndSignature,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4833,14 +4471,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericParameterClauseAndSignature(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericParameterClauseAndSignature)
+    let newData = data.replacingChild(raw, at: 10)
     return FunctionDeclSyntax(newData)
   }
 
   public var signature: FunctionSignatureSyntax {
     get {
-      let childData = data.child(at: Cursor.signature,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       return FunctionSignatureSyntax(childData!)
     }
     set(value) {
@@ -4854,14 +4491,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withSignature(
     _ newChild: FunctionSignatureSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionSignature, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.signature)
+    let newData = data.replacingChild(raw, at: 11)
     return FunctionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenSignatureAndGenericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4876,14 +4512,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenSignatureAndGenericWhereClause(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenSignatureAndGenericWhereClause)
+    let newData = data.replacingChild(raw, at: 12)
     return FunctionDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericWhereClauseSyntax(childData!)
     }
@@ -4898,14 +4533,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericWhereClause(
     _ newChild: GenericWhereClauseSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericWhereClause)
+    let newData = data.replacingChild(raw, at: 13)
     return FunctionDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericWhereClauseAndBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 14, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4920,14 +4554,13 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericWhereClauseAndBody(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericWhereClauseAndBody)
+    let newData = data.replacingChild(raw, at: 14)
     return FunctionDeclSyntax(newData)
   }
 
   public var body: CodeBlockSyntax? {
     get {
-      let childData = data.child(at: Cursor.body,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 15, parent: Syntax(self))
       if childData == nil { return nil }
       return CodeBlockSyntax(childData!)
     }
@@ -4942,7 +4575,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withBody(
     _ newChild: CodeBlockSyntax?) -> FunctionDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.body)
+    let newData = data.replacingChild(raw, at: 15)
     return FunctionDeclSyntax(newData)
   }
 }
@@ -4973,25 +4606,6 @@ extension FunctionDeclSyntax: CustomReflectable {
 // MARK: - InitializerDeclSyntax
 
 public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndInitKeyword
-    case initKeyword
-    case unexpectedBetweenInitKeywordAndOptionalMark
-    case optionalMark
-    case unexpectedBetweenOptionalMarkAndGenericParameterClause
-    case genericParameterClause
-    case unexpectedBetweenGenericParameterClauseAndSignature
-    case signature
-    case unexpectedBetweenSignatureAndGenericWhereClause
-    case genericWhereClause
-    case unexpectedBetweenGenericWhereClauseAndBody
-    case body
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `InitializerDeclSyntax` if possible. Returns
@@ -5057,8 +4671,7 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5073,14 +4686,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return InitializerDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -5097,14 +4709,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> InitializerDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5114,14 +4725,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return InitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5136,14 +4746,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return InitializerDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -5160,14 +4769,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> InitializerDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return InitializerDeclSyntax(newData)
   }
 
@@ -5177,14 +4785,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return InitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndInitKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndInitKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5199,14 +4806,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndInitKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndInitKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return InitializerDeclSyntax(newData)
   }
 
   public var initKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.initKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -5220,14 +4826,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withInitKeyword(
     _ newChild: TokenSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.initKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.initKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return InitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInitKeywordAndOptionalMark: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInitKeywordAndOptionalMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5242,14 +4847,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInitKeywordAndOptionalMark(
     _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInitKeywordAndOptionalMark)
+    let newData = data.replacingChild(raw, at: 6)
     return InitializerDeclSyntax(newData)
   }
 
   public var optionalMark: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.optionalMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -5264,14 +4868,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withOptionalMark(
     _ newChild: TokenSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.optionalMark)
+    let newData = data.replacingChild(raw, at: 7)
     return InitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenOptionalMarkAndGenericParameterClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenOptionalMarkAndGenericParameterClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5286,14 +4889,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenOptionalMarkAndGenericParameterClause(
     _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenOptionalMarkAndGenericParameterClause)
+    let newData = data.replacingChild(raw, at: 8)
     return InitializerDeclSyntax(newData)
   }
 
   public var genericParameterClause: GenericParameterClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericParameterClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericParameterClauseSyntax(childData!)
     }
@@ -5308,14 +4910,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericParameterClause(
     _ newChild: GenericParameterClauseSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericParameterClause)
+    let newData = data.replacingChild(raw, at: 9)
     return InitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericParameterClauseAndSignature,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5330,14 +4931,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericParameterClauseAndSignature(
     _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericParameterClauseAndSignature)
+    let newData = data.replacingChild(raw, at: 10)
     return InitializerDeclSyntax(newData)
   }
 
   public var signature: FunctionSignatureSyntax {
     get {
-      let childData = data.child(at: Cursor.signature,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       return FunctionSignatureSyntax(childData!)
     }
     set(value) {
@@ -5351,14 +4951,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withSignature(
     _ newChild: FunctionSignatureSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionSignature, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.signature)
+    let newData = data.replacingChild(raw, at: 11)
     return InitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenSignatureAndGenericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5373,14 +4972,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenSignatureAndGenericWhereClause(
     _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenSignatureAndGenericWhereClause)
+    let newData = data.replacingChild(raw, at: 12)
     return InitializerDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericWhereClauseSyntax(childData!)
     }
@@ -5395,14 +4993,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericWhereClause(
     _ newChild: GenericWhereClauseSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericWhereClause)
+    let newData = data.replacingChild(raw, at: 13)
     return InitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericWhereClauseAndBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 14, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5417,14 +5014,13 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericWhereClauseAndBody(
     _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericWhereClauseAndBody)
+    let newData = data.replacingChild(raw, at: 14)
     return InitializerDeclSyntax(newData)
   }
 
   public var body: CodeBlockSyntax? {
     get {
-      let childData = data.child(at: Cursor.body,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 15, parent: Syntax(self))
       if childData == nil { return nil }
       return CodeBlockSyntax(childData!)
     }
@@ -5439,7 +5035,7 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withBody(
     _ newChild: CodeBlockSyntax?) -> InitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.body)
+    let newData = data.replacingChild(raw, at: 15)
     return InitializerDeclSyntax(newData)
   }
 }
@@ -5470,17 +5066,6 @@ extension InitializerDeclSyntax: CustomReflectable {
 // MARK: - DeinitializerDeclSyntax
 
 public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndDeinitKeyword
-    case deinitKeyword
-    case unexpectedBetweenDeinitKeywordAndBody
-    case body
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DeinitializerDeclSyntax` if possible. Returns
@@ -5530,8 +5115,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5546,14 +5130,13 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return DeinitializerDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -5570,14 +5153,13 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> DeinitializerDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return DeinitializerDeclSyntax(newData)
   }
 
@@ -5587,14 +5169,13 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> DeinitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return DeinitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5609,14 +5190,13 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return DeinitializerDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -5633,14 +5213,13 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> DeinitializerDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return DeinitializerDeclSyntax(newData)
   }
 
@@ -5650,14 +5229,13 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> DeinitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return DeinitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndDeinitKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndDeinitKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5672,14 +5250,13 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndDeinitKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndDeinitKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return DeinitializerDeclSyntax(newData)
   }
 
   public var deinitKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.deinitKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -5693,14 +5270,13 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withDeinitKeyword(
     _ newChild: TokenSyntax?) -> DeinitializerDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.deinitKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.deinitKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return DeinitializerDeclSyntax(newData)
   }
 
   public var unexpectedBetweenDeinitKeywordAndBody: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDeinitKeywordAndBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5715,14 +5291,13 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenDeinitKeywordAndBody(
     _ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDeinitKeywordAndBody)
+    let newData = data.replacingChild(raw, at: 6)
     return DeinitializerDeclSyntax(newData)
   }
 
   public var body: CodeBlockSyntax? {
     get {
-      let childData = data.child(at: Cursor.body,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return CodeBlockSyntax(childData!)
     }
@@ -5737,7 +5312,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withBody(
     _ newChild: CodeBlockSyntax?) -> DeinitializerDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.body)
+    let newData = data.replacingChild(raw, at: 7)
     return DeinitializerDeclSyntax(newData)
   }
 }
@@ -5760,25 +5335,6 @@ extension DeinitializerDeclSyntax: CustomReflectable {
 // MARK: - SubscriptDeclSyntax
 
 public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndSubscriptKeyword
-    case subscriptKeyword
-    case unexpectedBetweenSubscriptKeywordAndGenericParameterClause
-    case genericParameterClause
-    case unexpectedBetweenGenericParameterClauseAndIndices
-    case indices
-    case unexpectedBetweenIndicesAndResult
-    case result
-    case unexpectedBetweenResultAndGenericWhereClause
-    case genericWhereClause
-    case unexpectedBetweenGenericWhereClauseAndAccessor
-    case accessor
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SubscriptDeclSyntax` if possible. Returns
@@ -5844,8 +5400,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5860,14 +5415,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return SubscriptDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -5884,14 +5438,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> SubscriptDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -5901,14 +5454,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return SubscriptDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5923,14 +5475,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return SubscriptDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -5947,14 +5498,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> SubscriptDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return SubscriptDeclSyntax(newData)
   }
 
@@ -5964,14 +5514,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return SubscriptDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndSubscriptKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndSubscriptKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5986,14 +5535,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndSubscriptKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndSubscriptKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return SubscriptDeclSyntax(newData)
   }
 
   public var subscriptKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.subscriptKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -6007,14 +5555,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withSubscriptKeyword(
     _ newChild: TokenSyntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.subscriptKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.subscriptKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return SubscriptDeclSyntax(newData)
   }
 
   public var unexpectedBetweenSubscriptKeywordAndGenericParameterClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenSubscriptKeywordAndGenericParameterClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6029,14 +5576,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenSubscriptKeywordAndGenericParameterClause(
     _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenSubscriptKeywordAndGenericParameterClause)
+    let newData = data.replacingChild(raw, at: 6)
     return SubscriptDeclSyntax(newData)
   }
 
   public var genericParameterClause: GenericParameterClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericParameterClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericParameterClauseSyntax(childData!)
     }
@@ -6051,14 +5597,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericParameterClause(
     _ newChild: GenericParameterClauseSyntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericParameterClause)
+    let newData = data.replacingChild(raw, at: 7)
     return SubscriptDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterClauseAndIndices: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericParameterClauseAndIndices,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6073,14 +5618,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericParameterClauseAndIndices(
     _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericParameterClauseAndIndices)
+    let newData = data.replacingChild(raw, at: 8)
     return SubscriptDeclSyntax(newData)
   }
 
   public var indices: ParameterClauseSyntax {
     get {
-      let childData = data.child(at: Cursor.indices,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       return ParameterClauseSyntax(childData!)
     }
     set(value) {
@@ -6094,14 +5638,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withIndices(
     _ newChild: ParameterClauseSyntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.parameterClause, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.indices)
+    let newData = data.replacingChild(raw, at: 9)
     return SubscriptDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIndicesAndResult: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIndicesAndResult,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6116,14 +5659,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIndicesAndResult(
     _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIndicesAndResult)
+    let newData = data.replacingChild(raw, at: 10)
     return SubscriptDeclSyntax(newData)
   }
 
   public var result: ReturnClauseSyntax {
     get {
-      let childData = data.child(at: Cursor.result,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       return ReturnClauseSyntax(childData!)
     }
     set(value) {
@@ -6137,14 +5679,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withResult(
     _ newChild: ReturnClauseSyntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.returnClause, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.result)
+    let newData = data.replacingChild(raw, at: 11)
     return SubscriptDeclSyntax(newData)
   }
 
   public var unexpectedBetweenResultAndGenericWhereClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenResultAndGenericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6159,14 +5700,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenResultAndGenericWhereClause(
     _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenResultAndGenericWhereClause)
+    let newData = data.replacingChild(raw, at: 12)
     return SubscriptDeclSyntax(newData)
   }
 
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericWhereClauseSyntax(childData!)
     }
@@ -6181,14 +5721,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericWhereClause(
     _ newChild: GenericWhereClauseSyntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericWhereClause)
+    let newData = data.replacingChild(raw, at: 13)
     return SubscriptDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndAccessor: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericWhereClauseAndAccessor,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 14, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6203,14 +5742,13 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericWhereClauseAndAccessor(
     _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericWhereClauseAndAccessor)
+    let newData = data.replacingChild(raw, at: 14)
     return SubscriptDeclSyntax(newData)
   }
 
   public var accessor: Syntax? {
     get {
-      let childData = data.child(at: Cursor.accessor,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 15, parent: Syntax(self))
       if childData == nil { return nil }
       return Syntax(childData!)
     }
@@ -6225,7 +5763,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAccessor(
     _ newChild: Syntax?) -> SubscriptDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.accessor)
+    let newData = data.replacingChild(raw, at: 15)
     return SubscriptDeclSyntax(newData)
   }
 }
@@ -6256,19 +5794,6 @@ extension SubscriptDeclSyntax: CustomReflectable {
 // MARK: - ImportDeclSyntax
 
 public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndImportTok
-    case importTok
-    case unexpectedBetweenImportTokAndImportKind
-    case importKind
-    case unexpectedBetweenImportKindAndPath
-    case path
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ImportDeclSyntax` if possible. Returns
@@ -6322,8 +5847,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6338,14 +5862,13 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return ImportDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -6362,14 +5885,13 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> ImportDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return ImportDeclSyntax(newData)
   }
 
@@ -6379,14 +5901,13 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> ImportDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return ImportDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6401,14 +5922,13 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return ImportDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -6425,14 +5945,13 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> ImportDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return ImportDeclSyntax(newData)
   }
 
@@ -6442,14 +5961,13 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> ImportDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return ImportDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndImportTok: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndImportTok,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6464,14 +5982,13 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndImportTok(
     _ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndImportTok)
+    let newData = data.replacingChild(raw, at: 4)
     return ImportDeclSyntax(newData)
   }
 
   public var importTok: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.importTok,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -6485,14 +6002,13 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withImportTok(
     _ newChild: TokenSyntax?) -> ImportDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.importKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.importTok)
+    let newData = data.replacingChild(raw, at: 5)
     return ImportDeclSyntax(newData)
   }
 
   public var unexpectedBetweenImportTokAndImportKind: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenImportTokAndImportKind,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6507,14 +6023,13 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenImportTokAndImportKind(
     _ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenImportTokAndImportKind)
+    let newData = data.replacingChild(raw, at: 6)
     return ImportDeclSyntax(newData)
   }
 
   public var importKind: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.importKind,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -6529,14 +6044,13 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withImportKind(
     _ newChild: TokenSyntax?) -> ImportDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.importKind)
+    let newData = data.replacingChild(raw, at: 7)
     return ImportDeclSyntax(newData)
   }
 
   public var unexpectedBetweenImportKindAndPath: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenImportKindAndPath,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6551,14 +6065,13 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenImportKindAndPath(
     _ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenImportKindAndPath)
+    let newData = data.replacingChild(raw, at: 8)
     return ImportDeclSyntax(newData)
   }
 
   public var path: AccessPathSyntax {
     get {
-      let childData = data.child(at: Cursor.path,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       return AccessPathSyntax(childData!)
     }
     set(value) {
@@ -6574,14 +6087,13 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `path` collection.
   public func addPathComponent(_ element: AccessPathComponentSyntax) -> ImportDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.path] {
+    if let col = raw.layoutView!.children[9] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.accessPath,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.path)
+    let newData = data.replacingChild(collection, at: 9)
     return ImportDeclSyntax(newData)
   }
 
@@ -6591,7 +6103,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withPath(
     _ newChild: AccessPathSyntax?) -> ImportDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.accessPath, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.path)
+    let newData = data.replacingChild(raw, at: 9)
     return ImportDeclSyntax(newData)
   }
 }
@@ -6616,23 +6128,6 @@ extension ImportDeclSyntax: CustomReflectable {
 // MARK: - AccessorDeclSyntax
 
 public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifier
-    case modifier
-    case unexpectedBetweenModifierAndAccessorKind
-    case accessorKind
-    case unexpectedBetweenAccessorKindAndParameter
-    case parameter
-    case unexpectedBetweenParameterAndAsyncKeyword
-    case asyncKeyword
-    case unexpectedBetweenAsyncKeywordAndThrowsKeyword
-    case throwsKeyword
-    case unexpectedBetweenThrowsKeywordAndBody
-    case body
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AccessorDeclSyntax` if possible. Returns
@@ -6694,8 +6189,7 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6710,14 +6204,13 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return AccessorDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -6734,14 +6227,13 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> AccessorDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return AccessorDeclSyntax(newData)
   }
 
@@ -6751,14 +6243,13 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> AccessorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return AccessorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6773,14 +6264,13 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifier(
     _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifier)
+    let newData = data.replacingChild(raw, at: 2)
     return AccessorDeclSyntax(newData)
   }
 
   public var modifier: DeclModifierSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return DeclModifierSyntax(childData!)
     }
@@ -6795,14 +6285,13 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifier(
     _ newChild: DeclModifierSyntax?) -> AccessorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifier)
+    let newData = data.replacingChild(raw, at: 3)
     return AccessorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifierAndAccessorKind: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifierAndAccessorKind,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6817,14 +6306,13 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifierAndAccessorKind(
     _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifierAndAccessorKind)
+    let newData = data.replacingChild(raw, at: 4)
     return AccessorDeclSyntax(newData)
   }
 
   public var accessorKind: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.accessorKind,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -6838,14 +6326,13 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAccessorKind(
     _ newChild: TokenSyntax?) -> AccessorDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.accessorKind)
+    let newData = data.replacingChild(raw, at: 5)
     return AccessorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAccessorKindAndParameter: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAccessorKindAndParameter,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6860,14 +6347,13 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAccessorKindAndParameter(
     _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAccessorKindAndParameter)
+    let newData = data.replacingChild(raw, at: 6)
     return AccessorDeclSyntax(newData)
   }
 
   public var parameter: AccessorParameterSyntax? {
     get {
-      let childData = data.child(at: Cursor.parameter,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return AccessorParameterSyntax(childData!)
     }
@@ -6882,14 +6368,13 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withParameter(
     _ newChild: AccessorParameterSyntax?) -> AccessorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.parameter)
+    let newData = data.replacingChild(raw, at: 7)
     return AccessorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenParameterAndAsyncKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenParameterAndAsyncKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6904,14 +6389,13 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenParameterAndAsyncKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenParameterAndAsyncKeyword)
+    let newData = data.replacingChild(raw, at: 8)
     return AccessorDeclSyntax(newData)
   }
 
   public var asyncKeyword: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.asyncKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -6926,14 +6410,13 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAsyncKeyword(
     _ newChild: TokenSyntax?) -> AccessorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.asyncKeyword)
+    let newData = data.replacingChild(raw, at: 9)
     return AccessorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAsyncKeywordAndThrowsKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAsyncKeywordAndThrowsKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6948,14 +6431,13 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAsyncKeywordAndThrowsKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAsyncKeywordAndThrowsKeyword)
+    let newData = data.replacingChild(raw, at: 10)
     return AccessorDeclSyntax(newData)
   }
 
   public var throwsKeyword: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.throwsKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -6970,14 +6452,13 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withThrowsKeyword(
     _ newChild: TokenSyntax?) -> AccessorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.throwsKeyword)
+    let newData = data.replacingChild(raw, at: 11)
     return AccessorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenThrowsKeywordAndBody: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenThrowsKeywordAndBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6992,14 +6473,13 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenThrowsKeywordAndBody(
     _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenThrowsKeywordAndBody)
+    let newData = data.replacingChild(raw, at: 12)
     return AccessorDeclSyntax(newData)
   }
 
   public var body: CodeBlockSyntax? {
     get {
-      let childData = data.child(at: Cursor.body,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       if childData == nil { return nil }
       return CodeBlockSyntax(childData!)
     }
@@ -7014,7 +6494,7 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withBody(
     _ newChild: CodeBlockSyntax?) -> AccessorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.body)
+    let newData = data.replacingChild(raw, at: 13)
     return AccessorDeclSyntax(newData)
   }
 }
@@ -7043,17 +6523,6 @@ extension AccessorDeclSyntax: CustomReflectable {
 // MARK: - VariableDeclSyntax
 
 public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndLetOrVarKeyword
-    case letOrVarKeyword
-    case unexpectedBetweenLetOrVarKeywordAndBindings
-    case bindings
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `VariableDeclSyntax` if possible. Returns
@@ -7103,8 +6572,7 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7119,14 +6587,13 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return VariableDeclSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -7143,14 +6610,13 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> VariableDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return VariableDeclSyntax(newData)
   }
 
@@ -7160,14 +6626,13 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> VariableDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return VariableDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7182,14 +6647,13 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return VariableDeclSyntax(newData)
   }
 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -7206,14 +6670,13 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> VariableDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return VariableDeclSyntax(newData)
   }
 
@@ -7223,14 +6686,13 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> VariableDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return VariableDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndLetOrVarKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndLetOrVarKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7245,14 +6707,13 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndLetOrVarKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndLetOrVarKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return VariableDeclSyntax(newData)
   }
 
   public var letOrVarKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.letOrVarKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7266,14 +6727,13 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withLetOrVarKeyword(
     _ newChild: TokenSyntax?) -> VariableDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.letOrVarKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return VariableDeclSyntax(newData)
   }
 
   public var unexpectedBetweenLetOrVarKeywordAndBindings: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLetOrVarKeywordAndBindings,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7288,14 +6748,13 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLetOrVarKeywordAndBindings(
     _ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLetOrVarKeywordAndBindings)
+    let newData = data.replacingChild(raw, at: 6)
     return VariableDeclSyntax(newData)
   }
 
   public var bindings: PatternBindingListSyntax {
     get {
-      let childData = data.child(at: Cursor.bindings,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return PatternBindingListSyntax(childData!)
     }
     set(value) {
@@ -7311,14 +6770,13 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `bindings` collection.
   public func addBinding(_ element: PatternBindingSyntax) -> VariableDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.bindings] {
+    if let col = raw.layoutView!.children[7] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.patternBindingList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.bindings)
+    let newData = data.replacingChild(collection, at: 7)
     return VariableDeclSyntax(newData)
   }
 
@@ -7328,7 +6786,7 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withBindings(
     _ newChild: PatternBindingListSyntax?) -> VariableDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.patternBindingList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.bindings)
+    let newData = data.replacingChild(raw, at: 7)
     return VariableDeclSyntax(newData)
   }
 }
@@ -7356,17 +6814,6 @@ extension VariableDeclSyntax: CustomReflectable {
 /// enum.
 /// 
 public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndCaseKeyword
-    case caseKeyword
-    case unexpectedBetweenCaseKeywordAndElements
-    case elements
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `EnumCaseDeclSyntax` if possible. Returns
@@ -7416,8 +6863,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7432,7 +6878,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return EnumCaseDeclSyntax(newData)
   }
 
@@ -7441,8 +6887,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -7459,14 +6904,13 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> EnumCaseDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return EnumCaseDeclSyntax(newData)
   }
 
@@ -7476,14 +6920,13 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> EnumCaseDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return EnumCaseDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7498,7 +6941,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return EnumCaseDeclSyntax(newData)
   }
 
@@ -7507,8 +6950,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -7525,14 +6967,13 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> EnumCaseDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return EnumCaseDeclSyntax(newData)
   }
 
@@ -7542,14 +6983,13 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> EnumCaseDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return EnumCaseDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndCaseKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndCaseKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7564,15 +7004,14 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndCaseKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndCaseKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return EnumCaseDeclSyntax(newData)
   }
 
   /// The `case` keyword for this case.
   public var caseKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.caseKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7586,14 +7025,13 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withCaseKeyword(
     _ newChild: TokenSyntax?) -> EnumCaseDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.caseKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return EnumCaseDeclSyntax(newData)
   }
 
   public var unexpectedBetweenCaseKeywordAndElements: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCaseKeywordAndElements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7608,15 +7046,14 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCaseKeywordAndElements(
     _ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCaseKeywordAndElements)
+    let newData = data.replacingChild(raw, at: 6)
     return EnumCaseDeclSyntax(newData)
   }
 
   /// The elements this case declares.
   public var elements: EnumCaseElementListSyntax {
     get {
-      let childData = data.child(at: Cursor.elements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return EnumCaseElementListSyntax(childData!)
     }
     set(value) {
@@ -7632,14 +7069,13 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `elements` collection.
   public func addElement(_ element: EnumCaseElementSyntax) -> EnumCaseDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.elements] {
+    if let col = raw.layoutView!.children[7] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.elements)
+    let newData = data.replacingChild(collection, at: 7)
     return EnumCaseDeclSyntax(newData)
   }
 
@@ -7649,7 +7085,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withElements(
     _ newChild: EnumCaseElementListSyntax?) -> EnumCaseDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.enumCaseElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.elements)
+    let newData = data.replacingChild(raw, at: 7)
     return EnumCaseDeclSyntax(newData)
   }
 }
@@ -7673,25 +7109,6 @@ extension EnumCaseDeclSyntax: CustomReflectable {
 
 /// A Swift `enum` declaration.
 public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndEnumKeyword
-    case enumKeyword
-    case unexpectedBetweenEnumKeywordAndIdentifier
-    case identifier
-    case unexpectedBetweenIdentifierAndGenericParameters
-    case genericParameters
-    case unexpectedBetweenGenericParametersAndInheritanceClause
-    case inheritanceClause
-    case unexpectedBetweenInheritanceClauseAndGenericWhereClause
-    case genericWhereClause
-    case unexpectedBetweenGenericWhereClauseAndMembers
-    case members
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `EnumDeclSyntax` if possible. Returns
@@ -7757,8 +7174,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7773,7 +7189,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return EnumDeclSyntax(newData)
   }
 
@@ -7782,8 +7198,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -7800,14 +7215,13 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> EnumDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return EnumDeclSyntax(newData)
   }
 
@@ -7817,14 +7231,13 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return EnumDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7839,7 +7252,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return EnumDeclSyntax(newData)
   }
 
@@ -7848,8 +7261,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -7866,14 +7278,13 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> EnumDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return EnumDeclSyntax(newData)
   }
 
@@ -7883,14 +7294,13 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return EnumDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndEnumKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndEnumKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7905,7 +7315,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndEnumKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndEnumKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return EnumDeclSyntax(newData)
   }
 
@@ -7914,8 +7324,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var enumKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.enumKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7929,14 +7338,13 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withEnumKeyword(
     _ newChild: TokenSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.enumKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.enumKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return EnumDeclSyntax(newData)
   }
 
   public var unexpectedBetweenEnumKeywordAndIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenEnumKeywordAndIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7951,7 +7359,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenEnumKeywordAndIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenEnumKeywordAndIdentifier)
+    let newData = data.replacingChild(raw, at: 6)
     return EnumDeclSyntax(newData)
   }
 
@@ -7960,8 +7368,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7975,14 +7382,13 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 7)
     return EnumDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndGenericParameters: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIdentifierAndGenericParameters,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7997,7 +7403,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIdentifierAndGenericParameters(
     _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIdentifierAndGenericParameters)
+    let newData = data.replacingChild(raw, at: 8)
     return EnumDeclSyntax(newData)
   }
 
@@ -8006,8 +7412,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var genericParameters: GenericParameterClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericParameters,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericParameterClauseSyntax(childData!)
     }
@@ -8022,14 +7427,13 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericParameters(
     _ newChild: GenericParameterClauseSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericParameters)
+    let newData = data.replacingChild(raw, at: 9)
     return EnumDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParametersAndInheritanceClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericParametersAndInheritanceClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8044,7 +7448,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericParametersAndInheritanceClause(
     _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericParametersAndInheritanceClause)
+    let newData = data.replacingChild(raw, at: 10)
     return EnumDeclSyntax(newData)
   }
 
@@ -8054,8 +7458,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var inheritanceClause: TypeInheritanceClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.inheritanceClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeInheritanceClauseSyntax(childData!)
     }
@@ -8070,14 +7473,13 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withInheritanceClause(
     _ newChild: TypeInheritanceClauseSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.inheritanceClause)
+    let newData = data.replacingChild(raw, at: 11)
     return EnumDeclSyntax(newData)
   }
 
   public var unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInheritanceClauseAndGenericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8092,7 +7494,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInheritanceClauseAndGenericWhereClause(
     _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInheritanceClauseAndGenericWhereClause)
+    let newData = data.replacingChild(raw, at: 12)
     return EnumDeclSyntax(newData)
   }
 
@@ -8102,8 +7504,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var genericWhereClause: GenericWhereClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericWhereClauseSyntax(childData!)
     }
@@ -8118,14 +7519,13 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGenericWhereClause(
     _ newChild: GenericWhereClauseSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericWhereClause)
+    let newData = data.replacingChild(raw, at: 13)
     return EnumDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericWhereClauseAndMembers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 14, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8140,7 +7540,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericWhereClauseAndMembers(
     _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericWhereClauseAndMembers)
+    let newData = data.replacingChild(raw, at: 14)
     return EnumDeclSyntax(newData)
   }
 
@@ -8149,8 +7549,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var members: MemberDeclBlockSyntax {
     get {
-      let childData = data.child(at: Cursor.members,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 15, parent: Syntax(self))
       return MemberDeclBlockSyntax(childData!)
     }
     set(value) {
@@ -8164,7 +7563,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withMembers(
     _ newChild: MemberDeclBlockSyntax?) -> EnumDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.members)
+    let newData = data.replacingChild(raw, at: 15)
     return EnumDeclSyntax(newData)
   }
 }
@@ -8196,19 +7595,6 @@ extension EnumDeclSyntax: CustomReflectable {
 
 /// A Swift `operator` declaration.
 public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndOperatorKeyword
-    case operatorKeyword
-    case unexpectedBetweenOperatorKeywordAndIdentifier
-    case identifier
-    case unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes
-    case operatorPrecedenceAndTypes
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `OperatorDeclSyntax` if possible. Returns
@@ -8262,8 +7648,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8278,7 +7663,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return OperatorDeclSyntax(newData)
   }
 
@@ -8287,8 +7672,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -8305,14 +7689,13 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> OperatorDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return OperatorDeclSyntax(newData)
   }
 
@@ -8322,14 +7705,13 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> OperatorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return OperatorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8344,7 +7726,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return OperatorDeclSyntax(newData)
   }
 
@@ -8354,8 +7736,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -8372,14 +7753,13 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> OperatorDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return OperatorDeclSyntax(newData)
   }
 
@@ -8389,14 +7769,13 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> OperatorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return OperatorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndOperatorKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndOperatorKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8411,14 +7790,13 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndOperatorKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndOperatorKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return OperatorDeclSyntax(newData)
   }
 
   public var operatorKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.operatorKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8432,14 +7810,13 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withOperatorKeyword(
     _ newChild: TokenSyntax?) -> OperatorDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.operatorKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.operatorKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return OperatorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenOperatorKeywordAndIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenOperatorKeywordAndIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8454,14 +7831,13 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenOperatorKeywordAndIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenOperatorKeywordAndIdentifier)
+    let newData = data.replacingChild(raw, at: 6)
     return OperatorDeclSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8475,14 +7851,13 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> OperatorDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unspacedBinaryOperator(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 7)
     return OperatorDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8497,7 +7872,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes(
     _ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes)
+    let newData = data.replacingChild(raw, at: 8)
     return OperatorDeclSyntax(newData)
   }
 
@@ -8506,8 +7881,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var operatorPrecedenceAndTypes: OperatorPrecedenceAndTypesSyntax? {
     get {
-      let childData = data.child(at: Cursor.operatorPrecedenceAndTypes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return OperatorPrecedenceAndTypesSyntax(childData!)
     }
@@ -8522,7 +7896,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withOperatorPrecedenceAndTypes(
     _ newChild: OperatorPrecedenceAndTypesSyntax?) -> OperatorDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.operatorPrecedenceAndTypes)
+    let newData = data.replacingChild(raw, at: 9)
     return OperatorDeclSyntax(newData)
   }
 }
@@ -8548,23 +7922,6 @@ extension OperatorDeclSyntax: CustomReflectable {
 
 /// A Swift `precedencegroup` declaration.
 public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndModifiers
-    case modifiers
-    case unexpectedBetweenModifiersAndPrecedencegroupKeyword
-    case precedencegroupKeyword
-    case unexpectedBetweenPrecedencegroupKeywordAndIdentifier
-    case identifier
-    case unexpectedBetweenIdentifierAndLeftBrace
-    case leftBrace
-    case unexpectedBetweenLeftBraceAndGroupAttributes
-    case groupAttributes
-    case unexpectedBetweenGroupAttributesAndRightBrace
-    case rightBrace
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PrecedenceGroupDeclSyntax` if possible. Returns
@@ -8626,8 +7983,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8642,7 +7998,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -8651,8 +8007,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -8669,14 +8024,13 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> PrecedenceGroupDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -8686,14 +8040,13 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> PrecedenceGroupDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndModifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8708,7 +8061,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndModifiers(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndModifiers)
+    let newData = data.replacingChild(raw, at: 2)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -8718,8 +8071,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var modifiers: ModifierListSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifiers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ModifierListSyntax(childData!)
     }
@@ -8736,14 +8088,13 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `modifiers` collection.
   public func addModifier(_ element: DeclModifierSyntax) -> PrecedenceGroupDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.modifiers] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.modifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.modifiers)
+    let newData = data.replacingChild(collection, at: 3)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -8753,14 +8104,13 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withModifiers(
     _ newChild: ModifierListSyntax?) -> PrecedenceGroupDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifiers)
+    let newData = data.replacingChild(raw, at: 3)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var unexpectedBetweenModifiersAndPrecedencegroupKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenModifiersAndPrecedencegroupKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8775,14 +8125,13 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenModifiersAndPrecedencegroupKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenModifiersAndPrecedencegroupKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var precedencegroupKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.precedencegroupKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8796,14 +8145,13 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withPrecedencegroupKeyword(
     _ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.precedencegroupKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.precedencegroupKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var unexpectedBetweenPrecedencegroupKeywordAndIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPrecedencegroupKeywordAndIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8818,7 +8166,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPrecedencegroupKeywordAndIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPrecedencegroupKeywordAndIdentifier)
+    let newData = data.replacingChild(raw, at: 6)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -8827,8 +8175,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8842,14 +8189,13 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 7)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndLeftBrace: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIdentifierAndLeftBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8864,14 +8210,13 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIdentifierAndLeftBrace(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIdentifierAndLeftBrace)
+    let newData = data.replacingChild(raw, at: 8)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var leftBrace: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8885,14 +8230,13 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withLeftBrace(
     _ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftBrace)
+    let newData = data.replacingChild(raw, at: 9)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var unexpectedBetweenLeftBraceAndGroupAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftBraceAndGroupAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8907,7 +8251,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftBraceAndGroupAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftBraceAndGroupAttributes)
+    let newData = data.replacingChild(raw, at: 10)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -8916,8 +8260,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   /// 
   public var groupAttributes: PrecedenceGroupAttributeListSyntax {
     get {
-      let childData = data.child(at: Cursor.groupAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       return PrecedenceGroupAttributeListSyntax(childData!)
     }
     set(value) {
@@ -8933,14 +8276,13 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   ///            appended to its `groupAttributes` collection.
   public func addGroupAttribute(_ element: Syntax) -> PrecedenceGroupDeclSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.groupAttributes] {
+    if let col = raw.layoutView!.children[11] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAttributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.groupAttributes)
+    let newData = data.replacingChild(collection, at: 11)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
@@ -8950,14 +8292,13 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withGroupAttributes(
     _ newChild: PrecedenceGroupAttributeListSyntax?) -> PrecedenceGroupDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.precedenceGroupAttributeList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.groupAttributes)
+    let newData = data.replacingChild(raw, at: 11)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var unexpectedBetweenGroupAttributesAndRightBrace: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGroupAttributesAndRightBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8972,14 +8313,13 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGroupAttributesAndRightBrace(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGroupAttributesAndRightBrace)
+    let newData = data.replacingChild(raw, at: 12)
     return PrecedenceGroupDeclSyntax(newData)
   }
 
   public var rightBrace: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8993,7 +8333,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func withRightBrace(
     _ newChild: TokenSyntax?) -> PrecedenceGroupDeclSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightBrace)
+    let newData = data.replacingChild(raw, at: 13)
     return PrecedenceGroupDeclSyntax(newData)
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -16,7 +16,6 @@
 // MARK: - UnknownExprSyntax
 
 public struct UnknownExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `UnknownExprSyntax` if possible. Returns
@@ -59,7 +58,6 @@ extension UnknownExprSyntax: CustomReflectable {
 // MARK: - MissingExprSyntax
 
 public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `MissingExprSyntax` if possible. Returns
@@ -102,13 +100,6 @@ extension MissingExprSyntax: CustomReflectable {
 // MARK: - InOutExprSyntax
 
 public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAmpersand
-    case ampersand
-    case unexpectedBetweenAmpersandAndExpression
-    case expression
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `InOutExprSyntax` if possible. Returns
@@ -150,8 +141,7 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAmpersand: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAmpersand,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -166,14 +156,13 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAmpersand(
     _ newChild: UnexpectedNodesSyntax?) -> InOutExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAmpersand)
+    let newData = data.replacingChild(raw, at: 0)
     return InOutExprSyntax(newData)
   }
 
   public var ampersand: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.ampersand,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -187,14 +176,13 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withAmpersand(
     _ newChild: TokenSyntax?) -> InOutExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.prefixAmpersand, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.ampersand)
+    let newData = data.replacingChild(raw, at: 1)
     return InOutExprSyntax(newData)
   }
 
   public var unexpectedBetweenAmpersandAndExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAmpersandAndExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -209,14 +197,13 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAmpersandAndExpression(
     _ newChild: UnexpectedNodesSyntax?) -> InOutExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAmpersandAndExpression)
+    let newData = data.replacingChild(raw, at: 2)
     return InOutExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -230,7 +217,7 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> InOutExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 3)
     return InOutExprSyntax(newData)
   }
 }
@@ -249,11 +236,6 @@ extension InOutExprSyntax: CustomReflectable {
 // MARK: - PoundColumnExprSyntax
 
 public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePoundColumn
-    case poundColumn
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PoundColumnExprSyntax` if possible. Returns
@@ -291,8 +273,7 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePoundColumn: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePoundColumn,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -307,14 +288,13 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePoundColumn(
     _ newChild: UnexpectedNodesSyntax?) -> PoundColumnExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePoundColumn)
+    let newData = data.replacingChild(raw, at: 0)
     return PoundColumnExprSyntax(newData)
   }
 
   public var poundColumn: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundColumn,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -328,7 +308,7 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withPoundColumn(
     _ newChild: TokenSyntax?) -> PoundColumnExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundColumnKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundColumn)
+    let newData = data.replacingChild(raw, at: 1)
     return PoundColumnExprSyntax(newData)
   }
 }
@@ -345,15 +325,6 @@ extension PoundColumnExprSyntax: CustomReflectable {
 // MARK: - TryExprSyntax
 
 public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeTryKeyword
-    case tryKeyword
-    case unexpectedBetweenTryKeywordAndQuestionOrExclamationMark
-    case questionOrExclamationMark
-    case unexpectedBetweenQuestionOrExclamationMarkAndExpression
-    case expression
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TryExprSyntax` if possible. Returns
@@ -399,8 +370,7 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeTryKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeTryKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -415,14 +385,13 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeTryKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeTryKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return TryExprSyntax(newData)
   }
 
   public var tryKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.tryKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -436,14 +405,13 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withTryKeyword(
     _ newChild: TokenSyntax?) -> TryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.tryKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.tryKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return TryExprSyntax(newData)
   }
 
   public var unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTryKeywordAndQuestionOrExclamationMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -458,14 +426,13 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTryKeywordAndQuestionOrExclamationMark(
     _ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTryKeywordAndQuestionOrExclamationMark)
+    let newData = data.replacingChild(raw, at: 2)
     return TryExprSyntax(newData)
   }
 
   public var questionOrExclamationMark: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.questionOrExclamationMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -480,14 +447,13 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withQuestionOrExclamationMark(
     _ newChild: TokenSyntax?) -> TryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.questionOrExclamationMark)
+    let newData = data.replacingChild(raw, at: 3)
     return TryExprSyntax(newData)
   }
 
   public var unexpectedBetweenQuestionOrExclamationMarkAndExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenQuestionOrExclamationMarkAndExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -502,14 +468,13 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenQuestionOrExclamationMarkAndExpression(
     _ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenQuestionOrExclamationMarkAndExpression)
+    let newData = data.replacingChild(raw, at: 4)
     return TryExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -523,7 +488,7 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> TryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 5)
     return TryExprSyntax(newData)
   }
 }
@@ -544,13 +509,6 @@ extension TryExprSyntax: CustomReflectable {
 // MARK: - AwaitExprSyntax
 
 public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAwaitKeyword
-    case awaitKeyword
-    case unexpectedBetweenAwaitKeywordAndExpression
-    case expression
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AwaitExprSyntax` if possible. Returns
@@ -592,8 +550,7 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAwaitKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAwaitKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -608,14 +565,13 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAwaitKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> AwaitExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAwaitKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return AwaitExprSyntax(newData)
   }
 
   public var awaitKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.awaitKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -629,14 +585,13 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withAwaitKeyword(
     _ newChild: TokenSyntax?) -> AwaitExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.awaitKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return AwaitExprSyntax(newData)
   }
 
   public var unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAwaitKeywordAndExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -651,14 +606,13 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAwaitKeywordAndExpression(
     _ newChild: UnexpectedNodesSyntax?) -> AwaitExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAwaitKeywordAndExpression)
+    let newData = data.replacingChild(raw, at: 2)
     return AwaitExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -672,7 +626,7 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> AwaitExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 3)
     return AwaitExprSyntax(newData)
   }
 }
@@ -691,13 +645,6 @@ extension AwaitExprSyntax: CustomReflectable {
 // MARK: - MoveExprSyntax
 
 public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeMoveKeyword
-    case moveKeyword
-    case unexpectedBetweenMoveKeywordAndExpression
-    case expression
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `MoveExprSyntax` if possible. Returns
@@ -739,8 +686,7 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeMoveKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeMoveKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -755,14 +701,13 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeMoveKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> MoveExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeMoveKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return MoveExprSyntax(newData)
   }
 
   public var moveKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.moveKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -776,14 +721,13 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withMoveKeyword(
     _ newChild: TokenSyntax?) -> MoveExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.moveKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return MoveExprSyntax(newData)
   }
 
   public var unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenMoveKeywordAndExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -798,14 +742,13 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenMoveKeywordAndExpression(
     _ newChild: UnexpectedNodesSyntax?) -> MoveExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenMoveKeywordAndExpression)
+    let newData = data.replacingChild(raw, at: 2)
     return MoveExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -819,7 +762,7 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> MoveExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 3)
     return MoveExprSyntax(newData)
   }
 }
@@ -838,13 +781,6 @@ extension MoveExprSyntax: CustomReflectable {
 // MARK: - IdentifierExprSyntax
 
 public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeIdentifier
-    case identifier
-    case unexpectedBetweenIdentifierAndDeclNameArguments
-    case declNameArguments
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `IdentifierExprSyntax` if possible. Returns
@@ -886,8 +822,7 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -902,14 +837,13 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> IdentifierExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeIdentifier)
+    let newData = data.replacingChild(raw, at: 0)
     return IdentifierExprSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -923,14 +857,13 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> IdentifierExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 1)
     return IdentifierExprSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIdentifierAndDeclNameArguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -945,14 +878,13 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIdentifierAndDeclNameArguments(
     _ newChild: UnexpectedNodesSyntax?) -> IdentifierExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIdentifierAndDeclNameArguments)
+    let newData = data.replacingChild(raw, at: 2)
     return IdentifierExprSyntax(newData)
   }
 
   public var declNameArguments: DeclNameArgumentsSyntax? {
     get {
-      let childData = data.child(at: Cursor.declNameArguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return DeclNameArgumentsSyntax(childData!)
     }
@@ -967,7 +899,7 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withDeclNameArguments(
     _ newChild: DeclNameArgumentsSyntax?) -> IdentifierExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.declNameArguments)
+    let newData = data.replacingChild(raw, at: 3)
     return IdentifierExprSyntax(newData)
   }
 }
@@ -986,11 +918,6 @@ extension IdentifierExprSyntax: CustomReflectable {
 // MARK: - SuperRefExprSyntax
 
 public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeSuperKeyword
-    case superKeyword
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SuperRefExprSyntax` if possible. Returns
@@ -1028,8 +955,7 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeSuperKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeSuperKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1044,14 +970,13 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeSuperKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> SuperRefExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeSuperKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return SuperRefExprSyntax(newData)
   }
 
   public var superKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.superKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1065,7 +990,7 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withSuperKeyword(
     _ newChild: TokenSyntax?) -> SuperRefExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.superKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.superKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return SuperRefExprSyntax(newData)
   }
 }
@@ -1082,11 +1007,6 @@ extension SuperRefExprSyntax: CustomReflectable {
 // MARK: - NilLiteralExprSyntax
 
 public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeNilKeyword
-    case nilKeyword
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `NilLiteralExprSyntax` if possible. Returns
@@ -1124,8 +1044,7 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeNilKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeNilKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1140,14 +1059,13 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeNilKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> NilLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeNilKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return NilLiteralExprSyntax(newData)
   }
 
   public var nilKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.nilKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1161,7 +1079,7 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withNilKeyword(
     _ newChild: TokenSyntax?) -> NilLiteralExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.nilKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.nilKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return NilLiteralExprSyntax(newData)
   }
 }
@@ -1178,11 +1096,6 @@ extension NilLiteralExprSyntax: CustomReflectable {
 // MARK: - DiscardAssignmentExprSyntax
 
 public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeWildcard
-    case wildcard
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DiscardAssignmentExprSyntax` if possible. Returns
@@ -1220,8 +1133,7 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeWildcard: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeWildcard,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1236,14 +1148,13 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeWildcard(
     _ newChild: UnexpectedNodesSyntax?) -> DiscardAssignmentExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeWildcard)
+    let newData = data.replacingChild(raw, at: 0)
     return DiscardAssignmentExprSyntax(newData)
   }
 
   public var wildcard: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.wildcard,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1257,7 +1168,7 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withWildcard(
     _ newChild: TokenSyntax?) -> DiscardAssignmentExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.wildcardKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.wildcard)
+    let newData = data.replacingChild(raw, at: 1)
     return DiscardAssignmentExprSyntax(newData)
   }
 }
@@ -1274,11 +1185,6 @@ extension DiscardAssignmentExprSyntax: CustomReflectable {
 // MARK: - AssignmentExprSyntax
 
 public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAssignToken
-    case assignToken
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AssignmentExprSyntax` if possible. Returns
@@ -1316,8 +1222,7 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAssignToken: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAssignToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1332,14 +1237,13 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAssignToken(
     _ newChild: UnexpectedNodesSyntax?) -> AssignmentExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAssignToken)
+    let newData = data.replacingChild(raw, at: 0)
     return AssignmentExprSyntax(newData)
   }
 
   public var assignToken: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.assignToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1353,7 +1257,7 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withAssignToken(
     _ newChild: TokenSyntax?) -> AssignmentExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.assignToken)
+    let newData = data.replacingChild(raw, at: 1)
     return AssignmentExprSyntax(newData)
   }
 }
@@ -1370,11 +1274,6 @@ extension AssignmentExprSyntax: CustomReflectable {
 // MARK: - SequenceExprSyntax
 
 public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeElements
-    case elements
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SequenceExprSyntax` if possible. Returns
@@ -1412,8 +1311,7 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeElements: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeElements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1428,14 +1326,13 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeElements(
     _ newChild: UnexpectedNodesSyntax?) -> SequenceExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeElements)
+    let newData = data.replacingChild(raw, at: 0)
     return SequenceExprSyntax(newData)
   }
 
   public var elements: ExprListSyntax {
     get {
-      let childData = data.child(at: Cursor.elements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return ExprListSyntax(childData!)
     }
     set(value) {
@@ -1451,14 +1348,13 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `elements` collection.
   public func addElement(_ element: ExprSyntax) -> SequenceExprSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.elements] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.exprList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.elements)
+    let newData = data.replacingChild(collection, at: 1)
     return SequenceExprSyntax(newData)
   }
 
@@ -1468,7 +1364,7 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withElements(
     _ newChild: ExprListSyntax?) -> SequenceExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.exprList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.elements)
+    let newData = data.replacingChild(raw, at: 1)
     return SequenceExprSyntax(newData)
   }
 }
@@ -1485,11 +1381,6 @@ extension SequenceExprSyntax: CustomReflectable {
 // MARK: - PoundLineExprSyntax
 
 public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePoundLine
-    case poundLine
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PoundLineExprSyntax` if possible. Returns
@@ -1527,8 +1418,7 @@ public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePoundLine: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePoundLine,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1543,14 +1433,13 @@ public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePoundLine(
     _ newChild: UnexpectedNodesSyntax?) -> PoundLineExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePoundLine)
+    let newData = data.replacingChild(raw, at: 0)
     return PoundLineExprSyntax(newData)
   }
 
   public var poundLine: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundLine,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1564,7 +1453,7 @@ public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withPoundLine(
     _ newChild: TokenSyntax?) -> PoundLineExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundLineKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundLine)
+    let newData = data.replacingChild(raw, at: 1)
     return PoundLineExprSyntax(newData)
   }
 }
@@ -1581,11 +1470,6 @@ extension PoundLineExprSyntax: CustomReflectable {
 // MARK: - PoundFileExprSyntax
 
 public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePoundFile
-    case poundFile
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PoundFileExprSyntax` if possible. Returns
@@ -1623,8 +1507,7 @@ public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePoundFile: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePoundFile,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1639,14 +1522,13 @@ public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePoundFile(
     _ newChild: UnexpectedNodesSyntax?) -> PoundFileExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePoundFile)
+    let newData = data.replacingChild(raw, at: 0)
     return PoundFileExprSyntax(newData)
   }
 
   public var poundFile: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundFile,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1660,7 +1542,7 @@ public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withPoundFile(
     _ newChild: TokenSyntax?) -> PoundFileExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundFileKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundFile)
+    let newData = data.replacingChild(raw, at: 1)
     return PoundFileExprSyntax(newData)
   }
 }
@@ -1677,11 +1559,6 @@ extension PoundFileExprSyntax: CustomReflectable {
 // MARK: - PoundFileIDExprSyntax
 
 public struct PoundFileIDExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePoundFileID
-    case poundFileID
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PoundFileIDExprSyntax` if possible. Returns
@@ -1719,8 +1596,7 @@ public struct PoundFileIDExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePoundFileID: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePoundFileID,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1735,14 +1611,13 @@ public struct PoundFileIDExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePoundFileID(
     _ newChild: UnexpectedNodesSyntax?) -> PoundFileIDExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePoundFileID)
+    let newData = data.replacingChild(raw, at: 0)
     return PoundFileIDExprSyntax(newData)
   }
 
   public var poundFileID: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundFileID,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1756,7 +1631,7 @@ public struct PoundFileIDExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withPoundFileID(
     _ newChild: TokenSyntax?) -> PoundFileIDExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundFileIDKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundFileID)
+    let newData = data.replacingChild(raw, at: 1)
     return PoundFileIDExprSyntax(newData)
   }
 }
@@ -1773,11 +1648,6 @@ extension PoundFileIDExprSyntax: CustomReflectable {
 // MARK: - PoundFilePathExprSyntax
 
 public struct PoundFilePathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePoundFilePath
-    case poundFilePath
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PoundFilePathExprSyntax` if possible. Returns
@@ -1815,8 +1685,7 @@ public struct PoundFilePathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePoundFilePath: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePoundFilePath,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1831,14 +1700,13 @@ public struct PoundFilePathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePoundFilePath(
     _ newChild: UnexpectedNodesSyntax?) -> PoundFilePathExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePoundFilePath)
+    let newData = data.replacingChild(raw, at: 0)
     return PoundFilePathExprSyntax(newData)
   }
 
   public var poundFilePath: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundFilePath,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1852,7 +1720,7 @@ public struct PoundFilePathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withPoundFilePath(
     _ newChild: TokenSyntax?) -> PoundFilePathExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundFilePathKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundFilePath)
+    let newData = data.replacingChild(raw, at: 1)
     return PoundFilePathExprSyntax(newData)
   }
 }
@@ -1869,11 +1737,6 @@ extension PoundFilePathExprSyntax: CustomReflectable {
 // MARK: - PoundFunctionExprSyntax
 
 public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePoundFunction
-    case poundFunction
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PoundFunctionExprSyntax` if possible. Returns
@@ -1911,8 +1774,7 @@ public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePoundFunction: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePoundFunction,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1927,14 +1789,13 @@ public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePoundFunction(
     _ newChild: UnexpectedNodesSyntax?) -> PoundFunctionExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePoundFunction)
+    let newData = data.replacingChild(raw, at: 0)
     return PoundFunctionExprSyntax(newData)
   }
 
   public var poundFunction: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundFunction,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1948,7 +1809,7 @@ public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withPoundFunction(
     _ newChild: TokenSyntax?) -> PoundFunctionExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundFunctionKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundFunction)
+    let newData = data.replacingChild(raw, at: 1)
     return PoundFunctionExprSyntax(newData)
   }
 }
@@ -1965,11 +1826,6 @@ extension PoundFunctionExprSyntax: CustomReflectable {
 // MARK: - PoundDsohandleExprSyntax
 
 public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePoundDsohandle
-    case poundDsohandle
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PoundDsohandleExprSyntax` if possible. Returns
@@ -2007,8 +1863,7 @@ public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePoundDsohandle: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePoundDsohandle,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2023,14 +1878,13 @@ public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePoundDsohandle(
     _ newChild: UnexpectedNodesSyntax?) -> PoundDsohandleExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePoundDsohandle)
+    let newData = data.replacingChild(raw, at: 0)
     return PoundDsohandleExprSyntax(newData)
   }
 
   public var poundDsohandle: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundDsohandle,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2044,7 +1898,7 @@ public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withPoundDsohandle(
     _ newChild: TokenSyntax?) -> PoundDsohandleExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundDsohandleKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundDsohandle)
+    let newData = data.replacingChild(raw, at: 1)
     return PoundDsohandleExprSyntax(newData)
   }
 }
@@ -2061,13 +1915,6 @@ extension PoundDsohandleExprSyntax: CustomReflectable {
 // MARK: - SymbolicReferenceExprSyntax
 
 public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeIdentifier
-    case identifier
-    case unexpectedBetweenIdentifierAndGenericArgumentClause
-    case genericArgumentClause
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SymbolicReferenceExprSyntax` if possible. Returns
@@ -2109,8 +1956,7 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2125,14 +1971,13 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> SymbolicReferenceExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeIdentifier)
+    let newData = data.replacingChild(raw, at: 0)
     return SymbolicReferenceExprSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2146,14 +1991,13 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> SymbolicReferenceExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 1)
     return SymbolicReferenceExprSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndGenericArgumentClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIdentifierAndGenericArgumentClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2168,14 +2012,13 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIdentifierAndGenericArgumentClause(
     _ newChild: UnexpectedNodesSyntax?) -> SymbolicReferenceExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIdentifierAndGenericArgumentClause)
+    let newData = data.replacingChild(raw, at: 2)
     return SymbolicReferenceExprSyntax(newData)
   }
 
   public var genericArgumentClause: GenericArgumentClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericArgumentClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericArgumentClauseSyntax(childData!)
     }
@@ -2190,7 +2033,7 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withGenericArgumentClause(
     _ newChild: GenericArgumentClauseSyntax?) -> SymbolicReferenceExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericArgumentClause)
+    let newData = data.replacingChild(raw, at: 3)
     return SymbolicReferenceExprSyntax(newData)
   }
 }
@@ -2209,13 +2052,6 @@ extension SymbolicReferenceExprSyntax: CustomReflectable {
 // MARK: - PrefixOperatorExprSyntax
 
 public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeOperatorToken
-    case operatorToken
-    case unexpectedBetweenOperatorTokenAndPostfixExpression
-    case postfixExpression
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PrefixOperatorExprSyntax` if possible. Returns
@@ -2257,8 +2093,7 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeOperatorToken: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeOperatorToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2273,14 +2108,13 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeOperatorToken(
     _ newChild: UnexpectedNodesSyntax?) -> PrefixOperatorExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeOperatorToken)
+    let newData = data.replacingChild(raw, at: 0)
     return PrefixOperatorExprSyntax(newData)
   }
 
   public var operatorToken: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.operatorToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -2295,14 +2129,13 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withOperatorToken(
     _ newChild: TokenSyntax?) -> PrefixOperatorExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.operatorToken)
+    let newData = data.replacingChild(raw, at: 1)
     return PrefixOperatorExprSyntax(newData)
   }
 
   public var unexpectedBetweenOperatorTokenAndPostfixExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenOperatorTokenAndPostfixExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2317,14 +2150,13 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenOperatorTokenAndPostfixExpression(
     _ newChild: UnexpectedNodesSyntax?) -> PrefixOperatorExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenOperatorTokenAndPostfixExpression)
+    let newData = data.replacingChild(raw, at: 2)
     return PrefixOperatorExprSyntax(newData)
   }
 
   public var postfixExpression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.postfixExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -2338,7 +2170,7 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withPostfixExpression(
     _ newChild: ExprSyntax?) -> PrefixOperatorExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.postfixExpression)
+    let newData = data.replacingChild(raw, at: 3)
     return PrefixOperatorExprSyntax(newData)
   }
 }
@@ -2357,11 +2189,6 @@ extension PrefixOperatorExprSyntax: CustomReflectable {
 // MARK: - BinaryOperatorExprSyntax
 
 public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeOperatorToken
-    case operatorToken
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `BinaryOperatorExprSyntax` if possible. Returns
@@ -2399,8 +2226,7 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeOperatorToken: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeOperatorToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2415,14 +2241,13 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeOperatorToken(
     _ newChild: UnexpectedNodesSyntax?) -> BinaryOperatorExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeOperatorToken)
+    let newData = data.replacingChild(raw, at: 0)
     return BinaryOperatorExprSyntax(newData)
   }
 
   public var operatorToken: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.operatorToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2436,7 +2261,7 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withOperatorToken(
     _ newChild: TokenSyntax?) -> BinaryOperatorExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.operatorToken)
+    let newData = data.replacingChild(raw, at: 1)
     return BinaryOperatorExprSyntax(newData)
   }
 }
@@ -2453,15 +2278,6 @@ extension BinaryOperatorExprSyntax: CustomReflectable {
 // MARK: - ArrowExprSyntax
 
 public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAsyncKeyword
-    case asyncKeyword
-    case unexpectedBetweenAsyncKeywordAndThrowsToken
-    case throwsToken
-    case unexpectedBetweenThrowsTokenAndArrowToken
-    case arrowToken
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ArrowExprSyntax` if possible. Returns
@@ -2507,8 +2323,7 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAsyncKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAsyncKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2523,14 +2338,13 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAsyncKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ArrowExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAsyncKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return ArrowExprSyntax(newData)
   }
 
   public var asyncKeyword: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.asyncKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -2545,14 +2359,13 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withAsyncKeyword(
     _ newChild: TokenSyntax?) -> ArrowExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.asyncKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return ArrowExprSyntax(newData)
   }
 
   public var unexpectedBetweenAsyncKeywordAndThrowsToken: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAsyncKeywordAndThrowsToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2567,14 +2380,13 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAsyncKeywordAndThrowsToken(
     _ newChild: UnexpectedNodesSyntax?) -> ArrowExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAsyncKeywordAndThrowsToken)
+    let newData = data.replacingChild(raw, at: 2)
     return ArrowExprSyntax(newData)
   }
 
   public var throwsToken: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.throwsToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -2589,14 +2401,13 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withThrowsToken(
     _ newChild: TokenSyntax?) -> ArrowExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.throwsToken)
+    let newData = data.replacingChild(raw, at: 3)
     return ArrowExprSyntax(newData)
   }
 
   public var unexpectedBetweenThrowsTokenAndArrowToken: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenThrowsTokenAndArrowToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2611,14 +2422,13 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenThrowsTokenAndArrowToken(
     _ newChild: UnexpectedNodesSyntax?) -> ArrowExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenThrowsTokenAndArrowToken)
+    let newData = data.replacingChild(raw, at: 4)
     return ArrowExprSyntax(newData)
   }
 
   public var arrowToken: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.arrowToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2632,7 +2442,7 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withArrowToken(
     _ newChild: TokenSyntax?) -> ArrowExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.arrowToken)
+    let newData = data.replacingChild(raw, at: 5)
     return ArrowExprSyntax(newData)
   }
 }
@@ -2653,15 +2463,6 @@ extension ArrowExprSyntax: CustomReflectable {
 // MARK: - InfixOperatorExprSyntax
 
 public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftOperand
-    case leftOperand
-    case unexpectedBetweenLeftOperandAndOperatorOperand
-    case operatorOperand
-    case unexpectedBetweenOperatorOperandAndRightOperand
-    case rightOperand
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `InfixOperatorExprSyntax` if possible. Returns
@@ -2707,8 +2508,7 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftOperand: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftOperand,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2723,14 +2523,13 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftOperand(
     _ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftOperand)
+    let newData = data.replacingChild(raw, at: 0)
     return InfixOperatorExprSyntax(newData)
   }
 
   public var leftOperand: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.leftOperand,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -2744,14 +2543,13 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withLeftOperand(
     _ newChild: ExprSyntax?) -> InfixOperatorExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftOperand)
+    let newData = data.replacingChild(raw, at: 1)
     return InfixOperatorExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftOperandAndOperatorOperand: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftOperandAndOperatorOperand,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2766,14 +2564,13 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftOperandAndOperatorOperand(
     _ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftOperandAndOperatorOperand)
+    let newData = data.replacingChild(raw, at: 2)
     return InfixOperatorExprSyntax(newData)
   }
 
   public var operatorOperand: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.operatorOperand,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -2787,14 +2584,13 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withOperatorOperand(
     _ newChild: ExprSyntax?) -> InfixOperatorExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.operatorOperand)
+    let newData = data.replacingChild(raw, at: 3)
     return InfixOperatorExprSyntax(newData)
   }
 
   public var unexpectedBetweenOperatorOperandAndRightOperand: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenOperatorOperandAndRightOperand,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2809,14 +2605,13 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenOperatorOperandAndRightOperand(
     _ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenOperatorOperandAndRightOperand)
+    let newData = data.replacingChild(raw, at: 4)
     return InfixOperatorExprSyntax(newData)
   }
 
   public var rightOperand: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.rightOperand,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -2830,7 +2625,7 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withRightOperand(
     _ newChild: ExprSyntax?) -> InfixOperatorExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightOperand)
+    let newData = data.replacingChild(raw, at: 5)
     return InfixOperatorExprSyntax(newData)
   }
 }
@@ -2851,11 +2646,6 @@ extension InfixOperatorExprSyntax: CustomReflectable {
 // MARK: - FloatLiteralExprSyntax
 
 public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeFloatingDigits
-    case floatingDigits
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `FloatLiteralExprSyntax` if possible. Returns
@@ -2893,8 +2683,7 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeFloatingDigits: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeFloatingDigits,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2909,14 +2698,13 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeFloatingDigits(
     _ newChild: UnexpectedNodesSyntax?) -> FloatLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeFloatingDigits)
+    let newData = data.replacingChild(raw, at: 0)
     return FloatLiteralExprSyntax(newData)
   }
 
   public var floatingDigits: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.floatingDigits,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2930,7 +2718,7 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withFloatingDigits(
     _ newChild: TokenSyntax?) -> FloatLiteralExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.floatingLiteral(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.floatingDigits)
+    let newData = data.replacingChild(raw, at: 1)
     return FloatLiteralExprSyntax(newData)
   }
 }
@@ -2947,15 +2735,6 @@ extension FloatLiteralExprSyntax: CustomReflectable {
 // MARK: - TupleExprSyntax
 
 public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndElementList
-    case elementList
-    case unexpectedBetweenElementListAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TupleExprSyntax` if possible. Returns
@@ -3001,8 +2780,7 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3017,14 +2795,13 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftParen)
+    let newData = data.replacingChild(raw, at: 0)
     return TupleExprSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3038,14 +2815,13 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> TupleExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 1)
     return TupleExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndElementList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3060,14 +2836,13 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndElementList(
     _ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndElementList)
+    let newData = data.replacingChild(raw, at: 2)
     return TupleExprSyntax(newData)
   }
 
   public var elementList: TupleExprElementListSyntax {
     get {
-      let childData = data.child(at: Cursor.elementList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TupleExprElementListSyntax(childData!)
     }
     set(value) {
@@ -3083,14 +2858,13 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `elementList` collection.
   public func addElement(_ element: TupleExprElementSyntax) -> TupleExprSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.elementList] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.elementList)
+    let newData = data.replacingChild(collection, at: 3)
     return TupleExprSyntax(newData)
   }
 
@@ -3100,14 +2874,13 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withElementList(
     _ newChild: TupleExprElementListSyntax?) -> TupleExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.elementList)
+    let newData = data.replacingChild(raw, at: 3)
     return TupleExprSyntax(newData)
   }
 
   public var unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenElementListAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3122,14 +2895,13 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenElementListAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenElementListAndRightParen)
+    let newData = data.replacingChild(raw, at: 4)
     return TupleExprSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3143,7 +2915,7 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> TupleExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 5)
     return TupleExprSyntax(newData)
   }
 }
@@ -3164,15 +2936,6 @@ extension TupleExprSyntax: CustomReflectable {
 // MARK: - ArrayExprSyntax
 
 public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftSquare
-    case leftSquare
-    case unexpectedBetweenLeftSquareAndElements
-    case elements
-    case unexpectedBetweenElementsAndRightSquare
-    case rightSquare
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ArrayExprSyntax` if possible. Returns
@@ -3218,8 +2981,7 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftSquare: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftSquare,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3234,14 +2996,13 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftSquare(
     _ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftSquare)
+    let newData = data.replacingChild(raw, at: 0)
     return ArrayExprSyntax(newData)
   }
 
   public var leftSquare: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftSquare,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3255,14 +3016,13 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withLeftSquare(
     _ newChild: TokenSyntax?) -> ArrayExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftSquare)
+    let newData = data.replacingChild(raw, at: 1)
     return ArrayExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftSquareAndElements: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftSquareAndElements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3277,14 +3037,13 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftSquareAndElements(
     _ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftSquareAndElements)
+    let newData = data.replacingChild(raw, at: 2)
     return ArrayExprSyntax(newData)
   }
 
   public var elements: ArrayElementListSyntax {
     get {
-      let childData = data.child(at: Cursor.elements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return ArrayElementListSyntax(childData!)
     }
     set(value) {
@@ -3300,14 +3059,13 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `elements` collection.
   public func addElement(_ element: ArrayElementSyntax) -> ArrayExprSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.elements] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.arrayElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.elements)
+    let newData = data.replacingChild(collection, at: 3)
     return ArrayExprSyntax(newData)
   }
 
@@ -3317,14 +3075,13 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withElements(
     _ newChild: ArrayElementListSyntax?) -> ArrayExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.arrayElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.elements)
+    let newData = data.replacingChild(raw, at: 3)
     return ArrayExprSyntax(newData)
   }
 
   public var unexpectedBetweenElementsAndRightSquare: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenElementsAndRightSquare,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3339,14 +3096,13 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenElementsAndRightSquare(
     _ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenElementsAndRightSquare)
+    let newData = data.replacingChild(raw, at: 4)
     return ArrayExprSyntax(newData)
   }
 
   public var rightSquare: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightSquare,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3360,7 +3116,7 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withRightSquare(
     _ newChild: TokenSyntax?) -> ArrayExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightSquare)
+    let newData = data.replacingChild(raw, at: 5)
     return ArrayExprSyntax(newData)
   }
 }
@@ -3381,15 +3137,6 @@ extension ArrayExprSyntax: CustomReflectable {
 // MARK: - DictionaryExprSyntax
 
 public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftSquare
-    case leftSquare
-    case unexpectedBetweenLeftSquareAndContent
-    case content
-    case unexpectedBetweenContentAndRightSquare
-    case rightSquare
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DictionaryExprSyntax` if possible. Returns
@@ -3435,8 +3182,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftSquare: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftSquare,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3451,14 +3197,13 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftSquare(
     _ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftSquare)
+    let newData = data.replacingChild(raw, at: 0)
     return DictionaryExprSyntax(newData)
   }
 
   public var leftSquare: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftSquare,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3472,14 +3217,13 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withLeftSquare(
     _ newChild: TokenSyntax?) -> DictionaryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftSquare)
+    let newData = data.replacingChild(raw, at: 1)
     return DictionaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftSquareAndContent: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftSquareAndContent,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3494,14 +3238,13 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftSquareAndContent(
     _ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftSquareAndContent)
+    let newData = data.replacingChild(raw, at: 2)
     return DictionaryExprSyntax(newData)
   }
 
   public var content: Syntax {
     get {
-      let childData = data.child(at: Cursor.content,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -3515,14 +3258,13 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withContent(
     _ newChild: Syntax?) -> DictionaryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.content)
+    let newData = data.replacingChild(raw, at: 3)
     return DictionaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenContentAndRightSquare: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenContentAndRightSquare,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3537,14 +3279,13 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenContentAndRightSquare(
     _ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenContentAndRightSquare)
+    let newData = data.replacingChild(raw, at: 4)
     return DictionaryExprSyntax(newData)
   }
 
   public var rightSquare: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightSquare,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3558,7 +3299,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withRightSquare(
     _ newChild: TokenSyntax?) -> DictionaryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightSquare)
+    let newData = data.replacingChild(raw, at: 5)
     return DictionaryExprSyntax(newData)
   }
 }
@@ -3579,11 +3320,6 @@ extension DictionaryExprSyntax: CustomReflectable {
 // MARK: - IntegerLiteralExprSyntax
 
 public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeDigits
-    case digits
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `IntegerLiteralExprSyntax` if possible. Returns
@@ -3621,8 +3357,7 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeDigits: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeDigits,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3637,14 +3372,13 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeDigits(
     _ newChild: UnexpectedNodesSyntax?) -> IntegerLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeDigits)
+    let newData = data.replacingChild(raw, at: 0)
     return IntegerLiteralExprSyntax(newData)
   }
 
   public var digits: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.digits,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3658,7 +3392,7 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withDigits(
     _ newChild: TokenSyntax?) -> IntegerLiteralExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.digits)
+    let newData = data.replacingChild(raw, at: 1)
     return IntegerLiteralExprSyntax(newData)
   }
 }
@@ -3675,11 +3409,6 @@ extension IntegerLiteralExprSyntax: CustomReflectable {
 // MARK: - BooleanLiteralExprSyntax
 
 public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeBooleanLiteral
-    case booleanLiteral
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `BooleanLiteralExprSyntax` if possible. Returns
@@ -3717,8 +3446,7 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeBooleanLiteral: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeBooleanLiteral,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3733,14 +3461,13 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeBooleanLiteral(
     _ newChild: UnexpectedNodesSyntax?) -> BooleanLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeBooleanLiteral)
+    let newData = data.replacingChild(raw, at: 0)
     return BooleanLiteralExprSyntax(newData)
   }
 
   public var booleanLiteral: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.booleanLiteral,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3754,7 +3481,7 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withBooleanLiteral(
     _ newChild: TokenSyntax?) -> BooleanLiteralExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.trueKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.booleanLiteral)
+    let newData = data.replacingChild(raw, at: 1)
     return BooleanLiteralExprSyntax(newData)
   }
 }
@@ -3771,15 +3498,6 @@ extension BooleanLiteralExprSyntax: CustomReflectable {
 // MARK: - UnresolvedTernaryExprSyntax
 
 public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeQuestionMark
-    case questionMark
-    case unexpectedBetweenQuestionMarkAndFirstChoice
-    case firstChoice
-    case unexpectedBetweenFirstChoiceAndColonMark
-    case colonMark
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `UnresolvedTernaryExprSyntax` if possible. Returns
@@ -3825,8 +3543,7 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeQuestionMark: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeQuestionMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3841,14 +3558,13 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeQuestionMark(
     _ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeQuestionMark)
+    let newData = data.replacingChild(raw, at: 0)
     return UnresolvedTernaryExprSyntax(newData)
   }
 
   public var questionMark: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.questionMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3862,14 +3578,13 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withQuestionMark(
     _ newChild: TokenSyntax?) -> UnresolvedTernaryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.infixQuestionMark, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.questionMark)
+    let newData = data.replacingChild(raw, at: 1)
     return UnresolvedTernaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenQuestionMarkAndFirstChoice,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3884,14 +3599,13 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenQuestionMarkAndFirstChoice(
     _ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenQuestionMarkAndFirstChoice)
+    let newData = data.replacingChild(raw, at: 2)
     return UnresolvedTernaryExprSyntax(newData)
   }
 
   public var firstChoice: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.firstChoice,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -3905,14 +3619,13 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withFirstChoice(
     _ newChild: ExprSyntax?) -> UnresolvedTernaryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.firstChoice)
+    let newData = data.replacingChild(raw, at: 3)
     return UnresolvedTernaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenFirstChoiceAndColonMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3927,14 +3640,13 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenFirstChoiceAndColonMark(
     _ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenFirstChoiceAndColonMark)
+    let newData = data.replacingChild(raw, at: 4)
     return UnresolvedTernaryExprSyntax(newData)
   }
 
   public var colonMark: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colonMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3948,7 +3660,7 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withColonMark(
     _ newChild: TokenSyntax?) -> UnresolvedTernaryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colonMark)
+    let newData = data.replacingChild(raw, at: 5)
     return UnresolvedTernaryExprSyntax(newData)
   }
 }
@@ -3969,19 +3681,6 @@ extension UnresolvedTernaryExprSyntax: CustomReflectable {
 // MARK: - TernaryExprSyntax
 
 public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeConditionExpression
-    case conditionExpression
-    case unexpectedBetweenConditionExpressionAndQuestionMark
-    case questionMark
-    case unexpectedBetweenQuestionMarkAndFirstChoice
-    case firstChoice
-    case unexpectedBetweenFirstChoiceAndColonMark
-    case colonMark
-    case unexpectedBetweenColonMarkAndSecondChoice
-    case secondChoice
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TernaryExprSyntax` if possible. Returns
@@ -4035,8 +3734,7 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeConditionExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeConditionExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4051,14 +3749,13 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeConditionExpression(
     _ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeConditionExpression)
+    let newData = data.replacingChild(raw, at: 0)
     return TernaryExprSyntax(newData)
   }
 
   public var conditionExpression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.conditionExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -4072,14 +3769,13 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withConditionExpression(
     _ newChild: ExprSyntax?) -> TernaryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.conditionExpression)
+    let newData = data.replacingChild(raw, at: 1)
     return TernaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenConditionExpressionAndQuestionMark: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenConditionExpressionAndQuestionMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4094,14 +3790,13 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenConditionExpressionAndQuestionMark(
     _ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenConditionExpressionAndQuestionMark)
+    let newData = data.replacingChild(raw, at: 2)
     return TernaryExprSyntax(newData)
   }
 
   public var questionMark: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.questionMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4115,14 +3810,13 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withQuestionMark(
     _ newChild: TokenSyntax?) -> TernaryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.infixQuestionMark, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.questionMark)
+    let newData = data.replacingChild(raw, at: 3)
     return TernaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenQuestionMarkAndFirstChoice,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4137,14 +3831,13 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenQuestionMarkAndFirstChoice(
     _ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenQuestionMarkAndFirstChoice)
+    let newData = data.replacingChild(raw, at: 4)
     return TernaryExprSyntax(newData)
   }
 
   public var firstChoice: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.firstChoice,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -4158,14 +3851,13 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withFirstChoice(
     _ newChild: ExprSyntax?) -> TernaryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.firstChoice)
+    let newData = data.replacingChild(raw, at: 5)
     return TernaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenFirstChoiceAndColonMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4180,14 +3872,13 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenFirstChoiceAndColonMark(
     _ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenFirstChoiceAndColonMark)
+    let newData = data.replacingChild(raw, at: 6)
     return TernaryExprSyntax(newData)
   }
 
   public var colonMark: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colonMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4201,14 +3892,13 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withColonMark(
     _ newChild: TokenSyntax?) -> TernaryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colonMark)
+    let newData = data.replacingChild(raw, at: 7)
     return TernaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenColonMarkAndSecondChoice: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonMarkAndSecondChoice,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4223,14 +3913,13 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonMarkAndSecondChoice(
     _ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonMarkAndSecondChoice)
+    let newData = data.replacingChild(raw, at: 8)
     return TernaryExprSyntax(newData)
   }
 
   public var secondChoice: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.secondChoice,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -4244,7 +3933,7 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withSecondChoice(
     _ newChild: ExprSyntax?) -> TernaryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.secondChoice)
+    let newData = data.replacingChild(raw, at: 9)
     return TernaryExprSyntax(newData)
   }
 }
@@ -4269,17 +3958,6 @@ extension TernaryExprSyntax: CustomReflectable {
 // MARK: - MemberAccessExprSyntax
 
 public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeBase
-    case base
-    case unexpectedBetweenBaseAndDot
-    case dot
-    case unexpectedBetweenDotAndName
-    case name
-    case unexpectedBetweenNameAndDeclNameArguments
-    case declNameArguments
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `MemberAccessExprSyntax` if possible. Returns
@@ -4329,8 +4007,7 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeBase: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeBase,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4345,14 +4022,13 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeBase(
     _ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeBase)
+    let newData = data.replacingChild(raw, at: 0)
     return MemberAccessExprSyntax(newData)
   }
 
   public var base: ExprSyntax? {
     get {
-      let childData = data.child(at: Cursor.base,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return ExprSyntax(childData!)
     }
@@ -4367,14 +4043,13 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withBase(
     _ newChild: ExprSyntax?) -> MemberAccessExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.base)
+    let newData = data.replacingChild(raw, at: 1)
     return MemberAccessExprSyntax(newData)
   }
 
   public var unexpectedBetweenBaseAndDot: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenBaseAndDot,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4389,14 +4064,13 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenBaseAndDot(
     _ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenBaseAndDot)
+    let newData = data.replacingChild(raw, at: 2)
     return MemberAccessExprSyntax(newData)
   }
 
   public var dot: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.dot,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4410,14 +4084,13 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withDot(
     _ newChild: TokenSyntax?) -> MemberAccessExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.dot)
+    let newData = data.replacingChild(raw, at: 3)
     return MemberAccessExprSyntax(newData)
   }
 
   public var unexpectedBetweenDotAndName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDotAndName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4432,14 +4105,13 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenDotAndName(
     _ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDotAndName)
+    let newData = data.replacingChild(raw, at: 4)
     return MemberAccessExprSyntax(newData)
   }
 
   public var name: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4453,14 +4125,13 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> MemberAccessExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 5)
     return MemberAccessExprSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndDeclNameArguments: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndDeclNameArguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4475,14 +4146,13 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndDeclNameArguments(
     _ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndDeclNameArguments)
+    let newData = data.replacingChild(raw, at: 6)
     return MemberAccessExprSyntax(newData)
   }
 
   public var declNameArguments: DeclNameArgumentsSyntax? {
     get {
-      let childData = data.child(at: Cursor.declNameArguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return DeclNameArgumentsSyntax(childData!)
     }
@@ -4497,7 +4167,7 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withDeclNameArguments(
     _ newChild: DeclNameArgumentsSyntax?) -> MemberAccessExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.declNameArguments)
+    let newData = data.replacingChild(raw, at: 7)
     return MemberAccessExprSyntax(newData)
   }
 }
@@ -4520,13 +4190,6 @@ extension MemberAccessExprSyntax: CustomReflectable {
 // MARK: - IsExprSyntax
 
 public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeIsTok
-    case isTok
-    case unexpectedBetweenIsTokAndTypeName
-    case typeName
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `IsExprSyntax` if possible. Returns
@@ -4568,8 +4231,7 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeIsTok: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeIsTok,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4584,14 +4246,13 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeIsTok(
     _ newChild: UnexpectedNodesSyntax?) -> IsExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeIsTok)
+    let newData = data.replacingChild(raw, at: 0)
     return IsExprSyntax(newData)
   }
 
   public var isTok: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.isTok,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4605,14 +4266,13 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withIsTok(
     _ newChild: TokenSyntax?) -> IsExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.isTok)
+    let newData = data.replacingChild(raw, at: 1)
     return IsExprSyntax(newData)
   }
 
   public var unexpectedBetweenIsTokAndTypeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIsTokAndTypeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4627,14 +4287,13 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIsTokAndTypeName(
     _ newChild: UnexpectedNodesSyntax?) -> IsExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIsTokAndTypeName)
+    let newData = data.replacingChild(raw, at: 2)
     return IsExprSyntax(newData)
   }
 
   public var typeName: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.typeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -4648,7 +4307,7 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withTypeName(
     _ newChild: TypeSyntax?) -> IsExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.typeName)
+    let newData = data.replacingChild(raw, at: 3)
     return IsExprSyntax(newData)
   }
 }
@@ -4667,15 +4326,6 @@ extension IsExprSyntax: CustomReflectable {
 // MARK: - AsExprSyntax
 
 public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAsTok
-    case asTok
-    case unexpectedBetweenAsTokAndQuestionOrExclamationMark
-    case questionOrExclamationMark
-    case unexpectedBetweenQuestionOrExclamationMarkAndTypeName
-    case typeName
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AsExprSyntax` if possible. Returns
@@ -4721,8 +4371,7 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAsTok: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAsTok,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4737,14 +4386,13 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAsTok(
     _ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAsTok)
+    let newData = data.replacingChild(raw, at: 0)
     return AsExprSyntax(newData)
   }
 
   public var asTok: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.asTok,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4758,14 +4406,13 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withAsTok(
     _ newChild: TokenSyntax?) -> AsExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.asTok)
+    let newData = data.replacingChild(raw, at: 1)
     return AsExprSyntax(newData)
   }
 
   public var unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAsTokAndQuestionOrExclamationMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4780,14 +4427,13 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAsTokAndQuestionOrExclamationMark(
     _ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAsTokAndQuestionOrExclamationMark)
+    let newData = data.replacingChild(raw, at: 2)
     return AsExprSyntax(newData)
   }
 
   public var questionOrExclamationMark: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.questionOrExclamationMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -4802,14 +4448,13 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withQuestionOrExclamationMark(
     _ newChild: TokenSyntax?) -> AsExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.questionOrExclamationMark)
+    let newData = data.replacingChild(raw, at: 3)
     return AsExprSyntax(newData)
   }
 
   public var unexpectedBetweenQuestionOrExclamationMarkAndTypeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenQuestionOrExclamationMarkAndTypeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4824,14 +4469,13 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenQuestionOrExclamationMarkAndTypeName(
     _ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenQuestionOrExclamationMarkAndTypeName)
+    let newData = data.replacingChild(raw, at: 4)
     return AsExprSyntax(newData)
   }
 
   public var typeName: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.typeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -4845,7 +4489,7 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withTypeName(
     _ newChild: TypeSyntax?) -> AsExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.typeName)
+    let newData = data.replacingChild(raw, at: 5)
     return AsExprSyntax(newData)
   }
 }
@@ -4866,11 +4510,6 @@ extension AsExprSyntax: CustomReflectable {
 // MARK: - TypeExprSyntax
 
 public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeType
-    case type
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TypeExprSyntax` if possible. Returns
@@ -4908,8 +4547,7 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4924,14 +4562,13 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeType(
     _ newChild: UnexpectedNodesSyntax?) -> TypeExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeType)
+    let newData = data.replacingChild(raw, at: 0)
     return TypeExprSyntax(newData)
   }
 
   public var type: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.type,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -4945,7 +4582,7 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withType(
     _ newChild: TypeSyntax?) -> TypeExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.type)
+    let newData = data.replacingChild(raw, at: 1)
     return TypeExprSyntax(newData)
   }
 }
@@ -4962,17 +4599,6 @@ extension TypeExprSyntax: CustomReflectable {
 // MARK: - ClosureExprSyntax
 
 public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftBrace
-    case leftBrace
-    case unexpectedBetweenLeftBraceAndSignature
-    case signature
-    case unexpectedBetweenSignatureAndStatements
-    case statements
-    case unexpectedBetweenStatementsAndRightBrace
-    case rightBrace
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ClosureExprSyntax` if possible. Returns
@@ -5022,8 +4648,7 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5038,14 +4663,13 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftBrace(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftBrace)
+    let newData = data.replacingChild(raw, at: 0)
     return ClosureExprSyntax(newData)
   }
 
   public var leftBrace: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -5059,14 +4683,13 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withLeftBrace(
     _ newChild: TokenSyntax?) -> ClosureExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftBrace)
+    let newData = data.replacingChild(raw, at: 1)
     return ClosureExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftBraceAndSignature: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftBraceAndSignature,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5081,14 +4704,13 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftBraceAndSignature(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftBraceAndSignature)
+    let newData = data.replacingChild(raw, at: 2)
     return ClosureExprSyntax(newData)
   }
 
   public var signature: ClosureSignatureSyntax? {
     get {
-      let childData = data.child(at: Cursor.signature,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ClosureSignatureSyntax(childData!)
     }
@@ -5103,14 +4725,13 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withSignature(
     _ newChild: ClosureSignatureSyntax?) -> ClosureExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.signature)
+    let newData = data.replacingChild(raw, at: 3)
     return ClosureExprSyntax(newData)
   }
 
   public var unexpectedBetweenSignatureAndStatements: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenSignatureAndStatements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5125,14 +4746,13 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenSignatureAndStatements(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenSignatureAndStatements)
+    let newData = data.replacingChild(raw, at: 4)
     return ClosureExprSyntax(newData)
   }
 
   public var statements: CodeBlockItemListSyntax {
     get {
-      let childData = data.child(at: Cursor.statements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return CodeBlockItemListSyntax(childData!)
     }
     set(value) {
@@ -5148,14 +4768,13 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `statements` collection.
   public func addStatement(_ element: CodeBlockItemSyntax) -> ClosureExprSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.statements] {
+    if let col = raw.layoutView!.children[5] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.statements)
+    let newData = data.replacingChild(collection, at: 5)
     return ClosureExprSyntax(newData)
   }
 
@@ -5165,14 +4784,13 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withStatements(
     _ newChild: CodeBlockItemListSyntax?) -> ClosureExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.statements)
+    let newData = data.replacingChild(raw, at: 5)
     return ClosureExprSyntax(newData)
   }
 
   public var unexpectedBetweenStatementsAndRightBrace: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenStatementsAndRightBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5187,14 +4805,13 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenStatementsAndRightBrace(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenStatementsAndRightBrace)
+    let newData = data.replacingChild(raw, at: 6)
     return ClosureExprSyntax(newData)
   }
 
   public var rightBrace: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -5208,7 +4825,7 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withRightBrace(
     _ newChild: TokenSyntax?) -> ClosureExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightBrace)
+    let newData = data.replacingChild(raw, at: 7)
     return ClosureExprSyntax(newData)
   }
 }
@@ -5231,11 +4848,6 @@ extension ClosureExprSyntax: CustomReflectable {
 // MARK: - UnresolvedPatternExprSyntax
 
 public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePattern
-    case pattern
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `UnresolvedPatternExprSyntax` if possible. Returns
@@ -5273,8 +4885,7 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePattern: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5289,14 +4900,13 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePattern(
     _ newChild: UnexpectedNodesSyntax?) -> UnresolvedPatternExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePattern)
+    let newData = data.replacingChild(raw, at: 0)
     return UnresolvedPatternExprSyntax(newData)
   }
 
   public var pattern: PatternSyntax {
     get {
-      let childData = data.child(at: Cursor.pattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return PatternSyntax(childData!)
     }
     set(value) {
@@ -5310,7 +4920,7 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withPattern(
     _ newChild: PatternSyntax?) -> UnresolvedPatternExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.pattern)
+    let newData = data.replacingChild(raw, at: 1)
     return UnresolvedPatternExprSyntax(newData)
   }
 }
@@ -5327,21 +4937,6 @@ extension UnresolvedPatternExprSyntax: CustomReflectable {
 // MARK: - FunctionCallExprSyntax
 
 public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeCalledExpression
-    case calledExpression
-    case unexpectedBetweenCalledExpressionAndLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndArgumentList
-    case argumentList
-    case unexpectedBetweenArgumentListAndRightParen
-    case rightParen
-    case unexpectedBetweenRightParenAndTrailingClosure
-    case trailingClosure
-    case unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures
-    case additionalTrailingClosures
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `FunctionCallExprSyntax` if possible. Returns
@@ -5399,8 +4994,7 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeCalledExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeCalledExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5415,14 +5009,13 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeCalledExpression(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeCalledExpression)
+    let newData = data.replacingChild(raw, at: 0)
     return FunctionCallExprSyntax(newData)
   }
 
   public var calledExpression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.calledExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -5436,14 +5029,13 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withCalledExpression(
     _ newChild: ExprSyntax?) -> FunctionCallExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.calledExpression)
+    let newData = data.replacingChild(raw, at: 1)
     return FunctionCallExprSyntax(newData)
   }
 
   public var unexpectedBetweenCalledExpressionAndLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCalledExpressionAndLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5458,14 +5050,13 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCalledExpressionAndLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCalledExpressionAndLeftParen)
+    let newData = data.replacingChild(raw, at: 2)
     return FunctionCallExprSyntax(newData)
   }
 
   public var leftParen: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -5480,14 +5071,13 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> FunctionCallExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 3)
     return FunctionCallExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndArgumentList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5502,14 +5092,13 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndArgumentList(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndArgumentList)
+    let newData = data.replacingChild(raw, at: 4)
     return FunctionCallExprSyntax(newData)
   }
 
   public var argumentList: TupleExprElementListSyntax {
     get {
-      let childData = data.child(at: Cursor.argumentList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TupleExprElementListSyntax(childData!)
     }
     set(value) {
@@ -5525,14 +5114,13 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `argumentList` collection.
   public func addArgument(_ element: TupleExprElementSyntax) -> FunctionCallExprSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.argumentList] {
+    if let col = raw.layoutView!.children[5] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.argumentList)
+    let newData = data.replacingChild(collection, at: 5)
     return FunctionCallExprSyntax(newData)
   }
 
@@ -5542,14 +5130,13 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withArgumentList(
     _ newChild: TupleExprElementListSyntax?) -> FunctionCallExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.argumentList)
+    let newData = data.replacingChild(raw, at: 5)
     return FunctionCallExprSyntax(newData)
   }
 
   public var unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenArgumentListAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5564,14 +5151,13 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenArgumentListAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenArgumentListAndRightParen)
+    let newData = data.replacingChild(raw, at: 6)
     return FunctionCallExprSyntax(newData)
   }
 
   public var rightParen: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -5586,14 +5172,13 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> FunctionCallExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 7)
     return FunctionCallExprSyntax(newData)
   }
 
   public var unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenRightParenAndTrailingClosure,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5608,14 +5193,13 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenRightParenAndTrailingClosure(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenRightParenAndTrailingClosure)
+    let newData = data.replacingChild(raw, at: 8)
     return FunctionCallExprSyntax(newData)
   }
 
   public var trailingClosure: ClosureExprSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingClosure,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return ClosureExprSyntax(childData!)
     }
@@ -5630,14 +5214,13 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withTrailingClosure(
     _ newChild: ClosureExprSyntax?) -> FunctionCallExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingClosure)
+    let newData = data.replacingChild(raw, at: 9)
     return FunctionCallExprSyntax(newData)
   }
 
   public var unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5652,14 +5235,13 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures)
+    let newData = data.replacingChild(raw, at: 10)
     return FunctionCallExprSyntax(newData)
   }
 
   public var additionalTrailingClosures: MultipleTrailingClosureElementListSyntax? {
     get {
-      let childData = data.child(at: Cursor.additionalTrailingClosures,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return MultipleTrailingClosureElementListSyntax(childData!)
     }
@@ -5676,14 +5258,13 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `additionalTrailingClosures` collection.
   public func addAdditionalTrailingClosure(_ element: MultipleTrailingClosureElementSyntax) -> FunctionCallExprSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.additionalTrailingClosures] {
+    if let col = raw.layoutView!.children[11] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.additionalTrailingClosures)
+    let newData = data.replacingChild(collection, at: 11)
     return FunctionCallExprSyntax(newData)
   }
 
@@ -5693,7 +5274,7 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withAdditionalTrailingClosures(
     _ newChild: MultipleTrailingClosureElementListSyntax?) -> FunctionCallExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.additionalTrailingClosures)
+    let newData = data.replacingChild(raw, at: 11)
     return FunctionCallExprSyntax(newData)
   }
 }
@@ -5720,21 +5301,6 @@ extension FunctionCallExprSyntax: CustomReflectable {
 // MARK: - SubscriptExprSyntax
 
 public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeCalledExpression
-    case calledExpression
-    case unexpectedBetweenCalledExpressionAndLeftBracket
-    case leftBracket
-    case unexpectedBetweenLeftBracketAndArgumentList
-    case argumentList
-    case unexpectedBetweenArgumentListAndRightBracket
-    case rightBracket
-    case unexpectedBetweenRightBracketAndTrailingClosure
-    case trailingClosure
-    case unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures
-    case additionalTrailingClosures
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SubscriptExprSyntax` if possible. Returns
@@ -5792,8 +5358,7 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeCalledExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeCalledExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5808,14 +5373,13 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeCalledExpression(
     _ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeCalledExpression)
+    let newData = data.replacingChild(raw, at: 0)
     return SubscriptExprSyntax(newData)
   }
 
   public var calledExpression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.calledExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -5829,14 +5393,13 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withCalledExpression(
     _ newChild: ExprSyntax?) -> SubscriptExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.calledExpression)
+    let newData = data.replacingChild(raw, at: 1)
     return SubscriptExprSyntax(newData)
   }
 
   public var unexpectedBetweenCalledExpressionAndLeftBracket: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCalledExpressionAndLeftBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5851,14 +5414,13 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCalledExpressionAndLeftBracket(
     _ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCalledExpressionAndLeftBracket)
+    let newData = data.replacingChild(raw, at: 2)
     return SubscriptExprSyntax(newData)
   }
 
   public var leftBracket: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -5872,14 +5434,13 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withLeftBracket(
     _ newChild: TokenSyntax?) -> SubscriptExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftBracket)
+    let newData = data.replacingChild(raw, at: 3)
     return SubscriptExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftBracketAndArgumentList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5894,14 +5455,13 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftBracketAndArgumentList(
     _ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftBracketAndArgumentList)
+    let newData = data.replacingChild(raw, at: 4)
     return SubscriptExprSyntax(newData)
   }
 
   public var argumentList: TupleExprElementListSyntax {
     get {
-      let childData = data.child(at: Cursor.argumentList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TupleExprElementListSyntax(childData!)
     }
     set(value) {
@@ -5917,14 +5477,13 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `argumentList` collection.
   public func addArgument(_ element: TupleExprElementSyntax) -> SubscriptExprSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.argumentList] {
+    if let col = raw.layoutView!.children[5] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.argumentList)
+    let newData = data.replacingChild(collection, at: 5)
     return SubscriptExprSyntax(newData)
   }
 
@@ -5934,14 +5493,13 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withArgumentList(
     _ newChild: TupleExprElementListSyntax?) -> SubscriptExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.argumentList)
+    let newData = data.replacingChild(raw, at: 5)
     return SubscriptExprSyntax(newData)
   }
 
   public var unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenArgumentListAndRightBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5956,14 +5514,13 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenArgumentListAndRightBracket(
     _ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenArgumentListAndRightBracket)
+    let newData = data.replacingChild(raw, at: 6)
     return SubscriptExprSyntax(newData)
   }
 
   public var rightBracket: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -5977,14 +5534,13 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withRightBracket(
     _ newChild: TokenSyntax?) -> SubscriptExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightBracket)
+    let newData = data.replacingChild(raw, at: 7)
     return SubscriptExprSyntax(newData)
   }
 
   public var unexpectedBetweenRightBracketAndTrailingClosure: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenRightBracketAndTrailingClosure,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5999,14 +5555,13 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenRightBracketAndTrailingClosure(
     _ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenRightBracketAndTrailingClosure)
+    let newData = data.replacingChild(raw, at: 8)
     return SubscriptExprSyntax(newData)
   }
 
   public var trailingClosure: ClosureExprSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingClosure,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return ClosureExprSyntax(childData!)
     }
@@ -6021,14 +5576,13 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withTrailingClosure(
     _ newChild: ClosureExprSyntax?) -> SubscriptExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingClosure)
+    let newData = data.replacingChild(raw, at: 9)
     return SubscriptExprSyntax(newData)
   }
 
   public var unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6043,14 +5597,13 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTrailingClosureAndAdditionalTrailingClosures(
     _ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures)
+    let newData = data.replacingChild(raw, at: 10)
     return SubscriptExprSyntax(newData)
   }
 
   public var additionalTrailingClosures: MultipleTrailingClosureElementListSyntax? {
     get {
-      let childData = data.child(at: Cursor.additionalTrailingClosures,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return MultipleTrailingClosureElementListSyntax(childData!)
     }
@@ -6067,14 +5620,13 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `additionalTrailingClosures` collection.
   public func addAdditionalTrailingClosure(_ element: MultipleTrailingClosureElementSyntax) -> SubscriptExprSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.additionalTrailingClosures] {
+    if let col = raw.layoutView!.children[11] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.additionalTrailingClosures)
+    let newData = data.replacingChild(collection, at: 11)
     return SubscriptExprSyntax(newData)
   }
 
@@ -6084,7 +5636,7 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withAdditionalTrailingClosures(
     _ newChild: MultipleTrailingClosureElementListSyntax?) -> SubscriptExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.additionalTrailingClosures)
+    let newData = data.replacingChild(raw, at: 11)
     return SubscriptExprSyntax(newData)
   }
 }
@@ -6111,13 +5663,6 @@ extension SubscriptExprSyntax: CustomReflectable {
 // MARK: - OptionalChainingExprSyntax
 
 public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeExpression
-    case expression
-    case unexpectedBetweenExpressionAndQuestionMark
-    case questionMark
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `OptionalChainingExprSyntax` if possible. Returns
@@ -6159,8 +5704,7 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6175,14 +5719,13 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeExpression(
     _ newChild: UnexpectedNodesSyntax?) -> OptionalChainingExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeExpression)
+    let newData = data.replacingChild(raw, at: 0)
     return OptionalChainingExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -6196,14 +5739,13 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> OptionalChainingExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 1)
     return OptionalChainingExprSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndQuestionMark: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenExpressionAndQuestionMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6218,14 +5760,13 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenExpressionAndQuestionMark(
     _ newChild: UnexpectedNodesSyntax?) -> OptionalChainingExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenExpressionAndQuestionMark)
+    let newData = data.replacingChild(raw, at: 2)
     return OptionalChainingExprSyntax(newData)
   }
 
   public var questionMark: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.questionMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -6239,7 +5780,7 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withQuestionMark(
     _ newChild: TokenSyntax?) -> OptionalChainingExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.questionMark)
+    let newData = data.replacingChild(raw, at: 3)
     return OptionalChainingExprSyntax(newData)
   }
 }
@@ -6258,13 +5799,6 @@ extension OptionalChainingExprSyntax: CustomReflectable {
 // MARK: - ForcedValueExprSyntax
 
 public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeExpression
-    case expression
-    case unexpectedBetweenExpressionAndExclamationMark
-    case exclamationMark
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ForcedValueExprSyntax` if possible. Returns
@@ -6306,8 +5840,7 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6322,14 +5855,13 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeExpression(
     _ newChild: UnexpectedNodesSyntax?) -> ForcedValueExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeExpression)
+    let newData = data.replacingChild(raw, at: 0)
     return ForcedValueExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -6343,14 +5875,13 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> ForcedValueExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 1)
     return ForcedValueExprSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndExclamationMark: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenExpressionAndExclamationMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6365,14 +5896,13 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenExpressionAndExclamationMark(
     _ newChild: UnexpectedNodesSyntax?) -> ForcedValueExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenExpressionAndExclamationMark)
+    let newData = data.replacingChild(raw, at: 2)
     return ForcedValueExprSyntax(newData)
   }
 
   public var exclamationMark: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.exclamationMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -6386,7 +5916,7 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withExclamationMark(
     _ newChild: TokenSyntax?) -> ForcedValueExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.exclamationMark, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.exclamationMark)
+    let newData = data.replacingChild(raw, at: 3)
     return ForcedValueExprSyntax(newData)
   }
 }
@@ -6405,13 +5935,6 @@ extension ForcedValueExprSyntax: CustomReflectable {
 // MARK: - PostfixUnaryExprSyntax
 
 public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeExpression
-    case expression
-    case unexpectedBetweenExpressionAndOperatorToken
-    case operatorToken
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PostfixUnaryExprSyntax` if possible. Returns
@@ -6453,8 +5976,7 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6469,14 +5991,13 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeExpression(
     _ newChild: UnexpectedNodesSyntax?) -> PostfixUnaryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeExpression)
+    let newData = data.replacingChild(raw, at: 0)
     return PostfixUnaryExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -6490,14 +6011,13 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> PostfixUnaryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 1)
     return PostfixUnaryExprSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndOperatorToken: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenExpressionAndOperatorToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6512,14 +6032,13 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenExpressionAndOperatorToken(
     _ newChild: UnexpectedNodesSyntax?) -> PostfixUnaryExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenExpressionAndOperatorToken)
+    let newData = data.replacingChild(raw, at: 2)
     return PostfixUnaryExprSyntax(newData)
   }
 
   public var operatorToken: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.operatorToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -6533,7 +6052,7 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withOperatorToken(
     _ newChild: TokenSyntax?) -> PostfixUnaryExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixOperator(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.operatorToken)
+    let newData = data.replacingChild(raw, at: 3)
     return PostfixUnaryExprSyntax(newData)
   }
 }
@@ -6552,13 +6071,6 @@ extension PostfixUnaryExprSyntax: CustomReflectable {
 // MARK: - SpecializeExprSyntax
 
 public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeExpression
-    case expression
-    case unexpectedBetweenExpressionAndGenericArgumentClause
-    case genericArgumentClause
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SpecializeExprSyntax` if possible. Returns
@@ -6600,8 +6112,7 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6616,14 +6127,13 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeExpression(
     _ newChild: UnexpectedNodesSyntax?) -> SpecializeExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeExpression)
+    let newData = data.replacingChild(raw, at: 0)
     return SpecializeExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -6637,14 +6147,13 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> SpecializeExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 1)
     return SpecializeExprSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndGenericArgumentClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenExpressionAndGenericArgumentClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6659,14 +6168,13 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenExpressionAndGenericArgumentClause(
     _ newChild: UnexpectedNodesSyntax?) -> SpecializeExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenExpressionAndGenericArgumentClause)
+    let newData = data.replacingChild(raw, at: 2)
     return SpecializeExprSyntax(newData)
   }
 
   public var genericArgumentClause: GenericArgumentClauseSyntax {
     get {
-      let childData = data.child(at: Cursor.genericArgumentClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return GenericArgumentClauseSyntax(childData!)
     }
     set(value) {
@@ -6680,7 +6188,7 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withGenericArgumentClause(
     _ newChild: GenericArgumentClauseSyntax?) -> SpecializeExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericArgumentClause, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.genericArgumentClause)
+    let newData = data.replacingChild(raw, at: 3)
     return SpecializeExprSyntax(newData)
   }
 }
@@ -6699,19 +6207,6 @@ extension SpecializeExprSyntax: CustomReflectable {
 // MARK: - StringLiteralExprSyntax
 
 public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeOpenDelimiter
-    case openDelimiter
-    case unexpectedBetweenOpenDelimiterAndOpenQuote
-    case openQuote
-    case unexpectedBetweenOpenQuoteAndSegments
-    case segments
-    case unexpectedBetweenSegmentsAndCloseQuote
-    case closeQuote
-    case unexpectedBetweenCloseQuoteAndCloseDelimiter
-    case closeDelimiter
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `StringLiteralExprSyntax` if possible. Returns
@@ -6765,8 +6260,7 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeOpenDelimiter: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeOpenDelimiter,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6781,14 +6275,13 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeOpenDelimiter(
     _ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeOpenDelimiter)
+    let newData = data.replacingChild(raw, at: 0)
     return StringLiteralExprSyntax(newData)
   }
 
   public var openDelimiter: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.openDelimiter,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -6803,14 +6296,13 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withOpenDelimiter(
     _ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.openDelimiter)
+    let newData = data.replacingChild(raw, at: 1)
     return StringLiteralExprSyntax(newData)
   }
 
   public var unexpectedBetweenOpenDelimiterAndOpenQuote: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenOpenDelimiterAndOpenQuote,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6825,14 +6317,13 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenOpenDelimiterAndOpenQuote(
     _ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenOpenDelimiterAndOpenQuote)
+    let newData = data.replacingChild(raw, at: 2)
     return StringLiteralExprSyntax(newData)
   }
 
   public var openQuote: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.openQuote,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -6846,14 +6337,13 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withOpenQuote(
     _ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringQuote, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.openQuote)
+    let newData = data.replacingChild(raw, at: 3)
     return StringLiteralExprSyntax(newData)
   }
 
   public var unexpectedBetweenOpenQuoteAndSegments: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenOpenQuoteAndSegments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6868,14 +6358,13 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenOpenQuoteAndSegments(
     _ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenOpenQuoteAndSegments)
+    let newData = data.replacingChild(raw, at: 4)
     return StringLiteralExprSyntax(newData)
   }
 
   public var segments: StringLiteralSegmentsSyntax {
     get {
-      let childData = data.child(at: Cursor.segments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return StringLiteralSegmentsSyntax(childData!)
     }
     set(value) {
@@ -6891,14 +6380,13 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `segments` collection.
   public func addSegment(_ element: Syntax) -> StringLiteralExprSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.segments] {
+    if let col = raw.layoutView!.children[5] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralSegments,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.segments)
+    let newData = data.replacingChild(collection, at: 5)
     return StringLiteralExprSyntax(newData)
   }
 
@@ -6908,14 +6396,13 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withSegments(
     _ newChild: StringLiteralSegmentsSyntax?) -> StringLiteralExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralSegments, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.segments)
+    let newData = data.replacingChild(raw, at: 5)
     return StringLiteralExprSyntax(newData)
   }
 
   public var unexpectedBetweenSegmentsAndCloseQuote: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenSegmentsAndCloseQuote,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6930,14 +6417,13 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenSegmentsAndCloseQuote(
     _ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenSegmentsAndCloseQuote)
+    let newData = data.replacingChild(raw, at: 6)
     return StringLiteralExprSyntax(newData)
   }
 
   public var closeQuote: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.closeQuote,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -6951,14 +6437,13 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withCloseQuote(
     _ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringQuote, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.closeQuote)
+    let newData = data.replacingChild(raw, at: 7)
     return StringLiteralExprSyntax(newData)
   }
 
   public var unexpectedBetweenCloseQuoteAndCloseDelimiter: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCloseQuoteAndCloseDelimiter,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6973,14 +6458,13 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCloseQuoteAndCloseDelimiter(
     _ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCloseQuoteAndCloseDelimiter)
+    let newData = data.replacingChild(raw, at: 8)
     return StringLiteralExprSyntax(newData)
   }
 
   public var closeDelimiter: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.closeDelimiter,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -6995,7 +6479,7 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withCloseDelimiter(
     _ newChild: TokenSyntax?) -> StringLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.closeDelimiter)
+    let newData = data.replacingChild(raw, at: 9)
     return StringLiteralExprSyntax(newData)
   }
 }
@@ -7020,11 +6504,6 @@ extension StringLiteralExprSyntax: CustomReflectable {
 // MARK: - RegexLiteralExprSyntax
 
 public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeRegex
-    case regex
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `RegexLiteralExprSyntax` if possible. Returns
@@ -7062,8 +6541,7 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeRegex: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeRegex,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7078,14 +6556,13 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeRegex(
     _ newChild: UnexpectedNodesSyntax?) -> RegexLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeRegex)
+    let newData = data.replacingChild(raw, at: 0)
     return RegexLiteralExprSyntax(newData)
   }
 
   public var regex: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.regex,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7099,7 +6576,7 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withRegex(
     _ newChild: TokenSyntax?) -> RegexLiteralExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.regexLiteral(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.regex)
+    let newData = data.replacingChild(raw, at: 1)
     return RegexLiteralExprSyntax(newData)
   }
 }
@@ -7116,15 +6593,6 @@ extension RegexLiteralExprSyntax: CustomReflectable {
 // MARK: - KeyPathExprSyntax
 
 public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeBackslash
-    case backslash
-    case unexpectedBetweenBackslashAndRootExpr
-    case rootExpr
-    case unexpectedBetweenRootExprAndExpression
-    case expression
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `KeyPathExprSyntax` if possible. Returns
@@ -7170,8 +6638,7 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeBackslash: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeBackslash,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7186,14 +6653,13 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeBackslash(
     _ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeBackslash)
+    let newData = data.replacingChild(raw, at: 0)
     return KeyPathExprSyntax(newData)
   }
 
   public var backslash: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.backslash,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7207,14 +6673,13 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withBackslash(
     _ newChild: TokenSyntax?) -> KeyPathExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.backslash)
+    let newData = data.replacingChild(raw, at: 1)
     return KeyPathExprSyntax(newData)
   }
 
   public var unexpectedBetweenBackslashAndRootExpr: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenBackslashAndRootExpr,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7229,14 +6694,13 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenBackslashAndRootExpr(
     _ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenBackslashAndRootExpr)
+    let newData = data.replacingChild(raw, at: 2)
     return KeyPathExprSyntax(newData)
   }
 
   public var rootExpr: ExprSyntax? {
     get {
-      let childData = data.child(at: Cursor.rootExpr,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ExprSyntax(childData!)
     }
@@ -7251,14 +6715,13 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withRootExpr(
     _ newChild: ExprSyntax?) -> KeyPathExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.rootExpr)
+    let newData = data.replacingChild(raw, at: 3)
     return KeyPathExprSyntax(newData)
   }
 
   public var unexpectedBetweenRootExprAndExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenRootExprAndExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7273,14 +6736,13 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenRootExprAndExpression(
     _ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenRootExprAndExpression)
+    let newData = data.replacingChild(raw, at: 4)
     return KeyPathExprSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -7294,7 +6756,7 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> KeyPathExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 5)
     return KeyPathExprSyntax(newData)
   }
 }
@@ -7315,11 +6777,6 @@ extension KeyPathExprSyntax: CustomReflectable {
 // MARK: - KeyPathBaseExprSyntax
 
 public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePeriod
-    case period
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `KeyPathBaseExprSyntax` if possible. Returns
@@ -7357,8 +6814,7 @@ public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePeriod: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePeriod,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7373,14 +6829,13 @@ public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePeriod(
     _ newChild: UnexpectedNodesSyntax?) -> KeyPathBaseExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePeriod)
+    let newData = data.replacingChild(raw, at: 0)
     return KeyPathBaseExprSyntax(newData)
   }
 
   public var period: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.period,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7394,7 +6849,7 @@ public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withPeriod(
     _ newChild: TokenSyntax?) -> KeyPathBaseExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.period)
+    let newData = data.replacingChild(raw, at: 1)
     return KeyPathBaseExprSyntax(newData)
   }
 }
@@ -7411,17 +6866,6 @@ extension KeyPathBaseExprSyntax: CustomReflectable {
 // MARK: - ObjcKeyPathExprSyntax
 
 public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeKeyPath
-    case keyPath
-    case unexpectedBetweenKeyPathAndLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndName
-    case name
-    case unexpectedBetweenNameAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ObjcKeyPathExprSyntax` if possible. Returns
@@ -7471,8 +6915,7 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeKeyPath: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeKeyPath,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7487,14 +6930,13 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeKeyPath(
     _ newChild: UnexpectedNodesSyntax?) -> ObjcKeyPathExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeKeyPath)
+    let newData = data.replacingChild(raw, at: 0)
     return ObjcKeyPathExprSyntax(newData)
   }
 
   public var keyPath: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.keyPath,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7508,14 +6950,13 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withKeyPath(
     _ newChild: TokenSyntax?) -> ObjcKeyPathExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundKeyPathKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.keyPath)
+    let newData = data.replacingChild(raw, at: 1)
     return ObjcKeyPathExprSyntax(newData)
   }
 
   public var unexpectedBetweenKeyPathAndLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenKeyPathAndLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7530,14 +6971,13 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenKeyPathAndLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> ObjcKeyPathExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenKeyPathAndLeftParen)
+    let newData = data.replacingChild(raw, at: 2)
     return ObjcKeyPathExprSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7551,14 +6991,13 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> ObjcKeyPathExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 3)
     return ObjcKeyPathExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7573,14 +7012,13 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndName(
     _ newChild: UnexpectedNodesSyntax?) -> ObjcKeyPathExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndName)
+    let newData = data.replacingChild(raw, at: 4)
     return ObjcKeyPathExprSyntax(newData)
   }
 
   public var name: ObjcNameSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return ObjcNameSyntax(childData!)
     }
     set(value) {
@@ -7596,14 +7034,13 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `name` collection.
   public func addNamePiece(_ element: ObjcNamePieceSyntax) -> ObjcKeyPathExprSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.name] {
+    if let col = raw.layoutView!.children[5] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.objcName,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.name)
+    let newData = data.replacingChild(collection, at: 5)
     return ObjcKeyPathExprSyntax(newData)
   }
 
@@ -7613,14 +7050,13 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: ObjcNameSyntax?) -> ObjcKeyPathExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.objcName, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 5)
     return ObjcKeyPathExprSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7635,14 +7071,13 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> ObjcKeyPathExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndRightParen)
+    let newData = data.replacingChild(raw, at: 6)
     return ObjcKeyPathExprSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7656,7 +7091,7 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> ObjcKeyPathExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 7)
     return ObjcKeyPathExprSyntax(newData)
   }
 }
@@ -7679,21 +7114,6 @@ extension ObjcKeyPathExprSyntax: CustomReflectable {
 // MARK: - ObjcSelectorExprSyntax
 
 public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePoundSelector
-    case poundSelector
-    case unexpectedBetweenPoundSelectorAndLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndKind
-    case kind
-    case unexpectedBetweenKindAndColon
-    case colon
-    case unexpectedBetweenColonAndName
-    case name
-    case unexpectedBetweenNameAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ObjcSelectorExprSyntax` if possible. Returns
@@ -7751,8 +7171,7 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePoundSelector: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePoundSelector,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7767,14 +7186,13 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePoundSelector(
     _ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePoundSelector)
+    let newData = data.replacingChild(raw, at: 0)
     return ObjcSelectorExprSyntax(newData)
   }
 
   public var poundSelector: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundSelector,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7788,14 +7206,13 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withPoundSelector(
     _ newChild: TokenSyntax?) -> ObjcSelectorExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundSelectorKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundSelector)
+    let newData = data.replacingChild(raw, at: 1)
     return ObjcSelectorExprSyntax(newData)
   }
 
   public var unexpectedBetweenPoundSelectorAndLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPoundSelectorAndLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7810,14 +7227,13 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPoundSelectorAndLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPoundSelectorAndLeftParen)
+    let newData = data.replacingChild(raw, at: 2)
     return ObjcSelectorExprSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7831,14 +7247,13 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> ObjcSelectorExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 3)
     return ObjcSelectorExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndKind: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndKind,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7853,14 +7268,13 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndKind(
     _ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndKind)
+    let newData = data.replacingChild(raw, at: 4)
     return ObjcSelectorExprSyntax(newData)
   }
 
   public var kind: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.kind,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -7875,14 +7289,13 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withKind(
     _ newChild: TokenSyntax?) -> ObjcSelectorExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.kind)
+    let newData = data.replacingChild(raw, at: 5)
     return ObjcSelectorExprSyntax(newData)
   }
 
   public var unexpectedBetweenKindAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenKindAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7897,14 +7310,13 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenKindAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenKindAndColon)
+    let newData = data.replacingChild(raw, at: 6)
     return ObjcSelectorExprSyntax(newData)
   }
 
   public var colon: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -7919,14 +7331,13 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> ObjcSelectorExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 7)
     return ObjcSelectorExprSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7941,14 +7352,13 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndName(
     _ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndName)
+    let newData = data.replacingChild(raw, at: 8)
     return ObjcSelectorExprSyntax(newData)
   }
 
   public var name: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -7962,14 +7372,13 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: ExprSyntax?) -> ObjcSelectorExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 9)
     return ObjcSelectorExprSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7984,14 +7393,13 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndRightParen)
+    let newData = data.replacingChild(raw, at: 10)
     return ObjcSelectorExprSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8005,7 +7413,7 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> ObjcSelectorExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 11)
     return ObjcSelectorExprSyntax(newData)
   }
 }
@@ -8032,13 +7440,6 @@ extension ObjcSelectorExprSyntax: CustomReflectable {
 // MARK: - PostfixIfConfigExprSyntax
 
 public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeBase
-    case base
-    case unexpectedBetweenBaseAndConfig
-    case config
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PostfixIfConfigExprSyntax` if possible. Returns
@@ -8080,8 +7481,7 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeBase: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeBase,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8096,14 +7496,13 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeBase(
     _ newChild: UnexpectedNodesSyntax?) -> PostfixIfConfigExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeBase)
+    let newData = data.replacingChild(raw, at: 0)
     return PostfixIfConfigExprSyntax(newData)
   }
 
   public var base: ExprSyntax? {
     get {
-      let childData = data.child(at: Cursor.base,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return ExprSyntax(childData!)
     }
@@ -8118,14 +7517,13 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withBase(
     _ newChild: ExprSyntax?) -> PostfixIfConfigExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.base)
+    let newData = data.replacingChild(raw, at: 1)
     return PostfixIfConfigExprSyntax(newData)
   }
 
   public var unexpectedBetweenBaseAndConfig: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenBaseAndConfig,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8140,14 +7538,13 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenBaseAndConfig(
     _ newChild: UnexpectedNodesSyntax?) -> PostfixIfConfigExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenBaseAndConfig)
+    let newData = data.replacingChild(raw, at: 2)
     return PostfixIfConfigExprSyntax(newData)
   }
 
   public var config: IfConfigDeclSyntax {
     get {
-      let childData = data.child(at: Cursor.config,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return IfConfigDeclSyntax(childData!)
     }
     set(value) {
@@ -8161,7 +7558,7 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withConfig(
     _ newChild: IfConfigDeclSyntax?) -> PostfixIfConfigExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifConfigDecl, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.config)
+    let newData = data.replacingChild(raw, at: 3)
     return PostfixIfConfigExprSyntax(newData)
   }
 }
@@ -8180,11 +7577,6 @@ extension PostfixIfConfigExprSyntax: CustomReflectable {
 // MARK: - EditorPlaceholderExprSyntax
 
 public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeIdentifier
-    case identifier
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `EditorPlaceholderExprSyntax` if possible. Returns
@@ -8222,8 +7614,7 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8238,14 +7629,13 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> EditorPlaceholderExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeIdentifier)
+    let newData = data.replacingChild(raw, at: 0)
     return EditorPlaceholderExprSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8259,7 +7649,7 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> EditorPlaceholderExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 1)
     return EditorPlaceholderExprSyntax(newData)
   }
 }
@@ -8276,17 +7666,6 @@ extension EditorPlaceholderExprSyntax: CustomReflectable {
 // MARK: - ObjectLiteralExprSyntax
 
 public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeIdentifier
-    case identifier
-    case unexpectedBetweenIdentifierAndLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndArguments
-    case arguments
-    case unexpectedBetweenArgumentsAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ObjectLiteralExprSyntax` if possible. Returns
@@ -8336,8 +7715,7 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8352,14 +7730,13 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> ObjectLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeIdentifier)
+    let newData = data.replacingChild(raw, at: 0)
     return ObjectLiteralExprSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8373,14 +7750,13 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> ObjectLiteralExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundColorLiteralKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 1)
     return ObjectLiteralExprSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIdentifierAndLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8395,14 +7771,13 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIdentifierAndLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> ObjectLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIdentifierAndLeftParen)
+    let newData = data.replacingChild(raw, at: 2)
     return ObjectLiteralExprSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8416,14 +7791,13 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> ObjectLiteralExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 3)
     return ObjectLiteralExprSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndArguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8438,14 +7812,13 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndArguments(
     _ newChild: UnexpectedNodesSyntax?) -> ObjectLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndArguments)
+    let newData = data.replacingChild(raw, at: 4)
     return ObjectLiteralExprSyntax(newData)
   }
 
   public var arguments: TupleExprElementListSyntax {
     get {
-      let childData = data.child(at: Cursor.arguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TupleExprElementListSyntax(childData!)
     }
     set(value) {
@@ -8461,14 +7834,13 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   ///            appended to its `arguments` collection.
   public func addArgument(_ element: TupleExprElementSyntax) -> ObjectLiteralExprSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.arguments] {
+    if let col = raw.layoutView!.children[5] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.arguments)
+    let newData = data.replacingChild(collection, at: 5)
     return ObjectLiteralExprSyntax(newData)
   }
 
@@ -8478,14 +7850,13 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withArguments(
     _ newChild: TupleExprElementListSyntax?) -> ObjectLiteralExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.arguments)
+    let newData = data.replacingChild(raw, at: 5)
     return ObjectLiteralExprSyntax(newData)
   }
 
   public var unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenArgumentsAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8500,14 +7871,13 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenArgumentsAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> ObjectLiteralExprSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenArgumentsAndRightParen)
+    let newData = data.replacingChild(raw, at: 6)
     return ObjectLiteralExprSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8521,7 +7891,7 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> ObjectLiteralExprSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 7)
     return ObjectLiteralExprSyntax(newData)
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -16,7 +16,6 @@
 // MARK: - MissingSyntax
 
 public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `MissingSyntax` if possible. Returns
@@ -63,15 +62,6 @@ extension MissingSyntax: CustomReflectable {
 /// a CodeBlock.
 /// 
 public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeItem
-    case item
-    case unexpectedBetweenItemAndSemicolon
-    case semicolon
-    case unexpectedBetweenSemicolonAndErrorTokens
-    case errorTokens
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `CodeBlockItemSyntax` if possible. Returns
@@ -117,8 +107,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeItem: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeItem,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -133,15 +122,14 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeItem(
     _ newChild: UnexpectedNodesSyntax?) -> CodeBlockItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeItem)
+    let newData = data.replacingChild(raw, at: 0)
     return CodeBlockItemSyntax(newData)
   }
 
   /// The underlying node inside the code block.
   public var item: Syntax {
     get {
-      let childData = data.child(at: Cursor.item,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -155,14 +143,13 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withItem(
     _ newChild: Syntax?) -> CodeBlockItemSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.item)
+    let newData = data.replacingChild(raw, at: 1)
     return CodeBlockItemSyntax(newData)
   }
 
   public var unexpectedBetweenItemAndSemicolon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenItemAndSemicolon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -177,7 +164,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenItemAndSemicolon(
     _ newChild: UnexpectedNodesSyntax?) -> CodeBlockItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenItemAndSemicolon)
+    let newData = data.replacingChild(raw, at: 2)
     return CodeBlockItemSyntax(newData)
   }
 
@@ -186,8 +173,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var semicolon: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.semicolon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -202,14 +188,13 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withSemicolon(
     _ newChild: TokenSyntax?) -> CodeBlockItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.semicolon)
+    let newData = data.replacingChild(raw, at: 3)
     return CodeBlockItemSyntax(newData)
   }
 
   public var unexpectedBetweenSemicolonAndErrorTokens: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenSemicolonAndErrorTokens,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -224,14 +209,13 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenSemicolonAndErrorTokens(
     _ newChild: UnexpectedNodesSyntax?) -> CodeBlockItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenSemicolonAndErrorTokens)
+    let newData = data.replacingChild(raw, at: 4)
     return CodeBlockItemSyntax(newData)
   }
 
   public var errorTokens: Syntax? {
     get {
-      let childData = data.child(at: Cursor.errorTokens,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return Syntax(childData!)
     }
@@ -246,7 +230,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withErrorTokens(
     _ newChild: Syntax?) -> CodeBlockItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.errorTokens)
+    let newData = data.replacingChild(raw, at: 5)
     return CodeBlockItemSyntax(newData)
   }
 }
@@ -267,15 +251,6 @@ extension CodeBlockItemSyntax: CustomReflectable {
 // MARK: - CodeBlockSyntax
 
 public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftBrace
-    case leftBrace
-    case unexpectedBetweenLeftBraceAndStatements
-    case statements
-    case unexpectedBetweenStatementsAndRightBrace
-    case rightBrace
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `CodeBlockSyntax` if possible. Returns
@@ -321,8 +296,7 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -337,14 +311,13 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftBrace(
     _ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftBrace)
+    let newData = data.replacingChild(raw, at: 0)
     return CodeBlockSyntax(newData)
   }
 
   public var leftBrace: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -358,14 +331,13 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftBrace(
     _ newChild: TokenSyntax?) -> CodeBlockSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftBrace)
+    let newData = data.replacingChild(raw, at: 1)
     return CodeBlockSyntax(newData)
   }
 
   public var unexpectedBetweenLeftBraceAndStatements: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftBraceAndStatements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -380,14 +352,13 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftBraceAndStatements(
     _ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftBraceAndStatements)
+    let newData = data.replacingChild(raw, at: 2)
     return CodeBlockSyntax(newData)
   }
 
   public var statements: CodeBlockItemListSyntax {
     get {
-      let childData = data.child(at: Cursor.statements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return CodeBlockItemListSyntax(childData!)
     }
     set(value) {
@@ -403,14 +374,13 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `statements` collection.
   public func addStatement(_ element: CodeBlockItemSyntax) -> CodeBlockSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.statements] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.statements)
+    let newData = data.replacingChild(collection, at: 3)
     return CodeBlockSyntax(newData)
   }
 
@@ -420,14 +390,13 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withStatements(
     _ newChild: CodeBlockItemListSyntax?) -> CodeBlockSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.statements)
+    let newData = data.replacingChild(raw, at: 3)
     return CodeBlockSyntax(newData)
   }
 
   public var unexpectedBetweenStatementsAndRightBrace: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenStatementsAndRightBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -442,14 +411,13 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenStatementsAndRightBrace(
     _ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenStatementsAndRightBrace)
+    let newData = data.replacingChild(raw, at: 4)
     return CodeBlockSyntax(newData)
   }
 
   public var rightBrace: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -463,7 +431,7 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightBrace(
     _ newChild: TokenSyntax?) -> CodeBlockSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightBrace)
+    let newData = data.replacingChild(raw, at: 5)
     return CodeBlockSyntax(newData)
   }
 }
@@ -484,13 +452,6 @@ extension CodeBlockSyntax: CustomReflectable {
 // MARK: - DeclNameArgumentSyntax
 
 public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeName
-    case name
-    case unexpectedBetweenNameAndColon
-    case colon
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DeclNameArgumentSyntax` if possible. Returns
@@ -532,8 +493,7 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -548,14 +508,13 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeName(
     _ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeName)
+    let newData = data.replacingChild(raw, at: 0)
     return DeclNameArgumentSyntax(newData)
   }
 
   public var name: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -569,14 +528,13 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> DeclNameArgumentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 1)
     return DeclNameArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -591,14 +549,13 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return DeclNameArgumentSyntax(newData)
   }
 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -612,7 +569,7 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> DeclNameArgumentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return DeclNameArgumentSyntax(newData)
   }
 }
@@ -631,15 +588,6 @@ extension DeclNameArgumentSyntax: CustomReflectable {
 // MARK: - DeclNameArgumentsSyntax
 
 public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndArguments
-    case arguments
-    case unexpectedBetweenArgumentsAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DeclNameArgumentsSyntax` if possible. Returns
@@ -685,8 +633,7 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -701,14 +648,13 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftParen)
+    let newData = data.replacingChild(raw, at: 0)
     return DeclNameArgumentsSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -722,14 +668,13 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> DeclNameArgumentsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 1)
     return DeclNameArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndArguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -744,14 +689,13 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndArguments(
     _ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndArguments)
+    let newData = data.replacingChild(raw, at: 2)
     return DeclNameArgumentsSyntax(newData)
   }
 
   public var arguments: DeclNameArgumentListSyntax {
     get {
-      let childData = data.child(at: Cursor.arguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return DeclNameArgumentListSyntax(childData!)
     }
     set(value) {
@@ -767,14 +711,13 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `arguments` collection.
   public func addArgument(_ element: DeclNameArgumentSyntax) -> DeclNameArgumentsSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.arguments] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgumentList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.arguments)
+    let newData = data.replacingChild(collection, at: 3)
     return DeclNameArgumentsSyntax(newData)
   }
 
@@ -784,14 +727,13 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withArguments(
     _ newChild: DeclNameArgumentListSyntax?) -> DeclNameArgumentsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.declNameArgumentList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.arguments)
+    let newData = data.replacingChild(raw, at: 3)
     return DeclNameArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenArgumentsAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -806,14 +748,13 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenArgumentsAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenArgumentsAndRightParen)
+    let newData = data.replacingChild(raw, at: 4)
     return DeclNameArgumentsSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -827,7 +768,7 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> DeclNameArgumentsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 5)
     return DeclNameArgumentsSyntax(newData)
   }
 }
@@ -848,17 +789,6 @@ extension DeclNameArgumentsSyntax: CustomReflectable {
 // MARK: - TupleExprElementSyntax
 
 public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLabel
-    case label
-    case unexpectedBetweenLabelAndColon
-    case colon
-    case unexpectedBetweenColonAndExpression
-    case expression
-    case unexpectedBetweenExpressionAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TupleExprElementSyntax` if possible. Returns
@@ -908,8 +838,7 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLabel: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -924,14 +853,13 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLabel(
     _ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLabel)
+    let newData = data.replacingChild(raw, at: 0)
     return TupleExprElementSyntax(newData)
   }
 
   public var label: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.label,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -946,14 +874,13 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLabel(
     _ newChild: TokenSyntax?) -> TupleExprElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.label)
+    let newData = data.replacingChild(raw, at: 1)
     return TupleExprElementSyntax(newData)
   }
 
   public var unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLabelAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -968,14 +895,13 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLabelAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLabelAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return TupleExprElementSyntax(newData)
   }
 
   public var colon: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -990,14 +916,13 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> TupleExprElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return TupleExprElementSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1012,14 +937,13 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndExpression(
     _ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndExpression)
+    let newData = data.replacingChild(raw, at: 4)
     return TupleExprElementSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -1033,14 +957,13 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> TupleExprElementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 5)
     return TupleExprElementSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenExpressionAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1055,14 +978,13 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenExpressionAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenExpressionAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 6)
     return TupleExprElementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -1077,7 +999,7 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> TupleExprElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 7)
     return TupleExprElementSyntax(newData)
   }
 }
@@ -1100,13 +1022,6 @@ extension TupleExprElementSyntax: CustomReflectable {
 // MARK: - ArrayElementSyntax
 
 public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeExpression
-    case expression
-    case unexpectedBetweenExpressionAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ArrayElementSyntax` if possible. Returns
@@ -1148,8 +1063,7 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1164,14 +1078,13 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeExpression(
     _ newChild: UnexpectedNodesSyntax?) -> ArrayElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeExpression)
+    let newData = data.replacingChild(raw, at: 0)
     return ArrayElementSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -1185,14 +1098,13 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> ArrayElementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 1)
     return ArrayElementSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenExpressionAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1207,14 +1119,13 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenExpressionAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> ArrayElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenExpressionAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 2)
     return ArrayElementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -1229,7 +1140,7 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> ArrayElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 3)
     return ArrayElementSyntax(newData)
   }
 }
@@ -1248,17 +1159,6 @@ extension ArrayElementSyntax: CustomReflectable {
 // MARK: - DictionaryElementSyntax
 
 public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeKeyExpression
-    case keyExpression
-    case unexpectedBetweenKeyExpressionAndColon
-    case colon
-    case unexpectedBetweenColonAndValueExpression
-    case valueExpression
-    case unexpectedBetweenValueExpressionAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DictionaryElementSyntax` if possible. Returns
@@ -1308,8 +1208,7 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeKeyExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeKeyExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1324,14 +1223,13 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeKeyExpression(
     _ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeKeyExpression)
+    let newData = data.replacingChild(raw, at: 0)
     return DictionaryElementSyntax(newData)
   }
 
   public var keyExpression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.keyExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -1345,14 +1243,13 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withKeyExpression(
     _ newChild: ExprSyntax?) -> DictionaryElementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.keyExpression)
+    let newData = data.replacingChild(raw, at: 1)
     return DictionaryElementSyntax(newData)
   }
 
   public var unexpectedBetweenKeyExpressionAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenKeyExpressionAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1367,14 +1264,13 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenKeyExpressionAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenKeyExpressionAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return DictionaryElementSyntax(newData)
   }
 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1388,14 +1284,13 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> DictionaryElementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return DictionaryElementSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndValueExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndValueExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1410,14 +1305,13 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndValueExpression(
     _ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndValueExpression)
+    let newData = data.replacingChild(raw, at: 4)
     return DictionaryElementSyntax(newData)
   }
 
   public var valueExpression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.valueExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -1431,14 +1325,13 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withValueExpression(
     _ newChild: ExprSyntax?) -> DictionaryElementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.valueExpression)
+    let newData = data.replacingChild(raw, at: 5)
     return DictionaryElementSyntax(newData)
   }
 
   public var unexpectedBetweenValueExpressionAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenValueExpressionAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1453,14 +1346,13 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenValueExpressionAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenValueExpressionAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 6)
     return DictionaryElementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -1475,7 +1367,7 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> DictionaryElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 7)
     return DictionaryElementSyntax(newData)
   }
 }
@@ -1498,19 +1390,6 @@ extension DictionaryElementSyntax: CustomReflectable {
 // MARK: - ClosureCaptureItemSyntax
 
 public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeSpecifier
-    case specifier
-    case unexpectedBetweenSpecifierAndName
-    case name
-    case unexpectedBetweenNameAndAssignToken
-    case assignToken
-    case unexpectedBetweenAssignTokenAndExpression
-    case expression
-    case unexpectedBetweenExpressionAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ClosureCaptureItemSyntax` if possible. Returns
@@ -1564,8 +1443,7 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeSpecifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeSpecifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1580,14 +1458,13 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeSpecifier(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeSpecifier)
+    let newData = data.replacingChild(raw, at: 0)
     return ClosureCaptureItemSyntax(newData)
   }
 
   public var specifier: TokenListSyntax? {
     get {
-      let childData = data.child(at: Cursor.specifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenListSyntax(childData!)
     }
@@ -1604,14 +1481,13 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `specifier` collection.
   public func addSpecifierToken(_ element: TokenSyntax) -> ClosureCaptureItemSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.specifier] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tokenList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.specifier)
+    let newData = data.replacingChild(collection, at: 1)
     return ClosureCaptureItemSyntax(newData)
   }
 
@@ -1621,14 +1497,13 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withSpecifier(
     _ newChild: TokenListSyntax?) -> ClosureCaptureItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.specifier)
+    let newData = data.replacingChild(raw, at: 1)
     return ClosureCaptureItemSyntax(newData)
   }
 
   public var unexpectedBetweenSpecifierAndName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenSpecifierAndName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1643,14 +1518,13 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenSpecifierAndName(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenSpecifierAndName)
+    let newData = data.replacingChild(raw, at: 2)
     return ClosureCaptureItemSyntax(newData)
   }
 
   public var name: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -1665,14 +1539,13 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> ClosureCaptureItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 3)
     return ClosureCaptureItemSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndAssignToken: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndAssignToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1687,14 +1560,13 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndAssignToken(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndAssignToken)
+    let newData = data.replacingChild(raw, at: 4)
     return ClosureCaptureItemSyntax(newData)
   }
 
   public var assignToken: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.assignToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -1709,14 +1581,13 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAssignToken(
     _ newChild: TokenSyntax?) -> ClosureCaptureItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.assignToken)
+    let newData = data.replacingChild(raw, at: 5)
     return ClosureCaptureItemSyntax(newData)
   }
 
   public var unexpectedBetweenAssignTokenAndExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAssignTokenAndExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1731,14 +1602,13 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAssignTokenAndExpression(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAssignTokenAndExpression)
+    let newData = data.replacingChild(raw, at: 6)
     return ClosureCaptureItemSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -1752,14 +1622,13 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> ClosureCaptureItemSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 7)
     return ClosureCaptureItemSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenExpressionAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1774,14 +1643,13 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenExpressionAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenExpressionAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 8)
     return ClosureCaptureItemSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -1796,7 +1664,7 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> ClosureCaptureItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 9)
     return ClosureCaptureItemSyntax(newData)
   }
 }
@@ -1821,15 +1689,6 @@ extension ClosureCaptureItemSyntax: CustomReflectable {
 // MARK: - ClosureCaptureSignatureSyntax
 
 public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftSquare
-    case leftSquare
-    case unexpectedBetweenLeftSquareAndItems
-    case items
-    case unexpectedBetweenItemsAndRightSquare
-    case rightSquare
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ClosureCaptureSignatureSyntax` if possible. Returns
@@ -1875,8 +1734,7 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftSquare: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftSquare,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1891,14 +1749,13 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftSquare(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftSquare)
+    let newData = data.replacingChild(raw, at: 0)
     return ClosureCaptureSignatureSyntax(newData)
   }
 
   public var leftSquare: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftSquare,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1912,14 +1769,13 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftSquare(
     _ newChild: TokenSyntax?) -> ClosureCaptureSignatureSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftSquare)
+    let newData = data.replacingChild(raw, at: 1)
     return ClosureCaptureSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenLeftSquareAndItems: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftSquareAndItems,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1934,14 +1790,13 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftSquareAndItems(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftSquareAndItems)
+    let newData = data.replacingChild(raw, at: 2)
     return ClosureCaptureSignatureSyntax(newData)
   }
 
   public var items: ClosureCaptureItemListSyntax? {
     get {
-      let childData = data.child(at: Cursor.items,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ClosureCaptureItemListSyntax(childData!)
     }
@@ -1958,14 +1813,13 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `items` collection.
   public func addItem(_ element: ClosureCaptureItemSyntax) -> ClosureCaptureSignatureSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.items] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItemList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.items)
+    let newData = data.replacingChild(collection, at: 3)
     return ClosureCaptureSignatureSyntax(newData)
   }
 
@@ -1975,14 +1829,13 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withItems(
     _ newChild: ClosureCaptureItemListSyntax?) -> ClosureCaptureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.items)
+    let newData = data.replacingChild(raw, at: 3)
     return ClosureCaptureSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenItemsAndRightSquare: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenItemsAndRightSquare,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1997,14 +1850,13 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenItemsAndRightSquare(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenItemsAndRightSquare)
+    let newData = data.replacingChild(raw, at: 4)
     return ClosureCaptureSignatureSyntax(newData)
   }
 
   public var rightSquare: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightSquare,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2018,7 +1870,7 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightSquare(
     _ newChild: TokenSyntax?) -> ClosureCaptureSignatureSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightSquare)
+    let newData = data.replacingChild(raw, at: 5)
     return ClosureCaptureSignatureSyntax(newData)
   }
 }
@@ -2039,13 +1891,6 @@ extension ClosureCaptureSignatureSyntax: CustomReflectable {
 // MARK: - ClosureParamSyntax
 
 public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeName
-    case name
-    case unexpectedBetweenNameAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ClosureParamSyntax` if possible. Returns
@@ -2087,8 +1932,7 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2103,14 +1947,13 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeName(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureParamSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeName)
+    let newData = data.replacingChild(raw, at: 0)
     return ClosureParamSyntax(newData)
   }
 
   public var name: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2124,14 +1967,13 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> ClosureParamSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 1)
     return ClosureParamSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2146,14 +1988,13 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureParamSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 2)
     return ClosureParamSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -2168,7 +2009,7 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> ClosureParamSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 3)
     return ClosureParamSyntax(newData)
   }
 }
@@ -2187,23 +2028,6 @@ extension ClosureParamSyntax: CustomReflectable {
 // MARK: - ClosureSignatureSyntax
 
 public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndCapture
-    case capture
-    case unexpectedBetweenCaptureAndInput
-    case input
-    case unexpectedBetweenInputAndAsyncKeyword
-    case asyncKeyword
-    case unexpectedBetweenAsyncKeywordAndThrowsTok
-    case throwsTok
-    case unexpectedBetweenThrowsTokAndOutput
-    case output
-    case unexpectedBetweenOutputAndInTok
-    case inTok
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ClosureSignatureSyntax` if possible. Returns
@@ -2265,8 +2089,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2281,14 +2104,13 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return ClosureSignatureSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -2305,14 +2127,13 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> ClosureSignatureSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return ClosureSignatureSyntax(newData)
   }
 
@@ -2322,14 +2143,13 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return ClosureSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndCapture: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndCapture,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2344,14 +2164,13 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndCapture(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndCapture)
+    let newData = data.replacingChild(raw, at: 2)
     return ClosureSignatureSyntax(newData)
   }
 
   public var capture: ClosureCaptureSignatureSyntax? {
     get {
-      let childData = data.child(at: Cursor.capture,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ClosureCaptureSignatureSyntax(childData!)
     }
@@ -2366,14 +2185,13 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withCapture(
     _ newChild: ClosureCaptureSignatureSyntax?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.capture)
+    let newData = data.replacingChild(raw, at: 3)
     return ClosureSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenCaptureAndInput: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCaptureAndInput,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2388,14 +2206,13 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCaptureAndInput(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCaptureAndInput)
+    let newData = data.replacingChild(raw, at: 4)
     return ClosureSignatureSyntax(newData)
   }
 
   public var input: Syntax? {
     get {
-      let childData = data.child(at: Cursor.input,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return Syntax(childData!)
     }
@@ -2410,14 +2227,13 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withInput(
     _ newChild: Syntax?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.input)
+    let newData = data.replacingChild(raw, at: 5)
     return ClosureSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenInputAndAsyncKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInputAndAsyncKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2432,14 +2248,13 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInputAndAsyncKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInputAndAsyncKeyword)
+    let newData = data.replacingChild(raw, at: 6)
     return ClosureSignatureSyntax(newData)
   }
 
   public var asyncKeyword: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.asyncKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -2454,14 +2269,13 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAsyncKeyword(
     _ newChild: TokenSyntax?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.asyncKeyword)
+    let newData = data.replacingChild(raw, at: 7)
     return ClosureSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenAsyncKeywordAndThrowsTok: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAsyncKeywordAndThrowsTok,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2476,14 +2290,13 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAsyncKeywordAndThrowsTok(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAsyncKeywordAndThrowsTok)
+    let newData = data.replacingChild(raw, at: 8)
     return ClosureSignatureSyntax(newData)
   }
 
   public var throwsTok: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.throwsTok,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -2498,14 +2311,13 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withThrowsTok(
     _ newChild: TokenSyntax?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.throwsTok)
+    let newData = data.replacingChild(raw, at: 9)
     return ClosureSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenThrowsTokAndOutput: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenThrowsTokAndOutput,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2520,14 +2332,13 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenThrowsTokAndOutput(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenThrowsTokAndOutput)
+    let newData = data.replacingChild(raw, at: 10)
     return ClosureSignatureSyntax(newData)
   }
 
   public var output: ReturnClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.output,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return ReturnClauseSyntax(childData!)
     }
@@ -2542,14 +2353,13 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withOutput(
     _ newChild: ReturnClauseSyntax?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.output)
+    let newData = data.replacingChild(raw, at: 11)
     return ClosureSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenOutputAndInTok: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenOutputAndInTok,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2564,14 +2374,13 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenOutputAndInTok(
     _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenOutputAndInTok)
+    let newData = data.replacingChild(raw, at: 12)
     return ClosureSignatureSyntax(newData)
   }
 
   public var inTok: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.inTok,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2585,7 +2394,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withInTok(
     _ newChild: TokenSyntax?) -> ClosureSignatureSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.inKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.inTok)
+    let newData = data.replacingChild(raw, at: 13)
     return ClosureSignatureSyntax(newData)
   }
 }
@@ -2614,15 +2423,6 @@ extension ClosureSignatureSyntax: CustomReflectable {
 // MARK: - MultipleTrailingClosureElementSyntax
 
 public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLabel
-    case label
-    case unexpectedBetweenLabelAndColon
-    case colon
-    case unexpectedBetweenColonAndClosure
-    case closure
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `MultipleTrailingClosureElementSyntax` if possible. Returns
@@ -2668,8 +2468,7 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
 
   public var unexpectedBeforeLabel: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2684,14 +2483,13 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   public func withUnexpectedBeforeLabel(
     _ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLabel)
+    let newData = data.replacingChild(raw, at: 0)
     return MultipleTrailingClosureElementSyntax(newData)
   }
 
   public var label: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.label,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2705,14 +2503,13 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   public func withLabel(
     _ newChild: TokenSyntax?) -> MultipleTrailingClosureElementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.label)
+    let newData = data.replacingChild(raw, at: 1)
     return MultipleTrailingClosureElementSyntax(newData)
   }
 
   public var unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLabelAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2727,14 +2524,13 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   public func withUnexpectedBetweenLabelAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLabelAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return MultipleTrailingClosureElementSyntax(newData)
   }
 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2748,14 +2544,13 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   public func withColon(
     _ newChild: TokenSyntax?) -> MultipleTrailingClosureElementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return MultipleTrailingClosureElementSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndClosure: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndClosure,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2770,14 +2565,13 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   public func withUnexpectedBetweenColonAndClosure(
     _ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndClosure)
+    let newData = data.replacingChild(raw, at: 4)
     return MultipleTrailingClosureElementSyntax(newData)
   }
 
   public var closure: ClosureExprSyntax {
     get {
-      let childData = data.child(at: Cursor.closure,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return ClosureExprSyntax(childData!)
     }
     set(value) {
@@ -2791,7 +2585,7 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
   public func withClosure(
     _ newChild: ClosureExprSyntax?) -> MultipleTrailingClosureElementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.closureExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.closure)
+    let newData = data.replacingChild(raw, at: 5)
     return MultipleTrailingClosureElementSyntax(newData)
   }
 }
@@ -2812,11 +2606,6 @@ extension MultipleTrailingClosureElementSyntax: CustomReflectable {
 // MARK: - StringSegmentSyntax
 
 public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeContent
-    case content
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `StringSegmentSyntax` if possible. Returns
@@ -2854,8 +2643,7 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeContent: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeContent,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2870,14 +2658,13 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeContent(
     _ newChild: UnexpectedNodesSyntax?) -> StringSegmentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeContent)
+    let newData = data.replacingChild(raw, at: 0)
     return StringSegmentSyntax(newData)
   }
 
   public var content: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.content,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2891,7 +2678,7 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withContent(
     _ newChild: TokenSyntax?) -> StringSegmentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringSegment(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.content)
+    let newData = data.replacingChild(raw, at: 1)
     return StringSegmentSyntax(newData)
   }
 }
@@ -2908,19 +2695,6 @@ extension StringSegmentSyntax: CustomReflectable {
 // MARK: - ExpressionSegmentSyntax
 
 public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeBackslash
-    case backslash
-    case unexpectedBetweenBackslashAndDelimiter
-    case delimiter
-    case unexpectedBetweenDelimiterAndLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndExpressions
-    case expressions
-    case unexpectedBetweenExpressionsAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ExpressionSegmentSyntax` if possible. Returns
@@ -2974,8 +2748,7 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeBackslash: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeBackslash,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2990,14 +2763,13 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeBackslash(
     _ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeBackslash)
+    let newData = data.replacingChild(raw, at: 0)
     return ExpressionSegmentSyntax(newData)
   }
 
   public var backslash: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.backslash,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3011,14 +2783,13 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withBackslash(
     _ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.backslash, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.backslash)
+    let newData = data.replacingChild(raw, at: 1)
     return ExpressionSegmentSyntax(newData)
   }
 
   public var unexpectedBetweenBackslashAndDelimiter: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenBackslashAndDelimiter,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3033,14 +2804,13 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenBackslashAndDelimiter(
     _ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenBackslashAndDelimiter)
+    let newData = data.replacingChild(raw, at: 2)
     return ExpressionSegmentSyntax(newData)
   }
 
   public var delimiter: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.delimiter,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -3055,14 +2825,13 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withDelimiter(
     _ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.delimiter)
+    let newData = data.replacingChild(raw, at: 3)
     return ExpressionSegmentSyntax(newData)
   }
 
   public var unexpectedBetweenDelimiterAndLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDelimiterAndLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3077,14 +2846,13 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenDelimiterAndLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDelimiterAndLeftParen)
+    let newData = data.replacingChild(raw, at: 4)
     return ExpressionSegmentSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3098,14 +2866,13 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 5)
     return ExpressionSegmentSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndExpressions: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndExpressions,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3120,14 +2887,13 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndExpressions(
     _ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndExpressions)
+    let newData = data.replacingChild(raw, at: 6)
     return ExpressionSegmentSyntax(newData)
   }
 
   public var expressions: TupleExprElementListSyntax {
     get {
-      let childData = data.child(at: Cursor.expressions,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TupleExprElementListSyntax(childData!)
     }
     set(value) {
@@ -3143,14 +2909,13 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `expressions` collection.
   public func addExpression(_ element: TupleExprElementSyntax) -> ExpressionSegmentSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.expressions] {
+    if let col = raw.layoutView!.children[7] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.expressions)
+    let newData = data.replacingChild(collection, at: 7)
     return ExpressionSegmentSyntax(newData)
   }
 
@@ -3160,14 +2925,13 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withExpressions(
     _ newChild: TupleExprElementListSyntax?) -> ExpressionSegmentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expressions)
+    let newData = data.replacingChild(raw, at: 7)
     return ExpressionSegmentSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionsAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenExpressionsAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3182,14 +2946,13 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenExpressionsAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenExpressionsAndRightParen)
+    let newData = data.replacingChild(raw, at: 8)
     return ExpressionSegmentSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3203,7 +2966,7 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> ExpressionSegmentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringInterpolationAnchor, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 9)
     return ExpressionSegmentSyntax(newData)
   }
 }
@@ -3228,13 +2991,6 @@ extension ExpressionSegmentSyntax: CustomReflectable {
 // MARK: - ObjcNamePieceSyntax
 
 public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeName
-    case name
-    case unexpectedBetweenNameAndDot
-    case dot
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ObjcNamePieceSyntax` if possible. Returns
@@ -3276,8 +3032,7 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3292,14 +3047,13 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeName(
     _ newChild: UnexpectedNodesSyntax?) -> ObjcNamePieceSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeName)
+    let newData = data.replacingChild(raw, at: 0)
     return ObjcNamePieceSyntax(newData)
   }
 
   public var name: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3313,14 +3067,13 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> ObjcNamePieceSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 1)
     return ObjcNamePieceSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndDot: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndDot,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3335,14 +3088,13 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndDot(
     _ newChild: UnexpectedNodesSyntax?) -> ObjcNamePieceSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndDot)
+    let newData = data.replacingChild(raw, at: 2)
     return ObjcNamePieceSyntax(newData)
   }
 
   public var dot: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.dot,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -3357,7 +3109,7 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
   public func withDot(
     _ newChild: TokenSyntax?) -> ObjcNamePieceSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.dot)
+    let newData = data.replacingChild(raw, at: 3)
     return ObjcNamePieceSyntax(newData)
   }
 }
@@ -3376,13 +3128,6 @@ extension ObjcNamePieceSyntax: CustomReflectable {
 // MARK: - TypeInitializerClauseSyntax
 
 public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeEqual
-    case equal
-    case unexpectedBetweenEqualAndValue
-    case value
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TypeInitializerClauseSyntax` if possible. Returns
@@ -3424,8 +3169,7 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeEqual: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeEqual,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3440,14 +3184,13 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeEqual(
     _ newChild: UnexpectedNodesSyntax?) -> TypeInitializerClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeEqual)
+    let newData = data.replacingChild(raw, at: 0)
     return TypeInitializerClauseSyntax(newData)
   }
 
   public var equal: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.equal,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3461,14 +3204,13 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withEqual(
     _ newChild: TokenSyntax?) -> TypeInitializerClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.equal)
+    let newData = data.replacingChild(raw, at: 1)
     return TypeInitializerClauseSyntax(newData)
   }
 
   public var unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenEqualAndValue,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3483,14 +3225,13 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenEqualAndValue(
     _ newChild: UnexpectedNodesSyntax?) -> TypeInitializerClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenEqualAndValue)
+    let newData = data.replacingChild(raw, at: 2)
     return TypeInitializerClauseSyntax(newData)
   }
 
   public var value: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.value,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -3504,7 +3245,7 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withValue(
     _ newChild: TypeSyntax?) -> TypeInitializerClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.value)
+    let newData = data.replacingChild(raw, at: 3)
     return TypeInitializerClauseSyntax(newData)
   }
 }
@@ -3523,15 +3264,6 @@ extension TypeInitializerClauseSyntax: CustomReflectable {
 // MARK: - ParameterClauseSyntax
 
 public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndParameterList
-    case parameterList
-    case unexpectedBetweenParameterListAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ParameterClauseSyntax` if possible. Returns
@@ -3577,8 +3309,7 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3593,14 +3324,13 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftParen)
+    let newData = data.replacingChild(raw, at: 0)
     return ParameterClauseSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3614,14 +3344,13 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> ParameterClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 1)
     return ParameterClauseSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndParameterList: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndParameterList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3636,14 +3365,13 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndParameterList(
     _ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndParameterList)
+    let newData = data.replacingChild(raw, at: 2)
     return ParameterClauseSyntax(newData)
   }
 
   public var parameterList: FunctionParameterListSyntax {
     get {
-      let childData = data.child(at: Cursor.parameterList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return FunctionParameterListSyntax(childData!)
     }
     set(value) {
@@ -3659,14 +3387,13 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `parameterList` collection.
   public func addParameter(_ element: FunctionParameterSyntax) -> ParameterClauseSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.parameterList] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.functionParameterList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.parameterList)
+    let newData = data.replacingChild(collection, at: 3)
     return ParameterClauseSyntax(newData)
   }
 
@@ -3676,14 +3403,13 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withParameterList(
     _ newChild: FunctionParameterListSyntax?) -> ParameterClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionParameterList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.parameterList)
+    let newData = data.replacingChild(raw, at: 3)
     return ParameterClauseSyntax(newData)
   }
 
   public var unexpectedBetweenParameterListAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenParameterListAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3698,14 +3424,13 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenParameterListAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenParameterListAndRightParen)
+    let newData = data.replacingChild(raw, at: 4)
     return ParameterClauseSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3719,7 +3444,7 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> ParameterClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 5)
     return ParameterClauseSyntax(newData)
   }
 }
@@ -3740,13 +3465,6 @@ extension ParameterClauseSyntax: CustomReflectable {
 // MARK: - ReturnClauseSyntax
 
 public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeArrow
-    case arrow
-    case unexpectedBetweenArrowAndReturnType
-    case returnType
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ReturnClauseSyntax` if possible. Returns
@@ -3788,8 +3506,7 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeArrow: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeArrow,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3804,14 +3521,13 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeArrow(
     _ newChild: UnexpectedNodesSyntax?) -> ReturnClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeArrow)
+    let newData = data.replacingChild(raw, at: 0)
     return ReturnClauseSyntax(newData)
   }
 
   public var arrow: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.arrow,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3825,14 +3541,13 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withArrow(
     _ newChild: TokenSyntax?) -> ReturnClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.arrow)
+    let newData = data.replacingChild(raw, at: 1)
     return ReturnClauseSyntax(newData)
   }
 
   public var unexpectedBetweenArrowAndReturnType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenArrowAndReturnType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3847,14 +3562,13 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenArrowAndReturnType(
     _ newChild: UnexpectedNodesSyntax?) -> ReturnClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenArrowAndReturnType)
+    let newData = data.replacingChild(raw, at: 2)
     return ReturnClauseSyntax(newData)
   }
 
   public var returnType: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.returnType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -3868,7 +3582,7 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withReturnType(
     _ newChild: TypeSyntax?) -> ReturnClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.returnType)
+    let newData = data.replacingChild(raw, at: 3)
     return ReturnClauseSyntax(newData)
   }
 }
@@ -3887,17 +3601,6 @@ extension ReturnClauseSyntax: CustomReflectable {
 // MARK: - FunctionSignatureSyntax
 
 public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeInput
-    case input
-    case unexpectedBetweenInputAndAsyncOrReasyncKeyword
-    case asyncOrReasyncKeyword
-    case unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword
-    case throwsOrRethrowsKeyword
-    case unexpectedBetweenThrowsOrRethrowsKeywordAndOutput
-    case output
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `FunctionSignatureSyntax` if possible. Returns
@@ -3947,8 +3650,7 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeInput: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeInput,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3963,14 +3665,13 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeInput(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeInput)
+    let newData = data.replacingChild(raw, at: 0)
     return FunctionSignatureSyntax(newData)
   }
 
   public var input: ParameterClauseSyntax {
     get {
-      let childData = data.child(at: Cursor.input,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return ParameterClauseSyntax(childData!)
     }
     set(value) {
@@ -3984,14 +3685,13 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withInput(
     _ newChild: ParameterClauseSyntax?) -> FunctionSignatureSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.parameterClause, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.input)
+    let newData = data.replacingChild(raw, at: 1)
     return FunctionSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenInputAndAsyncOrReasyncKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInputAndAsyncOrReasyncKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4006,14 +3706,13 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInputAndAsyncOrReasyncKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInputAndAsyncOrReasyncKeyword)
+    let newData = data.replacingChild(raw, at: 2)
     return FunctionSignatureSyntax(newData)
   }
 
   public var asyncOrReasyncKeyword: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.asyncOrReasyncKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -4028,14 +3727,13 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAsyncOrReasyncKeyword(
     _ newChild: TokenSyntax?) -> FunctionSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.asyncOrReasyncKeyword)
+    let newData = data.replacingChild(raw, at: 3)
     return FunctionSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4050,14 +3748,13 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return FunctionSignatureSyntax(newData)
   }
 
   public var throwsOrRethrowsKeyword: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.throwsOrRethrowsKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -4072,14 +3769,13 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withThrowsOrRethrowsKeyword(
     _ newChild: TokenSyntax?) -> FunctionSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.throwsOrRethrowsKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return FunctionSignatureSyntax(newData)
   }
 
   public var unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenThrowsOrRethrowsKeywordAndOutput,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4094,14 +3790,13 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenThrowsOrRethrowsKeywordAndOutput(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenThrowsOrRethrowsKeywordAndOutput)
+    let newData = data.replacingChild(raw, at: 6)
     return FunctionSignatureSyntax(newData)
   }
 
   public var output: ReturnClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.output,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return ReturnClauseSyntax(childData!)
     }
@@ -4116,7 +3811,7 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
   public func withOutput(
     _ newChild: ReturnClauseSyntax?) -> FunctionSignatureSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.output)
+    let newData = data.replacingChild(raw, at: 7)
     return FunctionSignatureSyntax(newData)
   }
 }
@@ -4139,15 +3834,6 @@ extension FunctionSignatureSyntax: CustomReflectable {
 // MARK: - IfConfigClauseSyntax
 
 public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePoundKeyword
-    case poundKeyword
-    case unexpectedBetweenPoundKeywordAndCondition
-    case condition
-    case unexpectedBetweenConditionAndElements
-    case elements
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `IfConfigClauseSyntax` if possible. Returns
@@ -4193,8 +3879,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePoundKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePoundKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4209,14 +3894,13 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePoundKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePoundKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return IfConfigClauseSyntax(newData)
   }
 
   public var poundKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4230,14 +3914,13 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withPoundKeyword(
     _ newChild: TokenSyntax?) -> IfConfigClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundIfKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return IfConfigClauseSyntax(newData)
   }
 
   public var unexpectedBetweenPoundKeywordAndCondition: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPoundKeywordAndCondition,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4252,14 +3935,13 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPoundKeywordAndCondition(
     _ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPoundKeywordAndCondition)
+    let newData = data.replacingChild(raw, at: 2)
     return IfConfigClauseSyntax(newData)
   }
 
   public var condition: ExprSyntax? {
     get {
-      let childData = data.child(at: Cursor.condition,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ExprSyntax(childData!)
     }
@@ -4274,14 +3956,13 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withCondition(
     _ newChild: ExprSyntax?) -> IfConfigClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.condition)
+    let newData = data.replacingChild(raw, at: 3)
     return IfConfigClauseSyntax(newData)
   }
 
   public var unexpectedBetweenConditionAndElements: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenConditionAndElements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4296,14 +3977,13 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenConditionAndElements(
     _ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenConditionAndElements)
+    let newData = data.replacingChild(raw, at: 4)
     return IfConfigClauseSyntax(newData)
   }
 
   public var elements: Syntax {
     get {
-      let childData = data.child(at: Cursor.elements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -4317,7 +3997,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withElements(
     _ newChild: Syntax?) -> IfConfigClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.elements)
+    let newData = data.replacingChild(raw, at: 5)
     return IfConfigClauseSyntax(newData)
   }
 }
@@ -4338,23 +4018,6 @@ extension IfConfigClauseSyntax: CustomReflectable {
 // MARK: - PoundSourceLocationArgsSyntax
 
 public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeFileArgLabel
-    case fileArgLabel
-    case unexpectedBetweenFileArgLabelAndFileArgColon
-    case fileArgColon
-    case unexpectedBetweenFileArgColonAndFileName
-    case fileName
-    case unexpectedBetweenFileNameAndComma
-    case comma
-    case unexpectedBetweenCommaAndLineArgLabel
-    case lineArgLabel
-    case unexpectedBetweenLineArgLabelAndLineArgColon
-    case lineArgColon
-    case unexpectedBetweenLineArgColonAndLineNumber
-    case lineNumber
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PoundSourceLocationArgsSyntax` if possible. Returns
@@ -4416,8 +4079,7 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeFileArgLabel: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeFileArgLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4432,14 +4094,13 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeFileArgLabel(
     _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeFileArgLabel)
+    let newData = data.replacingChild(raw, at: 0)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var fileArgLabel: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.fileArgLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4453,14 +4114,13 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withFileArgLabel(
     _ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.fileArgLabel)
+    let newData = data.replacingChild(raw, at: 1)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var unexpectedBetweenFileArgLabelAndFileArgColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenFileArgLabelAndFileArgColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4475,14 +4135,13 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenFileArgLabelAndFileArgColon(
     _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenFileArgLabelAndFileArgColon)
+    let newData = data.replacingChild(raw, at: 2)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var fileArgColon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.fileArgColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4496,14 +4155,13 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withFileArgColon(
     _ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.fileArgColon)
+    let newData = data.replacingChild(raw, at: 3)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var unexpectedBetweenFileArgColonAndFileName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenFileArgColonAndFileName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4518,14 +4176,13 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenFileArgColonAndFileName(
     _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenFileArgColonAndFileName)
+    let newData = data.replacingChild(raw, at: 4)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var fileName: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.fileName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4539,14 +4196,13 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withFileName(
     _ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.fileName)
+    let newData = data.replacingChild(raw, at: 5)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var unexpectedBetweenFileNameAndComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenFileNameAndComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4561,14 +4217,13 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenFileNameAndComma(
     _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenFileNameAndComma)
+    let newData = data.replacingChild(raw, at: 6)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var comma: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.comma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4582,14 +4237,13 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withComma(
     _ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.comma)
+    let newData = data.replacingChild(raw, at: 7)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var unexpectedBetweenCommaAndLineArgLabel: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCommaAndLineArgLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4604,14 +4258,13 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCommaAndLineArgLabel(
     _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCommaAndLineArgLabel)
+    let newData = data.replacingChild(raw, at: 8)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var lineArgLabel: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.lineArgLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4625,14 +4278,13 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLineArgLabel(
     _ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.lineArgLabel)
+    let newData = data.replacingChild(raw, at: 9)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var unexpectedBetweenLineArgLabelAndLineArgColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLineArgLabelAndLineArgColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4647,14 +4299,13 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLineArgLabelAndLineArgColon(
     _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLineArgLabelAndLineArgColon)
+    let newData = data.replacingChild(raw, at: 10)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var lineArgColon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.lineArgColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4668,14 +4319,13 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLineArgColon(
     _ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.lineArgColon)
+    let newData = data.replacingChild(raw, at: 11)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var unexpectedBetweenLineArgColonAndLineNumber: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLineArgColonAndLineNumber,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4690,14 +4340,13 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLineArgColonAndLineNumber(
     _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLineArgColonAndLineNumber)
+    let newData = data.replacingChild(raw, at: 12)
     return PoundSourceLocationArgsSyntax(newData)
   }
 
   public var lineNumber: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.lineNumber,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4711,7 +4360,7 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLineNumber(
     _ newChild: TokenSyntax?) -> PoundSourceLocationArgsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.lineNumber)
+    let newData = data.replacingChild(raw, at: 13)
     return PoundSourceLocationArgsSyntax(newData)
   }
 }
@@ -4740,15 +4389,6 @@ extension PoundSourceLocationArgsSyntax: CustomReflectable {
 // MARK: - DeclModifierDetailSyntax
 
 public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndDetail
-    case detail
-    case unexpectedBetweenDetailAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DeclModifierDetailSyntax` if possible. Returns
@@ -4794,8 +4434,7 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4810,14 +4449,13 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftParen)
+    let newData = data.replacingChild(raw, at: 0)
     return DeclModifierDetailSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4831,14 +4469,13 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> DeclModifierDetailSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 1)
     return DeclModifierDetailSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndDetail: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndDetail,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4853,14 +4490,13 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndDetail(
     _ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndDetail)
+    let newData = data.replacingChild(raw, at: 2)
     return DeclModifierDetailSyntax(newData)
   }
 
   public var detail: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.detail,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4874,14 +4510,13 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   public func withDetail(
     _ newChild: TokenSyntax?) -> DeclModifierDetailSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.detail)
+    let newData = data.replacingChild(raw, at: 3)
     return DeclModifierDetailSyntax(newData)
   }
 
   public var unexpectedBetweenDetailAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDetailAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -4896,14 +4531,13 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenDetailAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDetailAndRightParen)
+    let newData = data.replacingChild(raw, at: 4)
     return DeclModifierDetailSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -4917,7 +4551,7 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> DeclModifierDetailSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 5)
     return DeclModifierDetailSyntax(newData)
   }
 }
@@ -4938,13 +4572,6 @@ extension DeclModifierDetailSyntax: CustomReflectable {
 // MARK: - DeclModifierSyntax
 
 public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeName
-    case name
-    case unexpectedBetweenNameAndDetail
-    case detail
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DeclModifierSyntax` if possible. Returns
@@ -4986,8 +4613,7 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5002,14 +4628,13 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeName(
     _ newChild: UnexpectedNodesSyntax?) -> DeclModifierSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeName)
+    let newData = data.replacingChild(raw, at: 0)
     return DeclModifierSyntax(newData)
   }
 
   public var name: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -5023,14 +4648,13 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> DeclModifierSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 1)
     return DeclModifierSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndDetail: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndDetail,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5045,14 +4669,13 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndDetail(
     _ newChild: UnexpectedNodesSyntax?) -> DeclModifierSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndDetail)
+    let newData = data.replacingChild(raw, at: 2)
     return DeclModifierSyntax(newData)
   }
 
   public var detail: DeclModifierDetailSyntax? {
     get {
-      let childData = data.child(at: Cursor.detail,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return DeclModifierDetailSyntax(childData!)
     }
@@ -5067,7 +4690,7 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
   public func withDetail(
     _ newChild: DeclModifierDetailSyntax?) -> DeclModifierSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.detail)
+    let newData = data.replacingChild(raw, at: 3)
     return DeclModifierSyntax(newData)
   }
 }
@@ -5086,13 +4709,6 @@ extension DeclModifierSyntax: CustomReflectable {
 // MARK: - InheritedTypeSyntax
 
 public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeTypeName
-    case typeName
-    case unexpectedBetweenTypeNameAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `InheritedTypeSyntax` if possible. Returns
@@ -5134,8 +4750,7 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeTypeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeTypeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5150,14 +4765,13 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeTypeName(
     _ newChild: UnexpectedNodesSyntax?) -> InheritedTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeTypeName)
+    let newData = data.replacingChild(raw, at: 0)
     return InheritedTypeSyntax(newData)
   }
 
   public var typeName: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.typeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -5171,14 +4785,13 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTypeName(
     _ newChild: TypeSyntax?) -> InheritedTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.typeName)
+    let newData = data.replacingChild(raw, at: 1)
     return InheritedTypeSyntax(newData)
   }
 
   public var unexpectedBetweenTypeNameAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTypeNameAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5193,14 +4806,13 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTypeNameAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> InheritedTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTypeNameAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 2)
     return InheritedTypeSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -5215,7 +4827,7 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> InheritedTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 3)
     return InheritedTypeSyntax(newData)
   }
 }
@@ -5234,13 +4846,6 @@ extension InheritedTypeSyntax: CustomReflectable {
 // MARK: - TypeInheritanceClauseSyntax
 
 public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeColon
-    case colon
-    case unexpectedBetweenColonAndInheritedTypeCollection
-    case inheritedTypeCollection
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TypeInheritanceClauseSyntax` if possible. Returns
@@ -5282,8 +4887,7 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5298,14 +4902,13 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeColon(
     _ newChild: UnexpectedNodesSyntax?) -> TypeInheritanceClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeColon)
+    let newData = data.replacingChild(raw, at: 0)
     return TypeInheritanceClauseSyntax(newData)
   }
 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -5319,14 +4922,13 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> TypeInheritanceClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 1)
     return TypeInheritanceClauseSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndInheritedTypeCollection: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndInheritedTypeCollection,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5341,14 +4943,13 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndInheritedTypeCollection(
     _ newChild: UnexpectedNodesSyntax?) -> TypeInheritanceClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndInheritedTypeCollection)
+    let newData = data.replacingChild(raw, at: 2)
     return TypeInheritanceClauseSyntax(newData)
   }
 
   public var inheritedTypeCollection: InheritedTypeListSyntax {
     get {
-      let childData = data.child(at: Cursor.inheritedTypeCollection,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return InheritedTypeListSyntax(childData!)
     }
     set(value) {
@@ -5364,14 +4965,13 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `inheritedTypeCollection` collection.
   public func addInheritedType(_ element: InheritedTypeSyntax) -> TypeInheritanceClauseSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.inheritedTypeCollection] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.inheritedTypeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.inheritedTypeCollection)
+    let newData = data.replacingChild(collection, at: 3)
     return TypeInheritanceClauseSyntax(newData)
   }
 
@@ -5381,7 +4981,7 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withInheritedTypeCollection(
     _ newChild: InheritedTypeListSyntax?) -> TypeInheritanceClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.inheritedTypeList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.inheritedTypeCollection)
+    let newData = data.replacingChild(raw, at: 3)
     return TypeInheritanceClauseSyntax(newData)
   }
 }
@@ -5400,15 +5000,6 @@ extension TypeInheritanceClauseSyntax: CustomReflectable {
 // MARK: - MemberDeclBlockSyntax
 
 public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftBrace
-    case leftBrace
-    case unexpectedBetweenLeftBraceAndMembers
-    case members
-    case unexpectedBetweenMembersAndRightBrace
-    case rightBrace
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `MemberDeclBlockSyntax` if possible. Returns
@@ -5454,8 +5045,7 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5470,14 +5060,13 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftBrace(
     _ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftBrace)
+    let newData = data.replacingChild(raw, at: 0)
     return MemberDeclBlockSyntax(newData)
   }
 
   public var leftBrace: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -5491,14 +5080,13 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftBrace(
     _ newChild: TokenSyntax?) -> MemberDeclBlockSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftBrace)
+    let newData = data.replacingChild(raw, at: 1)
     return MemberDeclBlockSyntax(newData)
   }
 
   public var unexpectedBetweenLeftBraceAndMembers: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftBraceAndMembers,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5513,14 +5101,13 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftBraceAndMembers(
     _ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftBraceAndMembers)
+    let newData = data.replacingChild(raw, at: 2)
     return MemberDeclBlockSyntax(newData)
   }
 
   public var members: MemberDeclListSyntax {
     get {
-      let childData = data.child(at: Cursor.members,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return MemberDeclListSyntax(childData!)
     }
     set(value) {
@@ -5536,14 +5123,13 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `members` collection.
   public func addMember(_ element: MemberDeclListItemSyntax) -> MemberDeclBlockSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.members] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.members)
+    let newData = data.replacingChild(collection, at: 3)
     return MemberDeclBlockSyntax(newData)
   }
 
@@ -5553,14 +5139,13 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withMembers(
     _ newChild: MemberDeclListSyntax?) -> MemberDeclBlockSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.members)
+    let newData = data.replacingChild(raw, at: 3)
     return MemberDeclBlockSyntax(newData)
   }
 
   public var unexpectedBetweenMembersAndRightBrace: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenMembersAndRightBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5575,14 +5160,13 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenMembersAndRightBrace(
     _ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenMembersAndRightBrace)
+    let newData = data.replacingChild(raw, at: 4)
     return MemberDeclBlockSyntax(newData)
   }
 
   public var rightBrace: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -5596,7 +5180,7 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightBrace(
     _ newChild: TokenSyntax?) -> MemberDeclBlockSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightBrace)
+    let newData = data.replacingChild(raw, at: 5)
     return MemberDeclBlockSyntax(newData)
   }
 }
@@ -5621,13 +5205,6 @@ extension MemberDeclBlockSyntax: CustomReflectable {
 /// optional semicolon;
 /// 
 public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeDecl
-    case decl
-    case unexpectedBetweenDeclAndSemicolon
-    case semicolon
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `MemberDeclListItemSyntax` if possible. Returns
@@ -5669,8 +5246,7 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeDecl: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeDecl,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5685,15 +5261,14 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeDecl(
     _ newChild: UnexpectedNodesSyntax?) -> MemberDeclListItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeDecl)
+    let newData = data.replacingChild(raw, at: 0)
     return MemberDeclListItemSyntax(newData)
   }
 
   /// The declaration of the type member.
   public var decl: DeclSyntax {
     get {
-      let childData = data.child(at: Cursor.decl,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return DeclSyntax(childData!)
     }
     set(value) {
@@ -5707,14 +5282,13 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withDecl(
     _ newChild: DeclSyntax?) -> MemberDeclListItemSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingDecl, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.decl)
+    let newData = data.replacingChild(raw, at: 1)
     return MemberDeclListItemSyntax(newData)
   }
 
   public var unexpectedBetweenDeclAndSemicolon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDeclAndSemicolon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5729,15 +5303,14 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenDeclAndSemicolon(
     _ newChild: UnexpectedNodesSyntax?) -> MemberDeclListItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDeclAndSemicolon)
+    let newData = data.replacingChild(raw, at: 2)
     return MemberDeclListItemSyntax(newData)
   }
 
   /// An optional trailing semicolon.
   public var semicolon: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.semicolon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -5752,7 +5325,7 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withSemicolon(
     _ newChild: TokenSyntax?) -> MemberDeclListItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.semicolon)
+    let newData = data.replacingChild(raw, at: 3)
     return MemberDeclListItemSyntax(newData)
   }
 }
@@ -5771,13 +5344,6 @@ extension MemberDeclListItemSyntax: CustomReflectable {
 // MARK: - SourceFileSyntax
 
 public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeStatements
-    case statements
-    case unexpectedBetweenStatementsAndEOFToken
-    case eofToken
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SourceFileSyntax` if possible. Returns
@@ -5819,8 +5385,7 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeStatements: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeStatements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5835,14 +5400,13 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeStatements(
     _ newChild: UnexpectedNodesSyntax?) -> SourceFileSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeStatements)
+    let newData = data.replacingChild(raw, at: 0)
     return SourceFileSyntax(newData)
   }
 
   public var statements: CodeBlockItemListSyntax {
     get {
-      let childData = data.child(at: Cursor.statements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return CodeBlockItemListSyntax(childData!)
     }
     set(value) {
@@ -5858,14 +5422,13 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `statements` collection.
   public func addStatement(_ element: CodeBlockItemSyntax) -> SourceFileSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.statements] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.statements)
+    let newData = data.replacingChild(collection, at: 1)
     return SourceFileSyntax(newData)
   }
 
@@ -5875,14 +5438,13 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   public func withStatements(
     _ newChild: CodeBlockItemListSyntax?) -> SourceFileSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.statements)
+    let newData = data.replacingChild(raw, at: 1)
     return SourceFileSyntax(newData)
   }
 
   public var unexpectedBetweenStatementsAndEOFToken: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenStatementsAndEOFToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -5897,14 +5459,13 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenStatementsAndEOFToken(
     _ newChild: UnexpectedNodesSyntax?) -> SourceFileSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenStatementsAndEOFToken)
+    let newData = data.replacingChild(raw, at: 2)
     return SourceFileSyntax(newData)
   }
 
   public var eofToken: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.eofToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -5918,7 +5479,7 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
   public func withEOFToken(
     _ newChild: TokenSyntax?) -> SourceFileSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.eofToken)
+    let newData = data.replacingChild(raw, at: 3)
     return SourceFileSyntax(newData)
   }
 }
@@ -5937,13 +5498,6 @@ extension SourceFileSyntax: CustomReflectable {
 // MARK: - InitializerClauseSyntax
 
 public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeEqual
-    case equal
-    case unexpectedBetweenEqualAndValue
-    case value
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `InitializerClauseSyntax` if possible. Returns
@@ -5985,8 +5539,7 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeEqual: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeEqual,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6001,14 +5554,13 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeEqual(
     _ newChild: UnexpectedNodesSyntax?) -> InitializerClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeEqual)
+    let newData = data.replacingChild(raw, at: 0)
     return InitializerClauseSyntax(newData)
   }
 
   public var equal: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.equal,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -6022,14 +5574,13 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withEqual(
     _ newChild: TokenSyntax?) -> InitializerClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.equal)
+    let newData = data.replacingChild(raw, at: 1)
     return InitializerClauseSyntax(newData)
   }
 
   public var unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenEqualAndValue,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6044,14 +5595,13 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenEqualAndValue(
     _ newChild: UnexpectedNodesSyntax?) -> InitializerClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenEqualAndValue)
+    let newData = data.replacingChild(raw, at: 2)
     return InitializerClauseSyntax(newData)
   }
 
   public var value: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.value,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -6065,7 +5615,7 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withValue(
     _ newChild: ExprSyntax?) -> InitializerClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.value)
+    let newData = data.replacingChild(raw, at: 3)
     return InitializerClauseSyntax(newData)
   }
 }
@@ -6084,25 +5634,6 @@ extension InitializerClauseSyntax: CustomReflectable {
 // MARK: - FunctionParameterSyntax
 
 public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndFirstName
-    case firstName
-    case unexpectedBetweenFirstNameAndSecondName
-    case secondName
-    case unexpectedBetweenSecondNameAndColon
-    case colon
-    case unexpectedBetweenColonAndType
-    case type
-    case unexpectedBetweenTypeAndEllipsis
-    case ellipsis
-    case unexpectedBetweenEllipsisAndDefaultArgument
-    case defaultArgument
-    case unexpectedBetweenDefaultArgumentAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `FunctionParameterSyntax` if possible. Returns
@@ -6168,8 +5699,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6184,14 +5714,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return FunctionParameterSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -6208,14 +5737,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> FunctionParameterSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return FunctionParameterSyntax(newData)
   }
 
@@ -6225,14 +5753,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return FunctionParameterSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndFirstName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndFirstName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6247,14 +5774,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndFirstName(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndFirstName)
+    let newData = data.replacingChild(raw, at: 2)
     return FunctionParameterSyntax(newData)
   }
 
   public var firstName: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.firstName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -6269,14 +5795,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withFirstName(
     _ newChild: TokenSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.firstName)
+    let newData = data.replacingChild(raw, at: 3)
     return FunctionParameterSyntax(newData)
   }
 
   public var unexpectedBetweenFirstNameAndSecondName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenFirstNameAndSecondName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6291,14 +5816,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenFirstNameAndSecondName(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenFirstNameAndSecondName)
+    let newData = data.replacingChild(raw, at: 4)
     return FunctionParameterSyntax(newData)
   }
 
   public var secondName: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.secondName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -6313,14 +5837,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withSecondName(
     _ newChild: TokenSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.secondName)
+    let newData = data.replacingChild(raw, at: 5)
     return FunctionParameterSyntax(newData)
   }
 
   public var unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenSecondNameAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6335,14 +5858,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenSecondNameAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenSecondNameAndColon)
+    let newData = data.replacingChild(raw, at: 6)
     return FunctionParameterSyntax(newData)
   }
 
   public var colon: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -6357,14 +5879,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 7)
     return FunctionParameterSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6379,14 +5900,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndType(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndType)
+    let newData = data.replacingChild(raw, at: 8)
     return FunctionParameterSyntax(newData)
   }
 
   public var type: TypeSyntax? {
     get {
-      let childData = data.child(at: Cursor.type,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeSyntax(childData!)
     }
@@ -6401,14 +5921,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withType(
     _ newChild: TypeSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.type)
+    let newData = data.replacingChild(raw, at: 9)
     return FunctionParameterSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTypeAndEllipsis,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6423,14 +5942,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTypeAndEllipsis(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTypeAndEllipsis)
+    let newData = data.replacingChild(raw, at: 10)
     return FunctionParameterSyntax(newData)
   }
 
   public var ellipsis: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.ellipsis,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -6445,14 +5963,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withEllipsis(
     _ newChild: TokenSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.ellipsis)
+    let newData = data.replacingChild(raw, at: 11)
     return FunctionParameterSyntax(newData)
   }
 
   public var unexpectedBetweenEllipsisAndDefaultArgument: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenEllipsisAndDefaultArgument,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6467,14 +5984,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenEllipsisAndDefaultArgument(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenEllipsisAndDefaultArgument)
+    let newData = data.replacingChild(raw, at: 12)
     return FunctionParameterSyntax(newData)
   }
 
   public var defaultArgument: InitializerClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.defaultArgument,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       if childData == nil { return nil }
       return InitializerClauseSyntax(childData!)
     }
@@ -6489,14 +6005,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withDefaultArgument(
     _ newChild: InitializerClauseSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.defaultArgument)
+    let newData = data.replacingChild(raw, at: 13)
     return FunctionParameterSyntax(newData)
   }
 
   public var unexpectedBetweenDefaultArgumentAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDefaultArgumentAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 14, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6511,14 +6026,13 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenDefaultArgumentAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDefaultArgumentAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 14)
     return FunctionParameterSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 15, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -6533,7 +6047,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> FunctionParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 15)
     return FunctionParameterSyntax(newData)
   }
 }
@@ -6564,13 +6078,6 @@ extension FunctionParameterSyntax: CustomReflectable {
 // MARK: - AccessLevelModifierSyntax
 
 public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeName
-    case name
-    case unexpectedBetweenNameAndModifier
-    case modifier
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AccessLevelModifierSyntax` if possible. Returns
@@ -6612,8 +6119,7 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6628,14 +6134,13 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeName(
     _ newChild: UnexpectedNodesSyntax?) -> AccessLevelModifierSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeName)
+    let newData = data.replacingChild(raw, at: 0)
     return AccessLevelModifierSyntax(newData)
   }
 
   public var name: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -6649,14 +6154,13 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> AccessLevelModifierSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 1)
     return AccessLevelModifierSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndModifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndModifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6671,14 +6175,13 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndModifier(
     _ newChild: UnexpectedNodesSyntax?) -> AccessLevelModifierSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndModifier)
+    let newData = data.replacingChild(raw, at: 2)
     return AccessLevelModifierSyntax(newData)
   }
 
   public var modifier: DeclModifierDetailSyntax? {
     get {
-      let childData = data.child(at: Cursor.modifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return DeclModifierDetailSyntax(childData!)
     }
@@ -6693,7 +6196,7 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
   public func withModifier(
     _ newChild: DeclModifierDetailSyntax?) -> AccessLevelModifierSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.modifier)
+    let newData = data.replacingChild(raw, at: 3)
     return AccessLevelModifierSyntax(newData)
   }
 }
@@ -6712,13 +6215,6 @@ extension AccessLevelModifierSyntax: CustomReflectable {
 // MARK: - AccessPathComponentSyntax
 
 public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeName
-    case name
-    case unexpectedBetweenNameAndTrailingDot
-    case trailingDot
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AccessPathComponentSyntax` if possible. Returns
@@ -6760,8 +6256,7 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6776,14 +6271,13 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeName(
     _ newChild: UnexpectedNodesSyntax?) -> AccessPathComponentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeName)
+    let newData = data.replacingChild(raw, at: 0)
     return AccessPathComponentSyntax(newData)
   }
 
   public var name: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -6797,14 +6291,13 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> AccessPathComponentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 1)
     return AccessPathComponentSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndTrailingDot: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndTrailingDot,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6819,14 +6312,13 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndTrailingDot(
     _ newChild: UnexpectedNodesSyntax?) -> AccessPathComponentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndTrailingDot)
+    let newData = data.replacingChild(raw, at: 2)
     return AccessPathComponentSyntax(newData)
   }
 
   public var trailingDot: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingDot,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -6841,7 +6333,7 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingDot(
     _ newChild: TokenSyntax?) -> AccessPathComponentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingDot)
+    let newData = data.replacingChild(raw, at: 3)
     return AccessPathComponentSyntax(newData)
   }
 }
@@ -6860,15 +6352,6 @@ extension AccessPathComponentSyntax: CustomReflectable {
 // MARK: - AccessorParameterSyntax
 
 public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndName
-    case name
-    case unexpectedBetweenNameAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AccessorParameterSyntax` if possible. Returns
@@ -6914,8 +6397,7 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6930,14 +6412,13 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftParen)
+    let newData = data.replacingChild(raw, at: 0)
     return AccessorParameterSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -6951,14 +6432,13 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> AccessorParameterSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 1)
     return AccessorParameterSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -6973,14 +6453,13 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndName(
     _ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndName)
+    let newData = data.replacingChild(raw, at: 2)
     return AccessorParameterSyntax(newData)
   }
 
   public var name: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -6994,14 +6473,13 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> AccessorParameterSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 3)
     return AccessorParameterSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7016,14 +6494,13 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndRightParen)
+    let newData = data.replacingChild(raw, at: 4)
     return AccessorParameterSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7037,7 +6514,7 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> AccessorParameterSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 5)
     return AccessorParameterSyntax(newData)
   }
 }
@@ -7058,15 +6535,6 @@ extension AccessorParameterSyntax: CustomReflectable {
 // MARK: - AccessorBlockSyntax
 
 public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftBrace
-    case leftBrace
-    case unexpectedBetweenLeftBraceAndAccessors
-    case accessors
-    case unexpectedBetweenAccessorsAndRightBrace
-    case rightBrace
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AccessorBlockSyntax` if possible. Returns
@@ -7112,8 +6580,7 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7128,14 +6595,13 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftBrace(
     _ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftBrace)
+    let newData = data.replacingChild(raw, at: 0)
     return AccessorBlockSyntax(newData)
   }
 
   public var leftBrace: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7149,14 +6615,13 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftBrace(
     _ newChild: TokenSyntax?) -> AccessorBlockSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftBrace)
+    let newData = data.replacingChild(raw, at: 1)
     return AccessorBlockSyntax(newData)
   }
 
   public var unexpectedBetweenLeftBraceAndAccessors: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftBraceAndAccessors,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7171,14 +6636,13 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftBraceAndAccessors(
     _ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftBraceAndAccessors)
+    let newData = data.replacingChild(raw, at: 2)
     return AccessorBlockSyntax(newData)
   }
 
   public var accessors: AccessorListSyntax {
     get {
-      let childData = data.child(at: Cursor.accessors,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return AccessorListSyntax(childData!)
     }
     set(value) {
@@ -7194,14 +6658,13 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `accessors` collection.
   public func addAccessor(_ element: AccessorDeclSyntax) -> AccessorBlockSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.accessors] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.accessorList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.accessors)
+    let newData = data.replacingChild(collection, at: 3)
     return AccessorBlockSyntax(newData)
   }
 
@@ -7211,14 +6674,13 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAccessors(
     _ newChild: AccessorListSyntax?) -> AccessorBlockSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.accessorList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.accessors)
+    let newData = data.replacingChild(raw, at: 3)
     return AccessorBlockSyntax(newData)
   }
 
   public var unexpectedBetweenAccessorsAndRightBrace: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAccessorsAndRightBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7233,14 +6695,13 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAccessorsAndRightBrace(
     _ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAccessorsAndRightBrace)
+    let newData = data.replacingChild(raw, at: 4)
     return AccessorBlockSyntax(newData)
   }
 
   public var rightBrace: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7254,7 +6715,7 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightBrace(
     _ newChild: TokenSyntax?) -> AccessorBlockSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightBrace)
+    let newData = data.replacingChild(raw, at: 5)
     return AccessorBlockSyntax(newData)
   }
 }
@@ -7275,19 +6736,6 @@ extension AccessorBlockSyntax: CustomReflectable {
 // MARK: - PatternBindingSyntax
 
 public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePattern
-    case pattern
-    case unexpectedBetweenPatternAndTypeAnnotation
-    case typeAnnotation
-    case unexpectedBetweenTypeAnnotationAndInitializer
-    case initializer
-    case unexpectedBetweenInitializerAndAccessor
-    case accessor
-    case unexpectedBetweenAccessorAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PatternBindingSyntax` if possible. Returns
@@ -7341,8 +6789,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePattern: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7357,14 +6804,13 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePattern(
     _ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePattern)
+    let newData = data.replacingChild(raw, at: 0)
     return PatternBindingSyntax(newData)
   }
 
   public var pattern: PatternSyntax {
     get {
-      let childData = data.child(at: Cursor.pattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return PatternSyntax(childData!)
     }
     set(value) {
@@ -7378,14 +6824,13 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   public func withPattern(
     _ newChild: PatternSyntax?) -> PatternBindingSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.pattern)
+    let newData = data.replacingChild(raw, at: 1)
     return PatternBindingSyntax(newData)
   }
 
   public var unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPatternAndTypeAnnotation,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7400,14 +6845,13 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPatternAndTypeAnnotation(
     _ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPatternAndTypeAnnotation)
+    let newData = data.replacingChild(raw, at: 2)
     return PatternBindingSyntax(newData)
   }
 
   public var typeAnnotation: TypeAnnotationSyntax? {
     get {
-      let childData = data.child(at: Cursor.typeAnnotation,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeAnnotationSyntax(childData!)
     }
@@ -7422,14 +6866,13 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTypeAnnotation(
     _ newChild: TypeAnnotationSyntax?) -> PatternBindingSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.typeAnnotation)
+    let newData = data.replacingChild(raw, at: 3)
     return PatternBindingSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTypeAnnotationAndInitializer,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7444,14 +6887,13 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTypeAnnotationAndInitializer(
     _ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTypeAnnotationAndInitializer)
+    let newData = data.replacingChild(raw, at: 4)
     return PatternBindingSyntax(newData)
   }
 
   public var initializer: InitializerClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.initializer,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return InitializerClauseSyntax(childData!)
     }
@@ -7466,14 +6908,13 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   public func withInitializer(
     _ newChild: InitializerClauseSyntax?) -> PatternBindingSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.initializer)
+    let newData = data.replacingChild(raw, at: 5)
     return PatternBindingSyntax(newData)
   }
 
   public var unexpectedBetweenInitializerAndAccessor: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInitializerAndAccessor,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7488,14 +6929,13 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInitializerAndAccessor(
     _ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInitializerAndAccessor)
+    let newData = data.replacingChild(raw, at: 6)
     return PatternBindingSyntax(newData)
   }
 
   public var accessor: Syntax? {
     get {
-      let childData = data.child(at: Cursor.accessor,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return Syntax(childData!)
     }
@@ -7510,14 +6950,13 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAccessor(
     _ newChild: Syntax?) -> PatternBindingSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.accessor)
+    let newData = data.replacingChild(raw, at: 7)
     return PatternBindingSyntax(newData)
   }
 
   public var unexpectedBetweenAccessorAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAccessorAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7532,14 +6971,13 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAccessorAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAccessorAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 8)
     return PatternBindingSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -7554,7 +6992,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> PatternBindingSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 9)
     return PatternBindingSyntax(newData)
   }
 }
@@ -7583,17 +7021,6 @@ extension PatternBindingSyntax: CustomReflectable {
 /// optionally, either associated values or an assignment to a raw value.
 /// 
 public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeIdentifier
-    case identifier
-    case unexpectedBetweenIdentifierAndAssociatedValue
-    case associatedValue
-    case unexpectedBetweenAssociatedValueAndRawValue
-    case rawValue
-    case unexpectedBetweenRawValueAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `EnumCaseElementSyntax` if possible. Returns
@@ -7643,8 +7070,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7659,15 +7085,14 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeIdentifier)
+    let newData = data.replacingChild(raw, at: 0)
     return EnumCaseElementSyntax(newData)
   }
 
   /// The name of this case.
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7681,14 +7106,13 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> EnumCaseElementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 1)
     return EnumCaseElementSyntax(newData)
   }
 
   public var unexpectedBetweenIdentifierAndAssociatedValue: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIdentifierAndAssociatedValue,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7703,15 +7127,14 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIdentifierAndAssociatedValue(
     _ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIdentifierAndAssociatedValue)
+    let newData = data.replacingChild(raw, at: 2)
     return EnumCaseElementSyntax(newData)
   }
 
   /// The set of associated values of the case.
   public var associatedValue: ParameterClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.associatedValue,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ParameterClauseSyntax(childData!)
     }
@@ -7726,14 +7149,13 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAssociatedValue(
     _ newChild: ParameterClauseSyntax?) -> EnumCaseElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.associatedValue)
+    let newData = data.replacingChild(raw, at: 3)
     return EnumCaseElementSyntax(newData)
   }
 
   public var unexpectedBetweenAssociatedValueAndRawValue: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAssociatedValueAndRawValue,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7748,7 +7170,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAssociatedValueAndRawValue(
     _ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAssociatedValueAndRawValue)
+    let newData = data.replacingChild(raw, at: 4)
     return EnumCaseElementSyntax(newData)
   }
 
@@ -7757,8 +7179,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var rawValue: InitializerClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.rawValue,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return InitializerClauseSyntax(childData!)
     }
@@ -7773,14 +7194,13 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRawValue(
     _ newChild: InitializerClauseSyntax?) -> EnumCaseElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.rawValue)
+    let newData = data.replacingChild(raw, at: 5)
     return EnumCaseElementSyntax(newData)
   }
 
   public var unexpectedBetweenRawValueAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenRawValueAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7795,7 +7215,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenRawValueAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenRawValueAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 6)
     return EnumCaseElementSyntax(newData)
   }
 
@@ -7805,8 +7225,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -7821,7 +7240,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> EnumCaseElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 7)
     return EnumCaseElementSyntax(newData)
   }
 }
@@ -7847,13 +7266,6 @@ extension EnumCaseElementSyntax: CustomReflectable {
 /// A clause to specify precedence group in infix operator declarations, and designated types in any operator declaration.
 /// 
 public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeColon
-    case colon
-    case unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes
-    case precedenceGroupAndDesignatedTypes
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `OperatorPrecedenceAndTypesSyntax` if possible. Returns
@@ -7895,8 +7307,7 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7911,14 +7322,13 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeColon(
     _ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeColon)
+    let newData = data.replacingChild(raw, at: 0)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -7932,14 +7342,13 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> OperatorPrecedenceAndTypesSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 1)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -7954,7 +7363,7 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes(
     _ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes)
+    let newData = data.replacingChild(raw, at: 2)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
@@ -7963,8 +7372,7 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var precedenceGroupAndDesignatedTypes: IdentifierListSyntax {
     get {
-      let childData = data.child(at: Cursor.precedenceGroupAndDesignatedTypes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return IdentifierListSyntax(childData!)
     }
     set(value) {
@@ -7980,14 +7388,13 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `precedenceGroupAndDesignatedTypes` collection.
   public func addPrecedenceGroupAndDesignatedType(_ element: TokenSyntax) -> OperatorPrecedenceAndTypesSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.precedenceGroupAndDesignatedTypes] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.identifierList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.precedenceGroupAndDesignatedTypes)
+    let newData = data.replacingChild(collection, at: 3)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
@@ -7997,7 +7404,7 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   public func withPrecedenceGroupAndDesignatedTypes(
     _ newChild: IdentifierListSyntax?) -> OperatorPrecedenceAndTypesSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.identifierList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.precedenceGroupAndDesignatedTypes)
+    let newData = data.replacingChild(raw, at: 3)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 }
@@ -8020,15 +7427,6 @@ extension OperatorPrecedenceAndTypesSyntax: CustomReflectable {
 /// groups.
 /// 
 public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeHigherThanOrLowerThan
-    case higherThanOrLowerThan
-    case unexpectedBetweenHigherThanOrLowerThanAndColon
-    case colon
-    case unexpectedBetweenColonAndOtherNames
-    case otherNames
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PrecedenceGroupRelationSyntax` if possible. Returns
@@ -8074,8 +7472,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeHigherThanOrLowerThan: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeHigherThanOrLowerThan,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8090,7 +7487,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeHigherThanOrLowerThan(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeHigherThanOrLowerThan)
+    let newData = data.replacingChild(raw, at: 0)
     return PrecedenceGroupRelationSyntax(newData)
   }
 
@@ -8099,8 +7496,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var higherThanOrLowerThan: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.higherThanOrLowerThan,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8114,14 +7510,13 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   public func withHigherThanOrLowerThan(
     _ newChild: TokenSyntax?) -> PrecedenceGroupRelationSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.higherThanOrLowerThan)
+    let newData = data.replacingChild(raw, at: 1)
     return PrecedenceGroupRelationSyntax(newData)
   }
 
   public var unexpectedBetweenHigherThanOrLowerThanAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenHigherThanOrLowerThanAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8136,14 +7531,13 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenHigherThanOrLowerThanAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenHigherThanOrLowerThanAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return PrecedenceGroupRelationSyntax(newData)
   }
 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8157,14 +7551,13 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> PrecedenceGroupRelationSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return PrecedenceGroupRelationSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndOtherNames: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndOtherNames,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8179,7 +7572,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndOtherNames(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndOtherNames)
+    let newData = data.replacingChild(raw, at: 4)
     return PrecedenceGroupRelationSyntax(newData)
   }
 
@@ -8189,8 +7582,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var otherNames: PrecedenceGroupNameListSyntax {
     get {
-      let childData = data.child(at: Cursor.otherNames,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return PrecedenceGroupNameListSyntax(childData!)
     }
     set(value) {
@@ -8206,14 +7598,13 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `otherNames` collection.
   public func addOtherName(_ element: PrecedenceGroupNameElementSyntax) -> PrecedenceGroupRelationSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.otherNames] {
+    if let col = raw.layoutView!.children[5] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.otherNames)
+    let newData = data.replacingChild(collection, at: 5)
     return PrecedenceGroupRelationSyntax(newData)
   }
 
@@ -8223,7 +7614,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
   public func withOtherNames(
     _ newChild: PrecedenceGroupNameListSyntax?) -> PrecedenceGroupRelationSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.precedenceGroupNameList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.otherNames)
+    let newData = data.replacingChild(raw, at: 5)
     return PrecedenceGroupRelationSyntax(newData)
   }
 }
@@ -8244,13 +7635,6 @@ extension PrecedenceGroupRelationSyntax: CustomReflectable {
 // MARK: - PrecedenceGroupNameElementSyntax
 
 public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeName
-    case name
-    case unexpectedBetweenNameAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PrecedenceGroupNameElementSyntax` if possible. Returns
@@ -8292,8 +7676,7 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8308,14 +7691,13 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeName(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupNameElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeName)
+    let newData = data.replacingChild(raw, at: 0)
     return PrecedenceGroupNameElementSyntax(newData)
   }
 
   public var name: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8329,14 +7711,13 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> PrecedenceGroupNameElementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 1)
     return PrecedenceGroupNameElementSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8351,14 +7732,13 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupNameElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 2)
     return PrecedenceGroupNameElementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -8373,7 +7753,7 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> PrecedenceGroupNameElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 3)
     return PrecedenceGroupNameElementSyntax(newData)
   }
 }
@@ -8396,15 +7776,6 @@ extension PrecedenceGroupNameElementSyntax: CustomReflectable {
 /// that includes optional chaining.
 /// 
 public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAssignmentKeyword
-    case assignmentKeyword
-    case unexpectedBetweenAssignmentKeywordAndColon
-    case colon
-    case unexpectedBetweenColonAndFlag
-    case flag
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PrecedenceGroupAssignmentSyntax` if possible. Returns
@@ -8450,8 +7821,7 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAssignmentKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAssignmentKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8466,14 +7836,13 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAssignmentKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAssignmentKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
 
   public var assignmentKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.assignmentKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8487,14 +7856,13 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAssignmentKeyword(
     _ newChild: TokenSyntax?) -> PrecedenceGroupAssignmentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.assignmentKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
 
   public var unexpectedBetweenAssignmentKeywordAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAssignmentKeywordAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8509,14 +7877,13 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAssignmentKeywordAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAssignmentKeywordAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8530,14 +7897,13 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> PrecedenceGroupAssignmentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndFlag: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndFlag,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8552,7 +7918,7 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndFlag(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndFlag)
+    let newData = data.replacingChild(raw, at: 4)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
 
@@ -8565,8 +7931,7 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var flag: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.flag,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8580,7 +7945,7 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withFlag(
     _ newChild: TokenSyntax?) -> PrecedenceGroupAssignmentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.trueKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.flag)
+    let newData = data.replacingChild(raw, at: 5)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
 }
@@ -8605,15 +7970,6 @@ extension PrecedenceGroupAssignmentSyntax: CustomReflectable {
 /// are grouped together in the absence of grouping parentheses.
 /// 
 public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAssociativityKeyword
-    case associativityKeyword
-    case unexpectedBetweenAssociativityKeywordAndColon
-    case colon
-    case unexpectedBetweenColonAndValue
-    case value
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PrecedenceGroupAssociativitySyntax` if possible. Returns
@@ -8659,8 +8015,7 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
 
   public var unexpectedBeforeAssociativityKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAssociativityKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8675,14 +8030,13 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   public func withUnexpectedBeforeAssociativityKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAssociativityKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
 
   public var associativityKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.associativityKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8696,14 +8050,13 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   public func withAssociativityKeyword(
     _ newChild: TokenSyntax?) -> PrecedenceGroupAssociativitySyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.associativityKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
 
   public var unexpectedBetweenAssociativityKeywordAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAssociativityKeywordAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8718,14 +8071,13 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   public func withUnexpectedBetweenAssociativityKeywordAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAssociativityKeywordAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8739,14 +8091,13 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   public func withColon(
     _ newChild: TokenSyntax?) -> PrecedenceGroupAssociativitySyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
 
   public var unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndValue,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8761,7 +8112,7 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   public func withUnexpectedBetweenColonAndValue(
     _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndValue)
+    let newData = data.replacingChild(raw, at: 4)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
 
@@ -8773,8 +8124,7 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   /// 
   public var value: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.value,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8788,7 +8138,7 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
   public func withValue(
     _ newChild: TokenSyntax?) -> PrecedenceGroupAssociativitySyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.value)
+    let newData = data.replacingChild(raw, at: 5)
     return PrecedenceGroupAssociativitySyntax(newData)
   }
 }
@@ -8812,19 +8162,6 @@ extension PrecedenceGroupAssociativitySyntax: CustomReflectable {
 /// A custom `@` attribute.
 /// 
 public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAtSignToken
-    case atSignToken
-    case unexpectedBetweenAtSignTokenAndAttributeName
-    case attributeName
-    case unexpectedBetweenAttributeNameAndLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndArgumentList
-    case argumentList
-    case unexpectedBetweenArgumentListAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `CustomAttributeSyntax` if possible. Returns
@@ -8878,8 +8215,7 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAtSignToken: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAtSignToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8894,15 +8230,14 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAtSignToken(
     _ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAtSignToken)
+    let newData = data.replacingChild(raw, at: 0)
     return CustomAttributeSyntax(newData)
   }
 
   /// The `@` sign.
   public var atSignToken: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.atSignToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -8916,14 +8251,13 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAtSignToken(
     _ newChild: TokenSyntax?) -> CustomAttributeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.atSign, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.atSignToken)
+    let newData = data.replacingChild(raw, at: 1)
     return CustomAttributeSyntax(newData)
   }
 
   public var unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAtSignTokenAndAttributeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8938,15 +8272,14 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAtSignTokenAndAttributeName(
     _ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAtSignTokenAndAttributeName)
+    let newData = data.replacingChild(raw, at: 2)
     return CustomAttributeSyntax(newData)
   }
 
   /// The name of the attribute.
   public var attributeName: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.attributeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -8960,14 +8293,13 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAttributeName(
     _ newChild: TypeSyntax?) -> CustomAttributeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.attributeName)
+    let newData = data.replacingChild(raw, at: 3)
     return CustomAttributeSyntax(newData)
   }
 
   public var unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributeNameAndLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -8982,14 +8314,13 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributeNameAndLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributeNameAndLeftParen)
+    let newData = data.replacingChild(raw, at: 4)
     return CustomAttributeSyntax(newData)
   }
 
   public var leftParen: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -9004,14 +8335,13 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> CustomAttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 5)
     return CustomAttributeSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndArgumentList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -9026,14 +8356,13 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndArgumentList(
     _ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndArgumentList)
+    let newData = data.replacingChild(raw, at: 6)
     return CustomAttributeSyntax(newData)
   }
 
   public var argumentList: TupleExprElementListSyntax? {
     get {
-      let childData = data.child(at: Cursor.argumentList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TupleExprElementListSyntax(childData!)
     }
@@ -9050,14 +8379,13 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `argumentList` collection.
   public func addArgument(_ element: TupleExprElementSyntax) -> CustomAttributeSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.argumentList] {
+    if let col = raw.layoutView!.children[7] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.argumentList)
+    let newData = data.replacingChild(collection, at: 7)
     return CustomAttributeSyntax(newData)
   }
 
@@ -9067,14 +8395,13 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withArgumentList(
     _ newChild: TupleExprElementListSyntax?) -> CustomAttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.argumentList)
+    let newData = data.replacingChild(raw, at: 7)
     return CustomAttributeSyntax(newData)
   }
 
   public var unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenArgumentListAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -9089,14 +8416,13 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenArgumentListAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenArgumentListAndRightParen)
+    let newData = data.replacingChild(raw, at: 8)
     return CustomAttributeSyntax(newData)
   }
 
   public var rightParen: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -9111,7 +8437,7 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> CustomAttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 9)
     return CustomAttributeSyntax(newData)
   }
 }
@@ -9139,21 +8465,6 @@ extension CustomAttributeSyntax: CustomReflectable {
 /// An `@` attribute.
 /// 
 public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAtSignToken
-    case atSignToken
-    case unexpectedBetweenAtSignTokenAndAttributeName
-    case attributeName
-    case unexpectedBetweenAttributeNameAndLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndArgument
-    case argument
-    case unexpectedBetweenArgumentAndRightParen
-    case rightParen
-    case unexpectedBetweenRightParenAndTokenList
-    case tokenList
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AttributeSyntax` if possible. Returns
@@ -9211,8 +8522,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAtSignToken: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAtSignToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -9227,15 +8537,14 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAtSignToken(
     _ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAtSignToken)
+    let newData = data.replacingChild(raw, at: 0)
     return AttributeSyntax(newData)
   }
 
   /// The `@` sign.
   public var atSignToken: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.atSignToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -9249,14 +8558,13 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAtSignToken(
     _ newChild: TokenSyntax?) -> AttributeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.atSign, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.atSignToken)
+    let newData = data.replacingChild(raw, at: 1)
     return AttributeSyntax(newData)
   }
 
   public var unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAtSignTokenAndAttributeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -9271,15 +8579,14 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAtSignTokenAndAttributeName(
     _ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAtSignTokenAndAttributeName)
+    let newData = data.replacingChild(raw, at: 2)
     return AttributeSyntax(newData)
   }
 
   /// The name of the attribute.
   public var attributeName: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.attributeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -9293,14 +8600,13 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAttributeName(
     _ newChild: TokenSyntax?) -> AttributeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.attributeName)
+    let newData = data.replacingChild(raw, at: 3)
     return AttributeSyntax(newData)
   }
 
   public var unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributeNameAndLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -9315,7 +8621,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributeNameAndLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributeNameAndLeftParen)
+    let newData = data.replacingChild(raw, at: 4)
     return AttributeSyntax(newData)
   }
 
@@ -9324,8 +8630,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var leftParen: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -9340,14 +8645,13 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> AttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 5)
     return AttributeSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndArgument: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndArgument,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -9362,7 +8666,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndArgument(
     _ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndArgument)
+    let newData = data.replacingChild(raw, at: 6)
     return AttributeSyntax(newData)
   }
 
@@ -9373,8 +8677,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var argument: Syntax? {
     get {
-      let childData = data.child(at: Cursor.argument,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return Syntax(childData!)
     }
@@ -9389,14 +8692,13 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withArgument(
     _ newChild: Syntax?) -> AttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.argument)
+    let newData = data.replacingChild(raw, at: 7)
     return AttributeSyntax(newData)
   }
 
   public var unexpectedBetweenArgumentAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenArgumentAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -9411,7 +8713,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenArgumentAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenArgumentAndRightParen)
+    let newData = data.replacingChild(raw, at: 8)
     return AttributeSyntax(newData)
   }
 
@@ -9420,8 +8722,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var rightParen: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -9436,14 +8737,13 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> AttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 9)
     return AttributeSyntax(newData)
   }
 
   public var unexpectedBetweenRightParenAndTokenList: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenRightParenAndTokenList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -9458,14 +8758,13 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenRightParenAndTokenList(
     _ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenRightParenAndTokenList)
+    let newData = data.replacingChild(raw, at: 10)
     return AttributeSyntax(newData)
   }
 
   public var tokenList: TokenListSyntax? {
     get {
-      let childData = data.child(at: Cursor.tokenList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenListSyntax(childData!)
     }
@@ -9482,14 +8781,13 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `tokenList` collection.
   public func addToken(_ element: TokenSyntax) -> AttributeSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.tokenList] {
+    if let col = raw.layoutView!.children[11] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tokenList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.tokenList)
+    let newData = data.replacingChild(collection, at: 11)
     return AttributeSyntax(newData)
   }
 
@@ -9499,7 +8797,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTokenList(
     _ newChild: TokenListSyntax?) -> AttributeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.tokenList)
+    let newData = data.replacingChild(raw, at: 11)
     return AttributeSyntax(newData)
   }
 }
@@ -9529,17 +8827,6 @@ extension AttributeSyntax: CustomReflectable {
 /// The availability argument for the _specialize attribute
 /// 
 public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLabel
-    case label
-    case unexpectedBetweenLabelAndColon
-    case colon
-    case unexpectedBetweenColonAndAvailabilityList
-    case availabilityList
-    case unexpectedBetweenAvailabilityListAndSemicolon
-    case semicolon
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AvailabilityEntrySyntax` if possible. Returns
@@ -9589,8 +8876,7 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLabel: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -9605,15 +8891,14 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLabel(
     _ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLabel)
+    let newData = data.replacingChild(raw, at: 0)
     return AvailabilityEntrySyntax(newData)
   }
 
   /// The label of the argument
   public var label: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.label,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -9627,14 +8912,13 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withLabel(
     _ newChild: TokenSyntax?) -> AvailabilityEntrySyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.label)
+    let newData = data.replacingChild(raw, at: 1)
     return AvailabilityEntrySyntax(newData)
   }
 
   public var unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLabelAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -9649,15 +8933,14 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLabelAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLabelAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return AvailabilityEntrySyntax(newData)
   }
 
   /// The colon separating the label and the value
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -9671,14 +8954,13 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> AvailabilityEntrySyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return AvailabilityEntrySyntax(newData)
   }
 
   public var unexpectedBetweenColonAndAvailabilityList: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndAvailabilityList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -9693,14 +8975,13 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndAvailabilityList(
     _ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndAvailabilityList)
+    let newData = data.replacingChild(raw, at: 4)
     return AvailabilityEntrySyntax(newData)
   }
 
   public var availabilityList: AvailabilitySpecListSyntax {
     get {
-      let childData = data.child(at: Cursor.availabilityList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return AvailabilitySpecListSyntax(childData!)
     }
     set(value) {
@@ -9716,14 +8997,13 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `availabilityList` collection.
   public func addAvailability(_ element: AvailabilityArgumentSyntax) -> AvailabilityEntrySyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.availabilityList] {
+    if let col = raw.layoutView!.children[5] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.availabilitySpecList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.availabilityList)
+    let newData = data.replacingChild(collection, at: 5)
     return AvailabilityEntrySyntax(newData)
   }
 
@@ -9733,14 +9013,13 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withAvailabilityList(
     _ newChild: AvailabilitySpecListSyntax?) -> AvailabilityEntrySyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.availabilityList)
+    let newData = data.replacingChild(raw, at: 5)
     return AvailabilityEntrySyntax(newData)
   }
 
   public var unexpectedBetweenAvailabilityListAndSemicolon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAvailabilityListAndSemicolon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -9755,14 +9034,13 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAvailabilityListAndSemicolon(
     _ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAvailabilityListAndSemicolon)
+    let newData = data.replacingChild(raw, at: 6)
     return AvailabilityEntrySyntax(newData)
   }
 
   public var semicolon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.semicolon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -9776,7 +9054,7 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withSemicolon(
     _ newChild: TokenSyntax?) -> AvailabilityEntrySyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.semicolon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.semicolon)
+    let newData = data.replacingChild(raw, at: 7)
     return AvailabilityEntrySyntax(newData)
   }
 }
@@ -9803,17 +9081,6 @@ extension AvailabilityEntrySyntax: CustomReflectable {
 /// `exported: true`
 /// 
 public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLabel
-    case label
-    case unexpectedBetweenLabelAndColon
-    case colon
-    case unexpectedBetweenColonAndValue
-    case value
-    case unexpectedBetweenValueAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `LabeledSpecializeEntrySyntax` if possible. Returns
@@ -9863,8 +9130,7 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLabel: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -9879,15 +9145,14 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLabel(
     _ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLabel)
+    let newData = data.replacingChild(raw, at: 0)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
   /// The label of the argument
   public var label: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.label,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -9901,14 +9166,13 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withLabel(
     _ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.label)
+    let newData = data.replacingChild(raw, at: 1)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
   public var unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLabelAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -9923,15 +9187,14 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLabelAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLabelAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
   /// The colon separating the label and the value
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -9945,14 +9208,13 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
   public var unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndValue,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -9967,15 +9229,14 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndValue(
     _ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndValue)
+    let newData = data.replacingChild(raw, at: 4)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
   /// The value for this argument
   public var value: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.value,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -9989,14 +9250,13 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withValue(
     _ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.value)
+    let newData = data.replacingChild(raw, at: 5)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
   public var unexpectedBetweenValueAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenValueAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -10011,7 +9271,7 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenValueAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenValueAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 6)
     return LabeledSpecializeEntrySyntax(newData)
   }
 
@@ -10020,8 +9280,7 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -10036,7 +9295,7 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 7)
     return LabeledSpecializeEntrySyntax(newData)
   }
 }
@@ -10064,17 +9323,6 @@ extension LabeledSpecializeEntrySyntax: CustomReflectable {
 /// `target: myFunc(_:)`
 /// 
 public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLabel
-    case label
-    case unexpectedBetweenLabelAndColon
-    case colon
-    case unexpectedBetweenColonAndDeclname
-    case declname
-    case unexpectedBetweenDeclnameAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TargetFunctionEntrySyntax` if possible. Returns
@@ -10124,8 +9372,7 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLabel: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -10140,15 +9387,14 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLabel(
     _ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLabel)
+    let newData = data.replacingChild(raw, at: 0)
     return TargetFunctionEntrySyntax(newData)
   }
 
   /// The label of the argument
   public var label: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.label,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -10162,14 +9408,13 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withLabel(
     _ newChild: TokenSyntax?) -> TargetFunctionEntrySyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.label)
+    let newData = data.replacingChild(raw, at: 1)
     return TargetFunctionEntrySyntax(newData)
   }
 
   public var unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLabelAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -10184,15 +9429,14 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLabelAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLabelAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return TargetFunctionEntrySyntax(newData)
   }
 
   /// The colon separating the label and the value
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -10206,14 +9450,13 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> TargetFunctionEntrySyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return TargetFunctionEntrySyntax(newData)
   }
 
   public var unexpectedBetweenColonAndDeclname: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndDeclname,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -10228,15 +9471,14 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndDeclname(
     _ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndDeclname)
+    let newData = data.replacingChild(raw, at: 4)
     return TargetFunctionEntrySyntax(newData)
   }
 
   /// The value for this argument
   public var declname: DeclNameSyntax {
     get {
-      let childData = data.child(at: Cursor.declname,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return DeclNameSyntax(childData!)
     }
     set(value) {
@@ -10250,14 +9492,13 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withDeclname(
     _ newChild: DeclNameSyntax?) -> TargetFunctionEntrySyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.declName, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.declname)
+    let newData = data.replacingChild(raw, at: 5)
     return TargetFunctionEntrySyntax(newData)
   }
 
   public var unexpectedBetweenDeclnameAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDeclnameAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -10272,7 +9513,7 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenDeclnameAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDeclnameAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 6)
     return TargetFunctionEntrySyntax(newData)
   }
 
@@ -10281,8 +9522,7 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -10297,7 +9537,7 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> TargetFunctionEntrySyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 7)
     return TargetFunctionEntrySyntax(newData)
   }
 }
@@ -10325,15 +9565,6 @@ extension TargetFunctionEntrySyntax: CustomReflectable {
 /// "Src.swift"`
 /// 
 public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeNameTok
-    case nameTok
-    case unexpectedBetweenNameTokAndColon
-    case colon
-    case unexpectedBetweenColonAndStringOrDeclname
-    case stringOrDeclname
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `NamedAttributeStringArgumentSyntax` if possible. Returns
@@ -10379,8 +9610,7 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
 
   public var unexpectedBeforeNameTok: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeNameTok,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -10395,15 +9625,14 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   public func withUnexpectedBeforeNameTok(
     _ newChild: UnexpectedNodesSyntax?) -> NamedAttributeStringArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeNameTok)
+    let newData = data.replacingChild(raw, at: 0)
     return NamedAttributeStringArgumentSyntax(newData)
   }
 
   /// The label of the argument
   public var nameTok: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.nameTok,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -10417,14 +9646,13 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   public func withNameTok(
     _ newChild: TokenSyntax?) -> NamedAttributeStringArgumentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.nameTok)
+    let newData = data.replacingChild(raw, at: 1)
     return NamedAttributeStringArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenNameTokAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameTokAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -10439,15 +9667,14 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   public func withUnexpectedBetweenNameTokAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> NamedAttributeStringArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameTokAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return NamedAttributeStringArgumentSyntax(newData)
   }
 
   /// The colon separating the label and the value
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -10461,14 +9688,13 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   public func withColon(
     _ newChild: TokenSyntax?) -> NamedAttributeStringArgumentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return NamedAttributeStringArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndStringOrDeclname: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndStringOrDeclname,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -10483,14 +9709,13 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   public func withUnexpectedBetweenColonAndStringOrDeclname(
     _ newChild: UnexpectedNodesSyntax?) -> NamedAttributeStringArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndStringOrDeclname)
+    let newData = data.replacingChild(raw, at: 4)
     return NamedAttributeStringArgumentSyntax(newData)
   }
 
   public var stringOrDeclname: Syntax {
     get {
-      let childData = data.child(at: Cursor.stringOrDeclname,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -10504,7 +9729,7 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
   public func withStringOrDeclname(
     _ newChild: Syntax?) -> NamedAttributeStringArgumentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.stringOrDeclname)
+    let newData = data.replacingChild(raw, at: 5)
     return NamedAttributeStringArgumentSyntax(newData)
   }
 }
@@ -10525,13 +9750,6 @@ extension NamedAttributeStringArgumentSyntax: CustomReflectable {
 // MARK: - DeclNameSyntax
 
 public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeDeclBaseName
-    case declBaseName
-    case unexpectedBetweenDeclBaseNameAndDeclNameArguments
-    case declNameArguments
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DeclNameSyntax` if possible. Returns
@@ -10573,8 +9791,7 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeDeclBaseName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeDeclBaseName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -10589,7 +9806,7 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeDeclBaseName(
     _ newChild: UnexpectedNodesSyntax?) -> DeclNameSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeDeclBaseName)
+    let newData = data.replacingChild(raw, at: 0)
     return DeclNameSyntax(newData)
   }
 
@@ -10598,8 +9815,7 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var declBaseName: Syntax {
     get {
-      let childData = data.child(at: Cursor.declBaseName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -10613,14 +9829,13 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withDeclBaseName(
     _ newChild: Syntax?) -> DeclNameSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.declBaseName)
+    let newData = data.replacingChild(raw, at: 1)
     return DeclNameSyntax(newData)
   }
 
   public var unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDeclBaseNameAndDeclNameArguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -10635,7 +9850,7 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenDeclBaseNameAndDeclNameArguments(
     _ newChild: UnexpectedNodesSyntax?) -> DeclNameSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDeclBaseNameAndDeclNameArguments)
+    let newData = data.replacingChild(raw, at: 2)
     return DeclNameSyntax(newData)
   }
 
@@ -10645,8 +9860,7 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var declNameArguments: DeclNameArgumentsSyntax? {
     get {
-      let childData = data.child(at: Cursor.declNameArguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return DeclNameArgumentsSyntax(childData!)
     }
@@ -10661,7 +9875,7 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withDeclNameArguments(
     _ newChild: DeclNameArgumentsSyntax?) -> DeclNameSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.declNameArguments)
+    let newData = data.replacingChild(raw, at: 3)
     return DeclNameSyntax(newData)
   }
 }
@@ -10684,17 +9898,6 @@ extension DeclNameSyntax: CustomReflectable {
 /// `Type, methodName(arg1Label:arg2Label:)`
 /// 
 public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeType
-    case type
-    case unexpectedBetweenTypeAndComma
-    case comma
-    case unexpectedBetweenCommaAndDeclBaseName
-    case declBaseName
-    case unexpectedBetweenDeclBaseNameAndDeclNameArguments
-    case declNameArguments
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ImplementsAttributeArgumentsSyntax` if possible. Returns
@@ -10744,8 +9947,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
 
   public var unexpectedBeforeType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -10760,7 +9962,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   public func withUnexpectedBeforeType(
     _ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeType)
+    let newData = data.replacingChild(raw, at: 0)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
@@ -10770,8 +9972,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// 
   public var type: SimpleTypeIdentifierSyntax {
     get {
-      let childData = data.child(at: Cursor.type,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return SimpleTypeIdentifierSyntax(childData!)
     }
     set(value) {
@@ -10785,14 +9986,13 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   public func withType(
     _ newChild: SimpleTypeIdentifierSyntax?) -> ImplementsAttributeArgumentsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.simpleTypeIdentifier, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.type)
+    let newData = data.replacingChild(raw, at: 1)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAndComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTypeAndComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -10807,7 +10007,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   public func withUnexpectedBetweenTypeAndComma(
     _ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTypeAndComma)
+    let newData = data.replacingChild(raw, at: 2)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
@@ -10816,8 +10016,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// 
   public var comma: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.comma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -10831,14 +10030,13 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   public func withComma(
     _ newChild: TokenSyntax?) -> ImplementsAttributeArgumentsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.comma)
+    let newData = data.replacingChild(raw, at: 3)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenCommaAndDeclBaseName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCommaAndDeclBaseName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -10853,7 +10051,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   public func withUnexpectedBetweenCommaAndDeclBaseName(
     _ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCommaAndDeclBaseName)
+    let newData = data.replacingChild(raw, at: 4)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
@@ -10862,8 +10060,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// 
   public var declBaseName: Syntax {
     get {
-      let childData = data.child(at: Cursor.declBaseName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -10877,14 +10074,13 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   public func withDeclBaseName(
     _ newChild: Syntax?) -> ImplementsAttributeArgumentsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.declBaseName)
+    let newData = data.replacingChild(raw, at: 5)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDeclBaseNameAndDeclNameArguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -10899,7 +10095,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   public func withUnexpectedBetweenDeclBaseNameAndDeclNameArguments(
     _ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDeclBaseNameAndDeclNameArguments)
+    let newData = data.replacingChild(raw, at: 6)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
@@ -10909,8 +10105,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   /// 
   public var declNameArguments: DeclNameArgumentsSyntax? {
     get {
-      let childData = data.child(at: Cursor.declNameArguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return DeclNameArgumentsSyntax(childData!)
     }
@@ -10925,7 +10120,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
   public func withDeclNameArguments(
     _ newChild: DeclNameArgumentsSyntax?) -> ImplementsAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.declNameArguments)
+    let newData = data.replacingChild(raw, at: 7)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 }
@@ -10953,13 +10148,6 @@ extension ImplementsAttributeArgumentsSyntax: CustomReflectable {
 /// labeled argument or just a colon for an unlabeled argument
 /// 
 public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeName
-    case name
-    case unexpectedBetweenNameAndColon
-    case colon
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ObjCSelectorPieceSyntax` if possible. Returns
@@ -11001,8 +10189,7 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -11017,14 +10204,13 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeName(
     _ newChild: UnexpectedNodesSyntax?) -> ObjCSelectorPieceSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeName)
+    let newData = data.replacingChild(raw, at: 0)
     return ObjCSelectorPieceSyntax(newData)
   }
 
   public var name: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -11039,14 +10225,13 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> ObjCSelectorPieceSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 1)
     return ObjCSelectorPieceSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -11061,14 +10246,13 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> ObjCSelectorPieceSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return ObjCSelectorPieceSyntax(newData)
   }
 
   public var colon: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -11083,7 +10267,7 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> ObjCSelectorPieceSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return ObjCSelectorPieceSyntax(newData)
   }
 }
@@ -11107,19 +10291,6 @@ extension ObjCSelectorPieceSyntax: CustomReflectable {
 /// and an optional 'where' clause.
 /// 
 public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeDiffKind
-    case diffKind
-    case unexpectedBetweenDiffKindAndDiffKindComma
-    case diffKindComma
-    case unexpectedBetweenDiffKindCommaAndDiffParams
-    case diffParams
-    case unexpectedBetweenDiffParamsAndDiffParamsComma
-    case diffParamsComma
-    case unexpectedBetweenDiffParamsCommaAndWhereClause
-    case whereClause
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DifferentiableAttributeArgumentsSyntax` if possible. Returns
@@ -11173,8 +10344,7 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
 
   public var unexpectedBeforeDiffKind: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeDiffKind,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -11189,14 +10359,13 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   public func withUnexpectedBeforeDiffKind(
     _ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeDiffKind)
+    let newData = data.replacingChild(raw, at: 0)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public var diffKind: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.diffKind,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -11211,14 +10380,13 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   public func withDiffKind(
     _ newChild: TokenSyntax?) -> DifferentiableAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.diffKind)
+    let newData = data.replacingChild(raw, at: 1)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenDiffKindAndDiffKindComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDiffKindAndDiffKindComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -11233,7 +10401,7 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   public func withUnexpectedBetweenDiffKindAndDiffKindComma(
     _ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDiffKindAndDiffKindComma)
+    let newData = data.replacingChild(raw, at: 2)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
@@ -11242,8 +10410,7 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   /// 
   public var diffKindComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.diffKindComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -11258,14 +10425,13 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   public func withDiffKindComma(
     _ newChild: TokenSyntax?) -> DifferentiableAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.diffKindComma)
+    let newData = data.replacingChild(raw, at: 3)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenDiffKindCommaAndDiffParams: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDiffKindCommaAndDiffParams,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -11280,14 +10446,13 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   public func withUnexpectedBetweenDiffKindCommaAndDiffParams(
     _ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDiffKindCommaAndDiffParams)
+    let newData = data.replacingChild(raw, at: 4)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public var diffParams: DifferentiabilityParamsClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.diffParams,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return DifferentiabilityParamsClauseSyntax(childData!)
     }
@@ -11302,14 +10467,13 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   public func withDiffParams(
     _ newChild: DifferentiabilityParamsClauseSyntax?) -> DifferentiableAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.diffParams)
+    let newData = data.replacingChild(raw, at: 5)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenDiffParamsAndDiffParamsComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDiffParamsAndDiffParamsComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -11324,7 +10488,7 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   public func withUnexpectedBetweenDiffParamsAndDiffParamsComma(
     _ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDiffParamsAndDiffParamsComma)
+    let newData = data.replacingChild(raw, at: 6)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
@@ -11334,8 +10498,7 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   /// 
   public var diffParamsComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.diffParamsComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -11350,14 +10513,13 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   public func withDiffParamsComma(
     _ newChild: TokenSyntax?) -> DifferentiableAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.diffParamsComma)
+    let newData = data.replacingChild(raw, at: 7)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenDiffParamsCommaAndWhereClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDiffParamsCommaAndWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -11372,14 +10534,13 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   public func withUnexpectedBetweenDiffParamsCommaAndWhereClause(
     _ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDiffParamsCommaAndWhereClause)
+    let newData = data.replacingChild(raw, at: 8)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
   public var whereClause: GenericWhereClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.whereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericWhereClauseSyntax(childData!)
     }
@@ -11394,7 +10555,7 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
   public func withWhereClause(
     _ newChild: GenericWhereClauseSyntax?) -> DifferentiableAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.whereClause)
+    let newData = data.replacingChild(raw, at: 9)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 }
@@ -11420,15 +10581,6 @@ extension DifferentiableAttributeArgumentsSyntax: CustomReflectable {
 
 /// A clause containing differentiability parameters.
 public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeWrtLabel
-    case wrtLabel
-    case unexpectedBetweenWrtLabelAndColon
-    case colon
-    case unexpectedBetweenColonAndParameters
-    case parameters
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DifferentiabilityParamsClauseSyntax` if possible. Returns
@@ -11474,8 +10626,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
 
   public var unexpectedBeforeWrtLabel: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeWrtLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -11490,15 +10641,14 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   public func withUnexpectedBeforeWrtLabel(
     _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeWrtLabel)
+    let newData = data.replacingChild(raw, at: 0)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
 
   /// The "wrt" label.
   public var wrtLabel: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.wrtLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -11512,14 +10662,13 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   public func withWrtLabel(
     _ newChild: TokenSyntax?) -> DifferentiabilityParamsClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.wrtLabel)
+    let newData = data.replacingChild(raw, at: 1)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
 
   public var unexpectedBetweenWrtLabelAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenWrtLabelAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -11534,7 +10683,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   public func withUnexpectedBetweenWrtLabelAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenWrtLabelAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
 
@@ -11543,8 +10692,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   /// 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -11558,14 +10706,13 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   public func withColon(
     _ newChild: TokenSyntax?) -> DifferentiabilityParamsClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndParameters: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndParameters,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -11580,14 +10727,13 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   public func withUnexpectedBetweenColonAndParameters(
     _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndParameters)
+    let newData = data.replacingChild(raw, at: 4)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
 
   public var parameters: Syntax {
     get {
-      let childData = data.child(at: Cursor.parameters,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -11601,7 +10747,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
   public func withParameters(
     _ newChild: Syntax?) -> DifferentiabilityParamsClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.parameters)
+    let newData = data.replacingChild(raw, at: 5)
     return DifferentiabilityParamsClauseSyntax(newData)
   }
 }
@@ -11623,15 +10769,6 @@ extension DifferentiabilityParamsClauseSyntax: CustomReflectable {
 
 /// The differentiability parameters.
 public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndDiffParams
-    case diffParams
-    case unexpectedBetweenDiffParamsAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DifferentiabilityParamsSyntax` if possible. Returns
@@ -11677,8 +10814,7 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -11693,14 +10829,13 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftParen)
+    let newData = data.replacingChild(raw, at: 0)
     return DifferentiabilityParamsSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -11714,14 +10849,13 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> DifferentiabilityParamsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 1)
     return DifferentiabilityParamsSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndDiffParams: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndDiffParams,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -11736,15 +10870,14 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndDiffParams(
     _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndDiffParams)
+    let newData = data.replacingChild(raw, at: 2)
     return DifferentiabilityParamsSyntax(newData)
   }
 
   /// The parameters for differentiation.
   public var diffParams: DifferentiabilityParamListSyntax {
     get {
-      let childData = data.child(at: Cursor.diffParams,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return DifferentiabilityParamListSyntax(childData!)
     }
     set(value) {
@@ -11760,14 +10893,13 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `diffParams` collection.
   public func addDifferentiabilityParam(_ element: DifferentiabilityParamSyntax) -> DifferentiabilityParamsSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.diffParams] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.diffParams)
+    let newData = data.replacingChild(collection, at: 3)
     return DifferentiabilityParamsSyntax(newData)
   }
 
@@ -11777,14 +10909,13 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withDiffParams(
     _ newChild: DifferentiabilityParamListSyntax?) -> DifferentiabilityParamsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.differentiabilityParamList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.diffParams)
+    let newData = data.replacingChild(raw, at: 3)
     return DifferentiabilityParamsSyntax(newData)
   }
 
   public var unexpectedBetweenDiffParamsAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDiffParamsAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -11799,14 +10930,13 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenDiffParamsAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDiffParamsAndRightParen)
+    let newData = data.replacingChild(raw, at: 4)
     return DifferentiabilityParamsSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -11820,7 +10950,7 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> DifferentiabilityParamsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 5)
     return DifferentiabilityParamsSyntax(newData)
   }
 }
@@ -11845,13 +10975,6 @@ extension DifferentiabilityParamsSyntax: CustomReflectable {
 /// parameter name, or a function parameter index.
 /// 
 public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeParameter
-    case parameter
-    case unexpectedBetweenParameterAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DifferentiabilityParamSyntax` if possible. Returns
@@ -11893,8 +11016,7 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeParameter: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeParameter,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -11909,14 +11031,13 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeParameter(
     _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeParameter)
+    let newData = data.replacingChild(raw, at: 0)
     return DifferentiabilityParamSyntax(newData)
   }
 
   public var parameter: Syntax {
     get {
-      let childData = data.child(at: Cursor.parameter,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -11930,14 +11051,13 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   public func withParameter(
     _ newChild: Syntax?) -> DifferentiabilityParamSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.parameter)
+    let newData = data.replacingChild(raw, at: 1)
     return DifferentiabilityParamSyntax(newData)
   }
 
   public var unexpectedBetweenParameterAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenParameterAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -11952,14 +11072,13 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenParameterAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenParameterAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 2)
     return DifferentiabilityParamSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -11974,7 +11093,7 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> DifferentiabilityParamSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 3)
     return DifferentiabilityParamSyntax(newData)
   }
 }
@@ -11998,23 +11117,6 @@ extension DifferentiabilityParamSyntax: CustomReflectable {
 /// optional differentiability parameter list.
 /// 
 public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeOfLabel
-    case ofLabel
-    case unexpectedBetweenOfLabelAndColon
-    case colon
-    case unexpectedBetweenColonAndOriginalDeclName
-    case originalDeclName
-    case unexpectedBetweenOriginalDeclNameAndPeriod
-    case period
-    case unexpectedBetweenPeriodAndAccessorKind
-    case accessorKind
-    case unexpectedBetweenAccessorKindAndComma
-    case comma
-    case unexpectedBetweenCommaAndDiffParams
-    case diffParams
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DerivativeRegistrationAttributeArgumentsSyntax` if possible. Returns
@@ -12076,8 +11178,7 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
 
   public var unexpectedBeforeOfLabel: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeOfLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -12092,15 +11193,14 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   public func withUnexpectedBeforeOfLabel(
     _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeOfLabel)
+    let newData = data.replacingChild(raw, at: 0)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   /// The "of" label.
   public var ofLabel: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.ofLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -12114,14 +11214,13 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   public func withOfLabel(
     _ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.ofLabel)
+    let newData = data.replacingChild(raw, at: 1)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenOfLabelAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenOfLabelAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -12136,7 +11235,7 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   public func withUnexpectedBetweenOfLabelAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenOfLabelAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -12146,8 +11245,7 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -12161,14 +11259,13 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   public func withColon(
     _ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndOriginalDeclName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndOriginalDeclName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -12183,15 +11280,14 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   public func withUnexpectedBetweenColonAndOriginalDeclName(
     _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndOriginalDeclName)
+    let newData = data.replacingChild(raw, at: 4)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   /// The referenced original declaration name.
   public var originalDeclName: QualifiedDeclNameSyntax {
     get {
-      let childData = data.child(at: Cursor.originalDeclName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return QualifiedDeclNameSyntax(childData!)
     }
     set(value) {
@@ -12205,14 +11301,13 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   public func withOriginalDeclName(
     _ newChild: QualifiedDeclNameSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.qualifiedDeclName, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.originalDeclName)
+    let newData = data.replacingChild(raw, at: 5)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenOriginalDeclNameAndPeriod: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenOriginalDeclNameAndPeriod,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -12227,7 +11322,7 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   public func withUnexpectedBetweenOriginalDeclNameAndPeriod(
     _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenOriginalDeclNameAndPeriod)
+    let newData = data.replacingChild(raw, at: 6)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
@@ -12237,8 +11332,7 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   /// 
   public var period: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.period,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -12253,14 +11347,13 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   public func withPeriod(
     _ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.period)
+    let newData = data.replacingChild(raw, at: 7)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenPeriodAndAccessorKind: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPeriodAndAccessorKind,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -12275,15 +11368,14 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   public func withUnexpectedBetweenPeriodAndAccessorKind(
     _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPeriodAndAccessorKind)
+    let newData = data.replacingChild(raw, at: 8)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   /// The accessor name.
   public var accessorKind: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.accessorKind,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -12298,14 +11390,13 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   public func withAccessorKind(
     _ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.accessorKind)
+    let newData = data.replacingChild(raw, at: 9)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenAccessorKindAndComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAccessorKindAndComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -12320,14 +11411,13 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   public func withUnexpectedBetweenAccessorKindAndComma(
     _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAccessorKindAndComma)
+    let newData = data.replacingChild(raw, at: 10)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var comma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.comma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -12342,14 +11432,13 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   public func withComma(
     _ newChild: TokenSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.comma)
+    let newData = data.replacingChild(raw, at: 11)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var unexpectedBetweenCommaAndDiffParams: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCommaAndDiffParams,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -12364,14 +11453,13 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   public func withUnexpectedBetweenCommaAndDiffParams(
     _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCommaAndDiffParams)
+    let newData = data.replacingChild(raw, at: 12)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
   public var diffParams: DifferentiabilityParamsClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.diffParams,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       if childData == nil { return nil }
       return DifferentiabilityParamsClauseSyntax(childData!)
     }
@@ -12386,7 +11474,7 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
   public func withDiffParams(
     _ newChild: DifferentiabilityParamsClauseSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.diffParams)
+    let newData = data.replacingChild(raw, at: 13)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 }
@@ -12419,17 +11507,6 @@ extension DerivativeRegistrationAttributeArgumentsSyntax: CustomReflectable {
 /// `A.B.C.foo(_:_:)`).
 /// 
 public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeBaseType
-    case baseType
-    case unexpectedBetweenBaseTypeAndDot
-    case dot
-    case unexpectedBetweenDotAndName
-    case name
-    case unexpectedBetweenNameAndArguments
-    case arguments
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `QualifiedDeclNameSyntax` if possible. Returns
@@ -12479,8 +11556,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeBaseType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeBaseType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -12495,7 +11571,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeBaseType(
     _ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeBaseType)
+    let newData = data.replacingChild(raw, at: 0)
     return QualifiedDeclNameSyntax(newData)
   }
 
@@ -12504,8 +11580,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var baseType: TypeSyntax? {
     get {
-      let childData = data.child(at: Cursor.baseType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeSyntax(childData!)
     }
@@ -12520,14 +11595,13 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withBaseType(
     _ newChild: TypeSyntax?) -> QualifiedDeclNameSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.baseType)
+    let newData = data.replacingChild(raw, at: 1)
     return QualifiedDeclNameSyntax(newData)
   }
 
   public var unexpectedBetweenBaseTypeAndDot: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenBaseTypeAndDot,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -12542,14 +11616,13 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenBaseTypeAndDot(
     _ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenBaseTypeAndDot)
+    let newData = data.replacingChild(raw, at: 2)
     return QualifiedDeclNameSyntax(newData)
   }
 
   public var dot: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.dot,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -12564,14 +11637,13 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withDot(
     _ newChild: TokenSyntax?) -> QualifiedDeclNameSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.dot)
+    let newData = data.replacingChild(raw, at: 3)
     return QualifiedDeclNameSyntax(newData)
   }
 
   public var unexpectedBetweenDotAndName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDotAndName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -12586,7 +11658,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenDotAndName(
     _ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDotAndName)
+    let newData = data.replacingChild(raw, at: 4)
     return QualifiedDeclNameSyntax(newData)
   }
 
@@ -12595,8 +11667,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var name: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -12610,14 +11681,13 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> QualifiedDeclNameSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 5)
     return QualifiedDeclNameSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndArguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -12632,7 +11702,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndArguments(
     _ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndArguments)
+    let newData = data.replacingChild(raw, at: 6)
     return QualifiedDeclNameSyntax(newData)
   }
 
@@ -12642,8 +11712,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var arguments: DeclNameArgumentsSyntax? {
     get {
-      let childData = data.child(at: Cursor.arguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return DeclNameArgumentsSyntax(childData!)
     }
@@ -12658,7 +11727,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withArguments(
     _ newChild: DeclNameArgumentsSyntax?) -> QualifiedDeclNameSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.arguments)
+    let newData = data.replacingChild(raw, at: 7)
     return QualifiedDeclNameSyntax(newData)
   }
 }
@@ -12682,13 +11751,6 @@ extension QualifiedDeclNameSyntax: CustomReflectable {
 
 /// A function declaration name (e.g. `foo(_:_:)`).
 public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeName
-    case name
-    case unexpectedBetweenNameAndArguments
-    case arguments
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `FunctionDeclNameSyntax` if possible. Returns
@@ -12730,8 +11792,7 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -12746,7 +11807,7 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeName(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclNameSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeName)
+    let newData = data.replacingChild(raw, at: 0)
     return FunctionDeclNameSyntax(newData)
   }
 
@@ -12755,8 +11816,7 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var name: Syntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -12770,14 +11830,13 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: Syntax?) -> FunctionDeclNameSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 1)
     return FunctionDeclNameSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndArguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -12792,7 +11851,7 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndArguments(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclNameSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndArguments)
+    let newData = data.replacingChild(raw, at: 2)
     return FunctionDeclNameSyntax(newData)
   }
 
@@ -12802,8 +11861,7 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var arguments: DeclNameArgumentsSyntax? {
     get {
-      let childData = data.child(at: Cursor.arguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return DeclNameArgumentsSyntax(childData!)
     }
@@ -12818,7 +11876,7 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
   public func withArguments(
     _ newChild: DeclNameArgumentsSyntax?) -> FunctionDeclNameSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.arguments)
+    let newData = data.replacingChild(raw, at: 3)
     return FunctionDeclNameSyntax(newData)
   }
 }
@@ -12840,15 +11898,6 @@ extension FunctionDeclNameSyntax: CustomReflectable {
 /// A collection of arguments for the `@_backDeploy` attribute
 /// 
 public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeBeforeLabel
-    case beforeLabel
-    case unexpectedBetweenBeforeLabelAndColon
-    case colon
-    case unexpectedBetweenColonAndVersionList
-    case versionList
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `BackDeployAttributeSpecListSyntax` if possible. Returns
@@ -12894,8 +11943,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
 
   public var unexpectedBeforeBeforeLabel: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeBeforeLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -12910,15 +11958,14 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   public func withUnexpectedBeforeBeforeLabel(
     _ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeBeforeLabel)
+    let newData = data.replacingChild(raw, at: 0)
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
   /// The "before" label.
   public var beforeLabel: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.beforeLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -12932,14 +11979,13 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   public func withBeforeLabel(
     _ newChild: TokenSyntax?) -> BackDeployAttributeSpecListSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.beforeLabel)
+    let newData = data.replacingChild(raw, at: 1)
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
   public var unexpectedBetweenBeforeLabelAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenBeforeLabelAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -12954,7 +12000,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   public func withUnexpectedBetweenBeforeLabelAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenBeforeLabelAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
@@ -12963,8 +12009,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   /// 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -12978,14 +12023,13 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   public func withColon(
     _ newChild: TokenSyntax?) -> BackDeployAttributeSpecListSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndVersionList: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndVersionList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -13000,7 +12044,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   public func withUnexpectedBetweenColonAndVersionList(
     _ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndVersionList)
+    let newData = data.replacingChild(raw, at: 4)
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
@@ -13010,8 +12054,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   /// 
   public var versionList: BackDeployVersionListSyntax {
     get {
-      let childData = data.child(at: Cursor.versionList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return BackDeployVersionListSyntax(childData!)
     }
     set(value) {
@@ -13027,14 +12070,13 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   ///            appended to its `versionList` collection.
   public func addAvailability(_ element: BackDeployVersionArgumentSyntax) -> BackDeployAttributeSpecListSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.versionList] {
+    if let col = raw.layoutView!.children[5] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.backDeployVersionList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.versionList)
+    let newData = data.replacingChild(collection, at: 5)
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
@@ -13044,7 +12086,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
   public func withVersionList(
     _ newChild: BackDeployVersionListSyntax?) -> BackDeployAttributeSpecListSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.backDeployVersionList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.versionList)
+    let newData = data.replacingChild(raw, at: 5)
     return BackDeployAttributeSpecListSyntax(newData)
   }
 }
@@ -13069,13 +12111,6 @@ extension BackDeployAttributeSpecListSyntax: CustomReflectable {
 /// e.g. `iOS 10.1`.
 /// 
 public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAvailabilityVersionRestriction
-    case availabilityVersionRestriction
-    case unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `BackDeployVersionArgumentSyntax` if possible. Returns
@@ -13117,8 +12152,7 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAvailabilityVersionRestriction: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAvailabilityVersionRestriction,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -13133,14 +12167,13 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAvailabilityVersionRestriction(
     _ newChild: UnexpectedNodesSyntax?) -> BackDeployVersionArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAvailabilityVersionRestriction)
+    let newData = data.replacingChild(raw, at: 0)
     return BackDeployVersionArgumentSyntax(newData)
   }
 
   public var availabilityVersionRestriction: AvailabilityVersionRestrictionSyntax {
     get {
-      let childData = data.child(at: Cursor.availabilityVersionRestriction,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return AvailabilityVersionRestrictionSyntax(childData!)
     }
     set(value) {
@@ -13154,14 +12187,13 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAvailabilityVersionRestriction(
     _ newChild: AvailabilityVersionRestrictionSyntax?) -> BackDeployVersionArgumentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilityVersionRestriction, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.availabilityVersionRestriction)
+    let newData = data.replacingChild(raw, at: 1)
     return BackDeployVersionArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -13176,7 +12208,7 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> BackDeployVersionArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 2)
     return BackDeployVersionArgumentSyntax(newData)
   }
 
@@ -13186,8 +12218,7 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -13202,7 +12233,7 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> BackDeployVersionArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 3)
     return BackDeployVersionArgumentSyntax(newData)
   }
 }
@@ -13221,13 +12252,6 @@ extension BackDeployVersionArgumentSyntax: CustomReflectable {
 // MARK: - WhereClauseSyntax
 
 public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeWhereKeyword
-    case whereKeyword
-    case unexpectedBetweenWhereKeywordAndGuardResult
-    case guardResult
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `WhereClauseSyntax` if possible. Returns
@@ -13269,8 +12293,7 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeWhereKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeWhereKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -13285,14 +12308,13 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeWhereKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> WhereClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeWhereKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return WhereClauseSyntax(newData)
   }
 
   public var whereKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.whereKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -13306,14 +12328,13 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withWhereKeyword(
     _ newChild: TokenSyntax?) -> WhereClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whereKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.whereKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return WhereClauseSyntax(newData)
   }
 
   public var unexpectedBetweenWhereKeywordAndGuardResult: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenWhereKeywordAndGuardResult,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -13328,14 +12349,13 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenWhereKeywordAndGuardResult(
     _ newChild: UnexpectedNodesSyntax?) -> WhereClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenWhereKeywordAndGuardResult)
+    let newData = data.replacingChild(raw, at: 2)
     return WhereClauseSyntax(newData)
   }
 
   public var guardResult: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.guardResult,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -13349,7 +12369,7 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withGuardResult(
     _ newChild: ExprSyntax?) -> WhereClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.guardResult)
+    let newData = data.replacingChild(raw, at: 3)
     return WhereClauseSyntax(newData)
   }
 }
@@ -13368,17 +12388,6 @@ extension WhereClauseSyntax: CustomReflectable {
 // MARK: - YieldListSyntax
 
 public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndElementList
-    case elementList
-    case unexpectedBetweenElementListAndTrailingComma
-    case trailingComma
-    case unexpectedBetweenTrailingCommaAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `YieldListSyntax` if possible. Returns
@@ -13428,8 +12437,7 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -13444,14 +12452,13 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftParen)
+    let newData = data.replacingChild(raw, at: 0)
     return YieldListSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -13465,14 +12472,13 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> YieldListSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 1)
     return YieldListSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndElementList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -13487,14 +12493,13 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndElementList(
     _ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndElementList)
+    let newData = data.replacingChild(raw, at: 2)
     return YieldListSyntax(newData)
   }
 
   public var elementList: ExprListSyntax {
     get {
-      let childData = data.child(at: Cursor.elementList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return ExprListSyntax(childData!)
     }
     set(value) {
@@ -13510,14 +12515,13 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `elementList` collection.
   public func addElement(_ element: ExprSyntax) -> YieldListSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.elementList] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.exprList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.elementList)
+    let newData = data.replacingChild(collection, at: 3)
     return YieldListSyntax(newData)
   }
 
@@ -13527,14 +12531,13 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   public func withElementList(
     _ newChild: ExprListSyntax?) -> YieldListSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.exprList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.elementList)
+    let newData = data.replacingChild(raw, at: 3)
     return YieldListSyntax(newData)
   }
 
   public var unexpectedBetweenElementListAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenElementListAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -13549,14 +12552,13 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenElementListAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenElementListAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 4)
     return YieldListSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -13571,14 +12573,13 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> YieldListSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 5)
     return YieldListSyntax(newData)
   }
 
   public var unexpectedBetweenTrailingCommaAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTrailingCommaAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -13593,14 +12594,13 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTrailingCommaAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTrailingCommaAndRightParen)
+    let newData = data.replacingChild(raw, at: 6)
     return YieldListSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -13614,7 +12614,7 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> YieldListSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 7)
     return YieldListSyntax(newData)
   }
 }
@@ -13637,13 +12637,6 @@ extension YieldListSyntax: CustomReflectable {
 // MARK: - ConditionElementSyntax
 
 public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeCondition
-    case condition
-    case unexpectedBetweenConditionAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ConditionElementSyntax` if possible. Returns
@@ -13685,8 +12678,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeCondition: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeCondition,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -13701,14 +12693,13 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeCondition(
     _ newChild: UnexpectedNodesSyntax?) -> ConditionElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeCondition)
+    let newData = data.replacingChild(raw, at: 0)
     return ConditionElementSyntax(newData)
   }
 
   public var condition: Syntax {
     get {
-      let childData = data.child(at: Cursor.condition,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -13722,14 +12713,13 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withCondition(
     _ newChild: Syntax?) -> ConditionElementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.condition)
+    let newData = data.replacingChild(raw, at: 1)
     return ConditionElementSyntax(newData)
   }
 
   public var unexpectedBetweenConditionAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenConditionAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -13744,14 +12734,13 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenConditionAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> ConditionElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenConditionAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 2)
     return ConditionElementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -13766,7 +12755,7 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> ConditionElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 3)
     return ConditionElementSyntax(newData)
   }
 }
@@ -13785,17 +12774,6 @@ extension ConditionElementSyntax: CustomReflectable {
 // MARK: - AvailabilityConditionSyntax
 
 public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePoundAvailableKeyword
-    case poundAvailableKeyword
-    case unexpectedBetweenPoundAvailableKeywordAndLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndAvailabilitySpec
-    case availabilitySpec
-    case unexpectedBetweenAvailabilitySpecAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AvailabilityConditionSyntax` if possible. Returns
@@ -13845,8 +12823,7 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePoundAvailableKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePoundAvailableKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -13861,14 +12838,13 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePoundAvailableKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePoundAvailableKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return AvailabilityConditionSyntax(newData)
   }
 
   public var poundAvailableKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundAvailableKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -13882,14 +12858,13 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withPoundAvailableKeyword(
     _ newChild: TokenSyntax?) -> AvailabilityConditionSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundAvailableKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundAvailableKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return AvailabilityConditionSyntax(newData)
   }
 
   public var unexpectedBetweenPoundAvailableKeywordAndLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPoundAvailableKeywordAndLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -13904,14 +12879,13 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPoundAvailableKeywordAndLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPoundAvailableKeywordAndLeftParen)
+    let newData = data.replacingChild(raw, at: 2)
     return AvailabilityConditionSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -13925,14 +12899,13 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> AvailabilityConditionSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 3)
     return AvailabilityConditionSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndAvailabilitySpec,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -13947,14 +12920,13 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndAvailabilitySpec(
     _ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndAvailabilitySpec)
+    let newData = data.replacingChild(raw, at: 4)
     return AvailabilityConditionSyntax(newData)
   }
 
   public var availabilitySpec: AvailabilitySpecListSyntax {
     get {
-      let childData = data.child(at: Cursor.availabilitySpec,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return AvailabilitySpecListSyntax(childData!)
     }
     set(value) {
@@ -13970,14 +12942,13 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `availabilitySpec` collection.
   public func addAvailabilityArgument(_ element: AvailabilityArgumentSyntax) -> AvailabilityConditionSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.availabilitySpec] {
+    if let col = raw.layoutView!.children[5] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.availabilitySpecList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.availabilitySpec)
+    let newData = data.replacingChild(collection, at: 5)
     return AvailabilityConditionSyntax(newData)
   }
 
@@ -13987,14 +12958,13 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAvailabilitySpec(
     _ newChild: AvailabilitySpecListSyntax?) -> AvailabilityConditionSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.availabilitySpec)
+    let newData = data.replacingChild(raw, at: 5)
     return AvailabilityConditionSyntax(newData)
   }
 
   public var unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAvailabilitySpecAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -14009,14 +12979,13 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAvailabilitySpecAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAvailabilitySpecAndRightParen)
+    let newData = data.replacingChild(raw, at: 6)
     return AvailabilityConditionSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -14030,7 +12999,7 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> AvailabilityConditionSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 7)
     return AvailabilityConditionSyntax(newData)
   }
 }
@@ -14053,17 +13022,6 @@ extension AvailabilityConditionSyntax: CustomReflectable {
 // MARK: - MatchingPatternConditionSyntax
 
 public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeCaseKeyword
-    case caseKeyword
-    case unexpectedBetweenCaseKeywordAndPattern
-    case pattern
-    case unexpectedBetweenPatternAndTypeAnnotation
-    case typeAnnotation
-    case unexpectedBetweenTypeAnnotationAndInitializer
-    case initializer
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `MatchingPatternConditionSyntax` if possible. Returns
@@ -14113,8 +13071,7 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeCaseKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeCaseKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -14129,14 +13086,13 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeCaseKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeCaseKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return MatchingPatternConditionSyntax(newData)
   }
 
   public var caseKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.caseKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -14150,14 +13106,13 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withCaseKeyword(
     _ newChild: TokenSyntax?) -> MatchingPatternConditionSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.caseKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return MatchingPatternConditionSyntax(newData)
   }
 
   public var unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCaseKeywordAndPattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -14172,14 +13127,13 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCaseKeywordAndPattern(
     _ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCaseKeywordAndPattern)
+    let newData = data.replacingChild(raw, at: 2)
     return MatchingPatternConditionSyntax(newData)
   }
 
   public var pattern: PatternSyntax {
     get {
-      let childData = data.child(at: Cursor.pattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return PatternSyntax(childData!)
     }
     set(value) {
@@ -14193,14 +13147,13 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withPattern(
     _ newChild: PatternSyntax?) -> MatchingPatternConditionSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.pattern)
+    let newData = data.replacingChild(raw, at: 3)
     return MatchingPatternConditionSyntax(newData)
   }
 
   public var unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPatternAndTypeAnnotation,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -14215,14 +13168,13 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPatternAndTypeAnnotation(
     _ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPatternAndTypeAnnotation)
+    let newData = data.replacingChild(raw, at: 4)
     return MatchingPatternConditionSyntax(newData)
   }
 
   public var typeAnnotation: TypeAnnotationSyntax? {
     get {
-      let childData = data.child(at: Cursor.typeAnnotation,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeAnnotationSyntax(childData!)
     }
@@ -14237,14 +13189,13 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTypeAnnotation(
     _ newChild: TypeAnnotationSyntax?) -> MatchingPatternConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.typeAnnotation)
+    let newData = data.replacingChild(raw, at: 5)
     return MatchingPatternConditionSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTypeAnnotationAndInitializer,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -14259,14 +13210,13 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTypeAnnotationAndInitializer(
     _ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTypeAnnotationAndInitializer)
+    let newData = data.replacingChild(raw, at: 6)
     return MatchingPatternConditionSyntax(newData)
   }
 
   public var initializer: InitializerClauseSyntax {
     get {
-      let childData = data.child(at: Cursor.initializer,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return InitializerClauseSyntax(childData!)
     }
     set(value) {
@@ -14280,7 +13230,7 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withInitializer(
     _ newChild: InitializerClauseSyntax?) -> MatchingPatternConditionSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.initializerClause, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.initializer)
+    let newData = data.replacingChild(raw, at: 7)
     return MatchingPatternConditionSyntax(newData)
   }
 }
@@ -14303,17 +13253,6 @@ extension MatchingPatternConditionSyntax: CustomReflectable {
 // MARK: - OptionalBindingConditionSyntax
 
 public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLetOrVarKeyword
-    case letOrVarKeyword
-    case unexpectedBetweenLetOrVarKeywordAndPattern
-    case pattern
-    case unexpectedBetweenPatternAndTypeAnnotation
-    case typeAnnotation
-    case unexpectedBetweenTypeAnnotationAndInitializer
-    case initializer
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `OptionalBindingConditionSyntax` if possible. Returns
@@ -14363,8 +13302,7 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLetOrVarKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLetOrVarKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -14379,14 +13317,13 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLetOrVarKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLetOrVarKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return OptionalBindingConditionSyntax(newData)
   }
 
   public var letOrVarKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.letOrVarKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -14400,14 +13337,13 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLetOrVarKeyword(
     _ newChild: TokenSyntax?) -> OptionalBindingConditionSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.letOrVarKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return OptionalBindingConditionSyntax(newData)
   }
 
   public var unexpectedBetweenLetOrVarKeywordAndPattern: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLetOrVarKeywordAndPattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -14422,14 +13358,13 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLetOrVarKeywordAndPattern(
     _ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLetOrVarKeywordAndPattern)
+    let newData = data.replacingChild(raw, at: 2)
     return OptionalBindingConditionSyntax(newData)
   }
 
   public var pattern: PatternSyntax {
     get {
-      let childData = data.child(at: Cursor.pattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return PatternSyntax(childData!)
     }
     set(value) {
@@ -14443,14 +13378,13 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withPattern(
     _ newChild: PatternSyntax?) -> OptionalBindingConditionSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.pattern)
+    let newData = data.replacingChild(raw, at: 3)
     return OptionalBindingConditionSyntax(newData)
   }
 
   public var unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPatternAndTypeAnnotation,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -14465,14 +13399,13 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPatternAndTypeAnnotation(
     _ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPatternAndTypeAnnotation)
+    let newData = data.replacingChild(raw, at: 4)
     return OptionalBindingConditionSyntax(newData)
   }
 
   public var typeAnnotation: TypeAnnotationSyntax? {
     get {
-      let childData = data.child(at: Cursor.typeAnnotation,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeAnnotationSyntax(childData!)
     }
@@ -14487,14 +13420,13 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTypeAnnotation(
     _ newChild: TypeAnnotationSyntax?) -> OptionalBindingConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.typeAnnotation)
+    let newData = data.replacingChild(raw, at: 5)
     return OptionalBindingConditionSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTypeAnnotationAndInitializer,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -14509,14 +13441,13 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTypeAnnotationAndInitializer(
     _ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTypeAnnotationAndInitializer)
+    let newData = data.replacingChild(raw, at: 6)
     return OptionalBindingConditionSyntax(newData)
   }
 
   public var initializer: InitializerClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.initializer,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return InitializerClauseSyntax(childData!)
     }
@@ -14531,7 +13462,7 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withInitializer(
     _ newChild: InitializerClauseSyntax?) -> OptionalBindingConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.initializer)
+    let newData = data.replacingChild(raw, at: 7)
     return OptionalBindingConditionSyntax(newData)
   }
 }
@@ -14554,17 +13485,6 @@ extension OptionalBindingConditionSyntax: CustomReflectable {
 // MARK: - UnavailabilityConditionSyntax
 
 public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePoundUnavailableKeyword
-    case poundUnavailableKeyword
-    case unexpectedBetweenPoundUnavailableKeywordAndLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndAvailabilitySpec
-    case availabilitySpec
-    case unexpectedBetweenAvailabilitySpecAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `UnavailabilityConditionSyntax` if possible. Returns
@@ -14614,8 +13534,7 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePoundUnavailableKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePoundUnavailableKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -14630,14 +13549,13 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePoundUnavailableKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePoundUnavailableKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return UnavailabilityConditionSyntax(newData)
   }
 
   public var poundUnavailableKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundUnavailableKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -14651,14 +13569,13 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withPoundUnavailableKeyword(
     _ newChild: TokenSyntax?) -> UnavailabilityConditionSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundUnavailableKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundUnavailableKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return UnavailabilityConditionSyntax(newData)
   }
 
   public var unexpectedBetweenPoundUnavailableKeywordAndLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPoundUnavailableKeywordAndLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -14673,14 +13590,13 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPoundUnavailableKeywordAndLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPoundUnavailableKeywordAndLeftParen)
+    let newData = data.replacingChild(raw, at: 2)
     return UnavailabilityConditionSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -14694,14 +13610,13 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> UnavailabilityConditionSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 3)
     return UnavailabilityConditionSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndAvailabilitySpec,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -14716,14 +13631,13 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndAvailabilitySpec(
     _ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndAvailabilitySpec)
+    let newData = data.replacingChild(raw, at: 4)
     return UnavailabilityConditionSyntax(newData)
   }
 
   public var availabilitySpec: AvailabilitySpecListSyntax {
     get {
-      let childData = data.child(at: Cursor.availabilitySpec,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return AvailabilitySpecListSyntax(childData!)
     }
     set(value) {
@@ -14739,14 +13653,13 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `availabilitySpec` collection.
   public func addAvailabilityArgument(_ element: AvailabilityArgumentSyntax) -> UnavailabilityConditionSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.availabilitySpec] {
+    if let col = raw.layoutView!.children[5] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.availabilitySpecList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.availabilitySpec)
+    let newData = data.replacingChild(collection, at: 5)
     return UnavailabilityConditionSyntax(newData)
   }
 
@@ -14756,14 +13669,13 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAvailabilitySpec(
     _ newChild: AvailabilitySpecListSyntax?) -> UnavailabilityConditionSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.availabilitySpec)
+    let newData = data.replacingChild(raw, at: 5)
     return UnavailabilityConditionSyntax(newData)
   }
 
   public var unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAvailabilitySpecAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -14778,14 +13690,13 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAvailabilitySpecAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAvailabilitySpecAndRightParen)
+    let newData = data.replacingChild(raw, at: 6)
     return UnavailabilityConditionSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -14799,7 +13710,7 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> UnavailabilityConditionSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 7)
     return UnavailabilityConditionSyntax(newData)
   }
 }
@@ -14822,11 +13733,6 @@ extension UnavailabilityConditionSyntax: CustomReflectable {
 // MARK: - ElseIfContinuationSyntax
 
 public struct ElseIfContinuationSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeIfStatement
-    case ifStatement
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ElseIfContinuationSyntax` if possible. Returns
@@ -14864,8 +13770,7 @@ public struct ElseIfContinuationSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeIfStatement: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeIfStatement,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -14880,14 +13785,13 @@ public struct ElseIfContinuationSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeIfStatement(
     _ newChild: UnexpectedNodesSyntax?) -> ElseIfContinuationSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeIfStatement)
+    let newData = data.replacingChild(raw, at: 0)
     return ElseIfContinuationSyntax(newData)
   }
 
   public var ifStatement: IfStmtSyntax {
     get {
-      let childData = data.child(at: Cursor.ifStatement,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return IfStmtSyntax(childData!)
     }
     set(value) {
@@ -14901,7 +13805,7 @@ public struct ElseIfContinuationSyntax: SyntaxProtocol, SyntaxHashable {
   public func withIfStatement(
     _ newChild: IfStmtSyntax?) -> ElseIfContinuationSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifStmt, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.ifStatement)
+    let newData = data.replacingChild(raw, at: 1)
     return ElseIfContinuationSyntax(newData)
   }
 }
@@ -14918,13 +13822,6 @@ extension ElseIfContinuationSyntax: CustomReflectable {
 // MARK: - ElseBlockSyntax
 
 public struct ElseBlockSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeElseKeyword
-    case elseKeyword
-    case unexpectedBetweenElseKeywordAndBody
-    case body
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ElseBlockSyntax` if possible. Returns
@@ -14966,8 +13863,7 @@ public struct ElseBlockSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeElseKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeElseKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -14982,14 +13878,13 @@ public struct ElseBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeElseKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ElseBlockSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeElseKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return ElseBlockSyntax(newData)
   }
 
   public var elseKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.elseKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -15003,14 +13898,13 @@ public struct ElseBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withElseKeyword(
     _ newChild: TokenSyntax?) -> ElseBlockSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.elseKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.elseKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return ElseBlockSyntax(newData)
   }
 
   public var unexpectedBetweenElseKeywordAndBody: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenElseKeywordAndBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -15025,14 +13919,13 @@ public struct ElseBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenElseKeywordAndBody(
     _ newChild: UnexpectedNodesSyntax?) -> ElseBlockSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenElseKeywordAndBody)
+    let newData = data.replacingChild(raw, at: 2)
     return ElseBlockSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
     get {
-      let childData = data.child(at: Cursor.body,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return CodeBlockSyntax(childData!)
     }
     set(value) {
@@ -15046,7 +13939,7 @@ public struct ElseBlockSyntax: SyntaxProtocol, SyntaxHashable {
   public func withBody(
     _ newChild: CodeBlockSyntax?) -> ElseBlockSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.body)
+    let newData = data.replacingChild(raw, at: 3)
     return ElseBlockSyntax(newData)
   }
 }
@@ -15065,15 +13958,6 @@ extension ElseBlockSyntax: CustomReflectable {
 // MARK: - SwitchCaseSyntax
 
 public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeUnknownAttr
-    case unknownAttr
-    case unexpectedBetweenUnknownAttrAndLabel
-    case label
-    case unexpectedBetweenLabelAndStatements
-    case statements
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SwitchCaseSyntax` if possible. Returns
@@ -15119,8 +14003,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeUnknownAttr: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeUnknownAttr,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -15135,14 +14018,13 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeUnknownAttr(
     _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeUnknownAttr)
+    let newData = data.replacingChild(raw, at: 0)
     return SwitchCaseSyntax(newData)
   }
 
   public var unknownAttr: AttributeSyntax? {
     get {
-      let childData = data.child(at: Cursor.unknownAttr,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeSyntax(childData!)
     }
@@ -15157,14 +14039,13 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnknownAttr(
     _ newChild: AttributeSyntax?) -> SwitchCaseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unknownAttr)
+    let newData = data.replacingChild(raw, at: 1)
     return SwitchCaseSyntax(newData)
   }
 
   public var unexpectedBetweenUnknownAttrAndLabel: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenUnknownAttrAndLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -15179,14 +14060,13 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenUnknownAttrAndLabel(
     _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenUnknownAttrAndLabel)
+    let newData = data.replacingChild(raw, at: 2)
     return SwitchCaseSyntax(newData)
   }
 
   public var label: Syntax {
     get {
-      let childData = data.child(at: Cursor.label,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -15200,14 +14080,13 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLabel(
     _ newChild: Syntax?) -> SwitchCaseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.label)
+    let newData = data.replacingChild(raw, at: 3)
     return SwitchCaseSyntax(newData)
   }
 
   public var unexpectedBetweenLabelAndStatements: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLabelAndStatements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -15222,14 +14101,13 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLabelAndStatements(
     _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLabelAndStatements)
+    let newData = data.replacingChild(raw, at: 4)
     return SwitchCaseSyntax(newData)
   }
 
   public var statements: CodeBlockItemListSyntax {
     get {
-      let childData = data.child(at: Cursor.statements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return CodeBlockItemListSyntax(childData!)
     }
     set(value) {
@@ -15245,14 +14123,13 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `statements` collection.
   public func addStatement(_ element: CodeBlockItemSyntax) -> SwitchCaseSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.statements] {
+    if let col = raw.layoutView!.children[5] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItemList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.statements)
+    let newData = data.replacingChild(collection, at: 5)
     return SwitchCaseSyntax(newData)
   }
 
@@ -15262,7 +14139,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withStatements(
     _ newChild: CodeBlockItemListSyntax?) -> SwitchCaseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.statements)
+    let newData = data.replacingChild(raw, at: 5)
     return SwitchCaseSyntax(newData)
   }
 }
@@ -15283,13 +14160,6 @@ extension SwitchCaseSyntax: CustomReflectable {
 // MARK: - SwitchDefaultLabelSyntax
 
 public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeDefaultKeyword
-    case defaultKeyword
-    case unexpectedBetweenDefaultKeywordAndColon
-    case colon
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SwitchDefaultLabelSyntax` if possible. Returns
@@ -15331,8 +14201,7 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeDefaultKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeDefaultKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -15347,14 +14216,13 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeDefaultKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> SwitchDefaultLabelSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeDefaultKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return SwitchDefaultLabelSyntax(newData)
   }
 
   public var defaultKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.defaultKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -15368,14 +14236,13 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public func withDefaultKeyword(
     _ newChild: TokenSyntax?) -> SwitchDefaultLabelSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.defaultKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.defaultKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return SwitchDefaultLabelSyntax(newData)
   }
 
   public var unexpectedBetweenDefaultKeywordAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDefaultKeywordAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -15390,14 +14257,13 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenDefaultKeywordAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> SwitchDefaultLabelSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDefaultKeywordAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return SwitchDefaultLabelSyntax(newData)
   }
 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -15411,7 +14277,7 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> SwitchDefaultLabelSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return SwitchDefaultLabelSyntax(newData)
   }
 }
@@ -15430,15 +14296,6 @@ extension SwitchDefaultLabelSyntax: CustomReflectable {
 // MARK: - CaseItemSyntax
 
 public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePattern
-    case pattern
-    case unexpectedBetweenPatternAndWhereClause
-    case whereClause
-    case unexpectedBetweenWhereClauseAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `CaseItemSyntax` if possible. Returns
@@ -15484,8 +14341,7 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePattern: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -15500,14 +14356,13 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePattern(
     _ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePattern)
+    let newData = data.replacingChild(raw, at: 0)
     return CaseItemSyntax(newData)
   }
 
   public var pattern: PatternSyntax {
     get {
-      let childData = data.child(at: Cursor.pattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return PatternSyntax(childData!)
     }
     set(value) {
@@ -15521,14 +14376,13 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withPattern(
     _ newChild: PatternSyntax?) -> CaseItemSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.pattern)
+    let newData = data.replacingChild(raw, at: 1)
     return CaseItemSyntax(newData)
   }
 
   public var unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPatternAndWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -15543,14 +14397,13 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPatternAndWhereClause(
     _ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPatternAndWhereClause)
+    let newData = data.replacingChild(raw, at: 2)
     return CaseItemSyntax(newData)
   }
 
   public var whereClause: WhereClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.whereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return WhereClauseSyntax(childData!)
     }
@@ -15565,14 +14418,13 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withWhereClause(
     _ newChild: WhereClauseSyntax?) -> CaseItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.whereClause)
+    let newData = data.replacingChild(raw, at: 3)
     return CaseItemSyntax(newData)
   }
 
   public var unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenWhereClauseAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -15587,14 +14439,13 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenWhereClauseAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenWhereClauseAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 4)
     return CaseItemSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -15609,7 +14460,7 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> CaseItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 5)
     return CaseItemSyntax(newData)
   }
 }
@@ -15630,15 +14481,6 @@ extension CaseItemSyntax: CustomReflectable {
 // MARK: - CatchItemSyntax
 
 public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePattern
-    case pattern
-    case unexpectedBetweenPatternAndWhereClause
-    case whereClause
-    case unexpectedBetweenWhereClauseAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `CatchItemSyntax` if possible. Returns
@@ -15684,8 +14526,7 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePattern: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -15700,14 +14541,13 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePattern(
     _ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePattern)
+    let newData = data.replacingChild(raw, at: 0)
     return CatchItemSyntax(newData)
   }
 
   public var pattern: PatternSyntax? {
     get {
-      let childData = data.child(at: Cursor.pattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return PatternSyntax(childData!)
     }
@@ -15722,14 +14562,13 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withPattern(
     _ newChild: PatternSyntax?) -> CatchItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.pattern)
+    let newData = data.replacingChild(raw, at: 1)
     return CatchItemSyntax(newData)
   }
 
   public var unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPatternAndWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -15744,14 +14583,13 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPatternAndWhereClause(
     _ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPatternAndWhereClause)
+    let newData = data.replacingChild(raw, at: 2)
     return CatchItemSyntax(newData)
   }
 
   public var whereClause: WhereClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.whereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return WhereClauseSyntax(childData!)
     }
@@ -15766,14 +14604,13 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withWhereClause(
     _ newChild: WhereClauseSyntax?) -> CatchItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.whereClause)
+    let newData = data.replacingChild(raw, at: 3)
     return CatchItemSyntax(newData)
   }
 
   public var unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenWhereClauseAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -15788,14 +14625,13 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenWhereClauseAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenWhereClauseAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 4)
     return CatchItemSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -15810,7 +14646,7 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> CatchItemSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 5)
     return CatchItemSyntax(newData)
   }
 }
@@ -15831,15 +14667,6 @@ extension CatchItemSyntax: CustomReflectable {
 // MARK: - SwitchCaseLabelSyntax
 
 public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeCaseKeyword
-    case caseKeyword
-    case unexpectedBetweenCaseKeywordAndCaseItems
-    case caseItems
-    case unexpectedBetweenCaseItemsAndColon
-    case colon
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SwitchCaseLabelSyntax` if possible. Returns
@@ -15885,8 +14712,7 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeCaseKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeCaseKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -15901,14 +14727,13 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeCaseKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeCaseKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return SwitchCaseLabelSyntax(newData)
   }
 
   public var caseKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.caseKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -15922,14 +14747,13 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public func withCaseKeyword(
     _ newChild: TokenSyntax?) -> SwitchCaseLabelSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.caseKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return SwitchCaseLabelSyntax(newData)
   }
 
   public var unexpectedBetweenCaseKeywordAndCaseItems: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCaseKeywordAndCaseItems,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -15944,14 +14768,13 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCaseKeywordAndCaseItems(
     _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCaseKeywordAndCaseItems)
+    let newData = data.replacingChild(raw, at: 2)
     return SwitchCaseLabelSyntax(newData)
   }
 
   public var caseItems: CaseItemListSyntax {
     get {
-      let childData = data.child(at: Cursor.caseItems,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return CaseItemListSyntax(childData!)
     }
     set(value) {
@@ -15967,14 +14790,13 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `caseItems` collection.
   public func addCaseItem(_ element: CaseItemSyntax) -> SwitchCaseLabelSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.caseItems] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.caseItemList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.caseItems)
+    let newData = data.replacingChild(collection, at: 3)
     return SwitchCaseLabelSyntax(newData)
   }
 
@@ -15984,14 +14806,13 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public func withCaseItems(
     _ newChild: CaseItemListSyntax?) -> SwitchCaseLabelSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.caseItemList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.caseItems)
+    let newData = data.replacingChild(raw, at: 3)
     return SwitchCaseLabelSyntax(newData)
   }
 
   public var unexpectedBetweenCaseItemsAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCaseItemsAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -16006,14 +14827,13 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCaseItemsAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCaseItemsAndColon)
+    let newData = data.replacingChild(raw, at: 4)
     return SwitchCaseLabelSyntax(newData)
   }
 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -16027,7 +14847,7 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> SwitchCaseLabelSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 5)
     return SwitchCaseLabelSyntax(newData)
   }
 }
@@ -16048,15 +14868,6 @@ extension SwitchCaseLabelSyntax: CustomReflectable {
 // MARK: - CatchClauseSyntax
 
 public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeCatchKeyword
-    case catchKeyword
-    case unexpectedBetweenCatchKeywordAndCatchItems
-    case catchItems
-    case unexpectedBetweenCatchItemsAndBody
-    case body
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `CatchClauseSyntax` if possible. Returns
@@ -16102,8 +14913,7 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeCatchKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeCatchKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -16118,14 +14928,13 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeCatchKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeCatchKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return CatchClauseSyntax(newData)
   }
 
   public var catchKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.catchKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -16139,14 +14948,13 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withCatchKeyword(
     _ newChild: TokenSyntax?) -> CatchClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.catchKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.catchKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return CatchClauseSyntax(newData)
   }
 
   public var unexpectedBetweenCatchKeywordAndCatchItems: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCatchKeywordAndCatchItems,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -16161,14 +14969,13 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCatchKeywordAndCatchItems(
     _ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCatchKeywordAndCatchItems)
+    let newData = data.replacingChild(raw, at: 2)
     return CatchClauseSyntax(newData)
   }
 
   public var catchItems: CatchItemListSyntax? {
     get {
-      let childData = data.child(at: Cursor.catchItems,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return CatchItemListSyntax(childData!)
     }
@@ -16185,14 +14992,13 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `catchItems` collection.
   public func addCatchItem(_ element: CatchItemSyntax) -> CatchClauseSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.catchItems] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.catchItemList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.catchItems)
+    let newData = data.replacingChild(collection, at: 3)
     return CatchClauseSyntax(newData)
   }
 
@@ -16202,14 +15008,13 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withCatchItems(
     _ newChild: CatchItemListSyntax?) -> CatchClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.catchItems)
+    let newData = data.replacingChild(raw, at: 3)
     return CatchClauseSyntax(newData)
   }
 
   public var unexpectedBetweenCatchItemsAndBody: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCatchItemsAndBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -16224,14 +15029,13 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCatchItemsAndBody(
     _ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCatchItemsAndBody)
+    let newData = data.replacingChild(raw, at: 4)
     return CatchClauseSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
     get {
-      let childData = data.child(at: Cursor.body,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return CodeBlockSyntax(childData!)
     }
     set(value) {
@@ -16245,7 +15049,7 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withBody(
     _ newChild: CodeBlockSyntax?) -> CatchClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.body)
+    let newData = data.replacingChild(raw, at: 5)
     return CatchClauseSyntax(newData)
   }
 }
@@ -16266,13 +15070,6 @@ extension CatchClauseSyntax: CustomReflectable {
 // MARK: - GenericWhereClauseSyntax
 
 public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeWhereKeyword
-    case whereKeyword
-    case unexpectedBetweenWhereKeywordAndRequirementList
-    case requirementList
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `GenericWhereClauseSyntax` if possible. Returns
@@ -16314,8 +15111,7 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeWhereKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeWhereKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -16330,14 +15126,13 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeWhereKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> GenericWhereClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeWhereKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return GenericWhereClauseSyntax(newData)
   }
 
   public var whereKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.whereKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -16351,14 +15146,13 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withWhereKeyword(
     _ newChild: TokenSyntax?) -> GenericWhereClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whereKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.whereKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return GenericWhereClauseSyntax(newData)
   }
 
   public var unexpectedBetweenWhereKeywordAndRequirementList: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenWhereKeywordAndRequirementList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -16373,14 +15167,13 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenWhereKeywordAndRequirementList(
     _ newChild: UnexpectedNodesSyntax?) -> GenericWhereClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenWhereKeywordAndRequirementList)
+    let newData = data.replacingChild(raw, at: 2)
     return GenericWhereClauseSyntax(newData)
   }
 
   public var requirementList: GenericRequirementListSyntax {
     get {
-      let childData = data.child(at: Cursor.requirementList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return GenericRequirementListSyntax(childData!)
     }
     set(value) {
@@ -16396,14 +15189,13 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `requirementList` collection.
   public func addRequirement(_ element: GenericRequirementSyntax) -> GenericWhereClauseSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.requirementList] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.requirementList)
+    let newData = data.replacingChild(collection, at: 3)
     return GenericWhereClauseSyntax(newData)
   }
 
@@ -16413,7 +15205,7 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRequirementList(
     _ newChild: GenericRequirementListSyntax?) -> GenericWhereClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericRequirementList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.requirementList)
+    let newData = data.replacingChild(raw, at: 3)
     return GenericWhereClauseSyntax(newData)
   }
 }
@@ -16432,13 +15224,6 @@ extension GenericWhereClauseSyntax: CustomReflectable {
 // MARK: - GenericRequirementSyntax
 
 public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeBody
-    case body
-    case unexpectedBetweenBodyAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `GenericRequirementSyntax` if possible. Returns
@@ -16480,8 +15265,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeBody: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -16496,14 +15280,13 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeBody(
     _ newChild: UnexpectedNodesSyntax?) -> GenericRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeBody)
+    let newData = data.replacingChild(raw, at: 0)
     return GenericRequirementSyntax(newData)
   }
 
   public var body: Syntax {
     get {
-      let childData = data.child(at: Cursor.body,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -16517,14 +15300,13 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withBody(
     _ newChild: Syntax?) -> GenericRequirementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.body)
+    let newData = data.replacingChild(raw, at: 1)
     return GenericRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenBodyAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenBodyAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -16539,14 +15321,13 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenBodyAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> GenericRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenBodyAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 2)
     return GenericRequirementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -16561,7 +15342,7 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> GenericRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 3)
     return GenericRequirementSyntax(newData)
   }
 }
@@ -16580,15 +15361,6 @@ extension GenericRequirementSyntax: CustomReflectable {
 // MARK: - SameTypeRequirementSyntax
 
 public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftTypeIdentifier
-    case leftTypeIdentifier
-    case unexpectedBetweenLeftTypeIdentifierAndEqualityToken
-    case equalityToken
-    case unexpectedBetweenEqualityTokenAndRightTypeIdentifier
-    case rightTypeIdentifier
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SameTypeRequirementSyntax` if possible. Returns
@@ -16634,8 +15406,7 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftTypeIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftTypeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -16650,14 +15421,13 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftTypeIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftTypeIdentifier)
+    let newData = data.replacingChild(raw, at: 0)
     return SameTypeRequirementSyntax(newData)
   }
 
   public var leftTypeIdentifier: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.leftTypeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -16671,14 +15441,13 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftTypeIdentifier(
     _ newChild: TypeSyntax?) -> SameTypeRequirementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftTypeIdentifier)
+    let newData = data.replacingChild(raw, at: 1)
     return SameTypeRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenLeftTypeIdentifierAndEqualityToken: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftTypeIdentifierAndEqualityToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -16693,14 +15462,13 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftTypeIdentifierAndEqualityToken(
     _ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftTypeIdentifierAndEqualityToken)
+    let newData = data.replacingChild(raw, at: 2)
     return SameTypeRequirementSyntax(newData)
   }
 
   public var equalityToken: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.equalityToken,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -16714,14 +15482,13 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withEqualityToken(
     _ newChild: TokenSyntax?) -> SameTypeRequirementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.spacedBinaryOperator(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.equalityToken)
+    let newData = data.replacingChild(raw, at: 3)
     return SameTypeRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenEqualityTokenAndRightTypeIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenEqualityTokenAndRightTypeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -16736,14 +15503,13 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenEqualityTokenAndRightTypeIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenEqualityTokenAndRightTypeIdentifier)
+    let newData = data.replacingChild(raw, at: 4)
     return SameTypeRequirementSyntax(newData)
   }
 
   public var rightTypeIdentifier: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.rightTypeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -16757,7 +15523,7 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightTypeIdentifier(
     _ newChild: TypeSyntax?) -> SameTypeRequirementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightTypeIdentifier)
+    let newData = data.replacingChild(raw, at: 5)
     return SameTypeRequirementSyntax(newData)
   }
 }
@@ -16778,25 +15544,6 @@ extension SameTypeRequirementSyntax: CustomReflectable {
 // MARK: - LayoutRequirementSyntax
 
 public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeTypeIdentifier
-    case typeIdentifier
-    case unexpectedBetweenTypeIdentifierAndColon
-    case colon
-    case unexpectedBetweenColonAndLayoutConstraint
-    case layoutConstraint
-    case unexpectedBetweenLayoutConstraintAndLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndSize
-    case size
-    case unexpectedBetweenSizeAndComma
-    case comma
-    case unexpectedBetweenCommaAndAlignment
-    case alignment
-    case unexpectedBetweenAlignmentAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `LayoutRequirementSyntax` if possible. Returns
@@ -16862,8 +15609,7 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeTypeIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeTypeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -16878,14 +15624,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeTypeIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeTypeIdentifier)
+    let newData = data.replacingChild(raw, at: 0)
     return LayoutRequirementSyntax(newData)
   }
 
   public var typeIdentifier: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.typeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -16899,14 +15644,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTypeIdentifier(
     _ newChild: TypeSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.typeIdentifier)
+    let newData = data.replacingChild(raw, at: 1)
     return LayoutRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenTypeIdentifierAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTypeIdentifierAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -16921,14 +15665,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTypeIdentifierAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTypeIdentifierAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return LayoutRequirementSyntax(newData)
   }
 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -16942,14 +15685,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return LayoutRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndLayoutConstraint: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndLayoutConstraint,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -16964,14 +15706,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndLayoutConstraint(
     _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndLayoutConstraint)
+    let newData = data.replacingChild(raw, at: 4)
     return LayoutRequirementSyntax(newData)
   }
 
   public var layoutConstraint: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.layoutConstraint,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -16985,14 +15726,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLayoutConstraint(
     _ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.layoutConstraint)
+    let newData = data.replacingChild(raw, at: 5)
     return LayoutRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenLayoutConstraintAndLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLayoutConstraintAndLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17007,14 +15747,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLayoutConstraintAndLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLayoutConstraintAndLeftParen)
+    let newData = data.replacingChild(raw, at: 6)
     return LayoutRequirementSyntax(newData)
   }
 
   public var leftParen: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -17029,14 +15768,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 7)
     return LayoutRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndSize: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndSize,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17051,14 +15789,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndSize(
     _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndSize)
+    let newData = data.replacingChild(raw, at: 8)
     return LayoutRequirementSyntax(newData)
   }
 
   public var size: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.size,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -17073,14 +15810,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withSize(
     _ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.size)
+    let newData = data.replacingChild(raw, at: 9)
     return LayoutRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenSizeAndComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenSizeAndComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17095,14 +15831,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenSizeAndComma(
     _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenSizeAndComma)
+    let newData = data.replacingChild(raw, at: 10)
     return LayoutRequirementSyntax(newData)
   }
 
   public var comma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.comma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -17117,14 +15852,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withComma(
     _ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.comma)
+    let newData = data.replacingChild(raw, at: 11)
     return LayoutRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenCommaAndAlignment: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCommaAndAlignment,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17139,14 +15873,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCommaAndAlignment(
     _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCommaAndAlignment)
+    let newData = data.replacingChild(raw, at: 12)
     return LayoutRequirementSyntax(newData)
   }
 
   public var alignment: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.alignment,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -17161,14 +15894,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAlignment(
     _ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.alignment)
+    let newData = data.replacingChild(raw, at: 13)
     return LayoutRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenAlignmentAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAlignmentAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 14, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17183,14 +15915,13 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAlignmentAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAlignmentAndRightParen)
+    let newData = data.replacingChild(raw, at: 14)
     return LayoutRequirementSyntax(newData)
   }
 
   public var rightParen: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 15, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -17205,7 +15936,7 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> LayoutRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 15)
     return LayoutRequirementSyntax(newData)
   }
 }
@@ -17236,19 +15967,6 @@ extension LayoutRequirementSyntax: CustomReflectable {
 // MARK: - GenericParameterSyntax
 
 public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndName
-    case name
-    case unexpectedBetweenNameAndColon
-    case colon
-    case unexpectedBetweenColonAndInheritedType
-    case inheritedType
-    case unexpectedBetweenInheritedTypeAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `GenericParameterSyntax` if possible. Returns
@@ -17302,8 +16020,7 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17318,14 +16035,13 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeAttributes)
+    let newData = data.replacingChild(raw, at: 0)
     return GenericParameterSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -17342,14 +16058,13 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> GenericParameterSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 1)
     return GenericParameterSyntax(newData)
   }
 
@@ -17359,14 +16074,13 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> GenericParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 1)
     return GenericParameterSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17381,14 +16095,13 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndName(
     _ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndName)
+    let newData = data.replacingChild(raw, at: 2)
     return GenericParameterSyntax(newData)
   }
 
   public var name: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -17402,14 +16115,13 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> GenericParameterSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 3)
     return GenericParameterSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17424,14 +16136,13 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndColon)
+    let newData = data.replacingChild(raw, at: 4)
     return GenericParameterSyntax(newData)
   }
 
   public var colon: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -17446,14 +16157,13 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> GenericParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 5)
     return GenericParameterSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndInheritedType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndInheritedType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17468,14 +16178,13 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndInheritedType(
     _ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndInheritedType)
+    let newData = data.replacingChild(raw, at: 6)
     return GenericParameterSyntax(newData)
   }
 
   public var inheritedType: TypeSyntax? {
     get {
-      let childData = data.child(at: Cursor.inheritedType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeSyntax(childData!)
     }
@@ -17490,14 +16199,13 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withInheritedType(
     _ newChild: TypeSyntax?) -> GenericParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.inheritedType)
+    let newData = data.replacingChild(raw, at: 7)
     return GenericParameterSyntax(newData)
   }
 
   public var unexpectedBetweenInheritedTypeAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInheritedTypeAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17512,14 +16220,13 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInheritedTypeAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInheritedTypeAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 8)
     return GenericParameterSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -17534,7 +16241,7 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> GenericParameterSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 9)
     return GenericParameterSyntax(newData)
   }
 }
@@ -17559,13 +16266,6 @@ extension GenericParameterSyntax: CustomReflectable {
 // MARK: - PrimaryAssociatedTypeSyntax
 
 public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeName
-    case name
-    case unexpectedBetweenNameAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PrimaryAssociatedTypeSyntax` if possible. Returns
@@ -17607,8 +16307,7 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17623,14 +16322,13 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeName(
     _ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeName)
+    let newData = data.replacingChild(raw, at: 0)
     return PrimaryAssociatedTypeSyntax(newData)
   }
 
   public var name: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -17644,14 +16342,13 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> PrimaryAssociatedTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 1)
     return PrimaryAssociatedTypeSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17666,14 +16363,13 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 2)
     return PrimaryAssociatedTypeSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -17688,7 +16384,7 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> PrimaryAssociatedTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 3)
     return PrimaryAssociatedTypeSyntax(newData)
   }
 }
@@ -17707,15 +16403,6 @@ extension PrimaryAssociatedTypeSyntax: CustomReflectable {
 // MARK: - GenericParameterClauseSyntax
 
 public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftAngleBracket
-    case leftAngleBracket
-    case unexpectedBetweenLeftAngleBracketAndGenericParameterList
-    case genericParameterList
-    case unexpectedBetweenGenericParameterListAndRightAngleBracket
-    case rightAngleBracket
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `GenericParameterClauseSyntax` if possible. Returns
@@ -17761,8 +16448,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftAngleBracket: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftAngleBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17777,14 +16463,13 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftAngleBracket(
     _ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftAngleBracket)
+    let newData = data.replacingChild(raw, at: 0)
     return GenericParameterClauseSyntax(newData)
   }
 
   public var leftAngleBracket: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftAngleBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -17798,14 +16483,13 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftAngleBracket(
     _ newChild: TokenSyntax?) -> GenericParameterClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftAngleBracket)
+    let newData = data.replacingChild(raw, at: 1)
     return GenericParameterClauseSyntax(newData)
   }
 
   public var unexpectedBetweenLeftAngleBracketAndGenericParameterList: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftAngleBracketAndGenericParameterList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17820,14 +16504,13 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftAngleBracketAndGenericParameterList(
     _ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftAngleBracketAndGenericParameterList)
+    let newData = data.replacingChild(raw, at: 2)
     return GenericParameterClauseSyntax(newData)
   }
 
   public var genericParameterList: GenericParameterListSyntax {
     get {
-      let childData = data.child(at: Cursor.genericParameterList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return GenericParameterListSyntax(childData!)
     }
     set(value) {
@@ -17843,14 +16526,13 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `genericParameterList` collection.
   public func addGenericParameter(_ element: GenericParameterSyntax) -> GenericParameterClauseSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.genericParameterList] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.genericParameterList)
+    let newData = data.replacingChild(collection, at: 3)
     return GenericParameterClauseSyntax(newData)
   }
 
@@ -17860,14 +16542,13 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withGenericParameterList(
     _ newChild: GenericParameterListSyntax?) -> GenericParameterClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericParameterList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.genericParameterList)
+    let newData = data.replacingChild(raw, at: 3)
     return GenericParameterClauseSyntax(newData)
   }
 
   public var unexpectedBetweenGenericParameterListAndRightAngleBracket: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGenericParameterListAndRightAngleBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17882,14 +16563,13 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGenericParameterListAndRightAngleBracket(
     _ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGenericParameterListAndRightAngleBracket)
+    let newData = data.replacingChild(raw, at: 4)
     return GenericParameterClauseSyntax(newData)
   }
 
   public var rightAngleBracket: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightAngleBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -17903,7 +16583,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightAngleBracket(
     _ newChild: TokenSyntax?) -> GenericParameterClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightAngleBracket)
+    let newData = data.replacingChild(raw, at: 5)
     return GenericParameterClauseSyntax(newData)
   }
 }
@@ -17924,15 +16604,6 @@ extension GenericParameterClauseSyntax: CustomReflectable {
 // MARK: - ConformanceRequirementSyntax
 
 public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftTypeIdentifier
-    case leftTypeIdentifier
-    case unexpectedBetweenLeftTypeIdentifierAndColon
-    case colon
-    case unexpectedBetweenColonAndRightTypeIdentifier
-    case rightTypeIdentifier
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ConformanceRequirementSyntax` if possible. Returns
@@ -17978,8 +16649,7 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftTypeIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftTypeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -17994,14 +16664,13 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftTypeIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftTypeIdentifier)
+    let newData = data.replacingChild(raw, at: 0)
     return ConformanceRequirementSyntax(newData)
   }
 
   public var leftTypeIdentifier: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.leftTypeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -18015,14 +16684,13 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftTypeIdentifier(
     _ newChild: TypeSyntax?) -> ConformanceRequirementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftTypeIdentifier)
+    let newData = data.replacingChild(raw, at: 1)
     return ConformanceRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenLeftTypeIdentifierAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftTypeIdentifierAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -18037,14 +16705,13 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftTypeIdentifierAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftTypeIdentifierAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return ConformanceRequirementSyntax(newData)
   }
 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -18058,14 +16725,13 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> ConformanceRequirementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return ConformanceRequirementSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndRightTypeIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndRightTypeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -18080,14 +16746,13 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndRightTypeIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndRightTypeIdentifier)
+    let newData = data.replacingChild(raw, at: 4)
     return ConformanceRequirementSyntax(newData)
   }
 
   public var rightTypeIdentifier: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.rightTypeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -18101,7 +16766,7 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightTypeIdentifier(
     _ newChild: TypeSyntax?) -> ConformanceRequirementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightTypeIdentifier)
+    let newData = data.replacingChild(raw, at: 5)
     return ConformanceRequirementSyntax(newData)
   }
 }
@@ -18122,15 +16787,6 @@ extension ConformanceRequirementSyntax: CustomReflectable {
 // MARK: - PrimaryAssociatedTypeClauseSyntax
 
 public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftAngleBracket
-    case leftAngleBracket
-    case unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList
-    case primaryAssociatedTypeList
-    case unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket
-    case rightAngleBracket
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PrimaryAssociatedTypeClauseSyntax` if possible. Returns
@@ -18176,8 +16832,7 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
 
   public var unexpectedBeforeLeftAngleBracket: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftAngleBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -18192,14 +16847,13 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   public func withUnexpectedBeforeLeftAngleBracket(
     _ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftAngleBracket)
+    let newData = data.replacingChild(raw, at: 0)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
   public var leftAngleBracket: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftAngleBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -18213,14 +16867,13 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   public func withLeftAngleBracket(
     _ newChild: TokenSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftAngleBracket)
+    let newData = data.replacingChild(raw, at: 1)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
   public var unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -18235,14 +16888,13 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   public func withUnexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList(
     _ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList)
+    let newData = data.replacingChild(raw, at: 2)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
   public var primaryAssociatedTypeList: PrimaryAssociatedTypeListSyntax {
     get {
-      let childData = data.child(at: Cursor.primaryAssociatedTypeList,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return PrimaryAssociatedTypeListSyntax(childData!)
     }
     set(value) {
@@ -18258,14 +16910,13 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   ///            appended to its `primaryAssociatedTypeList` collection.
   public func addPrimaryAssociatedType(_ element: PrimaryAssociatedTypeSyntax) -> PrimaryAssociatedTypeClauseSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.primaryAssociatedTypeList] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.primaryAssociatedTypeList)
+    let newData = data.replacingChild(collection, at: 3)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
@@ -18275,14 +16926,13 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   public func withPrimaryAssociatedTypeList(
     _ newChild: PrimaryAssociatedTypeListSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.primaryAssociatedTypeList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.primaryAssociatedTypeList)
+    let newData = data.replacingChild(raw, at: 3)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
   public var unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -18297,14 +16947,13 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   public func withUnexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket(
     _ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket)
+    let newData = data.replacingChild(raw, at: 4)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
   public var rightAngleBracket: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightAngleBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -18318,7 +16967,7 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
   public func withRightAngleBracket(
     _ newChild: TokenSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightAngleBracket)
+    let newData = data.replacingChild(raw, at: 5)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 }
@@ -18339,13 +16988,6 @@ extension PrimaryAssociatedTypeClauseSyntax: CustomReflectable {
 // MARK: - CompositionTypeElementSyntax
 
 public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeType
-    case type
-    case unexpectedBetweenTypeAndAmpersand
-    case ampersand
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `CompositionTypeElementSyntax` if possible. Returns
@@ -18387,8 +17029,7 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -18403,14 +17044,13 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeType(
     _ newChild: UnexpectedNodesSyntax?) -> CompositionTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeType)
+    let newData = data.replacingChild(raw, at: 0)
     return CompositionTypeElementSyntax(newData)
   }
 
   public var type: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.type,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -18424,14 +17064,13 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withType(
     _ newChild: TypeSyntax?) -> CompositionTypeElementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.type)
+    let newData = data.replacingChild(raw, at: 1)
     return CompositionTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAndAmpersand: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTypeAndAmpersand,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -18446,14 +17085,13 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTypeAndAmpersand(
     _ newChild: UnexpectedNodesSyntax?) -> CompositionTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTypeAndAmpersand)
+    let newData = data.replacingChild(raw, at: 2)
     return CompositionTypeElementSyntax(newData)
   }
 
   public var ampersand: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.ampersand,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -18468,7 +17106,7 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withAmpersand(
     _ newChild: TokenSyntax?) -> CompositionTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.ampersand)
+    let newData = data.replacingChild(raw, at: 3)
     return CompositionTypeElementSyntax(newData)
   }
 }
@@ -18487,25 +17125,6 @@ extension CompositionTypeElementSyntax: CustomReflectable {
 // MARK: - TupleTypeElementSyntax
 
 public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeInOut
-    case inOut
-    case unexpectedBetweenInOutAndName
-    case name
-    case unexpectedBetweenNameAndSecondName
-    case secondName
-    case unexpectedBetweenSecondNameAndColon
-    case colon
-    case unexpectedBetweenColonAndType
-    case type
-    case unexpectedBetweenTypeAndEllipsis
-    case ellipsis
-    case unexpectedBetweenEllipsisAndInitializer
-    case initializer
-    case unexpectedBetweenInitializerAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TupleTypeElementSyntax` if possible. Returns
@@ -18571,8 +17190,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeInOut: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeInOut,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -18587,14 +17205,13 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeInOut(
     _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeInOut)
+    let newData = data.replacingChild(raw, at: 0)
     return TupleTypeElementSyntax(newData)
   }
 
   public var inOut: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.inOut,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -18609,14 +17226,13 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withInOut(
     _ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.inOut)
+    let newData = data.replacingChild(raw, at: 1)
     return TupleTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenInOutAndName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInOutAndName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -18631,14 +17247,13 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInOutAndName(
     _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInOutAndName)
+    let newData = data.replacingChild(raw, at: 2)
     return TupleTypeElementSyntax(newData)
   }
 
   public var name: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -18653,14 +17268,13 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 3)
     return TupleTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndSecondName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndSecondName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -18675,14 +17289,13 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndSecondName(
     _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndSecondName)
+    let newData = data.replacingChild(raw, at: 4)
     return TupleTypeElementSyntax(newData)
   }
 
   public var secondName: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.secondName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -18697,14 +17310,13 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withSecondName(
     _ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.secondName)
+    let newData = data.replacingChild(raw, at: 5)
     return TupleTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenSecondNameAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -18719,14 +17331,13 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenSecondNameAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenSecondNameAndColon)
+    let newData = data.replacingChild(raw, at: 6)
     return TupleTypeElementSyntax(newData)
   }
 
   public var colon: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -18741,14 +17352,13 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 7)
     return TupleTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -18763,14 +17373,13 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndType(
     _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndType)
+    let newData = data.replacingChild(raw, at: 8)
     return TupleTypeElementSyntax(newData)
   }
 
   public var type: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.type,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -18784,14 +17393,13 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withType(
     _ newChild: TypeSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.type)
+    let newData = data.replacingChild(raw, at: 9)
     return TupleTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTypeAndEllipsis,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -18806,14 +17414,13 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTypeAndEllipsis(
     _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTypeAndEllipsis)
+    let newData = data.replacingChild(raw, at: 10)
     return TupleTypeElementSyntax(newData)
   }
 
   public var ellipsis: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.ellipsis,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -18828,14 +17435,13 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withEllipsis(
     _ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.ellipsis)
+    let newData = data.replacingChild(raw, at: 11)
     return TupleTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenEllipsisAndInitializer: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenEllipsisAndInitializer,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -18850,14 +17456,13 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenEllipsisAndInitializer(
     _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenEllipsisAndInitializer)
+    let newData = data.replacingChild(raw, at: 12)
     return TupleTypeElementSyntax(newData)
   }
 
   public var initializer: InitializerClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.initializer,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       if childData == nil { return nil }
       return InitializerClauseSyntax(childData!)
     }
@@ -18872,14 +17477,13 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withInitializer(
     _ newChild: InitializerClauseSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.initializer)
+    let newData = data.replacingChild(raw, at: 13)
     return TupleTypeElementSyntax(newData)
   }
 
   public var unexpectedBetweenInitializerAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInitializerAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 14, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -18894,14 +17498,13 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInitializerAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInitializerAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 14)
     return TupleTypeElementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 15, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -18916,7 +17519,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> TupleTypeElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 15)
     return TupleTypeElementSyntax(newData)
   }
 }
@@ -18947,13 +17550,6 @@ extension TupleTypeElementSyntax: CustomReflectable {
 // MARK: - GenericArgumentSyntax
 
 public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeArgumentType
-    case argumentType
-    case unexpectedBetweenArgumentTypeAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `GenericArgumentSyntax` if possible. Returns
@@ -18995,8 +17591,7 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeArgumentType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeArgumentType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -19011,14 +17606,13 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeArgumentType(
     _ newChild: UnexpectedNodesSyntax?) -> GenericArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeArgumentType)
+    let newData = data.replacingChild(raw, at: 0)
     return GenericArgumentSyntax(newData)
   }
 
   public var argumentType: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.argumentType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -19032,14 +17626,13 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withArgumentType(
     _ newChild: TypeSyntax?) -> GenericArgumentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.argumentType)
+    let newData = data.replacingChild(raw, at: 1)
     return GenericArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenArgumentTypeAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenArgumentTypeAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -19054,14 +17647,13 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenArgumentTypeAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> GenericArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenArgumentTypeAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 2)
     return GenericArgumentSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -19076,7 +17668,7 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> GenericArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 3)
     return GenericArgumentSyntax(newData)
   }
 }
@@ -19095,15 +17687,6 @@ extension GenericArgumentSyntax: CustomReflectable {
 // MARK: - GenericArgumentClauseSyntax
 
 public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftAngleBracket
-    case leftAngleBracket
-    case unexpectedBetweenLeftAngleBracketAndArguments
-    case arguments
-    case unexpectedBetweenArgumentsAndRightAngleBracket
-    case rightAngleBracket
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `GenericArgumentClauseSyntax` if possible. Returns
@@ -19149,8 +17732,7 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftAngleBracket: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftAngleBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -19165,14 +17747,13 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftAngleBracket(
     _ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftAngleBracket)
+    let newData = data.replacingChild(raw, at: 0)
     return GenericArgumentClauseSyntax(newData)
   }
 
   public var leftAngleBracket: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftAngleBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -19186,14 +17767,13 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLeftAngleBracket(
     _ newChild: TokenSyntax?) -> GenericArgumentClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftAngle, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftAngleBracket)
+    let newData = data.replacingChild(raw, at: 1)
     return GenericArgumentClauseSyntax(newData)
   }
 
   public var unexpectedBetweenLeftAngleBracketAndArguments: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftAngleBracketAndArguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -19208,14 +17788,13 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftAngleBracketAndArguments(
     _ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftAngleBracketAndArguments)
+    let newData = data.replacingChild(raw, at: 2)
     return GenericArgumentClauseSyntax(newData)
   }
 
   public var arguments: GenericArgumentListSyntax {
     get {
-      let childData = data.child(at: Cursor.arguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return GenericArgumentListSyntax(childData!)
     }
     set(value) {
@@ -19231,14 +17810,13 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   ///            appended to its `arguments` collection.
   public func addArgument(_ element: GenericArgumentSyntax) -> GenericArgumentClauseSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.arguments] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.arguments)
+    let newData = data.replacingChild(collection, at: 3)
     return GenericArgumentClauseSyntax(newData)
   }
 
@@ -19248,14 +17826,13 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withArguments(
     _ newChild: GenericArgumentListSyntax?) -> GenericArgumentClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericArgumentList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.arguments)
+    let newData = data.replacingChild(raw, at: 3)
     return GenericArgumentClauseSyntax(newData)
   }
 
   public var unexpectedBetweenArgumentsAndRightAngleBracket: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenArgumentsAndRightAngleBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -19270,14 +17847,13 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenArgumentsAndRightAngleBracket(
     _ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenArgumentsAndRightAngleBracket)
+    let newData = data.replacingChild(raw, at: 4)
     return GenericArgumentClauseSyntax(newData)
   }
 
   public var rightAngleBracket: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightAngleBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -19291,7 +17867,7 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightAngleBracket(
     _ newChild: TokenSyntax?) -> GenericArgumentClauseSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightAngleBracket)
+    let newData = data.replacingChild(raw, at: 5)
     return GenericArgumentClauseSyntax(newData)
   }
 }
@@ -19312,13 +17888,6 @@ extension GenericArgumentClauseSyntax: CustomReflectable {
 // MARK: - TypeAnnotationSyntax
 
 public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeColon
-    case colon
-    case unexpectedBetweenColonAndType
-    case type
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TypeAnnotationSyntax` if possible. Returns
@@ -19360,8 +17929,7 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -19376,14 +17944,13 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeColon(
     _ newChild: UnexpectedNodesSyntax?) -> TypeAnnotationSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeColon)
+    let newData = data.replacingChild(raw, at: 0)
     return TypeAnnotationSyntax(newData)
   }
 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -19397,14 +17964,13 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> TypeAnnotationSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 1)
     return TypeAnnotationSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -19419,14 +17985,13 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndType(
     _ newChild: UnexpectedNodesSyntax?) -> TypeAnnotationSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndType)
+    let newData = data.replacingChild(raw, at: 2)
     return TypeAnnotationSyntax(newData)
   }
 
   public var type: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.type,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -19440,7 +18005,7 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
   public func withType(
     _ newChild: TypeSyntax?) -> TypeAnnotationSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.type)
+    let newData = data.replacingChild(raw, at: 3)
     return TypeAnnotationSyntax(newData)
   }
 }
@@ -19459,17 +18024,6 @@ extension TypeAnnotationSyntax: CustomReflectable {
 // MARK: - TuplePatternElementSyntax
 
 public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLabelName
-    case labelName
-    case unexpectedBetweenLabelNameAndLabelColon
-    case labelColon
-    case unexpectedBetweenLabelColonAndPattern
-    case pattern
-    case unexpectedBetweenPatternAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TuplePatternElementSyntax` if possible. Returns
@@ -19519,8 +18073,7 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLabelName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLabelName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -19535,14 +18088,13 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLabelName(
     _ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLabelName)
+    let newData = data.replacingChild(raw, at: 0)
     return TuplePatternElementSyntax(newData)
   }
 
   public var labelName: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.labelName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -19557,14 +18109,13 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLabelName(
     _ newChild: TokenSyntax?) -> TuplePatternElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.labelName)
+    let newData = data.replacingChild(raw, at: 1)
     return TuplePatternElementSyntax(newData)
   }
 
   public var unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLabelNameAndLabelColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -19579,14 +18130,13 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLabelNameAndLabelColon(
     _ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLabelNameAndLabelColon)
+    let newData = data.replacingChild(raw, at: 2)
     return TuplePatternElementSyntax(newData)
   }
 
   public var labelColon: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.labelColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -19601,14 +18151,13 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withLabelColon(
     _ newChild: TokenSyntax?) -> TuplePatternElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.labelColon)
+    let newData = data.replacingChild(raw, at: 3)
     return TuplePatternElementSyntax(newData)
   }
 
   public var unexpectedBetweenLabelColonAndPattern: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLabelColonAndPattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -19623,14 +18172,13 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLabelColonAndPattern(
     _ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLabelColonAndPattern)
+    let newData = data.replacingChild(raw, at: 4)
     return TuplePatternElementSyntax(newData)
   }
 
   public var pattern: PatternSyntax {
     get {
-      let childData = data.child(at: Cursor.pattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return PatternSyntax(childData!)
     }
     set(value) {
@@ -19644,14 +18192,13 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withPattern(
     _ newChild: PatternSyntax?) -> TuplePatternElementSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.pattern)
+    let newData = data.replacingChild(raw, at: 5)
     return TuplePatternElementSyntax(newData)
   }
 
   public var unexpectedBetweenPatternAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPatternAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -19666,14 +18213,13 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPatternAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPatternAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 6)
     return TuplePatternElementSyntax(newData)
   }
 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -19688,7 +18234,7 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> TuplePatternElementSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 7)
     return TuplePatternElementSyntax(newData)
   }
 }
@@ -19715,13 +18261,6 @@ extension TuplePatternElementSyntax: CustomReflectable {
 /// or `message: "This has been deprecated"`.
 /// 
 public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeEntry
-    case entry
-    case unexpectedBetweenEntryAndTrailingComma
-    case trailingComma
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AvailabilityArgumentSyntax` if possible. Returns
@@ -19763,8 +18302,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeEntry: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeEntry,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -19779,15 +18317,14 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeEntry(
     _ newChild: UnexpectedNodesSyntax?) -> AvailabilityArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeEntry)
+    let newData = data.replacingChild(raw, at: 0)
     return AvailabilityArgumentSyntax(newData)
   }
 
   /// The actual argument
   public var entry: Syntax {
     get {
-      let childData = data.child(at: Cursor.entry,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -19801,14 +18338,13 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withEntry(
     _ newChild: Syntax?) -> AvailabilityArgumentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.entry)
+    let newData = data.replacingChild(raw, at: 1)
     return AvailabilityArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenEntryAndTrailingComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenEntryAndTrailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -19823,7 +18359,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenEntryAndTrailingComma(
     _ newChild: UnexpectedNodesSyntax?) -> AvailabilityArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenEntryAndTrailingComma)
+    let newData = data.replacingChild(raw, at: 2)
     return AvailabilityArgumentSyntax(newData)
   }
 
@@ -19833,8 +18369,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var trailingComma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.trailingComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -19849,7 +18384,7 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
   public func withTrailingComma(
     _ newChild: TokenSyntax?) -> AvailabilityArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.trailingComma)
+    let newData = data.replacingChild(raw, at: 3)
     return AvailabilityArgumentSyntax(newData)
   }
 }
@@ -19872,15 +18407,6 @@ extension AvailabilityArgumentSyntax: CustomReflectable {
 /// a value, e.g. `message: "This has been deprecated"`.
 /// 
 public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLabel
-    case label
-    case unexpectedBetweenLabelAndColon
-    case colon
-    case unexpectedBetweenColonAndValue
-    case value
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AvailabilityLabeledArgumentSyntax` if possible. Returns
@@ -19926,8 +18452,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
 
   public var unexpectedBeforeLabel: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -19942,15 +18467,14 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   public func withUnexpectedBeforeLabel(
     _ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLabel)
+    let newData = data.replacingChild(raw, at: 0)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
 
   /// The label of the argument
   public var label: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.label,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -19964,14 +18488,13 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   public func withLabel(
     _ newChild: TokenSyntax?) -> AvailabilityLabeledArgumentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.label)
+    let newData = data.replacingChild(raw, at: 1)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLabelAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -19986,15 +18509,14 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   public func withUnexpectedBetweenLabelAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLabelAndColon)
+    let newData = data.replacingChild(raw, at: 2)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
 
   /// The colon separating label and value
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -20008,14 +18530,13 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   public func withColon(
     _ newChild: TokenSyntax?) -> AvailabilityLabeledArgumentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 3)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndValue,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -20030,15 +18551,14 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   public func withUnexpectedBetweenColonAndValue(
     _ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndValue)
+    let newData = data.replacingChild(raw, at: 4)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
 
   /// The value of this labeled argument
   public var value: Syntax {
     get {
-      let childData = data.child(at: Cursor.value,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -20052,7 +18572,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
   public func withValue(
     _ newChild: Syntax?) -> AvailabilityLabeledArgumentSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.value)
+    let newData = data.replacingChild(raw, at: 5)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
 }
@@ -20077,13 +18597,6 @@ extension AvailabilityLabeledArgumentSyntax: CustomReflectable {
 /// certain platform to a version, e.g. `iOS 10` or `swift 3.4`.
 /// 
 public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePlatform
-    case platform
-    case unexpectedBetweenPlatformAndVersion
-    case version
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AvailabilityVersionRestrictionSyntax` if possible. Returns
@@ -20125,8 +18638,7 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
 
   public var unexpectedBeforePlatform: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePlatform,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -20141,7 +18653,7 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
   public func withUnexpectedBeforePlatform(
     _ newChild: UnexpectedNodesSyntax?) -> AvailabilityVersionRestrictionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePlatform)
+    let newData = data.replacingChild(raw, at: 0)
     return AvailabilityVersionRestrictionSyntax(newData)
   }
 
@@ -20152,8 +18664,7 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
   /// 
   public var platform: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.platform,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -20167,14 +18678,13 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
   public func withPlatform(
     _ newChild: TokenSyntax?) -> AvailabilityVersionRestrictionSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.platform)
+    let newData = data.replacingChild(raw, at: 1)
     return AvailabilityVersionRestrictionSyntax(newData)
   }
 
   public var unexpectedBetweenPlatformAndVersion: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPlatformAndVersion,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -20189,14 +18699,13 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
   public func withUnexpectedBetweenPlatformAndVersion(
     _ newChild: UnexpectedNodesSyntax?) -> AvailabilityVersionRestrictionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPlatformAndVersion)
+    let newData = data.replacingChild(raw, at: 2)
     return AvailabilityVersionRestrictionSyntax(newData)
   }
 
   public var version: VersionTupleSyntax? {
     get {
-      let childData = data.child(at: Cursor.version,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return VersionTupleSyntax(childData!)
     }
@@ -20211,7 +18720,7 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
   public func withVersion(
     _ newChild: VersionTupleSyntax?) -> AvailabilityVersionRestrictionSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.version)
+    let newData = data.replacingChild(raw, at: 3)
     return AvailabilityVersionRestrictionSyntax(newData)
   }
 }
@@ -20234,15 +18743,6 @@ extension AvailabilityVersionRestrictionSyntax: CustomReflectable {
 /// and patch part may be omitted.
 /// 
 public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeMajorMinor
-    case majorMinor
-    case unexpectedBetweenMajorMinorAndPatchPeriod
-    case patchPeriod
-    case unexpectedBetweenPatchPeriodAndPatchVersion
-    case patchVersion
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `VersionTupleSyntax` if possible. Returns
@@ -20288,8 +18788,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeMajorMinor: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeMajorMinor,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -20304,7 +18803,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeMajorMinor(
     _ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeMajorMinor)
+    let newData = data.replacingChild(raw, at: 0)
     return VersionTupleSyntax(newData)
   }
 
@@ -20317,8 +18816,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var majorMinor: Syntax {
     get {
-      let childData = data.child(at: Cursor.majorMinor,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -20332,14 +18830,13 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   public func withMajorMinor(
     _ newChild: Syntax?) -> VersionTupleSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.majorMinor)
+    let newData = data.replacingChild(raw, at: 1)
     return VersionTupleSyntax(newData)
   }
 
   public var unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenMajorMinorAndPatchPeriod,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -20354,7 +18851,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenMajorMinorAndPatchPeriod(
     _ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenMajorMinorAndPatchPeriod)
+    let newData = data.replacingChild(raw, at: 2)
     return VersionTupleSyntax(newData)
   }
 
@@ -20364,8 +18861,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var patchPeriod: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.patchPeriod,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -20380,14 +18876,13 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   public func withPatchPeriod(
     _ newChild: TokenSyntax?) -> VersionTupleSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.patchPeriod)
+    let newData = data.replacingChild(raw, at: 3)
     return VersionTupleSyntax(newData)
   }
 
   public var unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPatchPeriodAndPatchVersion,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -20402,7 +18897,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPatchPeriodAndPatchVersion(
     _ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPatchPeriodAndPatchVersion)
+    let newData = data.replacingChild(raw, at: 4)
     return VersionTupleSyntax(newData)
   }
 
@@ -20411,8 +18906,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   /// 
   public var patchVersion: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.patchVersion,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -20427,7 +18921,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
   public func withPatchVersion(
     _ newChild: TokenSyntax?) -> VersionTupleSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.patchVersion)
+    let newData = data.replacingChild(raw, at: 5)
     return VersionTupleSyntax(newData)
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
@@ -16,7 +16,6 @@
 // MARK: - UnknownPatternSyntax
 
 public struct UnknownPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `UnknownPatternSyntax` if possible. Returns
@@ -59,7 +58,6 @@ extension UnknownPatternSyntax: CustomReflectable {
 // MARK: - MissingPatternSyntax
 
 public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `MissingPatternSyntax` if possible. Returns
@@ -102,17 +100,6 @@ extension MissingPatternSyntax: CustomReflectable {
 // MARK: - EnumCasePatternSyntax
 
 public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeType
-    case type
-    case unexpectedBetweenTypeAndPeriod
-    case period
-    case unexpectedBetweenPeriodAndCaseName
-    case caseName
-    case unexpectedBetweenCaseNameAndAssociatedTuple
-    case associatedTuple
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `EnumCasePatternSyntax` if possible. Returns
@@ -162,8 +149,7 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -178,14 +164,13 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeType(
     _ newChild: UnexpectedNodesSyntax?) -> EnumCasePatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeType)
+    let newData = data.replacingChild(raw, at: 0)
     return EnumCasePatternSyntax(newData)
   }
 
   public var type: TypeSyntax? {
     get {
-      let childData = data.child(at: Cursor.type,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeSyntax(childData!)
     }
@@ -200,14 +185,13 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withType(
     _ newChild: TypeSyntax?) -> EnumCasePatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.type)
+    let newData = data.replacingChild(raw, at: 1)
     return EnumCasePatternSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAndPeriod: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTypeAndPeriod,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -222,14 +206,13 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTypeAndPeriod(
     _ newChild: UnexpectedNodesSyntax?) -> EnumCasePatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTypeAndPeriod)
+    let newData = data.replacingChild(raw, at: 2)
     return EnumCasePatternSyntax(newData)
   }
 
   public var period: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.period,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -243,14 +226,13 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withPeriod(
     _ newChild: TokenSyntax?) -> EnumCasePatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.period)
+    let newData = data.replacingChild(raw, at: 3)
     return EnumCasePatternSyntax(newData)
   }
 
   public var unexpectedBetweenPeriodAndCaseName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPeriodAndCaseName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -265,14 +247,13 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPeriodAndCaseName(
     _ newChild: UnexpectedNodesSyntax?) -> EnumCasePatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPeriodAndCaseName)
+    let newData = data.replacingChild(raw, at: 4)
     return EnumCasePatternSyntax(newData)
   }
 
   public var caseName: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.caseName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -286,14 +267,13 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withCaseName(
     _ newChild: TokenSyntax?) -> EnumCasePatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.caseName)
+    let newData = data.replacingChild(raw, at: 5)
     return EnumCasePatternSyntax(newData)
   }
 
   public var unexpectedBetweenCaseNameAndAssociatedTuple: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCaseNameAndAssociatedTuple,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -308,14 +288,13 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCaseNameAndAssociatedTuple(
     _ newChild: UnexpectedNodesSyntax?) -> EnumCasePatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCaseNameAndAssociatedTuple)
+    let newData = data.replacingChild(raw, at: 6)
     return EnumCasePatternSyntax(newData)
   }
 
   public var associatedTuple: TuplePatternSyntax? {
     get {
-      let childData = data.child(at: Cursor.associatedTuple,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TuplePatternSyntax(childData!)
     }
@@ -330,7 +309,7 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withAssociatedTuple(
     _ newChild: TuplePatternSyntax?) -> EnumCasePatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.associatedTuple)
+    let newData = data.replacingChild(raw, at: 7)
     return EnumCasePatternSyntax(newData)
   }
 }
@@ -353,13 +332,6 @@ extension EnumCasePatternSyntax: CustomReflectable {
 // MARK: - IsTypePatternSyntax
 
 public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeIsKeyword
-    case isKeyword
-    case unexpectedBetweenIsKeywordAndType
-    case type
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `IsTypePatternSyntax` if possible. Returns
@@ -401,8 +373,7 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeIsKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeIsKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -417,14 +388,13 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeIsKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> IsTypePatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeIsKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return IsTypePatternSyntax(newData)
   }
 
   public var isKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.isKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -438,14 +408,13 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withIsKeyword(
     _ newChild: TokenSyntax?) -> IsTypePatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.isKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return IsTypePatternSyntax(newData)
   }
 
   public var unexpectedBetweenIsKeywordAndType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIsKeywordAndType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -460,14 +429,13 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIsKeywordAndType(
     _ newChild: UnexpectedNodesSyntax?) -> IsTypePatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIsKeywordAndType)
+    let newData = data.replacingChild(raw, at: 2)
     return IsTypePatternSyntax(newData)
   }
 
   public var type: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.type,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -481,7 +449,7 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withType(
     _ newChild: TypeSyntax?) -> IsTypePatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.type)
+    let newData = data.replacingChild(raw, at: 3)
     return IsTypePatternSyntax(newData)
   }
 }
@@ -500,13 +468,6 @@ extension IsTypePatternSyntax: CustomReflectable {
 // MARK: - OptionalPatternSyntax
 
 public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeSubPattern
-    case subPattern
-    case unexpectedBetweenSubPatternAndQuestionMark
-    case questionMark
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `OptionalPatternSyntax` if possible. Returns
@@ -548,8 +509,7 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeSubPattern: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeSubPattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -564,14 +524,13 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeSubPattern(
     _ newChild: UnexpectedNodesSyntax?) -> OptionalPatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeSubPattern)
+    let newData = data.replacingChild(raw, at: 0)
     return OptionalPatternSyntax(newData)
   }
 
   public var subPattern: PatternSyntax {
     get {
-      let childData = data.child(at: Cursor.subPattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return PatternSyntax(childData!)
     }
     set(value) {
@@ -585,14 +544,13 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withSubPattern(
     _ newChild: PatternSyntax?) -> OptionalPatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.subPattern)
+    let newData = data.replacingChild(raw, at: 1)
     return OptionalPatternSyntax(newData)
   }
 
   public var unexpectedBetweenSubPatternAndQuestionMark: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenSubPatternAndQuestionMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -607,14 +565,13 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenSubPatternAndQuestionMark(
     _ newChild: UnexpectedNodesSyntax?) -> OptionalPatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenSubPatternAndQuestionMark)
+    let newData = data.replacingChild(raw, at: 2)
     return OptionalPatternSyntax(newData)
   }
 
   public var questionMark: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.questionMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -628,7 +585,7 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withQuestionMark(
     _ newChild: TokenSyntax?) -> OptionalPatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.questionMark)
+    let newData = data.replacingChild(raw, at: 3)
     return OptionalPatternSyntax(newData)
   }
 }
@@ -647,11 +604,6 @@ extension OptionalPatternSyntax: CustomReflectable {
 // MARK: - IdentifierPatternSyntax
 
 public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeIdentifier
-    case identifier
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `IdentifierPatternSyntax` if possible. Returns
@@ -689,8 +641,7 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeIdentifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeIdentifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -705,14 +656,13 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeIdentifier(
     _ newChild: UnexpectedNodesSyntax?) -> IdentifierPatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeIdentifier)
+    let newData = data.replacingChild(raw, at: 0)
     return IdentifierPatternSyntax(newData)
   }
 
   public var identifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.identifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -726,7 +676,7 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withIdentifier(
     _ newChild: TokenSyntax?) -> IdentifierPatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.selfKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.identifier)
+    let newData = data.replacingChild(raw, at: 1)
     return IdentifierPatternSyntax(newData)
   }
 }
@@ -743,15 +693,6 @@ extension IdentifierPatternSyntax: CustomReflectable {
 // MARK: - AsTypePatternSyntax
 
 public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePattern
-    case pattern
-    case unexpectedBetweenPatternAndAsKeyword
-    case asKeyword
-    case unexpectedBetweenAsKeywordAndType
-    case type
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AsTypePatternSyntax` if possible. Returns
@@ -797,8 +738,7 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePattern: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -813,14 +753,13 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePattern(
     _ newChild: UnexpectedNodesSyntax?) -> AsTypePatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePattern)
+    let newData = data.replacingChild(raw, at: 0)
     return AsTypePatternSyntax(newData)
   }
 
   public var pattern: PatternSyntax {
     get {
-      let childData = data.child(at: Cursor.pattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return PatternSyntax(childData!)
     }
     set(value) {
@@ -834,14 +773,13 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withPattern(
     _ newChild: PatternSyntax?) -> AsTypePatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.pattern)
+    let newData = data.replacingChild(raw, at: 1)
     return AsTypePatternSyntax(newData)
   }
 
   public var unexpectedBetweenPatternAndAsKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPatternAndAsKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -856,14 +794,13 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPatternAndAsKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> AsTypePatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPatternAndAsKeyword)
+    let newData = data.replacingChild(raw, at: 2)
     return AsTypePatternSyntax(newData)
   }
 
   public var asKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.asKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -877,14 +814,13 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withAsKeyword(
     _ newChild: TokenSyntax?) -> AsTypePatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.asKeyword)
+    let newData = data.replacingChild(raw, at: 3)
     return AsTypePatternSyntax(newData)
   }
 
   public var unexpectedBetweenAsKeywordAndType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAsKeywordAndType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -899,14 +835,13 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAsKeywordAndType(
     _ newChild: UnexpectedNodesSyntax?) -> AsTypePatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAsKeywordAndType)
+    let newData = data.replacingChild(raw, at: 4)
     return AsTypePatternSyntax(newData)
   }
 
   public var type: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.type,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -920,7 +855,7 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withType(
     _ newChild: TypeSyntax?) -> AsTypePatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.type)
+    let newData = data.replacingChild(raw, at: 5)
     return AsTypePatternSyntax(newData)
   }
 }
@@ -941,15 +876,6 @@ extension AsTypePatternSyntax: CustomReflectable {
 // MARK: - TuplePatternSyntax
 
 public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndElements
-    case elements
-    case unexpectedBetweenElementsAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TuplePatternSyntax` if possible. Returns
@@ -995,8 +921,7 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1011,14 +936,13 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftParen)
+    let newData = data.replacingChild(raw, at: 0)
     return TuplePatternSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1032,14 +956,13 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> TuplePatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 1)
     return TuplePatternSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndElements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1054,14 +977,13 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndElements(
     _ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndElements)
+    let newData = data.replacingChild(raw, at: 2)
     return TuplePatternSyntax(newData)
   }
 
   public var elements: TuplePatternElementListSyntax {
     get {
-      let childData = data.child(at: Cursor.elements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TuplePatternElementListSyntax(childData!)
     }
     set(value) {
@@ -1077,14 +999,13 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   ///            appended to its `elements` collection.
   public func addElement(_ element: TuplePatternElementSyntax) -> TuplePatternSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.elements] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.elements)
+    let newData = data.replacingChild(collection, at: 3)
     return TuplePatternSyntax(newData)
   }
 
@@ -1094,14 +1015,13 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withElements(
     _ newChild: TuplePatternElementListSyntax?) -> TuplePatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tuplePatternElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.elements)
+    let newData = data.replacingChild(raw, at: 3)
     return TuplePatternSyntax(newData)
   }
 
   public var unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenElementsAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1116,14 +1036,13 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenElementsAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenElementsAndRightParen)
+    let newData = data.replacingChild(raw, at: 4)
     return TuplePatternSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1137,7 +1056,7 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> TuplePatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 5)
     return TuplePatternSyntax(newData)
   }
 }
@@ -1158,13 +1077,6 @@ extension TuplePatternSyntax: CustomReflectable {
 // MARK: - WildcardPatternSyntax
 
 public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeWildcard
-    case wildcard
-    case unexpectedBetweenWildcardAndTypeAnnotation
-    case typeAnnotation
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `WildcardPatternSyntax` if possible. Returns
@@ -1206,8 +1118,7 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeWildcard: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeWildcard,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1222,14 +1133,13 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeWildcard(
     _ newChild: UnexpectedNodesSyntax?) -> WildcardPatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeWildcard)
+    let newData = data.replacingChild(raw, at: 0)
     return WildcardPatternSyntax(newData)
   }
 
   public var wildcard: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.wildcard,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1243,14 +1153,13 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withWildcard(
     _ newChild: TokenSyntax?) -> WildcardPatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.wildcardKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.wildcard)
+    let newData = data.replacingChild(raw, at: 1)
     return WildcardPatternSyntax(newData)
   }
 
   public var unexpectedBetweenWildcardAndTypeAnnotation: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenWildcardAndTypeAnnotation,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1265,14 +1174,13 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenWildcardAndTypeAnnotation(
     _ newChild: UnexpectedNodesSyntax?) -> WildcardPatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenWildcardAndTypeAnnotation)
+    let newData = data.replacingChild(raw, at: 2)
     return WildcardPatternSyntax(newData)
   }
 
   public var typeAnnotation: TypeAnnotationSyntax? {
     get {
-      let childData = data.child(at: Cursor.typeAnnotation,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeAnnotationSyntax(childData!)
     }
@@ -1287,7 +1195,7 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withTypeAnnotation(
     _ newChild: TypeAnnotationSyntax?) -> WildcardPatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.typeAnnotation)
+    let newData = data.replacingChild(raw, at: 3)
     return WildcardPatternSyntax(newData)
   }
 }
@@ -1306,11 +1214,6 @@ extension WildcardPatternSyntax: CustomReflectable {
 // MARK: - ExpressionPatternSyntax
 
 public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeExpression
-    case expression
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ExpressionPatternSyntax` if possible. Returns
@@ -1348,8 +1251,7 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1364,14 +1266,13 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeExpression(
     _ newChild: UnexpectedNodesSyntax?) -> ExpressionPatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeExpression)
+    let newData = data.replacingChild(raw, at: 0)
     return ExpressionPatternSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -1385,7 +1286,7 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> ExpressionPatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 1)
     return ExpressionPatternSyntax(newData)
   }
 }
@@ -1402,13 +1303,6 @@ extension ExpressionPatternSyntax: CustomReflectable {
 // MARK: - ValueBindingPatternSyntax
 
 public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLetOrVarKeyword
-    case letOrVarKeyword
-    case unexpectedBetweenLetOrVarKeywordAndValuePattern
-    case valuePattern
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ValueBindingPatternSyntax` if possible. Returns
@@ -1450,8 +1344,7 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLetOrVarKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLetOrVarKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1466,14 +1359,13 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLetOrVarKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ValueBindingPatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLetOrVarKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return ValueBindingPatternSyntax(newData)
   }
 
   public var letOrVarKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.letOrVarKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1487,14 +1379,13 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withLetOrVarKeyword(
     _ newChild: TokenSyntax?) -> ValueBindingPatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.letOrVarKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return ValueBindingPatternSyntax(newData)
   }
 
   public var unexpectedBetweenLetOrVarKeywordAndValuePattern: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLetOrVarKeywordAndValuePattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1509,14 +1400,13 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLetOrVarKeywordAndValuePattern(
     _ newChild: UnexpectedNodesSyntax?) -> ValueBindingPatternSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLetOrVarKeywordAndValuePattern)
+    let newData = data.replacingChild(raw, at: 2)
     return ValueBindingPatternSyntax(newData)
   }
 
   public var valuePattern: PatternSyntax {
     get {
-      let childData = data.child(at: Cursor.valuePattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return PatternSyntax(childData!)
     }
     set(value) {
@@ -1530,7 +1420,7 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   public func withValuePattern(
     _ newChild: PatternSyntax?) -> ValueBindingPatternSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.valuePattern)
+    let newData = data.replacingChild(raw, at: 3)
     return ValueBindingPatternSyntax(newData)
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -16,7 +16,6 @@
 // MARK: - UnknownStmtSyntax
 
 public struct UnknownStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `UnknownStmtSyntax` if possible. Returns
@@ -59,7 +58,6 @@ extension UnknownStmtSyntax: CustomReflectable {
 // MARK: - MissingStmtSyntax
 
 public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `MissingStmtSyntax` if possible. Returns
@@ -102,15 +100,6 @@ extension MissingStmtSyntax: CustomReflectable {
 // MARK: - LabeledStmtSyntax
 
 public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLabelName
-    case labelName
-    case unexpectedBetweenLabelNameAndLabelColon
-    case labelColon
-    case unexpectedBetweenLabelColonAndStatement
-    case statement
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `LabeledStmtSyntax` if possible. Returns
@@ -156,8 +145,7 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLabelName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLabelName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -172,14 +160,13 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLabelName(
     _ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLabelName)
+    let newData = data.replacingChild(raw, at: 0)
     return LabeledStmtSyntax(newData)
   }
 
   public var labelName: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.labelName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -193,14 +180,13 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withLabelName(
     _ newChild: TokenSyntax?) -> LabeledStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.labelName)
+    let newData = data.replacingChild(raw, at: 1)
     return LabeledStmtSyntax(newData)
   }
 
   public var unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLabelNameAndLabelColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -215,14 +201,13 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLabelNameAndLabelColon(
     _ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLabelNameAndLabelColon)
+    let newData = data.replacingChild(raw, at: 2)
     return LabeledStmtSyntax(newData)
   }
 
   public var labelColon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.labelColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -236,14 +221,13 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withLabelColon(
     _ newChild: TokenSyntax?) -> LabeledStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.labelColon)
+    let newData = data.replacingChild(raw, at: 3)
     return LabeledStmtSyntax(newData)
   }
 
   public var unexpectedBetweenLabelColonAndStatement: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLabelColonAndStatement,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -258,14 +242,13 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLabelColonAndStatement(
     _ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLabelColonAndStatement)
+    let newData = data.replacingChild(raw, at: 4)
     return LabeledStmtSyntax(newData)
   }
 
   public var statement: StmtSyntax {
     get {
-      let childData = data.child(at: Cursor.statement,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return StmtSyntax(childData!)
     }
     set(value) {
@@ -279,7 +262,7 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withStatement(
     _ newChild: StmtSyntax?) -> LabeledStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingStmt, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.statement)
+    let newData = data.replacingChild(raw, at: 5)
     return LabeledStmtSyntax(newData)
   }
 }
@@ -300,13 +283,6 @@ extension LabeledStmtSyntax: CustomReflectable {
 // MARK: - ContinueStmtSyntax
 
 public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeContinueKeyword
-    case continueKeyword
-    case unexpectedBetweenContinueKeywordAndLabel
-    case label
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ContinueStmtSyntax` if possible. Returns
@@ -348,8 +324,7 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeContinueKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeContinueKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -364,14 +339,13 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeContinueKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ContinueStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeContinueKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return ContinueStmtSyntax(newData)
   }
 
   public var continueKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.continueKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -385,14 +359,13 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withContinueKeyword(
     _ newChild: TokenSyntax?) -> ContinueStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.continueKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.continueKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return ContinueStmtSyntax(newData)
   }
 
   public var unexpectedBetweenContinueKeywordAndLabel: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenContinueKeywordAndLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -407,14 +380,13 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenContinueKeywordAndLabel(
     _ newChild: UnexpectedNodesSyntax?) -> ContinueStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenContinueKeywordAndLabel)
+    let newData = data.replacingChild(raw, at: 2)
     return ContinueStmtSyntax(newData)
   }
 
   public var label: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.label,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -429,7 +401,7 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withLabel(
     _ newChild: TokenSyntax?) -> ContinueStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.label)
+    let newData = data.replacingChild(raw, at: 3)
     return ContinueStmtSyntax(newData)
   }
 }
@@ -448,15 +420,6 @@ extension ContinueStmtSyntax: CustomReflectable {
 // MARK: - WhileStmtSyntax
 
 public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeWhileKeyword
-    case whileKeyword
-    case unexpectedBetweenWhileKeywordAndConditions
-    case conditions
-    case unexpectedBetweenConditionsAndBody
-    case body
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `WhileStmtSyntax` if possible. Returns
@@ -502,8 +465,7 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeWhileKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeWhileKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -518,14 +480,13 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeWhileKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeWhileKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return WhileStmtSyntax(newData)
   }
 
   public var whileKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.whileKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -539,14 +500,13 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withWhileKeyword(
     _ newChild: TokenSyntax?) -> WhileStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whileKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.whileKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return WhileStmtSyntax(newData)
   }
 
   public var unexpectedBetweenWhileKeywordAndConditions: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenWhileKeywordAndConditions,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -561,14 +521,13 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenWhileKeywordAndConditions(
     _ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenWhileKeywordAndConditions)
+    let newData = data.replacingChild(raw, at: 2)
     return WhileStmtSyntax(newData)
   }
 
   public var conditions: ConditionElementListSyntax {
     get {
-      let childData = data.child(at: Cursor.conditions,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return ConditionElementListSyntax(childData!)
     }
     set(value) {
@@ -584,14 +543,13 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///            appended to its `conditions` collection.
   public func addCondition(_ element: ConditionElementSyntax) -> WhileStmtSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.conditions] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.conditionElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.conditions)
+    let newData = data.replacingChild(collection, at: 3)
     return WhileStmtSyntax(newData)
   }
 
@@ -601,14 +559,13 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withConditions(
     _ newChild: ConditionElementListSyntax?) -> WhileStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.conditions)
+    let newData = data.replacingChild(raw, at: 3)
     return WhileStmtSyntax(newData)
   }
 
   public var unexpectedBetweenConditionsAndBody: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenConditionsAndBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -623,14 +580,13 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenConditionsAndBody(
     _ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenConditionsAndBody)
+    let newData = data.replacingChild(raw, at: 4)
     return WhileStmtSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
     get {
-      let childData = data.child(at: Cursor.body,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return CodeBlockSyntax(childData!)
     }
     set(value) {
@@ -644,7 +600,7 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withBody(
     _ newChild: CodeBlockSyntax?) -> WhileStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.body)
+    let newData = data.replacingChild(raw, at: 5)
     return WhileStmtSyntax(newData)
   }
 }
@@ -665,13 +621,6 @@ extension WhileStmtSyntax: CustomReflectable {
 // MARK: - DeferStmtSyntax
 
 public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeDeferKeyword
-    case deferKeyword
-    case unexpectedBetweenDeferKeywordAndBody
-    case body
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DeferStmtSyntax` if possible. Returns
@@ -713,8 +662,7 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeDeferKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeDeferKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -729,14 +677,13 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeDeferKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> DeferStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeDeferKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return DeferStmtSyntax(newData)
   }
 
   public var deferKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.deferKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -750,14 +697,13 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withDeferKeyword(
     _ newChild: TokenSyntax?) -> DeferStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.deferKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.deferKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return DeferStmtSyntax(newData)
   }
 
   public var unexpectedBetweenDeferKeywordAndBody: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDeferKeywordAndBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -772,14 +718,13 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenDeferKeywordAndBody(
     _ newChild: UnexpectedNodesSyntax?) -> DeferStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDeferKeywordAndBody)
+    let newData = data.replacingChild(raw, at: 2)
     return DeferStmtSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
     get {
-      let childData = data.child(at: Cursor.body,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return CodeBlockSyntax(childData!)
     }
     set(value) {
@@ -793,7 +738,7 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withBody(
     _ newChild: CodeBlockSyntax?) -> DeferStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.body)
+    let newData = data.replacingChild(raw, at: 3)
     return DeferStmtSyntax(newData)
   }
 }
@@ -812,11 +757,6 @@ extension DeferStmtSyntax: CustomReflectable {
 // MARK: - ExpressionStmtSyntax
 
 public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeExpression
-    case expression
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ExpressionStmtSyntax` if possible. Returns
@@ -854,8 +794,7 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -870,14 +809,13 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeExpression(
     _ newChild: UnexpectedNodesSyntax?) -> ExpressionStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeExpression)
+    let newData = data.replacingChild(raw, at: 0)
     return ExpressionStmtSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -891,7 +829,7 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> ExpressionStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 1)
     return ExpressionStmtSyntax(newData)
   }
 }
@@ -908,17 +846,6 @@ extension ExpressionStmtSyntax: CustomReflectable {
 // MARK: - RepeatWhileStmtSyntax
 
 public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeRepeatKeyword
-    case repeatKeyword
-    case unexpectedBetweenRepeatKeywordAndBody
-    case body
-    case unexpectedBetweenBodyAndWhileKeyword
-    case whileKeyword
-    case unexpectedBetweenWhileKeywordAndCondition
-    case condition
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `RepeatWhileStmtSyntax` if possible. Returns
@@ -968,8 +895,7 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeRepeatKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeRepeatKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -984,14 +910,13 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeRepeatKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeRepeatKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return RepeatWhileStmtSyntax(newData)
   }
 
   public var repeatKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.repeatKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1005,14 +930,13 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withRepeatKeyword(
     _ newChild: TokenSyntax?) -> RepeatWhileStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.repeatKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.repeatKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return RepeatWhileStmtSyntax(newData)
   }
 
   public var unexpectedBetweenRepeatKeywordAndBody: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenRepeatKeywordAndBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1027,14 +951,13 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenRepeatKeywordAndBody(
     _ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenRepeatKeywordAndBody)
+    let newData = data.replacingChild(raw, at: 2)
     return RepeatWhileStmtSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
     get {
-      let childData = data.child(at: Cursor.body,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return CodeBlockSyntax(childData!)
     }
     set(value) {
@@ -1048,14 +971,13 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withBody(
     _ newChild: CodeBlockSyntax?) -> RepeatWhileStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.body)
+    let newData = data.replacingChild(raw, at: 3)
     return RepeatWhileStmtSyntax(newData)
   }
 
   public var unexpectedBetweenBodyAndWhileKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenBodyAndWhileKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1070,14 +992,13 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenBodyAndWhileKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenBodyAndWhileKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return RepeatWhileStmtSyntax(newData)
   }
 
   public var whileKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.whileKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1091,14 +1012,13 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withWhileKeyword(
     _ newChild: TokenSyntax?) -> RepeatWhileStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.whileKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.whileKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return RepeatWhileStmtSyntax(newData)
   }
 
   public var unexpectedBetweenWhileKeywordAndCondition: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenWhileKeywordAndCondition,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1113,14 +1033,13 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenWhileKeywordAndCondition(
     _ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenWhileKeywordAndCondition)
+    let newData = data.replacingChild(raw, at: 6)
     return RepeatWhileStmtSyntax(newData)
   }
 
   public var condition: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.condition,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -1134,7 +1053,7 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withCondition(
     _ newChild: ExprSyntax?) -> RepeatWhileStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.condition)
+    let newData = data.replacingChild(raw, at: 7)
     return RepeatWhileStmtSyntax(newData)
   }
 }
@@ -1157,17 +1076,6 @@ extension RepeatWhileStmtSyntax: CustomReflectable {
 // MARK: - GuardStmtSyntax
 
 public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeGuardKeyword
-    case guardKeyword
-    case unexpectedBetweenGuardKeywordAndConditions
-    case conditions
-    case unexpectedBetweenConditionsAndElseKeyword
-    case elseKeyword
-    case unexpectedBetweenElseKeywordAndBody
-    case body
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `GuardStmtSyntax` if possible. Returns
@@ -1217,8 +1125,7 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeGuardKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeGuardKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1233,14 +1140,13 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeGuardKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeGuardKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return GuardStmtSyntax(newData)
   }
 
   public var guardKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.guardKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1254,14 +1160,13 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withGuardKeyword(
     _ newChild: TokenSyntax?) -> GuardStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.guardKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.guardKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return GuardStmtSyntax(newData)
   }
 
   public var unexpectedBetweenGuardKeywordAndConditions: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenGuardKeywordAndConditions,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1276,14 +1181,13 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenGuardKeywordAndConditions(
     _ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenGuardKeywordAndConditions)
+    let newData = data.replacingChild(raw, at: 2)
     return GuardStmtSyntax(newData)
   }
 
   public var conditions: ConditionElementListSyntax {
     get {
-      let childData = data.child(at: Cursor.conditions,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return ConditionElementListSyntax(childData!)
     }
     set(value) {
@@ -1299,14 +1203,13 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///            appended to its `conditions` collection.
   public func addCondition(_ element: ConditionElementSyntax) -> GuardStmtSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.conditions] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.conditionElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.conditions)
+    let newData = data.replacingChild(collection, at: 3)
     return GuardStmtSyntax(newData)
   }
 
@@ -1316,14 +1219,13 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withConditions(
     _ newChild: ConditionElementListSyntax?) -> GuardStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.conditions)
+    let newData = data.replacingChild(raw, at: 3)
     return GuardStmtSyntax(newData)
   }
 
   public var unexpectedBetweenConditionsAndElseKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenConditionsAndElseKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1338,14 +1240,13 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenConditionsAndElseKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenConditionsAndElseKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return GuardStmtSyntax(newData)
   }
 
   public var elseKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.elseKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1359,14 +1260,13 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withElseKeyword(
     _ newChild: TokenSyntax?) -> GuardStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.elseKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.elseKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return GuardStmtSyntax(newData)
   }
 
   public var unexpectedBetweenElseKeywordAndBody: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenElseKeywordAndBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1381,14 +1281,13 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenElseKeywordAndBody(
     _ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenElseKeywordAndBody)
+    let newData = data.replacingChild(raw, at: 6)
     return GuardStmtSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
     get {
-      let childData = data.child(at: Cursor.body,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return CodeBlockSyntax(childData!)
     }
     set(value) {
@@ -1402,7 +1301,7 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withBody(
     _ newChild: CodeBlockSyntax?) -> GuardStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.body)
+    let newData = data.replacingChild(raw, at: 7)
     return GuardStmtSyntax(newData)
   }
 }
@@ -1425,29 +1324,6 @@ extension GuardStmtSyntax: CustomReflectable {
 // MARK: - ForInStmtSyntax
 
 public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeForKeyword
-    case forKeyword
-    case unexpectedBetweenForKeywordAndTryKeyword
-    case tryKeyword
-    case unexpectedBetweenTryKeywordAndAwaitKeyword
-    case awaitKeyword
-    case unexpectedBetweenAwaitKeywordAndCaseKeyword
-    case caseKeyword
-    case unexpectedBetweenCaseKeywordAndPattern
-    case pattern
-    case unexpectedBetweenPatternAndTypeAnnotation
-    case typeAnnotation
-    case unexpectedBetweenTypeAnnotationAndInKeyword
-    case inKeyword
-    case unexpectedBetweenInKeywordAndSequenceExpr
-    case sequenceExpr
-    case unexpectedBetweenSequenceExprAndWhereClause
-    case whereClause
-    case unexpectedBetweenWhereClauseAndBody
-    case body
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ForInStmtSyntax` if possible. Returns
@@ -1521,8 +1397,7 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeForKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeForKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1537,14 +1412,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeForKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeForKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return ForInStmtSyntax(newData)
   }
 
   public var forKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.forKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1558,14 +1432,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withForKeyword(
     _ newChild: TokenSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.forKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.forKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenForKeywordAndTryKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenForKeywordAndTryKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1580,14 +1453,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenForKeywordAndTryKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenForKeywordAndTryKeyword)
+    let newData = data.replacingChild(raw, at: 2)
     return ForInStmtSyntax(newData)
   }
 
   public var tryKeyword: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.tryKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -1602,14 +1474,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withTryKeyword(
     _ newChild: TokenSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.tryKeyword)
+    let newData = data.replacingChild(raw, at: 3)
     return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenTryKeywordAndAwaitKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTryKeywordAndAwaitKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1624,14 +1495,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTryKeywordAndAwaitKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTryKeywordAndAwaitKeyword)
+    let newData = data.replacingChild(raw, at: 4)
     return ForInStmtSyntax(newData)
   }
 
   public var awaitKeyword: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.awaitKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -1646,14 +1516,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withAwaitKeyword(
     _ newChild: TokenSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.awaitKeyword)
+    let newData = data.replacingChild(raw, at: 5)
     return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenAwaitKeywordAndCaseKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAwaitKeywordAndCaseKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1668,14 +1537,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAwaitKeywordAndCaseKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAwaitKeywordAndCaseKeyword)
+    let newData = data.replacingChild(raw, at: 6)
     return ForInStmtSyntax(newData)
   }
 
   public var caseKeyword: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.caseKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -1690,14 +1558,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withCaseKeyword(
     _ newChild: TokenSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.caseKeyword)
+    let newData = data.replacingChild(raw, at: 7)
     return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCaseKeywordAndPattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1712,14 +1579,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCaseKeywordAndPattern(
     _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCaseKeywordAndPattern)
+    let newData = data.replacingChild(raw, at: 8)
     return ForInStmtSyntax(newData)
   }
 
   public var pattern: PatternSyntax {
     get {
-      let childData = data.child(at: Cursor.pattern,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       return PatternSyntax(childData!)
     }
     set(value) {
@@ -1733,14 +1599,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withPattern(
     _ newChild: PatternSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.pattern)
+    let newData = data.replacingChild(raw, at: 9)
     return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPatternAndTypeAnnotation,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1755,14 +1620,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPatternAndTypeAnnotation(
     _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPatternAndTypeAnnotation)
+    let newData = data.replacingChild(raw, at: 10)
     return ForInStmtSyntax(newData)
   }
 
   public var typeAnnotation: TypeAnnotationSyntax? {
     get {
-      let childData = data.child(at: Cursor.typeAnnotation,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       if childData == nil { return nil }
       return TypeAnnotationSyntax(childData!)
     }
@@ -1777,14 +1641,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withTypeAnnotation(
     _ newChild: TypeAnnotationSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.typeAnnotation)
+    let newData = data.replacingChild(raw, at: 11)
     return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenTypeAnnotationAndInKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenTypeAnnotationAndInKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1799,14 +1662,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenTypeAnnotationAndInKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenTypeAnnotationAndInKeyword)
+    let newData = data.replacingChild(raw, at: 12)
     return ForInStmtSyntax(newData)
   }
 
   public var inKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.inKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1820,14 +1682,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withInKeyword(
     _ newChild: TokenSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.inKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.inKeyword)
+    let newData = data.replacingChild(raw, at: 13)
     return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenInKeywordAndSequenceExpr: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenInKeywordAndSequenceExpr,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 14, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1842,14 +1703,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenInKeywordAndSequenceExpr(
     _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenInKeywordAndSequenceExpr)
+    let newData = data.replacingChild(raw, at: 14)
     return ForInStmtSyntax(newData)
   }
 
   public var sequenceExpr: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.sequenceExpr,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 15, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -1863,14 +1723,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withSequenceExpr(
     _ newChild: ExprSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.sequenceExpr)
+    let newData = data.replacingChild(raw, at: 15)
     return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenSequenceExprAndWhereClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenSequenceExprAndWhereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 16, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1885,14 +1744,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenSequenceExprAndWhereClause(
     _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenSequenceExprAndWhereClause)
+    let newData = data.replacingChild(raw, at: 16)
     return ForInStmtSyntax(newData)
   }
 
   public var whereClause: WhereClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.whereClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 17, parent: Syntax(self))
       if childData == nil { return nil }
       return WhereClauseSyntax(childData!)
     }
@@ -1907,14 +1765,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withWhereClause(
     _ newChild: WhereClauseSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.whereClause)
+    let newData = data.replacingChild(raw, at: 17)
     return ForInStmtSyntax(newData)
   }
 
   public var unexpectedBetweenWhereClauseAndBody: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenWhereClauseAndBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 18, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1929,14 +1786,13 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenWhereClauseAndBody(
     _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenWhereClauseAndBody)
+    let newData = data.replacingChild(raw, at: 18)
     return ForInStmtSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
     get {
-      let childData = data.child(at: Cursor.body,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 19, parent: Syntax(self))
       return CodeBlockSyntax(childData!)
     }
     set(value) {
@@ -1950,7 +1806,7 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withBody(
     _ newChild: CodeBlockSyntax?) -> ForInStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.body)
+    let newData = data.replacingChild(raw, at: 19)
     return ForInStmtSyntax(newData)
   }
 }
@@ -1985,19 +1841,6 @@ extension ForInStmtSyntax: CustomReflectable {
 // MARK: - SwitchStmtSyntax
 
 public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeSwitchKeyword
-    case switchKeyword
-    case unexpectedBetweenSwitchKeywordAndExpression
-    case expression
-    case unexpectedBetweenExpressionAndLeftBrace
-    case leftBrace
-    case unexpectedBetweenLeftBraceAndCases
-    case cases
-    case unexpectedBetweenCasesAndRightBrace
-    case rightBrace
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SwitchStmtSyntax` if possible. Returns
@@ -2051,8 +1894,7 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeSwitchKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeSwitchKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2067,14 +1909,13 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeSwitchKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeSwitchKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return SwitchStmtSyntax(newData)
   }
 
   public var switchKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.switchKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2088,14 +1929,13 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withSwitchKeyword(
     _ newChild: TokenSyntax?) -> SwitchStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.switchKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.switchKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return SwitchStmtSyntax(newData)
   }
 
   public var unexpectedBetweenSwitchKeywordAndExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenSwitchKeywordAndExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2110,14 +1950,13 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenSwitchKeywordAndExpression(
     _ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenSwitchKeywordAndExpression)
+    let newData = data.replacingChild(raw, at: 2)
     return SwitchStmtSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -2131,14 +1970,13 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> SwitchStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 3)
     return SwitchStmtSyntax(newData)
   }
 
   public var unexpectedBetweenExpressionAndLeftBrace: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenExpressionAndLeftBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2153,14 +1991,13 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenExpressionAndLeftBrace(
     _ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenExpressionAndLeftBrace)
+    let newData = data.replacingChild(raw, at: 4)
     return SwitchStmtSyntax(newData)
   }
 
   public var leftBrace: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2174,14 +2011,13 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withLeftBrace(
     _ newChild: TokenSyntax?) -> SwitchStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftBrace)
+    let newData = data.replacingChild(raw, at: 5)
     return SwitchStmtSyntax(newData)
   }
 
   public var unexpectedBetweenLeftBraceAndCases: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftBraceAndCases,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2196,14 +2032,13 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftBraceAndCases(
     _ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftBraceAndCases)
+    let newData = data.replacingChild(raw, at: 6)
     return SwitchStmtSyntax(newData)
   }
 
   public var cases: SwitchCaseListSyntax {
     get {
-      let childData = data.child(at: Cursor.cases,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return SwitchCaseListSyntax(childData!)
     }
     set(value) {
@@ -2219,14 +2054,13 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///            appended to its `cases` collection.
   public func addCase(_ element: Syntax) -> SwitchStmtSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.cases] {
+    if let col = raw.layoutView!.children[7] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.cases)
+    let newData = data.replacingChild(collection, at: 7)
     return SwitchStmtSyntax(newData)
   }
 
@@ -2236,14 +2070,13 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withCases(
     _ newChild: SwitchCaseListSyntax?) -> SwitchStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.switchCaseList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.cases)
+    let newData = data.replacingChild(raw, at: 7)
     return SwitchStmtSyntax(newData)
   }
 
   public var unexpectedBetweenCasesAndRightBrace: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCasesAndRightBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2258,14 +2091,13 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCasesAndRightBrace(
     _ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCasesAndRightBrace)
+    let newData = data.replacingChild(raw, at: 8)
     return SwitchStmtSyntax(newData)
   }
 
   public var rightBrace: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightBrace,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2279,7 +2111,7 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withRightBrace(
     _ newChild: TokenSyntax?) -> SwitchStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightBrace)
+    let newData = data.replacingChild(raw, at: 9)
     return SwitchStmtSyntax(newData)
   }
 }
@@ -2304,15 +2136,6 @@ extension SwitchStmtSyntax: CustomReflectable {
 // MARK: - DoStmtSyntax
 
 public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeDoKeyword
-    case doKeyword
-    case unexpectedBetweenDoKeywordAndBody
-    case body
-    case unexpectedBetweenBodyAndCatchClauses
-    case catchClauses
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DoStmtSyntax` if possible. Returns
@@ -2358,8 +2181,7 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeDoKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeDoKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2374,14 +2196,13 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeDoKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeDoKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return DoStmtSyntax(newData)
   }
 
   public var doKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.doKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2395,14 +2216,13 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withDoKeyword(
     _ newChild: TokenSyntax?) -> DoStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.doKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.doKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return DoStmtSyntax(newData)
   }
 
   public var unexpectedBetweenDoKeywordAndBody: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenDoKeywordAndBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2417,14 +2237,13 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenDoKeywordAndBody(
     _ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenDoKeywordAndBody)
+    let newData = data.replacingChild(raw, at: 2)
     return DoStmtSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
     get {
-      let childData = data.child(at: Cursor.body,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return CodeBlockSyntax(childData!)
     }
     set(value) {
@@ -2438,14 +2257,13 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withBody(
     _ newChild: CodeBlockSyntax?) -> DoStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.body)
+    let newData = data.replacingChild(raw, at: 3)
     return DoStmtSyntax(newData)
   }
 
   public var unexpectedBetweenBodyAndCatchClauses: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenBodyAndCatchClauses,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2460,14 +2278,13 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenBodyAndCatchClauses(
     _ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenBodyAndCatchClauses)
+    let newData = data.replacingChild(raw, at: 4)
     return DoStmtSyntax(newData)
   }
 
   public var catchClauses: CatchClauseListSyntax? {
     get {
-      let childData = data.child(at: Cursor.catchClauses,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       if childData == nil { return nil }
       return CatchClauseListSyntax(childData!)
     }
@@ -2484,14 +2301,13 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///            appended to its `catchClauses` collection.
   public func addCatchClause(_ element: CatchClauseSyntax) -> DoStmtSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.catchClauses] {
+    if let col = raw.layoutView!.children[5] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.catchClauseList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.catchClauses)
+    let newData = data.replacingChild(collection, at: 5)
     return DoStmtSyntax(newData)
   }
 
@@ -2501,7 +2317,7 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withCatchClauses(
     _ newChild: CatchClauseListSyntax?) -> DoStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.catchClauses)
+    let newData = data.replacingChild(raw, at: 5)
     return DoStmtSyntax(newData)
   }
 }
@@ -2522,13 +2338,6 @@ extension DoStmtSyntax: CustomReflectable {
 // MARK: - ReturnStmtSyntax
 
 public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeReturnKeyword
-    case returnKeyword
-    case unexpectedBetweenReturnKeywordAndExpression
-    case expression
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ReturnStmtSyntax` if possible. Returns
@@ -2570,8 +2379,7 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeReturnKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeReturnKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2586,14 +2394,13 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeReturnKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ReturnStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeReturnKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return ReturnStmtSyntax(newData)
   }
 
   public var returnKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.returnKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2607,14 +2414,13 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withReturnKeyword(
     _ newChild: TokenSyntax?) -> ReturnStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.returnKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.returnKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return ReturnStmtSyntax(newData)
   }
 
   public var unexpectedBetweenReturnKeywordAndExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenReturnKeywordAndExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2629,14 +2435,13 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenReturnKeywordAndExpression(
     _ newChild: UnexpectedNodesSyntax?) -> ReturnStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenReturnKeywordAndExpression)
+    let newData = data.replacingChild(raw, at: 2)
     return ReturnStmtSyntax(newData)
   }
 
   public var expression: ExprSyntax? {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return ExprSyntax(childData!)
     }
@@ -2651,7 +2456,7 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> ReturnStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 3)
     return ReturnStmtSyntax(newData)
   }
 }
@@ -2670,13 +2475,6 @@ extension ReturnStmtSyntax: CustomReflectable {
 // MARK: - YieldStmtSyntax
 
 public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeYieldKeyword
-    case yieldKeyword
-    case unexpectedBetweenYieldKeywordAndYields
-    case yields
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `YieldStmtSyntax` if possible. Returns
@@ -2718,8 +2516,7 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeYieldKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeYieldKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2734,14 +2531,13 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeYieldKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> YieldStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeYieldKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return YieldStmtSyntax(newData)
   }
 
   public var yieldKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.yieldKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2755,14 +2551,13 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withYieldKeyword(
     _ newChild: TokenSyntax?) -> YieldStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.yield, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.yieldKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return YieldStmtSyntax(newData)
   }
 
   public var unexpectedBetweenYieldKeywordAndYields: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenYieldKeywordAndYields,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2777,14 +2572,13 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenYieldKeywordAndYields(
     _ newChild: UnexpectedNodesSyntax?) -> YieldStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenYieldKeywordAndYields)
+    let newData = data.replacingChild(raw, at: 2)
     return YieldStmtSyntax(newData)
   }
 
   public var yields: Syntax {
     get {
-      let childData = data.child(at: Cursor.yields,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return Syntax(childData!)
     }
     set(value) {
@@ -2798,7 +2592,7 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withYields(
     _ newChild: Syntax?) -> YieldStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.yields)
+    let newData = data.replacingChild(raw, at: 3)
     return YieldStmtSyntax(newData)
   }
 }
@@ -2817,11 +2611,6 @@ extension YieldStmtSyntax: CustomReflectable {
 // MARK: - FallthroughStmtSyntax
 
 public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeFallthroughKeyword
-    case fallthroughKeyword
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `FallthroughStmtSyntax` if possible. Returns
@@ -2859,8 +2648,7 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeFallthroughKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeFallthroughKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2875,14 +2663,13 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeFallthroughKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> FallthroughStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeFallthroughKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return FallthroughStmtSyntax(newData)
   }
 
   public var fallthroughKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.fallthroughKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2896,7 +2683,7 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withFallthroughKeyword(
     _ newChild: TokenSyntax?) -> FallthroughStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.fallthroughKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.fallthroughKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return FallthroughStmtSyntax(newData)
   }
 }
@@ -2913,13 +2700,6 @@ extension FallthroughStmtSyntax: CustomReflectable {
 // MARK: - BreakStmtSyntax
 
 public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeBreakKeyword
-    case breakKeyword
-    case unexpectedBetweenBreakKeywordAndLabel
-    case label
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `BreakStmtSyntax` if possible. Returns
@@ -2961,8 +2741,7 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeBreakKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeBreakKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2977,14 +2756,13 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeBreakKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> BreakStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeBreakKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return BreakStmtSyntax(newData)
   }
 
   public var breakKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.breakKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2998,14 +2776,13 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withBreakKeyword(
     _ newChild: TokenSyntax?) -> BreakStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.breakKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.breakKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return BreakStmtSyntax(newData)
   }
 
   public var unexpectedBetweenBreakKeywordAndLabel: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenBreakKeywordAndLabel,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3020,14 +2797,13 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenBreakKeywordAndLabel(
     _ newChild: UnexpectedNodesSyntax?) -> BreakStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenBreakKeywordAndLabel)
+    let newData = data.replacingChild(raw, at: 2)
     return BreakStmtSyntax(newData)
   }
 
   public var label: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.label,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -3042,7 +2818,7 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withLabel(
     _ newChild: TokenSyntax?) -> BreakStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.label)
+    let newData = data.replacingChild(raw, at: 3)
     return BreakStmtSyntax(newData)
   }
 }
@@ -3061,11 +2837,6 @@ extension BreakStmtSyntax: CustomReflectable {
 // MARK: - DeclarationStmtSyntax
 
 public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeDeclaration
-    case declaration
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DeclarationStmtSyntax` if possible. Returns
@@ -3103,8 +2874,7 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeDeclaration: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeDeclaration,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3119,14 +2889,13 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeDeclaration(
     _ newChild: UnexpectedNodesSyntax?) -> DeclarationStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeDeclaration)
+    let newData = data.replacingChild(raw, at: 0)
     return DeclarationStmtSyntax(newData)
   }
 
   public var declaration: DeclSyntax {
     get {
-      let childData = data.child(at: Cursor.declaration,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return DeclSyntax(childData!)
     }
     set(value) {
@@ -3140,7 +2909,7 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withDeclaration(
     _ newChild: DeclSyntax?) -> DeclarationStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingDecl, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.declaration)
+    let newData = data.replacingChild(raw, at: 1)
     return DeclarationStmtSyntax(newData)
   }
 }
@@ -3157,13 +2926,6 @@ extension DeclarationStmtSyntax: CustomReflectable {
 // MARK: - ThrowStmtSyntax
 
 public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeThrowKeyword
-    case throwKeyword
-    case unexpectedBetweenThrowKeywordAndExpression
-    case expression
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ThrowStmtSyntax` if possible. Returns
@@ -3205,8 +2967,7 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeThrowKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeThrowKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3221,14 +2982,13 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeThrowKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ThrowStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeThrowKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return ThrowStmtSyntax(newData)
   }
 
   public var throwKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.throwKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3242,14 +3002,13 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withThrowKeyword(
     _ newChild: TokenSyntax?) -> ThrowStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.throwKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.throwKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return ThrowStmtSyntax(newData)
   }
 
   public var unexpectedBetweenThrowKeywordAndExpression: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenThrowKeywordAndExpression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3264,14 +3023,13 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenThrowKeywordAndExpression(
     _ newChild: UnexpectedNodesSyntax?) -> ThrowStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenThrowKeywordAndExpression)
+    let newData = data.replacingChild(raw, at: 2)
     return ThrowStmtSyntax(newData)
   }
 
   public var expression: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.expression,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -3285,7 +3043,7 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withExpression(
     _ newChild: ExprSyntax?) -> ThrowStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.expression)
+    let newData = data.replacingChild(raw, at: 3)
     return ThrowStmtSyntax(newData)
   }
 }
@@ -3304,19 +3062,6 @@ extension ThrowStmtSyntax: CustomReflectable {
 // MARK: - IfStmtSyntax
 
 public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeIfKeyword
-    case ifKeyword
-    case unexpectedBetweenIfKeywordAndConditions
-    case conditions
-    case unexpectedBetweenConditionsAndBody
-    case body
-    case unexpectedBetweenBodyAndElseKeyword
-    case elseKeyword
-    case unexpectedBetweenElseKeywordAndElseBody
-    case elseBody
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `IfStmtSyntax` if possible. Returns
@@ -3370,8 +3115,7 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeIfKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeIfKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3386,14 +3130,13 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeIfKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeIfKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return IfStmtSyntax(newData)
   }
 
   public var ifKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.ifKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3407,14 +3150,13 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withIfKeyword(
     _ newChild: TokenSyntax?) -> IfStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.ifKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.ifKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return IfStmtSyntax(newData)
   }
 
   public var unexpectedBetweenIfKeywordAndConditions: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenIfKeywordAndConditions,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3429,14 +3171,13 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenIfKeywordAndConditions(
     _ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenIfKeywordAndConditions)
+    let newData = data.replacingChild(raw, at: 2)
     return IfStmtSyntax(newData)
   }
 
   public var conditions: ConditionElementListSyntax {
     get {
-      let childData = data.child(at: Cursor.conditions,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return ConditionElementListSyntax(childData!)
     }
     set(value) {
@@ -3452,14 +3193,13 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   ///            appended to its `conditions` collection.
   public func addCondition(_ element: ConditionElementSyntax) -> IfStmtSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.conditions] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.conditionElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.conditions)
+    let newData = data.replacingChild(collection, at: 3)
     return IfStmtSyntax(newData)
   }
 
@@ -3469,14 +3209,13 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withConditions(
     _ newChild: ConditionElementListSyntax?) -> IfStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.conditions)
+    let newData = data.replacingChild(raw, at: 3)
     return IfStmtSyntax(newData)
   }
 
   public var unexpectedBetweenConditionsAndBody: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenConditionsAndBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3491,14 +3230,13 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenConditionsAndBody(
     _ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenConditionsAndBody)
+    let newData = data.replacingChild(raw, at: 4)
     return IfStmtSyntax(newData)
   }
 
   public var body: CodeBlockSyntax {
     get {
-      let childData = data.child(at: Cursor.body,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return CodeBlockSyntax(childData!)
     }
     set(value) {
@@ -3512,14 +3250,13 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withBody(
     _ newChild: CodeBlockSyntax?) -> IfStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.body)
+    let newData = data.replacingChild(raw, at: 5)
     return IfStmtSyntax(newData)
   }
 
   public var unexpectedBetweenBodyAndElseKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenBodyAndElseKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3534,14 +3271,13 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenBodyAndElseKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenBodyAndElseKeyword)
+    let newData = data.replacingChild(raw, at: 6)
     return IfStmtSyntax(newData)
   }
 
   public var elseKeyword: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.elseKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -3556,14 +3292,13 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withElseKeyword(
     _ newChild: TokenSyntax?) -> IfStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.elseKeyword)
+    let newData = data.replacingChild(raw, at: 7)
     return IfStmtSyntax(newData)
   }
 
   public var unexpectedBetweenElseKeywordAndElseBody: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenElseKeywordAndElseBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3578,14 +3313,13 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenElseKeywordAndElseBody(
     _ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenElseKeywordAndElseBody)
+    let newData = data.replacingChild(raw, at: 8)
     return IfStmtSyntax(newData)
   }
 
   public var elseBody: Syntax? {
     get {
-      let childData = data.child(at: Cursor.elseBody,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return Syntax(childData!)
     }
@@ -3600,7 +3334,7 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withElseBody(
     _ newChild: Syntax?) -> IfStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.elseBody)
+    let newData = data.replacingChild(raw, at: 9)
     return IfStmtSyntax(newData)
   }
 }
@@ -3625,21 +3359,6 @@ extension IfStmtSyntax: CustomReflectable {
 // MARK: - PoundAssertStmtSyntax
 
 public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforePoundAssert
-    case poundAssert
-    case unexpectedBetweenPoundAssertAndLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndCondition
-    case condition
-    case unexpectedBetweenConditionAndComma
-    case comma
-    case unexpectedBetweenCommaAndMessage
-    case message
-    case unexpectedBetweenMessageAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `PoundAssertStmtSyntax` if possible. Returns
@@ -3697,8 +3416,7 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforePoundAssert: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforePoundAssert,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3713,14 +3431,13 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforePoundAssert(
     _ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforePoundAssert)
+    let newData = data.replacingChild(raw, at: 0)
     return PoundAssertStmtSyntax(newData)
   }
 
   public var poundAssert: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.poundAssert,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3734,14 +3451,13 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withPoundAssert(
     _ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundAssertKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.poundAssert)
+    let newData = data.replacingChild(raw, at: 1)
     return PoundAssertStmtSyntax(newData)
   }
 
   public var unexpectedBetweenPoundAssertAndLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPoundAssertAndLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3756,14 +3472,13 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPoundAssertAndLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPoundAssertAndLeftParen)
+    let newData = data.replacingChild(raw, at: 2)
     return PoundAssertStmtSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3777,14 +3492,13 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 3)
     return PoundAssertStmtSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndCondition: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndCondition,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3799,15 +3513,14 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndCondition(
     _ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndCondition)
+    let newData = data.replacingChild(raw, at: 4)
     return PoundAssertStmtSyntax(newData)
   }
 
   /// The assertion condition.
   public var condition: ExprSyntax {
     get {
-      let childData = data.child(at: Cursor.condition,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return ExprSyntax(childData!)
     }
     set(value) {
@@ -3821,14 +3534,13 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withCondition(
     _ newChild: ExprSyntax?) -> PoundAssertStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.condition)
+    let newData = data.replacingChild(raw, at: 5)
     return PoundAssertStmtSyntax(newData)
   }
 
   public var unexpectedBetweenConditionAndComma: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenConditionAndComma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3843,15 +3555,14 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenConditionAndComma(
     _ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenConditionAndComma)
+    let newData = data.replacingChild(raw, at: 6)
     return PoundAssertStmtSyntax(newData)
   }
 
   /// The comma after the assertion condition.
   public var comma: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.comma,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -3866,14 +3577,13 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withComma(
     _ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.comma)
+    let newData = data.replacingChild(raw, at: 7)
     return PoundAssertStmtSyntax(newData)
   }
 
   public var unexpectedBetweenCommaAndMessage: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenCommaAndMessage,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3888,15 +3598,14 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenCommaAndMessage(
     _ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenCommaAndMessage)
+    let newData = data.replacingChild(raw, at: 8)
     return PoundAssertStmtSyntax(newData)
   }
 
   /// The assertion message.
   public var message: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.message,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -3911,14 +3620,13 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withMessage(
     _ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.message)
+    let newData = data.replacingChild(raw, at: 9)
     return PoundAssertStmtSyntax(newData)
   }
 
   public var unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenMessageAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -3933,14 +3641,13 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenMessageAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenMessageAndRightParen)
+    let newData = data.replacingChild(raw, at: 10)
     return PoundAssertStmtSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -3954,7 +3661,7 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> PoundAssertStmtSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 11)
     return PoundAssertStmtSyntax(newData)
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -16,7 +16,6 @@
 // MARK: - UnknownTypeSyntax
 
 public struct UnknownTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `UnknownTypeSyntax` if possible. Returns
@@ -59,7 +58,6 @@ extension UnknownTypeSyntax: CustomReflectable {
 // MARK: - MissingTypeSyntax
 
 public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `MissingTypeSyntax` if possible. Returns
@@ -102,13 +100,6 @@ extension MissingTypeSyntax: CustomReflectable {
 // MARK: - SimpleTypeIdentifierSyntax
 
 public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeName
-    case name
-    case unexpectedBetweenNameAndGenericArgumentClause
-    case genericArgumentClause
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `SimpleTypeIdentifierSyntax` if possible. Returns
@@ -150,8 +141,7 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -166,14 +156,13 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeName(
     _ newChild: UnexpectedNodesSyntax?) -> SimpleTypeIdentifierSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeName)
+    let newData = data.replacingChild(raw, at: 0)
     return SimpleTypeIdentifierSyntax(newData)
   }
 
   public var name: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -187,14 +176,13 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> SimpleTypeIdentifierSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 1)
     return SimpleTypeIdentifierSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndGenericArgumentClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -209,14 +197,13 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndGenericArgumentClause(
     _ newChild: UnexpectedNodesSyntax?) -> SimpleTypeIdentifierSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndGenericArgumentClause)
+    let newData = data.replacingChild(raw, at: 2)
     return SimpleTypeIdentifierSyntax(newData)
   }
 
   public var genericArgumentClause: GenericArgumentClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericArgumentClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericArgumentClauseSyntax(childData!)
     }
@@ -231,7 +218,7 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withGenericArgumentClause(
     _ newChild: GenericArgumentClauseSyntax?) -> SimpleTypeIdentifierSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericArgumentClause)
+    let newData = data.replacingChild(raw, at: 3)
     return SimpleTypeIdentifierSyntax(newData)
   }
 }
@@ -250,17 +237,6 @@ extension SimpleTypeIdentifierSyntax: CustomReflectable {
 // MARK: - MemberTypeIdentifierSyntax
 
 public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeBaseType
-    case baseType
-    case unexpectedBetweenBaseTypeAndPeriod
-    case period
-    case unexpectedBetweenPeriodAndName
-    case name
-    case unexpectedBetweenNameAndGenericArgumentClause
-    case genericArgumentClause
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `MemberTypeIdentifierSyntax` if possible. Returns
@@ -310,8 +286,7 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeBaseType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeBaseType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -326,14 +301,13 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeBaseType(
     _ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeBaseType)
+    let newData = data.replacingChild(raw, at: 0)
     return MemberTypeIdentifierSyntax(newData)
   }
 
   public var baseType: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.baseType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -347,14 +321,13 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withBaseType(
     _ newChild: TypeSyntax?) -> MemberTypeIdentifierSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.baseType)
+    let newData = data.replacingChild(raw, at: 1)
     return MemberTypeIdentifierSyntax(newData)
   }
 
   public var unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenBaseTypeAndPeriod,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -369,14 +342,13 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenBaseTypeAndPeriod(
     _ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenBaseTypeAndPeriod)
+    let newData = data.replacingChild(raw, at: 2)
     return MemberTypeIdentifierSyntax(newData)
   }
 
   public var period: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.period,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -390,14 +362,13 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withPeriod(
     _ newChild: TokenSyntax?) -> MemberTypeIdentifierSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.period)
+    let newData = data.replacingChild(raw, at: 3)
     return MemberTypeIdentifierSyntax(newData)
   }
 
   public var unexpectedBetweenPeriodAndName: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPeriodAndName,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -412,14 +383,13 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPeriodAndName(
     _ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPeriodAndName)
+    let newData = data.replacingChild(raw, at: 4)
     return MemberTypeIdentifierSyntax(newData)
   }
 
   public var name: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.name,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -433,14 +403,13 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withName(
     _ newChild: TokenSyntax?) -> MemberTypeIdentifierSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.name)
+    let newData = data.replacingChild(raw, at: 5)
     return MemberTypeIdentifierSyntax(newData)
   }
 
   public var unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenNameAndGenericArgumentClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -455,14 +424,13 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenNameAndGenericArgumentClause(
     _ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenNameAndGenericArgumentClause)
+    let newData = data.replacingChild(raw, at: 6)
     return MemberTypeIdentifierSyntax(newData)
   }
 
   public var genericArgumentClause: GenericArgumentClauseSyntax? {
     get {
-      let childData = data.child(at: Cursor.genericArgumentClause,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return GenericArgumentClauseSyntax(childData!)
     }
@@ -477,7 +445,7 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withGenericArgumentClause(
     _ newChild: GenericArgumentClauseSyntax?) -> MemberTypeIdentifierSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.genericArgumentClause)
+    let newData = data.replacingChild(raw, at: 7)
     return MemberTypeIdentifierSyntax(newData)
   }
 }
@@ -500,11 +468,6 @@ extension MemberTypeIdentifierSyntax: CustomReflectable {
 // MARK: - ClassRestrictionTypeSyntax
 
 public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeClassKeyword
-    case classKeyword
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ClassRestrictionTypeSyntax` if possible. Returns
@@ -542,8 +505,7 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeClassKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeClassKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -558,14 +520,13 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeClassKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> ClassRestrictionTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeClassKeyword)
+    let newData = data.replacingChild(raw, at: 0)
     return ClassRestrictionTypeSyntax(newData)
   }
 
   public var classKeyword: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.classKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -579,7 +540,7 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withClassKeyword(
     _ newChild: TokenSyntax?) -> ClassRestrictionTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.classKeyword, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.classKeyword)
+    let newData = data.replacingChild(raw, at: 1)
     return ClassRestrictionTypeSyntax(newData)
   }
 }
@@ -596,15 +557,6 @@ extension ClassRestrictionTypeSyntax: CustomReflectable {
 // MARK: - ArrayTypeSyntax
 
 public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftSquareBracket
-    case leftSquareBracket
-    case unexpectedBetweenLeftSquareBracketAndElementType
-    case elementType
-    case unexpectedBetweenElementTypeAndRightSquareBracket
-    case rightSquareBracket
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ArrayTypeSyntax` if possible. Returns
@@ -650,8 +602,7 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftSquareBracket: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftSquareBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -666,14 +617,13 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftSquareBracket(
     _ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftSquareBracket)
+    let newData = data.replacingChild(raw, at: 0)
     return ArrayTypeSyntax(newData)
   }
 
   public var leftSquareBracket: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftSquareBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -687,14 +637,13 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withLeftSquareBracket(
     _ newChild: TokenSyntax?) -> ArrayTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftSquareBracket)
+    let newData = data.replacingChild(raw, at: 1)
     return ArrayTypeSyntax(newData)
   }
 
   public var unexpectedBetweenLeftSquareBracketAndElementType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftSquareBracketAndElementType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -709,14 +658,13 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftSquareBracketAndElementType(
     _ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftSquareBracketAndElementType)
+    let newData = data.replacingChild(raw, at: 2)
     return ArrayTypeSyntax(newData)
   }
 
   public var elementType: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.elementType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -730,14 +678,13 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withElementType(
     _ newChild: TypeSyntax?) -> ArrayTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.elementType)
+    let newData = data.replacingChild(raw, at: 3)
     return ArrayTypeSyntax(newData)
   }
 
   public var unexpectedBetweenElementTypeAndRightSquareBracket: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenElementTypeAndRightSquareBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -752,14 +699,13 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenElementTypeAndRightSquareBracket(
     _ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenElementTypeAndRightSquareBracket)
+    let newData = data.replacingChild(raw, at: 4)
     return ArrayTypeSyntax(newData)
   }
 
   public var rightSquareBracket: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightSquareBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -773,7 +719,7 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withRightSquareBracket(
     _ newChild: TokenSyntax?) -> ArrayTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightSquareBracket)
+    let newData = data.replacingChild(raw, at: 5)
     return ArrayTypeSyntax(newData)
   }
 }
@@ -794,19 +740,6 @@ extension ArrayTypeSyntax: CustomReflectable {
 // MARK: - DictionaryTypeSyntax
 
 public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftSquareBracket
-    case leftSquareBracket
-    case unexpectedBetweenLeftSquareBracketAndKeyType
-    case keyType
-    case unexpectedBetweenKeyTypeAndColon
-    case colon
-    case unexpectedBetweenColonAndValueType
-    case valueType
-    case unexpectedBetweenValueTypeAndRightSquareBracket
-    case rightSquareBracket
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `DictionaryTypeSyntax` if possible. Returns
@@ -860,8 +793,7 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftSquareBracket: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftSquareBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -876,14 +808,13 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftSquareBracket(
     _ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftSquareBracket)
+    let newData = data.replacingChild(raw, at: 0)
     return DictionaryTypeSyntax(newData)
   }
 
   public var leftSquareBracket: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftSquareBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -897,14 +828,13 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withLeftSquareBracket(
     _ newChild: TokenSyntax?) -> DictionaryTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftSquareBracket)
+    let newData = data.replacingChild(raw, at: 1)
     return DictionaryTypeSyntax(newData)
   }
 
   public var unexpectedBetweenLeftSquareBracketAndKeyType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftSquareBracketAndKeyType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -919,14 +849,13 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftSquareBracketAndKeyType(
     _ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftSquareBracketAndKeyType)
+    let newData = data.replacingChild(raw, at: 2)
     return DictionaryTypeSyntax(newData)
   }
 
   public var keyType: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.keyType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -940,14 +869,13 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withKeyType(
     _ newChild: TypeSyntax?) -> DictionaryTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.keyType)
+    let newData = data.replacingChild(raw, at: 3)
     return DictionaryTypeSyntax(newData)
   }
 
   public var unexpectedBetweenKeyTypeAndColon: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenKeyTypeAndColon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -962,14 +890,13 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenKeyTypeAndColon(
     _ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenKeyTypeAndColon)
+    let newData = data.replacingChild(raw, at: 4)
     return DictionaryTypeSyntax(newData)
   }
 
   public var colon: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.colon,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -983,14 +910,13 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withColon(
     _ newChild: TokenSyntax?) -> DictionaryTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.colon)
+    let newData = data.replacingChild(raw, at: 5)
     return DictionaryTypeSyntax(newData)
   }
 
   public var unexpectedBetweenColonAndValueType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenColonAndValueType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1005,14 +931,13 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenColonAndValueType(
     _ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenColonAndValueType)
+    let newData = data.replacingChild(raw, at: 6)
     return DictionaryTypeSyntax(newData)
   }
 
   public var valueType: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.valueType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -1026,14 +951,13 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withValueType(
     _ newChild: TypeSyntax?) -> DictionaryTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.valueType)
+    let newData = data.replacingChild(raw, at: 7)
     return DictionaryTypeSyntax(newData)
   }
 
   public var unexpectedBetweenValueTypeAndRightSquareBracket: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenValueTypeAndRightSquareBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1048,14 +972,13 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenValueTypeAndRightSquareBracket(
     _ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenValueTypeAndRightSquareBracket)
+    let newData = data.replacingChild(raw, at: 8)
     return DictionaryTypeSyntax(newData)
   }
 
   public var rightSquareBracket: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightSquareBracket,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1069,7 +992,7 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withRightSquareBracket(
     _ newChild: TokenSyntax?) -> DictionaryTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightSquareBracket)
+    let newData = data.replacingChild(raw, at: 9)
     return DictionaryTypeSyntax(newData)
   }
 }
@@ -1094,15 +1017,6 @@ extension DictionaryTypeSyntax: CustomReflectable {
 // MARK: - MetatypeTypeSyntax
 
 public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeBaseType
-    case baseType
-    case unexpectedBetweenBaseTypeAndPeriod
-    case period
-    case unexpectedBetweenPeriodAndTypeOrProtocol
-    case typeOrProtocol
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `MetatypeTypeSyntax` if possible. Returns
@@ -1148,8 +1062,7 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeBaseType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeBaseType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1164,14 +1077,13 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeBaseType(
     _ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeBaseType)
+    let newData = data.replacingChild(raw, at: 0)
     return MetatypeTypeSyntax(newData)
   }
 
   public var baseType: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.baseType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -1185,14 +1097,13 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withBaseType(
     _ newChild: TypeSyntax?) -> MetatypeTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.baseType)
+    let newData = data.replacingChild(raw, at: 1)
     return MetatypeTypeSyntax(newData)
   }
 
   public var unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenBaseTypeAndPeriod,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1207,14 +1118,13 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenBaseTypeAndPeriod(
     _ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenBaseTypeAndPeriod)
+    let newData = data.replacingChild(raw, at: 2)
     return MetatypeTypeSyntax(newData)
   }
 
   public var period: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.period,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1228,14 +1138,13 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withPeriod(
     _ newChild: TokenSyntax?) -> MetatypeTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.period)
+    let newData = data.replacingChild(raw, at: 3)
     return MetatypeTypeSyntax(newData)
   }
 
   public var unexpectedBetweenPeriodAndTypeOrProtocol: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenPeriodAndTypeOrProtocol,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1250,14 +1159,13 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenPeriodAndTypeOrProtocol(
     _ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenPeriodAndTypeOrProtocol)
+    let newData = data.replacingChild(raw, at: 4)
     return MetatypeTypeSyntax(newData)
   }
 
   public var typeOrProtocol: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.typeOrProtocol,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1271,7 +1179,7 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withTypeOrProtocol(
     _ newChild: TokenSyntax?) -> MetatypeTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.typeOrProtocol)
+    let newData = data.replacingChild(raw, at: 5)
     return MetatypeTypeSyntax(newData)
   }
 }
@@ -1292,13 +1200,6 @@ extension MetatypeTypeSyntax: CustomReflectable {
 // MARK: - OptionalTypeSyntax
 
 public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeWrappedType
-    case wrappedType
-    case unexpectedBetweenWrappedTypeAndQuestionMark
-    case questionMark
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `OptionalTypeSyntax` if possible. Returns
@@ -1340,8 +1241,7 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeWrappedType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeWrappedType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1356,14 +1256,13 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeWrappedType(
     _ newChild: UnexpectedNodesSyntax?) -> OptionalTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeWrappedType)
+    let newData = data.replacingChild(raw, at: 0)
     return OptionalTypeSyntax(newData)
   }
 
   public var wrappedType: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.wrappedType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -1377,14 +1276,13 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withWrappedType(
     _ newChild: TypeSyntax?) -> OptionalTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.wrappedType)
+    let newData = data.replacingChild(raw, at: 1)
     return OptionalTypeSyntax(newData)
   }
 
   public var unexpectedBetweenWrappedTypeAndQuestionMark: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenWrappedTypeAndQuestionMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1399,14 +1297,13 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenWrappedTypeAndQuestionMark(
     _ newChild: UnexpectedNodesSyntax?) -> OptionalTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenWrappedTypeAndQuestionMark)
+    let newData = data.replacingChild(raw, at: 2)
     return OptionalTypeSyntax(newData)
   }
 
   public var questionMark: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.questionMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1420,7 +1317,7 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withQuestionMark(
     _ newChild: TokenSyntax?) -> OptionalTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.questionMark)
+    let newData = data.replacingChild(raw, at: 3)
     return OptionalTypeSyntax(newData)
   }
 }
@@ -1439,13 +1336,6 @@ extension OptionalTypeSyntax: CustomReflectable {
 // MARK: - ConstrainedSugarTypeSyntax
 
 public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeSomeOrAnySpecifier
-    case someOrAnySpecifier
-    case unexpectedBetweenSomeOrAnySpecifierAndBaseType
-    case baseType
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ConstrainedSugarTypeSyntax` if possible. Returns
@@ -1487,8 +1377,7 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeSomeOrAnySpecifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeSomeOrAnySpecifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1503,14 +1392,13 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeSomeOrAnySpecifier(
     _ newChild: UnexpectedNodesSyntax?) -> ConstrainedSugarTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeSomeOrAnySpecifier)
+    let newData = data.replacingChild(raw, at: 0)
     return ConstrainedSugarTypeSyntax(newData)
   }
 
   public var someOrAnySpecifier: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.someOrAnySpecifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1524,14 +1412,13 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withSomeOrAnySpecifier(
     _ newChild: TokenSyntax?) -> ConstrainedSugarTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.someOrAnySpecifier)
+    let newData = data.replacingChild(raw, at: 1)
     return ConstrainedSugarTypeSyntax(newData)
   }
 
   public var unexpectedBetweenSomeOrAnySpecifierAndBaseType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenSomeOrAnySpecifierAndBaseType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1546,14 +1433,13 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenSomeOrAnySpecifierAndBaseType(
     _ newChild: UnexpectedNodesSyntax?) -> ConstrainedSugarTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenSomeOrAnySpecifierAndBaseType)
+    let newData = data.replacingChild(raw, at: 2)
     return ConstrainedSugarTypeSyntax(newData)
   }
 
   public var baseType: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.baseType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -1567,7 +1453,7 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withBaseType(
     _ newChild: TypeSyntax?) -> ConstrainedSugarTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.baseType)
+    let newData = data.replacingChild(raw, at: 3)
     return ConstrainedSugarTypeSyntax(newData)
   }
 }
@@ -1586,13 +1472,6 @@ extension ConstrainedSugarTypeSyntax: CustomReflectable {
 // MARK: - ImplicitlyUnwrappedOptionalTypeSyntax
 
 public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeWrappedType
-    case wrappedType
-    case unexpectedBetweenWrappedTypeAndExclamationMark
-    case exclamationMark
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `ImplicitlyUnwrappedOptionalTypeSyntax` if possible. Returns
@@ -1634,8 +1513,7 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
 
   public var unexpectedBeforeWrappedType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeWrappedType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1650,14 +1528,13 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
   public func withUnexpectedBeforeWrappedType(
     _ newChild: UnexpectedNodesSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeWrappedType)
+    let newData = data.replacingChild(raw, at: 0)
     return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
 
   public var wrappedType: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.wrappedType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -1671,14 +1548,13 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
   public func withWrappedType(
     _ newChild: TypeSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.wrappedType)
+    let newData = data.replacingChild(raw, at: 1)
     return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
 
   public var unexpectedBetweenWrappedTypeAndExclamationMark: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenWrappedTypeAndExclamationMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1693,14 +1569,13 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
   public func withUnexpectedBetweenWrappedTypeAndExclamationMark(
     _ newChild: UnexpectedNodesSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenWrappedTypeAndExclamationMark)
+    let newData = data.replacingChild(raw, at: 2)
     return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
 
   public var exclamationMark: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.exclamationMark,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1714,7 +1589,7 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
   public func withExclamationMark(
     _ newChild: TokenSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.exclamationMark, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.exclamationMark)
+    let newData = data.replacingChild(raw, at: 3)
     return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
 }
@@ -1733,11 +1608,6 @@ extension ImplicitlyUnwrappedOptionalTypeSyntax: CustomReflectable {
 // MARK: - CompositionTypeSyntax
 
 public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeElements
-    case elements
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `CompositionTypeSyntax` if possible. Returns
@@ -1775,8 +1645,7 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeElements: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeElements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1791,14 +1660,13 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeElements(
     _ newChild: UnexpectedNodesSyntax?) -> CompositionTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeElements)
+    let newData = data.replacingChild(raw, at: 0)
     return CompositionTypeSyntax(newData)
   }
 
   public var elements: CompositionTypeElementListSyntax {
     get {
-      let childData = data.child(at: Cursor.elements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return CompositionTypeElementListSyntax(childData!)
     }
     set(value) {
@@ -1814,14 +1682,13 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///            appended to its `elements` collection.
   public func addElement(_ element: CompositionTypeElementSyntax) -> CompositionTypeSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.elements] {
+    if let col = raw.layoutView!.children[1] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.elements)
+    let newData = data.replacingChild(collection, at: 1)
     return CompositionTypeSyntax(newData)
   }
 
@@ -1831,7 +1698,7 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withElements(
     _ newChild: CompositionTypeElementListSyntax?) -> CompositionTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.compositionTypeElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.elements)
+    let newData = data.replacingChild(raw, at: 1)
     return CompositionTypeSyntax(newData)
   }
 }
@@ -1848,15 +1715,6 @@ extension CompositionTypeSyntax: CustomReflectable {
 // MARK: - TupleTypeSyntax
 
 public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndElements
-    case elements
-    case unexpectedBetweenElementsAndRightParen
-    case rightParen
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `TupleTypeSyntax` if possible. Returns
@@ -1902,8 +1760,7 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1918,14 +1775,13 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftParen)
+    let newData = data.replacingChild(raw, at: 0)
     return TupleTypeSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -1939,14 +1795,13 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> TupleTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 1)
     return TupleTypeSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndElements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -1961,14 +1816,13 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndElements(
     _ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndElements)
+    let newData = data.replacingChild(raw, at: 2)
     return TupleTypeSyntax(newData)
   }
 
   public var elements: TupleTypeElementListSyntax {
     get {
-      let childData = data.child(at: Cursor.elements,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TupleTypeElementListSyntax(childData!)
     }
     set(value) {
@@ -1984,14 +1838,13 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///            appended to its `elements` collection.
   public func addElement(_ element: TupleTypeElementSyntax) -> TupleTypeSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.elements] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.elements)
+    let newData = data.replacingChild(collection, at: 3)
     return TupleTypeSyntax(newData)
   }
 
@@ -2001,14 +1854,13 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withElements(
     _ newChild: TupleTypeElementListSyntax?) -> TupleTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleTypeElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.elements)
+    let newData = data.replacingChild(raw, at: 3)
     return TupleTypeSyntax(newData)
   }
 
   public var unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenElementsAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2023,14 +1875,13 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenElementsAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenElementsAndRightParen)
+    let newData = data.replacingChild(raw, at: 4)
     return TupleTypeSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2044,7 +1895,7 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> TupleTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 5)
     return TupleTypeSyntax(newData)
   }
 }
@@ -2065,23 +1916,6 @@ extension TupleTypeSyntax: CustomReflectable {
 // MARK: - FunctionTypeSyntax
 
 public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeLeftParen
-    case leftParen
-    case unexpectedBetweenLeftParenAndArguments
-    case arguments
-    case unexpectedBetweenArgumentsAndRightParen
-    case rightParen
-    case unexpectedBetweenRightParenAndAsyncKeyword
-    case asyncKeyword
-    case unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword
-    case throwsOrRethrowsKeyword
-    case unexpectedBetweenThrowsOrRethrowsKeywordAndArrow
-    case arrow
-    case unexpectedBetweenArrowAndReturnType
-    case returnType
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `FunctionTypeSyntax` if possible. Returns
@@ -2143,8 +1977,7 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeLeftParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeLeftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2159,14 +1992,13 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeLeftParen(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeLeftParen)
+    let newData = data.replacingChild(raw, at: 0)
     return FunctionTypeSyntax(newData)
   }
 
   public var leftParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.leftParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2180,14 +2012,13 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withLeftParen(
     _ newChild: TokenSyntax?) -> FunctionTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.leftParen)
+    let newData = data.replacingChild(raw, at: 1)
     return FunctionTypeSyntax(newData)
   }
 
   public var unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenLeftParenAndArguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2202,14 +2033,13 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenLeftParenAndArguments(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenLeftParenAndArguments)
+    let newData = data.replacingChild(raw, at: 2)
     return FunctionTypeSyntax(newData)
   }
 
   public var arguments: TupleTypeElementListSyntax {
     get {
-      let childData = data.child(at: Cursor.arguments,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       return TupleTypeElementListSyntax(childData!)
     }
     set(value) {
@@ -2225,14 +2055,13 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///            appended to its `arguments` collection.
   public func addArgument(_ element: TupleTypeElementSyntax) -> FunctionTypeSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.arguments] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElementList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.arguments)
+    let newData = data.replacingChild(collection, at: 3)
     return FunctionTypeSyntax(newData)
   }
 
@@ -2242,14 +2071,13 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withArguments(
     _ newChild: TupleTypeElementListSyntax?) -> FunctionTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleTypeElementList, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.arguments)
+    let newData = data.replacingChild(raw, at: 3)
     return FunctionTypeSyntax(newData)
   }
 
   public var unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenArgumentsAndRightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2264,14 +2092,13 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenArgumentsAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenArgumentsAndRightParen)
+    let newData = data.replacingChild(raw, at: 4)
     return FunctionTypeSyntax(newData)
   }
 
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.rightParen,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2285,14 +2112,13 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> FunctionTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.rightParen)
+    let newData = data.replacingChild(raw, at: 5)
     return FunctionTypeSyntax(newData)
   }
 
   public var unexpectedBetweenRightParenAndAsyncKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenRightParenAndAsyncKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 6, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2307,14 +2133,13 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenRightParenAndAsyncKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenRightParenAndAsyncKeyword)
+    let newData = data.replacingChild(raw, at: 6)
     return FunctionTypeSyntax(newData)
   }
 
   public var asyncKeyword: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.asyncKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 7, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -2329,14 +2154,13 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withAsyncKeyword(
     _ newChild: TokenSyntax?) -> FunctionTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.asyncKeyword)
+    let newData = data.replacingChild(raw, at: 7)
     return FunctionTypeSyntax(newData)
   }
 
   public var unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 8, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2351,14 +2175,13 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword)
+    let newData = data.replacingChild(raw, at: 8)
     return FunctionTypeSyntax(newData)
   }
 
   public var throwsOrRethrowsKeyword: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.throwsOrRethrowsKeyword,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 9, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -2373,14 +2196,13 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withThrowsOrRethrowsKeyword(
     _ newChild: TokenSyntax?) -> FunctionTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.throwsOrRethrowsKeyword)
+    let newData = data.replacingChild(raw, at: 9)
     return FunctionTypeSyntax(newData)
   }
 
   public var unexpectedBetweenThrowsOrRethrowsKeywordAndArrow: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenThrowsOrRethrowsKeywordAndArrow,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 10, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2395,14 +2217,13 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenThrowsOrRethrowsKeywordAndArrow(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenThrowsOrRethrowsKeywordAndArrow)
+    let newData = data.replacingChild(raw, at: 10)
     return FunctionTypeSyntax(newData)
   }
 
   public var arrow: TokenSyntax {
     get {
-      let childData = data.child(at: Cursor.arrow,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 11, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -2416,14 +2237,13 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withArrow(
     _ newChild: TokenSyntax?) -> FunctionTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.arrow)
+    let newData = data.replacingChild(raw, at: 11)
     return FunctionTypeSyntax(newData)
   }
 
   public var unexpectedBetweenArrowAndReturnType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenArrowAndReturnType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 12, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2438,14 +2258,13 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenArrowAndReturnType(
     _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenArrowAndReturnType)
+    let newData = data.replacingChild(raw, at: 12)
     return FunctionTypeSyntax(newData)
   }
 
   public var returnType: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.returnType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 13, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -2459,7 +2278,7 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withReturnType(
     _ newChild: TypeSyntax?) -> FunctionTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.returnType)
+    let newData = data.replacingChild(raw, at: 13)
     return FunctionTypeSyntax(newData)
   }
 }
@@ -2488,15 +2307,6 @@ extension FunctionTypeSyntax: CustomReflectable {
 // MARK: - AttributedTypeSyntax
 
 public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
-  enum Cursor: Int {
-    case unexpectedBeforeSpecifier
-    case specifier
-    case unexpectedBetweenSpecifierAndAttributes
-    case attributes
-    case unexpectedBetweenAttributesAndBaseType
-    case baseType
-  }
-
   public let _syntaxNode: Syntax
 
   /// Converts the given `Syntax` node to a `AttributedTypeSyntax` if possible. Returns
@@ -2542,8 +2352,7 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public var unexpectedBeforeSpecifier: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBeforeSpecifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 0, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2558,14 +2367,13 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBeforeSpecifier(
     _ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBeforeSpecifier)
+    let newData = data.replacingChild(raw, at: 0)
     return AttributedTypeSyntax(newData)
   }
 
   public var specifier: TokenSyntax? {
     get {
-      let childData = data.child(at: Cursor.specifier,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 1, parent: Syntax(self))
       if childData == nil { return nil }
       return TokenSyntax(childData!)
     }
@@ -2580,14 +2388,13 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withSpecifier(
     _ newChild: TokenSyntax?) -> AttributedTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.specifier)
+    let newData = data.replacingChild(raw, at: 1)
     return AttributedTypeSyntax(newData)
   }
 
   public var unexpectedBetweenSpecifierAndAttributes: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenSpecifierAndAttributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2602,14 +2409,13 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenSpecifierAndAttributes(
     _ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenSpecifierAndAttributes)
+    let newData = data.replacingChild(raw, at: 2)
     return AttributedTypeSyntax(newData)
   }
 
   public var attributes: AttributeListSyntax? {
     get {
-      let childData = data.child(at: Cursor.attributes,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 3, parent: Syntax(self))
       if childData == nil { return nil }
       return AttributeListSyntax(childData!)
     }
@@ -2626,14 +2432,13 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   ///            appended to its `attributes` collection.
   public func addAttribute(_ element: Syntax) -> AttributedTypeSyntax {
     var collection: RawSyntax
-    if let col = raw.layoutView![Cursor.attributes] {
+    if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
       collection = RawSyntax.makeLayout(kind: SyntaxKind.attributeList,
         from: [element.raw], arena: .default)
     }
-    let newData = data.replacingChild(collection,
-                                      at: Cursor.attributes)
+    let newData = data.replacingChild(collection, at: 3)
     return AttributedTypeSyntax(newData)
   }
 
@@ -2643,14 +2448,13 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withAttributes(
     _ newChild: AttributeListSyntax?) -> AttributedTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.attributes)
+    let newData = data.replacingChild(raw, at: 3)
     return AttributedTypeSyntax(newData)
   }
 
   public var unexpectedBetweenAttributesAndBaseType: UnexpectedNodesSyntax? {
     get {
-      let childData = data.child(at: Cursor.unexpectedBetweenAttributesAndBaseType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
@@ -2665,14 +2469,13 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withUnexpectedBetweenAttributesAndBaseType(
     _ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
     let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: Cursor.unexpectedBetweenAttributesAndBaseType)
+    let newData = data.replacingChild(raw, at: 4)
     return AttributedTypeSyntax(newData)
   }
 
   public var baseType: TypeSyntax {
     get {
-      let childData = data.child(at: Cursor.baseType,
-                                 parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TypeSyntax(childData!)
     }
     set(value) {
@@ -2686,7 +2489,7 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func withBaseType(
     _ newChild: TypeSyntax?) -> AttributedTypeSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
-    let newData = data.replacingChild(raw, at: Cursor.baseType)
+    let newData = data.replacingChild(raw, at: 5)
     return AttributedTypeSyntax(newData)
   }
 }


### PR DESCRIPTION
They are internal types which served as layout 'subscript' keys e.g. `layout[Cursor.propertyName]`. That looks nice, but in reality, the name is usually written very close, like:

```
  var propertyName: PropertyType {
    get { layout[Cursor.propertyName] }
  }
```

So it didn't give us much benefit. In the contrary, it hid the actual "index" information which might be useful when investigating issues. So just get rid of them for now.

Since they are just internal types, there's no external API changes.