### PR TITLE
Reapply: Use RawSyntax address as the 'rootId' of SyntaxIdentifier

### DIFF
--- a/Sources/SwiftSyntax/SyntaxChildren.swift
+++ b/Sources/SwiftSyntax/SyntaxChildren.swift
@@ -91,7 +91,7 @@ public struct SyntaxChildrenIndex: Comparable, ExpressibleByNilLiteral {
 
 fileprivate extension AbsoluteSyntaxInfo {
   /// Construct `AbsoluteSyntaxInfo` from the given index data and a `rootId`.
-  init(index: SyntaxChildrenIndexData, rootId: UInt32) {
+  init(index: SyntaxChildrenIndexData, rootId: UInt) {
     let position = AbsoluteSyntaxPosition(offset: index.offset,
                                           indexInParent: index.indexInParent)
     let identifier = SyntaxIdentifier(rootId: rootId,
@@ -137,7 +137,7 @@ struct RawSyntaxChildren: BidirectionalCollection {
   }
 
   /// The rootId of the tree the child nodes belong to
-  private let rootId: UInt32
+  private let rootId: UInt
   /// The number of childer in `parent`. Cached to avoid reaching into `parent` for every index
   /// advancement
   // FIXME: Do we need this cached?


### PR DESCRIPTION
(Reapply #635 without `_CSwiftSyntax` changes.)

---
We don't need to guarantee the uniqueness throughout the process lifetime. but only need to guarantee the uniqueness while the object is alive.