### PR TITLE
Get swift-syntax building with Swift 5.5 (again)

### DIFF
--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -53,7 +53,9 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     super.init(viewMode: .all)
   }
 
-  public static func diagnostics(for tree: SyntaxProtocol) -> [Diagnostic] {
+  public static func diagnostics<SyntaxType: SyntaxProtocol>(
+    for tree: SyntaxType
+  ) -> [Diagnostic] {
     let diagProducer = ParseDiagnosticsGenerator()
     diagProducer.walk(tree)
     return diagProducer.diagnostics

--- a/Tests/SwiftParserTest/RecoveryTests.swift
+++ b/Tests/SwiftParserTest/RecoveryTests.swift
@@ -267,10 +267,11 @@ public class RecoveryTests: XCTestCase {
     var source = """
     (first second third struct: Int)
     """
-    let (_, currentToken) = source.withUTF8 { buffer in
-      var parser = Parser(buffer)
-      return (parser.parseFunctionSignature(), parser.currentToken)
-    }
+    let (_, currentToken): (RawFunctionSignatureSyntax, Lexer.Lexeme) =
+      source.withUTF8 { buffer in
+        var parser = Parser(buffer)
+        return (parser.parseFunctionSignature(), parser.currentToken)
+      }
 
     // The 'struct' keyword should be taken as an indicator that a new decl
     // starts here, so `parseFunctionSignature` shouldn't eat it.
@@ -334,10 +335,11 @@ public class RecoveryTests: XCTestCase {
     (first second third
     : Int)
     """
-    let (_, currentToken) = source.withUTF8 { buffer in
-      var parser = Parser(buffer)
-      return (parser.parseFunctionSignature(), parser.currentToken)
-    }
+    let (_, currentToken): (RawFunctionSignatureSyntax, Lexer.Lexeme) =
+      source.withUTF8 { buffer in
+        var parser = Parser(buffer)
+        return (parser.parseFunctionSignature(), parser.currentToken)
+      }
 
     XCTAssertEqual(currentToken.tokenKind, .colon)
   }


### PR DESCRIPTION
Eliminate a use of implicit opening of existentials and add some type annotations to appease Swift 5.5.