### PR TITLE
Improvements to test case reduction using `swift-parser-test`

### DIFF
--- a/Sources/swift-parser-test/swift-parser-test.swift
+++ b/Sources/swift-parser-test/swift-parser-test.swift
@@ -231,7 +231,7 @@ class Reduce: ParsableCommand {
       }
 
       try process.run()
-      if sema.wait(timeout: DispatchTime.now() + .seconds(1)) == .timedOut {
+      if sema.wait(timeout: DispatchTime.now() + .seconds(2)) == .timedOut {
 #if os(Windows)
         _ = TerminateProcess(process.processHandle, 0)
 #else

--- a/Sources/swift-parser-test/swift-parser-test.swift
+++ b/Sources/swift-parser-test/swift-parser-test.swift
@@ -265,6 +265,10 @@ class Reduce: ParsableCommand {
     var reduced = source
     var chunkSize = source.count / 4
     while chunkSize > 0 {
+      if chunkSize < reduced.count / 20 {
+        // The chunk sizes are really tiny compared to the source file. Looks like we aren't making any progress reducing. Abort.
+        break
+      }
       if verbose {
         printerr("Current source size \(reduced.count), reducing with chunk size \(chunkSize)")
       }


### PR DESCRIPTION
- Increase reduce timeout in swift-stress-tester to 2 seconds
  - I’ve had a few cases where parsing didn’t finish in 1 second but 2 were sufficient (in debug build of swift-syntax-test). Increase the timeout so that reduction works properly
- Stop reduce subcommand if it’s not making progress
  - If the chunk sizes are really tiny compared to the reduced source file, it looks like we aren't making any progress reducing. Just abort the reduction in that case.