### PR TITLE
Add convenience initializer for `CustomAttribute`

### DIFF
--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/CustomAttributeConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/CustomAttributeConvenienceInitializers.swift
@@ -1,0 +1,32 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+extension CustomAttribute {
+  /// A convenience initializer that allows passing in arguments using a result builder
+  /// and automatically adds parentheses as needed, similar to the convenience
+  /// initializer for ``FunctionCallExpr``.
+  public init(
+    _ attributeName: ExpressibleAsTypeBuildable,
+    @TupleExprElementListBuilder argumentList: () -> ExpressibleAsTupleExprElementList? = { nil }
+  ) {
+    let argumentList = argumentList()
+    self.init(
+      attributeName: attributeName,
+      leftParen: argumentList != nil ? .leftParen : nil,
+      argumentList: argumentList,
+      rightParen: argumentList != nil ? .rightParen : nil
+    )
+  }
+}
+

--- a/Tests/SwiftSyntaxBuilderTest/CustomAttributeTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/CustomAttributeTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+import SwiftSyntax
+import SwiftSyntaxBuilder
+
+final class CustomAttributeTests: XCTestCase {
+  func testCustomAttributeConvenienceInitializer() {
+    let testCases: [UInt: (CustomAttribute, String)] = [
+      #line: (CustomAttribute("Test"), "@Test"),
+      #line: (CustomAttribute("WithParens") {}, "@WithParens()"),
+      #line: (CustomAttribute("WithArgs") {
+        TupleExprElement(expression: "value1")
+        TupleExprElement(label: "labelled", expression: "value2")
+      }, "@WithArgs(value1, labelled: value2)"),
+    ]
+
+    for (line, testCase) in testCases {
+      let (builder, expected) = testCase
+      let syntax = builder.buildSyntax(format: Format())
+
+      var text = ""
+      syntax.write(to: &text)
+
+      XCTAssertEqual(text, expected, line: line)
+    }
+  }
+}

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -107,29 +107,56 @@ final class VariableTests: XCTestCase {
   }
 
   func testAttributedVariables() {
-    let attributedVar = VariableDecl(
-      attributes: CustomAttribute(attributeName: "Test", argumentList: nil),
-      .var,
-      name: "x",
-      type: "Int"
-    )
+    let testCases: [UInt: (VariableDecl, String)] = [
+      #line: (
+        VariableDecl(
+          attributes: CustomAttribute("Test"),
+          .var,
+          name: "x",
+          type: "Int"
+        ),
+        """
+        @Test var x: Int
+        """
+      ),
+      #line: (
+        VariableDecl(
+          attributes: CustomAttribute("Test"),
+          name: "y",
+          type: "String"
+        ) {
+          StringLiteralExpr("Hello world!")
+        },
+        """
+        @Test var y: String {
+            "Hello world!"
+        }
+        """
+      ),
+      #line: (
+        VariableDecl(
+          attributes: CustomAttribute("WithArgs") {
+            TupleExprElement(expression: "value1")
+            TupleExprElement(label: "label", expression: "value2")
+          },
+          name: "z",
+          type: "Float"
+        ) {
+          FloatLiteralExpr(0.0)
+        },
+        """
+        @WithArgs(value1, label: value2) var z: Float {
+            0.0
+        }
+        """
+      ),
+    ]
 
-    XCTAssertEqual(attributedVar.buildSyntax(format: Format()).description, """
-      @Test var x: Int
-      """)
+    for (line, testCase) in testCases {
+      let (builder, expected) = testCase
+      let syntax = builder.buildSyntax(format: Format())
 
-    let attributedProperty = VariableDecl(
-      attributes: CustomAttribute(attributeName: "Test", argumentList: nil),
-      name: "y",
-      type: "String"
-    ) {
-      StringLiteralExpr("Hello world!")
+      XCTAssertEqual(syntax.description, expected, line: line)
     }
-
-    XCTAssertEqual(attributedProperty.buildSyntax(format: Format()).description, """
-      @Test var y: String {
-          "Hello world!"
-      }
-      """)
   }
 }


### PR DESCRIPTION
This makes `CustomAttribute`s constructible in a way similar to `FunctionCallExpr`s:

```swift
// @Test
CustomAttribute("Test")

// @Test()
CustomAttribute("Test") {}

// @Test(a, label: b)
CustomAttribute("Test") {
  TupleExprElement(expression: "a")
  TupleExprElement(label: "label", expression: "b")
}
```

I have placed the convenience initializer under `Sources/SwiftSyntaxBuilder/ConvenienceInitializers` already to be consistent with #647.