### PR TITLE
Store presence of a token in an explicit field

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1004,7 +1004,12 @@ extension Parser {
       textRange = wholeText.startIndex ..< wholeText.startIndex + text.count
     }
     return RawTokenSyntax(
-      kind: kind, wholeText: wholeText, textRange: textRange, arena: self.arena)
+      kind: kind,
+      wholeText: wholeText,
+      textRange: textRange,
+      presence: .present,
+      arena: self.arena
+    )
   }
 
   mutating func parseStringLiteralDelimiter(
@@ -1118,6 +1123,7 @@ extension Parser {
         kind: .stringSegment,
         text: SyntaxText(rebasing: text[stringLiteralSegmentStart..<slashIndex]),
         leadingTriviaPieces: [], trailingTriviaPieces: [],
+        presence: .present,
         arena: self.arena)
       segments.append(RawSyntax(RawStringSegmentSyntax(content: segmentToken, arena: self.arena)))
 
@@ -1133,6 +1139,7 @@ extension Parser {
           kind: .backslash,
           text: SyntaxText(rebasing: text[slashIndex..<text.index(after: slashIndex)]),
           leadingTriviaPieces: [], trailingTriviaPieces: [],
+          presence: .present,
           arena: self.arena)
 
         // `###`
@@ -1142,6 +1149,7 @@ extension Parser {
             kind: .rawStringDelimiter,
             text: SyntaxText(rebasing: text[delimiterStart..<contentStart]),
             leadingTriviaPieces: [], trailingTriviaPieces: [],
+            presence: .present,
             arena: self.arena)
         } else {
           delim = nil
@@ -1207,6 +1215,7 @@ extension Parser {
       kind: .stringSegment,
       text: SyntaxText(rebasing: segment),
       leadingTriviaPieces: [], trailingTriviaPieces: [],
+      presence: .present,
       arena: self.arena)
     segments.append(RawSyntax(RawStringSegmentSyntax(content: segmentToken,
                                                      arena: self.arena)))

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -180,8 +180,12 @@ extension Parser {
     let tok = self.currentToken
     self.currentToken = self.lexemes.advance()
     return RawTokenSyntax(
-      kind: tok.tokenKind, wholeText: tok.wholeText, textRange: tok.textRange,
-      arena: arena)
+      kind: tok.tokenKind,
+      wholeText: tok.wholeText,
+      textRange: tok.textRange,
+      presence: .present,
+      arena: arena
+    )
   }
 
   /// Consumes the current token and sets its kind to the given `TokenKind`,
@@ -298,7 +302,9 @@ extension Parser {
       kind: tokenKind,
       wholeText: SyntaxText(rebasing: current.wholeText[..<endIndex]),
       textRange: current.textRange.lowerBound ..< endIndex,
-      arena: self.arena)
+      presence: .present,
+      arena: self.arena
+    )
 
     // ... or a multi-character token with the first N characters being the one
     // that we want to consume as a separate token.

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -116,10 +116,16 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
     kind: RawTokenKind,
     wholeText: SyntaxText,
     textRange: Range<SyntaxText.Index>,
+    presence: SourcePresence,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.parsedToken(
-      kind: kind, wholeText: wholeText, textRange: textRange, arena: arena)
+      kind: kind,
+      wholeText: wholeText,
+      textRange: textRange,
+      presence: presence,
+      arena: arena
+    )
     self = RawTokenSyntax(raw: raw)
   }
 
@@ -130,12 +136,15 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
     text: SyntaxText,
     leadingTriviaPieces: [RawTriviaPiece],
     trailingTriviaPieces: [RawTriviaPiece],
+    presence: SourcePresence,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeMaterializedToken(
-      kind: kind, text: text,
+      kind: kind,
+      text: text,
       leadingTriviaPieceCount: leadingTriviaPieces.count,
       trailingTriviaPieceCount: trailingTriviaPieces.count,
+      presence: presence,
       arena: arena,
       initializingLeadingTriviaWith: { buffer in
         _ = buffer.initialize(from: leadingTriviaPieces)
@@ -146,10 +155,18 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
   }
 
   /// Creates a missing `TokenSyntax` with the specified kind.
+  /// If `text` is passed, it will be used to represent the missing token's text.
+  /// If `text` is `nil`, the `kind`'s default text will be used.
+  /// If that is also `nil`, the token will have empty text.
   public init(missing kind: RawTokenKind, arena: __shared SyntaxArena) {
     self.init(
-      kind: kind, text: "", leadingTriviaPieces: [], trailingTriviaPieces: [],
-      arena: arena)
+      kind: kind,
+      text: kind.defaultText ?? "",
+      leadingTriviaPieces: [],
+      trailingTriviaPieces: [],
+      presence: .missing,
+      arena: arena
+    )
   }
 }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxTokenView.swift
