### PR TITLE
Exclude `gyb_syntax_support` from Swift target

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -127,6 +127,7 @@ let package = Package(
         dependencies: ["SwiftSyntaxBuilder"],
         exclude: [
           "gyb_helpers",
+          "gyb_syntax_support",
           "AttributeNodes.swift.gyb",
           "AvailabilityNodes.swift.gyb",
           "BuilderInitializableTypes.swift.gyb",


### PR DESCRIPTION
Temporary Python compilation artifacts like `*.pyc` files tend to confuse the SPM build tool (i.e. cause a warning). Therefore this patch excludes `gyb_syntax_support` from `generate-swift-syntax-builder`, like `gyb_helpers`.