### PR TITLE
Specify node names for diagnostics in gyb_syntax_support

### DIFF
--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -16,25 +16,14 @@ import SwiftSyntax
 let diagnosticDomain: String = "SwiftParser"
 
 extension Syntax {
-  // FIXME: These should be defined in gyb_syntax_support.
   var nodeTypeNameForDiagnostics: String? {
-    if self.is(DeclSyntax.self) {
-      return "declaration"
-    } else if self.is(ExprSyntax.self) {
-      return "expression"
-    } else if self.is(PatternSyntax.self) {
-      return "pattern"
-    } else if self.is(StmtSyntax.self) {
-      return "statement"
-    } else if self.is(TypeSyntax.self) {
-      return "type"
-    } else if self.is(FunctionParameterSyntax.self) {
-      return "function parameter"
-    } else if self.is(ParameterClauseSyntax.self) {
-      return "parameter clause"
-    } else {
-      return nil
+    if let name = self.as(SyntaxEnum.self).nameForDiagnostics {
+      return name
     }
+    if let parent = self.parent {
+      return parent.nodeTypeNameForDiagnostics
+    }
+    return nil
   }
 }
 

--- a/Sources/SwiftSyntax/SyntaxEnum.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxEnum.swift.gyb
@@ -30,6 +30,23 @@ public enum SyntaxEnum {
   case ${node.swift_syntax_kind}(${node.name})
 %   end
 % end
+
+  public var nameForDiagnostics: String? {
+    switch self {
+    case .unknown:
+      return nil
+    case .token:
+      return "token"
+% for node in NON_BASE_SYNTAX_NODES:
+    case .${node.swift_syntax_kind}:
+%   if node.name_for_diagnostics:
+      return "${node.name_for_diagnostics}"
+%   else:
+      return nil
+%   end
+% end
+    }
+  }
 }
 
 public extension Syntax {

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -279,6 +279,541 @@ public enum SyntaxEnum {
   case availabilityLabeledArgument(AvailabilityLabeledArgumentSyntax)
   case availabilityVersionRestriction(AvailabilityVersionRestrictionSyntax)
   case versionTuple(VersionTupleSyntax)
+
+  public var nameForDiagnostics: String? {
+    switch self {
+    case .unknown:
+      return nil
+    case .token:
+      return "token"
+    case .unknownDecl:
+      return "declaration"
+    case .unknownExpr:
+      return "expression"
+    case .unknownStmt:
+      return "statement"
+    case .unknownType:
+      return "type"
+    case .unknownPattern:
+      return "pattern"
+    case .missing:
+      return nil
+    case .missingDecl:
+      return "declaration"
+    case .missingExpr:
+      return "expression"
+    case .missingStmt:
+      return "statement"
+    case .missingType:
+      return "type"
+    case .missingPattern:
+      return "pattern"
+    case .codeBlockItem:
+      return nil
+    case .codeBlockItemList:
+      return nil
+    case .codeBlock:
+      return nil
+    case .unexpectedNodes:
+      return nil
+    case .inOutExpr:
+      return "inout expression"
+    case .poundColumnExpr:
+      return nil
+    case .tupleExprElementList:
+      return nil
+    case .arrayElementList:
+      return nil
+    case .dictionaryElementList:
+      return nil
+    case .stringLiteralSegments:
+      return nil
+    case .tryExpr:
+      return "'try' expression"
+    case .awaitExpr:
+      return "'await' expression"
+    case .moveExpr:
+      return "'_move' expression"
+    case .declNameArgument:
+      return nil
+    case .declNameArgumentList:
+      return nil
+    case .declNameArguments:
+      return nil
+    case .identifierExpr:
+      return nil
+    case .superRefExpr:
+      return nil
+    case .nilLiteralExpr:
+      return nil
+    case .discardAssignmentExpr:
+      return nil
+    case .assignmentExpr:
+      return nil
+    case .sequenceExpr:
+      return nil
+    case .exprList:
+      return nil
+    case .poundLineExpr:
+      return nil
+    case .poundFileExpr:
+      return nil
+    case .poundFileIDExpr:
+      return nil
+    case .poundFilePathExpr:
+      return nil
+    case .poundFunctionExpr:
+      return nil
+    case .poundDsohandleExpr:
+      return nil
+    case .symbolicReferenceExpr:
+      return nil
+    case .prefixOperatorExpr:
+      return "prefix operator expression"
+    case .binaryOperatorExpr:
+      return nil
+    case .arrowExpr:
+      return nil
+    case .infixOperatorExpr:
+      return nil
+    case .floatLiteralExpr:
+      return "floating literal"
+    case .tupleExpr:
+      return "tuple"
+    case .arrayExpr:
+      return "array"
+    case .dictionaryExpr:
+      return "dictionary"
+    case .tupleExprElement:
+      return nil
+    case .arrayElement:
+      return nil
+    case .dictionaryElement:
+      return nil
+    case .integerLiteralExpr:
+      return "integer literal"
+    case .booleanLiteralExpr:
+      return "bool literal"
+    case .unresolvedTernaryExpr:
+      return nil
+    case .ternaryExpr:
+      return "ternay expression"
+    case .memberAccessExpr:
+      return "member access"
+    case .unresolvedIsExpr:
+      return nil
+    case .isExpr:
+      return "'is' expression"
+    case .unresolvedAsExpr:
+      return nil
+    case .asExpr:
+      return "'as' expression"
+    case .typeExpr:
+      return nil
+    case .closureCaptureItem:
+      return "closure capture item"
+    case .closureCaptureItemList:
+      return nil
+    case .closureCaptureSignature:
+      return "closure capture signature"
+    case .closureParam:
+      return "closure parameter"
+    case .closureParamList:
+      return nil
+    case .closureSignature:
+      return "closure signature"
+    case .closureExpr:
+      return "closure"
+    case .unresolvedPatternExpr:
+      return nil
+    case .multipleTrailingClosureElement:
+      return "trailing closure"
+    case .multipleTrailingClosureElementList:
+      return nil
+    case .functionCallExpr:
+      return "function call"
+    case .subscriptExpr:
+      return "subscript"
+    case .optionalChainingExpr:
+      return "optional chaining"
+    case .forcedValueExpr:
+      return "force unwrap"
+    case .postfixUnaryExpr:
+      return "postfix expression"
+    case .specializeExpr:
+      return nil
+    case .stringSegment:
+      return nil
+    case .expressionSegment:
+      return nil
+    case .stringLiteralExpr:
+      return "string literal"
+    case .regexLiteralExpr:
+      return "regex literal"
+    case .keyPathExpr:
+      return "key path"
+    case .keyPathBaseExpr:
+      return nil
+    case .objcNamePiece:
+      return nil
+    case .objcName:
+      return nil
+    case .objcKeyPathExpr:
+      return "'#keyPath' expression"
+    case .objcSelectorExpr:
+      return "'#selector' expression"
+    case .postfixIfConfigExpr:
+      return nil
+    case .editorPlaceholderExpr:
+      return "editor placeholder"
+    case .objectLiteralExpr:
+      return "object literal"
+    case .typeInitializerClause:
+      return nil
+    case .typealiasDecl:
+      return "typealias declaration"
+    case .associatedtypeDecl:
+      return "associatedtype declaration"
+    case .functionParameterList:
+      return "function parameter list"
+    case .parameterClause:
+      return "parameter clause"
+    case .returnClause:
+      return "return clause"
+    case .functionSignature:
+      return "function signature"
+    case .ifConfigClause:
+      return "conditional compilation clause"
+    case .ifConfigClauseList:
+      return nil
+    case .ifConfigDecl:
+      return "conditional compilation block"
+    case .poundErrorDecl:
+      return "'#error' directive"
+    case .poundWarningDecl:
+      return "'#warning' directive"
+    case .poundSourceLocation:
+      return "'#sourceLocation' directive"
+    case .poundSourceLocationArgs:
+      return "'#sourceLocation' arguments"
+    case .declModifierDetail:
+      return nil
+    case .declModifier:
+      return "modifier"
+    case .inheritedType:
+      return "type"
+    case .inheritedTypeList:
+      return nil
+    case .typeInheritanceClause:
+      return "inheritance clause"
+    case .classDecl:
+      return "class"
+    case .actorDecl:
+      return "actor"
+    case .structDecl:
+      return "struct"
+    case .protocolDecl:
+      return "protocol"
+    case .extensionDecl:
+      return "extension"
+    case .memberDeclBlock:
+      return nil
+    case .memberDeclList:
+      return nil
+    case .memberDeclListItem:
+      return "member"
+    case .sourceFile:
+      return "source file"
+    case .initializerClause:
+      return nil
+    case .functionParameter:
+      return "function parameter"
+    case .modifierList:
+      return nil
+    case .functionDecl:
+      return "function"
+    case .initializerDecl:
+      return "initializer"
+    case .deinitializerDecl:
+      return "deinitializer"
+    case .subscriptDecl:
+      return "subscript"
+    case .accessLevelModifier:
+      return "access level modifier"
+    case .accessPathComponent:
+      return nil
+    case .accessPath:
+      return nil
+    case .importDecl:
+      return "import"
+    case .accessorParameter:
+      return nil
+    case .accessorDecl:
+      return "accessor"
+    case .accessorList:
+      return nil
+    case .accessorBlock:
+      return nil
+    case .patternBinding:
+      return nil
+    case .patternBindingList:
+      return nil
+    case .variableDecl:
+      return "variable"
+    case .enumCaseElement:
+      return nil
+    case .enumCaseElementList:
+      return nil
+    case .enumCaseDecl:
+      return "enum case"
+    case .enumDecl:
+      return "enum"
+    case .operatorDecl:
+      return "operator"
+    case .identifierList:
+      return nil
+    case .operatorPrecedenceAndTypes:
+      return nil
+    case .precedenceGroupDecl:
+      return "precedencegroup"
+    case .precedenceGroupAttributeList:
+      return nil
+    case .precedenceGroupRelation:
+      return "'relation' property of precedencegroup"
+    case .precedenceGroupNameList:
+      return nil
+    case .precedenceGroupNameElement:
+      return nil
+    case .precedenceGroupAssignment:
+      return "'assignment' property of precedencegroup"
+    case .precedenceGroupAssociativity:
+      return "'associativity' property of precedencegroup"
+    case .tokenList:
+      return "token list"
+    case .nonEmptyTokenList:
+      return "token list"
+    case .customAttribute:
+      return "attribute"
+    case .attribute:
+      return "attribute"
+    case .attributeList:
+      return "attributes"
+    case .specializeAttributeSpecList:
+      return "argument to '@_specialize"
+    case .availabilityEntry:
+      return "availability entry"
+    case .labeledSpecializeEntry:
+      return "attribute argument"
+    case .targetFunctionEntry:
+      return "attribute argument"
+    case .namedAttributeStringArgument:
+      return "attribute argument"
+    case .declName:
+      return "declaration name"
+    case .implementsAttributeArguments:
+      return "@_implements arguemnts"
+    case .objCSelectorPiece:
+      return "Objective-C selector piece"
+    case .objCSelector:
+      return "Objective-C selector"
+    case .differentiableAttributeArguments:
+      return "'@differentiable' arguments"
+    case .differentiabilityParamsClause:
+      return "'@differentiable' argument"
+    case .differentiabilityParams:
+      return "differentiability parameters"
+    case .differentiabilityParamList:
+      return "differentiability parameters"
+    case .differentiabilityParam:
+      return "differentiability parameter"
+    case .derivativeRegistrationAttributeArguments:
+      return "attribute arguments"
+    case .qualifiedDeclName:
+      return "declaration name"
+    case .functionDeclName:
+      return "function declaration name"
+    case .backDeployAttributeSpecList:
+      return "'@_backDeploy' arguments"
+    case .backDeployVersionList:
+      return "version list"
+    case .backDeployVersionArgument:
+      return "version"
+    case .labeledStmt:
+      return "labeled statement"
+    case .continueStmt:
+      return "'continue' statement"
+    case .whileStmt:
+      return "'while' statement"
+    case .deferStmt:
+      return "'defer' statement"
+    case .expressionStmt:
+      return "expression"
+    case .switchCaseList:
+      return nil
+    case .repeatWhileStmt:
+      return "'repeat' statement"
+    case .guardStmt:
+      return "'guard' statement"
+    case .whereClause:
+      return "'where' clause"
+    case .forInStmt:
+      return "'for' statement"
+    case .switchStmt:
+      return "'switch' statement"
+    case .catchClauseList:
+      return "'catch' clause"
+    case .doStmt:
+      return "'do' statement"
+    case .returnStmt:
+      return "'return' statement"
+    case .yieldStmt:
+      return "'yield' statement"
+    case .yieldList:
+      return nil
+    case .fallthroughStmt:
+      return "'fallthrough' statement"
+    case .breakStmt:
+      return "'break' statement"
+    case .caseItemList:
+      return nil
+    case .catchItemList:
+      return nil
+    case .conditionElement:
+      return nil
+    case .availabilityCondition:
+      return "'#availabile' condition"
+    case .matchingPatternCondition:
+      return "pattern matching"
+    case .optionalBindingCondition:
+      return "optional binding"
+    case .unavailabilityCondition:
+      return "'#unavailable' condition"
+    case .conditionElementList:
+      return nil
+    case .declarationStmt:
+      return "declaration"
+    case .throwStmt:
+      return "'throw' statement"
+    case .ifStmt:
+      return "'if' statement"
+    case .elseIfContinuation:
+      return nil
+    case .elseBlock:
+      return "else block"
+    case .switchCase:
+      return "switch case"
+    case .switchDefaultLabel:
+      return nil
+    case .caseItem:
+      return nil
+    case .catchItem:
+      return nil
+    case .switchCaseLabel:
+      return nil
+    case .catchClause:
+      return "'catch' clause"
+    case .poundAssertStmt:
+      return "'#assert' statement"
+    case .genericWhereClause:
+      return "'where' clause"
+    case .genericRequirementList:
+      return nil
+    case .genericRequirement:
+      return nil
+    case .sameTypeRequirement:
+      return "same type requirement"
+    case .layoutRequirement:
+      return "layout requirement"
+    case .genericParameterList:
+      return nil
+    case .genericParameter:
+      return "generic parameter"
+    case .primaryAssociatedTypeList:
+      return nil
+    case .primaryAssociatedType:
+      return nil
+    case .genericParameterClause:
+      return "generic parameter clause"
+    case .conformanceRequirement:
+      return "conformance requirement"
+    case .primaryAssociatedTypeClause:
+      return "primary associated type clause"
+    case .simpleTypeIdentifier:
+      return "type"
+    case .memberTypeIdentifier:
+      return "member type"
+    case .classRestrictionType:
+      return nil
+    case .arrayType:
+      return "array type"
+    case .dictionaryType:
+      return "dictionary type"
+    case .metatypeType:
+      return "metatype"
+    case .optionalType:
+      return "optional type"
+    case .constrainedSugarType:
+      return "type"
+    case .implicitlyUnwrappedOptionalType:
+      return "implicitly unwrapped optional type"
+    case .compositionTypeElement:
+      return nil
+    case .compositionTypeElementList:
+      return nil
+    case .compositionType:
+      return "type composition"
+    case .tupleTypeElement:
+      return nil
+    case .tupleTypeElementList:
+      return nil
+    case .tupleType:
+      return "tuple type"
+    case .functionType:
+      return "function type"
+    case .attributedType:
+      return "type"
+    case .genericArgumentList:
+      return nil
+    case .genericArgument:
+      return "generic argument"
+    case .genericArgumentClause:
+      return "generic argument clause"
+    case .typeAnnotation:
+      return "type annotation"
+    case .enumCasePattern:
+      return "enum case pattern"
+    case .isTypePattern:
+      return "'is' pattern"
+    case .optionalPattern:
+      return "optional pattern"
+    case .identifierPattern:
+      return "pattern"
+    case .asTypePattern:
+      return "'as' pattern"
+    case .tuplePattern:
+      return "tuple pattern"
+    case .wildcardPattern:
+      return "wildcard pattern"
+    case .tuplePatternElement:
+      return nil
+    case .expressionPattern:
+      return "pattern"
+    case .tuplePatternElementList:
+      return nil
+    case .valueBindingPattern:
+      return "value binding pattern"
+    case .availabilitySpecList:
+      return "'@availability' arguments"
+    case .availabilityArgument:
+      return "'@available' argument"
+    case .availabilityLabeledArgument:
+      return "'@available' argument"
+    case .availabilityVersionRestriction:
+      return "'@available' argument"
+    case .versionTuple:
+      return "version tuple"
+    }
+  }
 }
 
 public extension Syntax {

--- a/Sources/generate-swift-syntax-builder/Node.swift
+++ b/Sources/generate-swift-syntax-builder/Node.swift
@@ -18,6 +18,7 @@ class Node {
   let syntaxKind: String
   let swiftSyntaxKind: String
   let name: String
+  let nameForDiagnostics: String?
   let description: String?
   let baseKind: String
   let traits: [String]
@@ -70,6 +71,7 @@ class Node {
   }
 
   init(name: String,
+       nameForDiagnostics: String?,
        description: String? = nil,
        kind: String,
        traits: [String] = [],
@@ -82,6 +84,7 @@ class Node {
     self.syntaxKind = name
     self.swiftSyntaxKind = lowercaseFirstWord(name: name)
     self.name = kindToType(kind: self.syntaxKind)
+    self.nameForDiagnostics = nameForDiagnostics
     self.description = description
 
     self.traits = traits

--- a/Sources/generate-swift-syntax-builder/gyb_generated/AttributeNodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/AttributeNodes.swift
@@ -14,15 +14,18 @@
 
 let ATTRIBUTE_NODES: [Node] = [
   Node(name: "TokenList",
+       nameForDiagnostics: "token list",
        kind: "SyntaxCollection",
        element: "Token"),
 
   Node(name: "NonEmptyTokenList",
+       nameForDiagnostics: "token list",
        kind: "SyntaxCollection",
        element: "Token",
        omitWhenEmpty: true),
 
   Node(name: "CustomAttribute",
+       nameForDiagnostics: "attribute",
        description: "A custom `@` attribute.",
        kind: "Syntax",
        children: [
@@ -55,6 +58,7 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "Attribute",
+       nameForDiagnostics: "attribute",
        description: "An `@` attribute.",
        kind: "Syntax",
        children: [
@@ -129,6 +133,7 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "AttributeList",
+       nameForDiagnostics: "attributes",
        kind: "SyntaxCollection",
        element: "Syntax",
        elementName: "Attribute",
@@ -136,6 +141,7 @@ let ATTRIBUTE_NODES: [Node] = [
        omitWhenEmpty: true),
 
   Node(name: "SpecializeAttributeSpecList",
+       nameForDiagnostics: "argument to '@_specialize",
        description: "A collection of arguments for the `@_specialize` attribute",
        kind: "SyntaxCollection",
        element: "Syntax",
@@ -143,6 +149,7 @@ let ATTRIBUTE_NODES: [Node] = [
        elementChoices: ["LabeledSpecializeEntry", "AvailabilityEntry", "TargetFunctionEntry", "GenericWhereClause"]),
 
   Node(name: "AvailabilityEntry",
+       nameForDiagnostics: "availability entry",
        description: "The availability argument for the _specialize attribute",
        kind: "Syntax",
        children: [
@@ -169,6 +176,7 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "LabeledSpecializeEntry",
+       nameForDiagnostics: "attribute argument",
        description: "A labeled argument for the `@_specialize` attribute like`exported: true`",
        kind: "Syntax",
        traits: [
@@ -200,6 +208,7 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "TargetFunctionEntry",
+       nameForDiagnostics: "attribute argument",
        description: "A labeled argument for the `@_specialize` attribute with a functiondecl value like`target: myFunc(_:)`",
        kind: "Syntax",
        traits: [
@@ -231,6 +240,7 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "NamedAttributeStringArgument",
+       nameForDiagnostics: "attribute argument",
        description: "The argument for the `@_dynamic_replacement` or `@_private`attribute of the form `for: \"function()\"` or `sourceFile:\"Src.swift\"`",
        kind: "Syntax",
        children: [
@@ -257,6 +267,7 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "DeclName",
+       nameForDiagnostics: "declaration name",
        kind: "Syntax",
        children: [
          Child(name: "DeclBaseName",
@@ -281,6 +292,7 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "ImplementsAttributeArguments",
+       nameForDiagnostics: "@_implements arguemnts",
        description: "The arguments for the `@_implements` attribute of the form`Type, methodName(arg1Label:arg2Label:)`",
        kind: "Syntax",
        children: [
@@ -315,6 +327,7 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "ObjCSelectorPiece",
+       nameForDiagnostics: "Objective-C selector piece",
        description: "A piece of an Objective-C selector. Either consisting of just anidentifier for a nullary selector, an identifier and a colon for alabeled argument or just a colon for an unlabeled argument",
        kind: "Syntax",
        children: [
@@ -333,10 +346,12 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "ObjCSelector",
+       nameForDiagnostics: "Objective-C selector",
        kind: "SyntaxCollection",
        element: "ObjCSelectorPiece"),
 
   Node(name: "DifferentiableAttributeArguments",
+       nameForDiagnostics: "'@differentiable' arguments",
        description: "The arguments for the `@differentiable` attribute: an optionaldifferentiability kind, an optional differentiability parameter clause,and an optional 'where' clause.",
        kind: "Syntax",
        children: [
@@ -374,6 +389,7 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "DifferentiabilityParamsClause",
+       nameForDiagnostics: "'@differentiable' argument",
        description: "A clause containing differentiability parameters.",
        kind: "Syntax",
        children: [
@@ -403,6 +419,7 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "DifferentiabilityParams",
+       nameForDiagnostics: "differentiability parameters",
        description: "The differentiability parameters.",
        kind: "Syntax",
        children: [
@@ -423,10 +440,12 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "DifferentiabilityParamList",
+       nameForDiagnostics: "differentiability parameters",
        kind: "SyntaxCollection",
        element: "DifferentiabilityParam"),
 
   Node(name: "DifferentiabilityParam",
+       nameForDiagnostics: "differentiability parameter",
        description: "A differentiability parameter: either the \"self\" identifier, a functionparameter name, or a function parameter index.",
        kind: "Syntax",
        traits: [
@@ -461,6 +480,7 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "DerivativeRegistrationAttributeArguments",
+       nameForDiagnostics: "attribute arguments",
        description: "The arguments for the '@derivative(of:)' and '@transpose(of:)'attributes: the 'of:' label, the original declaration name, and anoptional differentiability parameter list.",
        kind: "Syntax",
        children: [
@@ -512,6 +532,7 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "QualifiedDeclName",
+       nameForDiagnostics: "declaration name",
        description: "An optionally qualified function declaration name (e.g. `+(_:_:)`,`A.B.C.foo(_:_:)`).",
        kind: "Syntax",
        children: [
@@ -543,6 +564,7 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "FunctionDeclName",
+       nameForDiagnostics: "function declaration name",
        description: "A function declaration name (e.g. `foo(_:_:)`).",
        kind: "Syntax",
        children: [
@@ -573,6 +595,7 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "BackDeployAttributeSpecList",
+       nameForDiagnostics: "'@_backDeploy' arguments",
        description: "A collection of arguments for the `@_backDeploy` attribute",
        kind: "Syntax",
        children: [
@@ -598,10 +621,12 @@ let ATTRIBUTE_NODES: [Node] = [
        ]),
 
   Node(name: "BackDeployVersionList",
+       nameForDiagnostics: "version list",
        kind: "SyntaxCollection",
        element: "BackDeployVersionArgument"),
 
   Node(name: "BackDeployVersionArgument",
+       nameForDiagnostics: "version",
        description: "A single platform/version pair in a `@_backDeploy` attribute,e.g. `iOS 10.1`.",
        kind: "Syntax",
        children: [

--- a/Sources/generate-swift-syntax-builder/gyb_generated/AvailabilityNodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/AvailabilityNodes.swift
@@ -14,10 +14,12 @@
 
 let AVAILABILITY_NODES: [Node] = [
   Node(name: "AvailabilitySpecList",
+       nameForDiagnostics: "'@availability' arguments",
        kind: "SyntaxCollection",
        element: "AvailabilityArgument"),
 
   Node(name: "AvailabilityArgument",
+       nameForDiagnostics: "'@available' argument",
        description: "A single argument to an `@available` argument like `*`, `iOS 10.1`,or `message: \"This has been deprecated\"`.",
        kind: "Syntax",
        children: [
@@ -53,6 +55,7 @@ let AVAILABILITY_NODES: [Node] = [
        ]),
 
   Node(name: "AvailabilityLabeledArgument",
+       nameForDiagnostics: "'@available' argument",
        description: "A argument to an `@available` attribute that consists of a label anda value, e.g. `message: \"This has been deprecated\"`.",
        kind: "Syntax",
        children: [
@@ -83,6 +86,7 @@ let AVAILABILITY_NODES: [Node] = [
        ]),
 
   Node(name: "AvailabilityVersionRestriction",
+       nameForDiagnostics: "'@available' argument",
        description: "An argument to `@available` that restricts the availability on acertain platform to a version, e.g. `iOS 10` or `swift 3.4`.",
        kind: "Syntax",
        children: [
@@ -99,6 +103,7 @@ let AVAILABILITY_NODES: [Node] = [
        ]),
 
   Node(name: "VersionTuple",
+       nameForDiagnostics: "version tuple",
        description: "A version number of the form major.minor.patch in which the minorand patch part may be omitted.",
        kind: "Syntax",
        children: [

--- a/Sources/generate-swift-syntax-builder/gyb_generated/CommonNodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/CommonNodes.swift
@@ -14,39 +14,51 @@
 
 let COMMON_NODES: [Node] = [
   Node(name: "Decl",
+       nameForDiagnostics: "declaration",
        kind: "Syntax"),
 
   Node(name: "Expr",
+       nameForDiagnostics: "expression",
        kind: "Syntax"),
 
   Node(name: "Stmt",
+       nameForDiagnostics: "statement",
        kind: "Syntax"),
 
   Node(name: "Type",
+       nameForDiagnostics: "type",
        kind: "Syntax"),
 
   Node(name: "Pattern",
+       nameForDiagnostics: "pattern",
        kind: "Syntax"),
 
   Node(name: "UnknownDecl",
+       nameForDiagnostics: "declaration",
        kind: "Decl"),
 
   Node(name: "UnknownExpr",
+       nameForDiagnostics: "expression",
        kind: "Expr"),
 
   Node(name: "UnknownStmt",
+       nameForDiagnostics: "statement",
        kind: "Stmt"),
 
   Node(name: "UnknownType",
+       nameForDiagnostics: "type",
        kind: "Type"),
 
   Node(name: "UnknownPattern",
+       nameForDiagnostics: "pattern",
        kind: "Pattern"),
 
   Node(name: "Missing",
+       nameForDiagnostics: nil,
        kind: "Syntax"),
 
   Node(name: "MissingDecl",
+       nameForDiagnostics: "declaration",
        kind: "Decl",
        children: [
          Child(name: "Attributes",
@@ -60,18 +72,23 @@ let COMMON_NODES: [Node] = [
        ]),
 
   Node(name: "MissingExpr",
+       nameForDiagnostics: "expression",
        kind: "Expr"),
 
   Node(name: "MissingStmt",
+       nameForDiagnostics: "statement",
        kind: "Stmt"),
 
   Node(name: "MissingType",
+       nameForDiagnostics: "type",
        kind: "Type"),
 
   Node(name: "MissingPattern",
+       nameForDiagnostics: "pattern",
        kind: "Pattern"),
 
   Node(name: "CodeBlockItem",
+       nameForDiagnostics: nil,
        description: "A CodeBlockItem is any Syntax node that appears on its own line insidea CodeBlock.",
        kind: "Syntax",
        children: [
@@ -104,11 +121,13 @@ let COMMON_NODES: [Node] = [
        omitWhenEmpty: true),
 
   Node(name: "CodeBlockItemList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "CodeBlockItem",
        elementsSeparatedByNewline: true),
 
   Node(name: "CodeBlock",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "Braced",
@@ -133,6 +152,7 @@ let COMMON_NODES: [Node] = [
        ]),
 
   Node(name: "UnexpectedNodes",
+       nameForDiagnostics: nil,
        description: "A collection of syntax nodes that occurred in the source code butcould not be used to form a valid syntax tree.",
        kind: "SyntaxCollection",
        element: "Syntax"),

--- a/Sources/generate-swift-syntax-builder/gyb_generated/DeclNodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/DeclNodes.swift
@@ -14,6 +14,7 @@
 
 let DECL_NODES: [Node] = [
   Node(name: "TypeInitializerClause",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        children: [
          Child(name: "Equal",
@@ -26,6 +27,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "TypealiasDecl",
+       nameForDiagnostics: "typealias declaration",
        kind: "Decl",
        traits: [
          "IdentifiedDecl"
@@ -60,6 +62,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "AssociatedtypeDecl",
+       nameForDiagnostics: "associatedtype declaration",
        kind: "Decl",
        traits: [
          "IdentifiedDecl"
@@ -95,10 +98,12 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "FunctionParameterList",
+       nameForDiagnostics: "function parameter list",
        kind: "SyntaxCollection",
        element: "FunctionParameter"),
 
   Node(name: "ParameterClause",
+       nameForDiagnostics: "parameter clause",
        kind: "Syntax",
        traits: [
          "Parenthesized"
@@ -120,6 +125,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "ReturnClause",
+       nameForDiagnostics: "return clause",
        kind: "Syntax",
        children: [
          Child(name: "Arrow",
@@ -132,6 +138,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "FunctionSignature",
+       nameForDiagnostics: "function signature",
        kind: "Syntax",
        children: [
          Child(name: "Input",
@@ -159,6 +166,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "IfConfigClause",
+       nameForDiagnostics: "conditional compilation clause",
        kind: "Syntax",
        children: [
          Child(name: "PoundKeyword",
@@ -188,10 +196,12 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "IfConfigClauseList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "IfConfigClause"),
 
   Node(name: "IfConfigDecl",
+       nameForDiagnostics: "conditional compilation block",
        kind: "Decl",
        children: [
          Child(name: "Clauses",
@@ -206,6 +216,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "PoundErrorDecl",
+       nameForDiagnostics: "'#error' directive",
        kind: "Decl",
        traits: [
          "Parenthesized"
@@ -231,6 +242,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "PoundWarningDecl",
+       nameForDiagnostics: "'#warning' directive",
        kind: "Decl",
        traits: [
          "Parenthesized"
@@ -256,6 +268,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "PoundSourceLocation",
+       nameForDiagnostics: "'#sourceLocation' directive",
        kind: "Decl",
        traits: [
          "Parenthesized"
@@ -282,6 +295,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "PoundSourceLocationArgs",
+       nameForDiagnostics: "'#sourceLocation' arguments",
        kind: "Syntax",
        children: [
          Child(name: "FileArgLabel",
@@ -328,6 +342,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "DeclModifierDetail",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "Parenthesized"
@@ -351,6 +366,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "DeclModifier",
+       nameForDiagnostics: "modifier",
        kind: "Syntax",
        children: [
          Child(name: "Name",
@@ -394,6 +410,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "InheritedType",
+       nameForDiagnostics: "type",
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -410,10 +427,12 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "InheritedTypeList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "InheritedType"),
 
   Node(name: "TypeInheritanceClause",
+       nameForDiagnostics: "inheritance clause",
        kind: "Syntax",
        children: [
          Child(name: "Colon",
@@ -427,6 +446,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "ClassDecl",
+       nameForDiagnostics: "class",
        kind: "Decl",
        traits: [
          "DeclGroup",
@@ -465,6 +485,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "ActorDecl",
+       nameForDiagnostics: "actor",
        kind: "Decl",
        traits: [
          "DeclGroup",
@@ -506,6 +527,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "StructDecl",
+       nameForDiagnostics: "struct",
        kind: "Decl",
        traits: [
          "DeclGroup",
@@ -544,6 +566,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "ProtocolDecl",
+       nameForDiagnostics: "protocol",
        kind: "Decl",
        traits: [
          "DeclGroup",
@@ -582,6 +605,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "ExtensionDecl",
+       nameForDiagnostics: "extension",
        kind: "Decl",
        traits: [
          "DeclGroup"
@@ -613,6 +637,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "MemberDeclBlock",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "Braced"
@@ -636,11 +661,13 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "MemberDeclList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "MemberDeclListItem",
        elementsSeparatedByNewline: true),
 
   Node(name: "MemberDeclListItem",
+       nameForDiagnostics: "member",
        description: "A member declaration of a type consisting of a declaration and anoptional semicolon;",
        kind: "Syntax",
        children: [
@@ -658,6 +685,7 @@ let DECL_NODES: [Node] = [
        omitWhenEmpty: true),
 
   Node(name: "SourceFile",
+       nameForDiagnostics: "source file",
        kind: "Syntax",
        traits: [
          "WithStatements"
@@ -671,6 +699,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "InitializerClause",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        children: [
          Child(name: "Equal",
@@ -683,6 +712,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "FunctionParameter",
+       nameForDiagnostics: "function parameter",
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -733,12 +763,14 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "ModifierList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "DeclModifier",
        elementName: "Modifier",
        omitWhenEmpty: true),
 
   Node(name: "FunctionDecl",
+       nameForDiagnostics: "function",
        kind: "Decl",
        traits: [
          "IdentifiedDecl"
@@ -780,6 +812,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "InitializerDecl",
+       nameForDiagnostics: "initializer",
        kind: "Decl",
        children: [
          Child(name: "Attributes",
@@ -817,6 +850,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "DeinitializerDecl",
+       nameForDiagnostics: "deinitializer",
        kind: "Decl",
        children: [
          Child(name: "Attributes",
@@ -838,6 +872,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "SubscriptDecl",
+       nameForDiagnostics: "subscript",
        kind: "Decl",
        children: [
          Child(name: "Attributes",
@@ -875,6 +910,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "AccessLevelModifier",
+       nameForDiagnostics: "access level modifier",
        kind: "Syntax",
        children: [
          Child(name: "Name",
@@ -888,6 +924,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "AccessPathComponent",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        children: [
          Child(name: "Name",
@@ -904,10 +941,12 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "AccessPath",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "AccessPathComponent"),
 
   Node(name: "ImportDecl",
+       nameForDiagnostics: "import",
        kind: "Decl",
        children: [
          Child(name: "Attributes",
@@ -942,6 +981,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "AccessorParameter",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "Parenthesized"
@@ -965,6 +1005,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "AccessorDecl",
+       nameForDiagnostics: "accessor",
        kind: "Decl",
        children: [
          Child(name: "Attributes",
@@ -1015,10 +1056,12 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "AccessorList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "AccessorDecl"),
 
   Node(name: "AccessorBlock",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "Braced"
@@ -1040,6 +1083,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "PatternBinding",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -1071,10 +1115,12 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "PatternBindingList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "PatternBinding"),
 
   Node(name: "VariableDecl",
+       nameForDiagnostics: "variable",
        kind: "Decl",
        children: [
          Child(name: "Attributes",
@@ -1097,6 +1143,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "EnumCaseElement",
+       nameForDiagnostics: nil,
        description: "An element of an enum case, containing the name of the case and,optionally, either associated values or an assignment to a raw value.",
        kind: "Syntax",
        traits: [
@@ -1127,11 +1174,13 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "EnumCaseElementList",
+       nameForDiagnostics: nil,
        description: "A collection of 0 or more `EnumCaseElement`s.",
        kind: "SyntaxCollection",
        element: "EnumCaseElement"),
 
   Node(name: "EnumCaseDecl",
+       nameForDiagnostics: "enum case",
        description: "A `case` declaration of a Swift `enum`. It can have 1 or more`EnumCaseElement`s inside, each declaring a different case of theenum.",
        kind: "Decl",
        children: [
@@ -1158,6 +1207,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "EnumDecl",
+       nameForDiagnostics: "enum",
        description: "A Swift `enum` declaration.",
        kind: "Decl",
        traits: [
@@ -1204,6 +1254,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "OperatorDecl",
+       nameForDiagnostics: "operator",
        description: "A Swift `operator` declaration.",
        kind: "Decl",
        traits: [
@@ -1241,10 +1292,12 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "IdentifierList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "IdentifierToken"),
 
   Node(name: "OperatorPrecedenceAndTypes",
+       nameForDiagnostics: nil,
        description: "A clause to specify precedence group in infix operator declarations, and designated types in any operator declaration.",
        kind: "Syntax",
        children: [
@@ -1260,6 +1313,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "PrecedenceGroupDecl",
+       nameForDiagnostics: "precedencegroup",
        description: "A Swift `precedencegroup` declaration.",
        kind: "Decl",
        traits: [
@@ -1304,12 +1358,14 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "PrecedenceGroupAttributeList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "Syntax",
        elementName: "PrecedenceGroupAttribute",
        elementChoices: ["PrecedenceGroupRelation", "PrecedenceGroupAssignment", "PrecedenceGroupAssociativity"]),
 
   Node(name: "PrecedenceGroupRelation",
+       nameForDiagnostics: "'relation' property of precedencegroup",
        description: "Specify the new precedence group's relation to existing precedencegroups.",
        kind: "Syntax",
        children: [
@@ -1336,10 +1392,12 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "PrecedenceGroupNameList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "PrecedenceGroupNameElement"),
 
   Node(name: "PrecedenceGroupNameElement",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        children: [
          Child(name: "Name",
@@ -1356,6 +1414,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "PrecedenceGroupAssignment",
+       nameForDiagnostics: "'assignment' property of precedencegroup",
        description: "Specifies the precedence of an operator when used in an operationthat includes optional chaining.",
        kind: "Syntax",
        children: [
@@ -1382,6 +1441,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "PrecedenceGroupAssociativity",
+       nameForDiagnostics: "'associativity' property of precedencegroup",
        description: "Specifies how a sequence of operators with the same precedence levelare grouped together in the absence of grouping parentheses.",
        kind: "Syntax",
        children: [

--- a/Sources/generate-swift-syntax-builder/gyb_generated/ExprNodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/ExprNodes.swift
@@ -14,6 +14,7 @@
 
 let EXPR_NODES: [Node] = [
   Node(name: "InOutExpr",
+       nameForDiagnostics: "inout expression",
        kind: "Expr",
        children: [
          Child(name: "Ampersand",
@@ -26,6 +27,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "PoundColumnExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "PoundColumn",
@@ -36,24 +38,29 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "TupleExprElementList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "TupleExprElement"),
 
   Node(name: "ArrayElementList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "ArrayElement"),
 
   Node(name: "DictionaryElementList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "DictionaryElement"),
 
   Node(name: "StringLiteralSegments",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "Syntax",
        elementName: "Segment",
        elementChoices: ["StringSegment", "ExpressionSegment"]),
 
   Node(name: "TryExpr",
+       nameForDiagnostics: "'try' expression",
        kind: "Expr",
        children: [
          Child(name: "TryKeyword",
@@ -73,6 +80,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "AwaitExpr",
+       nameForDiagnostics: "'await' expression",
        kind: "Expr",
        children: [
          Child(name: "AwaitKeyword",
@@ -88,6 +96,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "MoveExpr",
+       nameForDiagnostics: "'_move' expression",
        kind: "Expr",
        children: [
          Child(name: "MoveKeyword",
@@ -103,6 +112,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "DeclNameArgument",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        children: [
          Child(name: "Name",
@@ -115,10 +125,12 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "DeclNameArgumentList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "DeclNameArgument"),
 
   Node(name: "DeclNameArguments",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "Parenthesized"
@@ -140,6 +152,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "IdentifierExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "Identifier",
@@ -157,6 +170,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "SuperRefExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "SuperKeyword",
@@ -167,6 +181,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "NilLiteralExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "NilKeyword",
@@ -177,6 +192,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "DiscardAssignmentExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "Wildcard",
@@ -187,6 +203,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "AssignmentExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "AssignToken",
@@ -197,6 +214,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "SequenceExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "Elements",
@@ -205,12 +223,14 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ExprList",
+       nameForDiagnostics: nil,
        description: "A list of expressions connected by operators. This list is containedby a `SequenceExprSyntax`.",
        kind: "SyntaxCollection",
        element: "Expr",
        elementName: "Expression"),
 
   Node(name: "PoundLineExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "PoundLine",
@@ -221,6 +241,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "PoundFileExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "PoundFile",
@@ -231,6 +252,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "PoundFileIDExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "PoundFileID",
@@ -241,6 +263,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "PoundFilePathExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "PoundFilePath",
@@ -251,6 +274,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "PoundFunctionExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "PoundFunction",
@@ -261,6 +285,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "PoundDsohandleExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "PoundDsohandle",
@@ -271,6 +296,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "SymbolicReferenceExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "Identifier",
@@ -284,6 +310,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "PrefixOperatorExpr",
+       nameForDiagnostics: "prefix operator expression",
        kind: "Expr",
        children: [
          Child(name: "OperatorToken",
@@ -297,6 +324,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "BinaryOperatorExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "OperatorToken",
@@ -304,6 +332,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ArrowExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "AsyncKeyword",
@@ -329,6 +358,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "InfixOperatorExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "LeftOperand",
@@ -340,6 +370,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "FloatLiteralExpr",
+       nameForDiagnostics: "floating literal",
        kind: "Expr",
        children: [
          Child(name: "FloatingDigits",
@@ -350,6 +381,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "TupleExpr",
+       nameForDiagnostics: "tuple",
        kind: "Expr",
        traits: [
          "Parenthesized"
@@ -371,6 +403,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ArrayExpr",
+       nameForDiagnostics: "array",
        kind: "Expr",
        children: [
          Child(name: "LeftSquare",
@@ -389,6 +422,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "DictionaryExpr",
+       nameForDiagnostics: "dictionary",
        kind: "Expr",
        children: [
          Child(name: "LeftSquare",
@@ -415,6 +449,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "TupleExprElement",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -444,6 +479,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ArrayElement",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -460,6 +496,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "DictionaryElement",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -483,6 +520,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "IntegerLiteralExpr",
+       nameForDiagnostics: "integer literal",
        kind: "Expr",
        children: [
          Child(name: "Digits",
@@ -493,6 +531,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "BooleanLiteralExpr",
+       nameForDiagnostics: "bool literal",
        kind: "Expr",
        children: [
          Child(name: "BooleanLiteral",
@@ -504,6 +543,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "UnresolvedTernaryExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "QuestionMark",
@@ -521,6 +561,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "TernaryExpr",
+       nameForDiagnostics: "ternay expression",
        kind: "Expr",
        children: [
          Child(name: "ConditionExpression",
@@ -542,6 +583,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "MemberAccessExpr",
+       nameForDiagnostics: "member access",
        kind: "Expr",
        children: [
          Child(name: "Base",
@@ -561,6 +603,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "UnresolvedIsExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "IsTok",
@@ -571,6 +614,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "IsExpr",
+       nameForDiagnostics: "'is' expression",
        kind: "Expr",
        children: [
          Child(name: "Expression",
@@ -585,6 +629,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "UnresolvedAsExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "AsTok",
@@ -602,6 +647,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "AsExpr",
+       nameForDiagnostics: "'as' expression",
        kind: "Expr",
        children: [
          Child(name: "Expression",
@@ -623,6 +669,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "TypeExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "Type",
@@ -630,6 +677,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ClosureCaptureItem",
+       nameForDiagnostics: "closure capture item",
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -662,10 +710,12 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ClosureCaptureItemList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "ClosureCaptureItem"),
 
   Node(name: "ClosureCaptureSignature",
+       nameForDiagnostics: "closure capture signature",
        kind: "Syntax",
        children: [
          Child(name: "LeftSquare",
@@ -685,6 +735,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ClosureParam",
+       nameForDiagnostics: "closure parameter",
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -705,10 +756,12 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ClosureParamList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "ClosureParam"),
 
   Node(name: "ClosureSignature",
+       nameForDiagnostics: "closure signature",
        kind: "Syntax",
        children: [
          Child(name: "Attributes",
@@ -753,6 +806,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ClosureExpr",
+       nameForDiagnostics: "closure",
        kind: "Expr",
        traits: [
          "Braced",
@@ -780,6 +834,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "UnresolvedPatternExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "Pattern",
@@ -787,6 +842,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "MultipleTrailingClosureElement",
+       nameForDiagnostics: "trailing closure",
        kind: "Syntax",
        children: [
          Child(name: "Label",
@@ -805,10 +861,12 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "MultipleTrailingClosureElementList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "MultipleTrailingClosureElement"),
 
   Node(name: "FunctionCallExpr",
+       nameForDiagnostics: "function call",
        kind: "Expr",
        children: [
          Child(name: "CalledExpression",
@@ -838,6 +896,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "SubscriptExpr",
+       nameForDiagnostics: "subscript",
        kind: "Expr",
        children: [
          Child(name: "CalledExpression",
@@ -865,6 +924,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "OptionalChainingExpr",
+       nameForDiagnostics: "optional chaining",
        kind: "Expr",
        children: [
          Child(name: "Expression",
@@ -877,6 +937,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ForcedValueExpr",
+       nameForDiagnostics: "force unwrap",
        kind: "Expr",
        children: [
          Child(name: "Expression",
@@ -889,6 +950,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "PostfixUnaryExpr",
+       nameForDiagnostics: "postfix expression",
        kind: "Expr",
        children: [
          Child(name: "Expression",
@@ -901,6 +963,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "SpecializeExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "Expression",
@@ -910,6 +973,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "StringSegment",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        children: [
          Child(name: "Content",
@@ -920,6 +984,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ExpressionSegment",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "Parenthesized"
@@ -954,6 +1019,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "StringLiteralExpr",
+       nameForDiagnostics: "string literal",
        kind: "Expr",
        children: [
          Child(name: "OpenDelimiter",
@@ -986,6 +1052,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "RegexLiteralExpr",
+       nameForDiagnostics: "regex literal",
        kind: "Expr",
        children: [
          Child(name: "Regex",
@@ -996,6 +1063,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "KeyPathExpr",
+       nameForDiagnostics: "key path",
        kind: "Expr",
        children: [
          Child(name: "Backslash",
@@ -1019,6 +1087,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "KeyPathBaseExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "Period",
@@ -1029,6 +1098,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ObjcNamePiece",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        children: [
          Child(name: "Name",
@@ -1045,10 +1115,12 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ObjcName",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "ObjcNamePiece"),
 
   Node(name: "ObjcKeyPathExpr",
+       nameForDiagnostics: "'#keyPath' expression",
        kind: "Expr",
        traits: [
          "Parenthesized"
@@ -1075,6 +1147,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ObjcSelectorExpr",
+       nameForDiagnostics: "'#selector' expression",
        kind: "Expr",
        traits: [
          "Parenthesized"
@@ -1116,6 +1189,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "PostfixIfConfigExpr",
+       nameForDiagnostics: nil,
        kind: "Expr",
        children: [
          Child(name: "Base",
@@ -1126,6 +1200,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "EditorPlaceholderExpr",
+       nameForDiagnostics: "editor placeholder",
        kind: "Expr",
        children: [
          Child(name: "Identifier",
@@ -1136,6 +1211,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ObjectLiteralExpr",
+       nameForDiagnostics: "object literal",
        kind: "Expr",
        traits: [
          "Parenthesized"

--- a/Sources/generate-swift-syntax-builder/gyb_generated/GenericNodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/GenericNodes.swift
@@ -14,6 +14,7 @@
 
 let GENERIC_NODES: [Node] = [
   Node(name: "GenericWhereClause",
+       nameForDiagnostics: "'where' clause",
        kind: "Syntax",
        children: [
          Child(name: "WhereKeyword",
@@ -27,11 +28,13 @@ let GENERIC_NODES: [Node] = [
        ]),
 
   Node(name: "GenericRequirementList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "GenericRequirement",
        elementName: "GenericRequirement"),
 
   Node(name: "GenericRequirement",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -56,6 +59,7 @@ let GENERIC_NODES: [Node] = [
        ]),
 
   Node(name: "SameTypeRequirement",
+       nameForDiagnostics: "same type requirement",
        kind: "Syntax",
        children: [
          Child(name: "LeftTypeIdentifier",
@@ -73,6 +77,7 @@ let GENERIC_NODES: [Node] = [
        ]),
 
   Node(name: "LayoutRequirement",
+       nameForDiagnostics: "layout requirement",
        kind: "Syntax",
        children: [
          Child(name: "TypeIdentifier",
@@ -120,10 +125,12 @@ let GENERIC_NODES: [Node] = [
        ]),
 
   Node(name: "GenericParameterList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "GenericParameter"),
 
   Node(name: "GenericParameter",
+       nameForDiagnostics: "generic parameter",
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -156,10 +163,12 @@ let GENERIC_NODES: [Node] = [
        ]),
 
   Node(name: "PrimaryAssociatedTypeList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "PrimaryAssociatedType"),
 
   Node(name: "PrimaryAssociatedType",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -179,6 +188,7 @@ let GENERIC_NODES: [Node] = [
        ]),
 
   Node(name: "GenericParameterClause",
+       nameForDiagnostics: "generic parameter clause",
        kind: "Syntax",
        children: [
          Child(name: "LeftAngleBracket",
@@ -197,6 +207,7 @@ let GENERIC_NODES: [Node] = [
        ]),
 
   Node(name: "ConformanceRequirement",
+       nameForDiagnostics: "conformance requirement",
        kind: "Syntax",
        children: [
          Child(name: "LeftTypeIdentifier",
@@ -211,6 +222,7 @@ let GENERIC_NODES: [Node] = [
        ]),
 
   Node(name: "PrimaryAssociatedTypeClause",
+       nameForDiagnostics: "primary associated type clause",
        kind: "Syntax",
        children: [
          Child(name: "LeftAngleBracket",

--- a/Sources/generate-swift-syntax-builder/gyb_generated/PatternNodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/PatternNodes.swift
@@ -14,6 +14,7 @@
 
 let PATTERN_NODES: [Node] = [
   Node(name: "TypeAnnotation",
+       nameForDiagnostics: "type annotation",
        kind: "Syntax",
        children: [
          Child(name: "Colon",
@@ -26,6 +27,7 @@ let PATTERN_NODES: [Node] = [
        ]),
 
   Node(name: "EnumCasePattern",
+       nameForDiagnostics: "enum case pattern",
        kind: "Pattern",
        children: [
          Child(name: "Type",
@@ -47,6 +49,7 @@ let PATTERN_NODES: [Node] = [
        ]),
 
   Node(name: "IsTypePattern",
+       nameForDiagnostics: "'is' pattern",
        kind: "Pattern",
        children: [
          Child(name: "IsKeyword",
@@ -59,6 +62,7 @@ let PATTERN_NODES: [Node] = [
        ]),
 
   Node(name: "OptionalPattern",
+       nameForDiagnostics: "optional pattern",
        kind: "Pattern",
        children: [
          Child(name: "SubPattern",
@@ -71,6 +75,7 @@ let PATTERN_NODES: [Node] = [
        ]),
 
   Node(name: "IdentifierPattern",
+       nameForDiagnostics: "pattern",
        kind: "Pattern",
        children: [
          Child(name: "Identifier",
@@ -82,6 +87,7 @@ let PATTERN_NODES: [Node] = [
        ]),
 
   Node(name: "AsTypePattern",
+       nameForDiagnostics: "'as' pattern",
        kind: "Pattern",
        children: [
          Child(name: "Pattern",
@@ -96,6 +102,7 @@ let PATTERN_NODES: [Node] = [
        ]),
 
   Node(name: "TuplePattern",
+       nameForDiagnostics: "tuple pattern",
        kind: "Pattern",
        traits: [
          "Parenthesized"
@@ -117,6 +124,7 @@ let PATTERN_NODES: [Node] = [
        ]),
 
   Node(name: "WildcardPattern",
+       nameForDiagnostics: "wildcard pattern",
        kind: "Pattern",
        children: [
          Child(name: "Wildcard",
@@ -130,6 +138,7 @@ let PATTERN_NODES: [Node] = [
        ]),
 
   Node(name: "TuplePatternElement",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -158,6 +167,7 @@ let PATTERN_NODES: [Node] = [
        ]),
 
   Node(name: "ExpressionPattern",
+       nameForDiagnostics: "pattern",
        kind: "Pattern",
        children: [
          Child(name: "Expression",
@@ -165,10 +175,12 @@ let PATTERN_NODES: [Node] = [
        ]),
 
   Node(name: "TuplePatternElementList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "TuplePatternElement"),
 
   Node(name: "ValueBindingPattern",
+       nameForDiagnostics: "value binding pattern",
        kind: "Pattern",
        children: [
          Child(name: "LetOrVarKeyword",

--- a/Sources/generate-swift-syntax-builder/gyb_generated/StmtNodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/StmtNodes.swift
@@ -14,6 +14,7 @@
 
 let STMT_NODES: [Node] = [
   Node(name: "LabeledStmt",
+       nameForDiagnostics: "labeled statement",
        kind: "Stmt",
        children: [
          Child(name: "LabelName",
@@ -31,6 +32,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "ContinueStmt",
+       nameForDiagnostics: "'continue' statement",
        kind: "Stmt",
        children: [
          Child(name: "ContinueKeyword",
@@ -47,6 +49,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "WhileStmt",
+       nameForDiagnostics: "'while' statement",
        kind: "Stmt",
        traits: [
          "WithCodeBlock"
@@ -65,6 +68,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "DeferStmt",
+       nameForDiagnostics: "'defer' statement",
        kind: "Stmt",
        traits: [
          "WithCodeBlock"
@@ -80,6 +84,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "ExpressionStmt",
+       nameForDiagnostics: "expression",
        kind: "Stmt",
        children: [
          Child(name: "Expression",
@@ -87,6 +92,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "SwitchCaseList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "Syntax",
        elementName: "SwitchCase",
@@ -94,6 +100,7 @@ let STMT_NODES: [Node] = [
        elementsSeparatedByNewline: true),
 
   Node(name: "RepeatWhileStmt",
+       nameForDiagnostics: "'repeat' statement",
        kind: "Stmt",
        traits: [
          "WithCodeBlock"
@@ -116,6 +123,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "GuardStmt",
+       nameForDiagnostics: "'guard' statement",
        kind: "Stmt",
        traits: [
          "WithCodeBlock"
@@ -139,6 +147,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "WhereClause",
+       nameForDiagnostics: "'where' clause",
        kind: "Syntax",
        children: [
          Child(name: "WhereKeyword",
@@ -151,6 +160,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "ForInStmt",
+       nameForDiagnostics: "'for' statement",
        kind: "Stmt",
        traits: [
          "WithCodeBlock"
@@ -203,6 +213,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "SwitchStmt",
+       nameForDiagnostics: "'switch' statement",
        kind: "Stmt",
        traits: [
          "Braced"
@@ -232,10 +243,12 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "CatchClauseList",
+       nameForDiagnostics: "'catch' clause",
        kind: "SyntaxCollection",
        element: "CatchClause"),
 
   Node(name: "DoStmt",
+       nameForDiagnostics: "'do' statement",
        kind: "Stmt",
        traits: [
          "WithCodeBlock"
@@ -255,6 +268,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "ReturnStmt",
+       nameForDiagnostics: "'return' statement",
        kind: "Stmt",
        children: [
          Child(name: "ReturnKeyword",
@@ -268,6 +282,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "YieldStmt",
+       nameForDiagnostics: "'yield' statement",
        kind: "Stmt",
        children: [
          Child(name: "YieldKeyword",
@@ -286,6 +301,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "YieldList",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        children: [
          Child(name: "LeftParen",
@@ -310,6 +326,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "FallthroughStmt",
+       nameForDiagnostics: "'fallthrough' statement",
        kind: "Stmt",
        children: [
          Child(name: "FallthroughKeyword",
@@ -320,6 +337,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "BreakStmt",
+       nameForDiagnostics: "'break' statement",
        kind: "Stmt",
        children: [
          Child(name: "BreakKeyword",
@@ -336,14 +354,17 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "CaseItemList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "CaseItem"),
 
   Node(name: "CatchItemList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "CatchItem"),
 
   Node(name: "ConditionElement",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -372,6 +393,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "AvailabilityCondition",
+       nameForDiagnostics: "'#availabile' condition",
        kind: "Syntax",
        children: [
          Child(name: "PoundAvailableKeyword",
@@ -395,6 +417,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "MatchingPatternCondition",
+       nameForDiagnostics: "pattern matching",
        kind: "Syntax",
        children: [
          Child(name: "CaseKeyword",
@@ -412,6 +435,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "OptionalBindingCondition",
+       nameForDiagnostics: "optional binding",
        kind: "Syntax",
        children: [
          Child(name: "LetOrVarKeyword",
@@ -431,6 +455,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "UnavailabilityCondition",
+       nameForDiagnostics: "'#unavailable' condition",
        kind: "Syntax",
        children: [
          Child(name: "PoundUnavailableKeyword",
@@ -454,10 +479,12 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "ConditionElementList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "ConditionElement"),
 
   Node(name: "DeclarationStmt",
+       nameForDiagnostics: "declaration",
        kind: "Stmt",
        children: [
          Child(name: "Declaration",
@@ -465,6 +492,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "ThrowStmt",
+       nameForDiagnostics: "'throw' statement",
        kind: "Stmt",
        children: [
          Child(name: "ThrowKeyword",
@@ -477,6 +505,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "IfStmt",
+       nameForDiagnostics: "'if' statement",
        kind: "Stmt",
        traits: [
          "WithCodeBlock"
@@ -510,6 +539,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "ElseIfContinuation",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        children: [
          Child(name: "IfStatement",
@@ -517,6 +547,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "ElseBlock",
+       nameForDiagnostics: "else block",
        kind: "Syntax",
        traits: [
          "WithCodeBlock"
@@ -532,6 +563,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "SwitchCase",
+       nameForDiagnostics: "switch case",
        kind: "Syntax",
        traits: [
          "WithStatements"
@@ -555,6 +587,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "SwitchDefaultLabel",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        children: [
          Child(name: "DefaultKeyword",
@@ -570,6 +603,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "CaseItem",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -589,6 +623,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "CatchItem",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -609,6 +644,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "SwitchCaseLabel",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        children: [
          Child(name: "CaseKeyword",
@@ -627,6 +663,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "CatchClause",
+       nameForDiagnostics: "'catch' clause",
        kind: "Syntax",
        traits: [
          "WithCodeBlock"
@@ -646,6 +683,7 @@ let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "PoundAssertStmt",
+       nameForDiagnostics: "'#assert' statement",
        kind: "Stmt",
        children: [
          Child(name: "PoundAssert",

--- a/Sources/generate-swift-syntax-builder/gyb_generated/TypeNodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/TypeNodes.swift
@@ -14,6 +14,7 @@
 
 let TYPE_NODES: [Node] = [
   Node(name: "SimpleTypeIdentifier",
+       nameForDiagnostics: "type",
        kind: "Type",
        children: [
          Child(name: "Name",
@@ -30,6 +31,7 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "MemberTypeIdentifier",
+       nameForDiagnostics: "member type",
        kind: "Type",
        children: [
          Child(name: "BaseType",
@@ -54,6 +56,7 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "ClassRestrictionType",
+       nameForDiagnostics: nil,
        kind: "Type",
        children: [
          Child(name: "ClassKeyword",
@@ -64,6 +67,7 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "ArrayType",
+       nameForDiagnostics: "array type",
        kind: "Type",
        children: [
          Child(name: "LeftSquareBracket",
@@ -81,6 +85,7 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "DictionaryType",
+       nameForDiagnostics: "dictionary type",
        kind: "Type",
        children: [
          Child(name: "LeftSquareBracket",
@@ -105,6 +110,7 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "MetatypeType",
+       nameForDiagnostics: "metatype",
        kind: "Type",
        children: [
          Child(name: "BaseType",
@@ -126,6 +132,7 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "OptionalType",
+       nameForDiagnostics: "optional type",
        kind: "Type",
        children: [
          Child(name: "WrappedType",
@@ -138,6 +145,7 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "ConstrainedSugarType",
+       nameForDiagnostics: "type",
        kind: "Type",
        children: [
          Child(name: "SomeOrAnySpecifier",
@@ -155,6 +163,7 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "ImplicitlyUnwrappedOptionalType",
+       nameForDiagnostics: "implicitly unwrapped optional type",
        kind: "Type",
        children: [
          Child(name: "WrappedType",
@@ -167,6 +176,7 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "CompositionTypeElement",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        children: [
          Child(name: "Type",
@@ -180,10 +190,12 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "CompositionTypeElementList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "CompositionTypeElement"),
   
   Node(name: "CompositionType",
+       nameForDiagnostics: "type composition",
        kind: "Type",
        children: [
          Child(name: "Elements",
@@ -192,6 +204,7 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "TupleTypeElement",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -243,10 +256,12 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "TupleTypeElementList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "TupleTypeElement"),
   
   Node(name: "TupleType",
+       nameForDiagnostics: "tuple type",
        kind: "Type",
        traits: [
          "Parenthesized"
@@ -268,6 +283,7 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "FunctionType",
+       nameForDiagnostics: "function type",
        kind: "Type",
        traits: [
          "Parenthesized"
@@ -310,6 +326,7 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "AttributedType",
+       nameForDiagnostics: "type",
        kind: "Type",
        children: [
          Child(name: "Specifier",
@@ -329,10 +346,12 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "GenericArgumentList",
+       nameForDiagnostics: nil,
        kind: "SyntaxCollection",
        element: "GenericArgument"),
   
   Node(name: "GenericArgument",
+       nameForDiagnostics: "generic argument",
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -349,6 +368,7 @@ let TYPE_NODES: [Node] = [
        ]),
   
   Node(name: "GenericArgumentClause",
+       nameForDiagnostics: "generic argument clause",
        kind: "Syntax",
        children: [
          Child(name: "LeftAngleBracket",

--- a/Sources/generate-swift-syntax-builder/gyb_helpers/utils.py
+++ b/Sources/generate-swift-syntax-builder/gyb_helpers/utils.py
@@ -6,7 +6,11 @@ def make_swift_node(node):
   """
   spaces = 9
   parameters = ['name: "%s"' % node.syntax_kind]
-  
+  if node.name_for_diagnostics:
+    parameters += [f'nameForDiagnostics: "{node.name_for_diagnostics}"']
+  else:
+    parameters += ['nameForDiagnostics: nil']
+
   if node.description:
     parameters += ['description: "%s"' % flat_documentation(node.description)]
 

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -138,7 +138,7 @@ func AssertDiagnostic<T: SyntaxProtocol>(
     XCTAssertEqual(diag.diagnosticID, id, file: file, line: line)
   }
   if let message = spec.message {
-    XCTAssertEqual(diag.message, message, file: file, line: line)
+    AssertStringsEqualWithDiff(diag.message, message, file: file, line: line)
   }
   if let highlight = spec.highlight {
     AssertStringsEqualWithDiff(diag.highlights.map(\.description).joined(), highlight, file: file, line: line)

--- a/Tests/SwiftParserTest/Attributes.swift
+++ b/Tests/SwiftParserTest/Attributes.swift
@@ -11,10 +11,9 @@ final class AttributeTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // FIXME: We should be complaining about the missing ')' for the attribute
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected 'for'"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ':'"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected ')'"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected 'for' in attribute argument"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ':' in attribute argument"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected ')' to end attribute"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -451,7 +451,7 @@ final class DeclarationTests: XCTestCase {
       """,
       diagnostics: [
         // FIXME: This diagnostic should be more contextual
-        DiagnosticSpec(message: "Expected '->'")
+        DiagnosticSpec(message: "Expected '->' in return clause")
       ]
     )
   }
@@ -469,9 +469,9 @@ final class DeclarationTests: XCTestCase {
       """,
       // FIXME: These are simply bad diagnostics. We should be complaining that identifiers cannot start with digits.
       diagnostics: [
-        DiagnosticSpec(message: "Expected '' in declaration"),
-        DiagnosticSpec(message: "Expected '{'"),
-        DiagnosticSpec(message: "Expected '}'"),
+        DiagnosticSpec(message: "Expected '' in class"),
+        DiagnosticSpec(message: "Expected '{' to start class"),
+        DiagnosticSpec(message: "Expected '}' to end class"),
       ]
     )
   }
@@ -506,7 +506,7 @@ final class DeclarationTests: XCTestCase {
         DiagnosticSpec(
           message: """
             Unexpected text '
-              / ###line 25 "line-directive.swift"'
+              / ###line 25 "line-directive.swift"' found in struct
             """
         )
       ]
@@ -530,8 +530,8 @@ final class DeclarationTests: XCTestCase {
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do #^DIAG_1^#eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.#^DIAG_2^#
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected '{'"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '}'"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected '{' to start 'do' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '}' to end 'do' statement"),
       ]
     )
   }
@@ -595,9 +595,9 @@ final class DeclarationTests: XCTestCase {
         DiagnosticSpec(locationMarker: "MISSING_COLON", message: "Expected ':' in function parameter"),
         DiagnosticSpec(locationMarker: "MISSING_RPAREN", message: "Expected ')' to end parameter clause"),
         // FIXME: We should issues something like "Expected identifier in declaration"
-        DiagnosticSpec(locationMarker: "MISSING_IDENTIFIER", message: "Expected '' in declaration"),
-        DiagnosticSpec(locationMarker: "BRACES", message: "Expected '{'"),
-        DiagnosticSpec(locationMarker: "BRACES", message: "Expected '}'"),
+        DiagnosticSpec(locationMarker: "MISSING_IDENTIFIER", message: "Expected '' in struct"),
+        DiagnosticSpec(locationMarker: "BRACES", message: "Expected '{' to start struct"),
+        DiagnosticSpec(locationMarker: "BRACES", message: "Expected '}' to end struct"),
       ]
     )
   }
@@ -647,7 +647,7 @@ final class DeclarationTests: XCTestCase {
       )),
       diagnostics: [
         DiagnosticSpec(locationMarker: "COLON", message: "Expected ':' in function parameter"),
-        DiagnosticSpec(locationMarker: "RSQUARE_COLON" , message: "Expected ']' to end type"),
+        DiagnosticSpec(locationMarker: "RSQUARE_COLON" , message: "Expected ']' to end array type"),
         DiagnosticSpec(locationMarker: "RSQUARE_COLON", message: "Expected ')' to end parameter clause"),
       ]
     )

--- a/Tests/SwiftParserTest/Directives.swift
+++ b/Tests/SwiftParserTest/Directives.swift
@@ -75,7 +75,7 @@ final class DirectiveTests: XCTestCase {
     AssertParse(
       "#if test#^DIAG^#",
       diagnostics: [
-        DiagnosticSpec(message: "Expected '#endif' in declaration")
+        DiagnosticSpec(message: "Expected '#endif' in conditional compilation block")
       ]
     )
   }

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -132,7 +132,7 @@ final class ExpressionTests: XCTestCase {
     AssertParse(
       "[,#^DIAG^#",
       diagnostics: [
-        DiagnosticSpec(message: "Expected ']' to end expression")
+        DiagnosticSpec(message: "Expected ']' to end array")
       ]
     )
 
@@ -142,8 +142,8 @@ final class ExpressionTests: XCTestCase {
       """,
       diagnostics: [
         // FIXME: Why is this diagnostic produced?
-        DiagnosticSpec(message: "Expected ':'"),
-        DiagnosticSpec(message: "Expected ']' to end expression"),
+        DiagnosticSpec(message: "Expected ':' in dictionary"),
+        DiagnosticSpec(message: "Expected ']' to end dictionary"),
       ]
     )
   }
@@ -202,7 +202,7 @@ final class ExpressionTests: XCTestCase {
       " >> \( abc #^DIAG^#} ) << "
       """#,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text '} '")
+        DiagnosticSpec(message: "Unexpected text '} ' found in string literal")
       ]
     )
 
@@ -223,8 +223,7 @@ final class ExpressionTests: XCTestCase {
       "\",#^DIAG^#
       """#,
       diagnostics: [
-        // FIXME: Should be Expected '"' in string literal
-        DiagnosticSpec(message: #"Expected '"' in expression"#)
+        DiagnosticSpec(message: #"Expected '"' in string literal"#)
       ]
     )
 
@@ -291,8 +290,7 @@ final class ExpressionTests: XCTestCase {
        """"#^DIAG^#
        """##,
        diagnostics: [
-         // FIXME: This should say: Expected '"""' in string literal
-         DiagnosticSpec(message: #"Expected '"""' in expression"#)
+         DiagnosticSpec(message: #"Expected '"""' in string literal"#)
        ]
      )
 
@@ -301,8 +299,7 @@ final class ExpressionTests: XCTestCase {
        """""#^DIAG^#
        """##,
        diagnostics: [
-         // FIXME: This should say: Expected '"""' in string literal
-         DiagnosticSpec(message: #"Expected '"""' in expression"#)
+         DiagnosticSpec(message: #"Expected '"""' in string literal"#)
        ]
      )
 
@@ -328,7 +325,7 @@ final class ExpressionTests: XCTestCase {
     AssertParse(
       #"\\(#^DIAG^#"#,
       diagnostics: [
-        DiagnosticSpec(message: "Expected ')' to end expression")
+        DiagnosticSpec(message: "Expected ')' to end tuple")
       ]
     )
 
@@ -343,7 +340,7 @@ final class ExpressionTests: XCTestCase {
       "#^DIAG^#
       """#,
       diagnostics: [
-        DiagnosticSpec(message: #"Expected '"' in expression"#)
+        DiagnosticSpec(message: #"Expected '"' in string literal"#)
       ]
     )
 
@@ -352,7 +349,7 @@ final class ExpressionTests: XCTestCase {
       "'#^DIAG^#
       """#,
       diagnostics: [
-        DiagnosticSpec(message: #"Expected '"' in expression"#)
+        DiagnosticSpec(message: #"Expected '"' in string literal"#)
       ]
     )
   }
@@ -380,9 +377,9 @@ final class ExpressionTests: XCTestCase {
       func nestThoseIfs() {\n    if false != true {\n       print "\(i)\"\n#^DIAG^#
       """#,
       diagnostics: [
-        DiagnosticSpec(message: #"Expected '"' in expression"#),
-        DiagnosticSpec(message: "Expected '}'"),
-        DiagnosticSpec(message: "Expected '}'"),
+        DiagnosticSpec(message: #"Expected '"' in string literal"#),
+        DiagnosticSpec(message: "Expected '}' to end 'if' statement"),
+        DiagnosticSpec(message: "Expected '}' to end function"),
       ]
     )
   }
@@ -392,14 +389,14 @@ final class ExpressionTests: XCTestCase {
       "[(Int) -> #^DIAG^#throws Int]()",
       diagnostics: [
         // FIXME: We should suggest to move 'throws' in front of '->'
-        DiagnosticSpec(message: "Unexpected text 'throws Int' found in expression")
+        DiagnosticSpec(message: "Unexpected text 'throws Int' found in array")
       ]
     )
 
     AssertParse(
       "let _ = [Int throws #^DIAG^#Int]()",
       diagnostics: [
-        DiagnosticSpec(message: "Expected '->' in expression")
+        DiagnosticSpec(message: "Expected '->' in array")
       ]
     )
   }

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -13,8 +13,8 @@ final class StatementTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected '='"),
-        DiagnosticSpec(message: "Unexpected text '* ! = x '"),
+        DiagnosticSpec(message: "Expected '=' in pattern matching"),
+        DiagnosticSpec(message: "Unexpected text '* ! = x ' found in 'if' statement"),
       ]
     )
   }


### PR DESCRIPTION
This produces more meaningful, contextual diagnostics and removes a FIXME that we were maintaining node names for diagnostics in SwiftParser.