@@ -189,19 +189,14 @@ struct RawSyntaxTokenView {
   }
 
   var presence: SourcePresence {
-    if self.raw.byteLength != 0 {
-      // The node has source text associated with it. It's present.
-      return .present
+    switch raw.rawData.payload {
+    case .parsedToken(let dat):
+      return dat.presence
+    case .materializedToken(let dat):
+      return dat.presence
+    case .layout(_):
+      preconditionFailure("'presence' is a token-only property")
     }
-    if rawKind == .eof || rawKind == .stringSegment {
-      // The end of file token never has source code associated with it but we
-      // still consider it valid.
-      // String segments can be empty if they occur in an empty string literal or in between two interpolation segments.
-      return .present
-    }
-
-    // If none of the above apply, the node is missing.
-    return .missing
   }
 
 }

--- a/Sources/SwiftSyntaxParser/RawSyntax+CNodes.swift
+++ b/Sources/SwiftSyntaxParser/RawSyntax+CNodes.swift
@@ -65,6 +65,7 @@ extension RawSyntax {
       kind: tokenKind, text: tokenText,
       leadingTriviaPieceCount: leadingTriviaInfo.count,
       trailingTriviaPieceCount: trailingTriviaInfo.count,
+      presence: cnode.present ? .present : .missing,
       arena: arena,
       initializingLeadingTriviaWith: {
         initializeRawTriviaBuffer($0, 0, leadingTriviaInfo)

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -208,8 +208,8 @@ func AssertParse<Node: RawSyntaxNodeProtocol>(
 
       // Applying Fix-Its
       if let expectedFixedSource = expectedFixedSource {
-        let fixedSource = FixItApplier.applyFixes(in: diags, to: tree).description
-        AssertStringsEqualWithDiff(fixedSource, expectedFixedSource, file: file, line: line)
+        let fixedTree = FixItApplier.applyFixes(in: diags, to: tree)
+        AssertStringsEqualWithDiff(fixedTree.description, expectedFixedSource, file: file, line: line)
       }
     }
   }

--- a/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
+++ b/Tests/SwiftSyntaxTest/RawSyntaxTests.swift
@@ -5,18 +5,22 @@ fileprivate func cannedStructDecl(arena: SyntaxArena) -> RawStructDeclSyntax {
   let structKW = RawTokenSyntax(
     kind: .structKeyword, text: arena.intern("struct"),
     leadingTriviaPieces: [], trailingTriviaPieces: [.spaces(1)],
+    presence: .present,
     arena: arena)
   let fooID = RawTokenSyntax(
     kind: .identifier, text: arena.intern("Foo"),
     leadingTriviaPieces: [], trailingTriviaPieces: [.spaces(1)],
+    presence: .present,
     arena: arena)
   let lBrace = RawTokenSyntax(
     kind: .leftBrace, text: arena.intern("{"),
     leadingTriviaPieces: [], trailingTriviaPieces: [],
+    presence: .present,
     arena: arena)
   let rBrace = RawTokenSyntax(
     kind: .leftBrace, text: arena.intern("}"),
     leadingTriviaPieces: [.newlines(1)], trailingTriviaPieces: [],
+    presence: .present,
     arena: arena)
   let members = RawMemberDeclBlockSyntax(
     leftBrace: lBrace,
@@ -67,6 +71,7 @@ final class RawSyntaxTests: XCTestCase {
       let ident = RawTokenSyntax(
         kind: .identifier, text: arena.intern("foo"),
         leadingTriviaPieces: [], trailingTriviaPieces: [],
+        presence: .present,
         arena: arena)
       XCTAssertEqual(ident.tokenKind, .identifier)
       XCTAssertEqual(ident.tokenText, "foo")
@@ -90,6 +95,7 @@ final class RawSyntaxTests: XCTestCase {
     withExtendedLifetime(SyntaxArena(parseTriviaFunction: dummyParseToken)) { arena in
       let ident = RawTokenSyntax(
         kind: .identifier, wholeText: arena.intern("\nfoo "), textRange: 1..<4,
+        presence: .present,
         arena: arena)
 
       XCTAssertEqual(ident.tokenKind, .identifier)


### PR DESCRIPTION
We recently changed a token’s presence to be implicitly determined by whether it contains any source code. It turns out that this has two downsides:
- We cannot synthesize missing tokens with explicitly known text, like a missing `for` identifier token for the `@_dynamicReplacable` attribute (this is the issue that I just stumbled over)
- We cannot synthesize missing tokens with trivia (this has been an issue in the past that we have been able to work around)