### PR TITLE
Add convenience initializer for `PrefixOperatorExpr`

### DIFF
--- a/Sources/SwiftSyntaxBuilder/PrefixOperatorExprConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/PrefixOperatorExprConvenienceInitializers.swift
@@ -1,0 +1,27 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+extension PrefixOperatorExpr {
+  public init(
+    leadingTrivia: Trivia = [],
+    _ prefixOperator: String,
+    _ postfixExpression: ExpressibleAsExprBuildable
+  ) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      operatorToken: .prefixOperator(prefixOperator),
+      postfixExpression: postfixExpression
+    )
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/PrefixOperatorExprTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/PrefixOperatorExprTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+final class PrefixOperatorExprTests: XCTestCase {
+  func testPrefixOperatorExprConvenienceInitializers() {
+    let leadingTrivia = Trivia.unexpectedText("␣")
+    let testCases: [UInt: (ExpressibleAsPrefixOperatorExpr, String)] = [
+      #line: (PrefixOperatorExpr("!", "test"), "␣!test"),
+      #line: (PrefixOperatorExpr("!", BooleanLiteralExpr(false)), "␣!false"),
+      #line: (PrefixOperatorExpr("~", IntegerLiteralExpr(23)), "␣~23"),
+    ]
+    
+    for (line, testCase) in testCases {
+      let (builder, expected) = testCase
+      let expr = builder.createPrefixOperatorExpr()
+      let syntax = expr.buildSyntax(format: Format(), leadingTrivia: leadingTrivia)
+
+      var text = ""
+      syntax.write(to: &text)
+
+      XCTAssertEqual(text, expected, line: line)
+    }
+  }
+}


### PR DESCRIPTION
...to make it slightly more convenient to initialize these, e.g. in if-conditions.