### PR TITLE
Add attributes to VariableDecl convenience initializers

### DIFF
--- a/Sources/SwiftSyntaxBuilder/VariableDeclConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/VariableDeclConvenienceInitializers.swift
@@ -16,13 +16,19 @@ extension VariableDecl {
   /// Creates an optionally initialized property.
   public init(
     leadingTrivia: Trivia = [],
-    modifiers: ModifierList? = nil,
+    attributes: ExpressibleAsAttributeList? = nil,
+    modifiers: ExpressibleAsModifierList? = nil,
     _ letOrVarKeyword: TokenSyntax,
     name: ExpressibleAsIdentifierPattern,
     type: ExpressibleAsTypeAnnotation? = nil,
     initializer: ExpressibleAsInitializerClause? = nil
   ) {
-    self.init(leadingTrivia: leadingTrivia, modifiers: modifiers, letOrVarKeyword: letOrVarKeyword) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      attributes: attributes,
+      modifiers: modifiers,
+      letOrVarKeyword: attributes != nil ? letOrVarKeyword.withLeadingTrivia(.space) : letOrVarKeyword
+    ) {
       PatternBinding(
         pattern: name,
         typeAnnotation: type,
@@ -34,12 +40,18 @@ extension VariableDecl {
   /// Creates a computed property with the given accessor.
   public init(
     leadingTrivia: Trivia = [],
-    modifiers: ModifierList? = nil,
+    attributes: ExpressibleAsAttributeList? = nil,
+    modifiers: ExpressibleAsModifierList? = nil,
     name: ExpressibleAsIdentifierPattern,
     type: ExpressibleAsTypeAnnotation,
     @CodeBlockItemListBuilder accessor: () -> ExpressibleAsCodeBlockItemList
   ) {
-    self.init(leadingTrivia: leadingTrivia, modifiers: modifiers, letOrVarKeyword: .var) {
+    self.init(
+      leadingTrivia: leadingTrivia,
+      attributes: attributes,
+      modifiers: modifiers,
+      letOrVarKeyword: .varKeyword(leadingTrivia: attributes != nil ? .space : .zero)
+    ) {
       PatternBinding(
         pattern: name,
         typeAnnotation: type,

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -105,4 +105,31 @@ final class VariableTests: XCTestCase {
       }
       """)
   }
+
+  func testAttributedVariables() {
+    let attributedVar = VariableDecl(
+      attributes: CustomAttribute(attributeName: "Test", argumentList: nil),
+      .var,
+      name: "x",
+      type: "Int"
+    )
+
+    XCTAssertEqual(attributedVar.buildSyntax(format: Format()).description, """
+      @Test var x: Int
+      """)
+
+    let attributedProperty = VariableDecl(
+      attributes: CustomAttribute(attributeName: "Test", argumentList: nil),
+      name: "y",
+      type: "String"
+    ) {
+      StringLiteralExpr("Hello world!")
+    }
+
+    XCTAssertEqual(attributedProperty.buildSyntax(format: Format()).description, """
+      @Test var y: String {
+          "Hello world!"
+      }
+      """)
+  }
 }


### PR DESCRIPTION
A small patch to make attributed declarations such as `@Test var x: Int` easier to generate (this could also be interesting for users who want to generate uses of property wrappers).