### PR TITLE
Introduce a C function that performs parser consistency checks.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -110,7 +110,8 @@ let package = Package(
       dependencies: ["SwiftDiagnostics", "SwiftSyntax"],
       exclude: [
         "CMakeLists.txt",
-        "README.md"
+        "README.md",
+        "SwiftParserCompilerSupport.h"
       ]
     ),
     .executableTarget(

--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -12,6 +12,7 @@ add_library(SwiftParser STATIC
   Declarations.swift
   Directives.swift
   CharacterInfo.swift
+  CompilerSupport.swift
   Attributes.swift
   Lookahead.swift
   Expressions.swift
@@ -39,7 +40,8 @@ set_property(GLOBAL APPEND PROPERTY SWIFTSYNTAX_EXPORTS SwiftParser)
 
 # NOTE: workaround for CMake not setting up include flags yet
 set_target_properties(SwiftParser PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
+  INTERFACE_INCLUDE_DIRECTORIES
+  "${CMAKE_Swift_MODULE_DIRECTORY} ${CMAKE_CURRENT_SOURCE_DIR}")
 
 install(TARGETS SwiftParser
   EXPORT SwiftSyntaxTargets

--- a/Sources/SwiftParser/CompilerSupport.swift
+++ b/Sources/SwiftParser/CompilerSupport.swift
@@ -37,7 +37,7 @@ public func _parserConsistencyCheck(
       var bufferArray = [UInt8](buffer)
       bufferArray.append(0)
       if "\(sourceFile)" != String(cString: bufferArray) {
-        debugPrint(
+        print(
           "\(String(cString: filename)): error: file failed to round-trip")
         return 1
       }

--- a/Sources/SwiftParser/CompilerSupport.swift
+++ b/Sources/SwiftParser/CompilerSupport.swift
@@ -1,0 +1,48 @@
+//===-------------------------- CompilerSupport.swift ---------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+/// Entry point for the Swift compiler to use for consistency checking.
+///
+/// - Parameters:
+///   - bufferPtr: Pointer to the input buffer.
+///   - bufferLength: Length of the input buffer.
+///   - filename: The name of the source file, which is used only for diagnostics
+///   - flags: Flags that indicate what checks should be performed.
+///       0x01: Perform round-trip checking.
+/// - Returns: 0 if all requested consistency checks passed, nonzero otherwise.
+@_cdecl("swift_parser_consistencyCheck")
+@_spi(SwiftCompiler)
+public func _parserConsistencyCheck(
+  bufferPtr: UnsafePointer<UInt8>, bufferLength: Int,
+  filename: UnsafePointer<UInt8>, flags: CUnsignedInt
+) -> CInt {
+  let buffer = UnsafeBufferPointer<UInt8>(
+    start: bufferPtr, count: bufferLength)
+  var parser = Parser(buffer)
+  return withExtendedLifetime(parser) { () -> CInt in
+    // Parse the source file
+    let sourceFile = parser.parseSourceFile()
+
+    // Round-trip test.
+    if flags & 0x01 != 0 {
+      var bufferArray = [UInt8](buffer)
+      bufferArray.append(0)
+      if "\(sourceFile)" != String(cString: bufferArray) {
+        debugPrint(
+          "\(String(cString: filename)): error: file failed to round-trip")
+        return 1
+      }
+    }
+
+    return 0
+  }
+}

--- a/Sources/SwiftParser/SwiftParserCompilerSupport.h
+++ b/Sources/SwiftParser/SwiftParserCompilerSupport.h
@@ -1,0 +1,44 @@
+/*===----------------------- SwiftParserCompilerSupport.h -------------------===
+
+   This source file is part of the Swift.org open source project
+
+   Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+   Licensed under Apache License v2.0 with Runtime Library Exception
+
+   See https://swift.org/LICENSE.txt for license information
+   See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+
+  ===----------------------------------------------------------------------===*/
+#ifndef SWIFT_PARSER_COMPILER_SUPPORT_H
+#define SWIFT_PARSER_COMPILER_SUPPORT_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum SwiftParserConsistencyCheckFlags {
+  /// Ensure that the syntax tree produced by the parser fully reproduces the
+  /// input source.
+  SPCC_RoundTrip = 0x01
+};
+
+/// Entry point for the Swift compiler to use for consistency checking.
+///
+/// - Parameters:
+///   - bufferPtr: Pointer to the input buffer.
+///   - bufferLength: Length of the input buffer.
+///   - filename: The name of the source file, which is used only for diagnostics
+///   - flags: Flags that indicate what checks should be performed.
+///       0x01: Perform round-trip checking.
+/// - Returns: 0 if all requested consistency checks passed, nonzero otherwise.
+int swift_parser_consistencyCheck(
+  const char *buffer, ptrdiff_t bufferLength, const char *filename,
+  unsigned int flags);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SWIFT_PARSER_COMPILER_SUPPORT_H */


### PR DESCRIPTION
Export a C function that can be used to perform various consistency
checks for each source file it processes. This will be used in the C++
compiler to improve testing coverage for the new parser.