### PR TITLE
Fix crash on nested interpolation

### DIFF
--- a/Sources/SwiftParser/Lexer.swift
+++ b/Sources/SwiftParser/Lexer.swift
@@ -1029,7 +1029,7 @@ extension Lexer.Cursor {
       }
       if !self.isAtEndOfFile, self.peek() == UInt8(ascii: "\\") &&
            TmpPtr.delimiterMatches(customDelimiterLength) &&
-            TmpPtr.advance() == UInt8(ascii: "(") {
+            TmpPtr.peek() == UInt8(ascii: "(") {
         // Consume tokens until we hit the corresponding ')'.
         self = Self.skipToEndOfInterpolatedExpression(TmpPtr, IsMultilineString)
         if self.advance(if: { $0 == Unicode.Scalar(")") }) {

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -194,6 +194,24 @@ final class ExpressionTests: XCTestCase {
       return "Fixit: \(range.debugDescription) Text: \"\(text)\""
       """#
     }
+
+    try AssertParse({ $0.parseExpression() }) {
+      #"""
+      "text \(array.map({ "\($0)" }).joined(separator: ",")) text"
+      """#
+    }
+
+    try AssertParse({ $0.parseExpression() }) {
+      #"""
+      """
+      \(gen(xx) { (x) in
+          return """
+          case
+      """
+      })
+      """
+      """#
+    }
   }
 
   func testStringLiterals() throws {


### PR DESCRIPTION
Fix #618, #636

`Lex.Cursor.skipToEndOfInterpolatedExpression` is called from two paths.

One is from `Lexer.Cursor.lexStringLiteral`.
Another is from `Lexer.lexToEndOfInterpolatedExpression` from `Parser.parseStringLiteralSegments`.

In first case, cursor position is after of `(` which opens interpolation.
But `skipToEndOfInterpolatedExpression` expects it called on position of `(`.

So Lexer split tokens wrongly with some inputs.
For example:

```
"text \(a.m({ "\($0)" }).j(s: ",")) text"
                       ^(1)       ^(2)
```

Lexer closes interpolation (1) wrongly. (2) is correct.

To fix this issue, I change `lexStringLiteral`.
As changing `advance` to `peek`,
cursor position is on `(` when it calls `skipToEndOfInterpolatedExpression`.
