### PR TITLE
Skip leading trivia generation if empty in BuildableNodes

### DIFF
--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -50,7 +50,11 @@ public struct CodeBlockItem: SyntaxBuildable, ExpressibleAsCodeBlockItem {
   func buildCodeBlockItem(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CodeBlockItemSyntax {
     let result = CodeBlockItemSyntax(unexpectedBeforeItem?.buildUnexpectedNodes(format: format, leadingTrivia: nil), item: item.buildSyntax(format: format, leadingTrivia: nil), unexpectedBetweenItemAndSemicolon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), semicolon: semicolon, unexpectedBetweenSemicolonAndErrorTokens?.buildUnexpectedNodes(format: format, leadingTrivia: nil), errorTokens: errorTokens?.buildSyntax(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -113,7 +117,11 @@ public struct CodeBlock: SyntaxBuildable, ExpressibleAsCodeBlock {
   func buildCodeBlock(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CodeBlockSyntax {
     let result = CodeBlockSyntax(unexpectedBeforeLeftBrace?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftBrace: leftBrace, unexpectedBetweenLeftBraceAndStatements?.buildUnexpectedNodes(format: format, leadingTrivia: nil), statements: statements.buildCodeBlockItemList(format: format._indented(), leadingTrivia: nil), unexpectedBetweenStatementsAndRightBrace?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightBrace: rightBrace.withLeadingTrivia(.newline + format._makeIndent() + (rightBrace.leadingTrivia ?? [])))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -161,7 +169,11 @@ public struct InOutExpr: ExprBuildable, ExpressibleAsInOutExpr {
   func buildInOutExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> InOutExprSyntax {
     let result = InOutExprSyntax(unexpectedBeforeAmpersand?.buildUnexpectedNodes(format: format, leadingTrivia: nil), ampersand: ampersand, unexpectedBetweenAmpersandAndExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -210,7 +222,11 @@ public struct PoundColumnExpr: ExprBuildable, ExpressibleAsPoundColumnExpr {
   func buildPoundColumnExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundColumnExprSyntax {
     let result = PoundColumnExprSyntax(unexpectedBeforePoundColumn?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundColumn: poundColumn)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -272,7 +288,11 @@ public struct TryExpr: ExprBuildable, ExpressibleAsTryExpr {
   func buildTryExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TryExprSyntax {
     let result = TryExprSyntax(unexpectedBeforeTryKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), tryKeyword: tryKeyword, unexpectedBetweenTryKeywordAndQuestionOrExclamationMark?.buildUnexpectedNodes(format: format, leadingTrivia: nil), questionOrExclamationMark: questionOrExclamationMark, unexpectedBetweenQuestionOrExclamationMarkAndExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -333,7 +353,11 @@ public struct AwaitExpr: ExprBuildable, ExpressibleAsAwaitExpr {
   func buildAwaitExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AwaitExprSyntax {
     let result = AwaitExprSyntax(unexpectedBeforeAwaitKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), awaitKeyword: awaitKeyword, unexpectedBetweenAwaitKeywordAndExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -394,7 +418,11 @@ public struct MoveExpr: ExprBuildable, ExpressibleAsMoveExpr {
   func buildMoveExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MoveExprSyntax {
     let result = MoveExprSyntax(unexpectedBeforeMoveKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), moveKeyword: moveKeyword, unexpectedBetweenMoveKeywordAndExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -449,7 +477,11 @@ public struct DeclNameArgument: SyntaxBuildable, ExpressibleAsDeclNameArgument {
   func buildDeclNameArgument(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclNameArgumentSyntax {
     let result = DeclNameArgumentSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -504,7 +536,11 @@ public struct DeclNameArguments: SyntaxBuildable, ExpressibleAsDeclNameArguments
   func buildDeclNameArguments(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclNameArgumentsSyntax {
     let result = DeclNameArgumentsSyntax(unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndArguments?.buildUnexpectedNodes(format: format, leadingTrivia: nil), arguments: arguments.buildDeclNameArgumentList(format: format, leadingTrivia: nil), unexpectedBetweenArgumentsAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -551,7 +587,11 @@ public struct IdentifierExpr: ExprBuildable, ExpressibleAsIdentifierExpr {
   func buildIdentifierExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IdentifierExprSyntax {
     let result = IdentifierExprSyntax(unexpectedBeforeIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier, unexpectedBetweenIdentifierAndDeclNameArguments?.buildUnexpectedNodes(format: format, leadingTrivia: nil), declNameArguments: declNameArguments?.buildDeclNameArguments(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -600,7 +640,11 @@ public struct SuperRefExpr: ExprBuildable, ExpressibleAsSuperRefExpr {
   func buildSuperRefExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SuperRefExprSyntax {
     let result = SuperRefExprSyntax(unexpectedBeforeSuperKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), superKeyword: superKeyword)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -649,7 +693,11 @@ public struct NilLiteralExpr: ExprBuildable, ExpressibleAsNilLiteralExpr {
   func buildNilLiteralExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> NilLiteralExprSyntax {
     let result = NilLiteralExprSyntax(unexpectedBeforeNilKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), nilKeyword: nilKeyword)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -698,7 +746,11 @@ public struct DiscardAssignmentExpr: ExprBuildable, ExpressibleAsDiscardAssignme
   func buildDiscardAssignmentExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DiscardAssignmentExprSyntax {
     let result = DiscardAssignmentExprSyntax(unexpectedBeforeWildcard?.buildUnexpectedNodes(format: format, leadingTrivia: nil), wildcard: wildcard)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -747,7 +799,11 @@ public struct AssignmentExpr: ExprBuildable, ExpressibleAsAssignmentExpr {
   func buildAssignmentExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AssignmentExprSyntax {
     let result = AssignmentExprSyntax(unexpectedBeforeAssignToken?.buildUnexpectedNodes(format: format, leadingTrivia: nil), assignToken: assignToken)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -803,7 +859,11 @@ public struct SequenceExpr: ExprBuildable, ExpressibleAsSequenceExpr {
   func buildSequenceExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SequenceExprSyntax {
     let result = SequenceExprSyntax(unexpectedBeforeElements?.buildUnexpectedNodes(format: format, leadingTrivia: nil), elements: elements.buildExprList(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -852,7 +912,11 @@ public struct PoundLineExpr: ExprBuildable, ExpressibleAsPoundLineExpr {
   func buildPoundLineExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundLineExprSyntax {
     let result = PoundLineExprSyntax(unexpectedBeforePoundLine?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundLine: poundLine)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -901,7 +965,11 @@ public struct PoundFileExpr: ExprBuildable, ExpressibleAsPoundFileExpr {
   func buildPoundFileExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundFileExprSyntax {
     let result = PoundFileExprSyntax(unexpectedBeforePoundFile?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundFile: poundFile)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -950,7 +1018,11 @@ public struct PoundFileIDExpr: ExprBuildable, ExpressibleAsPoundFileIDExpr {
   func buildPoundFileIDExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundFileIDExprSyntax {
     let result = PoundFileIDExprSyntax(unexpectedBeforePoundFileID?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundFileID: poundFileID)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -999,7 +1071,11 @@ public struct PoundFilePathExpr: ExprBuildable, ExpressibleAsPoundFilePathExpr {
   func buildPoundFilePathExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundFilePathExprSyntax {
     let result = PoundFilePathExprSyntax(unexpectedBeforePoundFilePath?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundFilePath: poundFilePath)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -1048,7 +1124,11 @@ public struct PoundFunctionExpr: ExprBuildable, ExpressibleAsPoundFunctionExpr {
   func buildPoundFunctionExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundFunctionExprSyntax {
     let result = PoundFunctionExprSyntax(unexpectedBeforePoundFunction?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundFunction: poundFunction)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -1097,7 +1177,11 @@ public struct PoundDsohandleExpr: ExprBuildable, ExpressibleAsPoundDsohandleExpr
   func buildPoundDsohandleExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundDsohandleExprSyntax {
     let result = PoundDsohandleExprSyntax(unexpectedBeforePoundDsohandle?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundDsohandle: poundDsohandle)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -1157,7 +1241,11 @@ public struct SymbolicReferenceExpr: ExprBuildable, ExpressibleAsSymbolicReferen
   func buildSymbolicReferenceExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SymbolicReferenceExprSyntax {
     let result = SymbolicReferenceExprSyntax(unexpectedBeforeIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier, unexpectedBetweenIdentifierAndGenericArgumentClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericArgumentClause: genericArgumentClause?.buildGenericArgumentClause(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -1219,7 +1307,11 @@ public struct PrefixOperatorExpr: ExprBuildable, ExpressibleAsPrefixOperatorExpr
   func buildPrefixOperatorExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrefixOperatorExprSyntax {
     let result = PrefixOperatorExprSyntax(unexpectedBeforeOperatorToken?.buildUnexpectedNodes(format: format, leadingTrivia: nil), operatorToken: operatorToken, unexpectedBetweenOperatorTokenAndPostfixExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), postfixExpression: postfixExpression.buildExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -1267,7 +1359,11 @@ public struct BinaryOperatorExpr: ExprBuildable, ExpressibleAsBinaryOperatorExpr
   func buildBinaryOperatorExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> BinaryOperatorExprSyntax {
     let result = BinaryOperatorExprSyntax(unexpectedBeforeOperatorToken?.buildUnexpectedNodes(format: format, leadingTrivia: nil), operatorToken: operatorToken)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -1338,7 +1434,11 @@ public struct ArrowExpr: ExprBuildable, ExpressibleAsArrowExpr {
   func buildArrowExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ArrowExprSyntax {
     let result = ArrowExprSyntax(unexpectedBeforeAsyncKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), asyncKeyword: asyncKeyword, unexpectedBetweenAsyncKeywordAndThrowsToken?.buildUnexpectedNodes(format: format, leadingTrivia: nil), throwsToken: throwsToken, unexpectedBetweenThrowsTokenAndArrowToken?.buildUnexpectedNodes(format: format, leadingTrivia: nil), arrowToken: arrowToken)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -1398,7 +1498,11 @@ public struct InfixOperatorExpr: ExprBuildable, ExpressibleAsInfixOperatorExpr {
   func buildInfixOperatorExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> InfixOperatorExprSyntax {
     let result = InfixOperatorExprSyntax(unexpectedBeforeLeftOperand?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftOperand: leftOperand.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenLeftOperandAndOperatorOperand?.buildUnexpectedNodes(format: format, leadingTrivia: nil), operatorOperand: operatorOperand.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenOperatorOperandAndRightOperand?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightOperand: rightOperand.buildExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -1452,7 +1556,11 @@ public struct FloatLiteralExpr: ExprBuildable, ExpressibleAsFloatLiteralExpr {
   func buildFloatLiteralExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FloatLiteralExprSyntax {
     let result = FloatLiteralExprSyntax(unexpectedBeforeFloatingDigits?.buildUnexpectedNodes(format: format, leadingTrivia: nil), floatingDigits: floatingDigits)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -1522,7 +1630,11 @@ public struct TupleExpr: ExprBuildable, ExpressibleAsTupleExpr {
   func buildTupleExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TupleExprSyntax {
     let result = TupleExprSyntax(unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndElementList?.buildUnexpectedNodes(format: format, leadingTrivia: nil), elementList: elementList.buildTupleExprElementList(format: format, leadingTrivia: nil), unexpectedBetweenElementListAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -1592,7 +1704,11 @@ public struct ArrayExpr: ExprBuildable, ExpressibleAsArrayExpr {
   func buildArrayExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ArrayExprSyntax {
     let result = ArrayExprSyntax(unexpectedBeforeLeftSquare?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftSquare: leftSquare, unexpectedBetweenLeftSquareAndElements?.buildUnexpectedNodes(format: format, leadingTrivia: nil), elements: elements.buildArrayElementList(format: format, leadingTrivia: nil), unexpectedBetweenElementsAndRightSquare?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightSquare: rightSquare)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -1654,7 +1770,11 @@ public struct DictionaryExpr: ExprBuildable, ExpressibleAsDictionaryExpr {
   func buildDictionaryExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DictionaryExprSyntax {
     let result = DictionaryExprSyntax(unexpectedBeforeLeftSquare?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftSquare: leftSquare, unexpectedBetweenLeftSquareAndContent?.buildUnexpectedNodes(format: format, leadingTrivia: nil), content: content.buildSyntax(format: format, leadingTrivia: nil), unexpectedBetweenContentAndRightSquare?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightSquare: rightSquare)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -1722,7 +1842,11 @@ public struct TupleExprElement: SyntaxBuildable, ExpressibleAsTupleExprElement, 
   func buildTupleExprElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TupleExprElementSyntax {
     let result = TupleExprElementSyntax(unexpectedBeforeLabel?.buildUnexpectedNodes(format: format, leadingTrivia: nil), label: label, unexpectedBetweenLabelAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenExpressionAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -1774,7 +1898,11 @@ public struct ArrayElement: SyntaxBuildable, ExpressibleAsArrayElement, HasTrail
   func buildArrayElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ArrayElementSyntax {
     let result = ArrayElementSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenExpressionAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -1839,7 +1967,11 @@ public struct DictionaryElement: SyntaxBuildable, ExpressibleAsDictionaryElement
   func buildDictionaryElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DictionaryElementSyntax {
     let result = DictionaryElementSyntax(unexpectedBeforeKeyExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), keyExpression: keyExpression.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenKeyExpressionAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndValueExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), valueExpression: valueExpression.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenValueExpressionAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -1890,7 +2022,11 @@ public struct IntegerLiteralExpr: ExprBuildable, ExpressibleAsIntegerLiteralExpr
   func buildIntegerLiteralExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IntegerLiteralExprSyntax {
     let result = IntegerLiteralExprSyntax(unexpectedBeforeDigits?.buildUnexpectedNodes(format: format, leadingTrivia: nil), digits: digits)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -1939,7 +2075,11 @@ public struct BooleanLiteralExpr: ExprBuildable, ExpressibleAsBooleanLiteralExpr
   func buildBooleanLiteralExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> BooleanLiteralExprSyntax {
     let result = BooleanLiteralExprSyntax(unexpectedBeforeBooleanLiteral?.buildUnexpectedNodes(format: format, leadingTrivia: nil), booleanLiteral: booleanLiteral)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -2001,7 +2141,11 @@ public struct UnresolvedTernaryExpr: ExprBuildable, ExpressibleAsUnresolvedTerna
   func buildUnresolvedTernaryExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> UnresolvedTernaryExprSyntax {
     let result = UnresolvedTernaryExprSyntax(unexpectedBeforeQuestionMark?.buildUnexpectedNodes(format: format, leadingTrivia: nil), questionMark: questionMark, unexpectedBetweenQuestionMarkAndFirstChoice?.buildUnexpectedNodes(format: format, leadingTrivia: nil), firstChoice: firstChoice.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenFirstChoiceAndColonMark?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colonMark: colonMark)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -2075,7 +2219,11 @@ public struct TernaryExpr: ExprBuildable, ExpressibleAsTernaryExpr {
   func buildTernaryExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TernaryExprSyntax {
     let result = TernaryExprSyntax(unexpectedBeforeConditionExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), conditionExpression: conditionExpression.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenConditionExpressionAndQuestionMark?.buildUnexpectedNodes(format: format, leadingTrivia: nil), questionMark: questionMark, unexpectedBetweenQuestionMarkAndFirstChoice?.buildUnexpectedNodes(format: format, leadingTrivia: nil), firstChoice: firstChoice.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenFirstChoiceAndColonMark?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colonMark: colonMark, unexpectedBetweenColonMarkAndSecondChoice?.buildUnexpectedNodes(format: format, leadingTrivia: nil), secondChoice: secondChoice.buildExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -2142,7 +2290,11 @@ public struct MemberAccessExpr: ExprBuildable, ExpressibleAsMemberAccessExpr {
   func buildMemberAccessExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MemberAccessExprSyntax {
     let result = MemberAccessExprSyntax(unexpectedBeforeBase?.buildUnexpectedNodes(format: format, leadingTrivia: nil), base: base?.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenBaseAndDot?.buildUnexpectedNodes(format: format, leadingTrivia: nil), dot: dot, unexpectedBetweenDotAndName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndDeclNameArguments?.buildUnexpectedNodes(format: format, leadingTrivia: nil), declNameArguments: declNameArguments?.buildDeclNameArguments(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -2191,7 +2343,11 @@ public struct UnresolvedIsExpr: ExprBuildable, ExpressibleAsUnresolvedIsExpr {
   func buildUnresolvedIsExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> UnresolvedIsExprSyntax {
     let result = UnresolvedIsExprSyntax(unexpectedBeforeIsTok?.buildUnexpectedNodes(format: format, leadingTrivia: nil), isTok: isTok)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -2252,7 +2408,11 @@ public struct IsExpr: ExprBuildable, ExpressibleAsIsExpr {
   func buildIsExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IsExprSyntax {
     let result = IsExprSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenExpressionAndIsTok?.buildUnexpectedNodes(format: format, leadingTrivia: nil), isTok: isTok, unexpectedBetweenIsTokAndTypeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), typeName: typeName.buildType(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -2308,7 +2468,11 @@ public struct UnresolvedAsExpr: ExprBuildable, ExpressibleAsUnresolvedAsExpr {
   func buildUnresolvedAsExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> UnresolvedAsExprSyntax {
     let result = UnresolvedAsExprSyntax(unexpectedBeforeAsTok?.buildUnexpectedNodes(format: format, leadingTrivia: nil), asTok: asTok, unexpectedBetweenAsTokAndQuestionOrExclamationMark?.buildUnexpectedNodes(format: format, leadingTrivia: nil), questionOrExclamationMark: questionOrExclamationMark)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -2376,7 +2540,11 @@ public struct AsExpr: ExprBuildable, ExpressibleAsAsExpr {
   func buildAsExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AsExprSyntax {
     let result = AsExprSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenExpressionAndAsTok?.buildUnexpectedNodes(format: format, leadingTrivia: nil), asTok: asTok, unexpectedBetweenAsTokAndQuestionOrExclamationMark?.buildUnexpectedNodes(format: format, leadingTrivia: nil), questionOrExclamationMark: questionOrExclamationMark, unexpectedBetweenQuestionOrExclamationMarkAndTypeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), typeName: typeName.buildType(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -2424,7 +2592,11 @@ public struct TypeExpr: ExprBuildable, ExpressibleAsTypeExpr {
   func buildTypeExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeExprSyntax {
     let result = TypeExprSyntax(unexpectedBeforeType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), type: type.buildType(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -2506,7 +2678,11 @@ public struct ClosureCaptureItem: SyntaxBuildable, ExpressibleAsClosureCaptureIt
   func buildClosureCaptureItem(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ClosureCaptureItemSyntax {
     let result = ClosureCaptureItemSyntax(unexpectedBeforeSpecifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), specifier: specifier?.buildTokenList(format: format, leadingTrivia: nil), unexpectedBetweenSpecifierAndName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndAssignToken?.buildUnexpectedNodes(format: format, leadingTrivia: nil), assignToken: assignToken, unexpectedBetweenAssignTokenAndExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenExpressionAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -2573,7 +2749,11 @@ public struct ClosureCaptureSignature: SyntaxBuildable, ExpressibleAsClosureCapt
   func buildClosureCaptureSignature(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ClosureCaptureSignatureSyntax {
     let result = ClosureCaptureSignatureSyntax(unexpectedBeforeLeftSquare?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftSquare: leftSquare, unexpectedBetweenLeftSquareAndItems?.buildUnexpectedNodes(format: format, leadingTrivia: nil), items: items?.buildClosureCaptureItemList(format: format, leadingTrivia: nil), unexpectedBetweenItemsAndRightSquare?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightSquare: rightSquare)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -2621,7 +2801,11 @@ public struct ClosureParam: SyntaxBuildable, ExpressibleAsClosureParam, HasTrail
   func buildClosureParam(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ClosureParamSyntax {
     let result = ClosureParamSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -2713,7 +2897,11 @@ public struct ClosureSignature: SyntaxBuildable, ExpressibleAsClosureSignature {
   func buildClosureSignature(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ClosureSignatureSyntax {
     let result = ClosureSignatureSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndCapture?.buildUnexpectedNodes(format: format, leadingTrivia: nil), capture: capture?.buildClosureCaptureSignature(format: format, leadingTrivia: nil), unexpectedBetweenCaptureAndInput?.buildUnexpectedNodes(format: format, leadingTrivia: nil), input: input?.buildSyntax(format: format, leadingTrivia: nil), unexpectedBetweenInputAndAsyncKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), asyncKeyword: asyncKeyword, unexpectedBetweenAsyncKeywordAndThrowsTok?.buildUnexpectedNodes(format: format, leadingTrivia: nil), throwsTok: throwsTok, unexpectedBetweenThrowsTokAndOutput?.buildUnexpectedNodes(format: format, leadingTrivia: nil), output: output?.buildReturnClause(format: format, leadingTrivia: nil), unexpectedBetweenOutputAndInTok?.buildUnexpectedNodes(format: format, leadingTrivia: nil), inTok: inTok)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -2782,7 +2970,11 @@ public struct ClosureExpr: ExprBuildable, ExpressibleAsClosureExpr {
   func buildClosureExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ClosureExprSyntax {
     let result = ClosureExprSyntax(unexpectedBeforeLeftBrace?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftBrace: leftBrace, unexpectedBetweenLeftBraceAndSignature?.buildUnexpectedNodes(format: format, leadingTrivia: nil), signature: signature?.buildClosureSignature(format: format, leadingTrivia: nil), unexpectedBetweenSignatureAndStatements?.buildUnexpectedNodes(format: format, leadingTrivia: nil), statements: statements.buildCodeBlockItemList(format: format._indented(), leadingTrivia: nil), unexpectedBetweenStatementsAndRightBrace?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightBrace: rightBrace.withLeadingTrivia(.newline + format._makeIndent() + (rightBrace.leadingTrivia ?? [])))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -2830,7 +3022,11 @@ public struct UnresolvedPatternExpr: ExprBuildable, ExpressibleAsUnresolvedPatte
   func buildUnresolvedPatternExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> UnresolvedPatternExprSyntax {
     let result = UnresolvedPatternExprSyntax(unexpectedBeforePattern?.buildUnexpectedNodes(format: format, leadingTrivia: nil), pattern: pattern.buildPattern(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -2891,7 +3087,11 @@ public struct MultipleTrailingClosureElement: SyntaxBuildable, ExpressibleAsMult
   func buildMultipleTrailingClosureElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MultipleTrailingClosureElementSyntax {
     let result = MultipleTrailingClosureElementSyntax(unexpectedBeforeLabel?.buildUnexpectedNodes(format: format, leadingTrivia: nil), label: label, unexpectedBetweenLabelAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndClosure?.buildUnexpectedNodes(format: format, leadingTrivia: nil), closure: closure.buildClosureExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -2972,7 +3172,11 @@ public struct FunctionCallExpr: ExprBuildable, ExpressibleAsFunctionCallExpr {
   func buildFunctionCallExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FunctionCallExprSyntax {
     let result = FunctionCallExprSyntax(unexpectedBeforeCalledExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), calledExpression: calledExpression.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenCalledExpressionAndLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList?.buildUnexpectedNodes(format: format, leadingTrivia: nil), argumentList: argumentList.buildTupleExprElementList(format: format, leadingTrivia: nil), unexpectedBetweenArgumentListAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen, unexpectedBetweenRightParenAndTrailingClosure?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingClosure: trailingClosure?.buildClosureExpr(format: format, leadingTrivia: nil), unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.buildUnexpectedNodes(format: format, leadingTrivia: nil), additionalTrailingClosures: additionalTrailingClosures?.buildMultipleTrailingClosureElementList(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -3060,7 +3264,11 @@ public struct SubscriptExpr: ExprBuildable, ExpressibleAsSubscriptExpr {
   func buildSubscriptExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SubscriptExprSyntax {
     let result = SubscriptExprSyntax(unexpectedBeforeCalledExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), calledExpression: calledExpression.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenCalledExpressionAndLeftBracket?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftBracket: leftBracket, unexpectedBetweenLeftBracketAndArgumentList?.buildUnexpectedNodes(format: format, leadingTrivia: nil), argumentList: argumentList.buildTupleExprElementList(format: format, leadingTrivia: nil), unexpectedBetweenArgumentListAndRightBracket?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightBracket: rightBracket, unexpectedBetweenRightBracketAndTrailingClosure?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingClosure: trailingClosure?.buildClosureExpr(format: format, leadingTrivia: nil), unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.buildUnexpectedNodes(format: format, leadingTrivia: nil), additionalTrailingClosures: additionalTrailingClosures?.buildMultipleTrailingClosureElementList(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -3115,7 +3323,11 @@ public struct OptionalChainingExpr: ExprBuildable, ExpressibleAsOptionalChaining
   func buildOptionalChainingExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> OptionalChainingExprSyntax {
     let result = OptionalChainingExprSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenExpressionAndQuestionMark?.buildUnexpectedNodes(format: format, leadingTrivia: nil), questionMark: questionMark)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -3170,7 +3382,11 @@ public struct ForcedValueExpr: ExprBuildable, ExpressibleAsForcedValueExpr {
   func buildForcedValueExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ForcedValueExprSyntax {
     let result = ForcedValueExprSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenExpressionAndExclamationMark?.buildUnexpectedNodes(format: format, leadingTrivia: nil), exclamationMark: exclamationMark)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -3230,7 +3446,11 @@ public struct PostfixUnaryExpr: ExprBuildable, ExpressibleAsPostfixUnaryExpr {
   func buildPostfixUnaryExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PostfixUnaryExprSyntax {
     let result = PostfixUnaryExprSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenExpressionAndOperatorToken?.buildUnexpectedNodes(format: format, leadingTrivia: nil), operatorToken: operatorToken)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -3284,7 +3504,11 @@ public struct SpecializeExpr: ExprBuildable, ExpressibleAsSpecializeExpr {
   func buildSpecializeExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SpecializeExprSyntax {
     let result = SpecializeExprSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenExpressionAndGenericArgumentClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericArgumentClause: genericArgumentClause.buildGenericArgumentClause(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -3338,7 +3562,11 @@ public struct StringSegment: SyntaxBuildable, ExpressibleAsStringSegment {
   func buildStringSegment(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StringSegmentSyntax {
     let result = StringSegmentSyntax(unexpectedBeforeContent?.buildUnexpectedNodes(format: format, leadingTrivia: nil), content: content)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -3416,7 +3644,11 @@ public struct ExpressionSegment: SyntaxBuildable, ExpressibleAsExpressionSegment
   func buildExpressionSegment(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExpressionSegmentSyntax {
     let result = ExpressionSegmentSyntax(unexpectedBeforeBackslash?.buildUnexpectedNodes(format: format, leadingTrivia: nil), backslash: backslash, unexpectedBetweenBackslashAndDelimiter?.buildUnexpectedNodes(format: format, leadingTrivia: nil), delimiter: delimiter, unexpectedBetweenDelimiterAndLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndExpressions?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expressions: expressions.buildTupleExprElementList(format: format, leadingTrivia: nil), unexpectedBetweenExpressionsAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -3493,7 +3725,11 @@ public struct StringLiteralExpr: ExprBuildable, ExpressibleAsStringLiteralExpr {
   func buildStringLiteralExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StringLiteralExprSyntax {
     let result = StringLiteralExprSyntax(unexpectedBeforeOpenDelimiter?.buildUnexpectedNodes(format: format, leadingTrivia: nil), openDelimiter: openDelimiter, unexpectedBetweenOpenDelimiterAndOpenQuote?.buildUnexpectedNodes(format: format, leadingTrivia: nil), openQuote: openQuote, unexpectedBetweenOpenQuoteAndSegments?.buildUnexpectedNodes(format: format, leadingTrivia: nil), segments: segments.buildStringLiteralSegments(format: format, leadingTrivia: nil), unexpectedBetweenSegmentsAndCloseQuote?.buildUnexpectedNodes(format: format, leadingTrivia: nil), closeQuote: closeQuote, unexpectedBetweenCloseQuoteAndCloseDelimiter?.buildUnexpectedNodes(format: format, leadingTrivia: nil), closeDelimiter: closeDelimiter)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -3547,7 +3783,11 @@ public struct RegexLiteralExpr: ExprBuildable, ExpressibleAsRegexLiteralExpr {
   func buildRegexLiteralExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> RegexLiteralExprSyntax {
     let result = RegexLiteralExprSyntax(unexpectedBeforeRegex?.buildUnexpectedNodes(format: format, leadingTrivia: nil), regex: regex)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -3608,7 +3848,11 @@ public struct KeyPathExpr: ExprBuildable, ExpressibleAsKeyPathExpr {
   func buildKeyPathExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> KeyPathExprSyntax {
     let result = KeyPathExprSyntax(unexpectedBeforeBackslash?.buildUnexpectedNodes(format: format, leadingTrivia: nil), backslash: backslash, unexpectedBetweenBackslashAndRootExpr?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rootExpr: rootExpr?.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenRootExprAndExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -3657,7 +3901,11 @@ public struct KeyPathBaseExpr: ExprBuildable, ExpressibleAsKeyPathBaseExpr {
   func buildKeyPathBaseExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> KeyPathBaseExprSyntax {
     let result = KeyPathBaseExprSyntax(unexpectedBeforePeriod?.buildUnexpectedNodes(format: format, leadingTrivia: nil), period: period)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -3718,7 +3966,11 @@ public struct ObjcNamePiece: SyntaxBuildable, ExpressibleAsObjcNamePiece {
   func buildObjcNamePiece(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ObjcNamePieceSyntax {
     let result = ObjcNamePieceSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndDot?.buildUnexpectedNodes(format: format, leadingTrivia: nil), dot: dot)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -3780,7 +4032,11 @@ public struct ObjcKeyPathExpr: ExprBuildable, ExpressibleAsObjcKeyPathExpr {
   func buildObjcKeyPathExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ObjcKeyPathExprSyntax {
     let result = ObjcKeyPathExprSyntax(unexpectedBeforeKeyPath?.buildUnexpectedNodes(format: format, leadingTrivia: nil), keyPath: keyPath, unexpectedBetweenKeyPathAndLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name.buildObjcName(format: format, leadingTrivia: nil), unexpectedBetweenNameAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -3871,7 +4127,11 @@ public struct ObjcSelectorExpr: ExprBuildable, ExpressibleAsObjcSelectorExpr {
   func buildObjcSelectorExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ObjcSelectorExprSyntax {
     let result = ObjcSelectorExprSyntax(unexpectedBeforePoundSelector?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundSelector: poundSelector, unexpectedBetweenPoundSelectorAndLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndKind?.buildUnexpectedNodes(format: format, leadingTrivia: nil), kind: kind, unexpectedBetweenKindAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenNameAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -3925,7 +4185,11 @@ public struct PostfixIfConfigExpr: ExprBuildable, ExpressibleAsPostfixIfConfigEx
   func buildPostfixIfConfigExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PostfixIfConfigExprSyntax {
     let result = PostfixIfConfigExprSyntax(unexpectedBeforeBase?.buildUnexpectedNodes(format: format, leadingTrivia: nil), base: base?.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenBaseAndConfig?.buildUnexpectedNodes(format: format, leadingTrivia: nil), config: config.buildIfConfigDecl(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -3979,7 +4243,11 @@ public struct EditorPlaceholderExpr: ExprBuildable, ExpressibleAsEditorPlacehold
   func buildEditorPlaceholderExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> EditorPlaceholderExprSyntax {
     let result = EditorPlaceholderExprSyntax(unexpectedBeforeIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -4056,7 +4324,11 @@ public struct ObjectLiteralExpr: ExprBuildable, ExpressibleAsObjectLiteralExpr {
   func buildObjectLiteralExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ObjectLiteralExprSyntax {
     let result = ObjectLiteralExprSyntax(unexpectedBeforeIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier, unexpectedBetweenIdentifierAndLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndArguments?.buildUnexpectedNodes(format: format, leadingTrivia: nil), arguments: arguments.buildTupleExprElementList(format: format, leadingTrivia: nil), unexpectedBetweenArgumentsAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `ExprBuildable`.
   public func buildExpr(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExprSyntax {
@@ -4111,7 +4383,11 @@ public struct TypeInitializerClause: SyntaxBuildable, ExpressibleAsTypeInitializ
   func buildTypeInitializerClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeInitializerClauseSyntax {
     let result = TypeInitializerClauseSyntax(unexpectedBeforeEqual?.buildUnexpectedNodes(format: format, leadingTrivia: nil), equal: equal, unexpectedBetweenEqualAndValue?.buildUnexpectedNodes(format: format, leadingTrivia: nil), value: value.buildType(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -4195,7 +4471,11 @@ public struct TypealiasDecl: DeclBuildable, ExpressibleAsTypealiasDecl {
   func buildTypealiasDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypealiasDeclSyntax {
     let result = TypealiasDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndTypealiasKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), typealiasKeyword: typealiasKeyword, unexpectedBetweenTypealiasKeywordAndIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier, unexpectedBetweenIdentifierAndGenericParameterClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericParameterClause: genericParameterClause?.buildGenericParameterClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericParameterClauseAndInitializer?.buildUnexpectedNodes(format: format, leadingTrivia: nil), initializer: initializer.buildTypeInitializerClause(format: format, leadingTrivia: nil), unexpectedBetweenInitializerAndGenericWhereClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericWhereClause: genericWhereClause?.buildGenericWhereClause(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -4286,7 +4566,11 @@ public struct AssociatedtypeDecl: DeclBuildable, ExpressibleAsAssociatedtypeDecl
   func buildAssociatedtypeDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AssociatedtypeDeclSyntax {
     let result = AssociatedtypeDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndAssociatedtypeKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), associatedtypeKeyword: associatedtypeKeyword, unexpectedBetweenAssociatedtypeKeywordAndIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier, unexpectedBetweenIdentifierAndInheritanceClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), inheritanceClause: inheritanceClause?.buildTypeInheritanceClause(format: format, leadingTrivia: nil), unexpectedBetweenInheritanceClauseAndInitializer?.buildUnexpectedNodes(format: format, leadingTrivia: nil), initializer: initializer?.buildTypeInitializerClause(format: format, leadingTrivia: nil), unexpectedBetweenInitializerAndGenericWhereClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericWhereClause: genericWhereClause?.buildGenericWhereClause(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -4356,7 +4640,11 @@ public struct ParameterClause: SyntaxBuildable, ExpressibleAsParameterClause {
   func buildParameterClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ParameterClauseSyntax {
     let result = ParameterClauseSyntax(unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndParameterList?.buildUnexpectedNodes(format: format, leadingTrivia: nil), parameterList: parameterList.buildFunctionParameterList(format: format, leadingTrivia: nil), unexpectedBetweenParameterListAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -4404,7 +4692,11 @@ public struct ReturnClause: SyntaxBuildable, ExpressibleAsReturnClause {
   func buildReturnClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ReturnClauseSyntax {
     let result = ReturnClauseSyntax(unexpectedBeforeArrow?.buildUnexpectedNodes(format: format, leadingTrivia: nil), arrow: arrow, unexpectedBetweenArrowAndReturnType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), returnType: returnType.buildType(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -4473,7 +4765,11 @@ public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature
   func buildFunctionSignature(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FunctionSignatureSyntax {
     let result = FunctionSignatureSyntax(unexpectedBeforeInput?.buildUnexpectedNodes(format: format, leadingTrivia: nil), input: input.buildParameterClause(format: format, leadingTrivia: nil), unexpectedBetweenInputAndAsyncOrReasyncKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), asyncOrReasyncKeyword: asyncOrReasyncKeyword, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), throwsOrRethrowsKeyword: throwsOrRethrowsKeyword, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput?.buildUnexpectedNodes(format: format, leadingTrivia: nil), output: output?.buildReturnClause(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -4527,7 +4823,11 @@ public struct IfConfigClause: SyntaxBuildable, ExpressibleAsIfConfigClause {
   func buildIfConfigClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IfConfigClauseSyntax {
     let result = IfConfigClauseSyntax(unexpectedBeforePoundKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundKeyword: poundKeyword, unexpectedBetweenPoundKeywordAndCondition?.buildUnexpectedNodes(format: format, leadingTrivia: nil), condition: condition?.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenConditionAndElements?.buildUnexpectedNodes(format: format, leadingTrivia: nil), elements: elements.buildSyntax(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -4575,7 +4875,11 @@ public struct IfConfigDecl: DeclBuildable, ExpressibleAsIfConfigDecl {
   func buildIfConfigDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IfConfigDeclSyntax {
     let result = IfConfigDeclSyntax(unexpectedBeforeClauses?.buildUnexpectedNodes(format: format, leadingTrivia: nil), clauses: clauses.buildIfConfigClauseList(format: format, leadingTrivia: nil), unexpectedBetweenClausesAndPoundEndif?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundEndif: poundEndif)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -4644,7 +4948,11 @@ public struct PoundErrorDecl: DeclBuildable, ExpressibleAsPoundErrorDecl {
   func buildPoundErrorDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundErrorDeclSyntax {
     let result = PoundErrorDeclSyntax(unexpectedBeforePoundError?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundError: poundError, unexpectedBetweenPoundErrorAndLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndMessage?.buildUnexpectedNodes(format: format, leadingTrivia: nil), message: message.buildStringLiteralExpr(format: format, leadingTrivia: nil), unexpectedBetweenMessageAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -4713,7 +5021,11 @@ public struct PoundWarningDecl: DeclBuildable, ExpressibleAsPoundWarningDecl {
   func buildPoundWarningDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundWarningDeclSyntax {
     let result = PoundWarningDeclSyntax(unexpectedBeforePoundWarning?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundWarning: poundWarning, unexpectedBetweenPoundWarningAndLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndMessage?.buildUnexpectedNodes(format: format, leadingTrivia: nil), message: message.buildStringLiteralExpr(format: format, leadingTrivia: nil), unexpectedBetweenMessageAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -4782,7 +5094,11 @@ public struct PoundSourceLocation: DeclBuildable, ExpressibleAsPoundSourceLocati
   func buildPoundSourceLocation(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundSourceLocationSyntax {
     let result = PoundSourceLocationSyntax(unexpectedBeforePoundSourceLocation?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundSourceLocation: poundSourceLocation, unexpectedBetweenPoundSourceLocationAndLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndArgs?.buildUnexpectedNodes(format: format, leadingTrivia: nil), args: args?.buildPoundSourceLocationArgs(format: format, leadingTrivia: nil), unexpectedBetweenArgsAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -4877,7 +5193,11 @@ public struct PoundSourceLocationArgs: SyntaxBuildable, ExpressibleAsPoundSource
   func buildPoundSourceLocationArgs(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundSourceLocationArgsSyntax {
     let result = PoundSourceLocationArgsSyntax(unexpectedBeforeFileArgLabel?.buildUnexpectedNodes(format: format, leadingTrivia: nil), fileArgLabel: fileArgLabel, unexpectedBetweenFileArgLabelAndFileArgColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), fileArgColon: fileArgColon, unexpectedBetweenFileArgColonAndFileName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), fileName: fileName, unexpectedBetweenFileNameAndComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), comma: comma, unexpectedBetweenCommaAndLineArgLabel?.buildUnexpectedNodes(format: format, leadingTrivia: nil), lineArgLabel: lineArgLabel, unexpectedBetweenLineArgLabelAndLineArgColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), lineArgColon: lineArgColon, unexpectedBetweenLineArgColonAndLineNumber?.buildUnexpectedNodes(format: format, leadingTrivia: nil), lineNumber: lineNumber)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -4938,7 +5258,11 @@ public struct DeclModifierDetail: SyntaxBuildable, ExpressibleAsDeclModifierDeta
   func buildDeclModifierDetail(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclModifierDetailSyntax {
     let result = DeclModifierDetailSyntax(unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndDetail?.buildUnexpectedNodes(format: format, leadingTrivia: nil), detail: detail, unexpectedBetweenDetailAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -4986,7 +5310,11 @@ public struct DeclModifier: SyntaxBuildable, ExpressibleAsDeclModifier {
   func buildDeclModifier(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclModifierSyntax {
     let result = DeclModifierSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndDetail?.buildUnexpectedNodes(format: format, leadingTrivia: nil), detail: detail?.buildDeclModifierDetail(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -5034,7 +5362,11 @@ public struct InheritedType: SyntaxBuildable, ExpressibleAsInheritedType, HasTra
   func buildInheritedType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> InheritedTypeSyntax {
     let result = InheritedTypeSyntax(unexpectedBeforeTypeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), typeName: typeName.buildType(format: format, leadingTrivia: nil), unexpectedBetweenTypeNameAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -5094,7 +5426,11 @@ public struct TypeInheritanceClause: SyntaxBuildable, ExpressibleAsTypeInheritan
   func buildTypeInheritanceClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeInheritanceClauseSyntax {
     let result = TypeInheritanceClauseSyntax(unexpectedBeforeColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndInheritedTypeCollection?.buildUnexpectedNodes(format: format, leadingTrivia: nil), inheritedTypeCollection: inheritedTypeCollection.buildInheritedTypeList(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -5186,7 +5522,11 @@ public struct ClassDecl: DeclBuildable, ExpressibleAsClassDecl {
   func buildClassDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ClassDeclSyntax {
     let result = ClassDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndClassKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), classKeyword: classKeyword, unexpectedBetweenClassKeywordAndIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier, unexpectedBetweenIdentifierAndGenericParameterClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericParameterClause: genericParameterClause?.buildGenericParameterClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericParameterClauseAndInheritanceClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), inheritanceClause: inheritanceClause?.buildTypeInheritanceClause(format: format, leadingTrivia: nil), unexpectedBetweenInheritanceClauseAndGenericWhereClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericWhereClause: genericWhereClause?.buildGenericWhereClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericWhereClauseAndMembers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), members: members.buildMemberDeclBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -5285,7 +5625,11 @@ public struct ActorDecl: DeclBuildable, ExpressibleAsActorDecl {
   func buildActorDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ActorDeclSyntax {
     let result = ActorDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndActorKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), actorKeyword: actorKeyword, unexpectedBetweenActorKeywordAndIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier, unexpectedBetweenIdentifierAndGenericParameterClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericParameterClause: genericParameterClause?.buildGenericParameterClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericParameterClauseAndInheritanceClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), inheritanceClause: inheritanceClause?.buildTypeInheritanceClause(format: format, leadingTrivia: nil), unexpectedBetweenInheritanceClauseAndGenericWhereClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericWhereClause: genericWhereClause?.buildGenericWhereClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericWhereClauseAndMembers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), members: members.buildMemberDeclBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -5384,7 +5728,11 @@ public struct StructDecl: DeclBuildable, ExpressibleAsStructDecl {
   func buildStructDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StructDeclSyntax {
     let result = StructDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndStructKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), structKeyword: structKeyword, unexpectedBetweenStructKeywordAndIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier, unexpectedBetweenIdentifierAndGenericParameterClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericParameterClause: genericParameterClause?.buildGenericParameterClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericParameterClauseAndInheritanceClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), inheritanceClause: inheritanceClause?.buildTypeInheritanceClause(format: format, leadingTrivia: nil), unexpectedBetweenInheritanceClauseAndGenericWhereClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericWhereClause: genericWhereClause?.buildGenericWhereClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericWhereClauseAndMembers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), members: members.buildMemberDeclBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -5483,7 +5831,11 @@ public struct ProtocolDecl: DeclBuildable, ExpressibleAsProtocolDecl {
   func buildProtocolDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ProtocolDeclSyntax {
     let result = ProtocolDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndProtocolKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), protocolKeyword: protocolKeyword, unexpectedBetweenProtocolKeywordAndIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier, unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), primaryAssociatedTypeClause: primaryAssociatedTypeClause?.buildPrimaryAssociatedTypeClause(format: format, leadingTrivia: nil), unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), inheritanceClause: inheritanceClause?.buildTypeInheritanceClause(format: format, leadingTrivia: nil), unexpectedBetweenInheritanceClauseAndGenericWhereClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericWhereClause: genericWhereClause?.buildGenericWhereClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericWhereClauseAndMembers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), members: members.buildMemberDeclBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -5576,7 +5928,11 @@ public struct ExtensionDecl: DeclBuildable, ExpressibleAsExtensionDecl {
   func buildExtensionDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExtensionDeclSyntax {
     let result = ExtensionDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndExtensionKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), extensionKeyword: extensionKeyword, unexpectedBetweenExtensionKeywordAndExtendedType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), extendedType: extendedType.buildType(format: format, leadingTrivia: nil), unexpectedBetweenExtendedTypeAndInheritanceClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), inheritanceClause: inheritanceClause?.buildTypeInheritanceClause(format: format, leadingTrivia: nil), unexpectedBetweenInheritanceClauseAndGenericWhereClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericWhereClause: genericWhereClause?.buildGenericWhereClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericWhereClauseAndMembers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), members: members.buildMemberDeclBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -5646,7 +6002,11 @@ public struct MemberDeclBlock: SyntaxBuildable, ExpressibleAsMemberDeclBlock {
   func buildMemberDeclBlock(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MemberDeclBlockSyntax {
     let result = MemberDeclBlockSyntax(unexpectedBeforeLeftBrace?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftBrace: leftBrace, unexpectedBetweenLeftBraceAndMembers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), members: members.buildMemberDeclList(format: format._indented(), leadingTrivia: nil), unexpectedBetweenMembersAndRightBrace?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightBrace: rightBrace.withLeadingTrivia(.newline + format._makeIndent() + (rightBrace.leadingTrivia ?? [])))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -5695,7 +6055,11 @@ public struct MemberDeclListItem: SyntaxBuildable, ExpressibleAsMemberDeclListIt
   func buildMemberDeclListItem(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MemberDeclListItemSyntax {
     let result = MemberDeclListItemSyntax(unexpectedBeforeDecl?.buildUnexpectedNodes(format: format, leadingTrivia: nil), decl: decl.buildDecl(format: format, leadingTrivia: nil), unexpectedBetweenDeclAndSemicolon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), semicolon: semicolon)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -5750,7 +6114,11 @@ public struct SourceFile: SyntaxBuildable, ExpressibleAsSourceFile {
   func buildSourceFile(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SourceFileSyntax {
     let result = SourceFileSyntax(unexpectedBeforeStatements?.buildUnexpectedNodes(format: format, leadingTrivia: nil), statements: statements.buildCodeBlockItemList(format: format, leadingTrivia: nil), unexpectedBetweenStatementsAndEOFToken?.buildUnexpectedNodes(format: format, leadingTrivia: nil), eofToken: eofToken)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -5798,7 +6166,11 @@ public struct InitializerClause: SyntaxBuildable, ExpressibleAsInitializerClause
   func buildInitializerClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> InitializerClauseSyntax {
     let result = InitializerClauseSyntax(unexpectedBeforeEqual?.buildUnexpectedNodes(format: format, leadingTrivia: nil), equal: equal, unexpectedBetweenEqualAndValue?.buildUnexpectedNodes(format: format, leadingTrivia: nil), value: value.buildExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -5884,7 +6256,11 @@ public struct FunctionParameter: SyntaxBuildable, ExpressibleAsFunctionParameter
   func buildFunctionParameter(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FunctionParameterSyntax {
     let result = FunctionParameterSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndFirstName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), firstName: firstName, unexpectedBetweenFirstNameAndSecondName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), secondName: secondName, unexpectedBetweenSecondNameAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), type: type?.buildType(format: format, leadingTrivia: nil), unexpectedBetweenTypeAndEllipsis?.buildUnexpectedNodes(format: format, leadingTrivia: nil), ellipsis: ellipsis, unexpectedBetweenEllipsisAndDefaultArgument?.buildUnexpectedNodes(format: format, leadingTrivia: nil), defaultArgument: defaultArgument?.buildInitializerClause(format: format, leadingTrivia: nil), unexpectedBetweenDefaultArgumentAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -5980,7 +6356,11 @@ public struct FunctionDecl: DeclBuildable, ExpressibleAsFunctionDecl {
   func buildFunctionDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FunctionDeclSyntax {
     let result = FunctionDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndFuncKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), funcKeyword: funcKeyword, unexpectedBetweenFuncKeywordAndIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier, unexpectedBetweenIdentifierAndGenericParameterClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericParameterClause: genericParameterClause?.buildGenericParameterClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericParameterClauseAndSignature?.buildUnexpectedNodes(format: format, leadingTrivia: nil), signature: signature.buildFunctionSignature(format: format, leadingTrivia: nil), unexpectedBetweenSignatureAndGenericWhereClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericWhereClause: genericWhereClause?.buildGenericWhereClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericWhereClauseAndBody?.buildUnexpectedNodes(format: format, leadingTrivia: nil), body: body?.buildCodeBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -6080,7 +6460,11 @@ public struct InitializerDecl: DeclBuildable, ExpressibleAsInitializerDecl {
   func buildInitializerDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> InitializerDeclSyntax {
     let result = InitializerDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndInitKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), initKeyword: initKeyword, unexpectedBetweenInitKeywordAndOptionalMark?.buildUnexpectedNodes(format: format, leadingTrivia: nil), optionalMark: optionalMark, unexpectedBetweenOptionalMarkAndGenericParameterClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericParameterClause: genericParameterClause?.buildGenericParameterClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericParameterClauseAndSignature?.buildUnexpectedNodes(format: format, leadingTrivia: nil), signature: signature.buildFunctionSignature(format: format, leadingTrivia: nil), unexpectedBetweenSignatureAndGenericWhereClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericWhereClause: genericWhereClause?.buildGenericWhereClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericWhereClauseAndBody?.buildUnexpectedNodes(format: format, leadingTrivia: nil), body: body?.buildCodeBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -6155,7 +6539,11 @@ public struct DeinitializerDecl: DeclBuildable, ExpressibleAsDeinitializerDecl {
   func buildDeinitializerDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeinitializerDeclSyntax {
     let result = DeinitializerDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndDeinitKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), deinitKeyword: deinitKeyword, unexpectedBetweenDeinitKeywordAndBody?.buildUnexpectedNodes(format: format, leadingTrivia: nil), body: body?.buildCodeBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -6246,7 +6634,11 @@ public struct SubscriptDecl: DeclBuildable, ExpressibleAsSubscriptDecl {
   func buildSubscriptDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SubscriptDeclSyntax {
     let result = SubscriptDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndSubscriptKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), subscriptKeyword: subscriptKeyword, unexpectedBetweenSubscriptKeywordAndGenericParameterClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericParameterClause: genericParameterClause?.buildGenericParameterClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericParameterClauseAndIndices?.buildUnexpectedNodes(format: format, leadingTrivia: nil), indices: indices.buildParameterClause(format: format, leadingTrivia: nil), unexpectedBetweenIndicesAndResult?.buildUnexpectedNodes(format: format, leadingTrivia: nil), result: result.buildReturnClause(format: format, leadingTrivia: nil), unexpectedBetweenResultAndGenericWhereClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericWhereClause: genericWhereClause?.buildGenericWhereClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericWhereClauseAndAccessor?.buildUnexpectedNodes(format: format, leadingTrivia: nil), accessor: accessor?.buildSyntax(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -6306,7 +6698,11 @@ public struct AccessLevelModifier: SyntaxBuildable, ExpressibleAsAccessLevelModi
   func buildAccessLevelModifier(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AccessLevelModifierSyntax {
     let result = AccessLevelModifierSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndModifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifier: modifier?.buildDeclModifierDetail(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -6360,7 +6756,11 @@ public struct AccessPathComponent: SyntaxBuildable, ExpressibleAsAccessPathCompo
   func buildAccessPathComponent(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AccessPathComponentSyntax {
     let result = AccessPathComponentSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndTrailingDot?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingDot: trailingDot)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -6427,7 +6827,11 @@ public struct ImportDecl: DeclBuildable, ExpressibleAsImportDecl {
   func buildImportDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ImportDeclSyntax {
     let result = ImportDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndImportTok?.buildUnexpectedNodes(format: format, leadingTrivia: nil), importTok: importTok, unexpectedBetweenImportTokAndImportKind?.buildUnexpectedNodes(format: format, leadingTrivia: nil), importKind: importKind, unexpectedBetweenImportKindAndPath?.buildUnexpectedNodes(format: format, leadingTrivia: nil), path: path.buildAccessPath(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -6495,7 +6899,11 @@ public struct AccessorParameter: SyntaxBuildable, ExpressibleAsAccessorParameter
   func buildAccessorParameter(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AccessorParameterSyntax {
     let result = AccessorParameterSyntax(unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -6585,7 +6993,11 @@ public struct AccessorDecl: DeclBuildable, ExpressibleAsAccessorDecl {
   func buildAccessorDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AccessorDeclSyntax {
     let result = AccessorDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifier: modifier?.buildDeclModifier(format: format, leadingTrivia: nil), unexpectedBetweenModifierAndAccessorKind?.buildUnexpectedNodes(format: format, leadingTrivia: nil), accessorKind: accessorKind, unexpectedBetweenAccessorKindAndParameter?.buildUnexpectedNodes(format: format, leadingTrivia: nil), parameter: parameter?.buildAccessorParameter(format: format, leadingTrivia: nil), unexpectedBetweenParameterAndAsyncKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), asyncKeyword: asyncKeyword, unexpectedBetweenAsyncKeywordAndThrowsKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), throwsKeyword: throwsKeyword, unexpectedBetweenThrowsKeywordAndBody?.buildUnexpectedNodes(format: format, leadingTrivia: nil), body: body?.buildCodeBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -6647,7 +7059,11 @@ public struct AccessorBlock: SyntaxBuildable, ExpressibleAsAccessorBlock {
   func buildAccessorBlock(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AccessorBlockSyntax {
     let result = AccessorBlockSyntax(unexpectedBeforeLeftBrace?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftBrace: leftBrace, unexpectedBetweenLeftBraceAndAccessors?.buildUnexpectedNodes(format: format, leadingTrivia: nil), accessors: accessors.buildAccessorList(format: format, leadingTrivia: nil), unexpectedBetweenAccessorsAndRightBrace?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightBrace: rightBrace)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -6713,7 +7129,11 @@ public struct PatternBinding: SyntaxBuildable, ExpressibleAsPatternBinding, HasT
   func buildPatternBinding(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PatternBindingSyntax {
     let result = PatternBindingSyntax(unexpectedBeforePattern?.buildUnexpectedNodes(format: format, leadingTrivia: nil), pattern: pattern.buildPattern(format: format, leadingTrivia: nil), unexpectedBetweenPatternAndTypeAnnotation?.buildUnexpectedNodes(format: format, leadingTrivia: nil), typeAnnotation: typeAnnotation?.buildTypeAnnotation(format: format, leadingTrivia: nil), unexpectedBetweenTypeAnnotationAndInitializer?.buildUnexpectedNodes(format: format, leadingTrivia: nil), initializer: initializer?.buildInitializerClause(format: format, leadingTrivia: nil), unexpectedBetweenInitializerAndAccessor?.buildUnexpectedNodes(format: format, leadingTrivia: nil), accessor: accessor?.buildSyntax(format: format, leadingTrivia: nil), unexpectedBetweenAccessorAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -6785,7 +7205,11 @@ public struct VariableDecl: DeclBuildable, ExpressibleAsVariableDecl {
   func buildVariableDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> VariableDeclSyntax {
     let result = VariableDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndLetOrVarKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), letOrVarKeyword: letOrVarKeyword, unexpectedBetweenLetOrVarKeywordAndBindings?.buildUnexpectedNodes(format: format, leadingTrivia: nil), bindings: bindings.buildPatternBindingList(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -6859,7 +7283,11 @@ public struct EnumCaseElement: SyntaxBuildable, ExpressibleAsEnumCaseElement, Ha
   func buildEnumCaseElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> EnumCaseElementSyntax {
     let result = EnumCaseElementSyntax(unexpectedBeforeIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier, unexpectedBetweenIdentifierAndAssociatedValue?.buildUnexpectedNodes(format: format, leadingTrivia: nil), associatedValue: associatedValue?.buildParameterClause(format: format, leadingTrivia: nil), unexpectedBetweenAssociatedValueAndRawValue?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rawValue: rawValue?.buildInitializerClause(format: format, leadingTrivia: nil), unexpectedBetweenRawValueAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -6932,7 +7360,11 @@ public struct EnumCaseDecl: DeclBuildable, ExpressibleAsEnumCaseDecl {
   func buildEnumCaseDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> EnumCaseDeclSyntax {
     let result = EnumCaseDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndCaseKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndElements?.buildUnexpectedNodes(format: format, leadingTrivia: nil), elements: elements.buildEnumCaseElementList(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -7032,7 +7464,11 @@ public struct EnumDecl: DeclBuildable, ExpressibleAsEnumDecl {
   func buildEnumDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> EnumDeclSyntax {
     let result = EnumDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndEnumKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), enumKeyword: enumKeyword, unexpectedBetweenEnumKeywordAndIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier, unexpectedBetweenIdentifierAndGenericParameters?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericParameters: genericParameters?.buildGenericParameterClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericParametersAndInheritanceClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), inheritanceClause: inheritanceClause?.buildTypeInheritanceClause(format: format, leadingTrivia: nil), unexpectedBetweenInheritanceClauseAndGenericWhereClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericWhereClause: genericWhereClause?.buildGenericWhereClause(format: format, leadingTrivia: nil), unexpectedBetweenGenericWhereClauseAndMembers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), members: members.buildMemberDeclBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -7106,7 +7542,11 @@ public struct OperatorDecl: DeclBuildable, ExpressibleAsOperatorDecl {
   func buildOperatorDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> OperatorDeclSyntax {
     let result = OperatorDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndOperatorKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), operatorKeyword: operatorKeyword, unexpectedBetweenOperatorKeywordAndIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier, unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), operatorPrecedenceAndTypes: operatorPrecedenceAndTypes?.buildOperatorPrecedenceAndTypes(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -7162,7 +7602,11 @@ public struct OperatorPrecedenceAndTypes: SyntaxBuildable, ExpressibleAsOperator
   func buildOperatorPrecedenceAndTypes(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> OperatorPrecedenceAndTypesSyntax {
     let result = OperatorPrecedenceAndTypesSyntax(unexpectedBeforeColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), precedenceGroupAndDesignatedTypes: precedenceGroupAndDesignatedTypes.buildIdentifierList(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -7249,7 +7693,11 @@ public struct PrecedenceGroupDecl: DeclBuildable, ExpressibleAsPrecedenceGroupDe
   func buildPrecedenceGroupDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrecedenceGroupDeclSyntax {
     let result = PrecedenceGroupDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format, leadingTrivia: nil), modifiers: modifiers?.buildModifierList(format: format, leadingTrivia: nil), unexpectedBetweenModifiersAndPrecedencegroupKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), precedencegroupKeyword: precedencegroupKeyword, unexpectedBetweenPrecedencegroupKeywordAndIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier, unexpectedBetweenIdentifierAndLeftBrace?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftBrace: leftBrace, unexpectedBetweenLeftBraceAndGroupAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), groupAttributes: groupAttributes.buildPrecedenceGroupAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenGroupAttributesAndRightBrace?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightBrace: rightBrace)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `DeclBuildable`.
   public func buildDecl(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclSyntax {
@@ -7318,7 +7766,11 @@ public struct PrecedenceGroupRelation: SyntaxBuildable, ExpressibleAsPrecedenceG
   func buildPrecedenceGroupRelation(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrecedenceGroupRelationSyntax {
     let result = PrecedenceGroupRelationSyntax(unexpectedBeforeHigherThanOrLowerThan?.buildUnexpectedNodes(format: format, leadingTrivia: nil), higherThanOrLowerThan: higherThanOrLowerThan, unexpectedBetweenHigherThanOrLowerThanAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndOtherNames?.buildUnexpectedNodes(format: format, leadingTrivia: nil), otherNames: otherNames.buildPrecedenceGroupNameList(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -7372,7 +7824,11 @@ public struct PrecedenceGroupNameElement: SyntaxBuildable, ExpressibleAsPreceden
   func buildPrecedenceGroupNameElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrecedenceGroupNameElementSyntax {
     let result = PrecedenceGroupNameElementSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -7435,7 +7891,11 @@ public struct PrecedenceGroupAssignment: SyntaxBuildable, ExpressibleAsPrecedenc
   func buildPrecedenceGroupAssignment(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrecedenceGroupAssignmentSyntax {
     let result = PrecedenceGroupAssignmentSyntax(unexpectedBeforeAssignmentKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), assignmentKeyword: assignmentKeyword, unexpectedBetweenAssignmentKeywordAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndFlag?.buildUnexpectedNodes(format: format, leadingTrivia: nil), flag: flag)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -7498,7 +7958,11 @@ public struct PrecedenceGroupAssociativity: SyntaxBuildable, ExpressibleAsPreced
   func buildPrecedenceGroupAssociativity(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrecedenceGroupAssociativitySyntax {
     let result = PrecedenceGroupAssociativitySyntax(unexpectedBeforeAssociativityKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), associativityKeyword: associativityKeyword, unexpectedBetweenAssociativityKeywordAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndValue?.buildUnexpectedNodes(format: format, leadingTrivia: nil), value: value)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -7575,7 +8039,11 @@ public struct CustomAttribute: SyntaxBuildable, ExpressibleAsCustomAttribute {
   func buildCustomAttribute(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CustomAttributeSyntax {
     let result = CustomAttributeSyntax(unexpectedBeforeAtSignToken?.buildUnexpectedNodes(format: format, leadingTrivia: nil), atSignToken: atSignToken, unexpectedBetweenAtSignTokenAndAttributeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributeName: attributeName.buildType(format: format, leadingTrivia: nil), unexpectedBetweenAttributeNameAndLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList?.buildUnexpectedNodes(format: format, leadingTrivia: nil), argumentList: argumentList?.buildTupleExprElementList(format: format, leadingTrivia: nil), unexpectedBetweenArgumentListAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -7650,7 +8118,11 @@ public struct Attribute: SyntaxBuildable, ExpressibleAsAttribute {
   func buildAttribute(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AttributeSyntax {
     let result = AttributeSyntax(unexpectedBeforeAtSignToken?.buildUnexpectedNodes(format: format, leadingTrivia: nil), atSignToken: atSignToken, unexpectedBetweenAtSignTokenAndAttributeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributeName: attributeName, unexpectedBetweenAttributeNameAndLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndArgument?.buildUnexpectedNodes(format: format, leadingTrivia: nil), argument: argument?.buildSyntax(format: format, leadingTrivia: nil), unexpectedBetweenArgumentAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen, unexpectedBetweenRightParenAndTokenList?.buildUnexpectedNodes(format: format, leadingTrivia: nil), tokenList: tokenList?.buildTokenList(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -7718,7 +8190,11 @@ public struct AvailabilityEntry: SyntaxBuildable, ExpressibleAsAvailabilityEntry
   func buildAvailabilityEntry(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AvailabilityEntrySyntax {
     let result = AvailabilityEntrySyntax(unexpectedBeforeLabel?.buildUnexpectedNodes(format: format, leadingTrivia: nil), label: label, unexpectedBetweenLabelAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndAvailabilityList?.buildUnexpectedNodes(format: format, leadingTrivia: nil), availabilityList: availabilityList.buildAvailabilitySpecList(format: format, leadingTrivia: nil), unexpectedBetweenAvailabilityListAndSemicolon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), semicolon: semicolon)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -7786,7 +8262,11 @@ public struct LabeledSpecializeEntry: SyntaxBuildable, ExpressibleAsLabeledSpeci
   func buildLabeledSpecializeEntry(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> LabeledSpecializeEntrySyntax {
     let result = LabeledSpecializeEntrySyntax(unexpectedBeforeLabel?.buildUnexpectedNodes(format: format, leadingTrivia: nil), label: label, unexpectedBetweenLabelAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndValue?.buildUnexpectedNodes(format: format, leadingTrivia: nil), value: value, unexpectedBetweenValueAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -7858,7 +8338,11 @@ public struct TargetFunctionEntry: SyntaxBuildable, ExpressibleAsTargetFunctionE
   func buildTargetFunctionEntry(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TargetFunctionEntrySyntax {
     let result = TargetFunctionEntrySyntax(unexpectedBeforeLabel?.buildUnexpectedNodes(format: format, leadingTrivia: nil), label: label, unexpectedBetweenLabelAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndDeclname?.buildUnexpectedNodes(format: format, leadingTrivia: nil), declname: declname.buildDeclName(format: format, leadingTrivia: nil), unexpectedBetweenDeclnameAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -7917,7 +8401,11 @@ public struct NamedAttributeStringArgument: SyntaxBuildable, ExpressibleAsNamedA
   func buildNamedAttributeStringArgument(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> NamedAttributeStringArgumentSyntax {
     let result = NamedAttributeStringArgumentSyntax(unexpectedBeforeNameTok?.buildUnexpectedNodes(format: format, leadingTrivia: nil), nameTok: nameTok, unexpectedBetweenNameTokAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndStringOrDeclname?.buildUnexpectedNodes(format: format, leadingTrivia: nil), stringOrDeclname: stringOrDeclname.buildSyntax(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -7964,7 +8452,11 @@ public struct DeclName: SyntaxBuildable, ExpressibleAsDeclName {
   func buildDeclName(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclNameSyntax {
     let result = DeclNameSyntax(unexpectedBeforeDeclBaseName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), declBaseName: declBaseName.buildSyntax(format: format, leadingTrivia: nil), unexpectedBetweenDeclBaseNameAndDeclNameArguments?.buildUnexpectedNodes(format: format, leadingTrivia: nil), declNameArguments: declNameArguments?.buildDeclNameArguments(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -8025,7 +8517,11 @@ public struct ImplementsAttributeArguments: SyntaxBuildable, ExpressibleAsImplem
   func buildImplementsAttributeArguments(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ImplementsAttributeArgumentsSyntax {
     let result = ImplementsAttributeArgumentsSyntax(unexpectedBeforeType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), type: type.buildSimpleTypeIdentifier(format: format, leadingTrivia: nil), unexpectedBetweenTypeAndComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), comma: comma, unexpectedBetweenCommaAndDeclBaseName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), declBaseName: declBaseName.buildSyntax(format: format, leadingTrivia: nil), unexpectedBetweenDeclBaseNameAndDeclNameArguments?.buildUnexpectedNodes(format: format, leadingTrivia: nil), declNameArguments: declNameArguments?.buildDeclNameArguments(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -8082,7 +8578,11 @@ public struct ObjCSelectorPiece: SyntaxBuildable, ExpressibleAsObjCSelectorPiece
   func buildObjCSelectorPiece(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ObjCSelectorPieceSyntax {
     let result = ObjCSelectorPieceSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -8159,7 +8659,11 @@ public struct DifferentiableAttributeArguments: SyntaxBuildable, ExpressibleAsDi
   func buildDifferentiableAttributeArguments(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DifferentiableAttributeArgumentsSyntax {
     let result = DifferentiableAttributeArgumentsSyntax(unexpectedBeforeDiffKind?.buildUnexpectedNodes(format: format, leadingTrivia: nil), diffKind: diffKind, unexpectedBetweenDiffKindAndDiffKindComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), diffKindComma: diffKindComma, unexpectedBetweenDiffKindCommaAndDiffParams?.buildUnexpectedNodes(format: format, leadingTrivia: nil), diffParams: diffParams?.buildDifferentiabilityParamsClause(format: format, leadingTrivia: nil), unexpectedBetweenDiffParamsAndDiffParamsComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), diffParamsComma: diffParamsComma, unexpectedBetweenDiffParamsCommaAndWhereClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), whereClause: whereClause?.buildGenericWhereClause(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -8221,7 +8725,11 @@ public struct DifferentiabilityParamsClause: SyntaxBuildable, ExpressibleAsDiffe
   func buildDifferentiabilityParamsClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DifferentiabilityParamsClauseSyntax {
     let result = DifferentiabilityParamsClauseSyntax(unexpectedBeforeWrtLabel?.buildUnexpectedNodes(format: format, leadingTrivia: nil), wrtLabel: wrtLabel, unexpectedBetweenWrtLabelAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndParameters?.buildUnexpectedNodes(format: format, leadingTrivia: nil), parameters: parameters.buildSyntax(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -8277,7 +8785,11 @@ public struct DifferentiabilityParams: SyntaxBuildable, ExpressibleAsDifferentia
   func buildDifferentiabilityParams(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DifferentiabilityParamsSyntax {
     let result = DifferentiabilityParamsSyntax(unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndDiffParams?.buildUnexpectedNodes(format: format, leadingTrivia: nil), diffParams: diffParams.buildDifferentiabilityParamList(format: format, leadingTrivia: nil), unexpectedBetweenDiffParamsAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -8326,7 +8838,11 @@ public struct DifferentiabilityParam: SyntaxBuildable, ExpressibleAsDifferentiab
   func buildDifferentiabilityParam(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DifferentiabilityParamSyntax {
     let result = DifferentiabilityParamSyntax(unexpectedBeforeParameter?.buildUnexpectedNodes(format: format, leadingTrivia: nil), parameter: parameter.buildSyntax(format: format, leadingTrivia: nil), unexpectedBetweenParameterAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -8421,7 +8937,11 @@ public struct DerivativeRegistrationAttributeArguments: SyntaxBuildable, Express
   func buildDerivativeRegistrationAttributeArguments(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let result = DerivativeRegistrationAttributeArgumentsSyntax(unexpectedBeforeOfLabel?.buildUnexpectedNodes(format: format, leadingTrivia: nil), ofLabel: ofLabel, unexpectedBetweenOfLabelAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndOriginalDeclName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), originalDeclName: originalDeclName.buildQualifiedDeclName(format: format, leadingTrivia: nil), unexpectedBetweenOriginalDeclNameAndPeriod?.buildUnexpectedNodes(format: format, leadingTrivia: nil), period: period, unexpectedBetweenPeriodAndAccessorKind?.buildUnexpectedNodes(format: format, leadingTrivia: nil), accessorKind: accessorKind, unexpectedBetweenAccessorKindAndComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), comma: comma, unexpectedBetweenCommaAndDiffParams?.buildUnexpectedNodes(format: format, leadingTrivia: nil), diffParams: diffParams?.buildDifferentiabilityParamsClause(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -8482,7 +9002,11 @@ public struct QualifiedDeclName: SyntaxBuildable, ExpressibleAsQualifiedDeclName
   func buildQualifiedDeclName(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> QualifiedDeclNameSyntax {
     let result = QualifiedDeclNameSyntax(unexpectedBeforeBaseType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), baseType: baseType?.buildType(format: format, leadingTrivia: nil), unexpectedBetweenBaseTypeAndDot?.buildUnexpectedNodes(format: format, leadingTrivia: nil), dot: dot, unexpectedBetweenDotAndName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndArguments?.buildUnexpectedNodes(format: format, leadingTrivia: nil), arguments: arguments?.buildDeclNameArguments(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -8530,7 +9054,11 @@ public struct FunctionDeclName: SyntaxBuildable, ExpressibleAsFunctionDeclName {
   func buildFunctionDeclName(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FunctionDeclNameSyntax {
     let result = FunctionDeclNameSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name.buildSyntax(format: format, leadingTrivia: nil), unexpectedBetweenNameAndArguments?.buildUnexpectedNodes(format: format, leadingTrivia: nil), arguments: arguments?.buildDeclNameArguments(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -8592,7 +9120,11 @@ public struct BackDeployAttributeSpecList: SyntaxBuildable, ExpressibleAsBackDep
   func buildBackDeployAttributeSpecList(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> BackDeployAttributeSpecListSyntax {
     let result = BackDeployAttributeSpecListSyntax(unexpectedBeforeBeforeLabel?.buildUnexpectedNodes(format: format, leadingTrivia: nil), beforeLabel: beforeLabel, unexpectedBetweenBeforeLabelAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndVersionList?.buildUnexpectedNodes(format: format, leadingTrivia: nil), versionList: versionList.buildBackDeployVersionList(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -8641,7 +9173,11 @@ public struct BackDeployVersionArgument: SyntaxBuildable, ExpressibleAsBackDeplo
   func buildBackDeployVersionArgument(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> BackDeployVersionArgumentSyntax {
     let result = BackDeployVersionArgumentSyntax(unexpectedBeforeAvailabilityVersionRestriction?.buildUnexpectedNodes(format: format, leadingTrivia: nil), availabilityVersionRestriction: availabilityVersionRestriction.buildAvailabilityVersionRestriction(format: format, leadingTrivia: nil), unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -8701,7 +9237,11 @@ public struct LabeledStmt: StmtBuildable, ExpressibleAsLabeledStmt {
   func buildLabeledStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> LabeledStmtSyntax {
     let result = LabeledStmtSyntax(unexpectedBeforeLabelName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), labelName: labelName, unexpectedBetweenLabelNameAndLabelColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), labelColon: labelColon, unexpectedBetweenLabelColonAndStatement?.buildUnexpectedNodes(format: format, leadingTrivia: nil), statement: statement.buildStmt(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -8764,7 +9304,11 @@ public struct ContinueStmt: StmtBuildable, ExpressibleAsContinueStmt {
   func buildContinueStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ContinueStmtSyntax {
     let result = ContinueStmtSyntax(unexpectedBeforeContinueKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), continueKeyword: continueKeyword, unexpectedBetweenContinueKeywordAndLabel?.buildUnexpectedNodes(format: format, leadingTrivia: nil), label: label)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -8833,7 +9377,11 @@ public struct WhileStmt: StmtBuildable, ExpressibleAsWhileStmt {
   func buildWhileStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> WhileStmtSyntax {
     let result = WhileStmtSyntax(unexpectedBeforeWhileKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), whileKeyword: whileKeyword, unexpectedBetweenWhileKeywordAndConditions?.buildUnexpectedNodes(format: format, leadingTrivia: nil), conditions: conditions.buildConditionElementList(format: format, leadingTrivia: nil), unexpectedBetweenConditionsAndBody?.buildUnexpectedNodes(format: format, leadingTrivia: nil), body: body.buildCodeBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -8896,7 +9444,11 @@ public struct DeferStmt: StmtBuildable, ExpressibleAsDeferStmt {
   func buildDeferStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeferStmtSyntax {
     let result = DeferStmtSyntax(unexpectedBeforeDeferKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), deferKeyword: deferKeyword, unexpectedBetweenDeferKeywordAndBody?.buildUnexpectedNodes(format: format, leadingTrivia: nil), body: body.buildCodeBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -8944,7 +9496,11 @@ public struct ExpressionStmt: StmtBuildable, ExpressibleAsExpressionStmt {
   func buildExpressionStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExpressionStmtSyntax {
     let result = ExpressionStmtSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -9020,7 +9576,11 @@ public struct RepeatWhileStmt: StmtBuildable, ExpressibleAsRepeatWhileStmt {
   func buildRepeatWhileStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> RepeatWhileStmtSyntax {
     let result = RepeatWhileStmtSyntax(unexpectedBeforeRepeatKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), repeatKeyword: repeatKeyword, unexpectedBetweenRepeatKeywordAndBody?.buildUnexpectedNodes(format: format, leadingTrivia: nil), body: body.buildCodeBlock(format: format, leadingTrivia: nil), unexpectedBetweenBodyAndWhileKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), whileKeyword: whileKeyword, unexpectedBetweenWhileKeywordAndCondition?.buildUnexpectedNodes(format: format, leadingTrivia: nil), condition: condition.buildExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -9096,7 +9656,11 @@ public struct GuardStmt: StmtBuildable, ExpressibleAsGuardStmt {
   func buildGuardStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> GuardStmtSyntax {
     let result = GuardStmtSyntax(unexpectedBeforeGuardKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), guardKeyword: guardKeyword, unexpectedBetweenGuardKeywordAndConditions?.buildUnexpectedNodes(format: format, leadingTrivia: nil), conditions: conditions.buildConditionElementList(format: format, leadingTrivia: nil), unexpectedBetweenConditionsAndElseKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndBody?.buildUnexpectedNodes(format: format, leadingTrivia: nil), body: body.buildCodeBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -9151,7 +9715,11 @@ public struct WhereClause: SyntaxBuildable, ExpressibleAsWhereClause {
   func buildWhereClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> WhereClauseSyntax {
     let result = WhereClauseSyntax(unexpectedBeforeWhereKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), whereKeyword: whereKeyword, unexpectedBetweenWhereKeywordAndGuardResult?.buildUnexpectedNodes(format: format, leadingTrivia: nil), guardResult: guardResult.buildExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -9261,7 +9829,11 @@ public struct ForInStmt: StmtBuildable, ExpressibleAsForInStmt {
   func buildForInStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ForInStmtSyntax {
     let result = ForInStmtSyntax(unexpectedBeforeForKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), forKeyword: forKeyword, unexpectedBetweenForKeywordAndTryKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), tryKeyword: tryKeyword, unexpectedBetweenTryKeywordAndAwaitKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), awaitKeyword: awaitKeyword, unexpectedBetweenAwaitKeywordAndCaseKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndPattern?.buildUnexpectedNodes(format: format, leadingTrivia: nil), pattern: pattern.buildPattern(format: format, leadingTrivia: nil), unexpectedBetweenPatternAndTypeAnnotation?.buildUnexpectedNodes(format: format, leadingTrivia: nil), typeAnnotation: typeAnnotation?.buildTypeAnnotation(format: format, leadingTrivia: nil), unexpectedBetweenTypeAnnotationAndInKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), inKeyword: inKeyword, unexpectedBetweenInKeywordAndSequenceExpr?.buildUnexpectedNodes(format: format, leadingTrivia: nil), sequenceExpr: sequenceExpr.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenSequenceExprAndWhereClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), whereClause: whereClause?.buildWhereClause(format: format, leadingTrivia: nil), unexpectedBetweenWhereClauseAndBody?.buildUnexpectedNodes(format: format, leadingTrivia: nil), body: body.buildCodeBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -9344,7 +9916,11 @@ public struct SwitchStmt: StmtBuildable, ExpressibleAsSwitchStmt {
   func buildSwitchStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SwitchStmtSyntax {
     let result = SwitchStmtSyntax(unexpectedBeforeSwitchKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), switchKeyword: switchKeyword, unexpectedBetweenSwitchKeywordAndExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenExpressionAndLeftBrace?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftBrace: leftBrace, unexpectedBetweenLeftBraceAndCases?.buildUnexpectedNodes(format: format, leadingTrivia: nil), cases: cases.buildSwitchCaseList(format: format, leadingTrivia: nil), unexpectedBetweenCasesAndRightBrace?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightBrace: rightBrace.withLeadingTrivia(.newline + format._makeIndent() + (rightBrace.leadingTrivia ?? [])))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -9413,7 +9989,11 @@ public struct DoStmt: StmtBuildable, ExpressibleAsDoStmt {
   func buildDoStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DoStmtSyntax {
     let result = DoStmtSyntax(unexpectedBeforeDoKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), doKeyword: doKeyword, unexpectedBetweenDoKeywordAndBody?.buildUnexpectedNodes(format: format, leadingTrivia: nil), body: body.buildCodeBlock(format: format, leadingTrivia: nil), unexpectedBetweenBodyAndCatchClauses?.buildUnexpectedNodes(format: format, leadingTrivia: nil), catchClauses: catchClauses?.buildCatchClauseList(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -9468,7 +10048,11 @@ public struct ReturnStmt: StmtBuildable, ExpressibleAsReturnStmt {
   func buildReturnStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ReturnStmtSyntax {
     let result = ReturnStmtSyntax(unexpectedBeforeReturnKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), returnKeyword: returnKeyword, unexpectedBetweenReturnKeywordAndExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression?.buildExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -9523,7 +10107,11 @@ public struct YieldStmt: StmtBuildable, ExpressibleAsYieldStmt {
   func buildYieldStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> YieldStmtSyntax {
     let result = YieldStmtSyntax(unexpectedBeforeYieldKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), yieldKeyword: yieldKeyword, unexpectedBetweenYieldKeywordAndYields?.buildUnexpectedNodes(format: format, leadingTrivia: nil), yields: yields.buildSyntax(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -9600,7 +10188,11 @@ public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
   func buildYieldList(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> YieldListSyntax {
     let result = YieldListSyntax(unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndElementList?.buildUnexpectedNodes(format: format, leadingTrivia: nil), elementList: elementList.buildExprList(format: format, leadingTrivia: nil), unexpectedBetweenElementListAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma, unexpectedBetweenTrailingCommaAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -9642,7 +10234,11 @@ public struct FallthroughStmt: StmtBuildable, ExpressibleAsFallthroughStmt {
   func buildFallthroughStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FallthroughStmtSyntax {
     let result = FallthroughStmtSyntax(unexpectedBeforeFallthroughKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), fallthroughKeyword: fallthroughKeyword)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -9705,7 +10301,11 @@ public struct BreakStmt: StmtBuildable, ExpressibleAsBreakStmt {
   func buildBreakStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> BreakStmtSyntax {
     let result = BreakStmtSyntax(unexpectedBeforeBreakKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), breakKeyword: breakKeyword, unexpectedBetweenBreakKeywordAndLabel?.buildUnexpectedNodes(format: format, leadingTrivia: nil), label: label)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -9760,7 +10360,11 @@ public struct ConditionElement: SyntaxBuildable, ExpressibleAsConditionElement, 
   func buildConditionElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ConditionElementSyntax {
     let result = ConditionElementSyntax(unexpectedBeforeCondition?.buildUnexpectedNodes(format: format, leadingTrivia: nil), condition: condition.buildSyntax(format: format, leadingTrivia: nil), unexpectedBetweenConditionAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -9826,7 +10430,11 @@ public struct AvailabilityCondition: SyntaxBuildable, ExpressibleAsAvailabilityC
   func buildAvailabilityCondition(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AvailabilityConditionSyntax {
     let result = AvailabilityConditionSyntax(unexpectedBeforePoundAvailableKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundAvailableKeyword: poundAvailableKeyword, unexpectedBetweenPoundAvailableKeywordAndLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndAvailabilitySpec?.buildUnexpectedNodes(format: format, leadingTrivia: nil), availabilitySpec: availabilitySpec.buildAvailabilitySpecList(format: format, leadingTrivia: nil), unexpectedBetweenAvailabilitySpecAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -9886,7 +10494,11 @@ public struct MatchingPatternCondition: SyntaxBuildable, ExpressibleAsMatchingPa
   func buildMatchingPatternCondition(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MatchingPatternConditionSyntax {
     let result = MatchingPatternConditionSyntax(unexpectedBeforeCaseKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndPattern?.buildUnexpectedNodes(format: format, leadingTrivia: nil), pattern: pattern.buildPattern(format: format, leadingTrivia: nil), unexpectedBetweenPatternAndTypeAnnotation?.buildUnexpectedNodes(format: format, leadingTrivia: nil), typeAnnotation: typeAnnotation?.buildTypeAnnotation(format: format, leadingTrivia: nil), unexpectedBetweenTypeAnnotationAndInitializer?.buildUnexpectedNodes(format: format, leadingTrivia: nil), initializer: initializer.buildInitializerClause(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -9946,7 +10558,11 @@ public struct OptionalBindingCondition: SyntaxBuildable, ExpressibleAsOptionalBi
   func buildOptionalBindingCondition(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> OptionalBindingConditionSyntax {
     let result = OptionalBindingConditionSyntax(unexpectedBeforeLetOrVarKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), letOrVarKeyword: letOrVarKeyword, unexpectedBetweenLetOrVarKeywordAndPattern?.buildUnexpectedNodes(format: format, leadingTrivia: nil), pattern: pattern.buildPattern(format: format, leadingTrivia: nil), unexpectedBetweenPatternAndTypeAnnotation?.buildUnexpectedNodes(format: format, leadingTrivia: nil), typeAnnotation: typeAnnotation?.buildTypeAnnotation(format: format, leadingTrivia: nil), unexpectedBetweenTypeAnnotationAndInitializer?.buildUnexpectedNodes(format: format, leadingTrivia: nil), initializer: initializer?.buildInitializerClause(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -10008,7 +10624,11 @@ public struct UnavailabilityCondition: SyntaxBuildable, ExpressibleAsUnavailabil
   func buildUnavailabilityCondition(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> UnavailabilityConditionSyntax {
     let result = UnavailabilityConditionSyntax(unexpectedBeforePoundUnavailableKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundUnavailableKeyword: poundUnavailableKeyword, unexpectedBetweenPoundUnavailableKeywordAndLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndAvailabilitySpec?.buildUnexpectedNodes(format: format, leadingTrivia: nil), availabilitySpec: availabilitySpec.buildAvailabilitySpecList(format: format, leadingTrivia: nil), unexpectedBetweenAvailabilitySpecAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -10049,7 +10669,11 @@ public struct DeclarationStmt: StmtBuildable, ExpressibleAsDeclarationStmt {
   func buildDeclarationStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DeclarationStmtSyntax {
     let result = DeclarationStmtSyntax(unexpectedBeforeDeclaration?.buildUnexpectedNodes(format: format, leadingTrivia: nil), declaration: declaration.buildDecl(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -10104,7 +10728,11 @@ public struct ThrowStmt: StmtBuildable, ExpressibleAsThrowStmt {
   func buildThrowStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ThrowStmtSyntax {
     let result = ThrowStmtSyntax(unexpectedBeforeThrowKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), throwKeyword: throwKeyword, unexpectedBetweenThrowKeywordAndExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -10186,7 +10814,11 @@ public struct IfStmt: StmtBuildable, ExpressibleAsIfStmt {
   func buildIfStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IfStmtSyntax {
     let result = IfStmtSyntax(unexpectedBeforeIfKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), ifKeyword: ifKeyword, unexpectedBetweenIfKeywordAndConditions?.buildUnexpectedNodes(format: format, leadingTrivia: nil), conditions: conditions.buildConditionElementList(format: format, leadingTrivia: nil), unexpectedBetweenConditionsAndBody?.buildUnexpectedNodes(format: format, leadingTrivia: nil), body: body.buildCodeBlock(format: format, leadingTrivia: nil), unexpectedBetweenBodyAndElseKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndElseBody?.buildUnexpectedNodes(format: format, leadingTrivia: nil), elseBody: elseBody?.buildSyntax(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -10234,7 +10866,11 @@ public struct ElseIfContinuation: SyntaxBuildable, ExpressibleAsElseIfContinuati
   func buildElseIfContinuation(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ElseIfContinuationSyntax {
     let result = ElseIfContinuationSyntax(unexpectedBeforeIfStatement?.buildUnexpectedNodes(format: format, leadingTrivia: nil), ifStatement: ifStatement.buildIfStmt(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -10290,7 +10926,11 @@ public struct ElseBlock: SyntaxBuildable, ExpressibleAsElseBlock {
   func buildElseBlock(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ElseBlockSyntax {
     let result = ElseBlockSyntax(unexpectedBeforeElseKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndBody?.buildUnexpectedNodes(format: format, leadingTrivia: nil), body: body.buildCodeBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -10351,7 +10991,11 @@ public struct SwitchCase: SyntaxBuildable, ExpressibleAsSwitchCase {
   func buildSwitchCase(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SwitchCaseSyntax {
     let result = SwitchCaseSyntax(unexpectedBeforeUnknownAttr?.buildUnexpectedNodes(format: format, leadingTrivia: nil), unknownAttr: unknownAttr?.buildAttribute(format: format, leadingTrivia: nil), unexpectedBetweenUnknownAttrAndLabel?.buildUnexpectedNodes(format: format, leadingTrivia: nil), label: label.buildSyntax(format: format, leadingTrivia: nil), unexpectedBetweenLabelAndStatements?.buildUnexpectedNodes(format: format, leadingTrivia: nil), statements: statements.buildCodeBlockItemList(format: format._indented(), leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -10400,7 +11044,11 @@ public struct SwitchDefaultLabel: SyntaxBuildable, ExpressibleAsSwitchDefaultLab
   func buildSwitchDefaultLabel(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SwitchDefaultLabelSyntax {
     let result = SwitchDefaultLabelSyntax(unexpectedBeforeDefaultKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), defaultKeyword: defaultKeyword, unexpectedBetweenDefaultKeywordAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -10454,7 +11102,11 @@ public struct CaseItem: SyntaxBuildable, ExpressibleAsCaseItem, HasTrailingComma
   func buildCaseItem(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CaseItemSyntax {
     let result = CaseItemSyntax(unexpectedBeforePattern?.buildUnexpectedNodes(format: format, leadingTrivia: nil), pattern: pattern.buildPattern(format: format, leadingTrivia: nil), unexpectedBetweenPatternAndWhereClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), whereClause: whereClause?.buildWhereClause(format: format, leadingTrivia: nil), unexpectedBetweenWhereClauseAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -10512,7 +11164,11 @@ public struct CatchItem: SyntaxBuildable, ExpressibleAsCatchItem, HasTrailingCom
   func buildCatchItem(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CatchItemSyntax {
     let result = CatchItemSyntax(unexpectedBeforePattern?.buildUnexpectedNodes(format: format, leadingTrivia: nil), pattern: pattern?.buildPattern(format: format, leadingTrivia: nil), unexpectedBetweenPatternAndWhereClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), whereClause: whereClause?.buildWhereClause(format: format, leadingTrivia: nil), unexpectedBetweenWhereClauseAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -10579,7 +11235,11 @@ public struct SwitchCaseLabel: SyntaxBuildable, ExpressibleAsSwitchCaseLabel {
   func buildSwitchCaseLabel(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SwitchCaseLabelSyntax {
     let result = SwitchCaseLabelSyntax(unexpectedBeforeCaseKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndCaseItems?.buildUnexpectedNodes(format: format, leadingTrivia: nil), caseItems: caseItems.buildCaseItemList(format: format, leadingTrivia: nil), unexpectedBetweenCaseItemsAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -10641,7 +11301,11 @@ public struct CatchClause: SyntaxBuildable, ExpressibleAsCatchClause {
   func buildCatchClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CatchClauseSyntax {
     let result = CatchClauseSyntax(unexpectedBeforeCatchKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), catchKeyword: catchKeyword, unexpectedBetweenCatchKeywordAndCatchItems?.buildUnexpectedNodes(format: format, leadingTrivia: nil), catchItems: catchItems?.buildCatchItemList(format: format, leadingTrivia: nil), unexpectedBetweenCatchItemsAndBody?.buildUnexpectedNodes(format: format, leadingTrivia: nil), body: body.buildCodeBlock(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -10724,7 +11388,11 @@ public struct PoundAssertStmt: StmtBuildable, ExpressibleAsPoundAssertStmt {
   func buildPoundAssertStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PoundAssertStmtSyntax {
     let result = PoundAssertStmtSyntax(unexpectedBeforePoundAssert?.buildUnexpectedNodes(format: format, leadingTrivia: nil), poundAssert: poundAssert, unexpectedBetweenPoundAssertAndLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndCondition?.buildUnexpectedNodes(format: format, leadingTrivia: nil), condition: condition.buildExpr(format: format, leadingTrivia: nil), unexpectedBetweenConditionAndComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), comma: comma, unexpectedBetweenCommaAndMessage?.buildUnexpectedNodes(format: format, leadingTrivia: nil), message: message, unexpectedBetweenMessageAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `StmtBuildable`.
   public func buildStmt(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> StmtSyntax {
@@ -10787,7 +11455,11 @@ public struct GenericWhereClause: SyntaxBuildable, ExpressibleAsGenericWhereClau
   func buildGenericWhereClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> GenericWhereClauseSyntax {
     let result = GenericWhereClauseSyntax(unexpectedBeforeWhereKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), whereKeyword: whereKeyword, unexpectedBetweenWhereKeywordAndRequirementList?.buildUnexpectedNodes(format: format, leadingTrivia: nil), requirementList: requirementList.buildGenericRequirementList(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -10835,7 +11507,11 @@ public struct GenericRequirement: SyntaxBuildable, ExpressibleAsGenericRequireme
   func buildGenericRequirement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> GenericRequirementSyntax {
     let result = GenericRequirementSyntax(unexpectedBeforeBody?.buildUnexpectedNodes(format: format, leadingTrivia: nil), body: body.buildSyntax(format: format, leadingTrivia: nil), unexpectedBetweenBodyAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -10892,7 +11568,11 @@ public struct SameTypeRequirement: SyntaxBuildable, ExpressibleAsSameTypeRequire
   func buildSameTypeRequirement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SameTypeRequirementSyntax {
     let result = SameTypeRequirementSyntax(unexpectedBeforeLeftTypeIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftTypeIdentifier: leftTypeIdentifier.buildType(format: format, leadingTrivia: nil), unexpectedBetweenLeftTypeIdentifierAndEqualityToken?.buildUnexpectedNodes(format: format, leadingTrivia: nil), equalityToken: equalityToken, unexpectedBetweenEqualityTokenAndRightTypeIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightTypeIdentifier: rightTypeIdentifier.buildType(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -10989,7 +11669,11 @@ public struct LayoutRequirement: SyntaxBuildable, ExpressibleAsLayoutRequirement
   func buildLayoutRequirement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> LayoutRequirementSyntax {
     let result = LayoutRequirementSyntax(unexpectedBeforeTypeIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), typeIdentifier: typeIdentifier.buildType(format: format, leadingTrivia: nil), unexpectedBetweenTypeIdentifierAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndLayoutConstraint?.buildUnexpectedNodes(format: format, leadingTrivia: nil), layoutConstraint: layoutConstraint, unexpectedBetweenLayoutConstraintAndLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndSize?.buildUnexpectedNodes(format: format, leadingTrivia: nil), size: size, unexpectedBetweenSizeAndComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), comma: comma, unexpectedBetweenCommaAndAlignment?.buildUnexpectedNodes(format: format, leadingTrivia: nil), alignment: alignment, unexpectedBetweenAlignmentAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -11062,7 +11746,11 @@ public struct GenericParameter: SyntaxBuildable, ExpressibleAsGenericParameter, 
   func buildGenericParameter(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> GenericParameterSyntax {
     let result = GenericParameterSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndInheritedType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), inheritedType: inheritedType?.buildType(format: format, leadingTrivia: nil), unexpectedBetweenInheritedTypeAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -11120,7 +11808,11 @@ public struct PrimaryAssociatedType: SyntaxBuildable, ExpressibleAsPrimaryAssoci
   func buildPrimaryAssociatedType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrimaryAssociatedTypeSyntax {
     let result = PrimaryAssociatedTypeSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -11187,7 +11879,11 @@ public struct GenericParameterClause: SyntaxBuildable, ExpressibleAsGenericParam
   func buildGenericParameterClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> GenericParameterClauseSyntax {
     let result = GenericParameterClauseSyntax(unexpectedBeforeLeftAngleBracket?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftAngleBracket: leftAngleBracket, unexpectedBetweenLeftAngleBracketAndGenericParameterList?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericParameterList: genericParameterList.buildGenericParameterList(format: format, leadingTrivia: nil), unexpectedBetweenGenericParameterListAndRightAngleBracket?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightAngleBracket: rightAngleBracket)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -11241,7 +11937,11 @@ public struct ConformanceRequirement: SyntaxBuildable, ExpressibleAsConformanceR
   func buildConformanceRequirement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ConformanceRequirementSyntax {
     let result = ConformanceRequirementSyntax(unexpectedBeforeLeftTypeIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftTypeIdentifier: leftTypeIdentifier.buildType(format: format, leadingTrivia: nil), unexpectedBetweenLeftTypeIdentifierAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndRightTypeIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightTypeIdentifier: rightTypeIdentifier.buildType(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -11296,7 +11996,11 @@ public struct PrimaryAssociatedTypeClause: SyntaxBuildable, ExpressibleAsPrimary
   func buildPrimaryAssociatedTypeClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PrimaryAssociatedTypeClauseSyntax {
     let result = PrimaryAssociatedTypeClauseSyntax(unexpectedBeforeLeftAngleBracket?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftAngleBracket: leftAngleBracket, unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList?.buildUnexpectedNodes(format: format, leadingTrivia: nil), primaryAssociatedTypeList: primaryAssociatedTypeList.buildPrimaryAssociatedTypeList(format: format, leadingTrivia: nil), unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightAngleBracket: rightAngleBracket)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -11343,7 +12047,11 @@ public struct SimpleTypeIdentifier: TypeBuildable, ExpressibleAsSimpleTypeIdenti
   func buildSimpleTypeIdentifier(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> SimpleTypeIdentifierSyntax {
     let result = SimpleTypeIdentifierSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndGenericArgumentClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericArgumentClause: genericArgumentClause?.buildGenericArgumentClause(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `TypeBuildable`.
   public func buildType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeSyntax {
@@ -11410,7 +12118,11 @@ public struct MemberTypeIdentifier: TypeBuildable, ExpressibleAsMemberTypeIdenti
   func buildMemberTypeIdentifier(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MemberTypeIdentifierSyntax {
     let result = MemberTypeIdentifierSyntax(unexpectedBeforeBaseType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), baseType: baseType.buildType(format: format, leadingTrivia: nil), unexpectedBetweenBaseTypeAndPeriod?.buildUnexpectedNodes(format: format, leadingTrivia: nil), period: period, unexpectedBetweenPeriodAndName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndGenericArgumentClause?.buildUnexpectedNodes(format: format, leadingTrivia: nil), genericArgumentClause: genericArgumentClause?.buildGenericArgumentClause(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `TypeBuildable`.
   public func buildType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeSyntax {
@@ -11459,7 +12171,11 @@ public struct ClassRestrictionType: TypeBuildable, ExpressibleAsClassRestriction
   func buildClassRestrictionType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ClassRestrictionTypeSyntax {
     let result = ClassRestrictionTypeSyntax(unexpectedBeforeClassKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), classKeyword: classKeyword)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `TypeBuildable`.
   public func buildType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeSyntax {
@@ -11521,7 +12237,11 @@ public struct ArrayType: TypeBuildable, ExpressibleAsArrayType {
   func buildArrayType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ArrayTypeSyntax {
     let result = ArrayTypeSyntax(unexpectedBeforeLeftSquareBracket?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftSquareBracket: leftSquareBracket, unexpectedBetweenLeftSquareBracketAndElementType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), elementType: elementType.buildType(format: format, leadingTrivia: nil), unexpectedBetweenElementTypeAndRightSquareBracket?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightSquareBracket: rightSquareBracket)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `TypeBuildable`.
   public func buildType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeSyntax {
@@ -11596,7 +12316,11 @@ public struct DictionaryType: TypeBuildable, ExpressibleAsDictionaryType {
   func buildDictionaryType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> DictionaryTypeSyntax {
     let result = DictionaryTypeSyntax(unexpectedBeforeLeftSquareBracket?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftSquareBracket: leftSquareBracket, unexpectedBetweenLeftSquareBracketAndKeyType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), keyType: keyType.buildType(format: format, leadingTrivia: nil), unexpectedBetweenKeyTypeAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndValueType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), valueType: valueType.buildType(format: format, leadingTrivia: nil), unexpectedBetweenValueTypeAndRightSquareBracket?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightSquareBracket: rightSquareBracket)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `TypeBuildable`.
   public func buildType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeSyntax {
@@ -11664,7 +12388,11 @@ public struct MetatypeType: TypeBuildable, ExpressibleAsMetatypeType {
   func buildMetatypeType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> MetatypeTypeSyntax {
     let result = MetatypeTypeSyntax(unexpectedBeforeBaseType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), baseType: baseType.buildType(format: format, leadingTrivia: nil), unexpectedBetweenBaseTypeAndPeriod?.buildUnexpectedNodes(format: format, leadingTrivia: nil), period: period, unexpectedBetweenPeriodAndTypeOrProtocol?.buildUnexpectedNodes(format: format, leadingTrivia: nil), typeOrProtocol: typeOrProtocol)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `TypeBuildable`.
   public func buildType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeSyntax {
@@ -11719,7 +12447,11 @@ public struct OptionalType: TypeBuildable, ExpressibleAsOptionalType {
   func buildOptionalType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> OptionalTypeSyntax {
     let result = OptionalTypeSyntax(unexpectedBeforeWrappedType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), wrappedType: wrappedType.buildType(format: format, leadingTrivia: nil), unexpectedBetweenWrappedTypeAndQuestionMark?.buildUnexpectedNodes(format: format, leadingTrivia: nil), questionMark: questionMark)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `TypeBuildable`.
   public func buildType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeSyntax {
@@ -11780,7 +12512,11 @@ public struct ConstrainedSugarType: TypeBuildable, ExpressibleAsConstrainedSugar
   func buildConstrainedSugarType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ConstrainedSugarTypeSyntax {
     let result = ConstrainedSugarTypeSyntax(unexpectedBeforeSomeOrAnySpecifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), someOrAnySpecifier: someOrAnySpecifier, unexpectedBetweenSomeOrAnySpecifierAndBaseType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), baseType: baseType.buildType(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `TypeBuildable`.
   public func buildType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeSyntax {
@@ -11835,7 +12571,11 @@ public struct ImplicitlyUnwrappedOptionalType: TypeBuildable, ExpressibleAsImpli
   func buildImplicitlyUnwrappedOptionalType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ImplicitlyUnwrappedOptionalTypeSyntax {
     let result = ImplicitlyUnwrappedOptionalTypeSyntax(unexpectedBeforeWrappedType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), wrappedType: wrappedType.buildType(format: format, leadingTrivia: nil), unexpectedBetweenWrappedTypeAndExclamationMark?.buildUnexpectedNodes(format: format, leadingTrivia: nil), exclamationMark: exclamationMark)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `TypeBuildable`.
   public func buildType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeSyntax {
@@ -11890,7 +12630,11 @@ public struct CompositionTypeElement: SyntaxBuildable, ExpressibleAsCompositionT
   func buildCompositionTypeElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CompositionTypeElementSyntax {
     let result = CompositionTypeElementSyntax(unexpectedBeforeType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), type: type.buildType(format: format, leadingTrivia: nil), unexpectedBetweenTypeAndAmpersand?.buildUnexpectedNodes(format: format, leadingTrivia: nil), ampersand: ampersand)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -11931,7 +12675,11 @@ public struct CompositionType: TypeBuildable, ExpressibleAsCompositionType {
   func buildCompositionType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> CompositionTypeSyntax {
     let result = CompositionTypeSyntax(unexpectedBeforeElements?.buildUnexpectedNodes(format: format, leadingTrivia: nil), elements: elements.buildCompositionTypeElementList(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `TypeBuildable`.
   public func buildType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeSyntax {
@@ -12025,7 +12773,11 @@ public struct TupleTypeElement: SyntaxBuildable, ExpressibleAsTupleTypeElement, 
   func buildTupleTypeElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TupleTypeElementSyntax {
     let result = TupleTypeElementSyntax(unexpectedBeforeInOut?.buildUnexpectedNodes(format: format, leadingTrivia: nil), inOut: inOut, unexpectedBetweenInOutAndName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), name: name, unexpectedBetweenNameAndSecondName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), secondName: secondName, unexpectedBetweenSecondNameAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), type: type.buildType(format: format, leadingTrivia: nil), unexpectedBetweenTypeAndEllipsis?.buildUnexpectedNodes(format: format, leadingTrivia: nil), ellipsis: ellipsis, unexpectedBetweenEllipsisAndInitializer?.buildUnexpectedNodes(format: format, leadingTrivia: nil), initializer: initializer?.buildInitializerClause(format: format, leadingTrivia: nil), unexpectedBetweenInitializerAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -12084,7 +12836,11 @@ public struct TupleType: TypeBuildable, ExpressibleAsTupleType {
   func buildTupleType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TupleTypeSyntax {
     let result = TupleTypeSyntax(unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndElements?.buildUnexpectedNodes(format: format, leadingTrivia: nil), elements: elements.buildTupleTypeElementList(format: format, leadingTrivia: nil), unexpectedBetweenElementsAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `TypeBuildable`.
   public func buildType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeSyntax {
@@ -12173,7 +12929,11 @@ public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
   func buildFunctionType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> FunctionTypeSyntax {
     let result = FunctionTypeSyntax(unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndArguments?.buildUnexpectedNodes(format: format, leadingTrivia: nil), arguments: arguments.buildTupleTypeElementList(format: format, leadingTrivia: nil), unexpectedBetweenArgumentsAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen, unexpectedBetweenRightParenAndAsyncKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), asyncKeyword: asyncKeyword, unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), throwsOrRethrowsKeyword: throwsOrRethrowsKeyword, unexpectedBetweenThrowsOrRethrowsKeywordAndArrow?.buildUnexpectedNodes(format: format, leadingTrivia: nil), arrow: arrow, unexpectedBetweenArrowAndReturnType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), returnType: returnType.buildType(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `TypeBuildable`.
   public func buildType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeSyntax {
@@ -12234,7 +12994,11 @@ public struct AttributedType: TypeBuildable, ExpressibleAsAttributedType {
   func buildAttributedType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AttributedTypeSyntax {
     let result = AttributedTypeSyntax(unexpectedBeforeSpecifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), specifier: specifier, unexpectedBetweenSpecifierAndAttributes?.buildUnexpectedNodes(format: format, leadingTrivia: nil), attributes: attributes?.buildAttributeList(format: format, leadingTrivia: nil), unexpectedBetweenAttributesAndBaseType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), baseType: baseType.buildType(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `TypeBuildable`.
   public func buildType(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeSyntax {
@@ -12289,7 +13053,11 @@ public struct GenericArgument: SyntaxBuildable, ExpressibleAsGenericArgument, Ha
   func buildGenericArgument(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> GenericArgumentSyntax {
     let result = GenericArgumentSyntax(unexpectedBeforeArgumentType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), argumentType: argumentType.buildType(format: format, leadingTrivia: nil), unexpectedBetweenArgumentTypeAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -12356,7 +13124,11 @@ public struct GenericArgumentClause: SyntaxBuildable, ExpressibleAsGenericArgume
   func buildGenericArgumentClause(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> GenericArgumentClauseSyntax {
     let result = GenericArgumentClauseSyntax(unexpectedBeforeLeftAngleBracket?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftAngleBracket: leftAngleBracket, unexpectedBetweenLeftAngleBracketAndArguments?.buildUnexpectedNodes(format: format, leadingTrivia: nil), arguments: arguments.buildGenericArgumentList(format: format, leadingTrivia: nil), unexpectedBetweenArgumentsAndRightAngleBracket?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightAngleBracket: rightAngleBracket)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -12404,7 +13176,11 @@ public struct TypeAnnotation: SyntaxBuildable, ExpressibleAsTypeAnnotation {
   func buildTypeAnnotation(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TypeAnnotationSyntax {
     let result = TypeAnnotationSyntax(unexpectedBeforeColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), type: type.buildType(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -12470,7 +13246,11 @@ public struct EnumCasePattern: PatternBuildable, ExpressibleAsEnumCasePattern {
   func buildEnumCasePattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> EnumCasePatternSyntax {
     let result = EnumCasePatternSyntax(unexpectedBeforeType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), type: type?.buildType(format: format, leadingTrivia: nil), unexpectedBetweenTypeAndPeriod?.buildUnexpectedNodes(format: format, leadingTrivia: nil), period: period, unexpectedBetweenPeriodAndCaseName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), caseName: caseName, unexpectedBetweenCaseNameAndAssociatedTuple?.buildUnexpectedNodes(format: format, leadingTrivia: nil), associatedTuple: associatedTuple?.buildTuplePattern(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `PatternBuildable`.
   public func buildPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PatternSyntax {
@@ -12525,7 +13305,11 @@ public struct IsTypePattern: PatternBuildable, ExpressibleAsIsTypePattern {
   func buildIsTypePattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IsTypePatternSyntax {
     let result = IsTypePatternSyntax(unexpectedBeforeIsKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), isKeyword: isKeyword, unexpectedBetweenIsKeywordAndType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), type: type.buildType(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `PatternBuildable`.
   public func buildPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PatternSyntax {
@@ -12580,7 +13364,11 @@ public struct OptionalPattern: PatternBuildable, ExpressibleAsOptionalPattern {
   func buildOptionalPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> OptionalPatternSyntax {
     let result = OptionalPatternSyntax(unexpectedBeforeSubPattern?.buildUnexpectedNodes(format: format, leadingTrivia: nil), subPattern: subPattern.buildPattern(format: format, leadingTrivia: nil), unexpectedBetweenSubPatternAndQuestionMark?.buildUnexpectedNodes(format: format, leadingTrivia: nil), questionMark: questionMark)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `PatternBuildable`.
   public func buildPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PatternSyntax {
@@ -12628,7 +13416,11 @@ public struct IdentifierPattern: PatternBuildable, ExpressibleAsIdentifierPatter
   func buildIdentifierPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> IdentifierPatternSyntax {
     let result = IdentifierPatternSyntax(unexpectedBeforeIdentifier?.buildUnexpectedNodes(format: format, leadingTrivia: nil), identifier: identifier)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `PatternBuildable`.
   public func buildPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PatternSyntax {
@@ -12689,7 +13481,11 @@ public struct AsTypePattern: PatternBuildable, ExpressibleAsAsTypePattern {
   func buildAsTypePattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AsTypePatternSyntax {
     let result = AsTypePatternSyntax(unexpectedBeforePattern?.buildUnexpectedNodes(format: format, leadingTrivia: nil), pattern: pattern.buildPattern(format: format, leadingTrivia: nil), unexpectedBetweenPatternAndAsKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), asKeyword: asKeyword, unexpectedBetweenAsKeywordAndType?.buildUnexpectedNodes(format: format, leadingTrivia: nil), type: type.buildType(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `PatternBuildable`.
   public func buildPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PatternSyntax {
@@ -12759,7 +13555,11 @@ public struct TuplePattern: PatternBuildable, ExpressibleAsTuplePattern {
   func buildTuplePattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TuplePatternSyntax {
     let result = TuplePatternSyntax(unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), leftParen: leftParen, unexpectedBetweenLeftParenAndElements?.buildUnexpectedNodes(format: format, leadingTrivia: nil), elements: elements.buildTuplePatternElementList(format: format, leadingTrivia: nil), unexpectedBetweenElementsAndRightParen?.buildUnexpectedNodes(format: format, leadingTrivia: nil), rightParen: rightParen)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `PatternBuildable`.
   public func buildPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PatternSyntax {
@@ -12814,7 +13614,11 @@ public struct WildcardPattern: PatternBuildable, ExpressibleAsWildcardPattern {
   func buildWildcardPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> WildcardPatternSyntax {
     let result = WildcardPatternSyntax(unexpectedBeforeWildcard?.buildUnexpectedNodes(format: format, leadingTrivia: nil), wildcard: wildcard, unexpectedBetweenWildcardAndTypeAnnotation?.buildUnexpectedNodes(format: format, leadingTrivia: nil), typeAnnotation: typeAnnotation?.buildTypeAnnotation(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `PatternBuildable`.
   public func buildPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PatternSyntax {
@@ -12890,7 +13694,11 @@ public struct TuplePatternElement: SyntaxBuildable, ExpressibleAsTuplePatternEle
   func buildTuplePatternElement(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> TuplePatternElementSyntax {
     let result = TuplePatternElementSyntax(unexpectedBeforeLabelName?.buildUnexpectedNodes(format: format, leadingTrivia: nil), labelName: labelName, unexpectedBetweenLabelNameAndLabelColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), labelColon: labelColon, unexpectedBetweenLabelColonAndPattern?.buildUnexpectedNodes(format: format, leadingTrivia: nil), pattern: pattern.buildPattern(format: format, leadingTrivia: nil), unexpectedBetweenPatternAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -12935,7 +13743,11 @@ public struct ExpressionPattern: PatternBuildable, ExpressibleAsExpressionPatter
   func buildExpressionPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ExpressionPatternSyntax {
     let result = ExpressionPatternSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format, leadingTrivia: nil), expression: expression.buildExpr(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `PatternBuildable`.
   public func buildPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PatternSyntax {
@@ -12990,7 +13802,11 @@ public struct ValueBindingPattern: PatternBuildable, ExpressibleAsValueBindingPa
   func buildValueBindingPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> ValueBindingPatternSyntax {
     let result = ValueBindingPatternSyntax(unexpectedBeforeLetOrVarKeyword?.buildUnexpectedNodes(format: format, leadingTrivia: nil), letOrVarKeyword: letOrVarKeyword, unexpectedBetweenLetOrVarKeywordAndValuePattern?.buildUnexpectedNodes(format: format, leadingTrivia: nil), valuePattern: valuePattern.buildPattern(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `PatternBuildable`.
   public func buildPattern(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> PatternSyntax {
@@ -13046,7 +13862,11 @@ public struct AvailabilityArgument: SyntaxBuildable, ExpressibleAsAvailabilityAr
   func buildAvailabilityArgument(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AvailabilityArgumentSyntax {
     let result = AvailabilityArgumentSyntax(unexpectedBeforeEntry?.buildUnexpectedNodes(format: format, leadingTrivia: nil), entry: entry.buildSyntax(format: format, leadingTrivia: nil), unexpectedBetweenEntryAndTrailingComma?.buildUnexpectedNodes(format: format, leadingTrivia: nil), trailingComma: trailingComma)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -13107,7 +13927,11 @@ public struct AvailabilityLabeledArgument: SyntaxBuildable, ExpressibleAsAvailab
   func buildAvailabilityLabeledArgument(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AvailabilityLabeledArgumentSyntax {
     let result = AvailabilityLabeledArgumentSyntax(unexpectedBeforeLabel?.buildUnexpectedNodes(format: format, leadingTrivia: nil), label: label, unexpectedBetweenLabelAndColon?.buildUnexpectedNodes(format: format, leadingTrivia: nil), colon: colon, unexpectedBetweenColonAndValue?.buildUnexpectedNodes(format: format, leadingTrivia: nil), value: value.buildSyntax(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -13161,7 +13985,11 @@ public struct AvailabilityVersionRestriction: SyntaxBuildable, ExpressibleAsAvai
   func buildAvailabilityVersionRestriction(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> AvailabilityVersionRestrictionSyntax {
     let result = AvailabilityVersionRestrictionSyntax(unexpectedBeforePlatform?.buildUnexpectedNodes(format: format, leadingTrivia: nil), platform: platform, unexpectedBetweenPlatformAndVersion?.buildUnexpectedNodes(format: format, leadingTrivia: nil), version: version?.buildVersionTuple(format: format, leadingTrivia: nil))
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {
@@ -13224,7 +14052,11 @@ public struct VersionTuple: SyntaxBuildable, ExpressibleAsVersionTuple {
   func buildVersionTuple(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> VersionTupleSyntax {
     let result = VersionTupleSyntax(unexpectedBeforeMajorMinor?.buildUnexpectedNodes(format: format, leadingTrivia: nil), majorMinor: majorMinor.buildSyntax(format: format, leadingTrivia: nil), unexpectedBetweenMajorMinorAndPatchPeriod?.buildUnexpectedNodes(format: format, leadingTrivia: nil), patchPeriod: patchPeriod, unexpectedBetweenPatchPeriodAndPatchVersion?.buildUnexpectedNodes(format: format, leadingTrivia: nil), patchVersion: patchVersion)
     let combinedLeadingTrivia = leadingTrivia + (additionalLeadingTrivia ?? []) + (result.leadingTrivia ?? [])
-    return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    if combinedLeadingTrivia.isEmpty {
+      return result
+    } else {
+      return result.withLeadingTrivia(combinedLeadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
   }
   /// Conformance to `SyntaxBuildable`.
   public func buildSyntax(format: Format, leadingTrivia additionalLeadingTrivia: Trivia? = nil) -> Syntax {

--- a/Sources/generate-swift-syntax-builder/Templates/BuildableNodesFile.swift
+++ b/Sources/generate-swift-syntax-builder/Templates/BuildableNodesFile.swift
@@ -277,12 +277,18 @@ private func createBuildFunction(node: Node) -> FunctionDecl {
         }
       }
     )
-    ReturnStmt(expression: FunctionCallExpr(MemberAccessExpr(base: "result", name: "withLeadingTrivia")) {
-      TupleExprElement(expression: FunctionCallExpr(MemberAccessExpr(
-        base: "combinedLeadingTrivia",
-        name: "addingSpacingAfterNewlinesIfNeeded"
-      )))
-    })
+    IfStmt(
+      conditions: ExprList([MemberAccessExpr(base: "combinedLeadingTrivia", name: "isEmpty")])
+    ) {
+      ReturnStmt(expression: "result")
+    } elseBody: {
+      ReturnStmt(expression: FunctionCallExpr(MemberAccessExpr(base: "result", name: "withLeadingTrivia")) {
+        TupleExprElement(expression: FunctionCallExpr(MemberAccessExpr(
+          base: "combinedLeadingTrivia",
+          name: "addingSpacingAfterNewlinesIfNeeded"
+        )))
+      })
+    }
   }
 }
 


### PR DESCRIPTION
Although we [discussed this earlier](https://github.com/apple/swift-syntax/pull/475#discussion_r907132139), I would like to revisit the optimization to skip leading trivia generation on buildable nodes in `SwiftSyntaxBuilder` when empty, since it actually does have a noticeable performance impact on `generate-swift-syntax-builder`: The optimization cuts down generation time from ~13 seconds to ~7 seconds on my machine, nearly a 50% improvement in performance! Profiling the executable with Instruments reveals that this indeed seems to be the issue, the heaviest stack trace points to `withLeadingTrivia`.

The improvement in performance with this patch becomes especially noticeable during development of generated files where shorter feedback cycles greatly improve the workflow.

(This change should be mostly orthogonal to the upcoming formatting-related changes)