### PR TITLE
Add trailing trivia and `with{Leading,Trailing}Trivia` to buildable nodes

### DIFF
--- a/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
@@ -16,6 +16,10 @@
 import SwiftSyntax
 /// `CodeBlockItemList` represents a collection of `CodeBlockItem`
 public struct CodeBlockItemList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsCodeBlockItemList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [CodeBlockItem]
   /// Creates a `CodeBlockItemList` with the provided list of elements.
   /// - Parameters:
@@ -35,9 +39,15 @@ public struct CodeBlockItemList: ExpressibleByArrayLiteral, SyntaxBuildable, Exp
     self.init(elements)
   }
   public func buildCodeBlockItemList(format: Format) -> CodeBlockItemListSyntax {
-    let result = CodeBlockItemListSyntax(elements.map {
+    var result = CodeBlockItemListSyntax(elements.map {
       $0.buildCodeBlockItem(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -54,9 +64,23 @@ public struct CodeBlockItemList: ExpressibleByArrayLiteral, SyntaxBuildable, Exp
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// A collection of syntax nodes that occurred in the source code butcould not be used to form a valid syntax tree.
 public struct UnexpectedNodes: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsUnexpectedNodes {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [SyntaxBuildable]
   /// Creates a `UnexpectedNodes` with the provided list of elements.
   /// - Parameters:
@@ -76,9 +100,15 @@ public struct UnexpectedNodes: ExpressibleByArrayLiteral, SyntaxBuildable, Expre
     self.init(elements)
   }
   public func buildUnexpectedNodes(format: Format) -> UnexpectedNodesSyntax {
-    let result = UnexpectedNodesSyntax(elements.map {
+    var result = UnexpectedNodesSyntax(elements.map {
       $0.buildSyntax(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -95,6 +125,16 @@ public struct UnexpectedNodes: ExpressibleByArrayLiteral, SyntaxBuildable, Expre
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsUnexpectedNodes where Element == ExpressibleAsSyntaxBuildable {
   public func createUnexpectedNodes() -> UnexpectedNodes {
@@ -103,6 +143,10 @@ extension Array: ExpressibleAsUnexpectedNodes where Element == ExpressibleAsSynt
 }
 /// `TupleExprElementList` represents a collection of `TupleExprElement`
 public struct TupleExprElementList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsTupleExprElementList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [TupleExprElement]
   /// Creates a `TupleExprElementList` with the provided list of elements.
   /// - Parameters:
@@ -122,9 +166,15 @@ public struct TupleExprElementList: ExpressibleByArrayLiteral, SyntaxBuildable, 
     self.init(elements)
   }
   public func buildTupleExprElementList(format: Format) -> TupleExprElementListSyntax {
-    let result = TupleExprElementListSyntax(elements.map {
+    var result = TupleExprElementListSyntax(elements.map {
       $0.buildTupleExprElement(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -141,6 +191,16 @@ public struct TupleExprElementList: ExpressibleByArrayLiteral, SyntaxBuildable, 
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsTupleExprElementList where Element == ExpressibleAsTupleExprElement {
   public func createTupleExprElementList() -> TupleExprElementList {
@@ -149,6 +209,10 @@ extension Array: ExpressibleAsTupleExprElementList where Element == ExpressibleA
 }
 /// `ArrayElementList` represents a collection of `ArrayElement`
 public struct ArrayElementList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsArrayElementList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [ArrayElement]
   /// Creates a `ArrayElementList` with the provided list of elements.
   /// - Parameters:
@@ -168,9 +232,15 @@ public struct ArrayElementList: ExpressibleByArrayLiteral, SyntaxBuildable, Expr
     self.init(elements)
   }
   public func buildArrayElementList(format: Format) -> ArrayElementListSyntax {
-    let result = ArrayElementListSyntax(elements.map {
+    var result = ArrayElementListSyntax(elements.map {
       $0.buildArrayElement(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -187,9 +257,23 @@ public struct ArrayElementList: ExpressibleByArrayLiteral, SyntaxBuildable, Expr
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// `DictionaryElementList` represents a collection of `DictionaryElement`
 public struct DictionaryElementList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsDictionaryElementList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [DictionaryElement]
   /// Creates a `DictionaryElementList` with the provided list of elements.
   /// - Parameters:
@@ -209,9 +293,15 @@ public struct DictionaryElementList: ExpressibleByArrayLiteral, SyntaxBuildable,
     self.init(elements)
   }
   public func buildDictionaryElementList(format: Format) -> DictionaryElementListSyntax {
-    let result = DictionaryElementListSyntax(elements.map {
+    var result = DictionaryElementListSyntax(elements.map {
       $0.buildDictionaryElement(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -228,6 +318,16 @@ public struct DictionaryElementList: ExpressibleByArrayLiteral, SyntaxBuildable,
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsDictionaryElementList where Element == ExpressibleAsDictionaryElement {
   public func createDictionaryElementList() -> DictionaryElementList {
@@ -236,6 +336,10 @@ extension Array: ExpressibleAsDictionaryElementList where Element == Expressible
 }
 /// `StringLiteralSegments` represents a collection of `SyntaxBuildable`
 public struct StringLiteralSegments: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsStringLiteralSegments {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [SyntaxBuildable]
   /// Creates a `StringLiteralSegments` with the provided list of elements.
   /// - Parameters:
@@ -255,9 +359,15 @@ public struct StringLiteralSegments: ExpressibleByArrayLiteral, SyntaxBuildable,
     self.init(elements)
   }
   public func buildStringLiteralSegments(format: Format) -> StringLiteralSegmentsSyntax {
-    let result = StringLiteralSegmentsSyntax(elements.map {
+    var result = StringLiteralSegmentsSyntax(elements.map {
       $0.buildSyntax(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -274,6 +384,16 @@ public struct StringLiteralSegments: ExpressibleByArrayLiteral, SyntaxBuildable,
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsStringLiteralSegments where Element == ExpressibleAsSyntaxBuildable {
   public func createStringLiteralSegments() -> StringLiteralSegments {
@@ -282,6 +402,10 @@ extension Array: ExpressibleAsStringLiteralSegments where Element == Expressible
 }
 /// `DeclNameArgumentList` represents a collection of `DeclNameArgument`
 public struct DeclNameArgumentList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsDeclNameArgumentList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [DeclNameArgument]
   /// Creates a `DeclNameArgumentList` with the provided list of elements.
   /// - Parameters:
@@ -301,9 +425,15 @@ public struct DeclNameArgumentList: ExpressibleByArrayLiteral, SyntaxBuildable, 
     self.init(elements)
   }
   public func buildDeclNameArgumentList(format: Format) -> DeclNameArgumentListSyntax {
-    let result = DeclNameArgumentListSyntax(elements.map {
+    var result = DeclNameArgumentListSyntax(elements.map {
       $0.buildDeclNameArgument(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -320,6 +450,16 @@ public struct DeclNameArgumentList: ExpressibleByArrayLiteral, SyntaxBuildable, 
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsDeclNameArgumentList where Element == ExpressibleAsDeclNameArgument {
   public func createDeclNameArgumentList() -> DeclNameArgumentList {
@@ -328,6 +468,10 @@ extension Array: ExpressibleAsDeclNameArgumentList where Element == ExpressibleA
 }
 /// A list of expressions connected by operators. This list is containedby a `SequenceExprSyntax`.
 public struct ExprList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsExprList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [ExprBuildable]
   /// Creates a `ExprList` with the provided list of elements.
   /// - Parameters:
@@ -347,9 +491,15 @@ public struct ExprList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleA
     self.init(elements)
   }
   public func buildExprList(format: Format) -> ExprListSyntax {
-    let result = ExprListSyntax(elements.map {
+    var result = ExprListSyntax(elements.map {
       $0.buildExpr(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -366,9 +516,23 @@ public struct ExprList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleA
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// `ClosureCaptureItemList` represents a collection of `ClosureCaptureItem`
 public struct ClosureCaptureItemList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsClosureCaptureItemList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [ClosureCaptureItem]
   /// Creates a `ClosureCaptureItemList` with the provided list of elements.
   /// - Parameters:
@@ -388,9 +552,15 @@ public struct ClosureCaptureItemList: ExpressibleByArrayLiteral, SyntaxBuildable
     self.init(elements)
   }
   public func buildClosureCaptureItemList(format: Format) -> ClosureCaptureItemListSyntax {
-    let result = ClosureCaptureItemListSyntax(elements.map {
+    var result = ClosureCaptureItemListSyntax(elements.map {
       $0.buildClosureCaptureItem(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -407,6 +577,16 @@ public struct ClosureCaptureItemList: ExpressibleByArrayLiteral, SyntaxBuildable
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsClosureCaptureItemList where Element == ExpressibleAsClosureCaptureItem {
   public func createClosureCaptureItemList() -> ClosureCaptureItemList {
@@ -415,6 +595,10 @@ extension Array: ExpressibleAsClosureCaptureItemList where Element == Expressibl
 }
 /// `ClosureParamList` represents a collection of `ClosureParam`
 public struct ClosureParamList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsClosureParamList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [ClosureParam]
   /// Creates a `ClosureParamList` with the provided list of elements.
   /// - Parameters:
@@ -434,9 +618,15 @@ public struct ClosureParamList: ExpressibleByArrayLiteral, SyntaxBuildable, Expr
     self.init(elements)
   }
   public func buildClosureParamList(format: Format) -> ClosureParamListSyntax {
-    let result = ClosureParamListSyntax(elements.map {
+    var result = ClosureParamListSyntax(elements.map {
       $0.buildClosureParam(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -453,6 +643,16 @@ public struct ClosureParamList: ExpressibleByArrayLiteral, SyntaxBuildable, Expr
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsClosureParamList where Element == ExpressibleAsClosureParam {
   public func createClosureParamList() -> ClosureParamList {
@@ -461,6 +661,10 @@ extension Array: ExpressibleAsClosureParamList where Element == ExpressibleAsClo
 }
 /// `MultipleTrailingClosureElementList` represents a collection of `MultipleTrailingClosureElement`
 public struct MultipleTrailingClosureElementList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsMultipleTrailingClosureElementList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [MultipleTrailingClosureElement]
   /// Creates a `MultipleTrailingClosureElementList` with the provided list of elements.
   /// - Parameters:
@@ -480,9 +684,15 @@ public struct MultipleTrailingClosureElementList: ExpressibleByArrayLiteral, Syn
     self.init(elements)
   }
   public func buildMultipleTrailingClosureElementList(format: Format) -> MultipleTrailingClosureElementListSyntax {
-    let result = MultipleTrailingClosureElementListSyntax(elements.map {
+    var result = MultipleTrailingClosureElementListSyntax(elements.map {
       $0.buildMultipleTrailingClosureElement(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -499,6 +709,16 @@ public struct MultipleTrailingClosureElementList: ExpressibleByArrayLiteral, Syn
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsMultipleTrailingClosureElementList where Element == ExpressibleAsMultipleTrailingClosureElement {
   public func createMultipleTrailingClosureElementList() -> MultipleTrailingClosureElementList {
@@ -507,6 +727,10 @@ extension Array: ExpressibleAsMultipleTrailingClosureElementList where Element =
 }
 /// `ObjcName` represents a collection of `ObjcNamePiece`
 public struct ObjcName: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsObjcName {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [ObjcNamePiece]
   /// Creates a `ObjcName` with the provided list of elements.
   /// - Parameters:
@@ -526,9 +750,15 @@ public struct ObjcName: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleA
     self.init(elements)
   }
   public func buildObjcName(format: Format) -> ObjcNameSyntax {
-    let result = ObjcNameSyntax(elements.map {
+    var result = ObjcNameSyntax(elements.map {
       $0.buildObjcNamePiece(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -545,6 +775,16 @@ public struct ObjcName: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleA
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsObjcName where Element == ExpressibleAsObjcNamePiece {
   public func createObjcName() -> ObjcName {
@@ -553,6 +793,10 @@ extension Array: ExpressibleAsObjcName where Element == ExpressibleAsObjcNamePie
 }
 /// `FunctionParameterList` represents a collection of `FunctionParameter`
 public struct FunctionParameterList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsFunctionParameterList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [FunctionParameter]
   /// Creates a `FunctionParameterList` with the provided list of elements.
   /// - Parameters:
@@ -572,9 +816,15 @@ public struct FunctionParameterList: ExpressibleByArrayLiteral, SyntaxBuildable,
     self.init(elements)
   }
   public func buildFunctionParameterList(format: Format) -> FunctionParameterListSyntax {
-    let result = FunctionParameterListSyntax(elements.map {
+    var result = FunctionParameterListSyntax(elements.map {
       $0.buildFunctionParameter(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -591,6 +841,16 @@ public struct FunctionParameterList: ExpressibleByArrayLiteral, SyntaxBuildable,
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsFunctionParameterList where Element == ExpressibleAsFunctionParameter {
   public func createFunctionParameterList() -> FunctionParameterList {
@@ -599,6 +859,10 @@ extension Array: ExpressibleAsFunctionParameterList where Element == Expressible
 }
 /// `IfConfigClauseList` represents a collection of `IfConfigClause`
 public struct IfConfigClauseList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsIfConfigClauseList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [IfConfigClause]
   /// Creates a `IfConfigClauseList` with the provided list of elements.
   /// - Parameters:
@@ -618,9 +882,15 @@ public struct IfConfigClauseList: ExpressibleByArrayLiteral, SyntaxBuildable, Ex
     self.init(elements)
   }
   public func buildIfConfigClauseList(format: Format) -> IfConfigClauseListSyntax {
-    let result = IfConfigClauseListSyntax(elements.map {
+    var result = IfConfigClauseListSyntax(elements.map {
       $0.buildIfConfigClause(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -637,6 +907,16 @@ public struct IfConfigClauseList: ExpressibleByArrayLiteral, SyntaxBuildable, Ex
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsIfConfigClauseList where Element == ExpressibleAsIfConfigClause {
   public func createIfConfigClauseList() -> IfConfigClauseList {
@@ -645,6 +925,10 @@ extension Array: ExpressibleAsIfConfigClauseList where Element == ExpressibleAsI
 }
 /// `InheritedTypeList` represents a collection of `InheritedType`
 public struct InheritedTypeList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsInheritedTypeList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [InheritedType]
   /// Creates a `InheritedTypeList` with the provided list of elements.
   /// - Parameters:
@@ -664,9 +948,15 @@ public struct InheritedTypeList: ExpressibleByArrayLiteral, SyntaxBuildable, Exp
     self.init(elements)
   }
   public func buildInheritedTypeList(format: Format) -> InheritedTypeListSyntax {
-    let result = InheritedTypeListSyntax(elements.map {
+    var result = InheritedTypeListSyntax(elements.map {
       $0.buildInheritedType(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -683,6 +973,16 @@ public struct InheritedTypeList: ExpressibleByArrayLiteral, SyntaxBuildable, Exp
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsInheritedTypeList where Element == ExpressibleAsInheritedType {
   public func createInheritedTypeList() -> InheritedTypeList {
@@ -691,6 +991,10 @@ extension Array: ExpressibleAsInheritedTypeList where Element == ExpressibleAsIn
 }
 /// `MemberDeclList` represents a collection of `MemberDeclListItem`
 public struct MemberDeclList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsMemberDeclList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [MemberDeclListItem]
   /// Creates a `MemberDeclList` with the provided list of elements.
   /// - Parameters:
@@ -710,9 +1014,15 @@ public struct MemberDeclList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
     self.init(elements)
   }
   public func buildMemberDeclList(format: Format) -> MemberDeclListSyntax {
-    let result = MemberDeclListSyntax(elements.map {
+    var result = MemberDeclListSyntax(elements.map {
       $0.buildMemberDeclListItem(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -729,9 +1039,23 @@ public struct MemberDeclList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// `ModifierList` represents a collection of `DeclModifier`
 public struct ModifierList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsModifierList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [DeclModifier]
   /// Creates a `ModifierList` with the provided list of elements.
   /// - Parameters:
@@ -751,9 +1075,15 @@ public struct ModifierList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
     self.init(elements)
   }
   public func buildModifierList(format: Format) -> ModifierListSyntax {
-    let result = ModifierListSyntax(elements.map {
+    var result = ModifierListSyntax(elements.map {
       $0.buildDeclModifier(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -770,6 +1100,16 @@ public struct ModifierList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsModifierList where Element == ExpressibleAsDeclModifier {
   public func createModifierList() -> ModifierList {
@@ -778,6 +1118,10 @@ extension Array: ExpressibleAsModifierList where Element == ExpressibleAsDeclMod
 }
 /// `AccessPath` represents a collection of `AccessPathComponent`
 public struct AccessPath: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsAccessPath {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [AccessPathComponent]
   /// Creates a `AccessPath` with the provided list of elements.
   /// - Parameters:
@@ -797,9 +1141,15 @@ public struct AccessPath: ExpressibleByArrayLiteral, SyntaxBuildable, Expressibl
     self.init(elements)
   }
   public func buildAccessPath(format: Format) -> AccessPathSyntax {
-    let result = AccessPathSyntax(elements.map {
+    var result = AccessPathSyntax(elements.map {
       $0.buildAccessPathComponent(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -816,6 +1166,16 @@ public struct AccessPath: ExpressibleByArrayLiteral, SyntaxBuildable, Expressibl
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsAccessPath where Element == ExpressibleAsAccessPathComponent {
   public func createAccessPath() -> AccessPath {
@@ -824,6 +1184,10 @@ extension Array: ExpressibleAsAccessPath where Element == ExpressibleAsAccessPat
 }
 /// `AccessorList` represents a collection of `AccessorDecl`
 public struct AccessorList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsAccessorList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [AccessorDecl]
   /// Creates a `AccessorList` with the provided list of elements.
   /// - Parameters:
@@ -843,9 +1207,15 @@ public struct AccessorList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
     self.init(elements)
   }
   public func buildAccessorList(format: Format) -> AccessorListSyntax {
-    let result = AccessorListSyntax(elements.map {
+    var result = AccessorListSyntax(elements.map {
       $0.buildAccessorDecl(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -862,9 +1232,23 @@ public struct AccessorList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// `PatternBindingList` represents a collection of `PatternBinding`
 public struct PatternBindingList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsPatternBindingList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [PatternBinding]
   /// Creates a `PatternBindingList` with the provided list of elements.
   /// - Parameters:
@@ -884,9 +1268,15 @@ public struct PatternBindingList: ExpressibleByArrayLiteral, SyntaxBuildable, Ex
     self.init(elements)
   }
   public func buildPatternBindingList(format: Format) -> PatternBindingListSyntax {
-    let result = PatternBindingListSyntax(elements.map {
+    var result = PatternBindingListSyntax(elements.map {
       $0.buildPatternBinding(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -903,6 +1293,16 @@ public struct PatternBindingList: ExpressibleByArrayLiteral, SyntaxBuildable, Ex
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsPatternBindingList where Element == ExpressibleAsPatternBinding {
   public func createPatternBindingList() -> PatternBindingList {
@@ -911,6 +1311,10 @@ extension Array: ExpressibleAsPatternBindingList where Element == ExpressibleAsP
 }
 /// A collection of 0 or more `EnumCaseElement`s.
 public struct EnumCaseElementList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsEnumCaseElementList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [EnumCaseElement]
   /// Creates a `EnumCaseElementList` with the provided list of elements.
   /// - Parameters:
@@ -930,9 +1334,15 @@ public struct EnumCaseElementList: ExpressibleByArrayLiteral, SyntaxBuildable, E
     self.init(elements)
   }
   public func buildEnumCaseElementList(format: Format) -> EnumCaseElementListSyntax {
-    let result = EnumCaseElementListSyntax(elements.map {
+    var result = EnumCaseElementListSyntax(elements.map {
       $0.buildEnumCaseElement(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -949,6 +1359,16 @@ public struct EnumCaseElementList: ExpressibleByArrayLiteral, SyntaxBuildable, E
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsEnumCaseElementList where Element == ExpressibleAsEnumCaseElement {
   public func createEnumCaseElementList() -> EnumCaseElementList {
@@ -957,6 +1377,10 @@ extension Array: ExpressibleAsEnumCaseElementList where Element == ExpressibleAs
 }
 /// `IdentifierList` represents a collection of `Token`
 public struct IdentifierList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsIdentifierList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [Token]
   /// Creates a `IdentifierList` with the provided list of elements.
   /// - Parameters:
@@ -974,9 +1398,15 @@ public struct IdentifierList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
     self.init(elements)
   }
   public func buildIdentifierList(format: Format) -> IdentifierListSyntax {
-    let result = IdentifierListSyntax(elements.map {
+    var result = IdentifierListSyntax(elements.map {
       $0.buildToken(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -993,6 +1423,16 @@ public struct IdentifierList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsIdentifierList where Element == Token {
   public func createIdentifierList() -> IdentifierList {
@@ -1001,6 +1441,10 @@ extension Array: ExpressibleAsIdentifierList where Element == Token {
 }
 /// `PrecedenceGroupAttributeList` represents a collection of `SyntaxBuildable`
 public struct PrecedenceGroupAttributeList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsPrecedenceGroupAttributeList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [SyntaxBuildable]
   /// Creates a `PrecedenceGroupAttributeList` with the provided list of elements.
   /// - Parameters:
@@ -1020,9 +1464,15 @@ public struct PrecedenceGroupAttributeList: ExpressibleByArrayLiteral, SyntaxBui
     self.init(elements)
   }
   public func buildPrecedenceGroupAttributeList(format: Format) -> PrecedenceGroupAttributeListSyntax {
-    let result = PrecedenceGroupAttributeListSyntax(elements.map {
+    var result = PrecedenceGroupAttributeListSyntax(elements.map {
       $0.buildSyntax(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1039,6 +1489,16 @@ public struct PrecedenceGroupAttributeList: ExpressibleByArrayLiteral, SyntaxBui
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsPrecedenceGroupAttributeList where Element == ExpressibleAsSyntaxBuildable {
   public func createPrecedenceGroupAttributeList() -> PrecedenceGroupAttributeList {
@@ -1047,6 +1507,10 @@ extension Array: ExpressibleAsPrecedenceGroupAttributeList where Element == Expr
 }
 /// `PrecedenceGroupNameList` represents a collection of `PrecedenceGroupNameElement`
 public struct PrecedenceGroupNameList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsPrecedenceGroupNameList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [PrecedenceGroupNameElement]
   /// Creates a `PrecedenceGroupNameList` with the provided list of elements.
   /// - Parameters:
@@ -1066,9 +1530,15 @@ public struct PrecedenceGroupNameList: ExpressibleByArrayLiteral, SyntaxBuildabl
     self.init(elements)
   }
   public func buildPrecedenceGroupNameList(format: Format) -> PrecedenceGroupNameListSyntax {
-    let result = PrecedenceGroupNameListSyntax(elements.map {
+    var result = PrecedenceGroupNameListSyntax(elements.map {
       $0.buildPrecedenceGroupNameElement(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1085,6 +1555,16 @@ public struct PrecedenceGroupNameList: ExpressibleByArrayLiteral, SyntaxBuildabl
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsPrecedenceGroupNameList where Element == ExpressibleAsPrecedenceGroupNameElement {
   public func createPrecedenceGroupNameList() -> PrecedenceGroupNameList {
@@ -1093,6 +1573,10 @@ extension Array: ExpressibleAsPrecedenceGroupNameList where Element == Expressib
 }
 /// `TokenList` represents a collection of `Token`
 public struct TokenList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsTokenList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [Token]
   /// Creates a `TokenList` with the provided list of elements.
   /// - Parameters:
@@ -1110,9 +1594,15 @@ public struct TokenList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressible
     self.init(elements)
   }
   public func buildTokenList(format: Format) -> TokenListSyntax {
-    let result = TokenListSyntax(elements.map {
+    var result = TokenListSyntax(elements.map {
       $0.buildToken(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1129,6 +1619,16 @@ public struct TokenList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressible
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsTokenList where Element == Token {
   public func createTokenList() -> TokenList {
@@ -1137,6 +1637,10 @@ extension Array: ExpressibleAsTokenList where Element == Token {
 }
 /// `NonEmptyTokenList` represents a collection of `Token`
 public struct NonEmptyTokenList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsNonEmptyTokenList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [Token]
   /// Creates a `NonEmptyTokenList` with the provided list of elements.
   /// - Parameters:
@@ -1154,9 +1658,15 @@ public struct NonEmptyTokenList: ExpressibleByArrayLiteral, SyntaxBuildable, Exp
     self.init(elements)
   }
   public func buildNonEmptyTokenList(format: Format) -> NonEmptyTokenListSyntax {
-    let result = NonEmptyTokenListSyntax(elements.map {
+    var result = NonEmptyTokenListSyntax(elements.map {
       $0.buildToken(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1173,6 +1683,16 @@ public struct NonEmptyTokenList: ExpressibleByArrayLiteral, SyntaxBuildable, Exp
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsNonEmptyTokenList where Element == Token {
   public func createNonEmptyTokenList() -> NonEmptyTokenList {
@@ -1181,6 +1701,10 @@ extension Array: ExpressibleAsNonEmptyTokenList where Element == Token {
 }
 /// `AttributeList` represents a collection of `SyntaxBuildable`
 public struct AttributeList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsAttributeList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [SyntaxBuildable]
   /// Creates a `AttributeList` with the provided list of elements.
   /// - Parameters:
@@ -1200,9 +1724,15 @@ public struct AttributeList: ExpressibleByArrayLiteral, SyntaxBuildable, Express
     self.init(elements)
   }
   public func buildAttributeList(format: Format) -> AttributeListSyntax {
-    let result = AttributeListSyntax(elements.map {
+    var result = AttributeListSyntax(elements.map {
       $0.buildSyntax(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1219,6 +1749,16 @@ public struct AttributeList: ExpressibleByArrayLiteral, SyntaxBuildable, Express
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsAttributeList where Element == ExpressibleAsSyntaxBuildable {
   public func createAttributeList() -> AttributeList {
@@ -1227,6 +1767,10 @@ extension Array: ExpressibleAsAttributeList where Element == ExpressibleAsSyntax
 }
 /// A collection of arguments for the `@_specialize` attribute
 public struct SpecializeAttributeSpecList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsSpecializeAttributeSpecList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [SyntaxBuildable]
   /// Creates a `SpecializeAttributeSpecList` with the provided list of elements.
   /// - Parameters:
@@ -1246,9 +1790,15 @@ public struct SpecializeAttributeSpecList: ExpressibleByArrayLiteral, SyntaxBuil
     self.init(elements)
   }
   public func buildSpecializeAttributeSpecList(format: Format) -> SpecializeAttributeSpecListSyntax {
-    let result = SpecializeAttributeSpecListSyntax(elements.map {
+    var result = SpecializeAttributeSpecListSyntax(elements.map {
       $0.buildSyntax(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1265,6 +1815,16 @@ public struct SpecializeAttributeSpecList: ExpressibleByArrayLiteral, SyntaxBuil
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsSpecializeAttributeSpecList where Element == ExpressibleAsSyntaxBuildable {
   public func createSpecializeAttributeSpecList() -> SpecializeAttributeSpecList {
@@ -1273,6 +1833,10 @@ extension Array: ExpressibleAsSpecializeAttributeSpecList where Element == Expre
 }
 /// `ObjCSelector` represents a collection of `ObjCSelectorPiece`
 public struct ObjCSelector: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsObjCSelector {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [ObjCSelectorPiece]
   /// Creates a `ObjCSelector` with the provided list of elements.
   /// - Parameters:
@@ -1292,9 +1856,15 @@ public struct ObjCSelector: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
     self.init(elements)
   }
   public func buildObjCSelector(format: Format) -> ObjCSelectorSyntax {
-    let result = ObjCSelectorSyntax(elements.map {
+    var result = ObjCSelectorSyntax(elements.map {
       $0.buildObjCSelectorPiece(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1311,6 +1881,16 @@ public struct ObjCSelector: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsObjCSelector where Element == ExpressibleAsObjCSelectorPiece {
   public func createObjCSelector() -> ObjCSelector {
@@ -1319,6 +1899,10 @@ extension Array: ExpressibleAsObjCSelector where Element == ExpressibleAsObjCSel
 }
 /// `DifferentiabilityParamList` represents a collection of `DifferentiabilityParam`
 public struct DifferentiabilityParamList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsDifferentiabilityParamList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [DifferentiabilityParam]
   /// Creates a `DifferentiabilityParamList` with the provided list of elements.
   /// - Parameters:
@@ -1338,9 +1922,15 @@ public struct DifferentiabilityParamList: ExpressibleByArrayLiteral, SyntaxBuild
     self.init(elements)
   }
   public func buildDifferentiabilityParamList(format: Format) -> DifferentiabilityParamListSyntax {
-    let result = DifferentiabilityParamListSyntax(elements.map {
+    var result = DifferentiabilityParamListSyntax(elements.map {
       $0.buildDifferentiabilityParam(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1357,6 +1947,16 @@ public struct DifferentiabilityParamList: ExpressibleByArrayLiteral, SyntaxBuild
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsDifferentiabilityParamList where Element == ExpressibleAsDifferentiabilityParam {
   public func createDifferentiabilityParamList() -> DifferentiabilityParamList {
@@ -1365,6 +1965,10 @@ extension Array: ExpressibleAsDifferentiabilityParamList where Element == Expres
 }
 /// `BackDeployVersionList` represents a collection of `BackDeployVersionArgument`
 public struct BackDeployVersionList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsBackDeployVersionList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [BackDeployVersionArgument]
   /// Creates a `BackDeployVersionList` with the provided list of elements.
   /// - Parameters:
@@ -1384,9 +1988,15 @@ public struct BackDeployVersionList: ExpressibleByArrayLiteral, SyntaxBuildable,
     self.init(elements)
   }
   public func buildBackDeployVersionList(format: Format) -> BackDeployVersionListSyntax {
-    let result = BackDeployVersionListSyntax(elements.map {
+    var result = BackDeployVersionListSyntax(elements.map {
       $0.buildBackDeployVersionArgument(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1403,6 +2013,16 @@ public struct BackDeployVersionList: ExpressibleByArrayLiteral, SyntaxBuildable,
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsBackDeployVersionList where Element == ExpressibleAsBackDeployVersionArgument {
   public func createBackDeployVersionList() -> BackDeployVersionList {
@@ -1411,6 +2031,10 @@ extension Array: ExpressibleAsBackDeployVersionList where Element == Expressible
 }
 /// `SwitchCaseList` represents a collection of `SyntaxBuildable`
 public struct SwitchCaseList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsSwitchCaseList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [SyntaxBuildable]
   /// Creates a `SwitchCaseList` with the provided list of elements.
   /// - Parameters:
@@ -1430,9 +2054,15 @@ public struct SwitchCaseList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
     self.init(elements)
   }
   public func buildSwitchCaseList(format: Format) -> SwitchCaseListSyntax {
-    let result = SwitchCaseListSyntax(elements.map {
+    var result = SwitchCaseListSyntax(elements.map {
       $0.buildSyntax(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1449,6 +2079,16 @@ public struct SwitchCaseList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsSwitchCaseList where Element == ExpressibleAsSyntaxBuildable {
   public func createSwitchCaseList() -> SwitchCaseList {
@@ -1457,6 +2097,10 @@ extension Array: ExpressibleAsSwitchCaseList where Element == ExpressibleAsSynta
 }
 /// `CatchClauseList` represents a collection of `CatchClause`
 public struct CatchClauseList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsCatchClauseList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [CatchClause]
   /// Creates a `CatchClauseList` with the provided list of elements.
   /// - Parameters:
@@ -1476,9 +2120,15 @@ public struct CatchClauseList: ExpressibleByArrayLiteral, SyntaxBuildable, Expre
     self.init(elements)
   }
   public func buildCatchClauseList(format: Format) -> CatchClauseListSyntax {
-    let result = CatchClauseListSyntax(elements.map {
+    var result = CatchClauseListSyntax(elements.map {
       $0.buildCatchClause(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1495,6 +2145,16 @@ public struct CatchClauseList: ExpressibleByArrayLiteral, SyntaxBuildable, Expre
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsCatchClauseList where Element == ExpressibleAsCatchClause {
   public func createCatchClauseList() -> CatchClauseList {
@@ -1503,6 +2163,10 @@ extension Array: ExpressibleAsCatchClauseList where Element == ExpressibleAsCatc
 }
 /// `CaseItemList` represents a collection of `CaseItem`
 public struct CaseItemList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsCaseItemList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [CaseItem]
   /// Creates a `CaseItemList` with the provided list of elements.
   /// - Parameters:
@@ -1522,9 +2186,15 @@ public struct CaseItemList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
     self.init(elements)
   }
   public func buildCaseItemList(format: Format) -> CaseItemListSyntax {
-    let result = CaseItemListSyntax(elements.map {
+    var result = CaseItemListSyntax(elements.map {
       $0.buildCaseItem(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1541,6 +2211,16 @@ public struct CaseItemList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsCaseItemList where Element == ExpressibleAsCaseItem {
   public func createCaseItemList() -> CaseItemList {
@@ -1549,6 +2229,10 @@ extension Array: ExpressibleAsCaseItemList where Element == ExpressibleAsCaseIte
 }
 /// `CatchItemList` represents a collection of `CatchItem`
 public struct CatchItemList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsCatchItemList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [CatchItem]
   /// Creates a `CatchItemList` with the provided list of elements.
   /// - Parameters:
@@ -1568,9 +2252,15 @@ public struct CatchItemList: ExpressibleByArrayLiteral, SyntaxBuildable, Express
     self.init(elements)
   }
   public func buildCatchItemList(format: Format) -> CatchItemListSyntax {
-    let result = CatchItemListSyntax(elements.map {
+    var result = CatchItemListSyntax(elements.map {
       $0.buildCatchItem(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1587,6 +2277,16 @@ public struct CatchItemList: ExpressibleByArrayLiteral, SyntaxBuildable, Express
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsCatchItemList where Element == ExpressibleAsCatchItem {
   public func createCatchItemList() -> CatchItemList {
@@ -1595,6 +2295,10 @@ extension Array: ExpressibleAsCatchItemList where Element == ExpressibleAsCatchI
 }
 /// `ConditionElementList` represents a collection of `ConditionElement`
 public struct ConditionElementList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsConditionElementList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [ConditionElement]
   /// Creates a `ConditionElementList` with the provided list of elements.
   /// - Parameters:
@@ -1614,9 +2318,15 @@ public struct ConditionElementList: ExpressibleByArrayLiteral, SyntaxBuildable, 
     self.init(elements)
   }
   public func buildConditionElementList(format: Format) -> ConditionElementListSyntax {
-    let result = ConditionElementListSyntax(elements.map {
+    var result = ConditionElementListSyntax(elements.map {
       $0.buildConditionElement(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1633,6 +2343,16 @@ public struct ConditionElementList: ExpressibleByArrayLiteral, SyntaxBuildable, 
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsConditionElementList where Element == ExpressibleAsConditionElement {
   public func createConditionElementList() -> ConditionElementList {
@@ -1641,6 +2361,10 @@ extension Array: ExpressibleAsConditionElementList where Element == ExpressibleA
 }
 /// `GenericRequirementList` represents a collection of `GenericRequirement`
 public struct GenericRequirementList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsGenericRequirementList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [GenericRequirement]
   /// Creates a `GenericRequirementList` with the provided list of elements.
   /// - Parameters:
@@ -1660,9 +2384,15 @@ public struct GenericRequirementList: ExpressibleByArrayLiteral, SyntaxBuildable
     self.init(elements)
   }
   public func buildGenericRequirementList(format: Format) -> GenericRequirementListSyntax {
-    let result = GenericRequirementListSyntax(elements.map {
+    var result = GenericRequirementListSyntax(elements.map {
       $0.buildGenericRequirement(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1679,6 +2409,16 @@ public struct GenericRequirementList: ExpressibleByArrayLiteral, SyntaxBuildable
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsGenericRequirementList where Element == ExpressibleAsGenericRequirement {
   public func createGenericRequirementList() -> GenericRequirementList {
@@ -1687,6 +2427,10 @@ extension Array: ExpressibleAsGenericRequirementList where Element == Expressibl
 }
 /// `GenericParameterList` represents a collection of `GenericParameter`
 public struct GenericParameterList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsGenericParameterList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [GenericParameter]
   /// Creates a `GenericParameterList` with the provided list of elements.
   /// - Parameters:
@@ -1706,9 +2450,15 @@ public struct GenericParameterList: ExpressibleByArrayLiteral, SyntaxBuildable, 
     self.init(elements)
   }
   public func buildGenericParameterList(format: Format) -> GenericParameterListSyntax {
-    let result = GenericParameterListSyntax(elements.map {
+    var result = GenericParameterListSyntax(elements.map {
       $0.buildGenericParameter(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1725,6 +2475,16 @@ public struct GenericParameterList: ExpressibleByArrayLiteral, SyntaxBuildable, 
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsGenericParameterList where Element == ExpressibleAsGenericParameter {
   public func createGenericParameterList() -> GenericParameterList {
@@ -1733,6 +2493,10 @@ extension Array: ExpressibleAsGenericParameterList where Element == ExpressibleA
 }
 /// `PrimaryAssociatedTypeList` represents a collection of `PrimaryAssociatedType`
 public struct PrimaryAssociatedTypeList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsPrimaryAssociatedTypeList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [PrimaryAssociatedType]
   /// Creates a `PrimaryAssociatedTypeList` with the provided list of elements.
   /// - Parameters:
@@ -1752,9 +2516,15 @@ public struct PrimaryAssociatedTypeList: ExpressibleByArrayLiteral, SyntaxBuilda
     self.init(elements)
   }
   public func buildPrimaryAssociatedTypeList(format: Format) -> PrimaryAssociatedTypeListSyntax {
-    let result = PrimaryAssociatedTypeListSyntax(elements.map {
+    var result = PrimaryAssociatedTypeListSyntax(elements.map {
       $0.buildPrimaryAssociatedType(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1771,6 +2541,16 @@ public struct PrimaryAssociatedTypeList: ExpressibleByArrayLiteral, SyntaxBuilda
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsPrimaryAssociatedTypeList where Element == ExpressibleAsPrimaryAssociatedType {
   public func createPrimaryAssociatedTypeList() -> PrimaryAssociatedTypeList {
@@ -1779,6 +2559,10 @@ extension Array: ExpressibleAsPrimaryAssociatedTypeList where Element == Express
 }
 /// `CompositionTypeElementList` represents a collection of `CompositionTypeElement`
 public struct CompositionTypeElementList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsCompositionTypeElementList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [CompositionTypeElement]
   /// Creates a `CompositionTypeElementList` with the provided list of elements.
   /// - Parameters:
@@ -1798,9 +2582,15 @@ public struct CompositionTypeElementList: ExpressibleByArrayLiteral, SyntaxBuild
     self.init(elements)
   }
   public func buildCompositionTypeElementList(format: Format) -> CompositionTypeElementListSyntax {
-    let result = CompositionTypeElementListSyntax(elements.map {
+    var result = CompositionTypeElementListSyntax(elements.map {
       $0.buildCompositionTypeElement(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1817,6 +2607,16 @@ public struct CompositionTypeElementList: ExpressibleByArrayLiteral, SyntaxBuild
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsCompositionTypeElementList where Element == ExpressibleAsCompositionTypeElement {
   public func createCompositionTypeElementList() -> CompositionTypeElementList {
@@ -1825,6 +2625,10 @@ extension Array: ExpressibleAsCompositionTypeElementList where Element == Expres
 }
 /// `TupleTypeElementList` represents a collection of `TupleTypeElement`
 public struct TupleTypeElementList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsTupleTypeElementList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [TupleTypeElement]
   /// Creates a `TupleTypeElementList` with the provided list of elements.
   /// - Parameters:
@@ -1844,9 +2648,15 @@ public struct TupleTypeElementList: ExpressibleByArrayLiteral, SyntaxBuildable, 
     self.init(elements)
   }
   public func buildTupleTypeElementList(format: Format) -> TupleTypeElementListSyntax {
-    let result = TupleTypeElementListSyntax(elements.map {
+    var result = TupleTypeElementListSyntax(elements.map {
       $0.buildTupleTypeElement(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1863,6 +2673,16 @@ public struct TupleTypeElementList: ExpressibleByArrayLiteral, SyntaxBuildable, 
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsTupleTypeElementList where Element == ExpressibleAsTupleTypeElement {
   public func createTupleTypeElementList() -> TupleTypeElementList {
@@ -1871,6 +2691,10 @@ extension Array: ExpressibleAsTupleTypeElementList where Element == ExpressibleA
 }
 /// `GenericArgumentList` represents a collection of `GenericArgument`
 public struct GenericArgumentList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsGenericArgumentList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [GenericArgument]
   /// Creates a `GenericArgumentList` with the provided list of elements.
   /// - Parameters:
@@ -1890,9 +2714,15 @@ public struct GenericArgumentList: ExpressibleByArrayLiteral, SyntaxBuildable, E
     self.init(elements)
   }
   public func buildGenericArgumentList(format: Format) -> GenericArgumentListSyntax {
-    let result = GenericArgumentListSyntax(elements.map {
+    var result = GenericArgumentListSyntax(elements.map {
       $0.buildGenericArgument(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1909,6 +2739,16 @@ public struct GenericArgumentList: ExpressibleByArrayLiteral, SyntaxBuildable, E
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsGenericArgumentList where Element == ExpressibleAsGenericArgument {
   public func createGenericArgumentList() -> GenericArgumentList {
@@ -1917,6 +2757,10 @@ extension Array: ExpressibleAsGenericArgumentList where Element == ExpressibleAs
 }
 /// `TuplePatternElementList` represents a collection of `TuplePatternElement`
 public struct TuplePatternElementList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsTuplePatternElementList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [TuplePatternElement]
   /// Creates a `TuplePatternElementList` with the provided list of elements.
   /// - Parameters:
@@ -1936,9 +2780,15 @@ public struct TuplePatternElementList: ExpressibleByArrayLiteral, SyntaxBuildabl
     self.init(elements)
   }
   public func buildTuplePatternElementList(format: Format) -> TuplePatternElementListSyntax {
-    let result = TuplePatternElementListSyntax(elements.map {
+    var result = TuplePatternElementListSyntax(elements.map {
       $0.buildTuplePatternElement(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -1955,6 +2805,16 @@ public struct TuplePatternElementList: ExpressibleByArrayLiteral, SyntaxBuildabl
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 extension Array: ExpressibleAsTuplePatternElementList where Element == ExpressibleAsTuplePatternElement {
   public func createTuplePatternElementList() -> TuplePatternElementList {
@@ -1963,6 +2823,10 @@ extension Array: ExpressibleAsTuplePatternElementList where Element == Expressib
 }
 /// `AvailabilitySpecList` represents a collection of `AvailabilityArgument`
 public struct AvailabilitySpecList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsAvailabilitySpecList {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia = []
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia = []
   let elements: [AvailabilityArgument]
   /// Creates a `AvailabilitySpecList` with the provided list of elements.
   /// - Parameters:
@@ -1982,9 +2846,15 @@ public struct AvailabilitySpecList: ExpressibleByArrayLiteral, SyntaxBuildable, 
     self.init(elements)
   }
   public func buildAvailabilitySpecList(format: Format) -> AvailabilitySpecListSyntax {
-    let result = AvailabilitySpecListSyntax(elements.map {
+    var result = AvailabilitySpecListSyntax(elements.map {
       $0.buildAvailabilityArgument(format: format)
     })
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
@@ -2000,6 +2870,16 @@ public struct AvailabilitySpecList: ExpressibleByArrayLiteral, SyntaxBuildable, 
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 extension Array: ExpressibleAsAvailabilitySpecList where Element == ExpressibleAsAvailabilityArgument {

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -17,8 +17,9 @@ import SwiftSyntax
 /// A CodeBlockItem is any Syntax node that appears on its own line insidea CodeBlock.
 public struct CodeBlockItem: SyntaxBuildable, ExpressibleAsCodeBlockItem {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeItem: UnexpectedNodes?
   var item: SyntaxBuildable
   var unexpectedBetweenItemAndSemicolon: UnexpectedNodes?
@@ -33,8 +34,9 @@ public struct CodeBlockItem: SyntaxBuildable, ExpressibleAsCodeBlockItem {
   ///   - semicolon: If present, the trailing semicolon at the end of the item.
   ///   - unexpectedBetweenSemicolonAndErrorTokens: 
   ///   - errorTokens: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeItem: ExpressibleAsUnexpectedNodes? = nil, item: ExpressibleAsSyntaxBuildable, unexpectedBetweenItemAndSemicolon: ExpressibleAsUnexpectedNodes? = nil, semicolon: Token? = nil, unexpectedBetweenSemicolonAndErrorTokens: ExpressibleAsUnexpectedNodes? = nil, errorTokens: ExpressibleAsSyntaxBuildable? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeItem: ExpressibleAsUnexpectedNodes? = nil, item: ExpressibleAsSyntaxBuildable, unexpectedBetweenItemAndSemicolon: ExpressibleAsUnexpectedNodes? = nil, semicolon: Token? = nil, unexpectedBetweenSemicolonAndErrorTokens: ExpressibleAsUnexpectedNodes? = nil, errorTokens: ExpressibleAsSyntaxBuildable? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeItem = unexpectedBeforeItem?.createUnexpectedNodes()
     self.item = item.createSyntaxBuildable()
     self.unexpectedBetweenItemAndSemicolon = unexpectedBetweenItemAndSemicolon?.createUnexpectedNodes()
@@ -51,6 +53,9 @@ public struct CodeBlockItem: SyntaxBuildable, ExpressibleAsCodeBlockItem {
     var result = CodeBlockItemSyntax(unexpectedBeforeItem?.buildUnexpectedNodes(format: format), item: item.buildSyntax(format: format), unexpectedBetweenItemAndSemicolon?.buildUnexpectedNodes(format: format), semicolon: semicolon?.buildToken(format: format), unexpectedBetweenSemicolonAndErrorTokens?.buildUnexpectedNodes(format: format), errorTokens: errorTokens?.buildSyntax(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -73,8 +78,9 @@ public struct CodeBlockItem: SyntaxBuildable, ExpressibleAsCodeBlockItem {
 }
 public struct CodeBlock: SyntaxBuildable, ExpressibleAsCodeBlock {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftBrace: UnexpectedNodes?
   var leftBrace: Token
   var unexpectedBetweenLeftBraceAndStatements: UnexpectedNodes?
@@ -89,8 +95,9 @@ public struct CodeBlock: SyntaxBuildable, ExpressibleAsCodeBlock {
   ///   - statements: 
   ///   - unexpectedBetweenStatementsAndRightBrace: 
   ///   - rightBrace: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftBrace: ExpressibleAsUnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndStatements: ExpressibleAsUnexpectedNodes? = nil, statements: ExpressibleAsCodeBlockItemList, unexpectedBetweenStatementsAndRightBrace: ExpressibleAsUnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftBrace: ExpressibleAsUnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndStatements: ExpressibleAsUnexpectedNodes? = nil, statements: ExpressibleAsCodeBlockItemList, unexpectedBetweenStatementsAndRightBrace: ExpressibleAsUnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftBrace = unexpectedBeforeLeftBrace?.createUnexpectedNodes()
     self.leftBrace = leftBrace
     assert(leftBrace.text == #"{"#)
@@ -117,6 +124,9 @@ public struct CodeBlock: SyntaxBuildable, ExpressibleAsCodeBlock {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -138,8 +148,9 @@ public struct CodeBlock: SyntaxBuildable, ExpressibleAsCodeBlock {
 }
 public struct InOutExpr: ExprBuildable, ExpressibleAsInOutExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAmpersand: UnexpectedNodes?
   var ampersand: Token
   var unexpectedBetweenAmpersandAndExpression: UnexpectedNodes?
@@ -150,8 +161,9 @@ public struct InOutExpr: ExprBuildable, ExpressibleAsInOutExpr {
   ///   - ampersand: 
   ///   - unexpectedBetweenAmpersandAndExpression: 
   ///   - expression: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAmpersand: ExpressibleAsUnexpectedNodes? = nil, ampersand: Token = Token.`prefixAmpersand`, unexpectedBetweenAmpersandAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAmpersand: ExpressibleAsUnexpectedNodes? = nil, ampersand: Token = Token.`prefixAmpersand`, unexpectedBetweenAmpersandAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAmpersand = unexpectedBeforeAmpersand?.createUnexpectedNodes()
     self.ampersand = ampersand
     assert(ampersand.text == #"&"#)
@@ -166,6 +178,9 @@ public struct InOutExpr: ExprBuildable, ExpressibleAsInOutExpr {
     var result = InOutExprSyntax(unexpectedBeforeAmpersand?.buildUnexpectedNodes(format: format), ampersand: ampersand.buildToken(format: format), unexpectedBetweenAmpersandAndExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -195,16 +210,18 @@ public struct InOutExpr: ExprBuildable, ExpressibleAsInOutExpr {
 }
 public struct PoundColumnExpr: ExprBuildable, ExpressibleAsPoundColumnExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePoundColumn: UnexpectedNodes?
   var poundColumn: Token
   /// Creates a `PoundColumnExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforePoundColumn: 
   ///   - poundColumn: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePoundColumn: ExpressibleAsUnexpectedNodes? = nil, poundColumn: Token = Token.`poundColumn`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundColumn: ExpressibleAsUnexpectedNodes? = nil, poundColumn: Token = Token.`poundColumn`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePoundColumn = unexpectedBeforePoundColumn?.createUnexpectedNodes()
     self.poundColumn = poundColumn
     assert(poundColumn.text == #"#column"#)
@@ -217,6 +234,9 @@ public struct PoundColumnExpr: ExprBuildable, ExpressibleAsPoundColumnExpr {
     var result = PoundColumnExprSyntax(unexpectedBeforePoundColumn?.buildUnexpectedNodes(format: format), poundColumn: poundColumn.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -246,8 +266,9 @@ public struct PoundColumnExpr: ExprBuildable, ExpressibleAsPoundColumnExpr {
 }
 public struct TryExpr: ExprBuildable, ExpressibleAsTryExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeTryKeyword: UnexpectedNodes?
   var tryKeyword: Token
   var unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: UnexpectedNodes?
@@ -262,8 +283,9 @@ public struct TryExpr: ExprBuildable, ExpressibleAsTryExpr {
   ///   - questionOrExclamationMark: 
   ///   - unexpectedBetweenQuestionOrExclamationMarkAndExpression: 
   ///   - expression: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeTryKeyword: ExpressibleAsUnexpectedNodes? = nil, tryKeyword: Token = Token.`try`, unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: ExpressibleAsUnexpectedNodes? = nil, questionOrExclamationMark: Token? = nil, unexpectedBetweenQuestionOrExclamationMarkAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeTryKeyword: ExpressibleAsUnexpectedNodes? = nil, tryKeyword: Token = Token.`try`, unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: ExpressibleAsUnexpectedNodes? = nil, questionOrExclamationMark: Token? = nil, unexpectedBetweenQuestionOrExclamationMarkAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeTryKeyword = unexpectedBeforeTryKeyword?.createUnexpectedNodes()
     self.tryKeyword = tryKeyword
     assert(tryKeyword.text == #"try"#)
@@ -281,6 +303,9 @@ public struct TryExpr: ExprBuildable, ExpressibleAsTryExpr {
     var result = TryExprSyntax(unexpectedBeforeTryKeyword?.buildUnexpectedNodes(format: format), tryKeyword: tryKeyword.buildToken(format: format), unexpectedBetweenTryKeywordAndQuestionOrExclamationMark?.buildUnexpectedNodes(format: format), questionOrExclamationMark: questionOrExclamationMark?.buildToken(format: format), unexpectedBetweenQuestionOrExclamationMarkAndExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -310,8 +335,9 @@ public struct TryExpr: ExprBuildable, ExpressibleAsTryExpr {
 }
 public struct AwaitExpr: ExprBuildable, ExpressibleAsAwaitExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAwaitKeyword: UnexpectedNodes?
   var awaitKeyword: Token
   var unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodes?
@@ -322,8 +348,9 @@ public struct AwaitExpr: ExprBuildable, ExpressibleAsAwaitExpr {
   ///   - awaitKeyword: 
   ///   - unexpectedBetweenAwaitKeywordAndExpression: 
   ///   - expression: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAwaitKeyword: ExpressibleAsUnexpectedNodes? = nil, awaitKeyword: Token, unexpectedBetweenAwaitKeywordAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAwaitKeyword: ExpressibleAsUnexpectedNodes? = nil, awaitKeyword: Token, unexpectedBetweenAwaitKeywordAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAwaitKeyword = unexpectedBeforeAwaitKeyword?.createUnexpectedNodes()
     self.awaitKeyword = awaitKeyword
     assert(awaitKeyword.text == #"await"#)
@@ -344,6 +371,9 @@ public struct AwaitExpr: ExprBuildable, ExpressibleAsAwaitExpr {
     var result = AwaitExprSyntax(unexpectedBeforeAwaitKeyword?.buildUnexpectedNodes(format: format), awaitKeyword: awaitKeyword.buildToken(format: format), unexpectedBetweenAwaitKeywordAndExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -373,8 +403,9 @@ public struct AwaitExpr: ExprBuildable, ExpressibleAsAwaitExpr {
 }
 public struct MoveExpr: ExprBuildable, ExpressibleAsMoveExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeMoveKeyword: UnexpectedNodes?
   var moveKeyword: Token
   var unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodes?
@@ -385,8 +416,9 @@ public struct MoveExpr: ExprBuildable, ExpressibleAsMoveExpr {
   ///   - moveKeyword: 
   ///   - unexpectedBetweenMoveKeywordAndExpression: 
   ///   - expression: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeMoveKeyword: ExpressibleAsUnexpectedNodes? = nil, moveKeyword: Token, unexpectedBetweenMoveKeywordAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeMoveKeyword: ExpressibleAsUnexpectedNodes? = nil, moveKeyword: Token, unexpectedBetweenMoveKeywordAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeMoveKeyword = unexpectedBeforeMoveKeyword?.createUnexpectedNodes()
     self.moveKeyword = moveKeyword
     assert(moveKeyword.text == #"_move"#)
@@ -407,6 +439,9 @@ public struct MoveExpr: ExprBuildable, ExpressibleAsMoveExpr {
     var result = MoveExprSyntax(unexpectedBeforeMoveKeyword?.buildUnexpectedNodes(format: format), moveKeyword: moveKeyword.buildToken(format: format), unexpectedBetweenMoveKeywordAndExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -436,8 +471,9 @@ public struct MoveExpr: ExprBuildable, ExpressibleAsMoveExpr {
 }
 public struct DeclNameArgument: SyntaxBuildable, ExpressibleAsDeclNameArgument {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeName: UnexpectedNodes?
   var name: Token
   var unexpectedBetweenNameAndColon: UnexpectedNodes?
@@ -448,8 +484,9 @@ public struct DeclNameArgument: SyntaxBuildable, ExpressibleAsDeclNameArgument {
   ///   - name: 
   ///   - unexpectedBetweenNameAndColon: 
   ///   - colon: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeName = unexpectedBeforeName?.createUnexpectedNodes()
     self.name = name
     self.unexpectedBetweenNameAndColon = unexpectedBetweenNameAndColon?.createUnexpectedNodes()
@@ -464,6 +501,9 @@ public struct DeclNameArgument: SyntaxBuildable, ExpressibleAsDeclNameArgument {
     var result = DeclNameArgumentSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format), name: name.buildToken(format: format), unexpectedBetweenNameAndColon?.buildUnexpectedNodes(format: format), colon: colon.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -486,8 +526,9 @@ public struct DeclNameArgument: SyntaxBuildable, ExpressibleAsDeclNameArgument {
 }
 public struct DeclNameArguments: SyntaxBuildable, ExpressibleAsDeclNameArguments {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftParen: UnexpectedNodes?
   var leftParen: Token
   var unexpectedBetweenLeftParenAndArguments: UnexpectedNodes?
@@ -502,8 +543,9 @@ public struct DeclNameArguments: SyntaxBuildable, ExpressibleAsDeclNameArguments
   ///   - arguments: 
   ///   - unexpectedBetweenArgumentsAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndArguments: ExpressibleAsUnexpectedNodes? = nil, arguments: ExpressibleAsDeclNameArgumentList, unexpectedBetweenArgumentsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndArguments: ExpressibleAsUnexpectedNodes? = nil, arguments: ExpressibleAsDeclNameArgumentList, unexpectedBetweenArgumentsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftParen = unexpectedBeforeLeftParen?.createUnexpectedNodes()
     self.leftParen = leftParen
     assert(leftParen.text == #"("#)
@@ -521,6 +563,9 @@ public struct DeclNameArguments: SyntaxBuildable, ExpressibleAsDeclNameArguments
     var result = DeclNameArgumentsSyntax(unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format), leftParen: leftParen.buildToken(format: format), unexpectedBetweenLeftParenAndArguments?.buildUnexpectedNodes(format: format), arguments: arguments.buildDeclNameArgumentList(format: format), unexpectedBetweenArgumentsAndRightParen?.buildUnexpectedNodes(format: format), rightParen: rightParen.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -543,8 +588,9 @@ public struct DeclNameArguments: SyntaxBuildable, ExpressibleAsDeclNameArguments
 }
 public struct IdentifierExpr: ExprBuildable, ExpressibleAsIdentifierExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeIdentifier: UnexpectedNodes?
   var identifier: Token
   var unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodes?
@@ -555,8 +601,9 @@ public struct IdentifierExpr: ExprBuildable, ExpressibleAsIdentifierExpr {
   ///   - identifier: 
   ///   - unexpectedBetweenIdentifierAndDeclNameArguments: 
   ///   - declNameArguments: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndDeclNameArguments: ExpressibleAsUnexpectedNodes? = nil, declNameArguments: ExpressibleAsDeclNameArguments? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndDeclNameArguments: ExpressibleAsUnexpectedNodes? = nil, declNameArguments: ExpressibleAsDeclNameArguments? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeIdentifier = unexpectedBeforeIdentifier?.createUnexpectedNodes()
     self.identifier = identifier
     self.unexpectedBetweenIdentifierAndDeclNameArguments = unexpectedBetweenIdentifierAndDeclNameArguments?.createUnexpectedNodes()
@@ -570,6 +617,9 @@ public struct IdentifierExpr: ExprBuildable, ExpressibleAsIdentifierExpr {
     var result = IdentifierExprSyntax(unexpectedBeforeIdentifier?.buildUnexpectedNodes(format: format), identifier: identifier.buildToken(format: format), unexpectedBetweenIdentifierAndDeclNameArguments?.buildUnexpectedNodes(format: format), declNameArguments: declNameArguments?.buildDeclNameArguments(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -599,16 +649,18 @@ public struct IdentifierExpr: ExprBuildable, ExpressibleAsIdentifierExpr {
 }
 public struct SuperRefExpr: ExprBuildable, ExpressibleAsSuperRefExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeSuperKeyword: UnexpectedNodes?
   var superKeyword: Token
   /// Creates a `SuperRefExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeSuperKeyword: 
   ///   - superKeyword: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeSuperKeyword: ExpressibleAsUnexpectedNodes? = nil, superKeyword: Token = Token.`super`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeSuperKeyword: ExpressibleAsUnexpectedNodes? = nil, superKeyword: Token = Token.`super`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeSuperKeyword = unexpectedBeforeSuperKeyword?.createUnexpectedNodes()
     self.superKeyword = superKeyword
     assert(superKeyword.text == #"super"#)
@@ -621,6 +673,9 @@ public struct SuperRefExpr: ExprBuildable, ExpressibleAsSuperRefExpr {
     var result = SuperRefExprSyntax(unexpectedBeforeSuperKeyword?.buildUnexpectedNodes(format: format), superKeyword: superKeyword.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -650,16 +705,18 @@ public struct SuperRefExpr: ExprBuildable, ExpressibleAsSuperRefExpr {
 }
 public struct NilLiteralExpr: ExprBuildable, ExpressibleAsNilLiteralExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeNilKeyword: UnexpectedNodes?
   var nilKeyword: Token
   /// Creates a `NilLiteralExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeNilKeyword: 
   ///   - nilKeyword: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeNilKeyword: ExpressibleAsUnexpectedNodes? = nil, nilKeyword: Token = Token.`nil`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeNilKeyword: ExpressibleAsUnexpectedNodes? = nil, nilKeyword: Token = Token.`nil`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeNilKeyword = unexpectedBeforeNilKeyword?.createUnexpectedNodes()
     self.nilKeyword = nilKeyword
     assert(nilKeyword.text == #"nil"#)
@@ -672,6 +729,9 @@ public struct NilLiteralExpr: ExprBuildable, ExpressibleAsNilLiteralExpr {
     var result = NilLiteralExprSyntax(unexpectedBeforeNilKeyword?.buildUnexpectedNodes(format: format), nilKeyword: nilKeyword.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -701,16 +761,18 @@ public struct NilLiteralExpr: ExprBuildable, ExpressibleAsNilLiteralExpr {
 }
 public struct DiscardAssignmentExpr: ExprBuildable, ExpressibleAsDiscardAssignmentExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeWildcard: UnexpectedNodes?
   var wildcard: Token
   /// Creates a `DiscardAssignmentExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeWildcard: 
   ///   - wildcard: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeWildcard: ExpressibleAsUnexpectedNodes? = nil, wildcard: Token = Token.`wildcard`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWildcard: ExpressibleAsUnexpectedNodes? = nil, wildcard: Token = Token.`wildcard`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeWildcard = unexpectedBeforeWildcard?.createUnexpectedNodes()
     self.wildcard = wildcard
     assert(wildcard.text == #"_"#)
@@ -723,6 +785,9 @@ public struct DiscardAssignmentExpr: ExprBuildable, ExpressibleAsDiscardAssignme
     var result = DiscardAssignmentExprSyntax(unexpectedBeforeWildcard?.buildUnexpectedNodes(format: format), wildcard: wildcard.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -752,16 +817,18 @@ public struct DiscardAssignmentExpr: ExprBuildable, ExpressibleAsDiscardAssignme
 }
 public struct AssignmentExpr: ExprBuildable, ExpressibleAsAssignmentExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAssignToken: UnexpectedNodes?
   var assignToken: Token
   /// Creates a `AssignmentExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeAssignToken: 
   ///   - assignToken: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAssignToken: ExpressibleAsUnexpectedNodes? = nil, assignToken: Token = Token.`equal`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAssignToken: ExpressibleAsUnexpectedNodes? = nil, assignToken: Token = Token.`equal`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAssignToken = unexpectedBeforeAssignToken?.createUnexpectedNodes()
     self.assignToken = assignToken
     assert(assignToken.text == #"="#)
@@ -774,6 +841,9 @@ public struct AssignmentExpr: ExprBuildable, ExpressibleAsAssignmentExpr {
     var result = AssignmentExprSyntax(unexpectedBeforeAssignToken?.buildUnexpectedNodes(format: format), assignToken: assignToken.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -803,16 +873,18 @@ public struct AssignmentExpr: ExprBuildable, ExpressibleAsAssignmentExpr {
 }
 public struct SequenceExpr: ExprBuildable, ExpressibleAsSequenceExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeElements: UnexpectedNodes?
   var elements: ExprList
   /// Creates a `SequenceExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeElements: 
   ///   - elements: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeElements: ExpressibleAsUnexpectedNodes? = nil, elements: ExpressibleAsExprList) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeElements: ExpressibleAsUnexpectedNodes? = nil, elements: ExpressibleAsExprList) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeElements = unexpectedBeforeElements?.createUnexpectedNodes()
     self.elements = elements.createExprList()
   }
@@ -832,6 +904,9 @@ public struct SequenceExpr: ExprBuildable, ExpressibleAsSequenceExpr {
     var result = SequenceExprSyntax(unexpectedBeforeElements?.buildUnexpectedNodes(format: format), elements: elements.buildExprList(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -861,16 +936,18 @@ public struct SequenceExpr: ExprBuildable, ExpressibleAsSequenceExpr {
 }
 public struct PoundLineExpr: ExprBuildable, ExpressibleAsPoundLineExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePoundLine: UnexpectedNodes?
   var poundLine: Token
   /// Creates a `PoundLineExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforePoundLine: 
   ///   - poundLine: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePoundLine: ExpressibleAsUnexpectedNodes? = nil, poundLine: Token = Token.`poundLine`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundLine: ExpressibleAsUnexpectedNodes? = nil, poundLine: Token = Token.`poundLine`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePoundLine = unexpectedBeforePoundLine?.createUnexpectedNodes()
     self.poundLine = poundLine
     assert(poundLine.text == #"#line"#)
@@ -883,6 +960,9 @@ public struct PoundLineExpr: ExprBuildable, ExpressibleAsPoundLineExpr {
     var result = PoundLineExprSyntax(unexpectedBeforePoundLine?.buildUnexpectedNodes(format: format), poundLine: poundLine.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -912,16 +992,18 @@ public struct PoundLineExpr: ExprBuildable, ExpressibleAsPoundLineExpr {
 }
 public struct PoundFileExpr: ExprBuildable, ExpressibleAsPoundFileExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePoundFile: UnexpectedNodes?
   var poundFile: Token
   /// Creates a `PoundFileExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforePoundFile: 
   ///   - poundFile: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePoundFile: ExpressibleAsUnexpectedNodes? = nil, poundFile: Token = Token.`poundFile`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundFile: ExpressibleAsUnexpectedNodes? = nil, poundFile: Token = Token.`poundFile`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePoundFile = unexpectedBeforePoundFile?.createUnexpectedNodes()
     self.poundFile = poundFile
     assert(poundFile.text == #"#file"#)
@@ -934,6 +1016,9 @@ public struct PoundFileExpr: ExprBuildable, ExpressibleAsPoundFileExpr {
     var result = PoundFileExprSyntax(unexpectedBeforePoundFile?.buildUnexpectedNodes(format: format), poundFile: poundFile.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -963,16 +1048,18 @@ public struct PoundFileExpr: ExprBuildable, ExpressibleAsPoundFileExpr {
 }
 public struct PoundFileIDExpr: ExprBuildable, ExpressibleAsPoundFileIDExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePoundFileID: UnexpectedNodes?
   var poundFileID: Token
   /// Creates a `PoundFileIDExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforePoundFileID: 
   ///   - poundFileID: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePoundFileID: ExpressibleAsUnexpectedNodes? = nil, poundFileID: Token = Token.`poundFileID`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundFileID: ExpressibleAsUnexpectedNodes? = nil, poundFileID: Token = Token.`poundFileID`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePoundFileID = unexpectedBeforePoundFileID?.createUnexpectedNodes()
     self.poundFileID = poundFileID
     assert(poundFileID.text == #"#fileID"#)
@@ -985,6 +1072,9 @@ public struct PoundFileIDExpr: ExprBuildable, ExpressibleAsPoundFileIDExpr {
     var result = PoundFileIDExprSyntax(unexpectedBeforePoundFileID?.buildUnexpectedNodes(format: format), poundFileID: poundFileID.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1014,16 +1104,18 @@ public struct PoundFileIDExpr: ExprBuildable, ExpressibleAsPoundFileIDExpr {
 }
 public struct PoundFilePathExpr: ExprBuildable, ExpressibleAsPoundFilePathExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePoundFilePath: UnexpectedNodes?
   var poundFilePath: Token
   /// Creates a `PoundFilePathExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforePoundFilePath: 
   ///   - poundFilePath: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePoundFilePath: ExpressibleAsUnexpectedNodes? = nil, poundFilePath: Token = Token.`poundFilePath`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundFilePath: ExpressibleAsUnexpectedNodes? = nil, poundFilePath: Token = Token.`poundFilePath`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePoundFilePath = unexpectedBeforePoundFilePath?.createUnexpectedNodes()
     self.poundFilePath = poundFilePath
     assert(poundFilePath.text == #"#filePath"#)
@@ -1036,6 +1128,9 @@ public struct PoundFilePathExpr: ExprBuildable, ExpressibleAsPoundFilePathExpr {
     var result = PoundFilePathExprSyntax(unexpectedBeforePoundFilePath?.buildUnexpectedNodes(format: format), poundFilePath: poundFilePath.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1065,16 +1160,18 @@ public struct PoundFilePathExpr: ExprBuildable, ExpressibleAsPoundFilePathExpr {
 }
 public struct PoundFunctionExpr: ExprBuildable, ExpressibleAsPoundFunctionExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePoundFunction: UnexpectedNodes?
   var poundFunction: Token
   /// Creates a `PoundFunctionExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforePoundFunction: 
   ///   - poundFunction: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePoundFunction: ExpressibleAsUnexpectedNodes? = nil, poundFunction: Token = Token.`poundFunction`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundFunction: ExpressibleAsUnexpectedNodes? = nil, poundFunction: Token = Token.`poundFunction`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePoundFunction = unexpectedBeforePoundFunction?.createUnexpectedNodes()
     self.poundFunction = poundFunction
     assert(poundFunction.text == #"#function"#)
@@ -1087,6 +1184,9 @@ public struct PoundFunctionExpr: ExprBuildable, ExpressibleAsPoundFunctionExpr {
     var result = PoundFunctionExprSyntax(unexpectedBeforePoundFunction?.buildUnexpectedNodes(format: format), poundFunction: poundFunction.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1116,16 +1216,18 @@ public struct PoundFunctionExpr: ExprBuildable, ExpressibleAsPoundFunctionExpr {
 }
 public struct PoundDsohandleExpr: ExprBuildable, ExpressibleAsPoundDsohandleExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePoundDsohandle: UnexpectedNodes?
   var poundDsohandle: Token
   /// Creates a `PoundDsohandleExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforePoundDsohandle: 
   ///   - poundDsohandle: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePoundDsohandle: ExpressibleAsUnexpectedNodes? = nil, poundDsohandle: Token = Token.`poundDsohandle`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundDsohandle: ExpressibleAsUnexpectedNodes? = nil, poundDsohandle: Token = Token.`poundDsohandle`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePoundDsohandle = unexpectedBeforePoundDsohandle?.createUnexpectedNodes()
     self.poundDsohandle = poundDsohandle
     assert(poundDsohandle.text == #"#dsohandle"#)
@@ -1138,6 +1240,9 @@ public struct PoundDsohandleExpr: ExprBuildable, ExpressibleAsPoundDsohandleExpr
     var result = PoundDsohandleExprSyntax(unexpectedBeforePoundDsohandle?.buildUnexpectedNodes(format: format), poundDsohandle: poundDsohandle.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1167,8 +1272,9 @@ public struct PoundDsohandleExpr: ExprBuildable, ExpressibleAsPoundDsohandleExpr
 }
 public struct SymbolicReferenceExpr: ExprBuildable, ExpressibleAsSymbolicReferenceExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeIdentifier: UnexpectedNodes?
   var identifier: Token
   var unexpectedBetweenIdentifierAndGenericArgumentClause: UnexpectedNodes?
@@ -1179,8 +1285,9 @@ public struct SymbolicReferenceExpr: ExprBuildable, ExpressibleAsSymbolicReferen
   ///   - identifier: 
   ///   - unexpectedBetweenIdentifierAndGenericArgumentClause: 
   ///   - genericArgumentClause: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericArgumentClause: ExpressibleAsUnexpectedNodes? = nil, genericArgumentClause: ExpressibleAsGenericArgumentClause? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericArgumentClause: ExpressibleAsUnexpectedNodes? = nil, genericArgumentClause: ExpressibleAsGenericArgumentClause? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeIdentifier = unexpectedBeforeIdentifier?.createUnexpectedNodes()
     self.identifier = identifier
     self.unexpectedBetweenIdentifierAndGenericArgumentClause = unexpectedBetweenIdentifierAndGenericArgumentClause?.createUnexpectedNodes()
@@ -1200,6 +1307,9 @@ public struct SymbolicReferenceExpr: ExprBuildable, ExpressibleAsSymbolicReferen
     var result = SymbolicReferenceExprSyntax(unexpectedBeforeIdentifier?.buildUnexpectedNodes(format: format), identifier: identifier.buildToken(format: format), unexpectedBetweenIdentifierAndGenericArgumentClause?.buildUnexpectedNodes(format: format), genericArgumentClause: genericArgumentClause?.buildGenericArgumentClause(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1229,8 +1339,9 @@ public struct SymbolicReferenceExpr: ExprBuildable, ExpressibleAsSymbolicReferen
 }
 public struct PrefixOperatorExpr: ExprBuildable, ExpressibleAsPrefixOperatorExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeOperatorToken: UnexpectedNodes?
   var operatorToken: Token?
   var unexpectedBetweenOperatorTokenAndPostfixExpression: UnexpectedNodes?
@@ -1241,8 +1352,9 @@ public struct PrefixOperatorExpr: ExprBuildable, ExpressibleAsPrefixOperatorExpr
   ///   - operatorToken: 
   ///   - unexpectedBetweenOperatorTokenAndPostfixExpression: 
   ///   - postfixExpression: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeOperatorToken: ExpressibleAsUnexpectedNodes? = nil, operatorToken: Token? = nil, unexpectedBetweenOperatorTokenAndPostfixExpression: ExpressibleAsUnexpectedNodes? = nil, postfixExpression: ExpressibleAsExprBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeOperatorToken: ExpressibleAsUnexpectedNodes? = nil, operatorToken: Token? = nil, unexpectedBetweenOperatorTokenAndPostfixExpression: ExpressibleAsUnexpectedNodes? = nil, postfixExpression: ExpressibleAsExprBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeOperatorToken = unexpectedBeforeOperatorToken?.createUnexpectedNodes()
     self.operatorToken = operatorToken
     self.unexpectedBetweenOperatorTokenAndPostfixExpression = unexpectedBetweenOperatorTokenAndPostfixExpression?.createUnexpectedNodes()
@@ -1264,6 +1376,9 @@ public struct PrefixOperatorExpr: ExprBuildable, ExpressibleAsPrefixOperatorExpr
     var result = PrefixOperatorExprSyntax(unexpectedBeforeOperatorToken?.buildUnexpectedNodes(format: format), operatorToken: operatorToken?.buildToken(format: format), unexpectedBetweenOperatorTokenAndPostfixExpression?.buildUnexpectedNodes(format: format), postfixExpression: postfixExpression.buildExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1293,16 +1408,18 @@ public struct PrefixOperatorExpr: ExprBuildable, ExpressibleAsPrefixOperatorExpr
 }
 public struct BinaryOperatorExpr: ExprBuildable, ExpressibleAsBinaryOperatorExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeOperatorToken: UnexpectedNodes?
   var operatorToken: Token
   /// Creates a `BinaryOperatorExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeOperatorToken: 
   ///   - operatorToken: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeOperatorToken: ExpressibleAsUnexpectedNodes? = nil, operatorToken: Token) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeOperatorToken: ExpressibleAsUnexpectedNodes? = nil, operatorToken: Token) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeOperatorToken = unexpectedBeforeOperatorToken?.createUnexpectedNodes()
     self.operatorToken = operatorToken
   }
@@ -1314,6 +1431,9 @@ public struct BinaryOperatorExpr: ExprBuildable, ExpressibleAsBinaryOperatorExpr
     var result = BinaryOperatorExprSyntax(unexpectedBeforeOperatorToken?.buildUnexpectedNodes(format: format), operatorToken: operatorToken.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1343,8 +1463,9 @@ public struct BinaryOperatorExpr: ExprBuildable, ExpressibleAsBinaryOperatorExpr
 }
 public struct ArrowExpr: ExprBuildable, ExpressibleAsArrowExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAsyncKeyword: UnexpectedNodes?
   var asyncKeyword: Token?
   var unexpectedBetweenAsyncKeywordAndThrowsToken: UnexpectedNodes?
@@ -1359,8 +1480,9 @@ public struct ArrowExpr: ExprBuildable, ExpressibleAsArrowExpr {
   ///   - throwsToken: 
   ///   - unexpectedBetweenThrowsTokenAndArrowToken: 
   ///   - arrowToken: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAsyncKeyword: ExpressibleAsUnexpectedNodes? = nil, asyncKeyword: Token? = nil, unexpectedBetweenAsyncKeywordAndThrowsToken: ExpressibleAsUnexpectedNodes? = nil, throwsToken: Token? = nil, unexpectedBetweenThrowsTokenAndArrowToken: ExpressibleAsUnexpectedNodes? = nil, arrowToken: Token = Token.`arrow`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAsyncKeyword: ExpressibleAsUnexpectedNodes? = nil, asyncKeyword: Token? = nil, unexpectedBetweenAsyncKeywordAndThrowsToken: ExpressibleAsUnexpectedNodes? = nil, throwsToken: Token? = nil, unexpectedBetweenThrowsTokenAndArrowToken: ExpressibleAsUnexpectedNodes? = nil, arrowToken: Token = Token.`arrow`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAsyncKeyword = unexpectedBeforeAsyncKeyword?.createUnexpectedNodes()
     self.asyncKeyword = asyncKeyword
     assert(asyncKeyword == nil || asyncKeyword!.text == #"async"#)
@@ -1387,6 +1509,9 @@ public struct ArrowExpr: ExprBuildable, ExpressibleAsArrowExpr {
     var result = ArrowExprSyntax(unexpectedBeforeAsyncKeyword?.buildUnexpectedNodes(format: format), asyncKeyword: asyncKeyword?.buildToken(format: format), unexpectedBetweenAsyncKeywordAndThrowsToken?.buildUnexpectedNodes(format: format), throwsToken: throwsToken?.buildToken(format: format), unexpectedBetweenThrowsTokenAndArrowToken?.buildUnexpectedNodes(format: format), arrowToken: arrowToken.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1416,8 +1541,9 @@ public struct ArrowExpr: ExprBuildable, ExpressibleAsArrowExpr {
 }
 public struct InfixOperatorExpr: ExprBuildable, ExpressibleAsInfixOperatorExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftOperand: UnexpectedNodes?
   var leftOperand: ExprBuildable
   var unexpectedBetweenLeftOperandAndOperatorOperand: UnexpectedNodes?
@@ -1432,8 +1558,9 @@ public struct InfixOperatorExpr: ExprBuildable, ExpressibleAsInfixOperatorExpr {
   ///   - operatorOperand: 
   ///   - unexpectedBetweenOperatorOperandAndRightOperand: 
   ///   - rightOperand: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftOperand: ExpressibleAsUnexpectedNodes? = nil, leftOperand: ExpressibleAsExprBuildable, unexpectedBetweenLeftOperandAndOperatorOperand: ExpressibleAsUnexpectedNodes? = nil, operatorOperand: ExpressibleAsExprBuildable, unexpectedBetweenOperatorOperandAndRightOperand: ExpressibleAsUnexpectedNodes? = nil, rightOperand: ExpressibleAsExprBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftOperand: ExpressibleAsUnexpectedNodes? = nil, leftOperand: ExpressibleAsExprBuildable, unexpectedBetweenLeftOperandAndOperatorOperand: ExpressibleAsUnexpectedNodes? = nil, operatorOperand: ExpressibleAsExprBuildable, unexpectedBetweenOperatorOperandAndRightOperand: ExpressibleAsUnexpectedNodes? = nil, rightOperand: ExpressibleAsExprBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftOperand = unexpectedBeforeLeftOperand?.createUnexpectedNodes()
     self.leftOperand = leftOperand.createExprBuildable()
     self.unexpectedBetweenLeftOperandAndOperatorOperand = unexpectedBetweenLeftOperandAndOperatorOperand?.createUnexpectedNodes()
@@ -1449,6 +1576,9 @@ public struct InfixOperatorExpr: ExprBuildable, ExpressibleAsInfixOperatorExpr {
     var result = InfixOperatorExprSyntax(unexpectedBeforeLeftOperand?.buildUnexpectedNodes(format: format), leftOperand: leftOperand.buildExpr(format: format), unexpectedBetweenLeftOperandAndOperatorOperand?.buildUnexpectedNodes(format: format), operatorOperand: operatorOperand.buildExpr(format: format), unexpectedBetweenOperatorOperandAndRightOperand?.buildUnexpectedNodes(format: format), rightOperand: rightOperand.buildExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1478,16 +1608,18 @@ public struct InfixOperatorExpr: ExprBuildable, ExpressibleAsInfixOperatorExpr {
 }
 public struct FloatLiteralExpr: ExprBuildable, ExpressibleAsFloatLiteralExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeFloatingDigits: UnexpectedNodes?
   var floatingDigits: Token
   /// Creates a `FloatLiteralExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeFloatingDigits: 
   ///   - floatingDigits: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeFloatingDigits: ExpressibleAsUnexpectedNodes? = nil, floatingDigits: Token) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeFloatingDigits: ExpressibleAsUnexpectedNodes? = nil, floatingDigits: Token) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeFloatingDigits = unexpectedBeforeFloatingDigits?.createUnexpectedNodes()
     self.floatingDigits = floatingDigits
   }
@@ -1505,6 +1637,9 @@ public struct FloatLiteralExpr: ExprBuildable, ExpressibleAsFloatLiteralExpr {
     var result = FloatLiteralExprSyntax(unexpectedBeforeFloatingDigits?.buildUnexpectedNodes(format: format), floatingDigits: floatingDigits.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1534,8 +1669,9 @@ public struct FloatLiteralExpr: ExprBuildable, ExpressibleAsFloatLiteralExpr {
 }
 public struct TupleExpr: ExprBuildable, ExpressibleAsTupleExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftParen: UnexpectedNodes?
   var leftParen: Token
   var unexpectedBetweenLeftParenAndElementList: UnexpectedNodes?
@@ -1550,8 +1686,9 @@ public struct TupleExpr: ExprBuildable, ExpressibleAsTupleExpr {
   ///   - elementList: 
   ///   - unexpectedBetweenElementListAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElementList: ExpressibleAsUnexpectedNodes? = nil, elementList: ExpressibleAsTupleExprElementList, unexpectedBetweenElementListAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElementList: ExpressibleAsUnexpectedNodes? = nil, elementList: ExpressibleAsTupleExprElementList, unexpectedBetweenElementListAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftParen = unexpectedBeforeLeftParen?.createUnexpectedNodes()
     self.leftParen = leftParen
     assert(leftParen.text == #"("#)
@@ -1577,6 +1714,9 @@ public struct TupleExpr: ExprBuildable, ExpressibleAsTupleExpr {
     var result = TupleExprSyntax(unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format), leftParen: leftParen.buildToken(format: format), unexpectedBetweenLeftParenAndElementList?.buildUnexpectedNodes(format: format), elementList: elementList.buildTupleExprElementList(format: format), unexpectedBetweenElementListAndRightParen?.buildUnexpectedNodes(format: format), rightParen: rightParen.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1606,8 +1746,9 @@ public struct TupleExpr: ExprBuildable, ExpressibleAsTupleExpr {
 }
 public struct ArrayExpr: ExprBuildable, ExpressibleAsArrayExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftSquare: UnexpectedNodes?
   var leftSquare: Token
   var unexpectedBetweenLeftSquareAndElements: UnexpectedNodes?
@@ -1622,8 +1763,9 @@ public struct ArrayExpr: ExprBuildable, ExpressibleAsArrayExpr {
   ///   - elements: 
   ///   - unexpectedBetweenElementsAndRightSquare: 
   ///   - rightSquare: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftSquare: ExpressibleAsUnexpectedNodes? = nil, leftSquare: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareAndElements: ExpressibleAsUnexpectedNodes? = nil, elements: ExpressibleAsArrayElementList, unexpectedBetweenElementsAndRightSquare: ExpressibleAsUnexpectedNodes? = nil, rightSquare: Token = Token.`rightSquareBracket`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftSquare: ExpressibleAsUnexpectedNodes? = nil, leftSquare: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareAndElements: ExpressibleAsUnexpectedNodes? = nil, elements: ExpressibleAsArrayElementList, unexpectedBetweenElementsAndRightSquare: ExpressibleAsUnexpectedNodes? = nil, rightSquare: Token = Token.`rightSquareBracket`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftSquare = unexpectedBeforeLeftSquare?.createUnexpectedNodes()
     self.leftSquare = leftSquare
     assert(leftSquare.text == #"["#)
@@ -1649,6 +1791,9 @@ public struct ArrayExpr: ExprBuildable, ExpressibleAsArrayExpr {
     var result = ArrayExprSyntax(unexpectedBeforeLeftSquare?.buildUnexpectedNodes(format: format), leftSquare: leftSquare.buildToken(format: format), unexpectedBetweenLeftSquareAndElements?.buildUnexpectedNodes(format: format), elements: elements.buildArrayElementList(format: format), unexpectedBetweenElementsAndRightSquare?.buildUnexpectedNodes(format: format), rightSquare: rightSquare.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1678,8 +1823,9 @@ public struct ArrayExpr: ExprBuildable, ExpressibleAsArrayExpr {
 }
 public struct DictionaryExpr: ExprBuildable, ExpressibleAsDictionaryExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftSquare: UnexpectedNodes?
   var leftSquare: Token
   var unexpectedBetweenLeftSquareAndContent: UnexpectedNodes?
@@ -1694,8 +1840,9 @@ public struct DictionaryExpr: ExprBuildable, ExpressibleAsDictionaryExpr {
   ///   - content: 
   ///   - unexpectedBetweenContentAndRightSquare: 
   ///   - rightSquare: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftSquare: ExpressibleAsUnexpectedNodes? = nil, leftSquare: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareAndContent: ExpressibleAsUnexpectedNodes? = nil, content: ExpressibleAsSyntaxBuildable, unexpectedBetweenContentAndRightSquare: ExpressibleAsUnexpectedNodes? = nil, rightSquare: Token = Token.`rightSquareBracket`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftSquare: ExpressibleAsUnexpectedNodes? = nil, leftSquare: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareAndContent: ExpressibleAsUnexpectedNodes? = nil, content: ExpressibleAsSyntaxBuildable, unexpectedBetweenContentAndRightSquare: ExpressibleAsUnexpectedNodes? = nil, rightSquare: Token = Token.`rightSquareBracket`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftSquare = unexpectedBeforeLeftSquare?.createUnexpectedNodes()
     self.leftSquare = leftSquare
     assert(leftSquare.text == #"["#)
@@ -1713,6 +1860,9 @@ public struct DictionaryExpr: ExprBuildable, ExpressibleAsDictionaryExpr {
     var result = DictionaryExprSyntax(unexpectedBeforeLeftSquare?.buildUnexpectedNodes(format: format), leftSquare: leftSquare.buildToken(format: format), unexpectedBetweenLeftSquareAndContent?.buildUnexpectedNodes(format: format), content: content.buildSyntax(format: format), unexpectedBetweenContentAndRightSquare?.buildUnexpectedNodes(format: format), rightSquare: rightSquare.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1742,8 +1892,9 @@ public struct DictionaryExpr: ExprBuildable, ExpressibleAsDictionaryExpr {
 }
 public struct TupleExprElement: SyntaxBuildable, ExpressibleAsTupleExprElement, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLabel: UnexpectedNodes?
   var label: Token?
   var unexpectedBetweenLabelAndColon: UnexpectedNodes?
@@ -1762,8 +1913,9 @@ public struct TupleExprElement: SyntaxBuildable, ExpressibleAsTupleExprElement, 
   ///   - expression: 
   ///   - unexpectedBetweenExpressionAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token? = nil, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token? = nil, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLabel = unexpectedBeforeLabel?.createUnexpectedNodes()
     self.label = label
     self.unexpectedBetweenLabelAndColon = unexpectedBetweenLabelAndColon?.createUnexpectedNodes()
@@ -1783,6 +1935,9 @@ public struct TupleExprElement: SyntaxBuildable, ExpressibleAsTupleExprElement, 
     var result = TupleExprElementSyntax(unexpectedBeforeLabel?.buildUnexpectedNodes(format: format), label: label?.buildToken(format: format), unexpectedBetweenLabelAndColon?.buildUnexpectedNodes(format: format), colon: colon?.buildToken(format: format), unexpectedBetweenColonAndExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format), unexpectedBetweenExpressionAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1811,8 +1966,9 @@ public struct TupleExprElement: SyntaxBuildable, ExpressibleAsTupleExprElement, 
 }
 public struct ArrayElement: SyntaxBuildable, ExpressibleAsArrayElement, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeExpression: UnexpectedNodes?
   var expression: ExprBuildable
   var unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodes?
@@ -1823,8 +1979,9 @@ public struct ArrayElement: SyntaxBuildable, ExpressibleAsArrayElement, HasTrail
   ///   - expression: 
   ///   - unexpectedBetweenExpressionAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeExpression = unexpectedBeforeExpression?.createUnexpectedNodes()
     self.expression = expression.createExprBuildable()
     self.unexpectedBetweenExpressionAndTrailingComma = unexpectedBetweenExpressionAndTrailingComma?.createUnexpectedNodes()
@@ -1839,6 +1996,9 @@ public struct ArrayElement: SyntaxBuildable, ExpressibleAsArrayElement, HasTrail
     var result = ArrayElementSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format), unexpectedBetweenExpressionAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1867,8 +2027,9 @@ public struct ArrayElement: SyntaxBuildable, ExpressibleAsArrayElement, HasTrail
 }
 public struct DictionaryElement: SyntaxBuildable, ExpressibleAsDictionaryElement, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeKeyExpression: UnexpectedNodes?
   var keyExpression: ExprBuildable
   var unexpectedBetweenKeyExpressionAndColon: UnexpectedNodes?
@@ -1887,8 +2048,9 @@ public struct DictionaryElement: SyntaxBuildable, ExpressibleAsDictionaryElement
   ///   - valueExpression: 
   ///   - unexpectedBetweenValueExpressionAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeKeyExpression: ExpressibleAsUnexpectedNodes? = nil, keyExpression: ExpressibleAsExprBuildable, unexpectedBetweenKeyExpressionAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValueExpression: ExpressibleAsUnexpectedNodes? = nil, valueExpression: ExpressibleAsExprBuildable, unexpectedBetweenValueExpressionAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeKeyExpression: ExpressibleAsUnexpectedNodes? = nil, keyExpression: ExpressibleAsExprBuildable, unexpectedBetweenKeyExpressionAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValueExpression: ExpressibleAsUnexpectedNodes? = nil, valueExpression: ExpressibleAsExprBuildable, unexpectedBetweenValueExpressionAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeKeyExpression = unexpectedBeforeKeyExpression?.createUnexpectedNodes()
     self.keyExpression = keyExpression.createExprBuildable()
     self.unexpectedBetweenKeyExpressionAndColon = unexpectedBetweenKeyExpressionAndColon?.createUnexpectedNodes()
@@ -1908,6 +2070,9 @@ public struct DictionaryElement: SyntaxBuildable, ExpressibleAsDictionaryElement
     var result = DictionaryElementSyntax(unexpectedBeforeKeyExpression?.buildUnexpectedNodes(format: format), keyExpression: keyExpression.buildExpr(format: format), unexpectedBetweenKeyExpressionAndColon?.buildUnexpectedNodes(format: format), colon: colon.buildToken(format: format), unexpectedBetweenColonAndValueExpression?.buildUnexpectedNodes(format: format), valueExpression: valueExpression.buildExpr(format: format), unexpectedBetweenValueExpressionAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1936,16 +2101,18 @@ public struct DictionaryElement: SyntaxBuildable, ExpressibleAsDictionaryElement
 }
 public struct IntegerLiteralExpr: ExprBuildable, ExpressibleAsIntegerLiteralExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeDigits: UnexpectedNodes?
   var digits: Token
   /// Creates a `IntegerLiteralExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeDigits: 
   ///   - digits: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeDigits: ExpressibleAsUnexpectedNodes? = nil, digits: Token) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDigits: ExpressibleAsUnexpectedNodes? = nil, digits: Token) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeDigits = unexpectedBeforeDigits?.createUnexpectedNodes()
     self.digits = digits
   }
@@ -1963,6 +2130,9 @@ public struct IntegerLiteralExpr: ExprBuildable, ExpressibleAsIntegerLiteralExpr
     var result = IntegerLiteralExprSyntax(unexpectedBeforeDigits?.buildUnexpectedNodes(format: format), digits: digits.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -1992,16 +2162,18 @@ public struct IntegerLiteralExpr: ExprBuildable, ExpressibleAsIntegerLiteralExpr
 }
 public struct BooleanLiteralExpr: ExprBuildable, ExpressibleAsBooleanLiteralExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeBooleanLiteral: UnexpectedNodes?
   var booleanLiteral: Token
   /// Creates a `BooleanLiteralExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeBooleanLiteral: 
   ///   - booleanLiteral: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeBooleanLiteral: ExpressibleAsUnexpectedNodes? = nil, booleanLiteral: Token) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBooleanLiteral: ExpressibleAsUnexpectedNodes? = nil, booleanLiteral: Token) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeBooleanLiteral = unexpectedBeforeBooleanLiteral?.createUnexpectedNodes()
     self.booleanLiteral = booleanLiteral
     assert(booleanLiteral.text == #"true"# || booleanLiteral.text == #"false"#)
@@ -2014,6 +2186,9 @@ public struct BooleanLiteralExpr: ExprBuildable, ExpressibleAsBooleanLiteralExpr
     var result = BooleanLiteralExprSyntax(unexpectedBeforeBooleanLiteral?.buildUnexpectedNodes(format: format), booleanLiteral: booleanLiteral.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -2043,8 +2218,9 @@ public struct BooleanLiteralExpr: ExprBuildable, ExpressibleAsBooleanLiteralExpr
 }
 public struct UnresolvedTernaryExpr: ExprBuildable, ExpressibleAsUnresolvedTernaryExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeQuestionMark: UnexpectedNodes?
   var questionMark: Token
   var unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodes?
@@ -2059,8 +2235,9 @@ public struct UnresolvedTernaryExpr: ExprBuildable, ExpressibleAsUnresolvedTerna
   ///   - firstChoice: 
   ///   - unexpectedBetweenFirstChoiceAndColonMark: 
   ///   - colonMark: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeQuestionMark: ExpressibleAsUnexpectedNodes? = nil, questionMark: Token = Token.`infixQuestionMark`, unexpectedBetweenQuestionMarkAndFirstChoice: ExpressibleAsUnexpectedNodes? = nil, firstChoice: ExpressibleAsExprBuildable, unexpectedBetweenFirstChoiceAndColonMark: ExpressibleAsUnexpectedNodes? = nil, colonMark: Token = Token.`colon`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeQuestionMark: ExpressibleAsUnexpectedNodes? = nil, questionMark: Token = Token.`infixQuestionMark`, unexpectedBetweenQuestionMarkAndFirstChoice: ExpressibleAsUnexpectedNodes? = nil, firstChoice: ExpressibleAsExprBuildable, unexpectedBetweenFirstChoiceAndColonMark: ExpressibleAsUnexpectedNodes? = nil, colonMark: Token = Token.`colon`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeQuestionMark = unexpectedBeforeQuestionMark?.createUnexpectedNodes()
     self.questionMark = questionMark
     assert(questionMark.text == #"?"#)
@@ -2078,6 +2255,9 @@ public struct UnresolvedTernaryExpr: ExprBuildable, ExpressibleAsUnresolvedTerna
     var result = UnresolvedTernaryExprSyntax(unexpectedBeforeQuestionMark?.buildUnexpectedNodes(format: format), questionMark: questionMark.buildToken(format: format), unexpectedBetweenQuestionMarkAndFirstChoice?.buildUnexpectedNodes(format: format), firstChoice: firstChoice.buildExpr(format: format), unexpectedBetweenFirstChoiceAndColonMark?.buildUnexpectedNodes(format: format), colonMark: colonMark.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -2107,8 +2287,9 @@ public struct UnresolvedTernaryExpr: ExprBuildable, ExpressibleAsUnresolvedTerna
 }
 public struct TernaryExpr: ExprBuildable, ExpressibleAsTernaryExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeConditionExpression: UnexpectedNodes?
   var conditionExpression: ExprBuildable
   var unexpectedBetweenConditionExpressionAndQuestionMark: UnexpectedNodes?
@@ -2131,8 +2312,9 @@ public struct TernaryExpr: ExprBuildable, ExpressibleAsTernaryExpr {
   ///   - colonMark: 
   ///   - unexpectedBetweenColonMarkAndSecondChoice: 
   ///   - secondChoice: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeConditionExpression: ExpressibleAsUnexpectedNodes? = nil, conditionExpression: ExpressibleAsExprBuildable, unexpectedBetweenConditionExpressionAndQuestionMark: ExpressibleAsUnexpectedNodes? = nil, questionMark: Token = Token.`infixQuestionMark`, unexpectedBetweenQuestionMarkAndFirstChoice: ExpressibleAsUnexpectedNodes? = nil, firstChoice: ExpressibleAsExprBuildable, unexpectedBetweenFirstChoiceAndColonMark: ExpressibleAsUnexpectedNodes? = nil, colonMark: Token = Token.`colon`, unexpectedBetweenColonMarkAndSecondChoice: ExpressibleAsUnexpectedNodes? = nil, secondChoice: ExpressibleAsExprBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeConditionExpression: ExpressibleAsUnexpectedNodes? = nil, conditionExpression: ExpressibleAsExprBuildable, unexpectedBetweenConditionExpressionAndQuestionMark: ExpressibleAsUnexpectedNodes? = nil, questionMark: Token = Token.`infixQuestionMark`, unexpectedBetweenQuestionMarkAndFirstChoice: ExpressibleAsUnexpectedNodes? = nil, firstChoice: ExpressibleAsExprBuildable, unexpectedBetweenFirstChoiceAndColonMark: ExpressibleAsUnexpectedNodes? = nil, colonMark: Token = Token.`colon`, unexpectedBetweenColonMarkAndSecondChoice: ExpressibleAsUnexpectedNodes? = nil, secondChoice: ExpressibleAsExprBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeConditionExpression = unexpectedBeforeConditionExpression?.createUnexpectedNodes()
     self.conditionExpression = conditionExpression.createExprBuildable()
     self.unexpectedBetweenConditionExpressionAndQuestionMark = unexpectedBetweenConditionExpressionAndQuestionMark?.createUnexpectedNodes()
@@ -2154,6 +2336,9 @@ public struct TernaryExpr: ExprBuildable, ExpressibleAsTernaryExpr {
     var result = TernaryExprSyntax(unexpectedBeforeConditionExpression?.buildUnexpectedNodes(format: format), conditionExpression: conditionExpression.buildExpr(format: format), unexpectedBetweenConditionExpressionAndQuestionMark?.buildUnexpectedNodes(format: format), questionMark: questionMark.buildToken(format: format), unexpectedBetweenQuestionMarkAndFirstChoice?.buildUnexpectedNodes(format: format), firstChoice: firstChoice.buildExpr(format: format), unexpectedBetweenFirstChoiceAndColonMark?.buildUnexpectedNodes(format: format), colonMark: colonMark.buildToken(format: format), unexpectedBetweenColonMarkAndSecondChoice?.buildUnexpectedNodes(format: format), secondChoice: secondChoice.buildExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -2183,8 +2368,9 @@ public struct TernaryExpr: ExprBuildable, ExpressibleAsTernaryExpr {
 }
 public struct MemberAccessExpr: ExprBuildable, ExpressibleAsMemberAccessExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeBase: UnexpectedNodes?
   var base: ExprBuildable?
   var unexpectedBetweenBaseAndDot: UnexpectedNodes?
@@ -2203,8 +2389,9 @@ public struct MemberAccessExpr: ExprBuildable, ExpressibleAsMemberAccessExpr {
   ///   - name: 
   ///   - unexpectedBetweenNameAndDeclNameArguments: 
   ///   - declNameArguments: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeBase: ExpressibleAsUnexpectedNodes? = nil, base: ExpressibleAsExprBuildable? = nil, unexpectedBetweenBaseAndDot: ExpressibleAsUnexpectedNodes? = nil, dot: Token, unexpectedBetweenDotAndName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndDeclNameArguments: ExpressibleAsUnexpectedNodes? = nil, declNameArguments: ExpressibleAsDeclNameArguments? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBase: ExpressibleAsUnexpectedNodes? = nil, base: ExpressibleAsExprBuildable? = nil, unexpectedBetweenBaseAndDot: ExpressibleAsUnexpectedNodes? = nil, dot: Token, unexpectedBetweenDotAndName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndDeclNameArguments: ExpressibleAsUnexpectedNodes? = nil, declNameArguments: ExpressibleAsDeclNameArguments? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeBase = unexpectedBeforeBase?.createUnexpectedNodes()
     self.base = base?.createExprBuildable()
     self.unexpectedBetweenBaseAndDot = unexpectedBetweenBaseAndDot?.createUnexpectedNodes()
@@ -2223,6 +2410,9 @@ public struct MemberAccessExpr: ExprBuildable, ExpressibleAsMemberAccessExpr {
     var result = MemberAccessExprSyntax(unexpectedBeforeBase?.buildUnexpectedNodes(format: format), base: base?.buildExpr(format: format), unexpectedBetweenBaseAndDot?.buildUnexpectedNodes(format: format), dot: dot.buildToken(format: format), unexpectedBetweenDotAndName?.buildUnexpectedNodes(format: format), name: name.buildToken(format: format), unexpectedBetweenNameAndDeclNameArguments?.buildUnexpectedNodes(format: format), declNameArguments: declNameArguments?.buildDeclNameArguments(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -2252,16 +2442,18 @@ public struct MemberAccessExpr: ExprBuildable, ExpressibleAsMemberAccessExpr {
 }
 public struct UnresolvedIsExpr: ExprBuildable, ExpressibleAsUnresolvedIsExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeIsTok: UnexpectedNodes?
   var isTok: Token
   /// Creates a `UnresolvedIsExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeIsTok: 
   ///   - isTok: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeIsTok: ExpressibleAsUnexpectedNodes? = nil, isTok: Token = Token.`is`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIsTok: ExpressibleAsUnexpectedNodes? = nil, isTok: Token = Token.`is`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeIsTok = unexpectedBeforeIsTok?.createUnexpectedNodes()
     self.isTok = isTok
     assert(isTok.text == #"is"#)
@@ -2274,6 +2466,9 @@ public struct UnresolvedIsExpr: ExprBuildable, ExpressibleAsUnresolvedIsExpr {
     var result = UnresolvedIsExprSyntax(unexpectedBeforeIsTok?.buildUnexpectedNodes(format: format), isTok: isTok.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -2303,8 +2498,9 @@ public struct UnresolvedIsExpr: ExprBuildable, ExpressibleAsUnresolvedIsExpr {
 }
 public struct IsExpr: ExprBuildable, ExpressibleAsIsExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeExpression: UnexpectedNodes?
   var expression: ExprBuildable
   var unexpectedBetweenExpressionAndIsTok: UnexpectedNodes?
@@ -2319,8 +2515,9 @@ public struct IsExpr: ExprBuildable, ExpressibleAsIsExpr {
   ///   - isTok: 
   ///   - unexpectedBetweenIsTokAndTypeName: 
   ///   - typeName: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndIsTok: ExpressibleAsUnexpectedNodes? = nil, isTok: Token = Token.`is`, unexpectedBetweenIsTokAndTypeName: ExpressibleAsUnexpectedNodes? = nil, typeName: ExpressibleAsTypeBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndIsTok: ExpressibleAsUnexpectedNodes? = nil, isTok: Token = Token.`is`, unexpectedBetweenIsTokAndTypeName: ExpressibleAsUnexpectedNodes? = nil, typeName: ExpressibleAsTypeBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeExpression = unexpectedBeforeExpression?.createUnexpectedNodes()
     self.expression = expression.createExprBuildable()
     self.unexpectedBetweenExpressionAndIsTok = unexpectedBetweenExpressionAndIsTok?.createUnexpectedNodes()
@@ -2337,6 +2534,9 @@ public struct IsExpr: ExprBuildable, ExpressibleAsIsExpr {
     var result = IsExprSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format), unexpectedBetweenExpressionAndIsTok?.buildUnexpectedNodes(format: format), isTok: isTok.buildToken(format: format), unexpectedBetweenIsTokAndTypeName?.buildUnexpectedNodes(format: format), typeName: typeName.buildType(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -2366,8 +2566,9 @@ public struct IsExpr: ExprBuildable, ExpressibleAsIsExpr {
 }
 public struct UnresolvedAsExpr: ExprBuildable, ExpressibleAsUnresolvedAsExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAsTok: UnexpectedNodes?
   var asTok: Token
   var unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodes?
@@ -2378,8 +2579,9 @@ public struct UnresolvedAsExpr: ExprBuildable, ExpressibleAsUnresolvedAsExpr {
   ///   - asTok: 
   ///   - unexpectedBetweenAsTokAndQuestionOrExclamationMark: 
   ///   - questionOrExclamationMark: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAsTok: ExpressibleAsUnexpectedNodes? = nil, asTok: Token = Token.`as`, unexpectedBetweenAsTokAndQuestionOrExclamationMark: ExpressibleAsUnexpectedNodes? = nil, questionOrExclamationMark: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAsTok: ExpressibleAsUnexpectedNodes? = nil, asTok: Token = Token.`as`, unexpectedBetweenAsTokAndQuestionOrExclamationMark: ExpressibleAsUnexpectedNodes? = nil, questionOrExclamationMark: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAsTok = unexpectedBeforeAsTok?.createUnexpectedNodes()
     self.asTok = asTok
     assert(asTok.text == #"as"#)
@@ -2395,6 +2597,9 @@ public struct UnresolvedAsExpr: ExprBuildable, ExpressibleAsUnresolvedAsExpr {
     var result = UnresolvedAsExprSyntax(unexpectedBeforeAsTok?.buildUnexpectedNodes(format: format), asTok: asTok.buildToken(format: format), unexpectedBetweenAsTokAndQuestionOrExclamationMark?.buildUnexpectedNodes(format: format), questionOrExclamationMark: questionOrExclamationMark?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -2424,8 +2629,9 @@ public struct UnresolvedAsExpr: ExprBuildable, ExpressibleAsUnresolvedAsExpr {
 }
 public struct AsExpr: ExprBuildable, ExpressibleAsAsExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeExpression: UnexpectedNodes?
   var expression: ExprBuildable
   var unexpectedBetweenExpressionAndAsTok: UnexpectedNodes?
@@ -2444,8 +2650,9 @@ public struct AsExpr: ExprBuildable, ExpressibleAsAsExpr {
   ///   - questionOrExclamationMark: 
   ///   - unexpectedBetweenQuestionOrExclamationMarkAndTypeName: 
   ///   - typeName: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndAsTok: ExpressibleAsUnexpectedNodes? = nil, asTok: Token = Token.`as`, unexpectedBetweenAsTokAndQuestionOrExclamationMark: ExpressibleAsUnexpectedNodes? = nil, questionOrExclamationMark: Token? = nil, unexpectedBetweenQuestionOrExclamationMarkAndTypeName: ExpressibleAsUnexpectedNodes? = nil, typeName: ExpressibleAsTypeBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndAsTok: ExpressibleAsUnexpectedNodes? = nil, asTok: Token = Token.`as`, unexpectedBetweenAsTokAndQuestionOrExclamationMark: ExpressibleAsUnexpectedNodes? = nil, questionOrExclamationMark: Token? = nil, unexpectedBetweenQuestionOrExclamationMarkAndTypeName: ExpressibleAsUnexpectedNodes? = nil, typeName: ExpressibleAsTypeBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeExpression = unexpectedBeforeExpression?.createUnexpectedNodes()
     self.expression = expression.createExprBuildable()
     self.unexpectedBetweenExpressionAndAsTok = unexpectedBetweenExpressionAndAsTok?.createUnexpectedNodes()
@@ -2465,6 +2672,9 @@ public struct AsExpr: ExprBuildable, ExpressibleAsAsExpr {
     var result = AsExprSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format), unexpectedBetweenExpressionAndAsTok?.buildUnexpectedNodes(format: format), asTok: asTok.buildToken(format: format), unexpectedBetweenAsTokAndQuestionOrExclamationMark?.buildUnexpectedNodes(format: format), questionOrExclamationMark: questionOrExclamationMark?.buildToken(format: format), unexpectedBetweenQuestionOrExclamationMarkAndTypeName?.buildUnexpectedNodes(format: format), typeName: typeName.buildType(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -2494,16 +2704,18 @@ public struct AsExpr: ExprBuildable, ExpressibleAsAsExpr {
 }
 public struct TypeExpr: ExprBuildable, ExpressibleAsTypeExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeType: UnexpectedNodes?
   var type: TypeBuildable
   /// Creates a `TypeExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeType: 
   ///   - type: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeType = unexpectedBeforeType?.createUnexpectedNodes()
     self.type = type.createTypeBuildable()
   }
@@ -2515,6 +2727,9 @@ public struct TypeExpr: ExprBuildable, ExpressibleAsTypeExpr {
     var result = TypeExprSyntax(unexpectedBeforeType?.buildUnexpectedNodes(format: format), type: type.buildType(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -2544,8 +2759,9 @@ public struct TypeExpr: ExprBuildable, ExpressibleAsTypeExpr {
 }
 public struct ClosureCaptureItem: SyntaxBuildable, ExpressibleAsClosureCaptureItem, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeSpecifier: UnexpectedNodes?
   var specifier: TokenList?
   var unexpectedBetweenSpecifierAndName: UnexpectedNodes?
@@ -2568,8 +2784,9 @@ public struct ClosureCaptureItem: SyntaxBuildable, ExpressibleAsClosureCaptureIt
   ///   - expression: 
   ///   - unexpectedBetweenExpressionAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeSpecifier: ExpressibleAsUnexpectedNodes? = nil, specifier: ExpressibleAsTokenList? = nil, unexpectedBetweenSpecifierAndName: ExpressibleAsUnexpectedNodes? = nil, name: Token? = nil, unexpectedBetweenNameAndAssignToken: ExpressibleAsUnexpectedNodes? = nil, assignToken: Token? = nil, unexpectedBetweenAssignTokenAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeSpecifier: ExpressibleAsUnexpectedNodes? = nil, specifier: ExpressibleAsTokenList? = nil, unexpectedBetweenSpecifierAndName: ExpressibleAsUnexpectedNodes? = nil, name: Token? = nil, unexpectedBetweenNameAndAssignToken: ExpressibleAsUnexpectedNodes? = nil, assignToken: Token? = nil, unexpectedBetweenAssignTokenAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeSpecifier = unexpectedBeforeSpecifier?.createUnexpectedNodes()
     self.specifier = specifier?.createTokenList()
     self.unexpectedBetweenSpecifierAndName = unexpectedBetweenSpecifierAndName?.createUnexpectedNodes()
@@ -2600,6 +2817,9 @@ public struct ClosureCaptureItem: SyntaxBuildable, ExpressibleAsClosureCaptureIt
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -2627,8 +2847,9 @@ public struct ClosureCaptureItem: SyntaxBuildable, ExpressibleAsClosureCaptureIt
 }
 public struct ClosureCaptureSignature: SyntaxBuildable, ExpressibleAsClosureCaptureSignature {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftSquare: UnexpectedNodes?
   var leftSquare: Token
   var unexpectedBetweenLeftSquareAndItems: UnexpectedNodes?
@@ -2643,8 +2864,9 @@ public struct ClosureCaptureSignature: SyntaxBuildable, ExpressibleAsClosureCapt
   ///   - items: 
   ///   - unexpectedBetweenItemsAndRightSquare: 
   ///   - rightSquare: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftSquare: ExpressibleAsUnexpectedNodes? = nil, leftSquare: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareAndItems: ExpressibleAsUnexpectedNodes? = nil, items: ExpressibleAsClosureCaptureItemList? = nil, unexpectedBetweenItemsAndRightSquare: ExpressibleAsUnexpectedNodes? = nil, rightSquare: Token = Token.`rightSquareBracket`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftSquare: ExpressibleAsUnexpectedNodes? = nil, leftSquare: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareAndItems: ExpressibleAsUnexpectedNodes? = nil, items: ExpressibleAsClosureCaptureItemList? = nil, unexpectedBetweenItemsAndRightSquare: ExpressibleAsUnexpectedNodes? = nil, rightSquare: Token = Token.`rightSquareBracket`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftSquare = unexpectedBeforeLeftSquare?.createUnexpectedNodes()
     self.leftSquare = leftSquare
     assert(leftSquare.text == #"["#)
@@ -2671,6 +2893,9 @@ public struct ClosureCaptureSignature: SyntaxBuildable, ExpressibleAsClosureCapt
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -2692,8 +2917,9 @@ public struct ClosureCaptureSignature: SyntaxBuildable, ExpressibleAsClosureCapt
 }
 public struct ClosureParam: SyntaxBuildable, ExpressibleAsClosureParam, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeName: UnexpectedNodes?
   var name: Token
   var unexpectedBetweenNameAndTrailingComma: UnexpectedNodes?
@@ -2704,8 +2930,9 @@ public struct ClosureParam: SyntaxBuildable, ExpressibleAsClosureParam, HasTrail
   ///   - name: 
   ///   - unexpectedBetweenNameAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeName = unexpectedBeforeName?.createUnexpectedNodes()
     self.name = name
     self.unexpectedBetweenNameAndTrailingComma = unexpectedBetweenNameAndTrailingComma?.createUnexpectedNodes()
@@ -2720,6 +2947,9 @@ public struct ClosureParam: SyntaxBuildable, ExpressibleAsClosureParam, HasTrail
     var result = ClosureParamSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format), name: name.buildToken(format: format), unexpectedBetweenNameAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -2748,8 +2978,9 @@ public struct ClosureParam: SyntaxBuildable, ExpressibleAsClosureParam, HasTrail
 }
 public struct ClosureSignature: SyntaxBuildable, ExpressibleAsClosureSignature {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndCapture: UnexpectedNodes?
@@ -2780,8 +3011,9 @@ public struct ClosureSignature: SyntaxBuildable, ExpressibleAsClosureSignature {
   ///   - output: 
   ///   - unexpectedBetweenOutputAndInTok: 
   ///   - inTok: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndCapture: ExpressibleAsUnexpectedNodes? = nil, capture: ExpressibleAsClosureCaptureSignature? = nil, unexpectedBetweenCaptureAndInput: ExpressibleAsUnexpectedNodes? = nil, input: ExpressibleAsSyntaxBuildable? = nil, unexpectedBetweenInputAndAsyncKeyword: ExpressibleAsUnexpectedNodes? = nil, asyncKeyword: Token? = nil, unexpectedBetweenAsyncKeywordAndThrowsTok: ExpressibleAsUnexpectedNodes? = nil, throwsTok: Token? = nil, unexpectedBetweenThrowsTokAndOutput: ExpressibleAsUnexpectedNodes? = nil, output: ExpressibleAsReturnClause? = nil, unexpectedBetweenOutputAndInTok: ExpressibleAsUnexpectedNodes? = nil, inTok: Token = Token.`in`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndCapture: ExpressibleAsUnexpectedNodes? = nil, capture: ExpressibleAsClosureCaptureSignature? = nil, unexpectedBetweenCaptureAndInput: ExpressibleAsUnexpectedNodes? = nil, input: ExpressibleAsSyntaxBuildable? = nil, unexpectedBetweenInputAndAsyncKeyword: ExpressibleAsUnexpectedNodes? = nil, asyncKeyword: Token? = nil, unexpectedBetweenAsyncKeywordAndThrowsTok: ExpressibleAsUnexpectedNodes? = nil, throwsTok: Token? = nil, unexpectedBetweenThrowsTokAndOutput: ExpressibleAsUnexpectedNodes? = nil, output: ExpressibleAsReturnClause? = nil, unexpectedBetweenOutputAndInTok: ExpressibleAsUnexpectedNodes? = nil, inTok: Token = Token.`in`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndCapture = unexpectedBetweenAttributesAndCapture?.createUnexpectedNodes()
@@ -2817,6 +3049,9 @@ public struct ClosureSignature: SyntaxBuildable, ExpressibleAsClosureSignature {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -2838,8 +3073,9 @@ public struct ClosureSignature: SyntaxBuildable, ExpressibleAsClosureSignature {
 }
 public struct ClosureExpr: ExprBuildable, ExpressibleAsClosureExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftBrace: UnexpectedNodes?
   var leftBrace: Token
   var unexpectedBetweenLeftBraceAndSignature: UnexpectedNodes?
@@ -2858,8 +3094,9 @@ public struct ClosureExpr: ExprBuildable, ExpressibleAsClosureExpr {
   ///   - statements: 
   ///   - unexpectedBetweenStatementsAndRightBrace: 
   ///   - rightBrace: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftBrace: ExpressibleAsUnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndSignature: ExpressibleAsUnexpectedNodes? = nil, signature: ExpressibleAsClosureSignature? = nil, unexpectedBetweenSignatureAndStatements: ExpressibleAsUnexpectedNodes? = nil, statements: ExpressibleAsCodeBlockItemList, unexpectedBetweenStatementsAndRightBrace: ExpressibleAsUnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftBrace: ExpressibleAsUnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndSignature: ExpressibleAsUnexpectedNodes? = nil, signature: ExpressibleAsClosureSignature? = nil, unexpectedBetweenSignatureAndStatements: ExpressibleAsUnexpectedNodes? = nil, statements: ExpressibleAsCodeBlockItemList, unexpectedBetweenStatementsAndRightBrace: ExpressibleAsUnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftBrace = unexpectedBeforeLeftBrace?.createUnexpectedNodes()
     self.leftBrace = leftBrace
     assert(leftBrace.text == #"{"#)
@@ -2887,6 +3124,9 @@ public struct ClosureExpr: ExprBuildable, ExpressibleAsClosureExpr {
     var result = ClosureExprSyntax(unexpectedBeforeLeftBrace?.buildUnexpectedNodes(format: format), leftBrace: leftBrace.buildToken(format: format), unexpectedBetweenLeftBraceAndSignature?.buildUnexpectedNodes(format: format), signature: signature?.buildClosureSignature(format: format), unexpectedBetweenSignatureAndStatements?.buildUnexpectedNodes(format: format), statements: statements.buildCodeBlockItemList(format: format._indented), unexpectedBetweenStatementsAndRightBrace?.buildUnexpectedNodes(format: format), rightBrace: rightBrace.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -2916,16 +3156,18 @@ public struct ClosureExpr: ExprBuildable, ExpressibleAsClosureExpr {
 }
 public struct UnresolvedPatternExpr: ExprBuildable, ExpressibleAsUnresolvedPatternExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePattern: UnexpectedNodes?
   var pattern: PatternBuildable
   /// Creates a `UnresolvedPatternExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforePattern: 
   ///   - pattern: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePattern = unexpectedBeforePattern?.createUnexpectedNodes()
     self.pattern = pattern.createPatternBuildable()
   }
@@ -2937,6 +3179,9 @@ public struct UnresolvedPatternExpr: ExprBuildable, ExpressibleAsUnresolvedPatte
     var result = UnresolvedPatternExprSyntax(unexpectedBeforePattern?.buildUnexpectedNodes(format: format), pattern: pattern.buildPattern(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -2966,8 +3211,9 @@ public struct UnresolvedPatternExpr: ExprBuildable, ExpressibleAsUnresolvedPatte
 }
 public struct MultipleTrailingClosureElement: SyntaxBuildable, ExpressibleAsMultipleTrailingClosureElement {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLabel: UnexpectedNodes?
   var label: Token
   var unexpectedBetweenLabelAndColon: UnexpectedNodes?
@@ -2982,8 +3228,9 @@ public struct MultipleTrailingClosureElement: SyntaxBuildable, ExpressibleAsMult
   ///   - colon: 
   ///   - unexpectedBetweenColonAndClosure: 
   ///   - closure: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndClosure: ExpressibleAsUnexpectedNodes? = nil, closure: ExpressibleAsClosureExpr) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndClosure: ExpressibleAsUnexpectedNodes? = nil, closure: ExpressibleAsClosureExpr) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLabel = unexpectedBeforeLabel?.createUnexpectedNodes()
     self.label = label
     self.unexpectedBetweenLabelAndColon = unexpectedBetweenLabelAndColon?.createUnexpectedNodes()
@@ -3000,6 +3247,9 @@ public struct MultipleTrailingClosureElement: SyntaxBuildable, ExpressibleAsMult
     var result = MultipleTrailingClosureElementSyntax(unexpectedBeforeLabel?.buildUnexpectedNodes(format: format), label: label.buildToken(format: format), unexpectedBetweenLabelAndColon?.buildUnexpectedNodes(format: format), colon: colon.buildToken(format: format), unexpectedBetweenColonAndClosure?.buildUnexpectedNodes(format: format), closure: closure.buildClosureExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -3022,8 +3272,9 @@ public struct MultipleTrailingClosureElement: SyntaxBuildable, ExpressibleAsMult
 }
 public struct FunctionCallExpr: ExprBuildable, ExpressibleAsFunctionCallExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeCalledExpression: UnexpectedNodes?
   var calledExpression: ExprBuildable
   var unexpectedBetweenCalledExpressionAndLeftParen: UnexpectedNodes?
@@ -3050,8 +3301,9 @@ public struct FunctionCallExpr: ExprBuildable, ExpressibleAsFunctionCallExpr {
   ///   - trailingClosure: 
   ///   - unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: 
   ///   - additionalTrailingClosures: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeCalledExpression: ExpressibleAsUnexpectedNodes? = nil, calledExpression: ExpressibleAsExprBuildable, unexpectedBetweenCalledExpressionAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: ExpressibleAsUnexpectedNodes? = nil, argumentList: ExpressibleAsTupleExprElementList, unexpectedBetweenArgumentListAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTrailingClosure: ExpressibleAsUnexpectedNodes? = nil, trailingClosure: ExpressibleAsClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: ExpressibleAsUnexpectedNodes? = nil, additionalTrailingClosures: ExpressibleAsMultipleTrailingClosureElementList? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeCalledExpression: ExpressibleAsUnexpectedNodes? = nil, calledExpression: ExpressibleAsExprBuildable, unexpectedBetweenCalledExpressionAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: ExpressibleAsUnexpectedNodes? = nil, argumentList: ExpressibleAsTupleExprElementList, unexpectedBetweenArgumentListAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTrailingClosure: ExpressibleAsUnexpectedNodes? = nil, trailingClosure: ExpressibleAsClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: ExpressibleAsUnexpectedNodes? = nil, additionalTrailingClosures: ExpressibleAsMultipleTrailingClosureElementList? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeCalledExpression = unexpectedBeforeCalledExpression?.createUnexpectedNodes()
     self.calledExpression = calledExpression.createExprBuildable()
     self.unexpectedBetweenCalledExpressionAndLeftParen = unexpectedBetweenCalledExpressionAndLeftParen?.createUnexpectedNodes()
@@ -3084,6 +3336,9 @@ public struct FunctionCallExpr: ExprBuildable, ExpressibleAsFunctionCallExpr {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `ExprBuildable`.
@@ -3112,8 +3367,9 @@ public struct FunctionCallExpr: ExprBuildable, ExpressibleAsFunctionCallExpr {
 }
 public struct SubscriptExpr: ExprBuildable, ExpressibleAsSubscriptExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeCalledExpression: UnexpectedNodes?
   var calledExpression: ExprBuildable
   var unexpectedBetweenCalledExpressionAndLeftBracket: UnexpectedNodes?
@@ -3140,8 +3396,9 @@ public struct SubscriptExpr: ExprBuildable, ExpressibleAsSubscriptExpr {
   ///   - trailingClosure: 
   ///   - unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: 
   ///   - additionalTrailingClosures: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeCalledExpression: ExpressibleAsUnexpectedNodes? = nil, calledExpression: ExpressibleAsExprBuildable, unexpectedBetweenCalledExpressionAndLeftBracket: ExpressibleAsUnexpectedNodes? = nil, leftBracket: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftBracketAndArgumentList: ExpressibleAsUnexpectedNodes? = nil, argumentList: ExpressibleAsTupleExprElementList, unexpectedBetweenArgumentListAndRightBracket: ExpressibleAsUnexpectedNodes? = nil, rightBracket: Token = Token.`rightSquareBracket`, unexpectedBetweenRightBracketAndTrailingClosure: ExpressibleAsUnexpectedNodes? = nil, trailingClosure: ExpressibleAsClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: ExpressibleAsUnexpectedNodes? = nil, additionalTrailingClosures: ExpressibleAsMultipleTrailingClosureElementList? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeCalledExpression: ExpressibleAsUnexpectedNodes? = nil, calledExpression: ExpressibleAsExprBuildable, unexpectedBetweenCalledExpressionAndLeftBracket: ExpressibleAsUnexpectedNodes? = nil, leftBracket: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftBracketAndArgumentList: ExpressibleAsUnexpectedNodes? = nil, argumentList: ExpressibleAsTupleExprElementList, unexpectedBetweenArgumentListAndRightBracket: ExpressibleAsUnexpectedNodes? = nil, rightBracket: Token = Token.`rightSquareBracket`, unexpectedBetweenRightBracketAndTrailingClosure: ExpressibleAsUnexpectedNodes? = nil, trailingClosure: ExpressibleAsClosureExpr? = nil, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: ExpressibleAsUnexpectedNodes? = nil, additionalTrailingClosures: ExpressibleAsMultipleTrailingClosureElementList? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeCalledExpression = unexpectedBeforeCalledExpression?.createUnexpectedNodes()
     self.calledExpression = calledExpression.createExprBuildable()
     self.unexpectedBetweenCalledExpressionAndLeftBracket = unexpectedBetweenCalledExpressionAndLeftBracket?.createUnexpectedNodes()
@@ -3174,6 +3431,9 @@ public struct SubscriptExpr: ExprBuildable, ExpressibleAsSubscriptExpr {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `ExprBuildable`.
@@ -3202,8 +3462,9 @@ public struct SubscriptExpr: ExprBuildable, ExpressibleAsSubscriptExpr {
 }
 public struct OptionalChainingExpr: ExprBuildable, ExpressibleAsOptionalChainingExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeExpression: UnexpectedNodes?
   var expression: ExprBuildable
   var unexpectedBetweenExpressionAndQuestionMark: UnexpectedNodes?
@@ -3214,8 +3475,9 @@ public struct OptionalChainingExpr: ExprBuildable, ExpressibleAsOptionalChaining
   ///   - expression: 
   ///   - unexpectedBetweenExpressionAndQuestionMark: 
   ///   - questionMark: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndQuestionMark: ExpressibleAsUnexpectedNodes? = nil, questionMark: Token = Token.`postfixQuestionMark`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndQuestionMark: ExpressibleAsUnexpectedNodes? = nil, questionMark: Token = Token.`postfixQuestionMark`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeExpression = unexpectedBeforeExpression?.createUnexpectedNodes()
     self.expression = expression.createExprBuildable()
     self.unexpectedBetweenExpressionAndQuestionMark = unexpectedBetweenExpressionAndQuestionMark?.createUnexpectedNodes()
@@ -3230,6 +3492,9 @@ public struct OptionalChainingExpr: ExprBuildable, ExpressibleAsOptionalChaining
     var result = OptionalChainingExprSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format), unexpectedBetweenExpressionAndQuestionMark?.buildUnexpectedNodes(format: format), questionMark: questionMark.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -3259,8 +3524,9 @@ public struct OptionalChainingExpr: ExprBuildable, ExpressibleAsOptionalChaining
 }
 public struct ForcedValueExpr: ExprBuildable, ExpressibleAsForcedValueExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeExpression: UnexpectedNodes?
   var expression: ExprBuildable
   var unexpectedBetweenExpressionAndExclamationMark: UnexpectedNodes?
@@ -3271,8 +3537,9 @@ public struct ForcedValueExpr: ExprBuildable, ExpressibleAsForcedValueExpr {
   ///   - expression: 
   ///   - unexpectedBetweenExpressionAndExclamationMark: 
   ///   - exclamationMark: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndExclamationMark: ExpressibleAsUnexpectedNodes? = nil, exclamationMark: Token = Token.`exclamationMark`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndExclamationMark: ExpressibleAsUnexpectedNodes? = nil, exclamationMark: Token = Token.`exclamationMark`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeExpression = unexpectedBeforeExpression?.createUnexpectedNodes()
     self.expression = expression.createExprBuildable()
     self.unexpectedBetweenExpressionAndExclamationMark = unexpectedBetweenExpressionAndExclamationMark?.createUnexpectedNodes()
@@ -3287,6 +3554,9 @@ public struct ForcedValueExpr: ExprBuildable, ExpressibleAsForcedValueExpr {
     var result = ForcedValueExprSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format), unexpectedBetweenExpressionAndExclamationMark?.buildUnexpectedNodes(format: format), exclamationMark: exclamationMark.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -3316,8 +3586,9 @@ public struct ForcedValueExpr: ExprBuildable, ExpressibleAsForcedValueExpr {
 }
 public struct PostfixUnaryExpr: ExprBuildable, ExpressibleAsPostfixUnaryExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeExpression: UnexpectedNodes?
   var expression: ExprBuildable
   var unexpectedBetweenExpressionAndOperatorToken: UnexpectedNodes?
@@ -3328,8 +3599,9 @@ public struct PostfixUnaryExpr: ExprBuildable, ExpressibleAsPostfixUnaryExpr {
   ///   - expression: 
   ///   - unexpectedBetweenExpressionAndOperatorToken: 
   ///   - operatorToken: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndOperatorToken: ExpressibleAsUnexpectedNodes? = nil, operatorToken: Token) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndOperatorToken: ExpressibleAsUnexpectedNodes? = nil, operatorToken: Token) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeExpression = unexpectedBeforeExpression?.createUnexpectedNodes()
     self.expression = expression.createExprBuildable()
     self.unexpectedBetweenExpressionAndOperatorToken = unexpectedBetweenExpressionAndOperatorToken?.createUnexpectedNodes()
@@ -3349,6 +3621,9 @@ public struct PostfixUnaryExpr: ExprBuildable, ExpressibleAsPostfixUnaryExpr {
     var result = PostfixUnaryExprSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format), unexpectedBetweenExpressionAndOperatorToken?.buildUnexpectedNodes(format: format), operatorToken: operatorToken.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -3378,8 +3653,9 @@ public struct PostfixUnaryExpr: ExprBuildable, ExpressibleAsPostfixUnaryExpr {
 }
 public struct SpecializeExpr: ExprBuildable, ExpressibleAsSpecializeExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeExpression: UnexpectedNodes?
   var expression: ExprBuildable
   var unexpectedBetweenExpressionAndGenericArgumentClause: UnexpectedNodes?
@@ -3390,8 +3666,9 @@ public struct SpecializeExpr: ExprBuildable, ExpressibleAsSpecializeExpr {
   ///   - expression: 
   ///   - unexpectedBetweenExpressionAndGenericArgumentClause: 
   ///   - genericArgumentClause: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndGenericArgumentClause: ExpressibleAsUnexpectedNodes? = nil, genericArgumentClause: ExpressibleAsGenericArgumentClause) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndGenericArgumentClause: ExpressibleAsUnexpectedNodes? = nil, genericArgumentClause: ExpressibleAsGenericArgumentClause) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeExpression = unexpectedBeforeExpression?.createUnexpectedNodes()
     self.expression = expression.createExprBuildable()
     self.unexpectedBetweenExpressionAndGenericArgumentClause = unexpectedBetweenExpressionAndGenericArgumentClause?.createUnexpectedNodes()
@@ -3405,6 +3682,9 @@ public struct SpecializeExpr: ExprBuildable, ExpressibleAsSpecializeExpr {
     var result = SpecializeExprSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format), unexpectedBetweenExpressionAndGenericArgumentClause?.buildUnexpectedNodes(format: format), genericArgumentClause: genericArgumentClause.buildGenericArgumentClause(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -3434,16 +3714,18 @@ public struct SpecializeExpr: ExprBuildable, ExpressibleAsSpecializeExpr {
 }
 public struct StringSegment: SyntaxBuildable, ExpressibleAsStringSegment {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeContent: UnexpectedNodes?
   var content: Token
   /// Creates a `StringSegment` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeContent: 
   ///   - content: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeContent: ExpressibleAsUnexpectedNodes? = nil, content: Token) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeContent: ExpressibleAsUnexpectedNodes? = nil, content: Token) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeContent = unexpectedBeforeContent?.createUnexpectedNodes()
     self.content = content
   }
@@ -3461,6 +3743,9 @@ public struct StringSegment: SyntaxBuildable, ExpressibleAsStringSegment {
     var result = StringSegmentSyntax(unexpectedBeforeContent?.buildUnexpectedNodes(format: format), content: content.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -3483,8 +3768,9 @@ public struct StringSegment: SyntaxBuildable, ExpressibleAsStringSegment {
 }
 public struct ExpressionSegment: SyntaxBuildable, ExpressibleAsExpressionSegment {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeBackslash: UnexpectedNodes?
   var backslash: Token
   var unexpectedBetweenBackslashAndDelimiter: UnexpectedNodes?
@@ -3507,8 +3793,9 @@ public struct ExpressionSegment: SyntaxBuildable, ExpressibleAsExpressionSegment
   ///   - expressions: 
   ///   - unexpectedBetweenExpressionsAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeBackslash: ExpressibleAsUnexpectedNodes? = nil, backslash: Token = Token.`backslash`, unexpectedBetweenBackslashAndDelimiter: ExpressibleAsUnexpectedNodes? = nil, delimiter: Token? = nil, unexpectedBetweenDelimiterAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndExpressions: ExpressibleAsUnexpectedNodes? = nil, expressions: ExpressibleAsTupleExprElementList, unexpectedBetweenExpressionsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`stringInterpolationAnchor`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBackslash: ExpressibleAsUnexpectedNodes? = nil, backslash: Token = Token.`backslash`, unexpectedBetweenBackslashAndDelimiter: ExpressibleAsUnexpectedNodes? = nil, delimiter: Token? = nil, unexpectedBetweenDelimiterAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndExpressions: ExpressibleAsUnexpectedNodes? = nil, expressions: ExpressibleAsTupleExprElementList, unexpectedBetweenExpressionsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`stringInterpolationAnchor`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeBackslash = unexpectedBeforeBackslash?.createUnexpectedNodes()
     self.backslash = backslash
     assert(backslash.text == #"\"#)
@@ -3542,6 +3829,9 @@ public struct ExpressionSegment: SyntaxBuildable, ExpressibleAsExpressionSegment
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -3563,8 +3853,9 @@ public struct ExpressionSegment: SyntaxBuildable, ExpressibleAsExpressionSegment
 }
 public struct StringLiteralExpr: ExprBuildable, ExpressibleAsStringLiteralExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeOpenDelimiter: UnexpectedNodes?
   var openDelimiter: Token?
   var unexpectedBetweenOpenDelimiterAndOpenQuote: UnexpectedNodes?
@@ -3587,8 +3878,9 @@ public struct StringLiteralExpr: ExprBuildable, ExpressibleAsStringLiteralExpr {
   ///   - closeQuote: 
   ///   - unexpectedBetweenCloseQuoteAndCloseDelimiter: 
   ///   - closeDelimiter: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeOpenDelimiter: ExpressibleAsUnexpectedNodes? = nil, openDelimiter: Token? = nil, unexpectedBetweenOpenDelimiterAndOpenQuote: ExpressibleAsUnexpectedNodes? = nil, openQuote: Token, unexpectedBetweenOpenQuoteAndSegments: ExpressibleAsUnexpectedNodes? = nil, segments: ExpressibleAsStringLiteralSegments, unexpectedBetweenSegmentsAndCloseQuote: ExpressibleAsUnexpectedNodes? = nil, closeQuote: Token, unexpectedBetweenCloseQuoteAndCloseDelimiter: ExpressibleAsUnexpectedNodes? = nil, closeDelimiter: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeOpenDelimiter: ExpressibleAsUnexpectedNodes? = nil, openDelimiter: Token? = nil, unexpectedBetweenOpenDelimiterAndOpenQuote: ExpressibleAsUnexpectedNodes? = nil, openQuote: Token, unexpectedBetweenOpenQuoteAndSegments: ExpressibleAsUnexpectedNodes? = nil, segments: ExpressibleAsStringLiteralSegments, unexpectedBetweenSegmentsAndCloseQuote: ExpressibleAsUnexpectedNodes? = nil, closeQuote: Token, unexpectedBetweenCloseQuoteAndCloseDelimiter: ExpressibleAsUnexpectedNodes? = nil, closeDelimiter: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeOpenDelimiter = unexpectedBeforeOpenDelimiter?.createUnexpectedNodes()
     self.openDelimiter = openDelimiter
     self.unexpectedBetweenOpenDelimiterAndOpenQuote = unexpectedBetweenOpenDelimiterAndOpenQuote?.createUnexpectedNodes()
@@ -3621,6 +3913,9 @@ public struct StringLiteralExpr: ExprBuildable, ExpressibleAsStringLiteralExpr {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `ExprBuildable`.
@@ -3649,16 +3944,18 @@ public struct StringLiteralExpr: ExprBuildable, ExpressibleAsStringLiteralExpr {
 }
 public struct RegexLiteralExpr: ExprBuildable, ExpressibleAsRegexLiteralExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeRegex: UnexpectedNodes?
   var regex: Token
   /// Creates a `RegexLiteralExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeRegex: 
   ///   - regex: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeRegex: ExpressibleAsUnexpectedNodes? = nil, regex: Token) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeRegex: ExpressibleAsUnexpectedNodes? = nil, regex: Token) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeRegex = unexpectedBeforeRegex?.createUnexpectedNodes()
     self.regex = regex
   }
@@ -3676,6 +3973,9 @@ public struct RegexLiteralExpr: ExprBuildable, ExpressibleAsRegexLiteralExpr {
     var result = RegexLiteralExprSyntax(unexpectedBeforeRegex?.buildUnexpectedNodes(format: format), regex: regex.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -3705,8 +4005,9 @@ public struct RegexLiteralExpr: ExprBuildable, ExpressibleAsRegexLiteralExpr {
 }
 public struct KeyPathExpr: ExprBuildable, ExpressibleAsKeyPathExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeBackslash: UnexpectedNodes?
   var backslash: Token
   var unexpectedBetweenBackslashAndRootExpr: UnexpectedNodes?
@@ -3721,8 +4022,9 @@ public struct KeyPathExpr: ExprBuildable, ExpressibleAsKeyPathExpr {
   ///   - rootExpr: 
   ///   - unexpectedBetweenRootExprAndExpression: 
   ///   - expression: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeBackslash: ExpressibleAsUnexpectedNodes? = nil, backslash: Token = Token.`backslash`, unexpectedBetweenBackslashAndRootExpr: ExpressibleAsUnexpectedNodes? = nil, rootExpr: ExpressibleAsExprBuildable? = nil, unexpectedBetweenRootExprAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBackslash: ExpressibleAsUnexpectedNodes? = nil, backslash: Token = Token.`backslash`, unexpectedBetweenBackslashAndRootExpr: ExpressibleAsUnexpectedNodes? = nil, rootExpr: ExpressibleAsExprBuildable? = nil, unexpectedBetweenRootExprAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeBackslash = unexpectedBeforeBackslash?.createUnexpectedNodes()
     self.backslash = backslash
     assert(backslash.text == #"\"#)
@@ -3739,6 +4041,9 @@ public struct KeyPathExpr: ExprBuildable, ExpressibleAsKeyPathExpr {
     var result = KeyPathExprSyntax(unexpectedBeforeBackslash?.buildUnexpectedNodes(format: format), backslash: backslash.buildToken(format: format), unexpectedBetweenBackslashAndRootExpr?.buildUnexpectedNodes(format: format), rootExpr: rootExpr?.buildExpr(format: format), unexpectedBetweenRootExprAndExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -3768,16 +4073,18 @@ public struct KeyPathExpr: ExprBuildable, ExpressibleAsKeyPathExpr {
 }
 public struct KeyPathBaseExpr: ExprBuildable, ExpressibleAsKeyPathBaseExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePeriod: UnexpectedNodes?
   var period: Token
   /// Creates a `KeyPathBaseExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforePeriod: 
   ///   - period: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePeriod: ExpressibleAsUnexpectedNodes? = nil, period: Token = Token.`period`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePeriod: ExpressibleAsUnexpectedNodes? = nil, period: Token = Token.`period`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePeriod = unexpectedBeforePeriod?.createUnexpectedNodes()
     self.period = period
     assert(period.text == #"."#)
@@ -3790,6 +4097,9 @@ public struct KeyPathBaseExpr: ExprBuildable, ExpressibleAsKeyPathBaseExpr {
     var result = KeyPathBaseExprSyntax(unexpectedBeforePeriod?.buildUnexpectedNodes(format: format), period: period.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -3819,8 +4129,9 @@ public struct KeyPathBaseExpr: ExprBuildable, ExpressibleAsKeyPathBaseExpr {
 }
 public struct ObjcNamePiece: SyntaxBuildable, ExpressibleAsObjcNamePiece {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeName: UnexpectedNodes?
   var name: Token
   var unexpectedBetweenNameAndDot: UnexpectedNodes?
@@ -3831,8 +4142,9 @@ public struct ObjcNamePiece: SyntaxBuildable, ExpressibleAsObjcNamePiece {
   ///   - name: 
   ///   - unexpectedBetweenNameAndDot: 
   ///   - dot: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndDot: ExpressibleAsUnexpectedNodes? = nil, dot: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndDot: ExpressibleAsUnexpectedNodes? = nil, dot: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeName = unexpectedBeforeName?.createUnexpectedNodes()
     self.name = name
     self.unexpectedBetweenNameAndDot = unexpectedBetweenNameAndDot?.createUnexpectedNodes()
@@ -3853,6 +4165,9 @@ public struct ObjcNamePiece: SyntaxBuildable, ExpressibleAsObjcNamePiece {
     var result = ObjcNamePieceSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format), name: name.buildToken(format: format), unexpectedBetweenNameAndDot?.buildUnexpectedNodes(format: format), dot: dot?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -3875,8 +4190,9 @@ public struct ObjcNamePiece: SyntaxBuildable, ExpressibleAsObjcNamePiece {
 }
 public struct ObjcKeyPathExpr: ExprBuildable, ExpressibleAsObjcKeyPathExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeKeyPath: UnexpectedNodes?
   var keyPath: Token
   var unexpectedBetweenKeyPathAndLeftParen: UnexpectedNodes?
@@ -3895,8 +4211,9 @@ public struct ObjcKeyPathExpr: ExprBuildable, ExpressibleAsObjcKeyPathExpr {
   ///   - name: 
   ///   - unexpectedBetweenNameAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeKeyPath: ExpressibleAsUnexpectedNodes? = nil, keyPath: Token = Token.`poundKeyPath`, unexpectedBetweenKeyPathAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndName: ExpressibleAsUnexpectedNodes? = nil, name: ExpressibleAsObjcName, unexpectedBetweenNameAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeKeyPath: ExpressibleAsUnexpectedNodes? = nil, keyPath: Token = Token.`poundKeyPath`, unexpectedBetweenKeyPathAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndName: ExpressibleAsUnexpectedNodes? = nil, name: ExpressibleAsObjcName, unexpectedBetweenNameAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeKeyPath = unexpectedBeforeKeyPath?.createUnexpectedNodes()
     self.keyPath = keyPath
     assert(keyPath.text == #"#keyPath"#)
@@ -3917,6 +4234,9 @@ public struct ObjcKeyPathExpr: ExprBuildable, ExpressibleAsObjcKeyPathExpr {
     var result = ObjcKeyPathExprSyntax(unexpectedBeforeKeyPath?.buildUnexpectedNodes(format: format), keyPath: keyPath.buildToken(format: format), unexpectedBetweenKeyPathAndLeftParen?.buildUnexpectedNodes(format: format), leftParen: leftParen.buildToken(format: format), unexpectedBetweenLeftParenAndName?.buildUnexpectedNodes(format: format), name: name.buildObjcName(format: format), unexpectedBetweenNameAndRightParen?.buildUnexpectedNodes(format: format), rightParen: rightParen.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -3946,8 +4266,9 @@ public struct ObjcKeyPathExpr: ExprBuildable, ExpressibleAsObjcKeyPathExpr {
 }
 public struct ObjcSelectorExpr: ExprBuildable, ExpressibleAsObjcSelectorExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePoundSelector: UnexpectedNodes?
   var poundSelector: Token
   var unexpectedBetweenPoundSelectorAndLeftParen: UnexpectedNodes?
@@ -3974,8 +4295,9 @@ public struct ObjcSelectorExpr: ExprBuildable, ExpressibleAsObjcSelectorExpr {
   ///   - name: 
   ///   - unexpectedBetweenNameAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePoundSelector: ExpressibleAsUnexpectedNodes? = nil, poundSelector: Token = Token.`poundSelector`, unexpectedBetweenPoundSelectorAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndKind: ExpressibleAsUnexpectedNodes? = nil, kind: Token? = nil, unexpectedBetweenKindAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndName: ExpressibleAsUnexpectedNodes? = nil, name: ExpressibleAsExprBuildable, unexpectedBetweenNameAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundSelector: ExpressibleAsUnexpectedNodes? = nil, poundSelector: Token = Token.`poundSelector`, unexpectedBetweenPoundSelectorAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndKind: ExpressibleAsUnexpectedNodes? = nil, kind: Token? = nil, unexpectedBetweenKindAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndName: ExpressibleAsUnexpectedNodes? = nil, name: ExpressibleAsExprBuildable, unexpectedBetweenNameAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePoundSelector = unexpectedBeforePoundSelector?.createUnexpectedNodes()
     self.poundSelector = poundSelector
     assert(poundSelector.text == #"#selector"#)
@@ -4011,6 +4333,9 @@ public struct ObjcSelectorExpr: ExprBuildable, ExpressibleAsObjcSelectorExpr {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `ExprBuildable`.
@@ -4039,8 +4364,9 @@ public struct ObjcSelectorExpr: ExprBuildable, ExpressibleAsObjcSelectorExpr {
 }
 public struct PostfixIfConfigExpr: ExprBuildable, ExpressibleAsPostfixIfConfigExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeBase: UnexpectedNodes?
   var base: ExprBuildable?
   var unexpectedBetweenBaseAndConfig: UnexpectedNodes?
@@ -4051,8 +4377,9 @@ public struct PostfixIfConfigExpr: ExprBuildable, ExpressibleAsPostfixIfConfigEx
   ///   - base: 
   ///   - unexpectedBetweenBaseAndConfig: 
   ///   - config: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeBase: ExpressibleAsUnexpectedNodes? = nil, base: ExpressibleAsExprBuildable? = nil, unexpectedBetweenBaseAndConfig: ExpressibleAsUnexpectedNodes? = nil, config: ExpressibleAsIfConfigDecl) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBase: ExpressibleAsUnexpectedNodes? = nil, base: ExpressibleAsExprBuildable? = nil, unexpectedBetweenBaseAndConfig: ExpressibleAsUnexpectedNodes? = nil, config: ExpressibleAsIfConfigDecl) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeBase = unexpectedBeforeBase?.createUnexpectedNodes()
     self.base = base?.createExprBuildable()
     self.unexpectedBetweenBaseAndConfig = unexpectedBetweenBaseAndConfig?.createUnexpectedNodes()
@@ -4066,6 +4393,9 @@ public struct PostfixIfConfigExpr: ExprBuildable, ExpressibleAsPostfixIfConfigEx
     var result = PostfixIfConfigExprSyntax(unexpectedBeforeBase?.buildUnexpectedNodes(format: format), base: base?.buildExpr(format: format), unexpectedBetweenBaseAndConfig?.buildUnexpectedNodes(format: format), config: config.buildIfConfigDecl(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -4095,16 +4425,18 @@ public struct PostfixIfConfigExpr: ExprBuildable, ExpressibleAsPostfixIfConfigEx
 }
 public struct EditorPlaceholderExpr: ExprBuildable, ExpressibleAsEditorPlaceholderExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeIdentifier: UnexpectedNodes?
   var identifier: Token
   /// Creates a `EditorPlaceholderExpr` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeIdentifier: 
   ///   - identifier: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeIdentifier = unexpectedBeforeIdentifier?.createUnexpectedNodes()
     self.identifier = identifier
   }
@@ -4122,6 +4454,9 @@ public struct EditorPlaceholderExpr: ExprBuildable, ExpressibleAsEditorPlacehold
     var result = EditorPlaceholderExprSyntax(unexpectedBeforeIdentifier?.buildUnexpectedNodes(format: format), identifier: identifier.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -4151,8 +4486,9 @@ public struct EditorPlaceholderExpr: ExprBuildable, ExpressibleAsEditorPlacehold
 }
 public struct ObjectLiteralExpr: ExprBuildable, ExpressibleAsObjectLiteralExpr {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeIdentifier: UnexpectedNodes?
   var identifier: Token
   var unexpectedBetweenIdentifierAndLeftParen: UnexpectedNodes?
@@ -4171,8 +4507,9 @@ public struct ObjectLiteralExpr: ExprBuildable, ExpressibleAsObjectLiteralExpr {
   ///   - arguments: 
   ///   - unexpectedBetweenArgumentsAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndArguments: ExpressibleAsUnexpectedNodes? = nil, arguments: ExpressibleAsTupleExprElementList, unexpectedBetweenArgumentsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndArguments: ExpressibleAsUnexpectedNodes? = nil, arguments: ExpressibleAsTupleExprElementList, unexpectedBetweenArgumentsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeIdentifier = unexpectedBeforeIdentifier?.createUnexpectedNodes()
     self.identifier = identifier
     assert(identifier.text == #"#colorLiteral"# || identifier.text == #"#fileLiteral"# || identifier.text == #"#imageLiteral"#)
@@ -4202,6 +4539,9 @@ public struct ObjectLiteralExpr: ExprBuildable, ExpressibleAsObjectLiteralExpr {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `ExprBuildable`.
@@ -4230,8 +4570,9 @@ public struct ObjectLiteralExpr: ExprBuildable, ExpressibleAsObjectLiteralExpr {
 }
 public struct TypeInitializerClause: SyntaxBuildable, ExpressibleAsTypeInitializerClause {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeEqual: UnexpectedNodes?
   var equal: Token
   var unexpectedBetweenEqualAndValue: UnexpectedNodes?
@@ -4242,8 +4583,9 @@ public struct TypeInitializerClause: SyntaxBuildable, ExpressibleAsTypeInitializ
   ///   - equal: 
   ///   - unexpectedBetweenEqualAndValue: 
   ///   - value: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeEqual: ExpressibleAsUnexpectedNodes? = nil, equal: Token = Token.`equal`, unexpectedBetweenEqualAndValue: ExpressibleAsUnexpectedNodes? = nil, value: ExpressibleAsTypeBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeEqual: ExpressibleAsUnexpectedNodes? = nil, equal: Token = Token.`equal`, unexpectedBetweenEqualAndValue: ExpressibleAsUnexpectedNodes? = nil, value: ExpressibleAsTypeBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeEqual = unexpectedBeforeEqual?.createUnexpectedNodes()
     self.equal = equal
     assert(equal.text == #"="#)
@@ -4258,6 +4600,9 @@ public struct TypeInitializerClause: SyntaxBuildable, ExpressibleAsTypeInitializ
     var result = TypeInitializerClauseSyntax(unexpectedBeforeEqual?.buildUnexpectedNodes(format: format), equal: equal.buildToken(format: format), unexpectedBetweenEqualAndValue?.buildUnexpectedNodes(format: format), value: value.buildType(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -4280,8 +4625,9 @@ public struct TypeInitializerClause: SyntaxBuildable, ExpressibleAsTypeInitializ
 }
 public struct TypealiasDecl: DeclBuildable, ExpressibleAsTypealiasDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -4312,8 +4658,9 @@ public struct TypealiasDecl: DeclBuildable, ExpressibleAsTypealiasDecl {
   ///   - initializer: 
   ///   - unexpectedBetweenInitializerAndGenericWhereClause: 
   ///   - genericWhereClause: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndTypealiasKeyword: ExpressibleAsUnexpectedNodes? = nil, typealiasKeyword: Token = Token.`typealias`, unexpectedBetweenTypealiasKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: ExpressibleAsUnexpectedNodes? = nil, genericParameterClause: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInitializer: ExpressibleAsUnexpectedNodes? = nil, initializer: ExpressibleAsTypeInitializerClause, unexpectedBetweenInitializerAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndTypealiasKeyword: ExpressibleAsUnexpectedNodes? = nil, typealiasKeyword: Token = Token.`typealias`, unexpectedBetweenTypealiasKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: ExpressibleAsUnexpectedNodes? = nil, genericParameterClause: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInitializer: ExpressibleAsUnexpectedNodes? = nil, initializer: ExpressibleAsTypeInitializerClause, unexpectedBetweenInitializerAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -4345,6 +4692,9 @@ public struct TypealiasDecl: DeclBuildable, ExpressibleAsTypealiasDecl {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `DeclBuildable`.
@@ -4373,8 +4723,9 @@ public struct TypealiasDecl: DeclBuildable, ExpressibleAsTypealiasDecl {
 }
 public struct AssociatedtypeDecl: DeclBuildable, ExpressibleAsAssociatedtypeDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -4405,8 +4756,9 @@ public struct AssociatedtypeDecl: DeclBuildable, ExpressibleAsAssociatedtypeDecl
   ///   - initializer: 
   ///   - unexpectedBetweenInitializerAndGenericWhereClause: 
   ///   - genericWhereClause: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndAssociatedtypeKeyword: ExpressibleAsUnexpectedNodes? = nil, associatedtypeKeyword: Token = Token.`associatedtype`, unexpectedBetweenAssociatedtypeKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndInheritanceClause: ExpressibleAsUnexpectedNodes? = nil, inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndInitializer: ExpressibleAsUnexpectedNodes? = nil, initializer: ExpressibleAsTypeInitializerClause? = nil, unexpectedBetweenInitializerAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndAssociatedtypeKeyword: ExpressibleAsUnexpectedNodes? = nil, associatedtypeKeyword: Token = Token.`associatedtype`, unexpectedBetweenAssociatedtypeKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndInheritanceClause: ExpressibleAsUnexpectedNodes? = nil, inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndInitializer: ExpressibleAsUnexpectedNodes? = nil, initializer: ExpressibleAsTypeInitializerClause? = nil, unexpectedBetweenInitializerAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -4438,6 +4790,9 @@ public struct AssociatedtypeDecl: DeclBuildable, ExpressibleAsAssociatedtypeDecl
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `DeclBuildable`.
@@ -4466,8 +4821,9 @@ public struct AssociatedtypeDecl: DeclBuildable, ExpressibleAsAssociatedtypeDecl
 }
 public struct ParameterClause: SyntaxBuildable, ExpressibleAsParameterClause {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftParen: UnexpectedNodes?
   var leftParen: Token
   var unexpectedBetweenLeftParenAndParameterList: UnexpectedNodes?
@@ -4482,8 +4838,9 @@ public struct ParameterClause: SyntaxBuildable, ExpressibleAsParameterClause {
   ///   - parameterList: 
   ///   - unexpectedBetweenParameterListAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndParameterList: ExpressibleAsUnexpectedNodes? = nil, parameterList: ExpressibleAsFunctionParameterList, unexpectedBetweenParameterListAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndParameterList: ExpressibleAsUnexpectedNodes? = nil, parameterList: ExpressibleAsFunctionParameterList, unexpectedBetweenParameterListAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftParen = unexpectedBeforeLeftParen?.createUnexpectedNodes()
     self.leftParen = leftParen
     assert(leftParen.text == #"("#)
@@ -4510,6 +4867,9 @@ public struct ParameterClause: SyntaxBuildable, ExpressibleAsParameterClause {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -4531,8 +4891,9 @@ public struct ParameterClause: SyntaxBuildable, ExpressibleAsParameterClause {
 }
 public struct ReturnClause: SyntaxBuildable, ExpressibleAsReturnClause {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeArrow: UnexpectedNodes?
   var arrow: Token
   var unexpectedBetweenArrowAndReturnType: UnexpectedNodes?
@@ -4543,8 +4904,9 @@ public struct ReturnClause: SyntaxBuildable, ExpressibleAsReturnClause {
   ///   - arrow: 
   ///   - unexpectedBetweenArrowAndReturnType: 
   ///   - returnType: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeArrow: ExpressibleAsUnexpectedNodes? = nil, arrow: Token = Token.`arrow`, unexpectedBetweenArrowAndReturnType: ExpressibleAsUnexpectedNodes? = nil, returnType: ExpressibleAsTypeBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeArrow: ExpressibleAsUnexpectedNodes? = nil, arrow: Token = Token.`arrow`, unexpectedBetweenArrowAndReturnType: ExpressibleAsUnexpectedNodes? = nil, returnType: ExpressibleAsTypeBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeArrow = unexpectedBeforeArrow?.createUnexpectedNodes()
     self.arrow = arrow
     assert(arrow.text == #"->"#)
@@ -4559,6 +4921,9 @@ public struct ReturnClause: SyntaxBuildable, ExpressibleAsReturnClause {
     var result = ReturnClauseSyntax(unexpectedBeforeArrow?.buildUnexpectedNodes(format: format), arrow: arrow.buildToken(format: format), unexpectedBetweenArrowAndReturnType?.buildUnexpectedNodes(format: format), returnType: returnType.buildType(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -4581,8 +4946,9 @@ public struct ReturnClause: SyntaxBuildable, ExpressibleAsReturnClause {
 }
 public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeInput: UnexpectedNodes?
   var input: ParameterClause
   var unexpectedBetweenInputAndAsyncOrReasyncKeyword: UnexpectedNodes?
@@ -4601,8 +4967,9 @@ public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature
   ///   - throwsOrRethrowsKeyword: 
   ///   - unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: 
   ///   - output: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeInput: ExpressibleAsUnexpectedNodes? = nil, input: ExpressibleAsParameterClause, unexpectedBetweenInputAndAsyncOrReasyncKeyword: ExpressibleAsUnexpectedNodes? = nil, asyncOrReasyncKeyword: Token? = nil, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: ExpressibleAsUnexpectedNodes? = nil, throwsOrRethrowsKeyword: Token? = nil, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: ExpressibleAsUnexpectedNodes? = nil, output: ExpressibleAsReturnClause? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeInput: ExpressibleAsUnexpectedNodes? = nil, input: ExpressibleAsParameterClause, unexpectedBetweenInputAndAsyncOrReasyncKeyword: ExpressibleAsUnexpectedNodes? = nil, asyncOrReasyncKeyword: Token? = nil, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: ExpressibleAsUnexpectedNodes? = nil, throwsOrRethrowsKeyword: Token? = nil, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: ExpressibleAsUnexpectedNodes? = nil, output: ExpressibleAsReturnClause? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeInput = unexpectedBeforeInput?.createUnexpectedNodes()
     self.input = input.createParameterClause()
     self.unexpectedBetweenInputAndAsyncOrReasyncKeyword = unexpectedBetweenInputAndAsyncOrReasyncKeyword?.createUnexpectedNodes()
@@ -4631,6 +4998,9 @@ public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -4652,8 +5022,9 @@ public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature
 }
 public struct IfConfigClause: SyntaxBuildable, ExpressibleAsIfConfigClause {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePoundKeyword: UnexpectedNodes?
   var poundKeyword: Token
   var unexpectedBetweenPoundKeywordAndCondition: UnexpectedNodes?
@@ -4668,8 +5039,9 @@ public struct IfConfigClause: SyntaxBuildable, ExpressibleAsIfConfigClause {
   ///   - condition: 
   ///   - unexpectedBetweenConditionAndElements: 
   ///   - elements: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePoundKeyword: ExpressibleAsUnexpectedNodes? = nil, poundKeyword: Token, unexpectedBetweenPoundKeywordAndCondition: ExpressibleAsUnexpectedNodes? = nil, condition: ExpressibleAsExprBuildable? = nil, unexpectedBetweenConditionAndElements: ExpressibleAsUnexpectedNodes? = nil, elements: ExpressibleAsSyntaxBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundKeyword: ExpressibleAsUnexpectedNodes? = nil, poundKeyword: Token, unexpectedBetweenPoundKeywordAndCondition: ExpressibleAsUnexpectedNodes? = nil, condition: ExpressibleAsExprBuildable? = nil, unexpectedBetweenConditionAndElements: ExpressibleAsUnexpectedNodes? = nil, elements: ExpressibleAsSyntaxBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePoundKeyword = unexpectedBeforePoundKeyword?.createUnexpectedNodes()
     self.poundKeyword = poundKeyword
     assert(poundKeyword.text == #"#if"# || poundKeyword.text == #"#elseif"# || poundKeyword.text == #"#else"#)
@@ -4686,6 +5058,9 @@ public struct IfConfigClause: SyntaxBuildable, ExpressibleAsIfConfigClause {
     var result = IfConfigClauseSyntax(unexpectedBeforePoundKeyword?.buildUnexpectedNodes(format: format), poundKeyword: poundKeyword.buildToken(format: format), unexpectedBetweenPoundKeywordAndCondition?.buildUnexpectedNodes(format: format), condition: condition?.buildExpr(format: format), unexpectedBetweenConditionAndElements?.buildUnexpectedNodes(format: format), elements: elements.buildSyntax(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -4708,8 +5083,9 @@ public struct IfConfigClause: SyntaxBuildable, ExpressibleAsIfConfigClause {
 }
 public struct IfConfigDecl: DeclBuildable, ExpressibleAsIfConfigDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeClauses: UnexpectedNodes?
   var clauses: IfConfigClauseList
   var unexpectedBetweenClausesAndPoundEndif: UnexpectedNodes?
@@ -4720,8 +5096,9 @@ public struct IfConfigDecl: DeclBuildable, ExpressibleAsIfConfigDecl {
   ///   - clauses: 
   ///   - unexpectedBetweenClausesAndPoundEndif: 
   ///   - poundEndif: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeClauses: ExpressibleAsUnexpectedNodes? = nil, clauses: ExpressibleAsIfConfigClauseList, unexpectedBetweenClausesAndPoundEndif: ExpressibleAsUnexpectedNodes? = nil, poundEndif: Token = Token.`poundEndif`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeClauses: ExpressibleAsUnexpectedNodes? = nil, clauses: ExpressibleAsIfConfigClauseList, unexpectedBetweenClausesAndPoundEndif: ExpressibleAsUnexpectedNodes? = nil, poundEndif: Token = Token.`poundEndif`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeClauses = unexpectedBeforeClauses?.createUnexpectedNodes()
     self.clauses = clauses.createIfConfigClauseList()
     self.unexpectedBetweenClausesAndPoundEndif = unexpectedBetweenClausesAndPoundEndif?.createUnexpectedNodes()
@@ -4736,6 +5113,9 @@ public struct IfConfigDecl: DeclBuildable, ExpressibleAsIfConfigDecl {
     var result = IfConfigDeclSyntax(unexpectedBeforeClauses?.buildUnexpectedNodes(format: format), clauses: clauses.buildIfConfigClauseList(format: format), unexpectedBetweenClausesAndPoundEndif?.buildUnexpectedNodes(format: format), poundEndif: poundEndif.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -4765,8 +5145,9 @@ public struct IfConfigDecl: DeclBuildable, ExpressibleAsIfConfigDecl {
 }
 public struct PoundErrorDecl: DeclBuildable, ExpressibleAsPoundErrorDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePoundError: UnexpectedNodes?
   var poundError: Token
   var unexpectedBetweenPoundErrorAndLeftParen: UnexpectedNodes?
@@ -4785,8 +5166,9 @@ public struct PoundErrorDecl: DeclBuildable, ExpressibleAsPoundErrorDecl {
   ///   - message: 
   ///   - unexpectedBetweenMessageAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePoundError: ExpressibleAsUnexpectedNodes? = nil, poundError: Token = Token.`poundError`, unexpectedBetweenPoundErrorAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndMessage: ExpressibleAsUnexpectedNodes? = nil, message: ExpressibleAsStringLiteralExpr, unexpectedBetweenMessageAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundError: ExpressibleAsUnexpectedNodes? = nil, poundError: Token = Token.`poundError`, unexpectedBetweenPoundErrorAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndMessage: ExpressibleAsUnexpectedNodes? = nil, message: ExpressibleAsStringLiteralExpr, unexpectedBetweenMessageAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePoundError = unexpectedBeforePoundError?.createUnexpectedNodes()
     self.poundError = poundError
     assert(poundError.text == #"#error"#)
@@ -4807,6 +5189,9 @@ public struct PoundErrorDecl: DeclBuildable, ExpressibleAsPoundErrorDecl {
     var result = PoundErrorDeclSyntax(unexpectedBeforePoundError?.buildUnexpectedNodes(format: format), poundError: poundError.buildToken(format: format), unexpectedBetweenPoundErrorAndLeftParen?.buildUnexpectedNodes(format: format), leftParen: leftParen.buildToken(format: format), unexpectedBetweenLeftParenAndMessage?.buildUnexpectedNodes(format: format), message: message.buildStringLiteralExpr(format: format), unexpectedBetweenMessageAndRightParen?.buildUnexpectedNodes(format: format), rightParen: rightParen.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -4836,8 +5221,9 @@ public struct PoundErrorDecl: DeclBuildable, ExpressibleAsPoundErrorDecl {
 }
 public struct PoundWarningDecl: DeclBuildable, ExpressibleAsPoundWarningDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePoundWarning: UnexpectedNodes?
   var poundWarning: Token
   var unexpectedBetweenPoundWarningAndLeftParen: UnexpectedNodes?
@@ -4856,8 +5242,9 @@ public struct PoundWarningDecl: DeclBuildable, ExpressibleAsPoundWarningDecl {
   ///   - message: 
   ///   - unexpectedBetweenMessageAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePoundWarning: ExpressibleAsUnexpectedNodes? = nil, poundWarning: Token = Token.`poundWarning`, unexpectedBetweenPoundWarningAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndMessage: ExpressibleAsUnexpectedNodes? = nil, message: ExpressibleAsStringLiteralExpr, unexpectedBetweenMessageAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundWarning: ExpressibleAsUnexpectedNodes? = nil, poundWarning: Token = Token.`poundWarning`, unexpectedBetweenPoundWarningAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndMessage: ExpressibleAsUnexpectedNodes? = nil, message: ExpressibleAsStringLiteralExpr, unexpectedBetweenMessageAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePoundWarning = unexpectedBeforePoundWarning?.createUnexpectedNodes()
     self.poundWarning = poundWarning
     assert(poundWarning.text == #"#warning"#)
@@ -4878,6 +5265,9 @@ public struct PoundWarningDecl: DeclBuildable, ExpressibleAsPoundWarningDecl {
     var result = PoundWarningDeclSyntax(unexpectedBeforePoundWarning?.buildUnexpectedNodes(format: format), poundWarning: poundWarning.buildToken(format: format), unexpectedBetweenPoundWarningAndLeftParen?.buildUnexpectedNodes(format: format), leftParen: leftParen.buildToken(format: format), unexpectedBetweenLeftParenAndMessage?.buildUnexpectedNodes(format: format), message: message.buildStringLiteralExpr(format: format), unexpectedBetweenMessageAndRightParen?.buildUnexpectedNodes(format: format), rightParen: rightParen.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -4907,8 +5297,9 @@ public struct PoundWarningDecl: DeclBuildable, ExpressibleAsPoundWarningDecl {
 }
 public struct PoundSourceLocation: DeclBuildable, ExpressibleAsPoundSourceLocation {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePoundSourceLocation: UnexpectedNodes?
   var poundSourceLocation: Token
   var unexpectedBetweenPoundSourceLocationAndLeftParen: UnexpectedNodes?
@@ -4927,8 +5318,9 @@ public struct PoundSourceLocation: DeclBuildable, ExpressibleAsPoundSourceLocati
   ///   - args: 
   ///   - unexpectedBetweenArgsAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePoundSourceLocation: ExpressibleAsUnexpectedNodes? = nil, poundSourceLocation: Token = Token.`poundSourceLocation`, unexpectedBetweenPoundSourceLocationAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndArgs: ExpressibleAsUnexpectedNodes? = nil, args: ExpressibleAsPoundSourceLocationArgs? = nil, unexpectedBetweenArgsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundSourceLocation: ExpressibleAsUnexpectedNodes? = nil, poundSourceLocation: Token = Token.`poundSourceLocation`, unexpectedBetweenPoundSourceLocationAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndArgs: ExpressibleAsUnexpectedNodes? = nil, args: ExpressibleAsPoundSourceLocationArgs? = nil, unexpectedBetweenArgsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePoundSourceLocation = unexpectedBeforePoundSourceLocation?.createUnexpectedNodes()
     self.poundSourceLocation = poundSourceLocation
     assert(poundSourceLocation.text == #"#sourceLocation"#)
@@ -4949,6 +5341,9 @@ public struct PoundSourceLocation: DeclBuildable, ExpressibleAsPoundSourceLocati
     var result = PoundSourceLocationSyntax(unexpectedBeforePoundSourceLocation?.buildUnexpectedNodes(format: format), poundSourceLocation: poundSourceLocation.buildToken(format: format), unexpectedBetweenPoundSourceLocationAndLeftParen?.buildUnexpectedNodes(format: format), leftParen: leftParen.buildToken(format: format), unexpectedBetweenLeftParenAndArgs?.buildUnexpectedNodes(format: format), args: args?.buildPoundSourceLocationArgs(format: format), unexpectedBetweenArgsAndRightParen?.buildUnexpectedNodes(format: format), rightParen: rightParen.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -4978,8 +5373,9 @@ public struct PoundSourceLocation: DeclBuildable, ExpressibleAsPoundSourceLocati
 }
 public struct PoundSourceLocationArgs: SyntaxBuildable, ExpressibleAsPoundSourceLocationArgs {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeFileArgLabel: UnexpectedNodes?
   var fileArgLabel: Token
   var unexpectedBetweenFileArgLabelAndFileArgColon: UnexpectedNodes?
@@ -5010,8 +5406,9 @@ public struct PoundSourceLocationArgs: SyntaxBuildable, ExpressibleAsPoundSource
   ///   - lineArgColon: 
   ///   - unexpectedBetweenLineArgColonAndLineNumber: 
   ///   - lineNumber: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeFileArgLabel: ExpressibleAsUnexpectedNodes? = nil, fileArgLabel: Token, unexpectedBetweenFileArgLabelAndFileArgColon: ExpressibleAsUnexpectedNodes? = nil, fileArgColon: Token = Token.`colon`, unexpectedBetweenFileArgColonAndFileName: ExpressibleAsUnexpectedNodes? = nil, fileName: Token, unexpectedBetweenFileNameAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token = Token.`comma`, unexpectedBetweenCommaAndLineArgLabel: ExpressibleAsUnexpectedNodes? = nil, lineArgLabel: Token, unexpectedBetweenLineArgLabelAndLineArgColon: ExpressibleAsUnexpectedNodes? = nil, lineArgColon: Token = Token.`colon`, unexpectedBetweenLineArgColonAndLineNumber: ExpressibleAsUnexpectedNodes? = nil, lineNumber: Token) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeFileArgLabel: ExpressibleAsUnexpectedNodes? = nil, fileArgLabel: Token, unexpectedBetweenFileArgLabelAndFileArgColon: ExpressibleAsUnexpectedNodes? = nil, fileArgColon: Token = Token.`colon`, unexpectedBetweenFileArgColonAndFileName: ExpressibleAsUnexpectedNodes? = nil, fileName: Token, unexpectedBetweenFileNameAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token = Token.`comma`, unexpectedBetweenCommaAndLineArgLabel: ExpressibleAsUnexpectedNodes? = nil, lineArgLabel: Token, unexpectedBetweenLineArgLabelAndLineArgColon: ExpressibleAsUnexpectedNodes? = nil, lineArgColon: Token = Token.`colon`, unexpectedBetweenLineArgColonAndLineNumber: ExpressibleAsUnexpectedNodes? = nil, lineNumber: Token) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeFileArgLabel = unexpectedBeforeFileArgLabel?.createUnexpectedNodes()
     self.fileArgLabel = fileArgLabel
     assert(fileArgLabel.text == #"file"#)
@@ -5047,6 +5444,9 @@ public struct PoundSourceLocationArgs: SyntaxBuildable, ExpressibleAsPoundSource
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -5068,8 +5468,9 @@ public struct PoundSourceLocationArgs: SyntaxBuildable, ExpressibleAsPoundSource
 }
 public struct DeclModifierDetail: SyntaxBuildable, ExpressibleAsDeclModifierDetail {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftParen: UnexpectedNodes?
   var leftParen: Token
   var unexpectedBetweenLeftParenAndDetail: UnexpectedNodes?
@@ -5084,8 +5485,9 @@ public struct DeclModifierDetail: SyntaxBuildable, ExpressibleAsDeclModifierDeta
   ///   - detail: 
   ///   - unexpectedBetweenDetailAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndDetail: ExpressibleAsUnexpectedNodes? = nil, detail: Token, unexpectedBetweenDetailAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndDetail: ExpressibleAsUnexpectedNodes? = nil, detail: Token, unexpectedBetweenDetailAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftParen = unexpectedBeforeLeftParen?.createUnexpectedNodes()
     self.leftParen = leftParen
     assert(leftParen.text == #"("#)
@@ -5110,6 +5512,9 @@ public struct DeclModifierDetail: SyntaxBuildable, ExpressibleAsDeclModifierDeta
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -5131,8 +5536,9 @@ public struct DeclModifierDetail: SyntaxBuildable, ExpressibleAsDeclModifierDeta
 }
 public struct DeclModifier: SyntaxBuildable, ExpressibleAsDeclModifier {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeName: UnexpectedNodes?
   var name: Token
   var unexpectedBetweenNameAndDetail: UnexpectedNodes?
@@ -5143,8 +5549,9 @@ public struct DeclModifier: SyntaxBuildable, ExpressibleAsDeclModifier {
   ///   - name: 
   ///   - unexpectedBetweenNameAndDetail: 
   ///   - detail: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndDetail: ExpressibleAsUnexpectedNodes? = nil, detail: ExpressibleAsDeclModifierDetail? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndDetail: ExpressibleAsUnexpectedNodes? = nil, detail: ExpressibleAsDeclModifierDetail? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeName = unexpectedBeforeName?.createUnexpectedNodes()
     self.name = name
     assert(name.text == #"class"# || name.text == #"convenience"# || name.text == #"dynamic"# || name.text == #"final"# || name.text == #"infix"# || name.text == #"lazy"# || name.text == #"optional"# || name.text == #"override"# || name.text == #"postfix"# || name.text == #"prefix"# || name.text == #"required"# || name.text == #"static"# || name.text == #"unowned"# || name.text == #"weak"# || name.text == #"private"# || name.text == #"fileprivate"# || name.text == #"internal"# || name.text == #"public"# || name.text == #"open"# || name.text == #"mutating"# || name.text == #"nonmutating"# || name.text == #"indirect"# || name.text == #"__consuming"# || name.text == #"actor"# || name.text == #"async"# || name.text == #"distributed"# || name.text == #"isolated"# || name.text == #"nonisolated"# || name.text == #"_const"# || name.text == #"_local"#)
@@ -5159,6 +5566,9 @@ public struct DeclModifier: SyntaxBuildable, ExpressibleAsDeclModifier {
     var result = DeclModifierSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format), name: name.buildToken(format: format), unexpectedBetweenNameAndDetail?.buildUnexpectedNodes(format: format), detail: detail?.buildDeclModifierDetail(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -5181,8 +5591,9 @@ public struct DeclModifier: SyntaxBuildable, ExpressibleAsDeclModifier {
 }
 public struct InheritedType: SyntaxBuildable, ExpressibleAsInheritedType, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeTypeName: UnexpectedNodes?
   var typeName: TypeBuildable
   var unexpectedBetweenTypeNameAndTrailingComma: UnexpectedNodes?
@@ -5193,8 +5604,9 @@ public struct InheritedType: SyntaxBuildable, ExpressibleAsInheritedType, HasTra
   ///   - typeName: 
   ///   - unexpectedBetweenTypeNameAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeTypeName: ExpressibleAsUnexpectedNodes? = nil, typeName: ExpressibleAsTypeBuildable, unexpectedBetweenTypeNameAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeTypeName: ExpressibleAsUnexpectedNodes? = nil, typeName: ExpressibleAsTypeBuildable, unexpectedBetweenTypeNameAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeTypeName = unexpectedBeforeTypeName?.createUnexpectedNodes()
     self.typeName = typeName.createTypeBuildable()
     self.unexpectedBetweenTypeNameAndTrailingComma = unexpectedBetweenTypeNameAndTrailingComma?.createUnexpectedNodes()
@@ -5209,6 +5621,9 @@ public struct InheritedType: SyntaxBuildable, ExpressibleAsInheritedType, HasTra
     var result = InheritedTypeSyntax(unexpectedBeforeTypeName?.buildUnexpectedNodes(format: format), typeName: typeName.buildType(format: format), unexpectedBetweenTypeNameAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -5237,8 +5652,9 @@ public struct InheritedType: SyntaxBuildable, ExpressibleAsInheritedType, HasTra
 }
 public struct TypeInheritanceClause: SyntaxBuildable, ExpressibleAsTypeInheritanceClause {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeColon: UnexpectedNodes?
   var colon: Token
   var unexpectedBetweenColonAndInheritedTypeCollection: UnexpectedNodes?
@@ -5249,8 +5665,9 @@ public struct TypeInheritanceClause: SyntaxBuildable, ExpressibleAsTypeInheritan
   ///   - colon: 
   ///   - unexpectedBetweenColonAndInheritedTypeCollection: 
   ///   - inheritedTypeCollection: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndInheritedTypeCollection: ExpressibleAsUnexpectedNodes? = nil, inheritedTypeCollection: ExpressibleAsInheritedTypeList) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndInheritedTypeCollection: ExpressibleAsUnexpectedNodes? = nil, inheritedTypeCollection: ExpressibleAsInheritedTypeList) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeColon = unexpectedBeforeColon?.createUnexpectedNodes()
     self.colon = colon
     assert(colon.text == #":"#)
@@ -5274,6 +5691,9 @@ public struct TypeInheritanceClause: SyntaxBuildable, ExpressibleAsTypeInheritan
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -5295,8 +5715,9 @@ public struct TypeInheritanceClause: SyntaxBuildable, ExpressibleAsTypeInheritan
 }
 public struct ClassDecl: DeclBuildable, ExpressibleAsClassDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -5331,8 +5752,9 @@ public struct ClassDecl: DeclBuildable, ExpressibleAsClassDecl {
   ///   - genericWhereClause: 
   ///   - unexpectedBetweenGenericWhereClauseAndMembers: 
   ///   - members: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndClassKeyword: ExpressibleAsUnexpectedNodes? = nil, classKeyword: Token = Token.`class`, unexpectedBetweenClassKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: ExpressibleAsUnexpectedNodes? = nil, genericParameterClause: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: ExpressibleAsUnexpectedNodes? = nil, inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: ExpressibleAsUnexpectedNodes? = nil, members: ExpressibleAsMemberDeclBlock) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndClassKeyword: ExpressibleAsUnexpectedNodes? = nil, classKeyword: Token = Token.`class`, unexpectedBetweenClassKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: ExpressibleAsUnexpectedNodes? = nil, genericParameterClause: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: ExpressibleAsUnexpectedNodes? = nil, inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: ExpressibleAsUnexpectedNodes? = nil, members: ExpressibleAsMemberDeclBlock) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -5368,6 +5790,9 @@ public struct ClassDecl: DeclBuildable, ExpressibleAsClassDecl {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `DeclBuildable`.
@@ -5396,8 +5821,9 @@ public struct ClassDecl: DeclBuildable, ExpressibleAsClassDecl {
 }
 public struct ActorDecl: DeclBuildable, ExpressibleAsActorDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -5432,8 +5858,9 @@ public struct ActorDecl: DeclBuildable, ExpressibleAsActorDecl {
   ///   - genericWhereClause: 
   ///   - unexpectedBetweenGenericWhereClauseAndMembers: 
   ///   - members: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndActorKeyword: ExpressibleAsUnexpectedNodes? = nil, actorKeyword: Token, unexpectedBetweenActorKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: ExpressibleAsUnexpectedNodes? = nil, genericParameterClause: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: ExpressibleAsUnexpectedNodes? = nil, inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: ExpressibleAsUnexpectedNodes? = nil, members: ExpressibleAsMemberDeclBlock) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndActorKeyword: ExpressibleAsUnexpectedNodes? = nil, actorKeyword: Token, unexpectedBetweenActorKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: ExpressibleAsUnexpectedNodes? = nil, genericParameterClause: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: ExpressibleAsUnexpectedNodes? = nil, inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: ExpressibleAsUnexpectedNodes? = nil, members: ExpressibleAsMemberDeclBlock) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -5469,6 +5896,9 @@ public struct ActorDecl: DeclBuildable, ExpressibleAsActorDecl {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `DeclBuildable`.
@@ -5497,8 +5927,9 @@ public struct ActorDecl: DeclBuildable, ExpressibleAsActorDecl {
 }
 public struct StructDecl: DeclBuildable, ExpressibleAsStructDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -5533,8 +5964,9 @@ public struct StructDecl: DeclBuildable, ExpressibleAsStructDecl {
   ///   - genericWhereClause: 
   ///   - unexpectedBetweenGenericWhereClauseAndMembers: 
   ///   - members: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndStructKeyword: ExpressibleAsUnexpectedNodes? = nil, structKeyword: Token = Token.`struct`, unexpectedBetweenStructKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: ExpressibleAsUnexpectedNodes? = nil, genericParameterClause: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: ExpressibleAsUnexpectedNodes? = nil, inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: ExpressibleAsUnexpectedNodes? = nil, members: ExpressibleAsMemberDeclBlock) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndStructKeyword: ExpressibleAsUnexpectedNodes? = nil, structKeyword: Token = Token.`struct`, unexpectedBetweenStructKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: ExpressibleAsUnexpectedNodes? = nil, genericParameterClause: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInheritanceClause: ExpressibleAsUnexpectedNodes? = nil, inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: ExpressibleAsUnexpectedNodes? = nil, members: ExpressibleAsMemberDeclBlock) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -5570,6 +6002,9 @@ public struct StructDecl: DeclBuildable, ExpressibleAsStructDecl {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `DeclBuildable`.
@@ -5598,8 +6033,9 @@ public struct StructDecl: DeclBuildable, ExpressibleAsStructDecl {
 }
 public struct ProtocolDecl: DeclBuildable, ExpressibleAsProtocolDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -5634,8 +6070,9 @@ public struct ProtocolDecl: DeclBuildable, ExpressibleAsProtocolDecl {
   ///   - genericWhereClause: 
   ///   - unexpectedBetweenGenericWhereClauseAndMembers: 
   ///   - members: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndProtocolKeyword: ExpressibleAsUnexpectedNodes? = nil, protocolKeyword: Token = Token.`protocol`, unexpectedBetweenProtocolKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause: ExpressibleAsUnexpectedNodes? = nil, primaryAssociatedTypeClause: ExpressibleAsPrimaryAssociatedTypeClause? = nil, unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause: ExpressibleAsUnexpectedNodes? = nil, inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: ExpressibleAsUnexpectedNodes? = nil, members: ExpressibleAsMemberDeclBlock) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndProtocolKeyword: ExpressibleAsUnexpectedNodes? = nil, protocolKeyword: Token = Token.`protocol`, unexpectedBetweenProtocolKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause: ExpressibleAsUnexpectedNodes? = nil, primaryAssociatedTypeClause: ExpressibleAsPrimaryAssociatedTypeClause? = nil, unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause: ExpressibleAsUnexpectedNodes? = nil, inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: ExpressibleAsUnexpectedNodes? = nil, members: ExpressibleAsMemberDeclBlock) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -5671,6 +6108,9 @@ public struct ProtocolDecl: DeclBuildable, ExpressibleAsProtocolDecl {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `DeclBuildable`.
@@ -5699,8 +6139,9 @@ public struct ProtocolDecl: DeclBuildable, ExpressibleAsProtocolDecl {
 }
 public struct ExtensionDecl: DeclBuildable, ExpressibleAsExtensionDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -5731,8 +6172,9 @@ public struct ExtensionDecl: DeclBuildable, ExpressibleAsExtensionDecl {
   ///   - genericWhereClause: 
   ///   - unexpectedBetweenGenericWhereClauseAndMembers: 
   ///   - members: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndExtensionKeyword: ExpressibleAsUnexpectedNodes? = nil, extensionKeyword: Token = Token.`extension`, unexpectedBetweenExtensionKeywordAndExtendedType: ExpressibleAsUnexpectedNodes? = nil, extendedType: ExpressibleAsTypeBuildable, unexpectedBetweenExtendedTypeAndInheritanceClause: ExpressibleAsUnexpectedNodes? = nil, inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: ExpressibleAsUnexpectedNodes? = nil, members: ExpressibleAsMemberDeclBlock) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndExtensionKeyword: ExpressibleAsUnexpectedNodes? = nil, extensionKeyword: Token = Token.`extension`, unexpectedBetweenExtensionKeywordAndExtendedType: ExpressibleAsUnexpectedNodes? = nil, extendedType: ExpressibleAsTypeBuildable, unexpectedBetweenExtendedTypeAndInheritanceClause: ExpressibleAsUnexpectedNodes? = nil, inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: ExpressibleAsUnexpectedNodes? = nil, members: ExpressibleAsMemberDeclBlock) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -5766,6 +6208,9 @@ public struct ExtensionDecl: DeclBuildable, ExpressibleAsExtensionDecl {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `DeclBuildable`.
@@ -5794,8 +6239,9 @@ public struct ExtensionDecl: DeclBuildable, ExpressibleAsExtensionDecl {
 }
 public struct MemberDeclBlock: SyntaxBuildable, ExpressibleAsMemberDeclBlock {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftBrace: UnexpectedNodes?
   var leftBrace: Token
   var unexpectedBetweenLeftBraceAndMembers: UnexpectedNodes?
@@ -5810,8 +6256,9 @@ public struct MemberDeclBlock: SyntaxBuildable, ExpressibleAsMemberDeclBlock {
   ///   - members: 
   ///   - unexpectedBetweenMembersAndRightBrace: 
   ///   - rightBrace: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftBrace: ExpressibleAsUnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndMembers: ExpressibleAsUnexpectedNodes? = nil, members: ExpressibleAsMemberDeclList, unexpectedBetweenMembersAndRightBrace: ExpressibleAsUnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftBrace: ExpressibleAsUnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndMembers: ExpressibleAsUnexpectedNodes? = nil, members: ExpressibleAsMemberDeclList, unexpectedBetweenMembersAndRightBrace: ExpressibleAsUnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftBrace = unexpectedBeforeLeftBrace?.createUnexpectedNodes()
     self.leftBrace = leftBrace
     assert(leftBrace.text == #"{"#)
@@ -5838,6 +6285,9 @@ public struct MemberDeclBlock: SyntaxBuildable, ExpressibleAsMemberDeclBlock {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -5860,8 +6310,9 @@ public struct MemberDeclBlock: SyntaxBuildable, ExpressibleAsMemberDeclBlock {
 /// A member declaration of a type consisting of a declaration and anoptional semicolon;
 public struct MemberDeclListItem: SyntaxBuildable, ExpressibleAsMemberDeclListItem {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeDecl: UnexpectedNodes?
   var decl: DeclBuildable
   var unexpectedBetweenDeclAndSemicolon: UnexpectedNodes?
@@ -5872,8 +6323,9 @@ public struct MemberDeclListItem: SyntaxBuildable, ExpressibleAsMemberDeclListIt
   ///   - decl: The declaration of the type member.
   ///   - unexpectedBetweenDeclAndSemicolon: 
   ///   - semicolon: An optional trailing semicolon.
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeDecl: ExpressibleAsUnexpectedNodes? = nil, decl: ExpressibleAsDeclBuildable, unexpectedBetweenDeclAndSemicolon: ExpressibleAsUnexpectedNodes? = nil, semicolon: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDecl: ExpressibleAsUnexpectedNodes? = nil, decl: ExpressibleAsDeclBuildable, unexpectedBetweenDeclAndSemicolon: ExpressibleAsUnexpectedNodes? = nil, semicolon: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeDecl = unexpectedBeforeDecl?.createUnexpectedNodes()
     self.decl = decl.createDeclBuildable()
     self.unexpectedBetweenDeclAndSemicolon = unexpectedBetweenDeclAndSemicolon?.createUnexpectedNodes()
@@ -5888,6 +6340,9 @@ public struct MemberDeclListItem: SyntaxBuildable, ExpressibleAsMemberDeclListIt
     var result = MemberDeclListItemSyntax(unexpectedBeforeDecl?.buildUnexpectedNodes(format: format), decl: decl.buildDecl(format: format), unexpectedBetweenDeclAndSemicolon?.buildUnexpectedNodes(format: format), semicolon: semicolon?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -5910,8 +6365,9 @@ public struct MemberDeclListItem: SyntaxBuildable, ExpressibleAsMemberDeclListIt
 }
 public struct SourceFile: SyntaxBuildable, ExpressibleAsSourceFile {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeStatements: UnexpectedNodes?
   var statements: CodeBlockItemList
   var unexpectedBetweenStatementsAndEOFToken: UnexpectedNodes?
@@ -5922,8 +6378,9 @@ public struct SourceFile: SyntaxBuildable, ExpressibleAsSourceFile {
   ///   - statements: 
   ///   - unexpectedBetweenStatementsAndEOFToken: 
   ///   - eofToken: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeStatements: ExpressibleAsUnexpectedNodes? = nil, statements: ExpressibleAsCodeBlockItemList, unexpectedBetweenStatementsAndEOFToken: ExpressibleAsUnexpectedNodes? = nil, eofToken: Token = Token.eof) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeStatements: ExpressibleAsUnexpectedNodes? = nil, statements: ExpressibleAsCodeBlockItemList, unexpectedBetweenStatementsAndEOFToken: ExpressibleAsUnexpectedNodes? = nil, eofToken: Token = Token.eof) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeStatements = unexpectedBeforeStatements?.createUnexpectedNodes()
     self.statements = statements.createCodeBlockItemList()
     self.unexpectedBetweenStatementsAndEOFToken = unexpectedBetweenStatementsAndEOFToken?.createUnexpectedNodes()
@@ -5946,6 +6403,9 @@ public struct SourceFile: SyntaxBuildable, ExpressibleAsSourceFile {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -5967,8 +6427,9 @@ public struct SourceFile: SyntaxBuildable, ExpressibleAsSourceFile {
 }
 public struct InitializerClause: SyntaxBuildable, ExpressibleAsInitializerClause {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeEqual: UnexpectedNodes?
   var equal: Token
   var unexpectedBetweenEqualAndValue: UnexpectedNodes?
@@ -5979,8 +6440,9 @@ public struct InitializerClause: SyntaxBuildable, ExpressibleAsInitializerClause
   ///   - equal: 
   ///   - unexpectedBetweenEqualAndValue: 
   ///   - value: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeEqual: ExpressibleAsUnexpectedNodes? = nil, equal: Token = Token.`equal`, unexpectedBetweenEqualAndValue: ExpressibleAsUnexpectedNodes? = nil, value: ExpressibleAsExprBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeEqual: ExpressibleAsUnexpectedNodes? = nil, equal: Token = Token.`equal`, unexpectedBetweenEqualAndValue: ExpressibleAsUnexpectedNodes? = nil, value: ExpressibleAsExprBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeEqual = unexpectedBeforeEqual?.createUnexpectedNodes()
     self.equal = equal
     assert(equal.text == #"="#)
@@ -5995,6 +6457,9 @@ public struct InitializerClause: SyntaxBuildable, ExpressibleAsInitializerClause
     var result = InitializerClauseSyntax(unexpectedBeforeEqual?.buildUnexpectedNodes(format: format), equal: equal.buildToken(format: format), unexpectedBetweenEqualAndValue?.buildUnexpectedNodes(format: format), value: value.buildExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -6017,8 +6482,9 @@ public struct InitializerClause: SyntaxBuildable, ExpressibleAsInitializerClause
 }
 public struct FunctionParameter: SyntaxBuildable, ExpressibleAsFunctionParameter, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndFirstName: UnexpectedNodes?
@@ -6053,8 +6519,9 @@ public struct FunctionParameter: SyntaxBuildable, ExpressibleAsFunctionParameter
   ///   - defaultArgument: 
   ///   - unexpectedBetweenDefaultArgumentAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndFirstName: ExpressibleAsUnexpectedNodes? = nil, firstName: Token? = nil, unexpectedBetweenFirstNameAndSecondName: ExpressibleAsUnexpectedNodes? = nil, secondName: Token? = nil, unexpectedBetweenSecondNameAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable? = nil, unexpectedBetweenTypeAndEllipsis: ExpressibleAsUnexpectedNodes? = nil, ellipsis: Token? = nil, unexpectedBetweenEllipsisAndDefaultArgument: ExpressibleAsUnexpectedNodes? = nil, defaultArgument: ExpressibleAsInitializerClause? = nil, unexpectedBetweenDefaultArgumentAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndFirstName: ExpressibleAsUnexpectedNodes? = nil, firstName: Token? = nil, unexpectedBetweenFirstNameAndSecondName: ExpressibleAsUnexpectedNodes? = nil, secondName: Token? = nil, unexpectedBetweenSecondNameAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable? = nil, unexpectedBetweenTypeAndEllipsis: ExpressibleAsUnexpectedNodes? = nil, ellipsis: Token? = nil, unexpectedBetweenEllipsisAndDefaultArgument: ExpressibleAsUnexpectedNodes? = nil, defaultArgument: ExpressibleAsInitializerClause? = nil, unexpectedBetweenDefaultArgumentAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndFirstName = unexpectedBetweenAttributesAndFirstName?.createUnexpectedNodes()
@@ -6084,6 +6551,9 @@ public struct FunctionParameter: SyntaxBuildable, ExpressibleAsFunctionParameter
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -6111,8 +6581,9 @@ public struct FunctionParameter: SyntaxBuildable, ExpressibleAsFunctionParameter
 }
 public struct FunctionDecl: DeclBuildable, ExpressibleAsFunctionDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -6147,8 +6618,9 @@ public struct FunctionDecl: DeclBuildable, ExpressibleAsFunctionDecl {
   ///   - genericWhereClause: 
   ///   - unexpectedBetweenGenericWhereClauseAndBody: 
   ///   - body: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndFuncKeyword: ExpressibleAsUnexpectedNodes? = nil, funcKeyword: Token = Token.`func`, unexpectedBetweenFuncKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: ExpressibleAsUnexpectedNodes? = nil, genericParameterClause: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: ExpressibleAsUnexpectedNodes? = nil, signature: ExpressibleAsFunctionSignature, unexpectedBetweenSignatureAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndFuncKeyword: ExpressibleAsUnexpectedNodes? = nil, funcKeyword: Token = Token.`func`, unexpectedBetweenFuncKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameterClause: ExpressibleAsUnexpectedNodes? = nil, genericParameterClause: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: ExpressibleAsUnexpectedNodes? = nil, signature: ExpressibleAsFunctionSignature, unexpectedBetweenSignatureAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -6184,6 +6656,9 @@ public struct FunctionDecl: DeclBuildable, ExpressibleAsFunctionDecl {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `DeclBuildable`.
@@ -6212,8 +6687,9 @@ public struct FunctionDecl: DeclBuildable, ExpressibleAsFunctionDecl {
 }
 public struct InitializerDecl: DeclBuildable, ExpressibleAsInitializerDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -6248,8 +6724,9 @@ public struct InitializerDecl: DeclBuildable, ExpressibleAsInitializerDecl {
   ///   - genericWhereClause: 
   ///   - unexpectedBetweenGenericWhereClauseAndBody: 
   ///   - body: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndInitKeyword: ExpressibleAsUnexpectedNodes? = nil, initKeyword: Token = Token.`init`, unexpectedBetweenInitKeywordAndOptionalMark: ExpressibleAsUnexpectedNodes? = nil, optionalMark: Token? = nil, unexpectedBetweenOptionalMarkAndGenericParameterClause: ExpressibleAsUnexpectedNodes? = nil, genericParameterClause: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: ExpressibleAsUnexpectedNodes? = nil, signature: ExpressibleAsFunctionSignature, unexpectedBetweenSignatureAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndInitKeyword: ExpressibleAsUnexpectedNodes? = nil, initKeyword: Token = Token.`init`, unexpectedBetweenInitKeywordAndOptionalMark: ExpressibleAsUnexpectedNodes? = nil, optionalMark: Token? = nil, unexpectedBetweenOptionalMarkAndGenericParameterClause: ExpressibleAsUnexpectedNodes? = nil, genericParameterClause: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndSignature: ExpressibleAsUnexpectedNodes? = nil, signature: ExpressibleAsFunctionSignature, unexpectedBetweenSignatureAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -6286,6 +6763,9 @@ public struct InitializerDecl: DeclBuildable, ExpressibleAsInitializerDecl {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `DeclBuildable`.
@@ -6314,8 +6794,9 @@ public struct InitializerDecl: DeclBuildable, ExpressibleAsInitializerDecl {
 }
 public struct DeinitializerDecl: DeclBuildable, ExpressibleAsDeinitializerDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -6334,8 +6815,9 @@ public struct DeinitializerDecl: DeclBuildable, ExpressibleAsDeinitializerDecl {
   ///   - deinitKeyword: 
   ///   - unexpectedBetweenDeinitKeywordAndBody: 
   ///   - body: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndDeinitKeyword: ExpressibleAsUnexpectedNodes? = nil, deinitKeyword: Token = Token.`deinit`, unexpectedBetweenDeinitKeywordAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndDeinitKeyword: ExpressibleAsUnexpectedNodes? = nil, deinitKeyword: Token = Token.`deinit`, unexpectedBetweenDeinitKeywordAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -6362,6 +6844,9 @@ public struct DeinitializerDecl: DeclBuildable, ExpressibleAsDeinitializerDecl {
     var result = DeinitializerDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format), attributes: attributes?.buildAttributeList(format: format), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format), modifiers: modifiers?.buildModifierList(format: format), unexpectedBetweenModifiersAndDeinitKeyword?.buildUnexpectedNodes(format: format), deinitKeyword: deinitKeyword.buildToken(format: format), unexpectedBetweenDeinitKeywordAndBody?.buildUnexpectedNodes(format: format), body: body?.buildCodeBlock(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -6391,8 +6876,9 @@ public struct DeinitializerDecl: DeclBuildable, ExpressibleAsDeinitializerDecl {
 }
 public struct SubscriptDecl: DeclBuildable, ExpressibleAsSubscriptDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -6427,8 +6913,9 @@ public struct SubscriptDecl: DeclBuildable, ExpressibleAsSubscriptDecl {
   ///   - genericWhereClause: 
   ///   - unexpectedBetweenGenericWhereClauseAndAccessor: 
   ///   - accessor: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndSubscriptKeyword: ExpressibleAsUnexpectedNodes? = nil, subscriptKeyword: Token = Token.`subscript`, unexpectedBetweenSubscriptKeywordAndGenericParameterClause: ExpressibleAsUnexpectedNodes? = nil, genericParameterClause: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndIndices: ExpressibleAsUnexpectedNodes? = nil, indices: ExpressibleAsParameterClause, unexpectedBetweenIndicesAndResult: ExpressibleAsUnexpectedNodes? = nil, result: ExpressibleAsReturnClause, unexpectedBetweenResultAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndAccessor: ExpressibleAsUnexpectedNodes? = nil, accessor: ExpressibleAsSyntaxBuildable? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndSubscriptKeyword: ExpressibleAsUnexpectedNodes? = nil, subscriptKeyword: Token = Token.`subscript`, unexpectedBetweenSubscriptKeywordAndGenericParameterClause: ExpressibleAsUnexpectedNodes? = nil, genericParameterClause: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndIndices: ExpressibleAsUnexpectedNodes? = nil, indices: ExpressibleAsParameterClause, unexpectedBetweenIndicesAndResult: ExpressibleAsUnexpectedNodes? = nil, result: ExpressibleAsReturnClause, unexpectedBetweenResultAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndAccessor: ExpressibleAsUnexpectedNodes? = nil, accessor: ExpressibleAsSyntaxBuildable? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -6455,6 +6942,9 @@ public struct SubscriptDecl: DeclBuildable, ExpressibleAsSubscriptDecl {
     var result = SubscriptDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format), attributes: attributes?.buildAttributeList(format: format), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format), modifiers: modifiers?.buildModifierList(format: format), unexpectedBetweenModifiersAndSubscriptKeyword?.buildUnexpectedNodes(format: format), subscriptKeyword: subscriptKeyword.buildToken(format: format), unexpectedBetweenSubscriptKeywordAndGenericParameterClause?.buildUnexpectedNodes(format: format), genericParameterClause: genericParameterClause?.buildGenericParameterClause(format: format), unexpectedBetweenGenericParameterClauseAndIndices?.buildUnexpectedNodes(format: format), indices: indices.buildParameterClause(format: format), unexpectedBetweenIndicesAndResult?.buildUnexpectedNodes(format: format), result: result.buildReturnClause(format: format), unexpectedBetweenResultAndGenericWhereClause?.buildUnexpectedNodes(format: format), genericWhereClause: genericWhereClause?.buildGenericWhereClause(format: format), unexpectedBetweenGenericWhereClauseAndAccessor?.buildUnexpectedNodes(format: format), accessor: accessor?.buildSyntax(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -6484,8 +6974,9 @@ public struct SubscriptDecl: DeclBuildable, ExpressibleAsSubscriptDecl {
 }
 public struct AccessLevelModifier: SyntaxBuildable, ExpressibleAsAccessLevelModifier {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeName: UnexpectedNodes?
   var name: Token
   var unexpectedBetweenNameAndModifier: UnexpectedNodes?
@@ -6496,8 +6987,9 @@ public struct AccessLevelModifier: SyntaxBuildable, ExpressibleAsAccessLevelModi
   ///   - name: 
   ///   - unexpectedBetweenNameAndModifier: 
   ///   - modifier: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndModifier: ExpressibleAsUnexpectedNodes? = nil, modifier: ExpressibleAsDeclModifierDetail? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndModifier: ExpressibleAsUnexpectedNodes? = nil, modifier: ExpressibleAsDeclModifierDetail? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeName = unexpectedBeforeName?.createUnexpectedNodes()
     self.name = name
     self.unexpectedBetweenNameAndModifier = unexpectedBetweenNameAndModifier?.createUnexpectedNodes()
@@ -6517,6 +7009,9 @@ public struct AccessLevelModifier: SyntaxBuildable, ExpressibleAsAccessLevelModi
     var result = AccessLevelModifierSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format), name: name.buildToken(format: format), unexpectedBetweenNameAndModifier?.buildUnexpectedNodes(format: format), modifier: modifier?.buildDeclModifierDetail(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -6539,8 +7034,9 @@ public struct AccessLevelModifier: SyntaxBuildable, ExpressibleAsAccessLevelModi
 }
 public struct AccessPathComponent: SyntaxBuildable, ExpressibleAsAccessPathComponent {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeName: UnexpectedNodes?
   var name: Token
   var unexpectedBetweenNameAndTrailingDot: UnexpectedNodes?
@@ -6551,8 +7047,9 @@ public struct AccessPathComponent: SyntaxBuildable, ExpressibleAsAccessPathCompo
   ///   - name: 
   ///   - unexpectedBetweenNameAndTrailingDot: 
   ///   - trailingDot: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndTrailingDot: ExpressibleAsUnexpectedNodes? = nil, trailingDot: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndTrailingDot: ExpressibleAsUnexpectedNodes? = nil, trailingDot: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeName = unexpectedBeforeName?.createUnexpectedNodes()
     self.name = name
     self.unexpectedBetweenNameAndTrailingDot = unexpectedBetweenNameAndTrailingDot?.createUnexpectedNodes()
@@ -6573,6 +7070,9 @@ public struct AccessPathComponent: SyntaxBuildable, ExpressibleAsAccessPathCompo
     var result = AccessPathComponentSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format), name: name.buildToken(format: format), unexpectedBetweenNameAndTrailingDot?.buildUnexpectedNodes(format: format), trailingDot: trailingDot?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -6595,8 +7095,9 @@ public struct AccessPathComponent: SyntaxBuildable, ExpressibleAsAccessPathCompo
 }
 public struct ImportDecl: DeclBuildable, ExpressibleAsImportDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -6619,8 +7120,9 @@ public struct ImportDecl: DeclBuildable, ExpressibleAsImportDecl {
   ///   - importKind: 
   ///   - unexpectedBetweenImportKindAndPath: 
   ///   - path: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndImportTok: ExpressibleAsUnexpectedNodes? = nil, importTok: Token = Token.`import`, unexpectedBetweenImportTokAndImportKind: ExpressibleAsUnexpectedNodes? = nil, importKind: Token? = nil, unexpectedBetweenImportKindAndPath: ExpressibleAsUnexpectedNodes? = nil, path: ExpressibleAsAccessPath) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndImportTok: ExpressibleAsUnexpectedNodes? = nil, importTok: Token = Token.`import`, unexpectedBetweenImportTokAndImportKind: ExpressibleAsUnexpectedNodes? = nil, importKind: Token? = nil, unexpectedBetweenImportKindAndPath: ExpressibleAsUnexpectedNodes? = nil, path: ExpressibleAsAccessPath) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -6642,6 +7144,9 @@ public struct ImportDecl: DeclBuildable, ExpressibleAsImportDecl {
     var result = ImportDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format), attributes: attributes?.buildAttributeList(format: format), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format), modifiers: modifiers?.buildModifierList(format: format), unexpectedBetweenModifiersAndImportTok?.buildUnexpectedNodes(format: format), importTok: importTok.buildToken(format: format), unexpectedBetweenImportTokAndImportKind?.buildUnexpectedNodes(format: format), importKind: importKind?.buildToken(format: format), unexpectedBetweenImportKindAndPath?.buildUnexpectedNodes(format: format), path: path.buildAccessPath(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -6671,8 +7176,9 @@ public struct ImportDecl: DeclBuildable, ExpressibleAsImportDecl {
 }
 public struct AccessorParameter: SyntaxBuildable, ExpressibleAsAccessorParameter {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftParen: UnexpectedNodes?
   var leftParen: Token
   var unexpectedBetweenLeftParenAndName: UnexpectedNodes?
@@ -6687,8 +7193,9 @@ public struct AccessorParameter: SyntaxBuildable, ExpressibleAsAccessorParameter
   ///   - name: 
   ///   - unexpectedBetweenNameAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftParen = unexpectedBeforeLeftParen?.createUnexpectedNodes()
     self.leftParen = leftParen
     assert(leftParen.text == #"("#)
@@ -6713,6 +7220,9 @@ public struct AccessorParameter: SyntaxBuildable, ExpressibleAsAccessorParameter
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -6734,8 +7244,9 @@ public struct AccessorParameter: SyntaxBuildable, ExpressibleAsAccessorParameter
 }
 public struct AccessorDecl: DeclBuildable, ExpressibleAsAccessorDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifier: UnexpectedNodes?
@@ -6766,8 +7277,9 @@ public struct AccessorDecl: DeclBuildable, ExpressibleAsAccessorDecl {
   ///   - throwsKeyword: 
   ///   - unexpectedBetweenThrowsKeywordAndBody: 
   ///   - body: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifier: ExpressibleAsUnexpectedNodes? = nil, modifier: ExpressibleAsDeclModifier? = nil, unexpectedBetweenModifierAndAccessorKind: ExpressibleAsUnexpectedNodes? = nil, accessorKind: Token, unexpectedBetweenAccessorKindAndParameter: ExpressibleAsUnexpectedNodes? = nil, parameter: ExpressibleAsAccessorParameter? = nil, unexpectedBetweenParameterAndAsyncKeyword: ExpressibleAsUnexpectedNodes? = nil, asyncKeyword: Token? = nil, unexpectedBetweenAsyncKeywordAndThrowsKeyword: ExpressibleAsUnexpectedNodes? = nil, throwsKeyword: Token? = nil, unexpectedBetweenThrowsKeywordAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifier: ExpressibleAsUnexpectedNodes? = nil, modifier: ExpressibleAsDeclModifier? = nil, unexpectedBetweenModifierAndAccessorKind: ExpressibleAsUnexpectedNodes? = nil, accessorKind: Token, unexpectedBetweenAccessorKindAndParameter: ExpressibleAsUnexpectedNodes? = nil, parameter: ExpressibleAsAccessorParameter? = nil, unexpectedBetweenParameterAndAsyncKeyword: ExpressibleAsUnexpectedNodes? = nil, asyncKeyword: Token? = nil, unexpectedBetweenAsyncKeywordAndThrowsKeyword: ExpressibleAsUnexpectedNodes? = nil, throwsKeyword: Token? = nil, unexpectedBetweenThrowsKeywordAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifier = unexpectedBetweenAttributesAndModifier?.createUnexpectedNodes()
@@ -6805,6 +7317,9 @@ public struct AccessorDecl: DeclBuildable, ExpressibleAsAccessorDecl {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `DeclBuildable`.
@@ -6833,8 +7348,9 @@ public struct AccessorDecl: DeclBuildable, ExpressibleAsAccessorDecl {
 }
 public struct AccessorBlock: SyntaxBuildable, ExpressibleAsAccessorBlock {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftBrace: UnexpectedNodes?
   var leftBrace: Token
   var unexpectedBetweenLeftBraceAndAccessors: UnexpectedNodes?
@@ -6849,8 +7365,9 @@ public struct AccessorBlock: SyntaxBuildable, ExpressibleAsAccessorBlock {
   ///   - accessors: 
   ///   - unexpectedBetweenAccessorsAndRightBrace: 
   ///   - rightBrace: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftBrace: ExpressibleAsUnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndAccessors: ExpressibleAsUnexpectedNodes? = nil, accessors: ExpressibleAsAccessorList, unexpectedBetweenAccessorsAndRightBrace: ExpressibleAsUnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftBrace: ExpressibleAsUnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndAccessors: ExpressibleAsUnexpectedNodes? = nil, accessors: ExpressibleAsAccessorList, unexpectedBetweenAccessorsAndRightBrace: ExpressibleAsUnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftBrace = unexpectedBeforeLeftBrace?.createUnexpectedNodes()
     self.leftBrace = leftBrace
     assert(leftBrace.text == #"{"#)
@@ -6868,6 +7385,9 @@ public struct AccessorBlock: SyntaxBuildable, ExpressibleAsAccessorBlock {
     var result = AccessorBlockSyntax(unexpectedBeforeLeftBrace?.buildUnexpectedNodes(format: format), leftBrace: leftBrace.buildToken(format: format), unexpectedBetweenLeftBraceAndAccessors?.buildUnexpectedNodes(format: format), accessors: accessors.buildAccessorList(format: format), unexpectedBetweenAccessorsAndRightBrace?.buildUnexpectedNodes(format: format), rightBrace: rightBrace.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -6890,8 +7410,9 @@ public struct AccessorBlock: SyntaxBuildable, ExpressibleAsAccessorBlock {
 }
 public struct PatternBinding: SyntaxBuildable, ExpressibleAsPatternBinding, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePattern: UnexpectedNodes?
   var pattern: PatternBuildable
   var unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodes?
@@ -6914,8 +7435,9 @@ public struct PatternBinding: SyntaxBuildable, ExpressibleAsPatternBinding, HasT
   ///   - accessor: 
   ///   - unexpectedBetweenAccessorAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndTypeAnnotation: ExpressibleAsUnexpectedNodes? = nil, typeAnnotation: ExpressibleAsTypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInitializer: ExpressibleAsUnexpectedNodes? = nil, initializer: ExpressibleAsInitializerClause? = nil, unexpectedBetweenInitializerAndAccessor: ExpressibleAsUnexpectedNodes? = nil, accessor: ExpressibleAsSyntaxBuildable? = nil, unexpectedBetweenAccessorAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndTypeAnnotation: ExpressibleAsUnexpectedNodes? = nil, typeAnnotation: ExpressibleAsTypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInitializer: ExpressibleAsUnexpectedNodes? = nil, initializer: ExpressibleAsInitializerClause? = nil, unexpectedBetweenInitializerAndAccessor: ExpressibleAsUnexpectedNodes? = nil, accessor: ExpressibleAsSyntaxBuildable? = nil, unexpectedBetweenAccessorAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePattern = unexpectedBeforePattern?.createUnexpectedNodes()
     self.pattern = pattern.createPatternBuildable()
     self.unexpectedBetweenPatternAndTypeAnnotation = unexpectedBetweenPatternAndTypeAnnotation?.createUnexpectedNodes()
@@ -6936,6 +7458,9 @@ public struct PatternBinding: SyntaxBuildable, ExpressibleAsPatternBinding, HasT
     var result = PatternBindingSyntax(unexpectedBeforePattern?.buildUnexpectedNodes(format: format), pattern: pattern.buildPattern(format: format), unexpectedBetweenPatternAndTypeAnnotation?.buildUnexpectedNodes(format: format), typeAnnotation: typeAnnotation?.buildTypeAnnotation(format: format), unexpectedBetweenTypeAnnotationAndInitializer?.buildUnexpectedNodes(format: format), initializer: initializer?.buildInitializerClause(format: format), unexpectedBetweenInitializerAndAccessor?.buildUnexpectedNodes(format: format), accessor: accessor?.buildSyntax(format: format), unexpectedBetweenAccessorAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -6964,8 +7489,9 @@ public struct PatternBinding: SyntaxBuildable, ExpressibleAsPatternBinding, HasT
 }
 public struct VariableDecl: DeclBuildable, ExpressibleAsVariableDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -6984,8 +7510,9 @@ public struct VariableDecl: DeclBuildable, ExpressibleAsVariableDecl {
   ///   - letOrVarKeyword: 
   ///   - unexpectedBetweenLetOrVarKeywordAndBindings: 
   ///   - bindings: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndLetOrVarKeyword: ExpressibleAsUnexpectedNodes? = nil, letOrVarKeyword: Token, unexpectedBetweenLetOrVarKeywordAndBindings: ExpressibleAsUnexpectedNodes? = nil, bindings: ExpressibleAsPatternBindingList) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndLetOrVarKeyword: ExpressibleAsUnexpectedNodes? = nil, letOrVarKeyword: Token, unexpectedBetweenLetOrVarKeywordAndBindings: ExpressibleAsUnexpectedNodes? = nil, bindings: ExpressibleAsPatternBindingList) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -7012,6 +7539,9 @@ public struct VariableDecl: DeclBuildable, ExpressibleAsVariableDecl {
     var result = VariableDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format), attributes: attributes?.buildAttributeList(format: format), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format), modifiers: modifiers?.buildModifierList(format: format), unexpectedBetweenModifiersAndLetOrVarKeyword?.buildUnexpectedNodes(format: format), letOrVarKeyword: letOrVarKeyword.buildToken(format: format), unexpectedBetweenLetOrVarKeywordAndBindings?.buildUnexpectedNodes(format: format), bindings: bindings.buildPatternBindingList(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -7042,8 +7572,9 @@ public struct VariableDecl: DeclBuildable, ExpressibleAsVariableDecl {
 /// An element of an enum case, containing the name of the case and,optionally, either associated values or an assignment to a raw value.
 public struct EnumCaseElement: SyntaxBuildable, ExpressibleAsEnumCaseElement, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeIdentifier: UnexpectedNodes?
   var identifier: Token
   var unexpectedBetweenIdentifierAndAssociatedValue: UnexpectedNodes?
@@ -7062,8 +7593,9 @@ public struct EnumCaseElement: SyntaxBuildable, ExpressibleAsEnumCaseElement, Ha
   ///   - rawValue: The raw value of this enum element, if present.
   ///   - unexpectedBetweenRawValueAndTrailingComma: 
   ///   - trailingComma: The trailing comma of this element, if the case hasmultiple elements.
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndAssociatedValue: ExpressibleAsUnexpectedNodes? = nil, associatedValue: ExpressibleAsParameterClause? = nil, unexpectedBetweenAssociatedValueAndRawValue: ExpressibleAsUnexpectedNodes? = nil, rawValue: ExpressibleAsInitializerClause? = nil, unexpectedBetweenRawValueAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndAssociatedValue: ExpressibleAsUnexpectedNodes? = nil, associatedValue: ExpressibleAsParameterClause? = nil, unexpectedBetweenAssociatedValueAndRawValue: ExpressibleAsUnexpectedNodes? = nil, rawValue: ExpressibleAsInitializerClause? = nil, unexpectedBetweenRawValueAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeIdentifier = unexpectedBeforeIdentifier?.createUnexpectedNodes()
     self.identifier = identifier
     self.unexpectedBetweenIdentifierAndAssociatedValue = unexpectedBetweenIdentifierAndAssociatedValue?.createUnexpectedNodes()
@@ -7088,6 +7620,9 @@ public struct EnumCaseElement: SyntaxBuildable, ExpressibleAsEnumCaseElement, Ha
     var result = EnumCaseElementSyntax(unexpectedBeforeIdentifier?.buildUnexpectedNodes(format: format), identifier: identifier.buildToken(format: format), unexpectedBetweenIdentifierAndAssociatedValue?.buildUnexpectedNodes(format: format), associatedValue: associatedValue?.buildParameterClause(format: format), unexpectedBetweenAssociatedValueAndRawValue?.buildUnexpectedNodes(format: format), rawValue: rawValue?.buildInitializerClause(format: format), unexpectedBetweenRawValueAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -7117,8 +7652,9 @@ public struct EnumCaseElement: SyntaxBuildable, ExpressibleAsEnumCaseElement, Ha
 /// A `case` declaration of a Swift `enum`. It can have 1 or more`EnumCaseElement`s inside, each declaring a different case of theenum.
 public struct EnumCaseDecl: DeclBuildable, ExpressibleAsEnumCaseDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -7137,8 +7673,9 @@ public struct EnumCaseDecl: DeclBuildable, ExpressibleAsEnumCaseDecl {
   ///   - caseKeyword: The `case` keyword for this case.
   ///   - unexpectedBetweenCaseKeywordAndElements: 
   ///   - elements: The elements this case declares.
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndCaseKeyword: ExpressibleAsUnexpectedNodes? = nil, caseKeyword: Token = Token.`case`, unexpectedBetweenCaseKeywordAndElements: ExpressibleAsUnexpectedNodes? = nil, elements: ExpressibleAsEnumCaseElementList) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndCaseKeyword: ExpressibleAsUnexpectedNodes? = nil, caseKeyword: Token = Token.`case`, unexpectedBetweenCaseKeywordAndElements: ExpressibleAsUnexpectedNodes? = nil, elements: ExpressibleAsEnumCaseElementList) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -7165,6 +7702,9 @@ public struct EnumCaseDecl: DeclBuildable, ExpressibleAsEnumCaseDecl {
     var result = EnumCaseDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format), attributes: attributes?.buildAttributeList(format: format), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format), modifiers: modifiers?.buildModifierList(format: format), unexpectedBetweenModifiersAndCaseKeyword?.buildUnexpectedNodes(format: format), caseKeyword: caseKeyword.buildToken(format: format), unexpectedBetweenCaseKeywordAndElements?.buildUnexpectedNodes(format: format), elements: elements.buildEnumCaseElementList(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -7195,8 +7735,9 @@ public struct EnumCaseDecl: DeclBuildable, ExpressibleAsEnumCaseDecl {
 /// A Swift `enum` declaration.
 public struct EnumDecl: DeclBuildable, ExpressibleAsEnumDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -7231,8 +7772,9 @@ public struct EnumDecl: DeclBuildable, ExpressibleAsEnumDecl {
   ///   - genericWhereClause: The `where` clause that applies to the generic parameters ofthis enum.
   ///   - unexpectedBetweenGenericWhereClauseAndMembers: 
   ///   - members: The cases and other members of this enum.
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndEnumKeyword: ExpressibleAsUnexpectedNodes? = nil, enumKeyword: Token = Token.`enum`, unexpectedBetweenEnumKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameters: ExpressibleAsUnexpectedNodes? = nil, genericParameters: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParametersAndInheritanceClause: ExpressibleAsUnexpectedNodes? = nil, inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: ExpressibleAsUnexpectedNodes? = nil, members: ExpressibleAsMemberDeclBlock) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndEnumKeyword: ExpressibleAsUnexpectedNodes? = nil, enumKeyword: Token = Token.`enum`, unexpectedBetweenEnumKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndGenericParameters: ExpressibleAsUnexpectedNodes? = nil, genericParameters: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParametersAndInheritanceClause: ExpressibleAsUnexpectedNodes? = nil, inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil, unexpectedBetweenGenericWhereClauseAndMembers: ExpressibleAsUnexpectedNodes? = nil, members: ExpressibleAsMemberDeclBlock) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -7268,6 +7810,9 @@ public struct EnumDecl: DeclBuildable, ExpressibleAsEnumDecl {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `DeclBuildable`.
@@ -7297,8 +7842,9 @@ public struct EnumDecl: DeclBuildable, ExpressibleAsEnumDecl {
 /// A Swift `operator` declaration.
 public struct OperatorDecl: DeclBuildable, ExpressibleAsOperatorDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -7321,8 +7867,9 @@ public struct OperatorDecl: DeclBuildable, ExpressibleAsOperatorDecl {
   ///   - identifier: 
   ///   - unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes: 
   ///   - operatorPrecedenceAndTypes: Optionally specify a precedence group and designated types.
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndOperatorKeyword: ExpressibleAsUnexpectedNodes? = nil, operatorKeyword: Token = Token.`operator`, unexpectedBetweenOperatorKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes: ExpressibleAsUnexpectedNodes? = nil, operatorPrecedenceAndTypes: ExpressibleAsOperatorPrecedenceAndTypes? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndOperatorKeyword: ExpressibleAsUnexpectedNodes? = nil, operatorKeyword: Token = Token.`operator`, unexpectedBetweenOperatorKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes: ExpressibleAsUnexpectedNodes? = nil, operatorPrecedenceAndTypes: ExpressibleAsOperatorPrecedenceAndTypes? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -7343,6 +7890,9 @@ public struct OperatorDecl: DeclBuildable, ExpressibleAsOperatorDecl {
     var result = OperatorDeclSyntax(unexpectedBeforeAttributes?.buildUnexpectedNodes(format: format), attributes: attributes?.buildAttributeList(format: format), unexpectedBetweenAttributesAndModifiers?.buildUnexpectedNodes(format: format), modifiers: modifiers?.buildModifierList(format: format), unexpectedBetweenModifiersAndOperatorKeyword?.buildUnexpectedNodes(format: format), operatorKeyword: operatorKeyword.buildToken(format: format), unexpectedBetweenOperatorKeywordAndIdentifier?.buildUnexpectedNodes(format: format), identifier: identifier.buildToken(format: format), unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes?.buildUnexpectedNodes(format: format), operatorPrecedenceAndTypes: operatorPrecedenceAndTypes?.buildOperatorPrecedenceAndTypes(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -7373,8 +7923,9 @@ public struct OperatorDecl: DeclBuildable, ExpressibleAsOperatorDecl {
 /// A clause to specify precedence group in infix operator declarations, and designated types in any operator declaration.
 public struct OperatorPrecedenceAndTypes: SyntaxBuildable, ExpressibleAsOperatorPrecedenceAndTypes {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeColon: UnexpectedNodes?
   var colon: Token
   var unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes: UnexpectedNodes?
@@ -7385,8 +7936,9 @@ public struct OperatorPrecedenceAndTypes: SyntaxBuildable, ExpressibleAsOperator
   ///   - colon: 
   ///   - unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes: 
   ///   - precedenceGroupAndDesignatedTypes: The precedence group and designated types for this operator
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes: ExpressibleAsUnexpectedNodes? = nil, precedenceGroupAndDesignatedTypes: ExpressibleAsIdentifierList) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes: ExpressibleAsUnexpectedNodes? = nil, precedenceGroupAndDesignatedTypes: ExpressibleAsIdentifierList) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeColon = unexpectedBeforeColon?.createUnexpectedNodes()
     self.colon = colon
     assert(colon.text == #":"#)
@@ -7401,6 +7953,9 @@ public struct OperatorPrecedenceAndTypes: SyntaxBuildable, ExpressibleAsOperator
     var result = OperatorPrecedenceAndTypesSyntax(unexpectedBeforeColon?.buildUnexpectedNodes(format: format), colon: colon.buildToken(format: format), unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes?.buildUnexpectedNodes(format: format), precedenceGroupAndDesignatedTypes: precedenceGroupAndDesignatedTypes.buildIdentifierList(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -7424,8 +7979,9 @@ public struct OperatorPrecedenceAndTypes: SyntaxBuildable, ExpressibleAsOperator
 /// A Swift `precedencegroup` declaration.
 public struct PrecedenceGroupDecl: DeclBuildable, ExpressibleAsPrecedenceGroupDecl {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndModifiers: UnexpectedNodes?
@@ -7456,8 +8012,9 @@ public struct PrecedenceGroupDecl: DeclBuildable, ExpressibleAsPrecedenceGroupDe
   ///   - groupAttributes: The characteristics of this precedence group.
   ///   - unexpectedBetweenGroupAttributesAndRightBrace: 
   ///   - rightBrace: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndPrecedencegroupKeyword: ExpressibleAsUnexpectedNodes? = nil, precedencegroupKeyword: Token = Token.`precedencegroup`, unexpectedBetweenPrecedencegroupKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndLeftBrace: ExpressibleAsUnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndGroupAttributes: ExpressibleAsUnexpectedNodes? = nil, groupAttributes: ExpressibleAsPrecedenceGroupAttributeList, unexpectedBetweenGroupAttributesAndRightBrace: ExpressibleAsUnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndPrecedencegroupKeyword: ExpressibleAsUnexpectedNodes? = nil, precedencegroupKeyword: Token = Token.`precedencegroup`, unexpectedBetweenPrecedencegroupKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndLeftBrace: ExpressibleAsUnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndGroupAttributes: ExpressibleAsUnexpectedNodes? = nil, groupAttributes: ExpressibleAsPrecedenceGroupAttributeList, unexpectedBetweenGroupAttributesAndRightBrace: ExpressibleAsUnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndModifiers = unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes()
@@ -7491,6 +8048,9 @@ public struct PrecedenceGroupDecl: DeclBuildable, ExpressibleAsPrecedenceGroupDe
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `DeclBuildable`.
@@ -7520,8 +8080,9 @@ public struct PrecedenceGroupDecl: DeclBuildable, ExpressibleAsPrecedenceGroupDe
 /// Specify the new precedence group's relation to existing precedencegroups.
 public struct PrecedenceGroupRelation: SyntaxBuildable, ExpressibleAsPrecedenceGroupRelation {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeHigherThanOrLowerThan: UnexpectedNodes?
   var higherThanOrLowerThan: Token
   var unexpectedBetweenHigherThanOrLowerThanAndColon: UnexpectedNodes?
@@ -7536,8 +8097,9 @@ public struct PrecedenceGroupRelation: SyntaxBuildable, ExpressibleAsPrecedenceG
   ///   - colon: 
   ///   - unexpectedBetweenColonAndOtherNames: 
   ///   - otherNames: The name of other precedence group to which this precedencegroup relates.
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeHigherThanOrLowerThan: ExpressibleAsUnexpectedNodes? = nil, higherThanOrLowerThan: Token, unexpectedBetweenHigherThanOrLowerThanAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndOtherNames: ExpressibleAsUnexpectedNodes? = nil, otherNames: ExpressibleAsPrecedenceGroupNameList) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeHigherThanOrLowerThan: ExpressibleAsUnexpectedNodes? = nil, higherThanOrLowerThan: Token, unexpectedBetweenHigherThanOrLowerThanAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndOtherNames: ExpressibleAsUnexpectedNodes? = nil, otherNames: ExpressibleAsPrecedenceGroupNameList) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeHigherThanOrLowerThan = unexpectedBeforeHigherThanOrLowerThan?.createUnexpectedNodes()
     self.higherThanOrLowerThan = higherThanOrLowerThan
     assert(higherThanOrLowerThan.text == #"higherThan"# || higherThanOrLowerThan.text == #"lowerThan"#)
@@ -7562,6 +8124,9 @@ public struct PrecedenceGroupRelation: SyntaxBuildable, ExpressibleAsPrecedenceG
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -7583,8 +8148,9 @@ public struct PrecedenceGroupRelation: SyntaxBuildable, ExpressibleAsPrecedenceG
 }
 public struct PrecedenceGroupNameElement: SyntaxBuildable, ExpressibleAsPrecedenceGroupNameElement {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeName: UnexpectedNodes?
   var name: Token
   var unexpectedBetweenNameAndTrailingComma: UnexpectedNodes?
@@ -7595,8 +8161,9 @@ public struct PrecedenceGroupNameElement: SyntaxBuildable, ExpressibleAsPreceden
   ///   - name: 
   ///   - unexpectedBetweenNameAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeName = unexpectedBeforeName?.createUnexpectedNodes()
     self.name = name
     self.unexpectedBetweenNameAndTrailingComma = unexpectedBetweenNameAndTrailingComma?.createUnexpectedNodes()
@@ -7617,6 +8184,9 @@ public struct PrecedenceGroupNameElement: SyntaxBuildable, ExpressibleAsPreceden
     var result = PrecedenceGroupNameElementSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format), name: name.buildToken(format: format), unexpectedBetweenNameAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -7640,8 +8210,9 @@ public struct PrecedenceGroupNameElement: SyntaxBuildable, ExpressibleAsPreceden
 /// Specifies the precedence of an operator when used in an operationthat includes optional chaining.
 public struct PrecedenceGroupAssignment: SyntaxBuildable, ExpressibleAsPrecedenceGroupAssignment {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAssignmentKeyword: UnexpectedNodes?
   var assignmentKeyword: Token
   var unexpectedBetweenAssignmentKeywordAndColon: UnexpectedNodes?
@@ -7656,8 +8227,9 @@ public struct PrecedenceGroupAssignment: SyntaxBuildable, ExpressibleAsPrecedenc
   ///   - colon: 
   ///   - unexpectedBetweenColonAndFlag: 
   ///   - flag: When true, an operator in the corresponding precedence groupuses the same grouping rules during optional chaining as theassignment operators from the standard library. Otherwise,operators in the precedence group follows the same optionalchaining rules as operators that don't perform assignment.
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAssignmentKeyword: ExpressibleAsUnexpectedNodes? = nil, assignmentKeyword: Token, unexpectedBetweenAssignmentKeywordAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndFlag: ExpressibleAsUnexpectedNodes? = nil, flag: Token) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAssignmentKeyword: ExpressibleAsUnexpectedNodes? = nil, assignmentKeyword: Token, unexpectedBetweenAssignmentKeywordAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndFlag: ExpressibleAsUnexpectedNodes? = nil, flag: Token) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAssignmentKeyword = unexpectedBeforeAssignmentKeyword?.createUnexpectedNodes()
     self.assignmentKeyword = assignmentKeyword
     assert(assignmentKeyword.text == #"assignment"#)
@@ -7683,6 +8255,9 @@ public struct PrecedenceGroupAssignment: SyntaxBuildable, ExpressibleAsPrecedenc
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -7705,8 +8280,9 @@ public struct PrecedenceGroupAssignment: SyntaxBuildable, ExpressibleAsPrecedenc
 /// Specifies how a sequence of operators with the same precedence levelare grouped together in the absence of grouping parentheses.
 public struct PrecedenceGroupAssociativity: SyntaxBuildable, ExpressibleAsPrecedenceGroupAssociativity {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAssociativityKeyword: UnexpectedNodes?
   var associativityKeyword: Token
   var unexpectedBetweenAssociativityKeywordAndColon: UnexpectedNodes?
@@ -7721,8 +8297,9 @@ public struct PrecedenceGroupAssociativity: SyntaxBuildable, ExpressibleAsPreced
   ///   - colon: 
   ///   - unexpectedBetweenColonAndValue: 
   ///   - value: Operators that are `left`-associative group left-to-right.Operators that are `right`-associative group right-to-left.Operators that are specified with an associativity of `none`don't associate at all
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAssociativityKeyword: ExpressibleAsUnexpectedNodes? = nil, associativityKeyword: Token, unexpectedBetweenAssociativityKeywordAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: ExpressibleAsUnexpectedNodes? = nil, value: Token) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAssociativityKeyword: ExpressibleAsUnexpectedNodes? = nil, associativityKeyword: Token, unexpectedBetweenAssociativityKeywordAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: ExpressibleAsUnexpectedNodes? = nil, value: Token) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAssociativityKeyword = unexpectedBeforeAssociativityKeyword?.createUnexpectedNodes()
     self.associativityKeyword = associativityKeyword
     assert(associativityKeyword.text == #"associativity"#)
@@ -7748,6 +8325,9 @@ public struct PrecedenceGroupAssociativity: SyntaxBuildable, ExpressibleAsPreced
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -7770,8 +8350,9 @@ public struct PrecedenceGroupAssociativity: SyntaxBuildable, ExpressibleAsPreced
 /// A custom `@` attribute.
 public struct CustomAttribute: SyntaxBuildable, ExpressibleAsCustomAttribute {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAtSignToken: UnexpectedNodes?
   var atSignToken: Token
   var unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodes?
@@ -7794,8 +8375,9 @@ public struct CustomAttribute: SyntaxBuildable, ExpressibleAsCustomAttribute {
   ///   - argumentList: 
   ///   - unexpectedBetweenArgumentListAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAtSignToken: ExpressibleAsUnexpectedNodes? = nil, atSignToken: Token = Token.`atSign`, unexpectedBetweenAtSignTokenAndAttributeName: ExpressibleAsUnexpectedNodes? = nil, attributeName: ExpressibleAsTypeBuildable, unexpectedBetweenAttributeNameAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: ExpressibleAsUnexpectedNodes? = nil, argumentList: ExpressibleAsTupleExprElementList? = nil, unexpectedBetweenArgumentListAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAtSignToken: ExpressibleAsUnexpectedNodes? = nil, atSignToken: Token = Token.`atSign`, unexpectedBetweenAtSignTokenAndAttributeName: ExpressibleAsUnexpectedNodes? = nil, attributeName: ExpressibleAsTypeBuildable, unexpectedBetweenAttributeNameAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgumentList: ExpressibleAsUnexpectedNodes? = nil, argumentList: ExpressibleAsTupleExprElementList? = nil, unexpectedBetweenArgumentListAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAtSignToken = unexpectedBeforeAtSignToken?.createUnexpectedNodes()
     self.atSignToken = atSignToken
     assert(atSignToken.text == #"@"#)
@@ -7827,6 +8409,9 @@ public struct CustomAttribute: SyntaxBuildable, ExpressibleAsCustomAttribute {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -7849,8 +8434,9 @@ public struct CustomAttribute: SyntaxBuildable, ExpressibleAsCustomAttribute {
 /// An `@` attribute.
 public struct Attribute: SyntaxBuildable, ExpressibleAsAttribute {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAtSignToken: UnexpectedNodes?
   var atSignToken: Token
   var unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodes?
@@ -7877,8 +8463,9 @@ public struct Attribute: SyntaxBuildable, ExpressibleAsAttribute {
   ///   - rightParen: If the attribute takes arguments, the closing parenthesis.
   ///   - unexpectedBetweenRightParenAndTokenList: 
   ///   - tokenList: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAtSignToken: ExpressibleAsUnexpectedNodes? = nil, atSignToken: Token = Token.`atSign`, unexpectedBetweenAtSignTokenAndAttributeName: ExpressibleAsUnexpectedNodes? = nil, attributeName: Token, unexpectedBetweenAttributeNameAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgument: ExpressibleAsUnexpectedNodes? = nil, argument: ExpressibleAsSyntaxBuildable? = nil, unexpectedBetweenArgumentAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTokenList: ExpressibleAsUnexpectedNodes? = nil, tokenList: ExpressibleAsTokenList? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAtSignToken: ExpressibleAsUnexpectedNodes? = nil, atSignToken: Token = Token.`atSign`, unexpectedBetweenAtSignTokenAndAttributeName: ExpressibleAsUnexpectedNodes? = nil, attributeName: Token, unexpectedBetweenAttributeNameAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndArgument: ExpressibleAsUnexpectedNodes? = nil, argument: ExpressibleAsSyntaxBuildable? = nil, unexpectedBetweenArgumentAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token? = nil, unexpectedBetweenRightParenAndTokenList: ExpressibleAsUnexpectedNodes? = nil, tokenList: ExpressibleAsTokenList? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAtSignToken = unexpectedBeforeAtSignToken?.createUnexpectedNodes()
     self.atSignToken = atSignToken
     assert(atSignToken.text == #"@"#)
@@ -7904,6 +8491,9 @@ public struct Attribute: SyntaxBuildable, ExpressibleAsAttribute {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -7926,8 +8516,9 @@ public struct Attribute: SyntaxBuildable, ExpressibleAsAttribute {
 /// The availability argument for the _specialize attribute
 public struct AvailabilityEntry: SyntaxBuildable, ExpressibleAsAvailabilityEntry {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLabel: UnexpectedNodes?
   var label: Token
   var unexpectedBetweenLabelAndColon: UnexpectedNodes?
@@ -7946,8 +8537,9 @@ public struct AvailabilityEntry: SyntaxBuildable, ExpressibleAsAvailabilityEntry
   ///   - availabilityList: 
   ///   - unexpectedBetweenAvailabilityListAndSemicolon: 
   ///   - semicolon: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndAvailabilityList: ExpressibleAsUnexpectedNodes? = nil, availabilityList: ExpressibleAsAvailabilitySpecList, unexpectedBetweenAvailabilityListAndSemicolon: ExpressibleAsUnexpectedNodes? = nil, semicolon: Token = Token.`semicolon`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndAvailabilityList: ExpressibleAsUnexpectedNodes? = nil, availabilityList: ExpressibleAsAvailabilitySpecList, unexpectedBetweenAvailabilityListAndSemicolon: ExpressibleAsUnexpectedNodes? = nil, semicolon: Token = Token.`semicolon`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLabel = unexpectedBeforeLabel?.createUnexpectedNodes()
     self.label = label
     self.unexpectedBetweenLabelAndColon = unexpectedBetweenLabelAndColon?.createUnexpectedNodes()
@@ -7974,6 +8566,9 @@ public struct AvailabilityEntry: SyntaxBuildable, ExpressibleAsAvailabilityEntry
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -7996,8 +8591,9 @@ public struct AvailabilityEntry: SyntaxBuildable, ExpressibleAsAvailabilityEntry
 /// A labeled argument for the `@_specialize` attribute like`exported: true`
 public struct LabeledSpecializeEntry: SyntaxBuildable, ExpressibleAsLabeledSpecializeEntry, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLabel: UnexpectedNodes?
   var label: Token
   var unexpectedBetweenLabelAndColon: UnexpectedNodes?
@@ -8016,8 +8612,9 @@ public struct LabeledSpecializeEntry: SyntaxBuildable, ExpressibleAsLabeledSpeci
   ///   - value: The value for this argument
   ///   - unexpectedBetweenValueAndTrailingComma: 
   ///   - trailingComma: A trailing comma if this argument is followed by another one
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: ExpressibleAsUnexpectedNodes? = nil, value: Token, unexpectedBetweenValueAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: ExpressibleAsUnexpectedNodes? = nil, value: Token, unexpectedBetweenValueAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLabel = unexpectedBeforeLabel?.createUnexpectedNodes()
     self.label = label
     self.unexpectedBetweenLabelAndColon = unexpectedBetweenLabelAndColon?.createUnexpectedNodes()
@@ -8043,6 +8640,9 @@ public struct LabeledSpecializeEntry: SyntaxBuildable, ExpressibleAsLabeledSpeci
     var result = LabeledSpecializeEntrySyntax(unexpectedBeforeLabel?.buildUnexpectedNodes(format: format), label: label.buildToken(format: format), unexpectedBetweenLabelAndColon?.buildUnexpectedNodes(format: format), colon: colon.buildToken(format: format), unexpectedBetweenColonAndValue?.buildUnexpectedNodes(format: format), value: value.buildToken(format: format), unexpectedBetweenValueAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -8072,8 +8672,9 @@ public struct LabeledSpecializeEntry: SyntaxBuildable, ExpressibleAsLabeledSpeci
 /// A labeled argument for the `@_specialize` attribute with a functiondecl value like`target: myFunc(_:)`
 public struct TargetFunctionEntry: SyntaxBuildable, ExpressibleAsTargetFunctionEntry, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLabel: UnexpectedNodes?
   var label: Token
   var unexpectedBetweenLabelAndColon: UnexpectedNodes?
@@ -8092,8 +8693,9 @@ public struct TargetFunctionEntry: SyntaxBuildable, ExpressibleAsTargetFunctionE
   ///   - declname: The value for this argument
   ///   - unexpectedBetweenDeclnameAndTrailingComma: 
   ///   - trailingComma: A trailing comma if this argument is followed by another one
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndDeclname: ExpressibleAsUnexpectedNodes? = nil, declname: ExpressibleAsDeclName, unexpectedBetweenDeclnameAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndDeclname: ExpressibleAsUnexpectedNodes? = nil, declname: ExpressibleAsDeclName, unexpectedBetweenDeclnameAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLabel = unexpectedBeforeLabel?.createUnexpectedNodes()
     self.label = label
     self.unexpectedBetweenLabelAndColon = unexpectedBetweenLabelAndColon?.createUnexpectedNodes()
@@ -8119,6 +8721,9 @@ public struct TargetFunctionEntry: SyntaxBuildable, ExpressibleAsTargetFunctionE
     var result = TargetFunctionEntrySyntax(unexpectedBeforeLabel?.buildUnexpectedNodes(format: format), label: label.buildToken(format: format), unexpectedBetweenLabelAndColon?.buildUnexpectedNodes(format: format), colon: colon.buildToken(format: format), unexpectedBetweenColonAndDeclname?.buildUnexpectedNodes(format: format), declname: declname.buildDeclName(format: format), unexpectedBetweenDeclnameAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -8148,8 +8753,9 @@ public struct TargetFunctionEntry: SyntaxBuildable, ExpressibleAsTargetFunctionE
 /// The argument for the `@_dynamic_replacement` or `@_private`attribute of the form `for: "function()"` or `sourceFile:"Src.swift"`
 public struct NamedAttributeStringArgument: SyntaxBuildable, ExpressibleAsNamedAttributeStringArgument {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeNameTok: UnexpectedNodes?
   var nameTok: Token
   var unexpectedBetweenNameTokAndColon: UnexpectedNodes?
@@ -8164,8 +8770,9 @@ public struct NamedAttributeStringArgument: SyntaxBuildable, ExpressibleAsNamedA
   ///   - colon: The colon separating the label and the value
   ///   - unexpectedBetweenColonAndStringOrDeclname: 
   ///   - stringOrDeclname: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeNameTok: ExpressibleAsUnexpectedNodes? = nil, nameTok: Token, unexpectedBetweenNameTokAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndStringOrDeclname: ExpressibleAsUnexpectedNodes? = nil, stringOrDeclname: ExpressibleAsSyntaxBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeNameTok: ExpressibleAsUnexpectedNodes? = nil, nameTok: Token, unexpectedBetweenNameTokAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndStringOrDeclname: ExpressibleAsUnexpectedNodes? = nil, stringOrDeclname: ExpressibleAsSyntaxBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeNameTok = unexpectedBeforeNameTok?.createUnexpectedNodes()
     self.nameTok = nameTok
     self.unexpectedBetweenNameTokAndColon = unexpectedBetweenNameTokAndColon?.createUnexpectedNodes()
@@ -8182,6 +8789,9 @@ public struct NamedAttributeStringArgument: SyntaxBuildable, ExpressibleAsNamedA
     var result = NamedAttributeStringArgumentSyntax(unexpectedBeforeNameTok?.buildUnexpectedNodes(format: format), nameTok: nameTok.buildToken(format: format), unexpectedBetweenNameTokAndColon?.buildUnexpectedNodes(format: format), colon: colon.buildToken(format: format), unexpectedBetweenColonAndStringOrDeclname?.buildUnexpectedNodes(format: format), stringOrDeclname: stringOrDeclname.buildSyntax(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -8204,8 +8814,9 @@ public struct NamedAttributeStringArgument: SyntaxBuildable, ExpressibleAsNamedA
 }
 public struct DeclName: SyntaxBuildable, ExpressibleAsDeclName {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeDeclBaseName: UnexpectedNodes?
   var declBaseName: SyntaxBuildable
   var unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodes?
@@ -8216,8 +8827,9 @@ public struct DeclName: SyntaxBuildable, ExpressibleAsDeclName {
   ///   - declBaseName: The base name of the protocol's requirement.
   ///   - unexpectedBetweenDeclBaseNameAndDeclNameArguments: 
   ///   - declNameArguments: The argument labels of the protocol's requirement if itis a function requirement.
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeDeclBaseName: ExpressibleAsUnexpectedNodes? = nil, declBaseName: ExpressibleAsSyntaxBuildable, unexpectedBetweenDeclBaseNameAndDeclNameArguments: ExpressibleAsUnexpectedNodes? = nil, declNameArguments: ExpressibleAsDeclNameArguments? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDeclBaseName: ExpressibleAsUnexpectedNodes? = nil, declBaseName: ExpressibleAsSyntaxBuildable, unexpectedBetweenDeclBaseNameAndDeclNameArguments: ExpressibleAsUnexpectedNodes? = nil, declNameArguments: ExpressibleAsDeclNameArguments? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeDeclBaseName = unexpectedBeforeDeclBaseName?.createUnexpectedNodes()
     self.declBaseName = declBaseName.createSyntaxBuildable()
     self.unexpectedBetweenDeclBaseNameAndDeclNameArguments = unexpectedBetweenDeclBaseNameAndDeclNameArguments?.createUnexpectedNodes()
@@ -8231,6 +8843,9 @@ public struct DeclName: SyntaxBuildable, ExpressibleAsDeclName {
     var result = DeclNameSyntax(unexpectedBeforeDeclBaseName?.buildUnexpectedNodes(format: format), declBaseName: declBaseName.buildSyntax(format: format), unexpectedBetweenDeclBaseNameAndDeclNameArguments?.buildUnexpectedNodes(format: format), declNameArguments: declNameArguments?.buildDeclNameArguments(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -8254,8 +8869,9 @@ public struct DeclName: SyntaxBuildable, ExpressibleAsDeclName {
 /// The arguments for the `@_implements` attribute of the form`Type, methodName(arg1Label:arg2Label:)`
 public struct ImplementsAttributeArguments: SyntaxBuildable, ExpressibleAsImplementsAttributeArguments {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeType: UnexpectedNodes?
   var type: SimpleTypeIdentifier
   var unexpectedBetweenTypeAndComma: UnexpectedNodes?
@@ -8274,8 +8890,9 @@ public struct ImplementsAttributeArguments: SyntaxBuildable, ExpressibleAsImplem
   ///   - declBaseName: The base name of the protocol's requirement.
   ///   - unexpectedBetweenDeclBaseNameAndDeclNameArguments: 
   ///   - declNameArguments: The argument labels of the protocol's requirement if itis a function requirement.
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsSimpleTypeIdentifier, unexpectedBetweenTypeAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token = Token.`comma`, unexpectedBetweenCommaAndDeclBaseName: ExpressibleAsUnexpectedNodes? = nil, declBaseName: ExpressibleAsSyntaxBuildable, unexpectedBetweenDeclBaseNameAndDeclNameArguments: ExpressibleAsUnexpectedNodes? = nil, declNameArguments: ExpressibleAsDeclNameArguments? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsSimpleTypeIdentifier, unexpectedBetweenTypeAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token = Token.`comma`, unexpectedBetweenCommaAndDeclBaseName: ExpressibleAsUnexpectedNodes? = nil, declBaseName: ExpressibleAsSyntaxBuildable, unexpectedBetweenDeclBaseNameAndDeclNameArguments: ExpressibleAsUnexpectedNodes? = nil, declNameArguments: ExpressibleAsDeclNameArguments? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeType = unexpectedBeforeType?.createUnexpectedNodes()
     self.type = type.createSimpleTypeIdentifier()
     self.unexpectedBetweenTypeAndComma = unexpectedBetweenTypeAndComma?.createUnexpectedNodes()
@@ -8294,6 +8911,9 @@ public struct ImplementsAttributeArguments: SyntaxBuildable, ExpressibleAsImplem
     var result = ImplementsAttributeArgumentsSyntax(unexpectedBeforeType?.buildUnexpectedNodes(format: format), type: type.buildSimpleTypeIdentifier(format: format), unexpectedBetweenTypeAndComma?.buildUnexpectedNodes(format: format), comma: comma.buildToken(format: format), unexpectedBetweenCommaAndDeclBaseName?.buildUnexpectedNodes(format: format), declBaseName: declBaseName.buildSyntax(format: format), unexpectedBetweenDeclBaseNameAndDeclNameArguments?.buildUnexpectedNodes(format: format), declNameArguments: declNameArguments?.buildDeclNameArguments(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -8317,8 +8937,9 @@ public struct ImplementsAttributeArguments: SyntaxBuildable, ExpressibleAsImplem
 /// A piece of an Objective-C selector. Either consisting of just anidentifier for a nullary selector, an identifier and a colon for alabeled argument or just a colon for an unlabeled argument
 public struct ObjCSelectorPiece: SyntaxBuildable, ExpressibleAsObjCSelectorPiece {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeName: UnexpectedNodes?
   var name: Token?
   var unexpectedBetweenNameAndColon: UnexpectedNodes?
@@ -8329,8 +8950,9 @@ public struct ObjCSelectorPiece: SyntaxBuildable, ExpressibleAsObjCSelectorPiece
   ///   - name: 
   ///   - unexpectedBetweenNameAndColon: 
   ///   - colon: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token? = nil, unexpectedBetweenNameAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token? = nil, unexpectedBetweenNameAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeName = unexpectedBeforeName?.createUnexpectedNodes()
     self.name = name
     self.unexpectedBetweenNameAndColon = unexpectedBetweenNameAndColon?.createUnexpectedNodes()
@@ -8354,6 +8976,9 @@ public struct ObjCSelectorPiece: SyntaxBuildable, ExpressibleAsObjCSelectorPiece
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -8376,8 +9001,9 @@ public struct ObjCSelectorPiece: SyntaxBuildable, ExpressibleAsObjCSelectorPiece
 /// The arguments for the `@differentiable` attribute: an optionaldifferentiability kind, an optional differentiability parameter clause,and an optional 'where' clause.
 public struct DifferentiableAttributeArguments: SyntaxBuildable, ExpressibleAsDifferentiableAttributeArguments {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeDiffKind: UnexpectedNodes?
   var diffKind: Token?
   var unexpectedBetweenDiffKindAndDiffKindComma: UnexpectedNodes?
@@ -8400,8 +9026,9 @@ public struct DifferentiableAttributeArguments: SyntaxBuildable, ExpressibleAsDi
   ///   - diffParamsComma: The comma following the differentiability parameters clause,if it exists.
   ///   - unexpectedBetweenDiffParamsCommaAndWhereClause: 
   ///   - whereClause: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeDiffKind: ExpressibleAsUnexpectedNodes? = nil, diffKind: Token? = nil, unexpectedBetweenDiffKindAndDiffKindComma: ExpressibleAsUnexpectedNodes? = nil, diffKindComma: Token? = nil, unexpectedBetweenDiffKindCommaAndDiffParams: ExpressibleAsUnexpectedNodes? = nil, diffParams: ExpressibleAsDifferentiabilityParamsClause? = nil, unexpectedBetweenDiffParamsAndDiffParamsComma: ExpressibleAsUnexpectedNodes? = nil, diffParamsComma: Token? = nil, unexpectedBetweenDiffParamsCommaAndWhereClause: ExpressibleAsUnexpectedNodes? = nil, whereClause: ExpressibleAsGenericWhereClause? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDiffKind: ExpressibleAsUnexpectedNodes? = nil, diffKind: Token? = nil, unexpectedBetweenDiffKindAndDiffKindComma: ExpressibleAsUnexpectedNodes? = nil, diffKindComma: Token? = nil, unexpectedBetweenDiffKindCommaAndDiffParams: ExpressibleAsUnexpectedNodes? = nil, diffParams: ExpressibleAsDifferentiabilityParamsClause? = nil, unexpectedBetweenDiffParamsAndDiffParamsComma: ExpressibleAsUnexpectedNodes? = nil, diffParamsComma: Token? = nil, unexpectedBetweenDiffParamsCommaAndWhereClause: ExpressibleAsUnexpectedNodes? = nil, whereClause: ExpressibleAsGenericWhereClause? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeDiffKind = unexpectedBeforeDiffKind?.createUnexpectedNodes()
     self.diffKind = diffKind
     assert(diffKind == nil || diffKind!.text == #"forward"# || diffKind!.text == #"reverse"# || diffKind!.text == #"linear"#)
@@ -8433,6 +9060,9 @@ public struct DifferentiableAttributeArguments: SyntaxBuildable, ExpressibleAsDi
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -8455,8 +9085,9 @@ public struct DifferentiableAttributeArguments: SyntaxBuildable, ExpressibleAsDi
 /// A clause containing differentiability parameters.
 public struct DifferentiabilityParamsClause: SyntaxBuildable, ExpressibleAsDifferentiabilityParamsClause {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeWrtLabel: UnexpectedNodes?
   var wrtLabel: Token
   var unexpectedBetweenWrtLabelAndColon: UnexpectedNodes?
@@ -8471,8 +9102,9 @@ public struct DifferentiabilityParamsClause: SyntaxBuildable, ExpressibleAsDiffe
   ///   - colon: The colon separating "wrt" and the parameter list.
   ///   - unexpectedBetweenColonAndParameters: 
   ///   - parameters: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeWrtLabel: ExpressibleAsUnexpectedNodes? = nil, wrtLabel: Token, unexpectedBetweenWrtLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndParameters: ExpressibleAsUnexpectedNodes? = nil, parameters: ExpressibleAsSyntaxBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWrtLabel: ExpressibleAsUnexpectedNodes? = nil, wrtLabel: Token, unexpectedBetweenWrtLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndParameters: ExpressibleAsUnexpectedNodes? = nil, parameters: ExpressibleAsSyntaxBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeWrtLabel = unexpectedBeforeWrtLabel?.createUnexpectedNodes()
     self.wrtLabel = wrtLabel
     assert(wrtLabel.text == #"wrt"#)
@@ -8497,6 +9129,9 @@ public struct DifferentiabilityParamsClause: SyntaxBuildable, ExpressibleAsDiffe
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -8519,8 +9154,9 @@ public struct DifferentiabilityParamsClause: SyntaxBuildable, ExpressibleAsDiffe
 /// The differentiability parameters.
 public struct DifferentiabilityParams: SyntaxBuildable, ExpressibleAsDifferentiabilityParams {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftParen: UnexpectedNodes?
   var leftParen: Token
   var unexpectedBetweenLeftParenAndDiffParams: UnexpectedNodes?
@@ -8535,8 +9171,9 @@ public struct DifferentiabilityParams: SyntaxBuildable, ExpressibleAsDifferentia
   ///   - diffParams: The parameters for differentiation.
   ///   - unexpectedBetweenDiffParamsAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndDiffParams: ExpressibleAsUnexpectedNodes? = nil, diffParams: ExpressibleAsDifferentiabilityParamList, unexpectedBetweenDiffParamsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndDiffParams: ExpressibleAsUnexpectedNodes? = nil, diffParams: ExpressibleAsDifferentiabilityParamList, unexpectedBetweenDiffParamsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftParen = unexpectedBeforeLeftParen?.createUnexpectedNodes()
     self.leftParen = leftParen
     assert(leftParen.text == #"("#)
@@ -8554,6 +9191,9 @@ public struct DifferentiabilityParams: SyntaxBuildable, ExpressibleAsDifferentia
     var result = DifferentiabilityParamsSyntax(unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format), leftParen: leftParen.buildToken(format: format), unexpectedBetweenLeftParenAndDiffParams?.buildUnexpectedNodes(format: format), diffParams: diffParams.buildDifferentiabilityParamList(format: format), unexpectedBetweenDiffParamsAndRightParen?.buildUnexpectedNodes(format: format), rightParen: rightParen.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -8577,8 +9217,9 @@ public struct DifferentiabilityParams: SyntaxBuildable, ExpressibleAsDifferentia
 /// A differentiability parameter: either the "self" identifier, a functionparameter name, or a function parameter index.
 public struct DifferentiabilityParam: SyntaxBuildable, ExpressibleAsDifferentiabilityParam, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeParameter: UnexpectedNodes?
   var parameter: SyntaxBuildable
   var unexpectedBetweenParameterAndTrailingComma: UnexpectedNodes?
@@ -8589,8 +9230,9 @@ public struct DifferentiabilityParam: SyntaxBuildable, ExpressibleAsDifferentiab
   ///   - parameter: 
   ///   - unexpectedBetweenParameterAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeParameter: ExpressibleAsUnexpectedNodes? = nil, parameter: ExpressibleAsSyntaxBuildable, unexpectedBetweenParameterAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeParameter: ExpressibleAsUnexpectedNodes? = nil, parameter: ExpressibleAsSyntaxBuildable, unexpectedBetweenParameterAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeParameter = unexpectedBeforeParameter?.createUnexpectedNodes()
     self.parameter = parameter.createSyntaxBuildable()
     self.unexpectedBetweenParameterAndTrailingComma = unexpectedBetweenParameterAndTrailingComma?.createUnexpectedNodes()
@@ -8605,6 +9247,9 @@ public struct DifferentiabilityParam: SyntaxBuildable, ExpressibleAsDifferentiab
     var result = DifferentiabilityParamSyntax(unexpectedBeforeParameter?.buildUnexpectedNodes(format: format), parameter: parameter.buildSyntax(format: format), unexpectedBetweenParameterAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -8634,8 +9279,9 @@ public struct DifferentiabilityParam: SyntaxBuildable, ExpressibleAsDifferentiab
 /// The arguments for the '@derivative(of:)' and '@transpose(of:)'attributes: the 'of:' label, the original declaration name, and anoptional differentiability parameter list.
 public struct DerivativeRegistrationAttributeArguments: SyntaxBuildable, ExpressibleAsDerivativeRegistrationAttributeArguments {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeOfLabel: UnexpectedNodes?
   var ofLabel: Token
   var unexpectedBetweenOfLabelAndColon: UnexpectedNodes?
@@ -8666,8 +9312,9 @@ public struct DerivativeRegistrationAttributeArguments: SyntaxBuildable, Express
   ///   - comma: 
   ///   - unexpectedBetweenCommaAndDiffParams: 
   ///   - diffParams: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeOfLabel: ExpressibleAsUnexpectedNodes? = nil, ofLabel: Token, unexpectedBetweenOfLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndOriginalDeclName: ExpressibleAsUnexpectedNodes? = nil, originalDeclName: ExpressibleAsQualifiedDeclName, unexpectedBetweenOriginalDeclNameAndPeriod: ExpressibleAsUnexpectedNodes? = nil, period: Token? = nil, unexpectedBetweenPeriodAndAccessorKind: ExpressibleAsUnexpectedNodes? = nil, accessorKind: Token? = nil, unexpectedBetweenAccessorKindAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndDiffParams: ExpressibleAsUnexpectedNodes? = nil, diffParams: ExpressibleAsDifferentiabilityParamsClause? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeOfLabel: ExpressibleAsUnexpectedNodes? = nil, ofLabel: Token, unexpectedBetweenOfLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndOriginalDeclName: ExpressibleAsUnexpectedNodes? = nil, originalDeclName: ExpressibleAsQualifiedDeclName, unexpectedBetweenOriginalDeclNameAndPeriod: ExpressibleAsUnexpectedNodes? = nil, period: Token? = nil, unexpectedBetweenPeriodAndAccessorKind: ExpressibleAsUnexpectedNodes? = nil, accessorKind: Token? = nil, unexpectedBetweenAccessorKindAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndDiffParams: ExpressibleAsUnexpectedNodes? = nil, diffParams: ExpressibleAsDifferentiabilityParamsClause? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeOfLabel = unexpectedBeforeOfLabel?.createUnexpectedNodes()
     self.ofLabel = ofLabel
     assert(ofLabel.text == #"of"#)
@@ -8705,6 +9352,9 @@ public struct DerivativeRegistrationAttributeArguments: SyntaxBuildable, Express
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -8727,8 +9377,9 @@ public struct DerivativeRegistrationAttributeArguments: SyntaxBuildable, Express
 /// An optionally qualified function declaration name (e.g. `+(_:_:)`,`A.B.C.foo(_:_:)`).
 public struct QualifiedDeclName: SyntaxBuildable, ExpressibleAsQualifiedDeclName {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeBaseType: UnexpectedNodes?
   var baseType: TypeBuildable?
   var unexpectedBetweenBaseTypeAndDot: UnexpectedNodes?
@@ -8747,8 +9398,9 @@ public struct QualifiedDeclName: SyntaxBuildable, ExpressibleAsQualifiedDeclName
   ///   - name: The base name of the referenced function.
   ///   - unexpectedBetweenNameAndArguments: 
   ///   - arguments: The argument labels of the referenced function, optionallyspecified.
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeBaseType: ExpressibleAsUnexpectedNodes? = nil, baseType: ExpressibleAsTypeBuildable? = nil, unexpectedBetweenBaseTypeAndDot: ExpressibleAsUnexpectedNodes? = nil, dot: Token? = nil, unexpectedBetweenDotAndName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndArguments: ExpressibleAsUnexpectedNodes? = nil, arguments: ExpressibleAsDeclNameArguments? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBaseType: ExpressibleAsUnexpectedNodes? = nil, baseType: ExpressibleAsTypeBuildable? = nil, unexpectedBetweenBaseTypeAndDot: ExpressibleAsUnexpectedNodes? = nil, dot: Token? = nil, unexpectedBetweenDotAndName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndArguments: ExpressibleAsUnexpectedNodes? = nil, arguments: ExpressibleAsDeclNameArguments? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeBaseType = unexpectedBeforeBaseType?.createUnexpectedNodes()
     self.baseType = baseType?.createTypeBuildable()
     self.unexpectedBetweenBaseTypeAndDot = unexpectedBetweenBaseTypeAndDot?.createUnexpectedNodes()
@@ -8767,6 +9419,9 @@ public struct QualifiedDeclName: SyntaxBuildable, ExpressibleAsQualifiedDeclName
     var result = QualifiedDeclNameSyntax(unexpectedBeforeBaseType?.buildUnexpectedNodes(format: format), baseType: baseType?.buildType(format: format), unexpectedBetweenBaseTypeAndDot?.buildUnexpectedNodes(format: format), dot: dot?.buildToken(format: format), unexpectedBetweenDotAndName?.buildUnexpectedNodes(format: format), name: name.buildToken(format: format), unexpectedBetweenNameAndArguments?.buildUnexpectedNodes(format: format), arguments: arguments?.buildDeclNameArguments(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -8790,8 +9445,9 @@ public struct QualifiedDeclName: SyntaxBuildable, ExpressibleAsQualifiedDeclName
 /// A function declaration name (e.g. `foo(_:_:)`).
 public struct FunctionDeclName: SyntaxBuildable, ExpressibleAsFunctionDeclName {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeName: UnexpectedNodes?
   var name: SyntaxBuildable
   var unexpectedBetweenNameAndArguments: UnexpectedNodes?
@@ -8802,8 +9458,9 @@ public struct FunctionDeclName: SyntaxBuildable, ExpressibleAsFunctionDeclName {
   ///   - name: The base name of the referenced function.
   ///   - unexpectedBetweenNameAndArguments: 
   ///   - arguments: The argument labels of the referenced function, optionallyspecified.
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: ExpressibleAsSyntaxBuildable, unexpectedBetweenNameAndArguments: ExpressibleAsUnexpectedNodes? = nil, arguments: ExpressibleAsDeclNameArguments? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: ExpressibleAsSyntaxBuildable, unexpectedBetweenNameAndArguments: ExpressibleAsUnexpectedNodes? = nil, arguments: ExpressibleAsDeclNameArguments? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeName = unexpectedBeforeName?.createUnexpectedNodes()
     self.name = name.createSyntaxBuildable()
     self.unexpectedBetweenNameAndArguments = unexpectedBetweenNameAndArguments?.createUnexpectedNodes()
@@ -8817,6 +9474,9 @@ public struct FunctionDeclName: SyntaxBuildable, ExpressibleAsFunctionDeclName {
     var result = FunctionDeclNameSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format), name: name.buildSyntax(format: format), unexpectedBetweenNameAndArguments?.buildUnexpectedNodes(format: format), arguments: arguments?.buildDeclNameArguments(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -8840,8 +9500,9 @@ public struct FunctionDeclName: SyntaxBuildable, ExpressibleAsFunctionDeclName {
 /// A collection of arguments for the `@_backDeploy` attribute
 public struct BackDeployAttributeSpecList: SyntaxBuildable, ExpressibleAsBackDeployAttributeSpecList {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeBeforeLabel: UnexpectedNodes?
   var beforeLabel: Token
   var unexpectedBetweenBeforeLabelAndColon: UnexpectedNodes?
@@ -8856,8 +9517,9 @@ public struct BackDeployAttributeSpecList: SyntaxBuildable, ExpressibleAsBackDep
   ///   - colon: The colon separating "before" and the parameter list.
   ///   - unexpectedBetweenColonAndVersionList: 
   ///   - versionList: The list of OS versions in which the declaration became ABIstable.
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, beforeLabel: Token, unexpectedBetweenBeforeLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndVersionList: ExpressibleAsUnexpectedNodes? = nil, versionList: ExpressibleAsBackDeployVersionList) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, beforeLabel: Token, unexpectedBetweenBeforeLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndVersionList: ExpressibleAsUnexpectedNodes? = nil, versionList: ExpressibleAsBackDeployVersionList) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeBeforeLabel = unexpectedBeforeBeforeLabel?.createUnexpectedNodes()
     self.beforeLabel = beforeLabel
     assert(beforeLabel.text == #"before"#)
@@ -8882,6 +9544,9 @@ public struct BackDeployAttributeSpecList: SyntaxBuildable, ExpressibleAsBackDep
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -8904,8 +9569,9 @@ public struct BackDeployAttributeSpecList: SyntaxBuildable, ExpressibleAsBackDep
 /// A single platform/version pair in a `@_backDeploy` attribute,e.g. `iOS 10.1`.
 public struct BackDeployVersionArgument: SyntaxBuildable, ExpressibleAsBackDeployVersionArgument {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAvailabilityVersionRestriction: UnexpectedNodes?
   var availabilityVersionRestriction: AvailabilityVersionRestriction
   var unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma: UnexpectedNodes?
@@ -8916,8 +9582,9 @@ public struct BackDeployVersionArgument: SyntaxBuildable, ExpressibleAsBackDeplo
   ///   - availabilityVersionRestriction: 
   ///   - unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma: 
   ///   - trailingComma: A trailing comma if the argument is followed by anotherargument
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAvailabilityVersionRestriction: ExpressibleAsUnexpectedNodes? = nil, availabilityVersionRestriction: ExpressibleAsAvailabilityVersionRestriction, unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAvailabilityVersionRestriction: ExpressibleAsUnexpectedNodes? = nil, availabilityVersionRestriction: ExpressibleAsAvailabilityVersionRestriction, unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAvailabilityVersionRestriction = unexpectedBeforeAvailabilityVersionRestriction?.createUnexpectedNodes()
     self.availabilityVersionRestriction = availabilityVersionRestriction.createAvailabilityVersionRestriction()
     self.unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma = unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma?.createUnexpectedNodes()
@@ -8932,6 +9599,9 @@ public struct BackDeployVersionArgument: SyntaxBuildable, ExpressibleAsBackDeplo
     var result = BackDeployVersionArgumentSyntax(unexpectedBeforeAvailabilityVersionRestriction?.buildUnexpectedNodes(format: format), availabilityVersionRestriction: availabilityVersionRestriction.buildAvailabilityVersionRestriction(format: format), unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -8954,8 +9624,9 @@ public struct BackDeployVersionArgument: SyntaxBuildable, ExpressibleAsBackDeplo
 }
 public struct LabeledStmt: StmtBuildable, ExpressibleAsLabeledStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLabelName: UnexpectedNodes?
   var labelName: Token
   var unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodes?
@@ -8970,8 +9641,9 @@ public struct LabeledStmt: StmtBuildable, ExpressibleAsLabeledStmt {
   ///   - labelColon: 
   ///   - unexpectedBetweenLabelColonAndStatement: 
   ///   - statement: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLabelName: ExpressibleAsUnexpectedNodes? = nil, labelName: Token, unexpectedBetweenLabelNameAndLabelColon: ExpressibleAsUnexpectedNodes? = nil, labelColon: Token = Token.`colon`, unexpectedBetweenLabelColonAndStatement: ExpressibleAsUnexpectedNodes? = nil, statement: ExpressibleAsStmtBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabelName: ExpressibleAsUnexpectedNodes? = nil, labelName: Token, unexpectedBetweenLabelNameAndLabelColon: ExpressibleAsUnexpectedNodes? = nil, labelColon: Token = Token.`colon`, unexpectedBetweenLabelColonAndStatement: ExpressibleAsUnexpectedNodes? = nil, statement: ExpressibleAsStmtBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLabelName = unexpectedBeforeLabelName?.createUnexpectedNodes()
     self.labelName = labelName
     self.unexpectedBetweenLabelNameAndLabelColon = unexpectedBetweenLabelNameAndLabelColon?.createUnexpectedNodes()
@@ -8994,6 +9666,9 @@ public struct LabeledStmt: StmtBuildable, ExpressibleAsLabeledStmt {
     var result = LabeledStmtSyntax(unexpectedBeforeLabelName?.buildUnexpectedNodes(format: format), labelName: labelName.buildToken(format: format), unexpectedBetweenLabelNameAndLabelColon?.buildUnexpectedNodes(format: format), labelColon: labelColon.buildToken(format: format), unexpectedBetweenLabelColonAndStatement?.buildUnexpectedNodes(format: format), statement: statement.buildStmt(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -9023,8 +9698,9 @@ public struct LabeledStmt: StmtBuildable, ExpressibleAsLabeledStmt {
 }
 public struct ContinueStmt: StmtBuildable, ExpressibleAsContinueStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeContinueKeyword: UnexpectedNodes?
   var continueKeyword: Token
   var unexpectedBetweenContinueKeywordAndLabel: UnexpectedNodes?
@@ -9035,8 +9711,9 @@ public struct ContinueStmt: StmtBuildable, ExpressibleAsContinueStmt {
   ///   - continueKeyword: 
   ///   - unexpectedBetweenContinueKeywordAndLabel: 
   ///   - label: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeContinueKeyword: ExpressibleAsUnexpectedNodes? = nil, continueKeyword: Token = Token.`continue`, unexpectedBetweenContinueKeywordAndLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeContinueKeyword: ExpressibleAsUnexpectedNodes? = nil, continueKeyword: Token = Token.`continue`, unexpectedBetweenContinueKeywordAndLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeContinueKeyword = unexpectedBeforeContinueKeyword?.createUnexpectedNodes()
     self.continueKeyword = continueKeyword
     assert(continueKeyword.text == #"continue"#)
@@ -9059,6 +9736,9 @@ public struct ContinueStmt: StmtBuildable, ExpressibleAsContinueStmt {
     var result = ContinueStmtSyntax(unexpectedBeforeContinueKeyword?.buildUnexpectedNodes(format: format), continueKeyword: continueKeyword.buildToken(format: format), unexpectedBetweenContinueKeywordAndLabel?.buildUnexpectedNodes(format: format), label: label?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -9088,8 +9768,9 @@ public struct ContinueStmt: StmtBuildable, ExpressibleAsContinueStmt {
 }
 public struct WhileStmt: StmtBuildable, ExpressibleAsWhileStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeWhileKeyword: UnexpectedNodes?
   var whileKeyword: Token
   var unexpectedBetweenWhileKeywordAndConditions: UnexpectedNodes?
@@ -9104,8 +9785,9 @@ public struct WhileStmt: StmtBuildable, ExpressibleAsWhileStmt {
   ///   - conditions: 
   ///   - unexpectedBetweenConditionsAndBody: 
   ///   - body: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeWhileKeyword: ExpressibleAsUnexpectedNodes? = nil, whileKeyword: Token = Token.`while`, unexpectedBetweenWhileKeywordAndConditions: ExpressibleAsUnexpectedNodes? = nil, conditions: ExpressibleAsConditionElementList, unexpectedBetweenConditionsAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWhileKeyword: ExpressibleAsUnexpectedNodes? = nil, whileKeyword: Token = Token.`while`, unexpectedBetweenWhileKeywordAndConditions: ExpressibleAsUnexpectedNodes? = nil, conditions: ExpressibleAsConditionElementList, unexpectedBetweenConditionsAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeWhileKeyword = unexpectedBeforeWhileKeyword?.createUnexpectedNodes()
     self.whileKeyword = whileKeyword
     assert(whileKeyword.text == #"while"#)
@@ -9130,6 +9812,9 @@ public struct WhileStmt: StmtBuildable, ExpressibleAsWhileStmt {
     var result = WhileStmtSyntax(unexpectedBeforeWhileKeyword?.buildUnexpectedNodes(format: format), whileKeyword: whileKeyword.buildToken(format: format), unexpectedBetweenWhileKeywordAndConditions?.buildUnexpectedNodes(format: format), conditions: conditions.buildConditionElementList(format: format), unexpectedBetweenConditionsAndBody?.buildUnexpectedNodes(format: format), body: body.buildCodeBlock(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -9159,8 +9844,9 @@ public struct WhileStmt: StmtBuildable, ExpressibleAsWhileStmt {
 }
 public struct DeferStmt: StmtBuildable, ExpressibleAsDeferStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeDeferKeyword: UnexpectedNodes?
   var deferKeyword: Token
   var unexpectedBetweenDeferKeywordAndBody: UnexpectedNodes?
@@ -9171,8 +9857,9 @@ public struct DeferStmt: StmtBuildable, ExpressibleAsDeferStmt {
   ///   - deferKeyword: 
   ///   - unexpectedBetweenDeferKeywordAndBody: 
   ///   - body: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeDeferKeyword: ExpressibleAsUnexpectedNodes? = nil, deferKeyword: Token = Token.`defer`, unexpectedBetweenDeferKeywordAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDeferKeyword: ExpressibleAsUnexpectedNodes? = nil, deferKeyword: Token = Token.`defer`, unexpectedBetweenDeferKeywordAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeDeferKeyword = unexpectedBeforeDeferKeyword?.createUnexpectedNodes()
     self.deferKeyword = deferKeyword
     assert(deferKeyword.text == #"defer"#)
@@ -9195,6 +9882,9 @@ public struct DeferStmt: StmtBuildable, ExpressibleAsDeferStmt {
     var result = DeferStmtSyntax(unexpectedBeforeDeferKeyword?.buildUnexpectedNodes(format: format), deferKeyword: deferKeyword.buildToken(format: format), unexpectedBetweenDeferKeywordAndBody?.buildUnexpectedNodes(format: format), body: body.buildCodeBlock(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -9224,16 +9914,18 @@ public struct DeferStmt: StmtBuildable, ExpressibleAsDeferStmt {
 }
 public struct ExpressionStmt: StmtBuildable, ExpressibleAsExpressionStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeExpression: UnexpectedNodes?
   var expression: ExprBuildable
   /// Creates a `ExpressionStmt` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeExpression: 
   ///   - expression: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeExpression = unexpectedBeforeExpression?.createUnexpectedNodes()
     self.expression = expression.createExprBuildable()
   }
@@ -9245,6 +9937,9 @@ public struct ExpressionStmt: StmtBuildable, ExpressibleAsExpressionStmt {
     var result = ExpressionStmtSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -9274,8 +9969,9 @@ public struct ExpressionStmt: StmtBuildable, ExpressibleAsExpressionStmt {
 }
 public struct RepeatWhileStmt: StmtBuildable, ExpressibleAsRepeatWhileStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeRepeatKeyword: UnexpectedNodes?
   var repeatKeyword: Token
   var unexpectedBetweenRepeatKeywordAndBody: UnexpectedNodes?
@@ -9294,8 +9990,9 @@ public struct RepeatWhileStmt: StmtBuildable, ExpressibleAsRepeatWhileStmt {
   ///   - whileKeyword: 
   ///   - unexpectedBetweenWhileKeywordAndCondition: 
   ///   - condition: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeRepeatKeyword: ExpressibleAsUnexpectedNodes? = nil, repeatKeyword: Token = Token.`repeat`, unexpectedBetweenRepeatKeywordAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock, unexpectedBetweenBodyAndWhileKeyword: ExpressibleAsUnexpectedNodes? = nil, whileKeyword: Token = Token.`while`, unexpectedBetweenWhileKeywordAndCondition: ExpressibleAsUnexpectedNodes? = nil, condition: ExpressibleAsExprBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeRepeatKeyword: ExpressibleAsUnexpectedNodes? = nil, repeatKeyword: Token = Token.`repeat`, unexpectedBetweenRepeatKeywordAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock, unexpectedBetweenBodyAndWhileKeyword: ExpressibleAsUnexpectedNodes? = nil, whileKeyword: Token = Token.`while`, unexpectedBetweenWhileKeywordAndCondition: ExpressibleAsUnexpectedNodes? = nil, condition: ExpressibleAsExprBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeRepeatKeyword = unexpectedBeforeRepeatKeyword?.createUnexpectedNodes()
     self.repeatKeyword = repeatKeyword
     assert(repeatKeyword.text == #"repeat"#)
@@ -9323,6 +10020,9 @@ public struct RepeatWhileStmt: StmtBuildable, ExpressibleAsRepeatWhileStmt {
     var result = RepeatWhileStmtSyntax(unexpectedBeforeRepeatKeyword?.buildUnexpectedNodes(format: format), repeatKeyword: repeatKeyword.buildToken(format: format), unexpectedBetweenRepeatKeywordAndBody?.buildUnexpectedNodes(format: format), body: body.buildCodeBlock(format: format), unexpectedBetweenBodyAndWhileKeyword?.buildUnexpectedNodes(format: format), whileKeyword: whileKeyword.buildToken(format: format), unexpectedBetweenWhileKeywordAndCondition?.buildUnexpectedNodes(format: format), condition: condition.buildExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -9352,8 +10052,9 @@ public struct RepeatWhileStmt: StmtBuildable, ExpressibleAsRepeatWhileStmt {
 }
 public struct GuardStmt: StmtBuildable, ExpressibleAsGuardStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeGuardKeyword: UnexpectedNodes?
   var guardKeyword: Token
   var unexpectedBetweenGuardKeywordAndConditions: UnexpectedNodes?
@@ -9372,8 +10073,9 @@ public struct GuardStmt: StmtBuildable, ExpressibleAsGuardStmt {
   ///   - elseKeyword: 
   ///   - unexpectedBetweenElseKeywordAndBody: 
   ///   - body: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeGuardKeyword: ExpressibleAsUnexpectedNodes? = nil, guardKeyword: Token = Token.`guard`, unexpectedBetweenGuardKeywordAndConditions: ExpressibleAsUnexpectedNodes? = nil, conditions: ExpressibleAsConditionElementList, unexpectedBetweenConditionsAndElseKeyword: ExpressibleAsUnexpectedNodes? = nil, elseKeyword: Token = Token.`else`, unexpectedBetweenElseKeywordAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeGuardKeyword: ExpressibleAsUnexpectedNodes? = nil, guardKeyword: Token = Token.`guard`, unexpectedBetweenGuardKeywordAndConditions: ExpressibleAsUnexpectedNodes? = nil, conditions: ExpressibleAsConditionElementList, unexpectedBetweenConditionsAndElseKeyword: ExpressibleAsUnexpectedNodes? = nil, elseKeyword: Token = Token.`else`, unexpectedBetweenElseKeywordAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeGuardKeyword = unexpectedBeforeGuardKeyword?.createUnexpectedNodes()
     self.guardKeyword = guardKeyword
     assert(guardKeyword.text == #"guard"#)
@@ -9401,6 +10103,9 @@ public struct GuardStmt: StmtBuildable, ExpressibleAsGuardStmt {
     var result = GuardStmtSyntax(unexpectedBeforeGuardKeyword?.buildUnexpectedNodes(format: format), guardKeyword: guardKeyword.buildToken(format: format), unexpectedBetweenGuardKeywordAndConditions?.buildUnexpectedNodes(format: format), conditions: conditions.buildConditionElementList(format: format), unexpectedBetweenConditionsAndElseKeyword?.buildUnexpectedNodes(format: format), elseKeyword: elseKeyword.buildToken(format: format), unexpectedBetweenElseKeywordAndBody?.buildUnexpectedNodes(format: format), body: body.buildCodeBlock(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -9430,8 +10135,9 @@ public struct GuardStmt: StmtBuildable, ExpressibleAsGuardStmt {
 }
 public struct WhereClause: SyntaxBuildable, ExpressibleAsWhereClause {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeWhereKeyword: UnexpectedNodes?
   var whereKeyword: Token
   var unexpectedBetweenWhereKeywordAndGuardResult: UnexpectedNodes?
@@ -9442,8 +10148,9 @@ public struct WhereClause: SyntaxBuildable, ExpressibleAsWhereClause {
   ///   - whereKeyword: 
   ///   - unexpectedBetweenWhereKeywordAndGuardResult: 
   ///   - guardResult: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeWhereKeyword: ExpressibleAsUnexpectedNodes? = nil, whereKeyword: Token = Token.`where`, unexpectedBetweenWhereKeywordAndGuardResult: ExpressibleAsUnexpectedNodes? = nil, guardResult: ExpressibleAsExprBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWhereKeyword: ExpressibleAsUnexpectedNodes? = nil, whereKeyword: Token = Token.`where`, unexpectedBetweenWhereKeywordAndGuardResult: ExpressibleAsUnexpectedNodes? = nil, guardResult: ExpressibleAsExprBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeWhereKeyword = unexpectedBeforeWhereKeyword?.createUnexpectedNodes()
     self.whereKeyword = whereKeyword
     assert(whereKeyword.text == #"where"#)
@@ -9458,6 +10165,9 @@ public struct WhereClause: SyntaxBuildable, ExpressibleAsWhereClause {
     var result = WhereClauseSyntax(unexpectedBeforeWhereKeyword?.buildUnexpectedNodes(format: format), whereKeyword: whereKeyword.buildToken(format: format), unexpectedBetweenWhereKeywordAndGuardResult?.buildUnexpectedNodes(format: format), guardResult: guardResult.buildExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -9480,8 +10190,9 @@ public struct WhereClause: SyntaxBuildable, ExpressibleAsWhereClause {
 }
 public struct ForInStmt: StmtBuildable, ExpressibleAsForInStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeForKeyword: UnexpectedNodes?
   var forKeyword: Token
   var unexpectedBetweenForKeywordAndTryKeyword: UnexpectedNodes?
@@ -9524,8 +10235,9 @@ public struct ForInStmt: StmtBuildable, ExpressibleAsForInStmt {
   ///   - whereClause: 
   ///   - unexpectedBetweenWhereClauseAndBody: 
   ///   - body: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeForKeyword: ExpressibleAsUnexpectedNodes? = nil, forKeyword: Token = Token.`for`, unexpectedBetweenForKeywordAndTryKeyword: ExpressibleAsUnexpectedNodes? = nil, tryKeyword: Token? = nil, unexpectedBetweenTryKeywordAndAwaitKeyword: ExpressibleAsUnexpectedNodes? = nil, awaitKeyword: Token? = nil, unexpectedBetweenAwaitKeywordAndCaseKeyword: ExpressibleAsUnexpectedNodes? = nil, caseKeyword: Token? = nil, unexpectedBetweenCaseKeywordAndPattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndTypeAnnotation: ExpressibleAsUnexpectedNodes? = nil, typeAnnotation: ExpressibleAsTypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInKeyword: ExpressibleAsUnexpectedNodes? = nil, inKeyword: Token = Token.`in`, unexpectedBetweenInKeywordAndSequenceExpr: ExpressibleAsUnexpectedNodes? = nil, sequenceExpr: ExpressibleAsExprBuildable, unexpectedBetweenSequenceExprAndWhereClause: ExpressibleAsUnexpectedNodes? = nil, whereClause: ExpressibleAsWhereClause? = nil, unexpectedBetweenWhereClauseAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeForKeyword: ExpressibleAsUnexpectedNodes? = nil, forKeyword: Token = Token.`for`, unexpectedBetweenForKeywordAndTryKeyword: ExpressibleAsUnexpectedNodes? = nil, tryKeyword: Token? = nil, unexpectedBetweenTryKeywordAndAwaitKeyword: ExpressibleAsUnexpectedNodes? = nil, awaitKeyword: Token? = nil, unexpectedBetweenAwaitKeywordAndCaseKeyword: ExpressibleAsUnexpectedNodes? = nil, caseKeyword: Token? = nil, unexpectedBetweenCaseKeywordAndPattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndTypeAnnotation: ExpressibleAsUnexpectedNodes? = nil, typeAnnotation: ExpressibleAsTypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInKeyword: ExpressibleAsUnexpectedNodes? = nil, inKeyword: Token = Token.`in`, unexpectedBetweenInKeywordAndSequenceExpr: ExpressibleAsUnexpectedNodes? = nil, sequenceExpr: ExpressibleAsExprBuildable, unexpectedBetweenSequenceExprAndWhereClause: ExpressibleAsUnexpectedNodes? = nil, whereClause: ExpressibleAsWhereClause? = nil, unexpectedBetweenWhereClauseAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeForKeyword = unexpectedBeforeForKeyword?.createUnexpectedNodes()
     self.forKeyword = forKeyword
     assert(forKeyword.text == #"for"#)
@@ -9571,6 +10283,9 @@ public struct ForInStmt: StmtBuildable, ExpressibleAsForInStmt {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `StmtBuildable`.
@@ -9599,8 +10314,9 @@ public struct ForInStmt: StmtBuildable, ExpressibleAsForInStmt {
 }
 public struct SwitchStmt: StmtBuildable, ExpressibleAsSwitchStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeSwitchKeyword: UnexpectedNodes?
   var switchKeyword: Token
   var unexpectedBetweenSwitchKeywordAndExpression: UnexpectedNodes?
@@ -9623,8 +10339,9 @@ public struct SwitchStmt: StmtBuildable, ExpressibleAsSwitchStmt {
   ///   - cases: 
   ///   - unexpectedBetweenCasesAndRightBrace: 
   ///   - rightBrace: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeSwitchKeyword: ExpressibleAsUnexpectedNodes? = nil, switchKeyword: Token = Token.`switch`, unexpectedBetweenSwitchKeywordAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndLeftBrace: ExpressibleAsUnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndCases: ExpressibleAsUnexpectedNodes? = nil, cases: ExpressibleAsSwitchCaseList, unexpectedBetweenCasesAndRightBrace: ExpressibleAsUnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeSwitchKeyword: ExpressibleAsUnexpectedNodes? = nil, switchKeyword: Token = Token.`switch`, unexpectedBetweenSwitchKeywordAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndLeftBrace: ExpressibleAsUnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndCases: ExpressibleAsUnexpectedNodes? = nil, cases: ExpressibleAsSwitchCaseList, unexpectedBetweenCasesAndRightBrace: ExpressibleAsUnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeSwitchKeyword = unexpectedBeforeSwitchKeyword?.createUnexpectedNodes()
     self.switchKeyword = switchKeyword
     assert(switchKeyword.text == #"switch"#)
@@ -9656,6 +10373,9 @@ public struct SwitchStmt: StmtBuildable, ExpressibleAsSwitchStmt {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `StmtBuildable`.
@@ -9684,8 +10404,9 @@ public struct SwitchStmt: StmtBuildable, ExpressibleAsSwitchStmt {
 }
 public struct DoStmt: StmtBuildable, ExpressibleAsDoStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeDoKeyword: UnexpectedNodes?
   var doKeyword: Token
   var unexpectedBetweenDoKeywordAndBody: UnexpectedNodes?
@@ -9700,8 +10421,9 @@ public struct DoStmt: StmtBuildable, ExpressibleAsDoStmt {
   ///   - body: 
   ///   - unexpectedBetweenBodyAndCatchClauses: 
   ///   - catchClauses: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeDoKeyword: ExpressibleAsUnexpectedNodes? = nil, doKeyword: Token = Token.`do`, unexpectedBetweenDoKeywordAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock, unexpectedBetweenBodyAndCatchClauses: ExpressibleAsUnexpectedNodes? = nil, catchClauses: ExpressibleAsCatchClauseList? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDoKeyword: ExpressibleAsUnexpectedNodes? = nil, doKeyword: Token = Token.`do`, unexpectedBetweenDoKeywordAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock, unexpectedBetweenBodyAndCatchClauses: ExpressibleAsUnexpectedNodes? = nil, catchClauses: ExpressibleAsCatchClauseList? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeDoKeyword = unexpectedBeforeDoKeyword?.createUnexpectedNodes()
     self.doKeyword = doKeyword
     assert(doKeyword.text == #"do"#)
@@ -9726,6 +10448,9 @@ public struct DoStmt: StmtBuildable, ExpressibleAsDoStmt {
     var result = DoStmtSyntax(unexpectedBeforeDoKeyword?.buildUnexpectedNodes(format: format), doKeyword: doKeyword.buildToken(format: format), unexpectedBetweenDoKeywordAndBody?.buildUnexpectedNodes(format: format), body: body.buildCodeBlock(format: format), unexpectedBetweenBodyAndCatchClauses?.buildUnexpectedNodes(format: format), catchClauses: catchClauses?.buildCatchClauseList(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -9755,8 +10480,9 @@ public struct DoStmt: StmtBuildable, ExpressibleAsDoStmt {
 }
 public struct ReturnStmt: StmtBuildable, ExpressibleAsReturnStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeReturnKeyword: UnexpectedNodes?
   var returnKeyword: Token
   var unexpectedBetweenReturnKeywordAndExpression: UnexpectedNodes?
@@ -9767,8 +10493,9 @@ public struct ReturnStmt: StmtBuildable, ExpressibleAsReturnStmt {
   ///   - returnKeyword: 
   ///   - unexpectedBetweenReturnKeywordAndExpression: 
   ///   - expression: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeReturnKeyword: ExpressibleAsUnexpectedNodes? = nil, returnKeyword: Token = Token.`return`, unexpectedBetweenReturnKeywordAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeReturnKeyword: ExpressibleAsUnexpectedNodes? = nil, returnKeyword: Token = Token.`return`, unexpectedBetweenReturnKeywordAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeReturnKeyword = unexpectedBeforeReturnKeyword?.createUnexpectedNodes()
     self.returnKeyword = returnKeyword
     assert(returnKeyword.text == #"return"#)
@@ -9783,6 +10510,9 @@ public struct ReturnStmt: StmtBuildable, ExpressibleAsReturnStmt {
     var result = ReturnStmtSyntax(unexpectedBeforeReturnKeyword?.buildUnexpectedNodes(format: format), returnKeyword: returnKeyword.buildToken(format: format), unexpectedBetweenReturnKeywordAndExpression?.buildUnexpectedNodes(format: format), expression: expression?.buildExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -9812,8 +10542,9 @@ public struct ReturnStmt: StmtBuildable, ExpressibleAsReturnStmt {
 }
 public struct YieldStmt: StmtBuildable, ExpressibleAsYieldStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeYieldKeyword: UnexpectedNodes?
   var yieldKeyword: Token
   var unexpectedBetweenYieldKeywordAndYields: UnexpectedNodes?
@@ -9824,8 +10555,9 @@ public struct YieldStmt: StmtBuildable, ExpressibleAsYieldStmt {
   ///   - yieldKeyword: 
   ///   - unexpectedBetweenYieldKeywordAndYields: 
   ///   - yields: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeYieldKeyword: ExpressibleAsUnexpectedNodes? = nil, yieldKeyword: Token = Token.`yield`, unexpectedBetweenYieldKeywordAndYields: ExpressibleAsUnexpectedNodes? = nil, yields: ExpressibleAsSyntaxBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeYieldKeyword: ExpressibleAsUnexpectedNodes? = nil, yieldKeyword: Token = Token.`yield`, unexpectedBetweenYieldKeywordAndYields: ExpressibleAsUnexpectedNodes? = nil, yields: ExpressibleAsSyntaxBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeYieldKeyword = unexpectedBeforeYieldKeyword?.createUnexpectedNodes()
     self.yieldKeyword = yieldKeyword
     assert(yieldKeyword.text == #"yield"#)
@@ -9840,6 +10572,9 @@ public struct YieldStmt: StmtBuildable, ExpressibleAsYieldStmt {
     var result = YieldStmtSyntax(unexpectedBeforeYieldKeyword?.buildUnexpectedNodes(format: format), yieldKeyword: yieldKeyword.buildToken(format: format), unexpectedBetweenYieldKeywordAndYields?.buildUnexpectedNodes(format: format), yields: yields.buildSyntax(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -9869,8 +10604,9 @@ public struct YieldStmt: StmtBuildable, ExpressibleAsYieldStmt {
 }
 public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftParen: UnexpectedNodes?
   var leftParen: Token
   var unexpectedBetweenLeftParenAndElementList: UnexpectedNodes?
@@ -9889,8 +10625,9 @@ public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
   ///   - trailingComma: 
   ///   - unexpectedBetweenTrailingCommaAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElementList: ExpressibleAsUnexpectedNodes? = nil, elementList: ExpressibleAsExprList, unexpectedBetweenElementListAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil, unexpectedBetweenTrailingCommaAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElementList: ExpressibleAsUnexpectedNodes? = nil, elementList: ExpressibleAsExprList, unexpectedBetweenElementListAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil, unexpectedBetweenTrailingCommaAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftParen = unexpectedBeforeLeftParen?.createUnexpectedNodes()
     self.leftParen = leftParen
     assert(leftParen.text == #"("#)
@@ -9920,6 +10657,9 @@ public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -9941,16 +10681,18 @@ public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
 }
 public struct FallthroughStmt: StmtBuildable, ExpressibleAsFallthroughStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeFallthroughKeyword: UnexpectedNodes?
   var fallthroughKeyword: Token
   /// Creates a `FallthroughStmt` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeFallthroughKeyword: 
   ///   - fallthroughKeyword: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeFallthroughKeyword: ExpressibleAsUnexpectedNodes? = nil, fallthroughKeyword: Token = Token.`fallthrough`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeFallthroughKeyword: ExpressibleAsUnexpectedNodes? = nil, fallthroughKeyword: Token = Token.`fallthrough`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeFallthroughKeyword = unexpectedBeforeFallthroughKeyword?.createUnexpectedNodes()
     self.fallthroughKeyword = fallthroughKeyword
     assert(fallthroughKeyword.text == #"fallthrough"#)
@@ -9963,6 +10705,9 @@ public struct FallthroughStmt: StmtBuildable, ExpressibleAsFallthroughStmt {
     var result = FallthroughStmtSyntax(unexpectedBeforeFallthroughKeyword?.buildUnexpectedNodes(format: format), fallthroughKeyword: fallthroughKeyword.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -9992,8 +10737,9 @@ public struct FallthroughStmt: StmtBuildable, ExpressibleAsFallthroughStmt {
 }
 public struct BreakStmt: StmtBuildable, ExpressibleAsBreakStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeBreakKeyword: UnexpectedNodes?
   var breakKeyword: Token
   var unexpectedBetweenBreakKeywordAndLabel: UnexpectedNodes?
@@ -10004,8 +10750,9 @@ public struct BreakStmt: StmtBuildable, ExpressibleAsBreakStmt {
   ///   - breakKeyword: 
   ///   - unexpectedBetweenBreakKeywordAndLabel: 
   ///   - label: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeBreakKeyword: ExpressibleAsUnexpectedNodes? = nil, breakKeyword: Token = Token.`break`, unexpectedBetweenBreakKeywordAndLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBreakKeyword: ExpressibleAsUnexpectedNodes? = nil, breakKeyword: Token = Token.`break`, unexpectedBetweenBreakKeywordAndLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeBreakKeyword = unexpectedBeforeBreakKeyword?.createUnexpectedNodes()
     self.breakKeyword = breakKeyword
     assert(breakKeyword.text == #"break"#)
@@ -10028,6 +10775,9 @@ public struct BreakStmt: StmtBuildable, ExpressibleAsBreakStmt {
     var result = BreakStmtSyntax(unexpectedBeforeBreakKeyword?.buildUnexpectedNodes(format: format), breakKeyword: breakKeyword.buildToken(format: format), unexpectedBetweenBreakKeywordAndLabel?.buildUnexpectedNodes(format: format), label: label?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -10057,8 +10807,9 @@ public struct BreakStmt: StmtBuildable, ExpressibleAsBreakStmt {
 }
 public struct ConditionElement: SyntaxBuildable, ExpressibleAsConditionElement, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeCondition: UnexpectedNodes?
   var condition: SyntaxBuildable
   var unexpectedBetweenConditionAndTrailingComma: UnexpectedNodes?
@@ -10069,8 +10820,9 @@ public struct ConditionElement: SyntaxBuildable, ExpressibleAsConditionElement, 
   ///   - condition: 
   ///   - unexpectedBetweenConditionAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeCondition: ExpressibleAsUnexpectedNodes? = nil, condition: ExpressibleAsSyntaxBuildable, unexpectedBetweenConditionAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeCondition: ExpressibleAsUnexpectedNodes? = nil, condition: ExpressibleAsSyntaxBuildable, unexpectedBetweenConditionAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeCondition = unexpectedBeforeCondition?.createUnexpectedNodes()
     self.condition = condition.createSyntaxBuildable()
     self.unexpectedBetweenConditionAndTrailingComma = unexpectedBetweenConditionAndTrailingComma?.createUnexpectedNodes()
@@ -10085,6 +10837,9 @@ public struct ConditionElement: SyntaxBuildable, ExpressibleAsConditionElement, 
     var result = ConditionElementSyntax(unexpectedBeforeCondition?.buildUnexpectedNodes(format: format), condition: condition.buildSyntax(format: format), unexpectedBetweenConditionAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -10113,8 +10868,9 @@ public struct ConditionElement: SyntaxBuildable, ExpressibleAsConditionElement, 
 }
 public struct AvailabilityCondition: SyntaxBuildable, ExpressibleAsAvailabilityCondition {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePoundAvailableKeyword: UnexpectedNodes?
   var poundAvailableKeyword: Token
   var unexpectedBetweenPoundAvailableKeywordAndLeftParen: UnexpectedNodes?
@@ -10133,8 +10889,9 @@ public struct AvailabilityCondition: SyntaxBuildable, ExpressibleAsAvailabilityC
   ///   - availabilitySpec: 
   ///   - unexpectedBetweenAvailabilitySpecAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePoundAvailableKeyword: ExpressibleAsUnexpectedNodes? = nil, poundAvailableKeyword: Token = Token.`poundAvailable`, unexpectedBetweenPoundAvailableKeywordAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndAvailabilitySpec: ExpressibleAsUnexpectedNodes? = nil, availabilitySpec: ExpressibleAsAvailabilitySpecList, unexpectedBetweenAvailabilitySpecAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundAvailableKeyword: ExpressibleAsUnexpectedNodes? = nil, poundAvailableKeyword: Token = Token.`poundAvailable`, unexpectedBetweenPoundAvailableKeywordAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndAvailabilitySpec: ExpressibleAsUnexpectedNodes? = nil, availabilitySpec: ExpressibleAsAvailabilitySpecList, unexpectedBetweenAvailabilitySpecAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePoundAvailableKeyword = unexpectedBeforePoundAvailableKeyword?.createUnexpectedNodes()
     self.poundAvailableKeyword = poundAvailableKeyword
     assert(poundAvailableKeyword.text == #"#available"#)
@@ -10155,6 +10912,9 @@ public struct AvailabilityCondition: SyntaxBuildable, ExpressibleAsAvailabilityC
     var result = AvailabilityConditionSyntax(unexpectedBeforePoundAvailableKeyword?.buildUnexpectedNodes(format: format), poundAvailableKeyword: poundAvailableKeyword.buildToken(format: format), unexpectedBetweenPoundAvailableKeywordAndLeftParen?.buildUnexpectedNodes(format: format), leftParen: leftParen.buildToken(format: format), unexpectedBetweenLeftParenAndAvailabilitySpec?.buildUnexpectedNodes(format: format), availabilitySpec: availabilitySpec.buildAvailabilitySpecList(format: format), unexpectedBetweenAvailabilitySpecAndRightParen?.buildUnexpectedNodes(format: format), rightParen: rightParen.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -10177,8 +10937,9 @@ public struct AvailabilityCondition: SyntaxBuildable, ExpressibleAsAvailabilityC
 }
 public struct MatchingPatternCondition: SyntaxBuildable, ExpressibleAsMatchingPatternCondition {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeCaseKeyword: UnexpectedNodes?
   var caseKeyword: Token
   var unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodes?
@@ -10197,8 +10958,9 @@ public struct MatchingPatternCondition: SyntaxBuildable, ExpressibleAsMatchingPa
   ///   - typeAnnotation: 
   ///   - unexpectedBetweenTypeAnnotationAndInitializer: 
   ///   - initializer: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeCaseKeyword: ExpressibleAsUnexpectedNodes? = nil, caseKeyword: Token = Token.`case`, unexpectedBetweenCaseKeywordAndPattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndTypeAnnotation: ExpressibleAsUnexpectedNodes? = nil, typeAnnotation: ExpressibleAsTypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInitializer: ExpressibleAsUnexpectedNodes? = nil, initializer: ExpressibleAsInitializerClause) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeCaseKeyword: ExpressibleAsUnexpectedNodes? = nil, caseKeyword: Token = Token.`case`, unexpectedBetweenCaseKeywordAndPattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndTypeAnnotation: ExpressibleAsUnexpectedNodes? = nil, typeAnnotation: ExpressibleAsTypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInitializer: ExpressibleAsUnexpectedNodes? = nil, initializer: ExpressibleAsInitializerClause) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeCaseKeyword = unexpectedBeforeCaseKeyword?.createUnexpectedNodes()
     self.caseKeyword = caseKeyword
     assert(caseKeyword.text == #"case"#)
@@ -10217,6 +10979,9 @@ public struct MatchingPatternCondition: SyntaxBuildable, ExpressibleAsMatchingPa
     var result = MatchingPatternConditionSyntax(unexpectedBeforeCaseKeyword?.buildUnexpectedNodes(format: format), caseKeyword: caseKeyword.buildToken(format: format), unexpectedBetweenCaseKeywordAndPattern?.buildUnexpectedNodes(format: format), pattern: pattern.buildPattern(format: format), unexpectedBetweenPatternAndTypeAnnotation?.buildUnexpectedNodes(format: format), typeAnnotation: typeAnnotation?.buildTypeAnnotation(format: format), unexpectedBetweenTypeAnnotationAndInitializer?.buildUnexpectedNodes(format: format), initializer: initializer.buildInitializerClause(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -10239,8 +11004,9 @@ public struct MatchingPatternCondition: SyntaxBuildable, ExpressibleAsMatchingPa
 }
 public struct OptionalBindingCondition: SyntaxBuildable, ExpressibleAsOptionalBindingCondition {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLetOrVarKeyword: UnexpectedNodes?
   var letOrVarKeyword: Token
   var unexpectedBetweenLetOrVarKeywordAndPattern: UnexpectedNodes?
@@ -10259,8 +11025,9 @@ public struct OptionalBindingCondition: SyntaxBuildable, ExpressibleAsOptionalBi
   ///   - typeAnnotation: 
   ///   - unexpectedBetweenTypeAnnotationAndInitializer: 
   ///   - initializer: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLetOrVarKeyword: ExpressibleAsUnexpectedNodes? = nil, letOrVarKeyword: Token, unexpectedBetweenLetOrVarKeywordAndPattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndTypeAnnotation: ExpressibleAsUnexpectedNodes? = nil, typeAnnotation: ExpressibleAsTypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInitializer: ExpressibleAsUnexpectedNodes? = nil, initializer: ExpressibleAsInitializerClause? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLetOrVarKeyword: ExpressibleAsUnexpectedNodes? = nil, letOrVarKeyword: Token, unexpectedBetweenLetOrVarKeywordAndPattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndTypeAnnotation: ExpressibleAsUnexpectedNodes? = nil, typeAnnotation: ExpressibleAsTypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInitializer: ExpressibleAsUnexpectedNodes? = nil, initializer: ExpressibleAsInitializerClause? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLetOrVarKeyword = unexpectedBeforeLetOrVarKeyword?.createUnexpectedNodes()
     self.letOrVarKeyword = letOrVarKeyword
     assert(letOrVarKeyword.text == #"let"# || letOrVarKeyword.text == #"var"#)
@@ -10279,6 +11046,9 @@ public struct OptionalBindingCondition: SyntaxBuildable, ExpressibleAsOptionalBi
     var result = OptionalBindingConditionSyntax(unexpectedBeforeLetOrVarKeyword?.buildUnexpectedNodes(format: format), letOrVarKeyword: letOrVarKeyword.buildToken(format: format), unexpectedBetweenLetOrVarKeywordAndPattern?.buildUnexpectedNodes(format: format), pattern: pattern.buildPattern(format: format), unexpectedBetweenPatternAndTypeAnnotation?.buildUnexpectedNodes(format: format), typeAnnotation: typeAnnotation?.buildTypeAnnotation(format: format), unexpectedBetweenTypeAnnotationAndInitializer?.buildUnexpectedNodes(format: format), initializer: initializer?.buildInitializerClause(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -10301,8 +11071,9 @@ public struct OptionalBindingCondition: SyntaxBuildable, ExpressibleAsOptionalBi
 }
 public struct UnavailabilityCondition: SyntaxBuildable, ExpressibleAsUnavailabilityCondition {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePoundUnavailableKeyword: UnexpectedNodes?
   var poundUnavailableKeyword: Token
   var unexpectedBetweenPoundUnavailableKeywordAndLeftParen: UnexpectedNodes?
@@ -10321,8 +11092,9 @@ public struct UnavailabilityCondition: SyntaxBuildable, ExpressibleAsUnavailabil
   ///   - availabilitySpec: 
   ///   - unexpectedBetweenAvailabilitySpecAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePoundUnavailableKeyword: ExpressibleAsUnexpectedNodes? = nil, poundUnavailableKeyword: Token = Token.`poundUnavailable`, unexpectedBetweenPoundUnavailableKeywordAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndAvailabilitySpec: ExpressibleAsUnexpectedNodes? = nil, availabilitySpec: ExpressibleAsAvailabilitySpecList, unexpectedBetweenAvailabilitySpecAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundUnavailableKeyword: ExpressibleAsUnexpectedNodes? = nil, poundUnavailableKeyword: Token = Token.`poundUnavailable`, unexpectedBetweenPoundUnavailableKeywordAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndAvailabilitySpec: ExpressibleAsUnexpectedNodes? = nil, availabilitySpec: ExpressibleAsAvailabilitySpecList, unexpectedBetweenAvailabilitySpecAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePoundUnavailableKeyword = unexpectedBeforePoundUnavailableKeyword?.createUnexpectedNodes()
     self.poundUnavailableKeyword = poundUnavailableKeyword
     assert(poundUnavailableKeyword.text == #"#unavailable"#)
@@ -10343,6 +11115,9 @@ public struct UnavailabilityCondition: SyntaxBuildable, ExpressibleAsUnavailabil
     var result = UnavailabilityConditionSyntax(unexpectedBeforePoundUnavailableKeyword?.buildUnexpectedNodes(format: format), poundUnavailableKeyword: poundUnavailableKeyword.buildToken(format: format), unexpectedBetweenPoundUnavailableKeywordAndLeftParen?.buildUnexpectedNodes(format: format), leftParen: leftParen.buildToken(format: format), unexpectedBetweenLeftParenAndAvailabilitySpec?.buildUnexpectedNodes(format: format), availabilitySpec: availabilitySpec.buildAvailabilitySpecList(format: format), unexpectedBetweenAvailabilitySpecAndRightParen?.buildUnexpectedNodes(format: format), rightParen: rightParen.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -10365,16 +11140,18 @@ public struct UnavailabilityCondition: SyntaxBuildable, ExpressibleAsUnavailabil
 }
 public struct DeclarationStmt: StmtBuildable, ExpressibleAsDeclarationStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeDeclaration: UnexpectedNodes?
   var declaration: DeclBuildable
   /// Creates a `DeclarationStmt` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeDeclaration: 
   ///   - declaration: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeDeclaration: ExpressibleAsUnexpectedNodes? = nil, declaration: ExpressibleAsDeclBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDeclaration: ExpressibleAsUnexpectedNodes? = nil, declaration: ExpressibleAsDeclBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeDeclaration = unexpectedBeforeDeclaration?.createUnexpectedNodes()
     self.declaration = declaration.createDeclBuildable()
   }
@@ -10386,6 +11163,9 @@ public struct DeclarationStmt: StmtBuildable, ExpressibleAsDeclarationStmt {
     var result = DeclarationStmtSyntax(unexpectedBeforeDeclaration?.buildUnexpectedNodes(format: format), declaration: declaration.buildDecl(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -10415,8 +11195,9 @@ public struct DeclarationStmt: StmtBuildable, ExpressibleAsDeclarationStmt {
 }
 public struct ThrowStmt: StmtBuildable, ExpressibleAsThrowStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeThrowKeyword: UnexpectedNodes?
   var throwKeyword: Token
   var unexpectedBetweenThrowKeywordAndExpression: UnexpectedNodes?
@@ -10427,8 +11208,9 @@ public struct ThrowStmt: StmtBuildable, ExpressibleAsThrowStmt {
   ///   - throwKeyword: 
   ///   - unexpectedBetweenThrowKeywordAndExpression: 
   ///   - expression: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeThrowKeyword: ExpressibleAsUnexpectedNodes? = nil, throwKeyword: Token = Token.`throw`, unexpectedBetweenThrowKeywordAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeThrowKeyword: ExpressibleAsUnexpectedNodes? = nil, throwKeyword: Token = Token.`throw`, unexpectedBetweenThrowKeywordAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeThrowKeyword = unexpectedBeforeThrowKeyword?.createUnexpectedNodes()
     self.throwKeyword = throwKeyword
     assert(throwKeyword.text == #"throw"#)
@@ -10443,6 +11225,9 @@ public struct ThrowStmt: StmtBuildable, ExpressibleAsThrowStmt {
     var result = ThrowStmtSyntax(unexpectedBeforeThrowKeyword?.buildUnexpectedNodes(format: format), throwKeyword: throwKeyword.buildToken(format: format), unexpectedBetweenThrowKeywordAndExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -10472,8 +11257,9 @@ public struct ThrowStmt: StmtBuildable, ExpressibleAsThrowStmt {
 }
 public struct IfStmt: StmtBuildable, ExpressibleAsIfStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeIfKeyword: UnexpectedNodes?
   var ifKeyword: Token
   var unexpectedBetweenIfKeywordAndConditions: UnexpectedNodes?
@@ -10496,8 +11282,9 @@ public struct IfStmt: StmtBuildable, ExpressibleAsIfStmt {
   ///   - elseKeyword: 
   ///   - unexpectedBetweenElseKeywordAndElseBody: 
   ///   - elseBody: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeIfKeyword: ExpressibleAsUnexpectedNodes? = nil, ifKeyword: Token = Token.`if`, unexpectedBetweenIfKeywordAndConditions: ExpressibleAsUnexpectedNodes? = nil, conditions: ExpressibleAsConditionElementList, unexpectedBetweenConditionsAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock, unexpectedBetweenBodyAndElseKeyword: ExpressibleAsUnexpectedNodes? = nil, elseKeyword: Token? = nil, unexpectedBetweenElseKeywordAndElseBody: ExpressibleAsUnexpectedNodes? = nil, elseBody: ExpressibleAsSyntaxBuildable? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIfKeyword: ExpressibleAsUnexpectedNodes? = nil, ifKeyword: Token = Token.`if`, unexpectedBetweenIfKeywordAndConditions: ExpressibleAsUnexpectedNodes? = nil, conditions: ExpressibleAsConditionElementList, unexpectedBetweenConditionsAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock, unexpectedBetweenBodyAndElseKeyword: ExpressibleAsUnexpectedNodes? = nil, elseKeyword: Token? = nil, unexpectedBetweenElseKeywordAndElseBody: ExpressibleAsUnexpectedNodes? = nil, elseBody: ExpressibleAsSyntaxBuildable? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeIfKeyword = unexpectedBeforeIfKeyword?.createUnexpectedNodes()
     self.ifKeyword = ifKeyword
     assert(ifKeyword.text == #"if"#)
@@ -10528,6 +11315,9 @@ public struct IfStmt: StmtBuildable, ExpressibleAsIfStmt {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `StmtBuildable`.
@@ -10556,16 +11346,18 @@ public struct IfStmt: StmtBuildable, ExpressibleAsIfStmt {
 }
 public struct ElseIfContinuation: SyntaxBuildable, ExpressibleAsElseIfContinuation {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeIfStatement: UnexpectedNodes?
   var ifStatement: IfStmt
   /// Creates a `ElseIfContinuation` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeIfStatement: 
   ///   - ifStatement: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeIfStatement: ExpressibleAsUnexpectedNodes? = nil, ifStatement: ExpressibleAsIfStmt) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIfStatement: ExpressibleAsUnexpectedNodes? = nil, ifStatement: ExpressibleAsIfStmt) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeIfStatement = unexpectedBeforeIfStatement?.createUnexpectedNodes()
     self.ifStatement = ifStatement.createIfStmt()
   }
@@ -10577,6 +11369,9 @@ public struct ElseIfContinuation: SyntaxBuildable, ExpressibleAsElseIfContinuati
     var result = ElseIfContinuationSyntax(unexpectedBeforeIfStatement?.buildUnexpectedNodes(format: format), ifStatement: ifStatement.buildIfStmt(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -10599,8 +11394,9 @@ public struct ElseIfContinuation: SyntaxBuildable, ExpressibleAsElseIfContinuati
 }
 public struct ElseBlock: SyntaxBuildable, ExpressibleAsElseBlock {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeElseKeyword: UnexpectedNodes?
   var elseKeyword: Token
   var unexpectedBetweenElseKeywordAndBody: UnexpectedNodes?
@@ -10611,8 +11407,9 @@ public struct ElseBlock: SyntaxBuildable, ExpressibleAsElseBlock {
   ///   - elseKeyword: 
   ///   - unexpectedBetweenElseKeywordAndBody: 
   ///   - body: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeElseKeyword: ExpressibleAsUnexpectedNodes? = nil, elseKeyword: Token = Token.`else`, unexpectedBetweenElseKeywordAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeElseKeyword: ExpressibleAsUnexpectedNodes? = nil, elseKeyword: Token = Token.`else`, unexpectedBetweenElseKeywordAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeElseKeyword = unexpectedBeforeElseKeyword?.createUnexpectedNodes()
     self.elseKeyword = elseKeyword
     assert(elseKeyword.text == #"else"#)
@@ -10636,6 +11433,9 @@ public struct ElseBlock: SyntaxBuildable, ExpressibleAsElseBlock {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -10657,8 +11457,9 @@ public struct ElseBlock: SyntaxBuildable, ExpressibleAsElseBlock {
 }
 public struct SwitchCase: SyntaxBuildable, ExpressibleAsSwitchCase {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeUnknownAttr: UnexpectedNodes?
   var unknownAttr: Attribute?
   var unexpectedBetweenUnknownAttrAndLabel: UnexpectedNodes?
@@ -10673,8 +11474,9 @@ public struct SwitchCase: SyntaxBuildable, ExpressibleAsSwitchCase {
   ///   - label: 
   ///   - unexpectedBetweenLabelAndStatements: 
   ///   - statements: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeUnknownAttr: ExpressibleAsUnexpectedNodes? = nil, unknownAttr: ExpressibleAsAttribute? = nil, unexpectedBetweenUnknownAttrAndLabel: ExpressibleAsUnexpectedNodes? = nil, label: ExpressibleAsSyntaxBuildable, unexpectedBetweenLabelAndStatements: ExpressibleAsUnexpectedNodes? = nil, statements: ExpressibleAsCodeBlockItemList) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeUnknownAttr: ExpressibleAsUnexpectedNodes? = nil, unknownAttr: ExpressibleAsAttribute? = nil, unexpectedBetweenUnknownAttrAndLabel: ExpressibleAsUnexpectedNodes? = nil, label: ExpressibleAsSyntaxBuildable, unexpectedBetweenLabelAndStatements: ExpressibleAsUnexpectedNodes? = nil, statements: ExpressibleAsCodeBlockItemList) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeUnknownAttr = unexpectedBeforeUnknownAttr?.createUnexpectedNodes()
     self.unknownAttr = unknownAttr?.createAttribute()
     self.unexpectedBetweenUnknownAttrAndLabel = unexpectedBetweenUnknownAttrAndLabel?.createUnexpectedNodes()
@@ -10699,6 +11501,9 @@ public struct SwitchCase: SyntaxBuildable, ExpressibleAsSwitchCase {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -10720,8 +11525,9 @@ public struct SwitchCase: SyntaxBuildable, ExpressibleAsSwitchCase {
 }
 public struct SwitchDefaultLabel: SyntaxBuildable, ExpressibleAsSwitchDefaultLabel {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeDefaultKeyword: UnexpectedNodes?
   var defaultKeyword: Token
   var unexpectedBetweenDefaultKeywordAndColon: UnexpectedNodes?
@@ -10732,8 +11538,9 @@ public struct SwitchDefaultLabel: SyntaxBuildable, ExpressibleAsSwitchDefaultLab
   ///   - defaultKeyword: 
   ///   - unexpectedBetweenDefaultKeywordAndColon: 
   ///   - colon: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeDefaultKeyword: ExpressibleAsUnexpectedNodes? = nil, defaultKeyword: Token = Token.`default`, unexpectedBetweenDefaultKeywordAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDefaultKeyword: ExpressibleAsUnexpectedNodes? = nil, defaultKeyword: Token = Token.`default`, unexpectedBetweenDefaultKeywordAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeDefaultKeyword = unexpectedBeforeDefaultKeyword?.createUnexpectedNodes()
     self.defaultKeyword = defaultKeyword
     assert(defaultKeyword.text == #"default"#)
@@ -10749,6 +11556,9 @@ public struct SwitchDefaultLabel: SyntaxBuildable, ExpressibleAsSwitchDefaultLab
     var result = SwitchDefaultLabelSyntax(unexpectedBeforeDefaultKeyword?.buildUnexpectedNodes(format: format), defaultKeyword: defaultKeyword.buildToken(format: format), unexpectedBetweenDefaultKeywordAndColon?.buildUnexpectedNodes(format: format), colon: colon.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -10771,8 +11581,9 @@ public struct SwitchDefaultLabel: SyntaxBuildable, ExpressibleAsSwitchDefaultLab
 }
 public struct CaseItem: SyntaxBuildable, ExpressibleAsCaseItem, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePattern: UnexpectedNodes?
   var pattern: PatternBuildable
   var unexpectedBetweenPatternAndWhereClause: UnexpectedNodes?
@@ -10787,8 +11598,9 @@ public struct CaseItem: SyntaxBuildable, ExpressibleAsCaseItem, HasTrailingComma
   ///   - whereClause: 
   ///   - unexpectedBetweenWhereClauseAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndWhereClause: ExpressibleAsUnexpectedNodes? = nil, whereClause: ExpressibleAsWhereClause? = nil, unexpectedBetweenWhereClauseAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndWhereClause: ExpressibleAsUnexpectedNodes? = nil, whereClause: ExpressibleAsWhereClause? = nil, unexpectedBetweenWhereClauseAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePattern = unexpectedBeforePattern?.createUnexpectedNodes()
     self.pattern = pattern.createPatternBuildable()
     self.unexpectedBetweenPatternAndWhereClause = unexpectedBetweenPatternAndWhereClause?.createUnexpectedNodes()
@@ -10805,6 +11617,9 @@ public struct CaseItem: SyntaxBuildable, ExpressibleAsCaseItem, HasTrailingComma
     var result = CaseItemSyntax(unexpectedBeforePattern?.buildUnexpectedNodes(format: format), pattern: pattern.buildPattern(format: format), unexpectedBetweenPatternAndWhereClause?.buildUnexpectedNodes(format: format), whereClause: whereClause?.buildWhereClause(format: format), unexpectedBetweenWhereClauseAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -10833,8 +11648,9 @@ public struct CaseItem: SyntaxBuildable, ExpressibleAsCaseItem, HasTrailingComma
 }
 public struct CatchItem: SyntaxBuildable, ExpressibleAsCatchItem, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePattern: UnexpectedNodes?
   var pattern: PatternBuildable?
   var unexpectedBetweenPatternAndWhereClause: UnexpectedNodes?
@@ -10849,8 +11665,9 @@ public struct CatchItem: SyntaxBuildable, ExpressibleAsCatchItem, HasTrailingCom
   ///   - whereClause: 
   ///   - unexpectedBetweenWhereClauseAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable? = nil, unexpectedBetweenPatternAndWhereClause: ExpressibleAsUnexpectedNodes? = nil, whereClause: ExpressibleAsWhereClause? = nil, unexpectedBetweenWhereClauseAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable? = nil, unexpectedBetweenPatternAndWhereClause: ExpressibleAsUnexpectedNodes? = nil, whereClause: ExpressibleAsWhereClause? = nil, unexpectedBetweenWhereClauseAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePattern = unexpectedBeforePattern?.createUnexpectedNodes()
     self.pattern = pattern?.createPatternBuildable()
     self.unexpectedBetweenPatternAndWhereClause = unexpectedBetweenPatternAndWhereClause?.createUnexpectedNodes()
@@ -10867,6 +11684,9 @@ public struct CatchItem: SyntaxBuildable, ExpressibleAsCatchItem, HasTrailingCom
     var result = CatchItemSyntax(unexpectedBeforePattern?.buildUnexpectedNodes(format: format), pattern: pattern?.buildPattern(format: format), unexpectedBetweenPatternAndWhereClause?.buildUnexpectedNodes(format: format), whereClause: whereClause?.buildWhereClause(format: format), unexpectedBetweenWhereClauseAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -10895,8 +11715,9 @@ public struct CatchItem: SyntaxBuildable, ExpressibleAsCatchItem, HasTrailingCom
 }
 public struct SwitchCaseLabel: SyntaxBuildable, ExpressibleAsSwitchCaseLabel {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeCaseKeyword: UnexpectedNodes?
   var caseKeyword: Token
   var unexpectedBetweenCaseKeywordAndCaseItems: UnexpectedNodes?
@@ -10911,8 +11732,9 @@ public struct SwitchCaseLabel: SyntaxBuildable, ExpressibleAsSwitchCaseLabel {
   ///   - caseItems: 
   ///   - unexpectedBetweenCaseItemsAndColon: 
   ///   - colon: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeCaseKeyword: ExpressibleAsUnexpectedNodes? = nil, caseKeyword: Token = Token.`case`, unexpectedBetweenCaseKeywordAndCaseItems: ExpressibleAsUnexpectedNodes? = nil, caseItems: ExpressibleAsCaseItemList, unexpectedBetweenCaseItemsAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeCaseKeyword: ExpressibleAsUnexpectedNodes? = nil, caseKeyword: Token = Token.`case`, unexpectedBetweenCaseKeywordAndCaseItems: ExpressibleAsUnexpectedNodes? = nil, caseItems: ExpressibleAsCaseItemList, unexpectedBetweenCaseItemsAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeCaseKeyword = unexpectedBeforeCaseKeyword?.createUnexpectedNodes()
     self.caseKeyword = caseKeyword
     assert(caseKeyword.text == #"case"#)
@@ -10939,6 +11761,9 @@ public struct SwitchCaseLabel: SyntaxBuildable, ExpressibleAsSwitchCaseLabel {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -10960,8 +11785,9 @@ public struct SwitchCaseLabel: SyntaxBuildable, ExpressibleAsSwitchCaseLabel {
 }
 public struct CatchClause: SyntaxBuildable, ExpressibleAsCatchClause {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeCatchKeyword: UnexpectedNodes?
   var catchKeyword: Token
   var unexpectedBetweenCatchKeywordAndCatchItems: UnexpectedNodes?
@@ -10976,8 +11802,9 @@ public struct CatchClause: SyntaxBuildable, ExpressibleAsCatchClause {
   ///   - catchItems: 
   ///   - unexpectedBetweenCatchItemsAndBody: 
   ///   - body: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeCatchKeyword: ExpressibleAsUnexpectedNodes? = nil, catchKeyword: Token = Token.`catch`, unexpectedBetweenCatchKeywordAndCatchItems: ExpressibleAsUnexpectedNodes? = nil, catchItems: ExpressibleAsCatchItemList? = nil, unexpectedBetweenCatchItemsAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeCatchKeyword: ExpressibleAsUnexpectedNodes? = nil, catchKeyword: Token = Token.`catch`, unexpectedBetweenCatchKeywordAndCatchItems: ExpressibleAsUnexpectedNodes? = nil, catchItems: ExpressibleAsCatchItemList? = nil, unexpectedBetweenCatchItemsAndBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsCodeBlock) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeCatchKeyword = unexpectedBeforeCatchKeyword?.createUnexpectedNodes()
     self.catchKeyword = catchKeyword
     assert(catchKeyword.text == #"catch"#)
@@ -11003,6 +11830,9 @@ public struct CatchClause: SyntaxBuildable, ExpressibleAsCatchClause {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -11024,8 +11854,9 @@ public struct CatchClause: SyntaxBuildable, ExpressibleAsCatchClause {
 }
 public struct PoundAssertStmt: StmtBuildable, ExpressibleAsPoundAssertStmt {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePoundAssert: UnexpectedNodes?
   var poundAssert: Token
   var unexpectedBetweenPoundAssertAndLeftParen: UnexpectedNodes?
@@ -11052,8 +11883,9 @@ public struct PoundAssertStmt: StmtBuildable, ExpressibleAsPoundAssertStmt {
   ///   - message: The assertion message.
   ///   - unexpectedBetweenMessageAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePoundAssert: ExpressibleAsUnexpectedNodes? = nil, poundAssert: Token = Token.`poundAssert`, unexpectedBetweenPoundAssertAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndCondition: ExpressibleAsUnexpectedNodes? = nil, condition: ExpressibleAsExprBuildable, unexpectedBetweenConditionAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndMessage: ExpressibleAsUnexpectedNodes? = nil, message: Token? = nil, unexpectedBetweenMessageAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePoundAssert: ExpressibleAsUnexpectedNodes? = nil, poundAssert: Token = Token.`poundAssert`, unexpectedBetweenPoundAssertAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndCondition: ExpressibleAsUnexpectedNodes? = nil, condition: ExpressibleAsExprBuildable, unexpectedBetweenConditionAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndMessage: ExpressibleAsUnexpectedNodes? = nil, message: Token? = nil, unexpectedBetweenMessageAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePoundAssert = unexpectedBeforePoundAssert?.createUnexpectedNodes()
     self.poundAssert = poundAssert
     assert(poundAssert.text == #"#assert"#)
@@ -11088,6 +11920,9 @@ public struct PoundAssertStmt: StmtBuildable, ExpressibleAsPoundAssertStmt {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `StmtBuildable`.
@@ -11116,8 +11951,9 @@ public struct PoundAssertStmt: StmtBuildable, ExpressibleAsPoundAssertStmt {
 }
 public struct GenericWhereClause: SyntaxBuildable, ExpressibleAsGenericWhereClause {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeWhereKeyword: UnexpectedNodes?
   var whereKeyword: Token
   var unexpectedBetweenWhereKeywordAndRequirementList: UnexpectedNodes?
@@ -11128,8 +11964,9 @@ public struct GenericWhereClause: SyntaxBuildable, ExpressibleAsGenericWhereClau
   ///   - whereKeyword: 
   ///   - unexpectedBetweenWhereKeywordAndRequirementList: 
   ///   - requirementList: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeWhereKeyword: ExpressibleAsUnexpectedNodes? = nil, whereKeyword: Token = Token.`where`, unexpectedBetweenWhereKeywordAndRequirementList: ExpressibleAsUnexpectedNodes? = nil, requirementList: ExpressibleAsGenericRequirementList) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWhereKeyword: ExpressibleAsUnexpectedNodes? = nil, whereKeyword: Token = Token.`where`, unexpectedBetweenWhereKeywordAndRequirementList: ExpressibleAsUnexpectedNodes? = nil, requirementList: ExpressibleAsGenericRequirementList) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeWhereKeyword = unexpectedBeforeWhereKeyword?.createUnexpectedNodes()
     self.whereKeyword = whereKeyword
     assert(whereKeyword.text == #"where"#)
@@ -11153,6 +11990,9 @@ public struct GenericWhereClause: SyntaxBuildable, ExpressibleAsGenericWhereClau
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -11174,8 +12014,9 @@ public struct GenericWhereClause: SyntaxBuildable, ExpressibleAsGenericWhereClau
 }
 public struct GenericRequirement: SyntaxBuildable, ExpressibleAsGenericRequirement, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeBody: UnexpectedNodes?
   var body: SyntaxBuildable
   var unexpectedBetweenBodyAndTrailingComma: UnexpectedNodes?
@@ -11186,8 +12027,9 @@ public struct GenericRequirement: SyntaxBuildable, ExpressibleAsGenericRequireme
   ///   - body: 
   ///   - unexpectedBetweenBodyAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsSyntaxBuildable, unexpectedBetweenBodyAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBody: ExpressibleAsUnexpectedNodes? = nil, body: ExpressibleAsSyntaxBuildable, unexpectedBetweenBodyAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeBody = unexpectedBeforeBody?.createUnexpectedNodes()
     self.body = body.createSyntaxBuildable()
     self.unexpectedBetweenBodyAndTrailingComma = unexpectedBetweenBodyAndTrailingComma?.createUnexpectedNodes()
@@ -11202,6 +12044,9 @@ public struct GenericRequirement: SyntaxBuildable, ExpressibleAsGenericRequireme
     var result = GenericRequirementSyntax(unexpectedBeforeBody?.buildUnexpectedNodes(format: format), body: body.buildSyntax(format: format), unexpectedBetweenBodyAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -11230,8 +12075,9 @@ public struct GenericRequirement: SyntaxBuildable, ExpressibleAsGenericRequireme
 }
 public struct SameTypeRequirement: SyntaxBuildable, ExpressibleAsSameTypeRequirement {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftTypeIdentifier: UnexpectedNodes?
   var leftTypeIdentifier: TypeBuildable
   var unexpectedBetweenLeftTypeIdentifierAndEqualityToken: UnexpectedNodes?
@@ -11246,8 +12092,9 @@ public struct SameTypeRequirement: SyntaxBuildable, ExpressibleAsSameTypeRequire
   ///   - equalityToken: 
   ///   - unexpectedBetweenEqualityTokenAndRightTypeIdentifier: 
   ///   - rightTypeIdentifier: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftTypeIdentifier: ExpressibleAsUnexpectedNodes? = nil, leftTypeIdentifier: ExpressibleAsTypeBuildable, unexpectedBetweenLeftTypeIdentifierAndEqualityToken: ExpressibleAsUnexpectedNodes? = nil, equalityToken: Token, unexpectedBetweenEqualityTokenAndRightTypeIdentifier: ExpressibleAsUnexpectedNodes? = nil, rightTypeIdentifier: ExpressibleAsTypeBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftTypeIdentifier: ExpressibleAsUnexpectedNodes? = nil, leftTypeIdentifier: ExpressibleAsTypeBuildable, unexpectedBetweenLeftTypeIdentifierAndEqualityToken: ExpressibleAsUnexpectedNodes? = nil, equalityToken: Token, unexpectedBetweenEqualityTokenAndRightTypeIdentifier: ExpressibleAsUnexpectedNodes? = nil, rightTypeIdentifier: ExpressibleAsTypeBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftTypeIdentifier = unexpectedBeforeLeftTypeIdentifier?.createUnexpectedNodes()
     self.leftTypeIdentifier = leftTypeIdentifier.createTypeBuildable()
     self.unexpectedBetweenLeftTypeIdentifierAndEqualityToken = unexpectedBetweenLeftTypeIdentifierAndEqualityToken?.createUnexpectedNodes()
@@ -11263,6 +12110,9 @@ public struct SameTypeRequirement: SyntaxBuildable, ExpressibleAsSameTypeRequire
     var result = SameTypeRequirementSyntax(unexpectedBeforeLeftTypeIdentifier?.buildUnexpectedNodes(format: format), leftTypeIdentifier: leftTypeIdentifier.buildType(format: format), unexpectedBetweenLeftTypeIdentifierAndEqualityToken?.buildUnexpectedNodes(format: format), equalityToken: equalityToken.buildToken(format: format), unexpectedBetweenEqualityTokenAndRightTypeIdentifier?.buildUnexpectedNodes(format: format), rightTypeIdentifier: rightTypeIdentifier.buildType(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -11285,8 +12135,9 @@ public struct SameTypeRequirement: SyntaxBuildable, ExpressibleAsSameTypeRequire
 }
 public struct LayoutRequirement: SyntaxBuildable, ExpressibleAsLayoutRequirement {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeTypeIdentifier: UnexpectedNodes?
   var typeIdentifier: TypeBuildable
   var unexpectedBetweenTypeIdentifierAndColon: UnexpectedNodes?
@@ -11321,8 +12172,9 @@ public struct LayoutRequirement: SyntaxBuildable, ExpressibleAsLayoutRequirement
   ///   - alignment: 
   ///   - unexpectedBetweenAlignmentAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeTypeIdentifier: ExpressibleAsUnexpectedNodes? = nil, typeIdentifier: ExpressibleAsTypeBuildable, unexpectedBetweenTypeIdentifierAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndLayoutConstraint: ExpressibleAsUnexpectedNodes? = nil, layoutConstraint: Token, unexpectedBetweenLayoutConstraintAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndSize: ExpressibleAsUnexpectedNodes? = nil, size: Token? = nil, unexpectedBetweenSizeAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndAlignment: ExpressibleAsUnexpectedNodes? = nil, alignment: Token? = nil, unexpectedBetweenAlignmentAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeTypeIdentifier: ExpressibleAsUnexpectedNodes? = nil, typeIdentifier: ExpressibleAsTypeBuildable, unexpectedBetweenTypeIdentifierAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndLayoutConstraint: ExpressibleAsUnexpectedNodes? = nil, layoutConstraint: Token, unexpectedBetweenLayoutConstraintAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndSize: ExpressibleAsUnexpectedNodes? = nil, size: Token? = nil, unexpectedBetweenSizeAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndAlignment: ExpressibleAsUnexpectedNodes? = nil, alignment: Token? = nil, unexpectedBetweenAlignmentAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeTypeIdentifier = unexpectedBeforeTypeIdentifier?.createUnexpectedNodes()
     self.typeIdentifier = typeIdentifier.createTypeBuildable()
     self.unexpectedBetweenTypeIdentifierAndColon = unexpectedBetweenTypeIdentifierAndColon?.createUnexpectedNodes()
@@ -11363,6 +12215,9 @@ public struct LayoutRequirement: SyntaxBuildable, ExpressibleAsLayoutRequirement
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -11384,8 +12239,9 @@ public struct LayoutRequirement: SyntaxBuildable, ExpressibleAsLayoutRequirement
 }
 public struct GenericParameter: SyntaxBuildable, ExpressibleAsGenericParameter, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeAttributes: UnexpectedNodes?
   var attributes: AttributeList?
   var unexpectedBetweenAttributesAndName: UnexpectedNodes?
@@ -11408,8 +12264,9 @@ public struct GenericParameter: SyntaxBuildable, ExpressibleAsGenericParameter, 
   ///   - inheritedType: 
   ///   - unexpectedBetweenInheritedTypeAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndInheritedType: ExpressibleAsUnexpectedNodes? = nil, inheritedType: ExpressibleAsTypeBuildable? = nil, unexpectedBetweenInheritedTypeAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndInheritedType: ExpressibleAsUnexpectedNodes? = nil, inheritedType: ExpressibleAsTypeBuildable? = nil, unexpectedBetweenInheritedTypeAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeAttributes = unexpectedBeforeAttributes?.createUnexpectedNodes()
     self.attributes = attributes?.createAttributeList()
     self.unexpectedBetweenAttributesAndName = unexpectedBetweenAttributesAndName?.createUnexpectedNodes()
@@ -11438,6 +12295,9 @@ public struct GenericParameter: SyntaxBuildable, ExpressibleAsGenericParameter, 
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -11465,8 +12325,9 @@ public struct GenericParameter: SyntaxBuildable, ExpressibleAsGenericParameter, 
 }
 public struct PrimaryAssociatedType: SyntaxBuildable, ExpressibleAsPrimaryAssociatedType, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeName: UnexpectedNodes?
   var name: Token
   var unexpectedBetweenNameAndTrailingComma: UnexpectedNodes?
@@ -11477,8 +12338,9 @@ public struct PrimaryAssociatedType: SyntaxBuildable, ExpressibleAsPrimaryAssoci
   ///   - name: 
   ///   - unexpectedBetweenNameAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeName = unexpectedBeforeName?.createUnexpectedNodes()
     self.name = name
     self.unexpectedBetweenNameAndTrailingComma = unexpectedBetweenNameAndTrailingComma?.createUnexpectedNodes()
@@ -11499,6 +12361,9 @@ public struct PrimaryAssociatedType: SyntaxBuildable, ExpressibleAsPrimaryAssoci
     var result = PrimaryAssociatedTypeSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format), name: name.buildToken(format: format), unexpectedBetweenNameAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -11527,8 +12392,9 @@ public struct PrimaryAssociatedType: SyntaxBuildable, ExpressibleAsPrimaryAssoci
 }
 public struct GenericParameterClause: SyntaxBuildable, ExpressibleAsGenericParameterClause {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftAngleBracket: UnexpectedNodes?
   var leftAngleBracket: Token
   var unexpectedBetweenLeftAngleBracketAndGenericParameterList: UnexpectedNodes?
@@ -11543,8 +12409,9 @@ public struct GenericParameterClause: SyntaxBuildable, ExpressibleAsGenericParam
   ///   - genericParameterList: 
   ///   - unexpectedBetweenGenericParameterListAndRightAngleBracket: 
   ///   - rightAngleBracket: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftAngleBracket: ExpressibleAsUnexpectedNodes? = nil, leftAngleBracket: Token = Token.`leftAngle`, unexpectedBetweenLeftAngleBracketAndGenericParameterList: ExpressibleAsUnexpectedNodes? = nil, genericParameterList: ExpressibleAsGenericParameterList, unexpectedBetweenGenericParameterListAndRightAngleBracket: ExpressibleAsUnexpectedNodes? = nil, rightAngleBracket: Token = Token.`rightAngle`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftAngleBracket: ExpressibleAsUnexpectedNodes? = nil, leftAngleBracket: Token = Token.`leftAngle`, unexpectedBetweenLeftAngleBracketAndGenericParameterList: ExpressibleAsUnexpectedNodes? = nil, genericParameterList: ExpressibleAsGenericParameterList, unexpectedBetweenGenericParameterListAndRightAngleBracket: ExpressibleAsUnexpectedNodes? = nil, rightAngleBracket: Token = Token.`rightAngle`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftAngleBracket = unexpectedBeforeLeftAngleBracket?.createUnexpectedNodes()
     self.leftAngleBracket = leftAngleBracket
     assert(leftAngleBracket.text == #"<"#)
@@ -11571,6 +12438,9 @@ public struct GenericParameterClause: SyntaxBuildable, ExpressibleAsGenericParam
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -11592,8 +12462,9 @@ public struct GenericParameterClause: SyntaxBuildable, ExpressibleAsGenericParam
 }
 public struct ConformanceRequirement: SyntaxBuildable, ExpressibleAsConformanceRequirement {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftTypeIdentifier: UnexpectedNodes?
   var leftTypeIdentifier: TypeBuildable
   var unexpectedBetweenLeftTypeIdentifierAndColon: UnexpectedNodes?
@@ -11608,8 +12479,9 @@ public struct ConformanceRequirement: SyntaxBuildable, ExpressibleAsConformanceR
   ///   - colon: 
   ///   - unexpectedBetweenColonAndRightTypeIdentifier: 
   ///   - rightTypeIdentifier: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftTypeIdentifier: ExpressibleAsUnexpectedNodes? = nil, leftTypeIdentifier: ExpressibleAsTypeBuildable, unexpectedBetweenLeftTypeIdentifierAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndRightTypeIdentifier: ExpressibleAsUnexpectedNodes? = nil, rightTypeIdentifier: ExpressibleAsTypeBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftTypeIdentifier: ExpressibleAsUnexpectedNodes? = nil, leftTypeIdentifier: ExpressibleAsTypeBuildable, unexpectedBetweenLeftTypeIdentifierAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndRightTypeIdentifier: ExpressibleAsUnexpectedNodes? = nil, rightTypeIdentifier: ExpressibleAsTypeBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftTypeIdentifier = unexpectedBeforeLeftTypeIdentifier?.createUnexpectedNodes()
     self.leftTypeIdentifier = leftTypeIdentifier.createTypeBuildable()
     self.unexpectedBetweenLeftTypeIdentifierAndColon = unexpectedBetweenLeftTypeIdentifierAndColon?.createUnexpectedNodes()
@@ -11626,6 +12498,9 @@ public struct ConformanceRequirement: SyntaxBuildable, ExpressibleAsConformanceR
     var result = ConformanceRequirementSyntax(unexpectedBeforeLeftTypeIdentifier?.buildUnexpectedNodes(format: format), leftTypeIdentifier: leftTypeIdentifier.buildType(format: format), unexpectedBetweenLeftTypeIdentifierAndColon?.buildUnexpectedNodes(format: format), colon: colon.buildToken(format: format), unexpectedBetweenColonAndRightTypeIdentifier?.buildUnexpectedNodes(format: format), rightTypeIdentifier: rightTypeIdentifier.buildType(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -11648,8 +12523,9 @@ public struct ConformanceRequirement: SyntaxBuildable, ExpressibleAsConformanceR
 }
 public struct PrimaryAssociatedTypeClause: SyntaxBuildable, ExpressibleAsPrimaryAssociatedTypeClause {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftAngleBracket: UnexpectedNodes?
   var leftAngleBracket: Token
   var unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList: UnexpectedNodes?
@@ -11664,8 +12540,9 @@ public struct PrimaryAssociatedTypeClause: SyntaxBuildable, ExpressibleAsPrimary
   ///   - primaryAssociatedTypeList: 
   ///   - unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket: 
   ///   - rightAngleBracket: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftAngleBracket: ExpressibleAsUnexpectedNodes? = nil, leftAngleBracket: Token = Token.`leftAngle`, unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList: ExpressibleAsUnexpectedNodes? = nil, primaryAssociatedTypeList: ExpressibleAsPrimaryAssociatedTypeList, unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket: ExpressibleAsUnexpectedNodes? = nil, rightAngleBracket: Token = Token.`rightAngle`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftAngleBracket: ExpressibleAsUnexpectedNodes? = nil, leftAngleBracket: Token = Token.`leftAngle`, unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList: ExpressibleAsUnexpectedNodes? = nil, primaryAssociatedTypeList: ExpressibleAsPrimaryAssociatedTypeList, unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket: ExpressibleAsUnexpectedNodes? = nil, rightAngleBracket: Token = Token.`rightAngle`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftAngleBracket = unexpectedBeforeLeftAngleBracket?.createUnexpectedNodes()
     self.leftAngleBracket = leftAngleBracket
     assert(leftAngleBracket.text == #"<"#)
@@ -11683,6 +12560,9 @@ public struct PrimaryAssociatedTypeClause: SyntaxBuildable, ExpressibleAsPrimary
     var result = PrimaryAssociatedTypeClauseSyntax(unexpectedBeforeLeftAngleBracket?.buildUnexpectedNodes(format: format), leftAngleBracket: leftAngleBracket.buildToken(format: format), unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList?.buildUnexpectedNodes(format: format), primaryAssociatedTypeList: primaryAssociatedTypeList.buildPrimaryAssociatedTypeList(format: format), unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket?.buildUnexpectedNodes(format: format), rightAngleBracket: rightAngleBracket.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -11705,8 +12585,9 @@ public struct PrimaryAssociatedTypeClause: SyntaxBuildable, ExpressibleAsPrimary
 }
 public struct SimpleTypeIdentifier: TypeBuildable, ExpressibleAsSimpleTypeIdentifier {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeName: UnexpectedNodes?
   var name: Token
   var unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodes?
@@ -11717,8 +12598,9 @@ public struct SimpleTypeIdentifier: TypeBuildable, ExpressibleAsSimpleTypeIdenti
   ///   - name: 
   ///   - unexpectedBetweenNameAndGenericArgumentClause: 
   ///   - genericArgumentClause: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndGenericArgumentClause: ExpressibleAsUnexpectedNodes? = nil, genericArgumentClause: ExpressibleAsGenericArgumentClause? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndGenericArgumentClause: ExpressibleAsUnexpectedNodes? = nil, genericArgumentClause: ExpressibleAsGenericArgumentClause? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeName = unexpectedBeforeName?.createUnexpectedNodes()
     self.name = name
     self.unexpectedBetweenNameAndGenericArgumentClause = unexpectedBetweenNameAndGenericArgumentClause?.createUnexpectedNodes()
@@ -11732,6 +12614,9 @@ public struct SimpleTypeIdentifier: TypeBuildable, ExpressibleAsSimpleTypeIdenti
     var result = SimpleTypeIdentifierSyntax(unexpectedBeforeName?.buildUnexpectedNodes(format: format), name: name.buildToken(format: format), unexpectedBetweenNameAndGenericArgumentClause?.buildUnexpectedNodes(format: format), genericArgumentClause: genericArgumentClause?.buildGenericArgumentClause(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -11761,8 +12646,9 @@ public struct SimpleTypeIdentifier: TypeBuildable, ExpressibleAsSimpleTypeIdenti
 }
 public struct MemberTypeIdentifier: TypeBuildable, ExpressibleAsMemberTypeIdentifier {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeBaseType: UnexpectedNodes?
   var baseType: TypeBuildable
   var unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodes?
@@ -11781,8 +12667,9 @@ public struct MemberTypeIdentifier: TypeBuildable, ExpressibleAsMemberTypeIdenti
   ///   - name: 
   ///   - unexpectedBetweenNameAndGenericArgumentClause: 
   ///   - genericArgumentClause: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeBaseType: ExpressibleAsUnexpectedNodes? = nil, baseType: ExpressibleAsTypeBuildable, unexpectedBetweenBaseTypeAndPeriod: ExpressibleAsUnexpectedNodes? = nil, period: Token, unexpectedBetweenPeriodAndName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndGenericArgumentClause: ExpressibleAsUnexpectedNodes? = nil, genericArgumentClause: ExpressibleAsGenericArgumentClause? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBaseType: ExpressibleAsUnexpectedNodes? = nil, baseType: ExpressibleAsTypeBuildable, unexpectedBetweenBaseTypeAndPeriod: ExpressibleAsUnexpectedNodes? = nil, period: Token, unexpectedBetweenPeriodAndName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndGenericArgumentClause: ExpressibleAsUnexpectedNodes? = nil, genericArgumentClause: ExpressibleAsGenericArgumentClause? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeBaseType = unexpectedBeforeBaseType?.createUnexpectedNodes()
     self.baseType = baseType.createTypeBuildable()
     self.unexpectedBetweenBaseTypeAndPeriod = unexpectedBetweenBaseTypeAndPeriod?.createUnexpectedNodes()
@@ -11801,6 +12688,9 @@ public struct MemberTypeIdentifier: TypeBuildable, ExpressibleAsMemberTypeIdenti
     var result = MemberTypeIdentifierSyntax(unexpectedBeforeBaseType?.buildUnexpectedNodes(format: format), baseType: baseType.buildType(format: format), unexpectedBetweenBaseTypeAndPeriod?.buildUnexpectedNodes(format: format), period: period.buildToken(format: format), unexpectedBetweenPeriodAndName?.buildUnexpectedNodes(format: format), name: name.buildToken(format: format), unexpectedBetweenNameAndGenericArgumentClause?.buildUnexpectedNodes(format: format), genericArgumentClause: genericArgumentClause?.buildGenericArgumentClause(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -11830,16 +12720,18 @@ public struct MemberTypeIdentifier: TypeBuildable, ExpressibleAsMemberTypeIdenti
 }
 public struct ClassRestrictionType: TypeBuildable, ExpressibleAsClassRestrictionType {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeClassKeyword: UnexpectedNodes?
   var classKeyword: Token
   /// Creates a `ClassRestrictionType` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeClassKeyword: 
   ///   - classKeyword: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeClassKeyword: ExpressibleAsUnexpectedNodes? = nil, classKeyword: Token = Token.`class`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeClassKeyword: ExpressibleAsUnexpectedNodes? = nil, classKeyword: Token = Token.`class`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeClassKeyword = unexpectedBeforeClassKeyword?.createUnexpectedNodes()
     self.classKeyword = classKeyword
     assert(classKeyword.text == #"class"#)
@@ -11852,6 +12744,9 @@ public struct ClassRestrictionType: TypeBuildable, ExpressibleAsClassRestriction
     var result = ClassRestrictionTypeSyntax(unexpectedBeforeClassKeyword?.buildUnexpectedNodes(format: format), classKeyword: classKeyword.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -11881,8 +12776,9 @@ public struct ClassRestrictionType: TypeBuildable, ExpressibleAsClassRestriction
 }
 public struct ArrayType: TypeBuildable, ExpressibleAsArrayType {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftSquareBracket: UnexpectedNodes?
   var leftSquareBracket: Token
   var unexpectedBetweenLeftSquareBracketAndElementType: UnexpectedNodes?
@@ -11897,8 +12793,9 @@ public struct ArrayType: TypeBuildable, ExpressibleAsArrayType {
   ///   - elementType: 
   ///   - unexpectedBetweenElementTypeAndRightSquareBracket: 
   ///   - rightSquareBracket: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftSquareBracket: ExpressibleAsUnexpectedNodes? = nil, leftSquareBracket: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareBracketAndElementType: ExpressibleAsUnexpectedNodes? = nil, elementType: ExpressibleAsTypeBuildable, unexpectedBetweenElementTypeAndRightSquareBracket: ExpressibleAsUnexpectedNodes? = nil, rightSquareBracket: Token = Token.`rightSquareBracket`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftSquareBracket: ExpressibleAsUnexpectedNodes? = nil, leftSquareBracket: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareBracketAndElementType: ExpressibleAsUnexpectedNodes? = nil, elementType: ExpressibleAsTypeBuildable, unexpectedBetweenElementTypeAndRightSquareBracket: ExpressibleAsUnexpectedNodes? = nil, rightSquareBracket: Token = Token.`rightSquareBracket`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftSquareBracket = unexpectedBeforeLeftSquareBracket?.createUnexpectedNodes()
     self.leftSquareBracket = leftSquareBracket
     assert(leftSquareBracket.text == #"["#)
@@ -11916,6 +12813,9 @@ public struct ArrayType: TypeBuildable, ExpressibleAsArrayType {
     var result = ArrayTypeSyntax(unexpectedBeforeLeftSquareBracket?.buildUnexpectedNodes(format: format), leftSquareBracket: leftSquareBracket.buildToken(format: format), unexpectedBetweenLeftSquareBracketAndElementType?.buildUnexpectedNodes(format: format), elementType: elementType.buildType(format: format), unexpectedBetweenElementTypeAndRightSquareBracket?.buildUnexpectedNodes(format: format), rightSquareBracket: rightSquareBracket.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -11945,8 +12845,9 @@ public struct ArrayType: TypeBuildable, ExpressibleAsArrayType {
 }
 public struct DictionaryType: TypeBuildable, ExpressibleAsDictionaryType {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftSquareBracket: UnexpectedNodes?
   var leftSquareBracket: Token
   var unexpectedBetweenLeftSquareBracketAndKeyType: UnexpectedNodes?
@@ -11969,8 +12870,9 @@ public struct DictionaryType: TypeBuildable, ExpressibleAsDictionaryType {
   ///   - valueType: 
   ///   - unexpectedBetweenValueTypeAndRightSquareBracket: 
   ///   - rightSquareBracket: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftSquareBracket: ExpressibleAsUnexpectedNodes? = nil, leftSquareBracket: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareBracketAndKeyType: ExpressibleAsUnexpectedNodes? = nil, keyType: ExpressibleAsTypeBuildable, unexpectedBetweenKeyTypeAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValueType: ExpressibleAsUnexpectedNodes? = nil, valueType: ExpressibleAsTypeBuildable, unexpectedBetweenValueTypeAndRightSquareBracket: ExpressibleAsUnexpectedNodes? = nil, rightSquareBracket: Token = Token.`rightSquareBracket`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftSquareBracket: ExpressibleAsUnexpectedNodes? = nil, leftSquareBracket: Token = Token.`leftSquareBracket`, unexpectedBetweenLeftSquareBracketAndKeyType: ExpressibleAsUnexpectedNodes? = nil, keyType: ExpressibleAsTypeBuildable, unexpectedBetweenKeyTypeAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValueType: ExpressibleAsUnexpectedNodes? = nil, valueType: ExpressibleAsTypeBuildable, unexpectedBetweenValueTypeAndRightSquareBracket: ExpressibleAsUnexpectedNodes? = nil, rightSquareBracket: Token = Token.`rightSquareBracket`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftSquareBracket = unexpectedBeforeLeftSquareBracket?.createUnexpectedNodes()
     self.leftSquareBracket = leftSquareBracket
     assert(leftSquareBracket.text == #"["#)
@@ -11993,6 +12895,9 @@ public struct DictionaryType: TypeBuildable, ExpressibleAsDictionaryType {
     var result = DictionaryTypeSyntax(unexpectedBeforeLeftSquareBracket?.buildUnexpectedNodes(format: format), leftSquareBracket: leftSquareBracket.buildToken(format: format), unexpectedBetweenLeftSquareBracketAndKeyType?.buildUnexpectedNodes(format: format), keyType: keyType.buildType(format: format), unexpectedBetweenKeyTypeAndColon?.buildUnexpectedNodes(format: format), colon: colon.buildToken(format: format), unexpectedBetweenColonAndValueType?.buildUnexpectedNodes(format: format), valueType: valueType.buildType(format: format), unexpectedBetweenValueTypeAndRightSquareBracket?.buildUnexpectedNodes(format: format), rightSquareBracket: rightSquareBracket.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -12022,8 +12927,9 @@ public struct DictionaryType: TypeBuildable, ExpressibleAsDictionaryType {
 }
 public struct MetatypeType: TypeBuildable, ExpressibleAsMetatypeType {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeBaseType: UnexpectedNodes?
   var baseType: TypeBuildable
   var unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodes?
@@ -12038,8 +12944,9 @@ public struct MetatypeType: TypeBuildable, ExpressibleAsMetatypeType {
   ///   - period: 
   ///   - unexpectedBetweenPeriodAndTypeOrProtocol: 
   ///   - typeOrProtocol: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeBaseType: ExpressibleAsUnexpectedNodes? = nil, baseType: ExpressibleAsTypeBuildable, unexpectedBetweenBaseTypeAndPeriod: ExpressibleAsUnexpectedNodes? = nil, period: Token = Token.`period`, unexpectedBetweenPeriodAndTypeOrProtocol: ExpressibleAsUnexpectedNodes? = nil, typeOrProtocol: Token) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBaseType: ExpressibleAsUnexpectedNodes? = nil, baseType: ExpressibleAsTypeBuildable, unexpectedBetweenBaseTypeAndPeriod: ExpressibleAsUnexpectedNodes? = nil, period: Token = Token.`period`, unexpectedBetweenPeriodAndTypeOrProtocol: ExpressibleAsUnexpectedNodes? = nil, typeOrProtocol: Token) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeBaseType = unexpectedBeforeBaseType?.createUnexpectedNodes()
     self.baseType = baseType.createTypeBuildable()
     self.unexpectedBetweenBaseTypeAndPeriod = unexpectedBetweenBaseTypeAndPeriod?.createUnexpectedNodes()
@@ -12063,6 +12970,9 @@ public struct MetatypeType: TypeBuildable, ExpressibleAsMetatypeType {
     var result = MetatypeTypeSyntax(unexpectedBeforeBaseType?.buildUnexpectedNodes(format: format), baseType: baseType.buildType(format: format), unexpectedBetweenBaseTypeAndPeriod?.buildUnexpectedNodes(format: format), period: period.buildToken(format: format), unexpectedBetweenPeriodAndTypeOrProtocol?.buildUnexpectedNodes(format: format), typeOrProtocol: typeOrProtocol.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -12092,8 +13002,9 @@ public struct MetatypeType: TypeBuildable, ExpressibleAsMetatypeType {
 }
 public struct OptionalType: TypeBuildable, ExpressibleAsOptionalType {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeWrappedType: UnexpectedNodes?
   var wrappedType: TypeBuildable
   var unexpectedBetweenWrappedTypeAndQuestionMark: UnexpectedNodes?
@@ -12104,8 +13015,9 @@ public struct OptionalType: TypeBuildable, ExpressibleAsOptionalType {
   ///   - wrappedType: 
   ///   - unexpectedBetweenWrappedTypeAndQuestionMark: 
   ///   - questionMark: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeWrappedType: ExpressibleAsUnexpectedNodes? = nil, wrappedType: ExpressibleAsTypeBuildable, unexpectedBetweenWrappedTypeAndQuestionMark: ExpressibleAsUnexpectedNodes? = nil, questionMark: Token = Token.`postfixQuestionMark`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWrappedType: ExpressibleAsUnexpectedNodes? = nil, wrappedType: ExpressibleAsTypeBuildable, unexpectedBetweenWrappedTypeAndQuestionMark: ExpressibleAsUnexpectedNodes? = nil, questionMark: Token = Token.`postfixQuestionMark`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeWrappedType = unexpectedBeforeWrappedType?.createUnexpectedNodes()
     self.wrappedType = wrappedType.createTypeBuildable()
     self.unexpectedBetweenWrappedTypeAndQuestionMark = unexpectedBetweenWrappedTypeAndQuestionMark?.createUnexpectedNodes()
@@ -12120,6 +13032,9 @@ public struct OptionalType: TypeBuildable, ExpressibleAsOptionalType {
     var result = OptionalTypeSyntax(unexpectedBeforeWrappedType?.buildUnexpectedNodes(format: format), wrappedType: wrappedType.buildType(format: format), unexpectedBetweenWrappedTypeAndQuestionMark?.buildUnexpectedNodes(format: format), questionMark: questionMark.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -12149,8 +13064,9 @@ public struct OptionalType: TypeBuildable, ExpressibleAsOptionalType {
 }
 public struct ConstrainedSugarType: TypeBuildable, ExpressibleAsConstrainedSugarType {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeSomeOrAnySpecifier: UnexpectedNodes?
   var someOrAnySpecifier: Token
   var unexpectedBetweenSomeOrAnySpecifierAndBaseType: UnexpectedNodes?
@@ -12161,8 +13077,9 @@ public struct ConstrainedSugarType: TypeBuildable, ExpressibleAsConstrainedSugar
   ///   - someOrAnySpecifier: 
   ///   - unexpectedBetweenSomeOrAnySpecifierAndBaseType: 
   ///   - baseType: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeSomeOrAnySpecifier: ExpressibleAsUnexpectedNodes? = nil, someOrAnySpecifier: Token, unexpectedBetweenSomeOrAnySpecifierAndBaseType: ExpressibleAsUnexpectedNodes? = nil, baseType: ExpressibleAsTypeBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeSomeOrAnySpecifier: ExpressibleAsUnexpectedNodes? = nil, someOrAnySpecifier: Token, unexpectedBetweenSomeOrAnySpecifierAndBaseType: ExpressibleAsUnexpectedNodes? = nil, baseType: ExpressibleAsTypeBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeSomeOrAnySpecifier = unexpectedBeforeSomeOrAnySpecifier?.createUnexpectedNodes()
     self.someOrAnySpecifier = someOrAnySpecifier
     assert(someOrAnySpecifier.text == #"some"# || someOrAnySpecifier.text == #"any"#)
@@ -12183,6 +13100,9 @@ public struct ConstrainedSugarType: TypeBuildable, ExpressibleAsConstrainedSugar
     var result = ConstrainedSugarTypeSyntax(unexpectedBeforeSomeOrAnySpecifier?.buildUnexpectedNodes(format: format), someOrAnySpecifier: someOrAnySpecifier.buildToken(format: format), unexpectedBetweenSomeOrAnySpecifierAndBaseType?.buildUnexpectedNodes(format: format), baseType: baseType.buildType(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -12212,8 +13132,9 @@ public struct ConstrainedSugarType: TypeBuildable, ExpressibleAsConstrainedSugar
 }
 public struct ImplicitlyUnwrappedOptionalType: TypeBuildable, ExpressibleAsImplicitlyUnwrappedOptionalType {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeWrappedType: UnexpectedNodes?
   var wrappedType: TypeBuildable
   var unexpectedBetweenWrappedTypeAndExclamationMark: UnexpectedNodes?
@@ -12224,8 +13145,9 @@ public struct ImplicitlyUnwrappedOptionalType: TypeBuildable, ExpressibleAsImpli
   ///   - wrappedType: 
   ///   - unexpectedBetweenWrappedTypeAndExclamationMark: 
   ///   - exclamationMark: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeWrappedType: ExpressibleAsUnexpectedNodes? = nil, wrappedType: ExpressibleAsTypeBuildable, unexpectedBetweenWrappedTypeAndExclamationMark: ExpressibleAsUnexpectedNodes? = nil, exclamationMark: Token = Token.`exclamationMark`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWrappedType: ExpressibleAsUnexpectedNodes? = nil, wrappedType: ExpressibleAsTypeBuildable, unexpectedBetweenWrappedTypeAndExclamationMark: ExpressibleAsUnexpectedNodes? = nil, exclamationMark: Token = Token.`exclamationMark`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeWrappedType = unexpectedBeforeWrappedType?.createUnexpectedNodes()
     self.wrappedType = wrappedType.createTypeBuildable()
     self.unexpectedBetweenWrappedTypeAndExclamationMark = unexpectedBetweenWrappedTypeAndExclamationMark?.createUnexpectedNodes()
@@ -12240,6 +13162,9 @@ public struct ImplicitlyUnwrappedOptionalType: TypeBuildable, ExpressibleAsImpli
     var result = ImplicitlyUnwrappedOptionalTypeSyntax(unexpectedBeforeWrappedType?.buildUnexpectedNodes(format: format), wrappedType: wrappedType.buildType(format: format), unexpectedBetweenWrappedTypeAndExclamationMark?.buildUnexpectedNodes(format: format), exclamationMark: exclamationMark.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -12269,8 +13194,9 @@ public struct ImplicitlyUnwrappedOptionalType: TypeBuildable, ExpressibleAsImpli
 }
 public struct CompositionTypeElement: SyntaxBuildable, ExpressibleAsCompositionTypeElement {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeType: UnexpectedNodes?
   var type: TypeBuildable
   var unexpectedBetweenTypeAndAmpersand: UnexpectedNodes?
@@ -12281,8 +13207,9 @@ public struct CompositionTypeElement: SyntaxBuildable, ExpressibleAsCompositionT
   ///   - type: 
   ///   - unexpectedBetweenTypeAndAmpersand: 
   ///   - ampersand: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable, unexpectedBetweenTypeAndAmpersand: ExpressibleAsUnexpectedNodes? = nil, ampersand: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable, unexpectedBetweenTypeAndAmpersand: ExpressibleAsUnexpectedNodes? = nil, ampersand: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeType = unexpectedBeforeType?.createUnexpectedNodes()
     self.type = type.createTypeBuildable()
     self.unexpectedBetweenTypeAndAmpersand = unexpectedBetweenTypeAndAmpersand?.createUnexpectedNodes()
@@ -12297,6 +13224,9 @@ public struct CompositionTypeElement: SyntaxBuildable, ExpressibleAsCompositionT
     var result = CompositionTypeElementSyntax(unexpectedBeforeType?.buildUnexpectedNodes(format: format), type: type.buildType(format: format), unexpectedBetweenTypeAndAmpersand?.buildUnexpectedNodes(format: format), ampersand: ampersand?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -12319,16 +13249,18 @@ public struct CompositionTypeElement: SyntaxBuildable, ExpressibleAsCompositionT
 }
 public struct CompositionType: TypeBuildable, ExpressibleAsCompositionType {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeElements: UnexpectedNodes?
   var elements: CompositionTypeElementList
   /// Creates a `CompositionType` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeElements: 
   ///   - elements: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeElements: ExpressibleAsUnexpectedNodes? = nil, elements: ExpressibleAsCompositionTypeElementList) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeElements: ExpressibleAsUnexpectedNodes? = nil, elements: ExpressibleAsCompositionTypeElementList) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeElements = unexpectedBeforeElements?.createUnexpectedNodes()
     self.elements = elements.createCompositionTypeElementList()
   }
@@ -12340,6 +13272,9 @@ public struct CompositionType: TypeBuildable, ExpressibleAsCompositionType {
     var result = CompositionTypeSyntax(unexpectedBeforeElements?.buildUnexpectedNodes(format: format), elements: elements.buildCompositionTypeElementList(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -12369,8 +13304,9 @@ public struct CompositionType: TypeBuildable, ExpressibleAsCompositionType {
 }
 public struct TupleTypeElement: SyntaxBuildable, ExpressibleAsTupleTypeElement, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeInOut: UnexpectedNodes?
   var inOut: Token?
   var unexpectedBetweenInOutAndName: UnexpectedNodes?
@@ -12405,8 +13341,9 @@ public struct TupleTypeElement: SyntaxBuildable, ExpressibleAsTupleTypeElement, 
   ///   - initializer: 
   ///   - unexpectedBetweenInitializerAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeInOut: ExpressibleAsUnexpectedNodes? = nil, inOut: Token? = nil, unexpectedBetweenInOutAndName: ExpressibleAsUnexpectedNodes? = nil, name: Token? = nil, unexpectedBetweenNameAndSecondName: ExpressibleAsUnexpectedNodes? = nil, secondName: Token? = nil, unexpectedBetweenSecondNameAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable, unexpectedBetweenTypeAndEllipsis: ExpressibleAsUnexpectedNodes? = nil, ellipsis: Token? = nil, unexpectedBetweenEllipsisAndInitializer: ExpressibleAsUnexpectedNodes? = nil, initializer: ExpressibleAsInitializerClause? = nil, unexpectedBetweenInitializerAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeInOut: ExpressibleAsUnexpectedNodes? = nil, inOut: Token? = nil, unexpectedBetweenInOutAndName: ExpressibleAsUnexpectedNodes? = nil, name: Token? = nil, unexpectedBetweenNameAndSecondName: ExpressibleAsUnexpectedNodes? = nil, secondName: Token? = nil, unexpectedBetweenSecondNameAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable, unexpectedBetweenTypeAndEllipsis: ExpressibleAsUnexpectedNodes? = nil, ellipsis: Token? = nil, unexpectedBetweenEllipsisAndInitializer: ExpressibleAsUnexpectedNodes? = nil, initializer: ExpressibleAsInitializerClause? = nil, unexpectedBetweenInitializerAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeInOut = unexpectedBeforeInOut?.createUnexpectedNodes()
     self.inOut = inOut
     assert(inOut == nil || inOut!.text == #"inout"#)
@@ -12437,6 +13374,9 @@ public struct TupleTypeElement: SyntaxBuildable, ExpressibleAsTupleTypeElement, 
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -12464,8 +13404,9 @@ public struct TupleTypeElement: SyntaxBuildable, ExpressibleAsTupleTypeElement, 
 }
 public struct TupleType: TypeBuildable, ExpressibleAsTupleType {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftParen: UnexpectedNodes?
   var leftParen: Token
   var unexpectedBetweenLeftParenAndElements: UnexpectedNodes?
@@ -12480,8 +13421,9 @@ public struct TupleType: TypeBuildable, ExpressibleAsTupleType {
   ///   - elements: 
   ///   - unexpectedBetweenElementsAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElements: ExpressibleAsUnexpectedNodes? = nil, elements: ExpressibleAsTupleTypeElementList, unexpectedBetweenElementsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElements: ExpressibleAsUnexpectedNodes? = nil, elements: ExpressibleAsTupleTypeElementList, unexpectedBetweenElementsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftParen = unexpectedBeforeLeftParen?.createUnexpectedNodes()
     self.leftParen = leftParen
     assert(leftParen.text == #"("#)
@@ -12499,6 +13441,9 @@ public struct TupleType: TypeBuildable, ExpressibleAsTupleType {
     var result = TupleTypeSyntax(unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format), leftParen: leftParen.buildToken(format: format), unexpectedBetweenLeftParenAndElements?.buildUnexpectedNodes(format: format), elements: elements.buildTupleTypeElementList(format: format), unexpectedBetweenElementsAndRightParen?.buildUnexpectedNodes(format: format), rightParen: rightParen.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -12528,8 +13473,9 @@ public struct TupleType: TypeBuildable, ExpressibleAsTupleType {
 }
 public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftParen: UnexpectedNodes?
   var leftParen: Token
   var unexpectedBetweenLeftParenAndArguments: UnexpectedNodes?
@@ -12560,8 +13506,9 @@ public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
   ///   - arrow: 
   ///   - unexpectedBetweenArrowAndReturnType: 
   ///   - returnType: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndArguments: ExpressibleAsUnexpectedNodes? = nil, arguments: ExpressibleAsTupleTypeElementList, unexpectedBetweenArgumentsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`, unexpectedBetweenRightParenAndAsyncKeyword: ExpressibleAsUnexpectedNodes? = nil, asyncKeyword: Token? = nil, unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword: ExpressibleAsUnexpectedNodes? = nil, throwsOrRethrowsKeyword: Token? = nil, unexpectedBetweenThrowsOrRethrowsKeywordAndArrow: ExpressibleAsUnexpectedNodes? = nil, arrow: Token = Token.`arrow`, unexpectedBetweenArrowAndReturnType: ExpressibleAsUnexpectedNodes? = nil, returnType: ExpressibleAsTypeBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndArguments: ExpressibleAsUnexpectedNodes? = nil, arguments: ExpressibleAsTupleTypeElementList, unexpectedBetweenArgumentsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`, unexpectedBetweenRightParenAndAsyncKeyword: ExpressibleAsUnexpectedNodes? = nil, asyncKeyword: Token? = nil, unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword: ExpressibleAsUnexpectedNodes? = nil, throwsOrRethrowsKeyword: Token? = nil, unexpectedBetweenThrowsOrRethrowsKeywordAndArrow: ExpressibleAsUnexpectedNodes? = nil, arrow: Token = Token.`arrow`, unexpectedBetweenArrowAndReturnType: ExpressibleAsUnexpectedNodes? = nil, returnType: ExpressibleAsTypeBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftParen = unexpectedBeforeLeftParen?.createUnexpectedNodes()
     self.leftParen = leftParen
     assert(leftParen.text == #"("#)
@@ -12591,6 +13538,9 @@ public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `TypeBuildable`.
@@ -12619,8 +13569,9 @@ public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
 }
 public struct AttributedType: TypeBuildable, ExpressibleAsAttributedType {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeSpecifier: UnexpectedNodes?
   var specifier: Token?
   var unexpectedBetweenSpecifierAndAttributes: UnexpectedNodes?
@@ -12635,8 +13586,9 @@ public struct AttributedType: TypeBuildable, ExpressibleAsAttributedType {
   ///   - attributes: 
   ///   - unexpectedBetweenAttributesAndBaseType: 
   ///   - baseType: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeSpecifier: ExpressibleAsUnexpectedNodes? = nil, specifier: Token? = nil, unexpectedBetweenSpecifierAndAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndBaseType: ExpressibleAsUnexpectedNodes? = nil, baseType: ExpressibleAsTypeBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeSpecifier: ExpressibleAsUnexpectedNodes? = nil, specifier: Token? = nil, unexpectedBetweenSpecifierAndAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndBaseType: ExpressibleAsUnexpectedNodes? = nil, baseType: ExpressibleAsTypeBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeSpecifier = unexpectedBeforeSpecifier?.createUnexpectedNodes()
     self.specifier = specifier
     assert(specifier == nil || specifier!.text == #"inout"# || specifier!.text == #"__shared"# || specifier!.text == #"__owned"#)
@@ -12653,6 +13605,9 @@ public struct AttributedType: TypeBuildable, ExpressibleAsAttributedType {
     var result = AttributedTypeSyntax(unexpectedBeforeSpecifier?.buildUnexpectedNodes(format: format), specifier: specifier?.buildToken(format: format), unexpectedBetweenSpecifierAndAttributes?.buildUnexpectedNodes(format: format), attributes: attributes?.buildAttributeList(format: format), unexpectedBetweenAttributesAndBaseType?.buildUnexpectedNodes(format: format), baseType: baseType.buildType(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -12682,8 +13637,9 @@ public struct AttributedType: TypeBuildable, ExpressibleAsAttributedType {
 }
 public struct GenericArgument: SyntaxBuildable, ExpressibleAsGenericArgument, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeArgumentType: UnexpectedNodes?
   var argumentType: TypeBuildable
   var unexpectedBetweenArgumentTypeAndTrailingComma: UnexpectedNodes?
@@ -12694,8 +13650,9 @@ public struct GenericArgument: SyntaxBuildable, ExpressibleAsGenericArgument, Ha
   ///   - argumentType: 
   ///   - unexpectedBetweenArgumentTypeAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeArgumentType: ExpressibleAsUnexpectedNodes? = nil, argumentType: ExpressibleAsTypeBuildable, unexpectedBetweenArgumentTypeAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeArgumentType: ExpressibleAsUnexpectedNodes? = nil, argumentType: ExpressibleAsTypeBuildable, unexpectedBetweenArgumentTypeAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeArgumentType = unexpectedBeforeArgumentType?.createUnexpectedNodes()
     self.argumentType = argumentType.createTypeBuildable()
     self.unexpectedBetweenArgumentTypeAndTrailingComma = unexpectedBetweenArgumentTypeAndTrailingComma?.createUnexpectedNodes()
@@ -12710,6 +13667,9 @@ public struct GenericArgument: SyntaxBuildable, ExpressibleAsGenericArgument, Ha
     var result = GenericArgumentSyntax(unexpectedBeforeArgumentType?.buildUnexpectedNodes(format: format), argumentType: argumentType.buildType(format: format), unexpectedBetweenArgumentTypeAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -12738,8 +13698,9 @@ public struct GenericArgument: SyntaxBuildable, ExpressibleAsGenericArgument, Ha
 }
 public struct GenericArgumentClause: SyntaxBuildable, ExpressibleAsGenericArgumentClause {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftAngleBracket: UnexpectedNodes?
   var leftAngleBracket: Token
   var unexpectedBetweenLeftAngleBracketAndArguments: UnexpectedNodes?
@@ -12754,8 +13715,9 @@ public struct GenericArgumentClause: SyntaxBuildable, ExpressibleAsGenericArgume
   ///   - arguments: 
   ///   - unexpectedBetweenArgumentsAndRightAngleBracket: 
   ///   - rightAngleBracket: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftAngleBracket: ExpressibleAsUnexpectedNodes? = nil, leftAngleBracket: Token = Token.`leftAngle`, unexpectedBetweenLeftAngleBracketAndArguments: ExpressibleAsUnexpectedNodes? = nil, arguments: ExpressibleAsGenericArgumentList, unexpectedBetweenArgumentsAndRightAngleBracket: ExpressibleAsUnexpectedNodes? = nil, rightAngleBracket: Token = Token.`rightAngle`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftAngleBracket: ExpressibleAsUnexpectedNodes? = nil, leftAngleBracket: Token = Token.`leftAngle`, unexpectedBetweenLeftAngleBracketAndArguments: ExpressibleAsUnexpectedNodes? = nil, arguments: ExpressibleAsGenericArgumentList, unexpectedBetweenArgumentsAndRightAngleBracket: ExpressibleAsUnexpectedNodes? = nil, rightAngleBracket: Token = Token.`rightAngle`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftAngleBracket = unexpectedBeforeLeftAngleBracket?.createUnexpectedNodes()
     self.leftAngleBracket = leftAngleBracket
     assert(leftAngleBracket.text == #"<"#)
@@ -12782,6 +13744,9 @@ public struct GenericArgumentClause: SyntaxBuildable, ExpressibleAsGenericArgume
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -12803,8 +13768,9 @@ public struct GenericArgumentClause: SyntaxBuildable, ExpressibleAsGenericArgume
 }
 public struct TypeAnnotation: SyntaxBuildable, ExpressibleAsTypeAnnotation {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeColon: UnexpectedNodes?
   var colon: Token
   var unexpectedBetweenColonAndType: UnexpectedNodes?
@@ -12815,8 +13781,9 @@ public struct TypeAnnotation: SyntaxBuildable, ExpressibleAsTypeAnnotation {
   ///   - colon: 
   ///   - unexpectedBetweenColonAndType: 
   ///   - type: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeColon = unexpectedBeforeColon?.createUnexpectedNodes()
     self.colon = colon
     assert(colon.text == #":"#)
@@ -12831,6 +13798,9 @@ public struct TypeAnnotation: SyntaxBuildable, ExpressibleAsTypeAnnotation {
     var result = TypeAnnotationSyntax(unexpectedBeforeColon?.buildUnexpectedNodes(format: format), colon: colon.buildToken(format: format), unexpectedBetweenColonAndType?.buildUnexpectedNodes(format: format), type: type.buildType(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -12853,8 +13823,9 @@ public struct TypeAnnotation: SyntaxBuildable, ExpressibleAsTypeAnnotation {
 }
 public struct EnumCasePattern: PatternBuildable, ExpressibleAsEnumCasePattern {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeType: UnexpectedNodes?
   var type: TypeBuildable?
   var unexpectedBetweenTypeAndPeriod: UnexpectedNodes?
@@ -12873,8 +13844,9 @@ public struct EnumCasePattern: PatternBuildable, ExpressibleAsEnumCasePattern {
   ///   - caseName: 
   ///   - unexpectedBetweenCaseNameAndAssociatedTuple: 
   ///   - associatedTuple: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable? = nil, unexpectedBetweenTypeAndPeriod: ExpressibleAsUnexpectedNodes? = nil, period: Token = Token.`period`, unexpectedBetweenPeriodAndCaseName: ExpressibleAsUnexpectedNodes? = nil, caseName: Token, unexpectedBetweenCaseNameAndAssociatedTuple: ExpressibleAsUnexpectedNodes? = nil, associatedTuple: ExpressibleAsTuplePattern? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable? = nil, unexpectedBetweenTypeAndPeriod: ExpressibleAsUnexpectedNodes? = nil, period: Token = Token.`period`, unexpectedBetweenPeriodAndCaseName: ExpressibleAsUnexpectedNodes? = nil, caseName: Token, unexpectedBetweenCaseNameAndAssociatedTuple: ExpressibleAsUnexpectedNodes? = nil, associatedTuple: ExpressibleAsTuplePattern? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeType = unexpectedBeforeType?.createUnexpectedNodes()
     self.type = type?.createTypeBuildable()
     self.unexpectedBetweenTypeAndPeriod = unexpectedBetweenTypeAndPeriod?.createUnexpectedNodes()
@@ -12899,6 +13871,9 @@ public struct EnumCasePattern: PatternBuildable, ExpressibleAsEnumCasePattern {
     var result = EnumCasePatternSyntax(unexpectedBeforeType?.buildUnexpectedNodes(format: format), type: type?.buildType(format: format), unexpectedBetweenTypeAndPeriod?.buildUnexpectedNodes(format: format), period: period.buildToken(format: format), unexpectedBetweenPeriodAndCaseName?.buildUnexpectedNodes(format: format), caseName: caseName.buildToken(format: format), unexpectedBetweenCaseNameAndAssociatedTuple?.buildUnexpectedNodes(format: format), associatedTuple: associatedTuple?.buildTuplePattern(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -12928,8 +13903,9 @@ public struct EnumCasePattern: PatternBuildable, ExpressibleAsEnumCasePattern {
 }
 public struct IsTypePattern: PatternBuildable, ExpressibleAsIsTypePattern {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeIsKeyword: UnexpectedNodes?
   var isKeyword: Token
   var unexpectedBetweenIsKeywordAndType: UnexpectedNodes?
@@ -12940,8 +13916,9 @@ public struct IsTypePattern: PatternBuildable, ExpressibleAsIsTypePattern {
   ///   - isKeyword: 
   ///   - unexpectedBetweenIsKeywordAndType: 
   ///   - type: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeIsKeyword: ExpressibleAsUnexpectedNodes? = nil, isKeyword: Token = Token.`is`, unexpectedBetweenIsKeywordAndType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIsKeyword: ExpressibleAsUnexpectedNodes? = nil, isKeyword: Token = Token.`is`, unexpectedBetweenIsKeywordAndType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeIsKeyword = unexpectedBeforeIsKeyword?.createUnexpectedNodes()
     self.isKeyword = isKeyword
     assert(isKeyword.text == #"is"#)
@@ -12956,6 +13933,9 @@ public struct IsTypePattern: PatternBuildable, ExpressibleAsIsTypePattern {
     var result = IsTypePatternSyntax(unexpectedBeforeIsKeyword?.buildUnexpectedNodes(format: format), isKeyword: isKeyword.buildToken(format: format), unexpectedBetweenIsKeywordAndType?.buildUnexpectedNodes(format: format), type: type.buildType(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -12985,8 +13965,9 @@ public struct IsTypePattern: PatternBuildable, ExpressibleAsIsTypePattern {
 }
 public struct OptionalPattern: PatternBuildable, ExpressibleAsOptionalPattern {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeSubPattern: UnexpectedNodes?
   var subPattern: PatternBuildable
   var unexpectedBetweenSubPatternAndQuestionMark: UnexpectedNodes?
@@ -12997,8 +13978,9 @@ public struct OptionalPattern: PatternBuildable, ExpressibleAsOptionalPattern {
   ///   - subPattern: 
   ///   - unexpectedBetweenSubPatternAndQuestionMark: 
   ///   - questionMark: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeSubPattern: ExpressibleAsUnexpectedNodes? = nil, subPattern: ExpressibleAsPatternBuildable, unexpectedBetweenSubPatternAndQuestionMark: ExpressibleAsUnexpectedNodes? = nil, questionMark: Token = Token.`postfixQuestionMark`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeSubPattern: ExpressibleAsUnexpectedNodes? = nil, subPattern: ExpressibleAsPatternBuildable, unexpectedBetweenSubPatternAndQuestionMark: ExpressibleAsUnexpectedNodes? = nil, questionMark: Token = Token.`postfixQuestionMark`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeSubPattern = unexpectedBeforeSubPattern?.createUnexpectedNodes()
     self.subPattern = subPattern.createPatternBuildable()
     self.unexpectedBetweenSubPatternAndQuestionMark = unexpectedBetweenSubPatternAndQuestionMark?.createUnexpectedNodes()
@@ -13013,6 +13995,9 @@ public struct OptionalPattern: PatternBuildable, ExpressibleAsOptionalPattern {
     var result = OptionalPatternSyntax(unexpectedBeforeSubPattern?.buildUnexpectedNodes(format: format), subPattern: subPattern.buildPattern(format: format), unexpectedBetweenSubPatternAndQuestionMark?.buildUnexpectedNodes(format: format), questionMark: questionMark.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -13042,16 +14027,18 @@ public struct OptionalPattern: PatternBuildable, ExpressibleAsOptionalPattern {
 }
 public struct IdentifierPattern: PatternBuildable, ExpressibleAsIdentifierPattern {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeIdentifier: UnexpectedNodes?
   var identifier: Token
   /// Creates a `IdentifierPattern` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeIdentifier: 
   ///   - identifier: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeIdentifier = unexpectedBeforeIdentifier?.createUnexpectedNodes()
     self.identifier = identifier
   }
@@ -13063,6 +14050,9 @@ public struct IdentifierPattern: PatternBuildable, ExpressibleAsIdentifierPatter
     var result = IdentifierPatternSyntax(unexpectedBeforeIdentifier?.buildUnexpectedNodes(format: format), identifier: identifier.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -13092,8 +14082,9 @@ public struct IdentifierPattern: PatternBuildable, ExpressibleAsIdentifierPatter
 }
 public struct AsTypePattern: PatternBuildable, ExpressibleAsAsTypePattern {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePattern: UnexpectedNodes?
   var pattern: PatternBuildable
   var unexpectedBetweenPatternAndAsKeyword: UnexpectedNodes?
@@ -13108,8 +14099,9 @@ public struct AsTypePattern: PatternBuildable, ExpressibleAsAsTypePattern {
   ///   - asKeyword: 
   ///   - unexpectedBetweenAsKeywordAndType: 
   ///   - type: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndAsKeyword: ExpressibleAsUnexpectedNodes? = nil, asKeyword: Token = Token.`as`, unexpectedBetweenAsKeywordAndType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndAsKeyword: ExpressibleAsUnexpectedNodes? = nil, asKeyword: Token = Token.`as`, unexpectedBetweenAsKeywordAndType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePattern = unexpectedBeforePattern?.createUnexpectedNodes()
     self.pattern = pattern.createPatternBuildable()
     self.unexpectedBetweenPatternAndAsKeyword = unexpectedBetweenPatternAndAsKeyword?.createUnexpectedNodes()
@@ -13126,6 +14118,9 @@ public struct AsTypePattern: PatternBuildable, ExpressibleAsAsTypePattern {
     var result = AsTypePatternSyntax(unexpectedBeforePattern?.buildUnexpectedNodes(format: format), pattern: pattern.buildPattern(format: format), unexpectedBetweenPatternAndAsKeyword?.buildUnexpectedNodes(format: format), asKeyword: asKeyword.buildToken(format: format), unexpectedBetweenAsKeywordAndType?.buildUnexpectedNodes(format: format), type: type.buildType(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -13155,8 +14150,9 @@ public struct AsTypePattern: PatternBuildable, ExpressibleAsAsTypePattern {
 }
 public struct TuplePattern: PatternBuildable, ExpressibleAsTuplePattern {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLeftParen: UnexpectedNodes?
   var leftParen: Token
   var unexpectedBetweenLeftParenAndElements: UnexpectedNodes?
@@ -13171,8 +14167,9 @@ public struct TuplePattern: PatternBuildable, ExpressibleAsTuplePattern {
   ///   - elements: 
   ///   - unexpectedBetweenElementsAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElements: ExpressibleAsUnexpectedNodes? = nil, elements: ExpressibleAsTuplePatternElementList, unexpectedBetweenElementsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElements: ExpressibleAsUnexpectedNodes? = nil, elements: ExpressibleAsTuplePatternElementList, unexpectedBetweenElementsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLeftParen = unexpectedBeforeLeftParen?.createUnexpectedNodes()
     self.leftParen = leftParen
     assert(leftParen.text == #"("#)
@@ -13198,6 +14195,9 @@ public struct TuplePattern: PatternBuildable, ExpressibleAsTuplePattern {
     var result = TuplePatternSyntax(unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format), leftParen: leftParen.buildToken(format: format), unexpectedBetweenLeftParenAndElements?.buildUnexpectedNodes(format: format), elements: elements.buildTuplePatternElementList(format: format), unexpectedBetweenElementsAndRightParen?.buildUnexpectedNodes(format: format), rightParen: rightParen.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -13227,8 +14227,9 @@ public struct TuplePattern: PatternBuildable, ExpressibleAsTuplePattern {
 }
 public struct WildcardPattern: PatternBuildable, ExpressibleAsWildcardPattern {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeWildcard: UnexpectedNodes?
   var wildcard: Token
   var unexpectedBetweenWildcardAndTypeAnnotation: UnexpectedNodes?
@@ -13239,8 +14240,9 @@ public struct WildcardPattern: PatternBuildable, ExpressibleAsWildcardPattern {
   ///   - wildcard: 
   ///   - unexpectedBetweenWildcardAndTypeAnnotation: 
   ///   - typeAnnotation: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeWildcard: ExpressibleAsUnexpectedNodes? = nil, wildcard: Token = Token.`wildcard`, unexpectedBetweenWildcardAndTypeAnnotation: ExpressibleAsUnexpectedNodes? = nil, typeAnnotation: ExpressibleAsTypeAnnotation? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWildcard: ExpressibleAsUnexpectedNodes? = nil, wildcard: Token = Token.`wildcard`, unexpectedBetweenWildcardAndTypeAnnotation: ExpressibleAsUnexpectedNodes? = nil, typeAnnotation: ExpressibleAsTypeAnnotation? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeWildcard = unexpectedBeforeWildcard?.createUnexpectedNodes()
     self.wildcard = wildcard
     assert(wildcard.text == #"_"#)
@@ -13255,6 +14257,9 @@ public struct WildcardPattern: PatternBuildable, ExpressibleAsWildcardPattern {
     var result = WildcardPatternSyntax(unexpectedBeforeWildcard?.buildUnexpectedNodes(format: format), wildcard: wildcard.buildToken(format: format), unexpectedBetweenWildcardAndTypeAnnotation?.buildUnexpectedNodes(format: format), typeAnnotation: typeAnnotation?.buildTypeAnnotation(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -13284,8 +14289,9 @@ public struct WildcardPattern: PatternBuildable, ExpressibleAsWildcardPattern {
 }
 public struct TuplePatternElement: SyntaxBuildable, ExpressibleAsTuplePatternElement, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLabelName: UnexpectedNodes?
   var labelName: Token?
   var unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodes?
@@ -13304,8 +14310,9 @@ public struct TuplePatternElement: SyntaxBuildable, ExpressibleAsTuplePatternEle
   ///   - pattern: 
   ///   - unexpectedBetweenPatternAndTrailingComma: 
   ///   - trailingComma: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLabelName: ExpressibleAsUnexpectedNodes? = nil, labelName: Token? = nil, unexpectedBetweenLabelNameAndLabelColon: ExpressibleAsUnexpectedNodes? = nil, labelColon: Token? = nil, unexpectedBetweenLabelColonAndPattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabelName: ExpressibleAsUnexpectedNodes? = nil, labelName: Token? = nil, unexpectedBetweenLabelNameAndLabelColon: ExpressibleAsUnexpectedNodes? = nil, labelColon: Token? = nil, unexpectedBetweenLabelColonAndPattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLabelName = unexpectedBeforeLabelName?.createUnexpectedNodes()
     self.labelName = labelName
     self.unexpectedBetweenLabelNameAndLabelColon = unexpectedBetweenLabelNameAndLabelColon?.createUnexpectedNodes()
@@ -13334,6 +14341,9 @@ public struct TuplePatternElement: SyntaxBuildable, ExpressibleAsTuplePatternEle
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -13361,16 +14371,18 @@ public struct TuplePatternElement: SyntaxBuildable, ExpressibleAsTuplePatternEle
 }
 public struct ExpressionPattern: PatternBuildable, ExpressibleAsExpressionPattern {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeExpression: UnexpectedNodes?
   var expression: ExprBuildable
   /// Creates a `ExpressionPattern` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeExpression: 
   ///   - expression: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeExpression = unexpectedBeforeExpression?.createUnexpectedNodes()
     self.expression = expression.createExprBuildable()
   }
@@ -13382,6 +14394,9 @@ public struct ExpressionPattern: PatternBuildable, ExpressibleAsExpressionPatter
     var result = ExpressionPatternSyntax(unexpectedBeforeExpression?.buildUnexpectedNodes(format: format), expression: expression.buildExpr(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -13411,8 +14426,9 @@ public struct ExpressionPattern: PatternBuildable, ExpressibleAsExpressionPatter
 }
 public struct ValueBindingPattern: PatternBuildable, ExpressibleAsValueBindingPattern {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLetOrVarKeyword: UnexpectedNodes?
   var letOrVarKeyword: Token
   var unexpectedBetweenLetOrVarKeywordAndValuePattern: UnexpectedNodes?
@@ -13423,8 +14439,9 @@ public struct ValueBindingPattern: PatternBuildable, ExpressibleAsValueBindingPa
   ///   - letOrVarKeyword: 
   ///   - unexpectedBetweenLetOrVarKeywordAndValuePattern: 
   ///   - valuePattern: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLetOrVarKeyword: ExpressibleAsUnexpectedNodes? = nil, letOrVarKeyword: Token, unexpectedBetweenLetOrVarKeywordAndValuePattern: ExpressibleAsUnexpectedNodes? = nil, valuePattern: ExpressibleAsPatternBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLetOrVarKeyword: ExpressibleAsUnexpectedNodes? = nil, letOrVarKeyword: Token, unexpectedBetweenLetOrVarKeywordAndValuePattern: ExpressibleAsUnexpectedNodes? = nil, valuePattern: ExpressibleAsPatternBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLetOrVarKeyword = unexpectedBeforeLetOrVarKeyword?.createUnexpectedNodes()
     self.letOrVarKeyword = letOrVarKeyword
     assert(letOrVarKeyword.text == #"let"# || letOrVarKeyword.text == #"var"#)
@@ -13439,6 +14456,9 @@ public struct ValueBindingPattern: PatternBuildable, ExpressibleAsValueBindingPa
     var result = ValueBindingPatternSyntax(unexpectedBeforeLetOrVarKeyword?.buildUnexpectedNodes(format: format), letOrVarKeyword: letOrVarKeyword.buildToken(format: format), unexpectedBetweenLetOrVarKeywordAndValuePattern?.buildUnexpectedNodes(format: format), valuePattern: valuePattern.buildPattern(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -13469,8 +14489,9 @@ public struct ValueBindingPattern: PatternBuildable, ExpressibleAsValueBindingPa
 /// A single argument to an `@available` argument like `*`, `iOS 10.1`,or `message: "This has been deprecated"`.
 public struct AvailabilityArgument: SyntaxBuildable, ExpressibleAsAvailabilityArgument {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeEntry: UnexpectedNodes?
   var entry: SyntaxBuildable
   var unexpectedBetweenEntryAndTrailingComma: UnexpectedNodes?
@@ -13481,8 +14502,9 @@ public struct AvailabilityArgument: SyntaxBuildable, ExpressibleAsAvailabilityAr
   ///   - entry: The actual argument
   ///   - unexpectedBetweenEntryAndTrailingComma: 
   ///   - trailingComma: A trailing comma if the argument is followed by anotherargument
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeEntry: ExpressibleAsUnexpectedNodes? = nil, entry: ExpressibleAsSyntaxBuildable, unexpectedBetweenEntryAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeEntry: ExpressibleAsUnexpectedNodes? = nil, entry: ExpressibleAsSyntaxBuildable, unexpectedBetweenEntryAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeEntry = unexpectedBeforeEntry?.createUnexpectedNodes()
     self.entry = entry.createSyntaxBuildable()
     self.unexpectedBetweenEntryAndTrailingComma = unexpectedBetweenEntryAndTrailingComma?.createUnexpectedNodes()
@@ -13497,6 +14519,9 @@ public struct AvailabilityArgument: SyntaxBuildable, ExpressibleAsAvailabilityAr
     var result = AvailabilityArgumentSyntax(unexpectedBeforeEntry?.buildUnexpectedNodes(format: format), entry: entry.buildSyntax(format: format), unexpectedBetweenEntryAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: trailingComma?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -13520,8 +14545,9 @@ public struct AvailabilityArgument: SyntaxBuildable, ExpressibleAsAvailabilityAr
 /// A argument to an `@available` attribute that consists of a label anda value, e.g. `message: "This has been deprecated"`.
 public struct AvailabilityLabeledArgument: SyntaxBuildable, ExpressibleAsAvailabilityLabeledArgument {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeLabel: UnexpectedNodes?
   var label: Token
   var unexpectedBetweenLabelAndColon: UnexpectedNodes?
@@ -13536,8 +14562,9 @@ public struct AvailabilityLabeledArgument: SyntaxBuildable, ExpressibleAsAvailab
   ///   - colon: The colon separating label and value
   ///   - unexpectedBetweenColonAndValue: 
   ///   - value: The value of this labeled argument
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: ExpressibleAsUnexpectedNodes? = nil, value: ExpressibleAsSyntaxBuildable) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: Token, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: ExpressibleAsUnexpectedNodes? = nil, value: ExpressibleAsSyntaxBuildable) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeLabel = unexpectedBeforeLabel?.createUnexpectedNodes()
     self.label = label
     self.unexpectedBetweenLabelAndColon = unexpectedBetweenLabelAndColon?.createUnexpectedNodes()
@@ -13561,6 +14588,9 @@ public struct AvailabilityLabeledArgument: SyntaxBuildable, ExpressibleAsAvailab
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
     return format._format(syntax: result)
   }
   /// Conformance to `SyntaxBuildable`.
@@ -13583,8 +14613,9 @@ public struct AvailabilityLabeledArgument: SyntaxBuildable, ExpressibleAsAvailab
 /// An argument to `@available` that restricts the availability on acertain platform to a version, e.g. `iOS 10` or `swift 3.4`.
 public struct AvailabilityVersionRestriction: SyntaxBuildable, ExpressibleAsAvailabilityVersionRestriction {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforePlatform: UnexpectedNodes?
   var platform: Token
   var unexpectedBetweenPlatformAndVersion: UnexpectedNodes?
@@ -13595,8 +14626,9 @@ public struct AvailabilityVersionRestriction: SyntaxBuildable, ExpressibleAsAvai
   ///   - platform: The name of the OS on which the availability should berestricted or 'swift' if the availability should berestricted based on a Swift version.
   ///   - unexpectedBetweenPlatformAndVersion: 
   ///   - version: 
-  public init (leadingTrivia: Trivia = [], unexpectedBeforePlatform: ExpressibleAsUnexpectedNodes? = nil, platform: Token, unexpectedBetweenPlatformAndVersion: ExpressibleAsUnexpectedNodes? = nil, version: ExpressibleAsVersionTuple? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePlatform: ExpressibleAsUnexpectedNodes? = nil, platform: Token, unexpectedBetweenPlatformAndVersion: ExpressibleAsUnexpectedNodes? = nil, version: ExpressibleAsVersionTuple? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforePlatform = unexpectedBeforePlatform?.createUnexpectedNodes()
     self.platform = platform
     self.unexpectedBetweenPlatformAndVersion = unexpectedBetweenPlatformAndVersion?.createUnexpectedNodes()
@@ -13616,6 +14648,9 @@ public struct AvailabilityVersionRestriction: SyntaxBuildable, ExpressibleAsAvai
     var result = AvailabilityVersionRestrictionSyntax(unexpectedBeforePlatform?.buildUnexpectedNodes(format: format), platform: platform.buildToken(format: format), unexpectedBetweenPlatformAndVersion?.buildUnexpectedNodes(format: format), version: version?.buildVersionTuple(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }
@@ -13639,8 +14674,9 @@ public struct AvailabilityVersionRestriction: SyntaxBuildable, ExpressibleAsAvai
 /// A version number of the form major.minor.patch in which the minorand patch part may be omitted.
 public struct VersionTuple: SyntaxBuildable, ExpressibleAsVersionTuple {
   /// The leading trivia attached to this syntax node once built.
-  /// This is typically used to add comments (e.g. for documentation).
   var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
   var unexpectedBeforeMajorMinor: UnexpectedNodes?
   var majorMinor: SyntaxBuildable
   var unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodes?
@@ -13655,8 +14691,9 @@ public struct VersionTuple: SyntaxBuildable, ExpressibleAsVersionTuple {
   ///   - patchPeriod: If the version contains a patch number, the periodseparating the minor from the patch number.
   ///   - unexpectedBetweenPatchPeriodAndPatchVersion: 
   ///   - patchVersion: The patch version if specified.
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeMajorMinor: ExpressibleAsUnexpectedNodes? = nil, majorMinor: ExpressibleAsSyntaxBuildable, unexpectedBetweenMajorMinorAndPatchPeriod: ExpressibleAsUnexpectedNodes? = nil, patchPeriod: Token? = nil, unexpectedBetweenPatchPeriodAndPatchVersion: ExpressibleAsUnexpectedNodes? = nil, patchVersion: Token? = nil) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeMajorMinor: ExpressibleAsUnexpectedNodes? = nil, majorMinor: ExpressibleAsSyntaxBuildable, unexpectedBetweenMajorMinorAndPatchPeriod: ExpressibleAsUnexpectedNodes? = nil, patchPeriod: Token? = nil, unexpectedBetweenPatchPeriodAndPatchVersion: ExpressibleAsUnexpectedNodes? = nil, patchVersion: Token? = nil) {
     self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeMajorMinor = unexpectedBeforeMajorMinor?.createUnexpectedNodes()
     self.majorMinor = majorMinor.createSyntaxBuildable()
     self.unexpectedBetweenMajorMinorAndPatchPeriod = unexpectedBetweenMajorMinorAndPatchPeriod?.createUnexpectedNodes()
@@ -13681,6 +14718,9 @@ public struct VersionTuple: SyntaxBuildable, ExpressibleAsVersionTuple {
     var result = VersionTupleSyntax(unexpectedBeforeMajorMinor?.buildUnexpectedNodes(format: format), majorMinor: majorMinor.buildSyntax(format: format), unexpectedBetweenMajorMinorAndPatchPeriod?.buildUnexpectedNodes(format: format), patchPeriod: patchPeriod?.buildToken(format: format), unexpectedBetweenPatchPeriodAndPatchVersion?.buildUnexpectedNodes(format: format), patchVersion: patchVersion?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
     }
     return format._format(syntax: result)
   }

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -75,6 +75,16 @@ public struct CodeBlockItem: SyntaxBuildable, ExpressibleAsCodeBlockItem {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct CodeBlock: SyntaxBuildable, ExpressibleAsCodeBlock {
   /// The leading trivia attached to this syntax node once built.
@@ -145,6 +155,16 @@ public struct CodeBlock: SyntaxBuildable, ExpressibleAsCodeBlock {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct InOutExpr: ExprBuildable, ExpressibleAsInOutExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -207,6 +227,16 @@ public struct InOutExpr: ExprBuildable, ExpressibleAsInOutExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct PoundColumnExpr: ExprBuildable, ExpressibleAsPoundColumnExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -262,6 +292,16 @@ public struct PoundColumnExpr: ExprBuildable, ExpressibleAsPoundColumnExpr {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct TryExpr: ExprBuildable, ExpressibleAsTryExpr {
@@ -332,6 +372,16 @@ public struct TryExpr: ExprBuildable, ExpressibleAsTryExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct AwaitExpr: ExprBuildable, ExpressibleAsAwaitExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -399,6 +449,16 @@ public struct AwaitExpr: ExprBuildable, ExpressibleAsAwaitExpr {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct MoveExpr: ExprBuildable, ExpressibleAsMoveExpr {
@@ -468,6 +528,16 @@ public struct MoveExpr: ExprBuildable, ExpressibleAsMoveExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct DeclNameArgument: SyntaxBuildable, ExpressibleAsDeclNameArgument {
   /// The leading trivia attached to this syntax node once built.
@@ -522,6 +592,16 @@ public struct DeclNameArgument: SyntaxBuildable, ExpressibleAsDeclNameArgument {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct DeclNameArguments: SyntaxBuildable, ExpressibleAsDeclNameArguments {
@@ -585,6 +665,16 @@ public struct DeclNameArguments: SyntaxBuildable, ExpressibleAsDeclNameArguments
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct IdentifierExpr: ExprBuildable, ExpressibleAsIdentifierExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -646,6 +736,16 @@ public struct IdentifierExpr: ExprBuildable, ExpressibleAsIdentifierExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct SuperRefExpr: ExprBuildable, ExpressibleAsSuperRefExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -701,6 +801,16 @@ public struct SuperRefExpr: ExprBuildable, ExpressibleAsSuperRefExpr {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct NilLiteralExpr: ExprBuildable, ExpressibleAsNilLiteralExpr {
@@ -758,6 +868,16 @@ public struct NilLiteralExpr: ExprBuildable, ExpressibleAsNilLiteralExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct DiscardAssignmentExpr: ExprBuildable, ExpressibleAsDiscardAssignmentExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -814,6 +934,16 @@ public struct DiscardAssignmentExpr: ExprBuildable, ExpressibleAsDiscardAssignme
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct AssignmentExpr: ExprBuildable, ExpressibleAsAssignmentExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -869,6 +999,16 @@ public struct AssignmentExpr: ExprBuildable, ExpressibleAsAssignmentExpr {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct SequenceExpr: ExprBuildable, ExpressibleAsSequenceExpr {
@@ -933,6 +1073,16 @@ public struct SequenceExpr: ExprBuildable, ExpressibleAsSequenceExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct PoundLineExpr: ExprBuildable, ExpressibleAsPoundLineExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -988,6 +1138,16 @@ public struct PoundLineExpr: ExprBuildable, ExpressibleAsPoundLineExpr {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct PoundFileExpr: ExprBuildable, ExpressibleAsPoundFileExpr {
@@ -1045,6 +1205,16 @@ public struct PoundFileExpr: ExprBuildable, ExpressibleAsPoundFileExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct PoundFileIDExpr: ExprBuildable, ExpressibleAsPoundFileIDExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -1100,6 +1270,16 @@ public struct PoundFileIDExpr: ExprBuildable, ExpressibleAsPoundFileIDExpr {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct PoundFilePathExpr: ExprBuildable, ExpressibleAsPoundFilePathExpr {
@@ -1157,6 +1337,16 @@ public struct PoundFilePathExpr: ExprBuildable, ExpressibleAsPoundFilePathExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct PoundFunctionExpr: ExprBuildable, ExpressibleAsPoundFunctionExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -1213,6 +1403,16 @@ public struct PoundFunctionExpr: ExprBuildable, ExpressibleAsPoundFunctionExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct PoundDsohandleExpr: ExprBuildable, ExpressibleAsPoundDsohandleExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -1268,6 +1468,16 @@ public struct PoundDsohandleExpr: ExprBuildable, ExpressibleAsPoundDsohandleExpr
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct SymbolicReferenceExpr: ExprBuildable, ExpressibleAsSymbolicReferenceExpr {
@@ -1335,6 +1545,16 @@ public struct SymbolicReferenceExpr: ExprBuildable, ExpressibleAsSymbolicReferen
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct PrefixOperatorExpr: ExprBuildable, ExpressibleAsPrefixOperatorExpr {
@@ -1405,6 +1625,16 @@ public struct PrefixOperatorExpr: ExprBuildable, ExpressibleAsPrefixOperatorExpr
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct BinaryOperatorExpr: ExprBuildable, ExpressibleAsBinaryOperatorExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -1459,6 +1689,16 @@ public struct BinaryOperatorExpr: ExprBuildable, ExpressibleAsBinaryOperatorExpr
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct ArrowExpr: ExprBuildable, ExpressibleAsArrowExpr {
@@ -1538,6 +1778,16 @@ public struct ArrowExpr: ExprBuildable, ExpressibleAsArrowExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct InfixOperatorExpr: ExprBuildable, ExpressibleAsInfixOperatorExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -1605,6 +1855,16 @@ public struct InfixOperatorExpr: ExprBuildable, ExpressibleAsInfixOperatorExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct FloatLiteralExpr: ExprBuildable, ExpressibleAsFloatLiteralExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -1665,6 +1925,16 @@ public struct FloatLiteralExpr: ExprBuildable, ExpressibleAsFloatLiteralExpr {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct TupleExpr: ExprBuildable, ExpressibleAsTupleExpr {
@@ -1743,6 +2013,16 @@ public struct TupleExpr: ExprBuildable, ExpressibleAsTupleExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ArrayExpr: ExprBuildable, ExpressibleAsArrayExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -1820,6 +2100,16 @@ public struct ArrayExpr: ExprBuildable, ExpressibleAsArrayExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct DictionaryExpr: ExprBuildable, ExpressibleAsDictionaryExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -1888,6 +2178,16 @@ public struct DictionaryExpr: ExprBuildable, ExpressibleAsDictionaryExpr {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct TupleExprElement: SyntaxBuildable, ExpressibleAsTupleExprElement, HasTrailingComma {
@@ -1963,6 +2263,16 @@ public struct TupleExprElement: SyntaxBuildable, ExpressibleAsTupleExprElement, 
     result.trailingComma = withComma ? .comma : nil
     return result
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ArrayElement: SyntaxBuildable, ExpressibleAsArrayElement, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
@@ -2022,6 +2332,16 @@ public struct ArrayElement: SyntaxBuildable, ExpressibleAsArrayElement, HasTrail
   public func withTrailingComma(_ withComma: Bool) -> Self {
     var result = self
     result.trailingComma = withComma ? .comma : nil
+    return result
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
     return result
   }
 }
@@ -2098,6 +2418,16 @@ public struct DictionaryElement: SyntaxBuildable, ExpressibleAsDictionaryElement
     result.trailingComma = withComma ? .comma : nil
     return result
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct IntegerLiteralExpr: ExprBuildable, ExpressibleAsIntegerLiteralExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -2159,6 +2489,16 @@ public struct IntegerLiteralExpr: ExprBuildable, ExpressibleAsIntegerLiteralExpr
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct BooleanLiteralExpr: ExprBuildable, ExpressibleAsBooleanLiteralExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -2214,6 +2554,16 @@ public struct BooleanLiteralExpr: ExprBuildable, ExpressibleAsBooleanLiteralExpr
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct UnresolvedTernaryExpr: ExprBuildable, ExpressibleAsUnresolvedTernaryExpr {
@@ -2283,6 +2633,16 @@ public struct UnresolvedTernaryExpr: ExprBuildable, ExpressibleAsUnresolvedTerna
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct TernaryExpr: ExprBuildable, ExpressibleAsTernaryExpr {
@@ -2365,6 +2725,16 @@ public struct TernaryExpr: ExprBuildable, ExpressibleAsTernaryExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct MemberAccessExpr: ExprBuildable, ExpressibleAsMemberAccessExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -2439,6 +2809,16 @@ public struct MemberAccessExpr: ExprBuildable, ExpressibleAsMemberAccessExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct UnresolvedIsExpr: ExprBuildable, ExpressibleAsUnresolvedIsExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -2494,6 +2874,16 @@ public struct UnresolvedIsExpr: ExprBuildable, ExpressibleAsUnresolvedIsExpr {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct IsExpr: ExprBuildable, ExpressibleAsIsExpr {
@@ -2563,6 +2953,16 @@ public struct IsExpr: ExprBuildable, ExpressibleAsIsExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct UnresolvedAsExpr: ExprBuildable, ExpressibleAsUnresolvedAsExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -2625,6 +3025,16 @@ public struct UnresolvedAsExpr: ExprBuildable, ExpressibleAsUnresolvedAsExpr {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct AsExpr: ExprBuildable, ExpressibleAsAsExpr {
@@ -2701,6 +3111,16 @@ public struct AsExpr: ExprBuildable, ExpressibleAsAsExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct TypeExpr: ExprBuildable, ExpressibleAsTypeExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -2755,6 +3175,16 @@ public struct TypeExpr: ExprBuildable, ExpressibleAsTypeExpr {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct ClosureCaptureItem: SyntaxBuildable, ExpressibleAsClosureCaptureItem, HasTrailingComma {
@@ -2844,6 +3274,16 @@ public struct ClosureCaptureItem: SyntaxBuildable, ExpressibleAsClosureCaptureIt
     result.trailingComma = withComma ? .comma : nil
     return result
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ClosureCaptureSignature: SyntaxBuildable, ExpressibleAsClosureCaptureSignature {
   /// The leading trivia attached to this syntax node once built.
@@ -2914,6 +3354,16 @@ public struct ClosureCaptureSignature: SyntaxBuildable, ExpressibleAsClosureCapt
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ClosureParam: SyntaxBuildable, ExpressibleAsClosureParam, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
@@ -2973,6 +3423,16 @@ public struct ClosureParam: SyntaxBuildable, ExpressibleAsClosureParam, HasTrail
   public func withTrailingComma(_ withComma: Bool) -> Self {
     var result = self
     result.trailingComma = withComma ? .comma : nil
+    return result
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
     return result
   }
 }
@@ -3070,6 +3530,16 @@ public struct ClosureSignature: SyntaxBuildable, ExpressibleAsClosureSignature {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ClosureExpr: ExprBuildable, ExpressibleAsClosureExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -3153,6 +3623,16 @@ public struct ClosureExpr: ExprBuildable, ExpressibleAsClosureExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct UnresolvedPatternExpr: ExprBuildable, ExpressibleAsUnresolvedPatternExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -3207,6 +3687,16 @@ public struct UnresolvedPatternExpr: ExprBuildable, ExpressibleAsUnresolvedPatte
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct MultipleTrailingClosureElement: SyntaxBuildable, ExpressibleAsMultipleTrailingClosureElement {
@@ -3268,6 +3758,16 @@ public struct MultipleTrailingClosureElement: SyntaxBuildable, ExpressibleAsMult
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct FunctionCallExpr: ExprBuildable, ExpressibleAsFunctionCallExpr {
@@ -3364,6 +3864,16 @@ public struct FunctionCallExpr: ExprBuildable, ExpressibleAsFunctionCallExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct SubscriptExpr: ExprBuildable, ExpressibleAsSubscriptExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -3459,6 +3969,16 @@ public struct SubscriptExpr: ExprBuildable, ExpressibleAsSubscriptExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct OptionalChainingExpr: ExprBuildable, ExpressibleAsOptionalChainingExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -3521,6 +4041,16 @@ public struct OptionalChainingExpr: ExprBuildable, ExpressibleAsOptionalChaining
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ForcedValueExpr: ExprBuildable, ExpressibleAsForcedValueExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -3582,6 +4112,16 @@ public struct ForcedValueExpr: ExprBuildable, ExpressibleAsForcedValueExpr {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct PostfixUnaryExpr: ExprBuildable, ExpressibleAsPostfixUnaryExpr {
@@ -3650,6 +4190,16 @@ public struct PostfixUnaryExpr: ExprBuildable, ExpressibleAsPostfixUnaryExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct SpecializeExpr: ExprBuildable, ExpressibleAsSpecializeExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -3711,6 +4261,16 @@ public struct SpecializeExpr: ExprBuildable, ExpressibleAsSpecializeExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct StringSegment: SyntaxBuildable, ExpressibleAsStringSegment {
   /// The leading trivia attached to this syntax node once built.
@@ -3764,6 +4324,16 @@ public struct StringSegment: SyntaxBuildable, ExpressibleAsStringSegment {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct ExpressionSegment: SyntaxBuildable, ExpressibleAsExpressionSegment {
@@ -3849,6 +4419,16 @@ public struct ExpressionSegment: SyntaxBuildable, ExpressibleAsExpressionSegment
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct StringLiteralExpr: ExprBuildable, ExpressibleAsStringLiteralExpr {
@@ -3941,6 +4521,16 @@ public struct StringLiteralExpr: ExprBuildable, ExpressibleAsStringLiteralExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct RegexLiteralExpr: ExprBuildable, ExpressibleAsRegexLiteralExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -4001,6 +4591,16 @@ public struct RegexLiteralExpr: ExprBuildable, ExpressibleAsRegexLiteralExpr {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct KeyPathExpr: ExprBuildable, ExpressibleAsKeyPathExpr {
@@ -4070,6 +4670,16 @@ public struct KeyPathExpr: ExprBuildable, ExpressibleAsKeyPathExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct KeyPathBaseExpr: ExprBuildable, ExpressibleAsKeyPathBaseExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -4125,6 +4735,16 @@ public struct KeyPathBaseExpr: ExprBuildable, ExpressibleAsKeyPathBaseExpr {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct ObjcNamePiece: SyntaxBuildable, ExpressibleAsObjcNamePiece {
@@ -4186,6 +4806,16 @@ public struct ObjcNamePiece: SyntaxBuildable, ExpressibleAsObjcNamePiece {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct ObjcKeyPathExpr: ExprBuildable, ExpressibleAsObjcKeyPathExpr {
@@ -4262,6 +4892,16 @@ public struct ObjcKeyPathExpr: ExprBuildable, ExpressibleAsObjcKeyPathExpr {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct ObjcSelectorExpr: ExprBuildable, ExpressibleAsObjcSelectorExpr {
@@ -4361,6 +5001,16 @@ public struct ObjcSelectorExpr: ExprBuildable, ExpressibleAsObjcSelectorExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct PostfixIfConfigExpr: ExprBuildable, ExpressibleAsPostfixIfConfigExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -4422,6 +5072,16 @@ public struct PostfixIfConfigExpr: ExprBuildable, ExpressibleAsPostfixIfConfigEx
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct EditorPlaceholderExpr: ExprBuildable, ExpressibleAsEditorPlaceholderExpr {
   /// The leading trivia attached to this syntax node once built.
@@ -4482,6 +5142,16 @@ public struct EditorPlaceholderExpr: ExprBuildable, ExpressibleAsEditorPlacehold
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct ObjectLiteralExpr: ExprBuildable, ExpressibleAsObjectLiteralExpr {
@@ -4567,6 +5237,16 @@ public struct ObjectLiteralExpr: ExprBuildable, ExpressibleAsObjectLiteralExpr {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct TypeInitializerClause: SyntaxBuildable, ExpressibleAsTypeInitializerClause {
   /// The leading trivia attached to this syntax node once built.
@@ -4621,6 +5301,16 @@ public struct TypeInitializerClause: SyntaxBuildable, ExpressibleAsTypeInitializ
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct TypealiasDecl: DeclBuildable, ExpressibleAsTypealiasDecl {
@@ -4720,6 +5410,16 @@ public struct TypealiasDecl: DeclBuildable, ExpressibleAsTypealiasDecl {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct AssociatedtypeDecl: DeclBuildable, ExpressibleAsAssociatedtypeDecl {
   /// The leading trivia attached to this syntax node once built.
@@ -4818,6 +5518,16 @@ public struct AssociatedtypeDecl: DeclBuildable, ExpressibleAsAssociatedtypeDecl
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ParameterClause: SyntaxBuildable, ExpressibleAsParameterClause {
   /// The leading trivia attached to this syntax node once built.
@@ -4888,6 +5598,16 @@ public struct ParameterClause: SyntaxBuildable, ExpressibleAsParameterClause {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ReturnClause: SyntaxBuildable, ExpressibleAsReturnClause {
   /// The leading trivia attached to this syntax node once built.
@@ -4942,6 +5662,16 @@ public struct ReturnClause: SyntaxBuildable, ExpressibleAsReturnClause {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature {
@@ -5019,6 +5749,16 @@ public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct IfConfigClause: SyntaxBuildable, ExpressibleAsIfConfigClause {
   /// The leading trivia attached to this syntax node once built.
@@ -5079,6 +5819,16 @@ public struct IfConfigClause: SyntaxBuildable, ExpressibleAsIfConfigClause {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct IfConfigDecl: DeclBuildable, ExpressibleAsIfConfigDecl {
@@ -5141,6 +5891,16 @@ public struct IfConfigDecl: DeclBuildable, ExpressibleAsIfConfigDecl {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct PoundErrorDecl: DeclBuildable, ExpressibleAsPoundErrorDecl {
@@ -5218,6 +5978,16 @@ public struct PoundErrorDecl: DeclBuildable, ExpressibleAsPoundErrorDecl {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct PoundWarningDecl: DeclBuildable, ExpressibleAsPoundWarningDecl {
   /// The leading trivia attached to this syntax node once built.
@@ -5294,6 +6064,16 @@ public struct PoundWarningDecl: DeclBuildable, ExpressibleAsPoundWarningDecl {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct PoundSourceLocation: DeclBuildable, ExpressibleAsPoundSourceLocation {
   /// The leading trivia attached to this syntax node once built.
@@ -5369,6 +6149,16 @@ public struct PoundSourceLocation: DeclBuildable, ExpressibleAsPoundSourceLocati
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct PoundSourceLocationArgs: SyntaxBuildable, ExpressibleAsPoundSourceLocationArgs {
@@ -5465,6 +6255,16 @@ public struct PoundSourceLocationArgs: SyntaxBuildable, ExpressibleAsPoundSource
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct DeclModifierDetail: SyntaxBuildable, ExpressibleAsDeclModifierDetail {
   /// The leading trivia attached to this syntax node once built.
@@ -5533,6 +6333,16 @@ public struct DeclModifierDetail: SyntaxBuildable, ExpressibleAsDeclModifierDeta
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct DeclModifier: SyntaxBuildable, ExpressibleAsDeclModifier {
   /// The leading trivia attached to this syntax node once built.
@@ -5587,6 +6397,16 @@ public struct DeclModifier: SyntaxBuildable, ExpressibleAsDeclModifier {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct InheritedType: SyntaxBuildable, ExpressibleAsInheritedType, HasTrailingComma {
@@ -5647,6 +6467,16 @@ public struct InheritedType: SyntaxBuildable, ExpressibleAsInheritedType, HasTra
   public func withTrailingComma(_ withComma: Bool) -> Self {
     var result = self
     result.trailingComma = withComma ? .comma : nil
+    return result
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
     return result
   }
 }
@@ -5711,6 +6541,16 @@ public struct TypeInheritanceClause: SyntaxBuildable, ExpressibleAsTypeInheritan
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct ClassDecl: DeclBuildable, ExpressibleAsClassDecl {
@@ -5818,6 +6658,16 @@ public struct ClassDecl: DeclBuildable, ExpressibleAsClassDecl {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ActorDecl: DeclBuildable, ExpressibleAsActorDecl {
   /// The leading trivia attached to this syntax node once built.
@@ -5923,6 +6773,16 @@ public struct ActorDecl: DeclBuildable, ExpressibleAsActorDecl {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct StructDecl: DeclBuildable, ExpressibleAsStructDecl {
@@ -6030,6 +6890,16 @@ public struct StructDecl: DeclBuildable, ExpressibleAsStructDecl {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ProtocolDecl: DeclBuildable, ExpressibleAsProtocolDecl {
   /// The leading trivia attached to this syntax node once built.
@@ -6136,6 +7006,16 @@ public struct ProtocolDecl: DeclBuildable, ExpressibleAsProtocolDecl {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ExtensionDecl: DeclBuildable, ExpressibleAsExtensionDecl {
   /// The leading trivia attached to this syntax node once built.
@@ -6236,6 +7116,16 @@ public struct ExtensionDecl: DeclBuildable, ExpressibleAsExtensionDecl {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct MemberDeclBlock: SyntaxBuildable, ExpressibleAsMemberDeclBlock {
   /// The leading trivia attached to this syntax node once built.
@@ -6306,6 +7196,16 @@ public struct MemberDeclBlock: SyntaxBuildable, ExpressibleAsMemberDeclBlock {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// A member declaration of a type consisting of a declaration and anoptional semicolon;
 public struct MemberDeclListItem: SyntaxBuildable, ExpressibleAsMemberDeclListItem {
@@ -6361,6 +7261,16 @@ public struct MemberDeclListItem: SyntaxBuildable, ExpressibleAsMemberDeclListIt
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct SourceFile: SyntaxBuildable, ExpressibleAsSourceFile {
@@ -6424,6 +7334,16 @@ public struct SourceFile: SyntaxBuildable, ExpressibleAsSourceFile {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct InitializerClause: SyntaxBuildable, ExpressibleAsInitializerClause {
   /// The leading trivia attached to this syntax node once built.
@@ -6478,6 +7398,16 @@ public struct InitializerClause: SyntaxBuildable, ExpressibleAsInitializerClause
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct FunctionParameter: SyntaxBuildable, ExpressibleAsFunctionParameter, HasTrailingComma {
@@ -6576,6 +7506,16 @@ public struct FunctionParameter: SyntaxBuildable, ExpressibleAsFunctionParameter
   public func withTrailingComma(_ withComma: Bool) -> Self {
     var result = self
     result.trailingComma = withComma ? .comma : nil
+    return result
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
     return result
   }
 }
@@ -6684,6 +7624,16 @@ public struct FunctionDecl: DeclBuildable, ExpressibleAsFunctionDecl {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct InitializerDecl: DeclBuildable, ExpressibleAsInitializerDecl {
   /// The leading trivia attached to this syntax node once built.
@@ -6791,6 +7741,16 @@ public struct InitializerDecl: DeclBuildable, ExpressibleAsInitializerDecl {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct DeinitializerDecl: DeclBuildable, ExpressibleAsDeinitializerDecl {
   /// The leading trivia attached to this syntax node once built.
@@ -6872,6 +7832,16 @@ public struct DeinitializerDecl: DeclBuildable, ExpressibleAsDeinitializerDecl {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct SubscriptDecl: DeclBuildable, ExpressibleAsSubscriptDecl {
@@ -6971,6 +7941,16 @@ public struct SubscriptDecl: DeclBuildable, ExpressibleAsSubscriptDecl {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct AccessLevelModifier: SyntaxBuildable, ExpressibleAsAccessLevelModifier {
   /// The leading trivia attached to this syntax node once built.
@@ -7030,6 +8010,16 @@ public struct AccessLevelModifier: SyntaxBuildable, ExpressibleAsAccessLevelModi
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct AccessPathComponent: SyntaxBuildable, ExpressibleAsAccessPathComponent {
@@ -7091,6 +8081,16 @@ public struct AccessPathComponent: SyntaxBuildable, ExpressibleAsAccessPathCompo
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct ImportDecl: DeclBuildable, ExpressibleAsImportDecl {
@@ -7173,6 +8173,16 @@ public struct ImportDecl: DeclBuildable, ExpressibleAsImportDecl {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct AccessorParameter: SyntaxBuildable, ExpressibleAsAccessorParameter {
   /// The leading trivia attached to this syntax node once built.
@@ -7240,6 +8250,16 @@ public struct AccessorParameter: SyntaxBuildable, ExpressibleAsAccessorParameter
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct AccessorDecl: DeclBuildable, ExpressibleAsAccessorDecl {
@@ -7345,6 +8365,16 @@ public struct AccessorDecl: DeclBuildable, ExpressibleAsAccessorDecl {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct AccessorBlock: SyntaxBuildable, ExpressibleAsAccessorBlock {
   /// The leading trivia attached to this syntax node once built.
@@ -7406,6 +8436,16 @@ public struct AccessorBlock: SyntaxBuildable, ExpressibleAsAccessorBlock {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct PatternBinding: SyntaxBuildable, ExpressibleAsPatternBinding, HasTrailingComma {
@@ -7484,6 +8524,16 @@ public struct PatternBinding: SyntaxBuildable, ExpressibleAsPatternBinding, HasT
   public func withTrailingComma(_ withComma: Bool) -> Self {
     var result = self
     result.trailingComma = withComma ? .comma : nil
+    return result
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
     return result
   }
 }
@@ -7568,6 +8618,16 @@ public struct VariableDecl: DeclBuildable, ExpressibleAsVariableDecl {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// An element of an enum case, containing the name of the case and,optionally, either associated values or an assignment to a raw value.
 public struct EnumCaseElement: SyntaxBuildable, ExpressibleAsEnumCaseElement, HasTrailingComma {
@@ -7646,6 +8706,16 @@ public struct EnumCaseElement: SyntaxBuildable, ExpressibleAsEnumCaseElement, Ha
   public func withTrailingComma(_ withComma: Bool) -> Self {
     var result = self
     result.trailingComma = withComma ? .comma : nil
+    return result
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
     return result
   }
 }
@@ -7730,6 +8800,16 @@ public struct EnumCaseDecl: DeclBuildable, ExpressibleAsEnumCaseDecl {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 /// A Swift `enum` declaration.
@@ -7838,6 +8918,16 @@ public struct EnumDecl: DeclBuildable, ExpressibleAsEnumDecl {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// A Swift `operator` declaration.
 public struct OperatorDecl: DeclBuildable, ExpressibleAsOperatorDecl {
@@ -7919,6 +9009,16 @@ public struct OperatorDecl: DeclBuildable, ExpressibleAsOperatorDecl {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// A clause to specify precedence group in infix operator declarations, and designated types in any operator declaration.
 public struct OperatorPrecedenceAndTypes: SyntaxBuildable, ExpressibleAsOperatorPrecedenceAndTypes {
@@ -7974,6 +9074,16 @@ public struct OperatorPrecedenceAndTypes: SyntaxBuildable, ExpressibleAsOperator
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 /// A Swift `precedencegroup` declaration.
@@ -8076,6 +9186,16 @@ public struct PrecedenceGroupDecl: DeclBuildable, ExpressibleAsPrecedenceGroupDe
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// Specify the new precedence group's relation to existing precedencegroups.
 public struct PrecedenceGroupRelation: SyntaxBuildable, ExpressibleAsPrecedenceGroupRelation {
@@ -8145,6 +9265,16 @@ public struct PrecedenceGroupRelation: SyntaxBuildable, ExpressibleAsPrecedenceG
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct PrecedenceGroupNameElement: SyntaxBuildable, ExpressibleAsPrecedenceGroupNameElement {
   /// The leading trivia attached to this syntax node once built.
@@ -8205,6 +9335,16 @@ public struct PrecedenceGroupNameElement: SyntaxBuildable, ExpressibleAsPreceden
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 /// Specifies the precedence of an operator when used in an operationthat includes optional chaining.
@@ -8276,6 +9416,16 @@ public struct PrecedenceGroupAssignment: SyntaxBuildable, ExpressibleAsPrecedenc
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// Specifies how a sequence of operators with the same precedence levelare grouped together in the absence of grouping parentheses.
 public struct PrecedenceGroupAssociativity: SyntaxBuildable, ExpressibleAsPrecedenceGroupAssociativity {
@@ -8345,6 +9495,16 @@ public struct PrecedenceGroupAssociativity: SyntaxBuildable, ExpressibleAsPreced
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 /// A custom `@` attribute.
@@ -8430,6 +9590,16 @@ public struct CustomAttribute: SyntaxBuildable, ExpressibleAsCustomAttribute {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// An `@` attribute.
 public struct Attribute: SyntaxBuildable, ExpressibleAsAttribute {
@@ -8512,6 +9682,16 @@ public struct Attribute: SyntaxBuildable, ExpressibleAsAttribute {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// The availability argument for the _specialize attribute
 public struct AvailabilityEntry: SyntaxBuildable, ExpressibleAsAvailabilityEntry {
@@ -8586,6 +9766,16 @@ public struct AvailabilityEntry: SyntaxBuildable, ExpressibleAsAvailabilityEntry
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 /// A labeled argument for the `@_specialize` attribute like`exported: true`
@@ -8666,6 +9856,16 @@ public struct LabeledSpecializeEntry: SyntaxBuildable, ExpressibleAsLabeledSpeci
   public func withTrailingComma(_ withComma: Bool) -> Self {
     var result = self
     result.trailingComma = withComma ? .comma : nil
+    return result
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
     return result
   }
 }
@@ -8749,6 +9949,16 @@ public struct TargetFunctionEntry: SyntaxBuildable, ExpressibleAsTargetFunctionE
     result.trailingComma = withComma ? .comma : nil
     return result
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// The argument for the `@_dynamic_replacement` or `@_private`attribute of the form `for: "function()"` or `sourceFile:"Src.swift"`
 public struct NamedAttributeStringArgument: SyntaxBuildable, ExpressibleAsNamedAttributeStringArgument {
@@ -8811,6 +10021,16 @@ public struct NamedAttributeStringArgument: SyntaxBuildable, ExpressibleAsNamedA
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct DeclName: SyntaxBuildable, ExpressibleAsDeclName {
   /// The leading trivia attached to this syntax node once built.
@@ -8864,6 +10084,16 @@ public struct DeclName: SyntaxBuildable, ExpressibleAsDeclName {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 /// The arguments for the `@_implements` attribute of the form`Type, methodName(arg1Label:arg2Label:)`
@@ -8933,6 +10163,16 @@ public struct ImplementsAttributeArguments: SyntaxBuildable, ExpressibleAsImplem
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// A piece of an Objective-C selector. Either consisting of just anidentifier for a nullary selector, an identifier and a colon for alabeled argument or just a colon for an unlabeled argument
 public struct ObjCSelectorPiece: SyntaxBuildable, ExpressibleAsObjCSelectorPiece {
@@ -8996,6 +10236,16 @@ public struct ObjCSelectorPiece: SyntaxBuildable, ExpressibleAsObjCSelectorPiece
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 /// The arguments for the `@differentiable` attribute: an optionaldifferentiability kind, an optional differentiability parameter clause,and an optional 'where' clause.
@@ -9081,6 +10331,16 @@ public struct DifferentiableAttributeArguments: SyntaxBuildable, ExpressibleAsDi
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// A clause containing differentiability parameters.
 public struct DifferentiabilityParamsClause: SyntaxBuildable, ExpressibleAsDifferentiabilityParamsClause {
@@ -9150,6 +10410,16 @@ public struct DifferentiabilityParamsClause: SyntaxBuildable, ExpressibleAsDiffe
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// The differentiability parameters.
 public struct DifferentiabilityParams: SyntaxBuildable, ExpressibleAsDifferentiabilityParams {
@@ -9213,6 +10483,16 @@ public struct DifferentiabilityParams: SyntaxBuildable, ExpressibleAsDifferentia
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// A differentiability parameter: either the "self" identifier, a functionparameter name, or a function parameter index.
 public struct DifferentiabilityParam: SyntaxBuildable, ExpressibleAsDifferentiabilityParam, HasTrailingComma {
@@ -9273,6 +10553,16 @@ public struct DifferentiabilityParam: SyntaxBuildable, ExpressibleAsDifferentiab
   public func withTrailingComma(_ withComma: Bool) -> Self {
     var result = self
     result.trailingComma = withComma ? .comma : nil
+    return result
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
     return result
   }
 }
@@ -9373,6 +10663,16 @@ public struct DerivativeRegistrationAttributeArguments: SyntaxBuildable, Express
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// An optionally qualified function declaration name (e.g. `+(_:_:)`,`A.B.C.foo(_:_:)`).
 public struct QualifiedDeclName: SyntaxBuildable, ExpressibleAsQualifiedDeclName {
@@ -9441,6 +10741,16 @@ public struct QualifiedDeclName: SyntaxBuildable, ExpressibleAsQualifiedDeclName
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// A function declaration name (e.g. `foo(_:_:)`).
 public struct FunctionDeclName: SyntaxBuildable, ExpressibleAsFunctionDeclName {
@@ -9495,6 +10805,16 @@ public struct FunctionDeclName: SyntaxBuildable, ExpressibleAsFunctionDeclName {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 /// A collection of arguments for the `@_backDeploy` attribute
@@ -9565,6 +10885,16 @@ public struct BackDeployAttributeSpecList: SyntaxBuildable, ExpressibleAsBackDep
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// A single platform/version pair in a `@_backDeploy` attribute,e.g. `iOS 10.1`.
 public struct BackDeployVersionArgument: SyntaxBuildable, ExpressibleAsBackDeployVersionArgument {
@@ -9620,6 +10950,16 @@ public struct BackDeployVersionArgument: SyntaxBuildable, ExpressibleAsBackDeplo
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct LabeledStmt: StmtBuildable, ExpressibleAsLabeledStmt {
@@ -9695,6 +11035,16 @@ public struct LabeledStmt: StmtBuildable, ExpressibleAsLabeledStmt {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ContinueStmt: StmtBuildable, ExpressibleAsContinueStmt {
   /// The leading trivia attached to this syntax node once built.
@@ -9764,6 +11114,16 @@ public struct ContinueStmt: StmtBuildable, ExpressibleAsContinueStmt {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct WhileStmt: StmtBuildable, ExpressibleAsWhileStmt {
@@ -9841,6 +11201,16 @@ public struct WhileStmt: StmtBuildable, ExpressibleAsWhileStmt {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct DeferStmt: StmtBuildable, ExpressibleAsDeferStmt {
   /// The leading trivia attached to this syntax node once built.
@@ -9911,6 +11281,16 @@ public struct DeferStmt: StmtBuildable, ExpressibleAsDeferStmt {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ExpressionStmt: StmtBuildable, ExpressibleAsExpressionStmt {
   /// The leading trivia attached to this syntax node once built.
@@ -9965,6 +11345,16 @@ public struct ExpressionStmt: StmtBuildable, ExpressibleAsExpressionStmt {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct RepeatWhileStmt: StmtBuildable, ExpressibleAsRepeatWhileStmt {
@@ -10049,6 +11439,16 @@ public struct RepeatWhileStmt: StmtBuildable, ExpressibleAsRepeatWhileStmt {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct GuardStmt: StmtBuildable, ExpressibleAsGuardStmt {
   /// The leading trivia attached to this syntax node once built.
@@ -10132,6 +11532,16 @@ public struct GuardStmt: StmtBuildable, ExpressibleAsGuardStmt {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct WhereClause: SyntaxBuildable, ExpressibleAsWhereClause {
   /// The leading trivia attached to this syntax node once built.
@@ -10186,6 +11596,16 @@ public struct WhereClause: SyntaxBuildable, ExpressibleAsWhereClause {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct ForInStmt: StmtBuildable, ExpressibleAsForInStmt {
@@ -10311,6 +11731,16 @@ public struct ForInStmt: StmtBuildable, ExpressibleAsForInStmt {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct SwitchStmt: StmtBuildable, ExpressibleAsSwitchStmt {
   /// The leading trivia attached to this syntax node once built.
@@ -10401,6 +11831,16 @@ public struct SwitchStmt: StmtBuildable, ExpressibleAsSwitchStmt {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct DoStmt: StmtBuildable, ExpressibleAsDoStmt {
   /// The leading trivia attached to this syntax node once built.
@@ -10477,6 +11917,16 @@ public struct DoStmt: StmtBuildable, ExpressibleAsDoStmt {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ReturnStmt: StmtBuildable, ExpressibleAsReturnStmt {
   /// The leading trivia attached to this syntax node once built.
@@ -10539,6 +11989,16 @@ public struct ReturnStmt: StmtBuildable, ExpressibleAsReturnStmt {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct YieldStmt: StmtBuildable, ExpressibleAsYieldStmt {
   /// The leading trivia attached to this syntax node once built.
@@ -10600,6 +12060,16 @@ public struct YieldStmt: StmtBuildable, ExpressibleAsYieldStmt {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
@@ -10678,6 +12148,16 @@ public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct FallthroughStmt: StmtBuildable, ExpressibleAsFallthroughStmt {
   /// The leading trivia attached to this syntax node once built.
@@ -10733,6 +12213,16 @@ public struct FallthroughStmt: StmtBuildable, ExpressibleAsFallthroughStmt {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct BreakStmt: StmtBuildable, ExpressibleAsBreakStmt {
@@ -10804,6 +12294,16 @@ public struct BreakStmt: StmtBuildable, ExpressibleAsBreakStmt {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ConditionElement: SyntaxBuildable, ExpressibleAsConditionElement, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
@@ -10863,6 +12363,16 @@ public struct ConditionElement: SyntaxBuildable, ExpressibleAsConditionElement, 
   public func withTrailingComma(_ withComma: Bool) -> Self {
     var result = self
     result.trailingComma = withComma ? .comma : nil
+    return result
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
     return result
   }
 }
@@ -10934,6 +12444,16 @@ public struct AvailabilityCondition: SyntaxBuildable, ExpressibleAsAvailabilityC
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct MatchingPatternCondition: SyntaxBuildable, ExpressibleAsMatchingPatternCondition {
   /// The leading trivia attached to this syntax node once built.
@@ -11001,6 +12521,16 @@ public struct MatchingPatternCondition: SyntaxBuildable, ExpressibleAsMatchingPa
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct OptionalBindingCondition: SyntaxBuildable, ExpressibleAsOptionalBindingCondition {
   /// The leading trivia attached to this syntax node once built.
@@ -11067,6 +12597,16 @@ public struct OptionalBindingCondition: SyntaxBuildable, ExpressibleAsOptionalBi
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct UnavailabilityCondition: SyntaxBuildable, ExpressibleAsUnavailabilityCondition {
@@ -11137,6 +12677,16 @@ public struct UnavailabilityCondition: SyntaxBuildable, ExpressibleAsUnavailabil
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct DeclarationStmt: StmtBuildable, ExpressibleAsDeclarationStmt {
   /// The leading trivia attached to this syntax node once built.
@@ -11191,6 +12741,16 @@ public struct DeclarationStmt: StmtBuildable, ExpressibleAsDeclarationStmt {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct ThrowStmt: StmtBuildable, ExpressibleAsThrowStmt {
@@ -11253,6 +12813,16 @@ public struct ThrowStmt: StmtBuildable, ExpressibleAsThrowStmt {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct IfStmt: StmtBuildable, ExpressibleAsIfStmt {
@@ -11343,6 +12913,16 @@ public struct IfStmt: StmtBuildable, ExpressibleAsIfStmt {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ElseIfContinuation: SyntaxBuildable, ExpressibleAsElseIfContinuation {
   /// The leading trivia attached to this syntax node once built.
@@ -11390,6 +12970,16 @@ public struct ElseIfContinuation: SyntaxBuildable, ExpressibleAsElseIfContinuati
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct ElseBlock: SyntaxBuildable, ExpressibleAsElseBlock {
@@ -11453,6 +13043,16 @@ public struct ElseBlock: SyntaxBuildable, ExpressibleAsElseBlock {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct SwitchCase: SyntaxBuildable, ExpressibleAsSwitchCase {
@@ -11522,6 +13122,16 @@ public struct SwitchCase: SyntaxBuildable, ExpressibleAsSwitchCase {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct SwitchDefaultLabel: SyntaxBuildable, ExpressibleAsSwitchDefaultLabel {
   /// The leading trivia attached to this syntax node once built.
@@ -11577,6 +13187,16 @@ public struct SwitchDefaultLabel: SyntaxBuildable, ExpressibleAsSwitchDefaultLab
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct CaseItem: SyntaxBuildable, ExpressibleAsCaseItem, HasTrailingComma {
@@ -11645,6 +13265,16 @@ public struct CaseItem: SyntaxBuildable, ExpressibleAsCaseItem, HasTrailingComma
     result.trailingComma = withComma ? .comma : nil
     return result
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct CatchItem: SyntaxBuildable, ExpressibleAsCatchItem, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
@@ -11710,6 +13340,16 @@ public struct CatchItem: SyntaxBuildable, ExpressibleAsCatchItem, HasTrailingCom
   public func withTrailingComma(_ withComma: Bool) -> Self {
     var result = self
     result.trailingComma = withComma ? .comma : nil
+    return result
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
     return result
   }
 }
@@ -11782,6 +13422,16 @@ public struct SwitchCaseLabel: SyntaxBuildable, ExpressibleAsSwitchCaseLabel {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct CatchClause: SyntaxBuildable, ExpressibleAsCatchClause {
   /// The leading trivia attached to this syntax node once built.
@@ -11850,6 +13500,16 @@ public struct CatchClause: SyntaxBuildable, ExpressibleAsCatchClause {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct PoundAssertStmt: StmtBuildable, ExpressibleAsPoundAssertStmt {
@@ -11948,6 +13608,16 @@ public struct PoundAssertStmt: StmtBuildable, ExpressibleAsPoundAssertStmt {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct GenericWhereClause: SyntaxBuildable, ExpressibleAsGenericWhereClause {
   /// The leading trivia attached to this syntax node once built.
@@ -12011,6 +13681,16 @@ public struct GenericWhereClause: SyntaxBuildable, ExpressibleAsGenericWhereClau
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct GenericRequirement: SyntaxBuildable, ExpressibleAsGenericRequirement, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
@@ -12072,6 +13752,16 @@ public struct GenericRequirement: SyntaxBuildable, ExpressibleAsGenericRequireme
     result.trailingComma = withComma ? .comma : nil
     return result
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct SameTypeRequirement: SyntaxBuildable, ExpressibleAsSameTypeRequirement {
   /// The leading trivia attached to this syntax node once built.
@@ -12131,6 +13821,16 @@ public struct SameTypeRequirement: SyntaxBuildable, ExpressibleAsSameTypeRequire
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct LayoutRequirement: SyntaxBuildable, ExpressibleAsLayoutRequirement {
@@ -12236,6 +13936,16 @@ public struct LayoutRequirement: SyntaxBuildable, ExpressibleAsLayoutRequirement
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct GenericParameter: SyntaxBuildable, ExpressibleAsGenericParameter, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
@@ -12322,6 +14032,16 @@ public struct GenericParameter: SyntaxBuildable, ExpressibleAsGenericParameter, 
     result.trailingComma = withComma ? .comma : nil
     return result
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct PrimaryAssociatedType: SyntaxBuildable, ExpressibleAsPrimaryAssociatedType, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
@@ -12387,6 +14107,16 @@ public struct PrimaryAssociatedType: SyntaxBuildable, ExpressibleAsPrimaryAssoci
   public func withTrailingComma(_ withComma: Bool) -> Self {
     var result = self
     result.trailingComma = withComma ? .comma : nil
+    return result
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
     return result
   }
 }
@@ -12459,6 +14189,16 @@ public struct GenericParameterClause: SyntaxBuildable, ExpressibleAsGenericParam
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ConformanceRequirement: SyntaxBuildable, ExpressibleAsConformanceRequirement {
   /// The leading trivia attached to this syntax node once built.
@@ -12519,6 +14259,16 @@ public struct ConformanceRequirement: SyntaxBuildable, ExpressibleAsConformanceR
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct PrimaryAssociatedTypeClause: SyntaxBuildable, ExpressibleAsPrimaryAssociatedTypeClause {
@@ -12582,6 +14332,16 @@ public struct PrimaryAssociatedTypeClause: SyntaxBuildable, ExpressibleAsPrimary
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct SimpleTypeIdentifier: TypeBuildable, ExpressibleAsSimpleTypeIdentifier {
   /// The leading trivia attached to this syntax node once built.
@@ -12642,6 +14402,16 @@ public struct SimpleTypeIdentifier: TypeBuildable, ExpressibleAsSimpleTypeIdenti
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct MemberTypeIdentifier: TypeBuildable, ExpressibleAsMemberTypeIdentifier {
@@ -12717,6 +14487,16 @@ public struct MemberTypeIdentifier: TypeBuildable, ExpressibleAsMemberTypeIdenti
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ClassRestrictionType: TypeBuildable, ExpressibleAsClassRestrictionType {
   /// The leading trivia attached to this syntax node once built.
@@ -12772,6 +14552,16 @@ public struct ClassRestrictionType: TypeBuildable, ExpressibleAsClassRestriction
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct ArrayType: TypeBuildable, ExpressibleAsArrayType {
@@ -12841,6 +14631,16 @@ public struct ArrayType: TypeBuildable, ExpressibleAsArrayType {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct DictionaryType: TypeBuildable, ExpressibleAsDictionaryType {
@@ -12924,6 +14724,16 @@ public struct DictionaryType: TypeBuildable, ExpressibleAsDictionaryType {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct MetatypeType: TypeBuildable, ExpressibleAsMetatypeType {
   /// The leading trivia attached to this syntax node once built.
@@ -12999,6 +14809,16 @@ public struct MetatypeType: TypeBuildable, ExpressibleAsMetatypeType {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct OptionalType: TypeBuildable, ExpressibleAsOptionalType {
   /// The leading trivia attached to this syntax node once built.
@@ -13060,6 +14880,16 @@ public struct OptionalType: TypeBuildable, ExpressibleAsOptionalType {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct ConstrainedSugarType: TypeBuildable, ExpressibleAsConstrainedSugarType {
@@ -13129,6 +14959,16 @@ public struct ConstrainedSugarType: TypeBuildable, ExpressibleAsConstrainedSugar
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ImplicitlyUnwrappedOptionalType: TypeBuildable, ExpressibleAsImplicitlyUnwrappedOptionalType {
   /// The leading trivia attached to this syntax node once built.
@@ -13191,6 +15031,16 @@ public struct ImplicitlyUnwrappedOptionalType: TypeBuildable, ExpressibleAsImpli
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct CompositionTypeElement: SyntaxBuildable, ExpressibleAsCompositionTypeElement {
   /// The leading trivia attached to this syntax node once built.
@@ -13246,6 +15096,16 @@ public struct CompositionTypeElement: SyntaxBuildable, ExpressibleAsCompositionT
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct CompositionType: TypeBuildable, ExpressibleAsCompositionType {
   /// The leading trivia attached to this syntax node once built.
@@ -13300,6 +15160,16 @@ public struct CompositionType: TypeBuildable, ExpressibleAsCompositionType {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct TupleTypeElement: SyntaxBuildable, ExpressibleAsTupleTypeElement, HasTrailingComma {
@@ -13401,6 +15271,16 @@ public struct TupleTypeElement: SyntaxBuildable, ExpressibleAsTupleTypeElement, 
     result.trailingComma = withComma ? .comma : nil
     return result
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct TupleType: TypeBuildable, ExpressibleAsTupleType {
   /// The leading trivia attached to this syntax node once built.
@@ -13469,6 +15349,16 @@ public struct TupleType: TypeBuildable, ExpressibleAsTupleType {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
@@ -13566,6 +15456,16 @@ public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct AttributedType: TypeBuildable, ExpressibleAsAttributedType {
   /// The leading trivia attached to this syntax node once built.
@@ -13634,6 +15534,16 @@ public struct AttributedType: TypeBuildable, ExpressibleAsAttributedType {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct GenericArgument: SyntaxBuildable, ExpressibleAsGenericArgument, HasTrailingComma {
   /// The leading trivia attached to this syntax node once built.
@@ -13693,6 +15603,16 @@ public struct GenericArgument: SyntaxBuildable, ExpressibleAsGenericArgument, Ha
   public func withTrailingComma(_ withComma: Bool) -> Self {
     var result = self
     result.trailingComma = withComma ? .comma : nil
+    return result
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
     return result
   }
 }
@@ -13765,6 +15685,16 @@ public struct GenericArgumentClause: SyntaxBuildable, ExpressibleAsGenericArgume
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct TypeAnnotation: SyntaxBuildable, ExpressibleAsTypeAnnotation {
   /// The leading trivia attached to this syntax node once built.
@@ -13819,6 +15749,16 @@ public struct TypeAnnotation: SyntaxBuildable, ExpressibleAsTypeAnnotation {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct EnumCasePattern: PatternBuildable, ExpressibleAsEnumCasePattern {
@@ -13900,6 +15840,16 @@ public struct EnumCasePattern: PatternBuildable, ExpressibleAsEnumCasePattern {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct IsTypePattern: PatternBuildable, ExpressibleAsIsTypePattern {
   /// The leading trivia attached to this syntax node once built.
@@ -13961,6 +15911,16 @@ public struct IsTypePattern: PatternBuildable, ExpressibleAsIsTypePattern {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct OptionalPattern: PatternBuildable, ExpressibleAsOptionalPattern {
@@ -14024,6 +15984,16 @@ public struct OptionalPattern: PatternBuildable, ExpressibleAsOptionalPattern {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct IdentifierPattern: PatternBuildable, ExpressibleAsIdentifierPattern {
   /// The leading trivia attached to this syntax node once built.
@@ -14078,6 +16048,16 @@ public struct IdentifierPattern: PatternBuildable, ExpressibleAsIdentifierPatter
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct AsTypePattern: PatternBuildable, ExpressibleAsAsTypePattern {
@@ -14146,6 +16126,16 @@ public struct AsTypePattern: PatternBuildable, ExpressibleAsAsTypePattern {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct TuplePattern: PatternBuildable, ExpressibleAsTuplePattern {
@@ -14224,6 +16214,16 @@ public struct TuplePattern: PatternBuildable, ExpressibleAsTuplePattern {
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct WildcardPattern: PatternBuildable, ExpressibleAsWildcardPattern {
   /// The leading trivia attached to this syntax node once built.
@@ -14285,6 +16285,16 @@ public struct WildcardPattern: PatternBuildable, ExpressibleAsWildcardPattern {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct TuplePatternElement: SyntaxBuildable, ExpressibleAsTuplePatternElement, HasTrailingComma {
@@ -14368,6 +16378,16 @@ public struct TuplePatternElement: SyntaxBuildable, ExpressibleAsTuplePatternEle
     result.trailingComma = withComma ? .comma : nil
     return result
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 public struct ExpressionPattern: PatternBuildable, ExpressibleAsExpressionPattern {
   /// The leading trivia attached to this syntax node once built.
@@ -14422,6 +16442,16 @@ public struct ExpressionPattern: PatternBuildable, ExpressibleAsExpressionPatter
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 public struct ValueBindingPattern: PatternBuildable, ExpressibleAsValueBindingPattern {
@@ -14485,6 +16515,16 @@ public struct ValueBindingPattern: PatternBuildable, ExpressibleAsValueBindingPa
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// A single argument to an `@available` argument like `*`, `iOS 10.1`,or `message: "This has been deprecated"`.
 public struct AvailabilityArgument: SyntaxBuildable, ExpressibleAsAvailabilityArgument {
@@ -14540,6 +16580,16 @@ public struct AvailabilityArgument: SyntaxBuildable, ExpressibleAsAvailabilityAr
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 /// A argument to an `@available` attribute that consists of a label anda value, e.g. `message: "This has been deprecated"`.
@@ -14609,6 +16659,16 @@ public struct AvailabilityLabeledArgument: SyntaxBuildable, ExpressibleAsAvailab
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
   }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
 }
 /// An argument to `@available` that restricts the availability on acertain platform to a version, e.g. `iOS 10` or `swift 3.4`.
 public struct AvailabilityVersionRestriction: SyntaxBuildable, ExpressibleAsAvailabilityVersionRestriction {
@@ -14669,6 +16729,16 @@ public struct AvailabilityVersionRestriction: SyntaxBuildable, ExpressibleAsAvai
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }
 /// A version number of the form major.minor.patch in which the minorand patch part may be omitted.
@@ -14739,5 +16809,15 @@ public struct VersionTuple: SyntaxBuildable, ExpressibleAsVersionTuple {
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
     return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
   }
 }

--- a/Sources/generate-swift-syntax-builder/String+Extensions.swift
+++ b/Sources/generate-swift-syntax-builder/String+Extensions.swift
@@ -14,5 +14,6 @@ import Foundation
 
 extension StringProtocol {
     var withFirstCharacterLowercased: String { prefix(1).lowercased() + dropFirst() }
+    var withFirstCharacterUppercased: String { prefix(1).uppercased() + dropFirst() }
     var backticked: String { "`\(self)`" }
 }

--- a/Sources/generate-swift-syntax-builder/SyntaxUtilities.swift
+++ b/Sources/generate-swift-syntax-builder/SyntaxUtilities.swift
@@ -99,3 +99,59 @@ func createDisambiguatingExpressibleAsCreateFunction(type: SyntaxBuildableType, 
     "/// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.",
   ]) 
 }
+
+/// Generate a `withATrivia` function.
+func createWithTriviaFunction(trivia: String) -> FunctionDecl {
+  FunctionDecl(
+    modifiers: [Token.public],
+    identifier: .identifier("with\(trivia.withFirstCharacterUppercased)"),
+    signature: FunctionSignature(
+      input: ParameterClause {
+        FunctionParameter(
+          firstName: .wildcard,
+          secondName: .identifier(trivia),
+          colon: .colon,
+          type: "Trivia"
+        )
+      },
+      output: "Self"
+    )
+  ) {
+    VariableDecl(.var, name: "result", initializer: "self")
+    SequenceExpr {
+      MemberAccessExpr(base: "result", name: trivia)
+      AssignmentExpr()
+      trivia
+    }
+    ReturnStmt(expression: "result")
+  }
+}
+
+func createTriviaAttachment(varName: String, triviaVarName: String, trivia: String) -> IfStmt {
+  IfStmt(
+    conditions: ExprList {
+      PrefixOperatorExpr(
+        operatorToken: .prefixOperator("!"),
+        postfixExpression: MemberAccessExpr(base: triviaVarName, name: "isEmpty")
+      )
+    }
+  ) {
+    SequenceExpr {
+      varName
+      AssignmentExpr()
+      FunctionCallExpr(MemberAccessExpr(base: varName, name: "with\(trivia.withFirstCharacterUppercased)")) {
+        TupleExprElement(expression: SequenceExpr {
+          triviaVarName
+          BinaryOperatorExpr("+")
+          TupleExpr {
+            SequenceExpr {
+              MemberAccessExpr(base: varName, name: trivia)
+              BinaryOperatorExpr("??")
+              ArrayExpr()
+            }
+          }
+        })
+      }
+    }
+  }
+}

--- a/Sources/generate-swift-syntax-builder/Templates/BuildableNodesFile.swift
+++ b/Sources/generate-swift-syntax-builder/Templates/BuildableNodesFile.swift
@@ -69,6 +69,9 @@ let buildableNodesFile = SourceFile {
       if hasTrailingComma {
         createWithTrailingCommaFunction()
       }
+      for trivia in trivias {
+        createWithTriviaFunction(trivia: trivia)
+      }
     }
   }
 }
@@ -350,6 +353,33 @@ private func createWithTrailingCommaFunction() -> FunctionDecl {
         then: MemberAccessExpr(name: "comma"),
         else: NilLiteralExpr()
       )
+    }
+    ReturnStmt(expression: "result")
+  }
+}
+
+/// Generate a `withATrivia` function.
+private func createWithTriviaFunction(trivia: String) -> FunctionDecl {
+  FunctionDecl(
+    modifiers: [Token.public],
+    identifier: .identifier("with\(trivia.withFirstCharacterUppercased)"),
+    signature: FunctionSignature(
+      input: ParameterClause {
+        FunctionParameter(
+          firstName: .wildcard,
+          secondName: .identifier(trivia),
+          colon: .colon,
+          type: "Trivia"
+        )
+      },
+      output: "Self"
+    )
+  ) {
+    VariableDecl(.var, name: "result", initializer: "self")
+    SequenceExpr {
+      MemberAccessExpr(base: "result", name: trivia)
+      AssignmentExpr()
+      trivia
     }
     ReturnStmt(expression: "result")
   }

--- a/Sources/generate-swift-syntax-builder/Templates/BuildableNodesFile.swift
+++ b/Sources/generate-swift-syntax-builder/Templates/BuildableNodesFile.swift
@@ -264,32 +264,7 @@ private func createBuildFunction(node: Node, trivias: [String]) -> FunctionDecl 
       }
     )
     for trivia in trivias {
-      IfStmt(
-        conditions: ExprList {
-          PrefixOperatorExpr(
-            operatorToken: .prefixOperator("!"),
-            postfixExpression: MemberAccessExpr(base: trivia, name: "isEmpty")
-          )
-        }
-      ) {
-        SequenceExpr {
-          "result"
-          AssignmentExpr()
-          FunctionCallExpr(MemberAccessExpr(base: "result", name: "with\(trivia.withFirstCharacterUppercased)")) {
-            TupleExprElement(expression: SequenceExpr {
-              trivia
-              BinaryOperatorExpr("+")
-              TupleExpr {
-                SequenceExpr {
-                  MemberAccessExpr(base: "result", name: trivia)
-                  BinaryOperatorExpr("??")
-                  ArrayExpr()
-                }
-              }
-            })
-          }
-        }
-      }
+      createTriviaAttachment(varName: "result", triviaVarName: trivia, trivia: trivia)
     }
     ReturnStmt(expression: FunctionCallExpr(MemberAccessExpr(base: "format", name: "_format")) {
       TupleExprElement(
@@ -353,33 +328,6 @@ private func createWithTrailingCommaFunction() -> FunctionDecl {
         then: MemberAccessExpr(name: "comma"),
         else: NilLiteralExpr()
       )
-    }
-    ReturnStmt(expression: "result")
-  }
-}
-
-/// Generate a `withATrivia` function.
-private func createWithTriviaFunction(trivia: String) -> FunctionDecl {
-  FunctionDecl(
-    modifiers: [Token.public],
-    identifier: .identifier("with\(trivia.withFirstCharacterUppercased)"),
-    signature: FunctionSignature(
-      input: ParameterClause {
-        FunctionParameter(
-          firstName: .wildcard,
-          secondName: .identifier(trivia),
-          colon: .colon,
-          type: "Trivia"
-        )
-      },
-      output: "Self"
-    )
-  ) {
-    VariableDecl(.var, name: "result", initializer: "self")
-    SequenceExpr {
-      MemberAccessExpr(base: "result", name: trivia)
-      AssignmentExpr()
-      trivia
     }
     ReturnStmt(expression: "result")
   }

--- a/Tests/SwiftSyntaxBuilderTest/TriviaTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/TriviaTests.swift
@@ -50,4 +50,22 @@ final class TriviaTests: XCTestCase {
       XCTAssertEqual(syntax.description, expected, line: line)
     }
   }
+
+  func testAttachedListTrivia() {
+    let testCases: [UInt: (AttributeList, String)] = [
+      #line: (
+        AttributeList([CustomAttribute("Test")]).withLeadingTrivia(.space),
+        " @Test"
+      ),
+      #line: (
+        AttributeList([CustomAttribute("A").withTrailingTrivia(.space), CustomAttribute("B")]).withTrailingTrivia(.space),
+        "@A @B "
+      ),
+    ]
+    for (line, testCase) in testCases {
+      let (decl, expected) = testCase
+      let syntax = decl.buildSyntax(format: Format())
+      XCTAssertEqual(syntax.description, expected, line: line)
+    }
+  }
 }

--- a/Tests/SwiftSyntaxBuilderTest/TriviaTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/TriviaTests.swift
@@ -32,4 +32,22 @@ final class TriviaTests: XCTestCase {
     XCTAssertEqual(y, x + .space)
     XCTAssertEqual(y, [.newlines(1), .spaces(1)])
   }
+
+  func testAttachedTrivia() {
+    let testCases: [UInt: (VariableDecl, String)] = [
+      #line: (
+        VariableDecl(.let, name: "x", type: "Int").withLeadingTrivia(.space),
+        " let x: Int"
+      ),
+      #line: (
+        VariableDecl(.let, name: "x", type: "Int").withTrailingTrivia(.space),
+        "let x: Int "
+      ),
+    ]
+    for (line, testCase) in testCases {
+      let (decl, expected) = testCase
+      let syntax = decl.buildSyntax(format: Format())
+      XCTAssertEqual(syntax.description, expected, line: line)
+    }
+  }
 }


### PR DESCRIPTION
Based on #666.

This PR adds a `trailingTrivia` field to buildable `SwiftSyntaxBuilder` nodes, along with `withLeadingTrivia`/`withTrailingTrivia` functions.

To do:
- [x] Add `trailingTrivia` to buildable nodes
- [x] Add `leadingTrivia` and `trailingTrivia` to buildable collection nodes
- [x] Add `withLeadingTrivia` and `withTrailingTrivia`
- [x] Add unit tests

For a future PR:

- Add protocol(s) for `withLeadingTrivia`/`withTrailingTrivia` (e.g. `HasLeadingTrivia`/`HasTrailingTrivia` or just a combined `HasTrivia`) that buildable nodes, collection nodes and e.g. tokens could conform to