### PR TITLE
Introduce an intentionally-partial CMake-based build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+cmake_minimum_required(VERSION 3.19.6)
+
+project(SwiftSyntax LANGUAGES C Swift)
+
+set(SWIFT_VERSION 5)
+set(CMAKE_Swift_LANGUAGE_VERSION ${SWIFT_VERSION})
+
+# ensure Swift compiler can find _CSwiftSyntax
+add_compile_options($<$<COMPILE_LANGUAGE:Swift>:-I$<SEMICOLON>${CMAKE_CURRENT_SOURCE_DIR}/Sources/_CSwiftSyntax/include>)
+
+set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
+
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+set(CMAKE_MACOSX_RPATH YES)
+
+add_subdirectory(Sources)

--- a/Package.swift
+++ b/Package.swift
@@ -55,17 +55,22 @@ let package = Package(
     .target(
       name: "_CSwiftSyntax",
       exclude: [
+        "CMakeLists.txt",
         "README.md"
       ]
     ),
     .target(
       name: "SwiftDiagnostics",
-      dependencies: ["SwiftSyntax"]
+      dependencies: ["SwiftSyntax"],
+      exclude: [
+        "CMakeLists.txt"
+      ]
     ),
     .target(
       name: "SwiftSyntax",
       dependencies: ["_CSwiftSyntax"],
       exclude: [
+        "CMakeLists.txt",
         "Misc.swift.gyb",
         "Raw/RawSyntaxNodes.swift.gyb",
         "Raw/RawSyntaxValidation.swift.gyb",
@@ -111,6 +116,7 @@ let package = Package(
       name: "SwiftParser",
       dependencies: ["SwiftDiagnostics", "SwiftSyntax"],
       exclude: [
+        "CMakeLists.txt",
         "README.md"
       ]
     ),

--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -1,0 +1,12 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_subdirectory(_CSwiftSyntax)
+add_subdirectory(SwiftSyntax)
+add_subdirectory(SwiftDiagnostics)
+add_subdirectory(SwiftParser)

--- a/Sources/SwiftDiagnostics/CMakeLists.txt
+++ b/Sources/SwiftDiagnostics/CMakeLists.txt
@@ -1,0 +1,27 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(SwiftDiagnostics STATIC
+  FixIt.swift
+  Message.swift
+  Diagnostic.swift
+)
+
+target_link_libraries(SwiftDiagnostics PUBLIC
+  SwiftSyntax)
+
+set_property(GLOBAL APPEND PROPERTY SWIFTSYNTAX_EXPORTS SwiftDiagnostics)
+
+# NOTE: workaround for CMake not setting up include flags yet
+set_target_properties(SwiftDiagnostics PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+install(TARGETS SwiftDiagnostics
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -1,0 +1,47 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(SwiftParser STATIC
+  Names.swift
+  Lexer.swift
+  Declarations.swift
+  Directives.swift
+  CharacterInfo.swift
+  Attributes.swift
+  Lookahead.swift
+  Expressions.swift
+  LoopProgressCondition.swift
+  Statements.swift
+  TokenPrecedence.swift
+  Modifiers.swift
+  Patterns.swift
+  Availability.swift
+  TriviaParser.swift
+  TokenConsumer.swift
+  Parser.swift
+  Recovery.swift
+  TopLevel.swift
+  Types.swift
+
+  Diagnostics/ParserDiagnosticMessages.swift
+  Diagnostics/ParseDiagnosticsGenerator.swift)
+
+target_link_libraries(SwiftParser PUBLIC
+  SwiftSyntax
+  SwiftDiagnostics)
+
+set_property(GLOBAL APPEND PROPERTY SWIFTSYNTAX_EXPORTS SwiftParser)
+
+# NOTE: workaround for CMake not setting up include flags yet
+set_target_properties(SwiftParser PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+install(TARGETS SwiftParser
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -37,6 +37,10 @@ target_link_libraries(SwiftParser PUBLIC
 
 set_property(GLOBAL APPEND PROPERTY SWIFTSYNTAX_EXPORTS SwiftParser)
 
+# Rename the installed library to avoid clashing with the C++
+# "libswiftParser" on case-insensitive file systems.
+set_target_properties(SwiftParser PROPERTIES OUTPUT_NAME "SwiftSwiftParser")
+
 # NOTE: workaround for CMake not setting up include flags yet
 set_target_properties(SwiftParser PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -1,0 +1,71 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+add_library(SwiftSyntax STATIC
+  AbsolutePosition.swift
+  AtomicCounter.swift
+  BumpPtrAllocator.swift
+  IncrementalParseTransition.swift
+  SourceLength.swift
+  SourceLocation.swift
+  SourcePresence.swift
+  Syntax.swift
+  SyntaxArena.swift
+  SyntaxChildren.swift
+  SyntaxClassifier.swift
+  SyntaxData.swift
+  SyntaxOtherNodes.swift
+  SyntaxText.swift
+  SyntaxTreeViewMode.swift
+  SyntaxVerifier.swift
+  Utils.swift
+
+  Raw/RawSyntax.swift
+  Raw/RawSyntaxLayoutView.swift
+  Raw/RawSyntaxNodeProtocol.swift
+  Raw/RawSyntaxTokenView.swift
+
+  Raw/gyb_generated/RawSyntaxNodes.swift
+  Raw/gyb_generated/RawSyntaxValidation.swift
+
+  gyb_generated/Misc.swift
+  gyb_generated/SyntaxAnyVisitor.swift
+  gyb_generated/SyntaxBaseNodes.swift
+  gyb_generated/SyntaxClassification.swift
+  gyb_generated/SyntaxCollections.swift
+  gyb_generated/SyntaxEnum.swift
+  gyb_generated/SyntaxFactory.swift
+  gyb_generated/SyntaxKind.swift
+  gyb_generated/SyntaxRewriter.swift
+  gyb_generated/SyntaxTraits.swift
+  gyb_generated/SyntaxVisitor.swift
+  gyb_generated/TokenKind.swift
+  gyb_generated/Tokens.swift
+  gyb_generated/Trivia.swift
+
+  gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+  gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+  gyb_generated/syntax_nodes/SyntaxNodes.swift
+  gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
+  gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+  gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+)
+
+target_link_libraries(SwiftSyntax PRIVATE
+  _CSwiftSyntax)
+
+set_property(GLOBAL APPEND PROPERTY SWIFTSYNTAX_EXPORTS SwiftSyntax)
+
+# NOTE: workaround for CMake not setting up include flags yet
+set_target_properties(SwiftSyntax PROPERTIES
+  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+
+install(TARGETS SwiftSyntax
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin)

--- a/Sources/_CSwiftSyntax/CMakeLists.txt
+++ b/Sources/_CSwiftSyntax/CMakeLists.txt
@@ -1,0 +1,12 @@
+# This source file is part of the Swift.org open source project
+#
+# Copyright (c) 2014 - 2020 Apple Inc. and the Swift project authors
+# Licensed under Apache License v2.0 with Runtime Library Exception
+#
+# See http://swift.org/LICENSE.txt for license information
+# See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+
+include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
+add_library(_CSwiftSyntax STATIC
+  src/atomic-counter.c)
+

--- a/Sources/_CSwiftSyntax/include/module.modulemap
+++ b/Sources/_CSwiftSyntax/include/module.modulemap
@@ -1,0 +1,3 @@
+module _CSwiftSyntax {
+  header "atomic-counter.h"
+}


### PR DESCRIPTION
Add a CMake-based build system that builds only the main modules
(SwiftSyntax, SwiftDiagnostics, SwiftParser) that would be used in
later stages of a host compiler. It does not run tests or build
auxiliar convenience modules like SwiftSyntaxBuilder that aren't
expected to be used in the compiler itself.