### PR TITLE
Implement recovery for declaration parsing

### DIFF
--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -129,10 +129,15 @@ extension Parser {
         case .deprecated:
           let argumentLabel = self.consumeAnyToken()
           if self.at(.colon) {
-            let colon = self.eat(.colon)
+            let (unexpectedBeforeColon, colon) = self.eat(.colon)
             let version = self.parseVersionTuple()
             entry = RawSyntax(RawAvailabilityLabeledArgumentSyntax(
-              label: argumentLabel, colon: colon, value: RawSyntax(version), arena: self.arena))
+              label: argumentLabel,
+              unexpectedBeforeColon,
+              colon: colon,
+              value: RawSyntax(version),
+              arena: self.arena
+            ))
           } else {
             entry = RawSyntax(argumentLabel)
           }

--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(SwiftParser STATIC
   Patterns.swift
   Availability.swift
   TriviaParser.swift
+  TokenClassification.swift
   TokenConsumer.swift
   Parser.swift
   Recovery.swift

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -68,14 +68,16 @@ extension Parser {
   ) -> RawIfConfigDeclSyntax {
     var clauses = [RawIfConfigClauseSyntax]()
     do {
-      var poundIf = self.eat(.poundIfKeyword)
+      var (unexpectedBeforePoundIf, poundIf) = self.eat(.poundIfKeyword)
       repeat {
         // Parse the condition.
         let condition: RawExprSyntax?
         if self.at(.poundElseKeyword) {
+          unexpectedBeforePoundIf = nil
           poundIf = self.consumeAnyToken()
           condition = nil
         } else if self.at(.poundElseifKeyword)  {
+          unexpectedBeforePoundIf = nil
           poundIf = self.consumeAnyToken()
           condition = RawExprSyntax(self.parseSequenceExpression(.basic, forDirective: true))
         } else {
@@ -94,6 +96,7 @@ extension Parser {
         }
 
         clauses.append(RawIfConfigClauseSyntax(
+          unexpectedBeforePoundIf,
           poundKeyword: poundIf,
           condition: condition,
           elements: syntax(&self, elements),
@@ -119,8 +122,12 @@ extension Parser {
   ///     literal-expression → '#line'
   @_spi(RawSyntax)
   public mutating func parsePoundLineDirective() -> RawPoundLineExprSyntax {
-    let token = self.eat(.poundLineKeyword)
-    return RawPoundLineExprSyntax(poundLine: token, arena: self.arena)
+    let (unexpectedBeforeToken, token) = self.eat(.poundLineKeyword)
+    return RawPoundLineExprSyntax(
+      unexpectedBeforeToken,
+      poundLine: token,
+      arena: self.arena
+    )
   }
 
   /// Parse a line control directive.

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -145,7 +145,7 @@ extension Parser.Lookahead {
     }
 
     repeat {
-      self.eat(.atSign)
+      self.eatWithoutRecovery(.atSign)
       self.consumeIdentifier()
       if self.consume(if: .leftParen) != nil {
         while !self.at(.eof), !self.at(.rightParen), !self.at(.poundEndifKeyword) {
@@ -310,9 +310,9 @@ extension Parser.Lookahead {
         self.isParenthesizedUnowned() {
       var lookahead = self.lookahead()
       lookahead.consumeIdentifier()
-      lookahead.eat(.leftParen)
+      lookahead.eatWithoutRecovery(.leftParen)
       lookahead.consumeIdentifier()
-      lookahead.eat(.rightParen)
+      lookahead.eatWithoutRecovery(.rightParen)
       return lookahead.isStartOfDeclaration()
     }
 
@@ -381,7 +381,7 @@ extension Parser.Lookahead {
 
     // Eat the "{".
     var lookahead = self.lookahead()
-    lookahead.eat(.leftBrace)
+    lookahead.eatWithoutRecovery(.leftBrace)
 
     // Eat attributes, if present.
     while lookahead.consume(if: .atSign) != nil {

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -220,6 +220,22 @@ extension Parser.Lookahead {
     return TokenClassification.isDeclarationStart(subparser.currentToken)
   }
 
+  func isStartOfExpression() -> Bool {
+    if self.atAny(TokenClassification.expressionStartKeywords) {
+      return true
+    }
+    if self.currentToken.isContextualKeyword(TokenClassification.contextualExpressionStartKeywords) {
+      return true
+    }
+    if self.at(.atSign) || self.at(.inoutKeyword) {
+      var backtrack = self.lookahead()
+      if backtrack.canParseType() {
+        return true
+      }
+    }
+    return false
+  }
+
   func isParenthesizedUnowned() -> Bool {
     assert(self.currentToken.tokenText == "unowned" && self.peek().tokenKind == .leftParen,
            "Invariant violated")

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -188,12 +188,18 @@ extension Lexer.Lexeme {
     }
   }
 
-  func isContextualDeclKeyword() -> Bool {
-    guard self.isIdentifier else {
+  func isContextualKeyword(_ names: [SyntaxText]) -> Bool {
+    switch self.tokenKind {
+    case .identifier, .contextualKeyword:
+      return names.contains(self.tokenText)
+    default:
       return false
     }
-    switch self.tokenText {
-    case "final",
+  }
+
+  func isContextualDeclKeyword() -> Bool {
+    return isContextualKeyword([
+      "final",
       "required",
       "optional",
       "lazy",
@@ -217,11 +223,8 @@ extension Lexer.Lexeme {
       "nonisolated",
       "distributed",
       "_const",
-      "_local":
-      return true
-    default:
-      return false
-    }
+      "_local",
+    ])
   }
 
   func isContextualPunctuator(_ name: SyntaxText) -> Bool {

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -104,16 +104,21 @@ extension Parser {
         // Check to see if there is an argument label.
         assert(self.currentToken.canBeArgumentLabel && self.peek().tokenKind == .colon)
         let name = self.consumeAnyToken()
-        let colon = self.eat(.colon)
+        let (unexpectedBeforeColon, colon) = self.eat(.colon)
         elements.append(RawDeclNameArgumentSyntax(
-          name: name, colon: colon, arena: arena))
+          name: name,
+          unexpectedBeforeColon,
+          colon: colon,
+          arena: arena
+        ))
       }
     }
-    let rparen = self.eat(.rightParen)
+    let (unexpectedBeforeRParen, rparen) = self.eat(.rightParen)
     return RawDeclNameArgumentsSyntax(
       unexpectedBeforeLParen,
       leftParen: lparen,
       arguments: RawDeclNameArgumentListSyntax(elements: elements, arena: self.arena),
+      unexpectedBeforeRParen,
       rightParen: rparen,
       arena: arena)
   }

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -217,7 +217,7 @@ extension Parser {
       for _ in 0..<lookahead.tokensConsumed {
         unexpectedNodes.append(RawSyntax(self.consumeAnyToken()))
       }
-      let token = eat(kind)
+      let token = eatWithoutRecovery(kind)
       return (RawUnexpectedNodesSyntax(elements: unexpectedNodes, arena: self.arena), token)
     }
     return (nil, RawTokenSyntax(missing: kind, arena: self.arena))
@@ -273,6 +273,13 @@ extension Parser {
       }
     }
     return RawTokenSyntax(missing: kind, arena: self.arena)
+  }
+
+  @_spi(RawSyntax)
+  public mutating func eat(_ kind: RawTokenKind) -> (unexpected: RawUnexpectedNodesSyntax?, token: Token) {
+    let (unexpected, token) = expect(kind)
+    assert(!token.isMissing)
+    return (unexpected, token)
   }
 }
 

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -54,7 +54,7 @@ extension Parser.Lookahead {
         guard self.canRecoverTo(closingDelimiter) else {
           break
         }
-        self.eat(closingDelimiter)
+        self.eatWithoutRecovery(closingDelimiter)
       }
     }
 

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -22,7 +22,7 @@ extension Parser.Lookahead {
   /// tokens this lookahead skipped over to find `kind` by consuming
   /// `lookahead.tokensConsumed` as unexpected.
   mutating func canRecoverTo(_ kind: RawTokenKind) -> Bool {
-    // If the `Set` implementation has noticable performance overheads, we could
+    // If the `Array` implementation has noticable performance overheads, we could
     // provide a matching implementaiton for a single `TokenKind` here.
     return canRecoverTo([kind])
   }

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -15,6 +15,19 @@
 // MARK: Lookahead
 
 extension Parser.Lookahead {
+  /// Information about the token that ended recovery.
+  struct RecoveryMatch {
+    /// The token kind to which the parser recovered.
+    let tokenKind: RawTokenKind
+    /// The text of the token to which the parser recovered.
+    let text: SyntaxText
+
+    init(_ lexeme: Lexer.Lexeme) {
+      self.tokenKind = lexeme.tokenKind
+      self.text = lexeme.tokenText
+    }
+  }
+
   /// Tries eating tokens until it finds a token of `kind` without skipping any
   /// higher precedence tokens. If it found a token of `kind` in this way,
   /// returns `true`, otherwise `false`.
@@ -24,28 +37,37 @@ extension Parser.Lookahead {
   mutating func canRecoverTo(_ kind: RawTokenKind) -> Bool {
     // If the `Array` implementation has noticable performance overheads, we could
     // provide a matching implementaiton for a single `TokenKind` here.
-    return canRecoverTo([kind])
+    return canRecoverToImpl([kind], recoveryPrecedence: TokenPrecedence(kind)) != nil
   }
 
   /// Tries eating tokens until it finds a token whose kind is in `kinds`
-  /// without skipping tokens that have a precedence that's higher than the
-  /// lowest precedence in `kinds`. If it found a token of `kind` in this way,
-  /// returns `true`, otherwise `false`.
-  /// If this method returns `true`, the parser probably wants to consume the
-  /// tokens this lookahead skipped over to find `kind` by consuming
-  /// `lookahead.tokensConsumed` as unexpected.
-  mutating func canRecoverTo(_ kinds: [RawTokenKind]) -> Bool {
+  /// without skipping tokens that have a precedence higher than
+  /// `recoveryPrecedence`. If it found a token this way, it returns the found
+  /// tokens's kind and text, otherwise it returns `nil`.
+  /// `contextualPrecedences` allows the caller to increase the precedence of
+  /// contextual keywords.
+  private mutating func canRecoverToImpl(
+    _ kinds: [RawTokenKind],
+    contextualPrecedences: [SyntaxText: TokenPrecedence] = [:],
+    recoveryPrecedence: TokenPrecedence
+  ) -> RecoveryMatch? {
     assert(!kinds.isEmpty)
-    let recoveryPrecedence = kinds.map(TokenPrecedence.init).min()!
     while !self.at(.eof) {
       if !recoveryPrecedence.shouldSkipOverNewlines,
-          self.currentToken.isAtStartOfLine {
+         self.currentToken.isAtStartOfLine {
         break
       }
       if self.atAny(kinds) {
-        return true
+        return RecoveryMatch(self.currentToken)
       }
-      let currentTokenPrecedence = TokenPrecedence(self.currentToken.tokenKind)
+      let currentTokenPrecedence: TokenPrecedence
+      if (self.currentToken.tokenKind == .identifier || self.currentToken.tokenKind == .contextualKeyword),
+         let contextualPrecedence = contextualPrecedences[self.currentToken.tokenText] {
+        currentTokenPrecedence = contextualPrecedence
+      } else {
+        currentTokenPrecedence = TokenPrecedence(self.currentToken.tokenKind)
+      }
+
       if currentTokenPrecedence >= recoveryPrecedence {
         break
       }
@@ -57,8 +79,44 @@ extension Parser.Lookahead {
         self.eatWithoutRecovery(closingDelimiter)
       }
     }
+    return nil
+  }
 
-    return false
+  /// Tries eating tokens until it finds a token whose kind is in `kinds`
+  /// without skipping tokens that have a precedence that's higher than the
+  /// lowest precedence in `kinds`. If it found a token this way, it returns the
+  /// found tokens's kind and text, otherwise it returns `nil`.
+  /// `contextualPrecedences` allows the caller to increase the precedence of
+  /// contextual keywords.
+  /// If this method returns a non-`nil` value, the parser probably wants to
+  /// consume the tokens this lookahead skipped over to find `kind` by consuming
+  /// `lookahead.tokensConsumed` as unexpected.
+  mutating func canRecoverTo(
+    _ kinds: [RawTokenKind],
+    contextualPrecedences: [SyntaxText: TokenPrecedence] = [:]
+  ) -> RecoveryMatch? {
+    var kindsByPrecedence = [TokenPrecedence: [RawTokenKind]]()
+    for kind in kinds {
+      kindsByPrecedence[TokenPrecedence(kind), default: []].append(kind)
+    }
+    // If we increase the precedence of certain contextual keywords, we need to
+    // also search the token stream for these contextual keywords at the remapped precedence.
+    for contextualPrecedence in contextualPrecedences.values {
+      kindsByPrecedence[contextualPrecedence, default: []].append(.identifier)
+      kindsByPrecedence[contextualPrecedence, default: []].append(.contextualKeyword)
+    }
+    // Start by trying to recover to tokens with lower precedence because they
+    // will skip fewer tokens.
+    for precedence in kindsByPrecedence.keys.sorted() {
+      if let recoveredLexeme = canRecoverToImpl(
+        kindsByPrecedence[precedence]!,
+        contextualPrecedences: contextualPrecedences,
+        recoveryPrecedence: precedence
+      ) {
+        return recoveredLexeme
+      }
+    }
+    return nil
   }
 }
 

--- a/Sources/SwiftParser/TokenClassification.swift
+++ b/Sources/SwiftParser/TokenClassification.swift
@@ -16,7 +16,7 @@
 enum TokenClassification {
   // MARK: Declaration start
 
-  static var declarationStartKeywords: [RawTokenKind] = [
+  static let declarationStartKeywords: [RawTokenKind] = [
     .associatedtypeKeyword,
     .classKeyword,
     // We don't consider caseKeyword a declStartKeyword because it cannot start a
@@ -37,7 +37,7 @@ enum TokenClassification {
     .varKeyword
   ]
 
-  static var contextualDeclarationStartKeywords: [SyntaxText] = [
+  static let contextualDeclarationStartKeywords: [SyntaxText] = [
     "actor"
   ]
 
@@ -63,6 +63,57 @@ enum TokenClassification {
       return false
     }
   }
+
+  // MARK: Expressions
+
+  static let expressionStartKeywords: [RawTokenKind] = [
+    .__column__Keyword,
+    .__dso_handle__Keyword,
+    .__file__Keyword,
+    .__function__Keyword,
+    .__line__Keyword,
+    .anyKeyword,
+    .backslash,
+    .capitalSelfKeyword,
+    .dollarIdentifier,
+    .falseKeyword,
+    .floatingLiteral,
+    .identifier,
+    .integerLiteral,
+    .isKeyword,
+    .leftBrace,
+    .leftParen,
+    .leftSquareBracket,
+    .letKeyword,
+    .nilKeyword,
+    .period,
+    .poundColorLiteralKeyword,
+    .poundColumnKeyword,
+    .poundDsohandleKeyword,
+    .poundFileKeyword,
+    .poundFileLiteralKeyword,
+    .poundFilePathKeyword,
+    .poundFunctionKeyword,
+    .poundImageLiteralKeyword,
+    .poundKeyPathKeyword,
+    .poundLineKeyword,
+    .poundSelectorKeyword,
+    .prefixAmpersand,
+    .prefixOperator,
+    .prefixPeriod,
+    .regexLiteral,
+    .selfKeyword,
+    .stringLiteral,
+    .superKeyword,
+    .trueKeyword,
+    .tryKeyword,
+    .varKeyword,
+    .wildcardKeyword,
+  ]
+
+  static let contextualExpressionStartKeywords: [SyntaxText] = [
+    "await"
+  ]
 
   // MARK: Pound declaration
 

--- a/Sources/SwiftParser/TokenClassification.swift
+++ b/Sources/SwiftParser/TokenClassification.swift
@@ -1,0 +1,77 @@
+//===--- TokenClassification.swift ----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RawSyntax) import SwiftSyntax
+
+/// A grabbag of token kind classifications for specific use cases
+enum TokenClassification {
+  // MARK: Declaration start
+
+  static var declarationStartKeywords: [RawTokenKind] = [
+    .associatedtypeKeyword,
+    .classKeyword,
+    // We don't consider caseKeyword a declStartKeyword because it cannot start a
+    // top-level decl - it can only occur in an `enum`.
+    .deinitKeyword,
+    .enumKeyword,
+    .extensionKeyword,
+    .funcKeyword,
+    .importKeyword,
+    .initKeyword,
+    .letKeyword,
+    .operatorKeyword,
+    .precedencegroupKeyword,
+    .protocolKeyword,
+    .structKeyword,
+    .subscriptKeyword,
+    .typealiasKeyword,
+    .varKeyword
+  ]
+
+  static var contextualDeclarationStartKeywords: [SyntaxText] = [
+    "actor"
+  ]
+
+  static func isDeclarationStart(_ lexeme: Lexer.Lexeme) -> Bool {
+    if declarationStartKeywords.contains(lexeme.tokenKind) {
+      return true
+    } else if lexeme.isContextualKeyword(contextualDeclarationStartKeywords) {
+      return true
+    } else {
+      return false
+    }
+  }
+
+  // MARK: Declaration modifier
+
+  static func isDeclarationModifier(_ lexeme: Lexer.Lexeme) -> Bool {
+    switch lexeme.tokenKind {
+    case .privateKeyword, .fileprivateKeyword, .internalKeyword, .publicKeyword, .staticKeyword:
+      fallthrough
+    case .identifier where Parser.DeclModifier(rawValue: lexeme.tokenText) != nil:
+      return true
+    default:
+      return false
+    }
+  }
+
+  // MARK: Pound declaration
+
+  static func isPoundDeclarationKeyword(_ lexeme: Lexer.Lexeme) -> Bool {
+    switch lexeme.tokenKind {
+    case .poundIfKeyword, .poundWarningKeyword, .poundErrorKeyword:
+      return true
+    default:
+      return false
+    }
+  }
+}

--- a/Sources/SwiftParser/TokenClassification.swift
+++ b/Sources/SwiftParser/TokenClassification.swift
@@ -41,6 +41,10 @@ enum TokenClassification {
     "actor"
   ]
 
+  static var contextualDeclarationStartPrecedences: [SyntaxText: TokenPrecedence] {
+    Dictionary(uniqueKeysWithValues: contextualDeclarationStartKeywords.map({ ($0, .declKeyword) }))
+  }
+
   static func isDeclarationStart(_ lexeme: Lexer.Lexeme) -> Bool {
     if declarationStartKeywords.contains(lexeme.tokenKind) {
       return true

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -79,7 +79,7 @@ extension TokenConsumer {
   ///
   /// - Parameter kind: The kind of token to consume.
   /// - Returns: A token of the given kind.
-  public mutating func eat(_ kind: RawTokenKind) -> Token {
+  public mutating func eatWithoutRecovery(_ kind: RawTokenKind) -> Token {
     return self.consume(if: kind)!
   }
 }

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -144,8 +144,6 @@ public enum TokenPrecedence: Comparable {
         .caseKeyword, .catchKeyword, .defaultKeyword, .elseKeyword,
       // Return-like statements
         .breakKeyword, .continueKeyword, .fallthroughKeyword, .returnKeyword, .throwKeyword, .yield,
-      // Misc
-        .importKeyword,
       // #error and #warning are statement-like
         .poundErrorKeyword, .poundWarningKeyword:
       self = .stmtKeyword
@@ -181,7 +179,9 @@ public enum TokenPrecedence: Comparable {
       // Variables
         .letKeyword, .varKeyword,
       // Operator stuff
-        .operatorKeyword, .precedencegroupKeyword:
+        .operatorKeyword, .precedencegroupKeyword,
+      // Misc
+        .importKeyword:
       self = .declKeyword
     }
   }

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -15,7 +15,7 @@ import SwiftSyntax
 /// Describes how distinctive a token is for parser recovery. When expecting a
 /// token, tokens with a lower token precedence may be skipped and considered
 /// unexpected.
-public enum TokenPrecedence: Comparable {
+public enum TokenPrecedence: Comparable, Hashable {
   /// Tokens that can be used similar to variable names or literals
   case identifierLike
   /// Keywords and operators that can occur in the middle of an expression

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -31,7 +31,7 @@ extension Parser {
       extraneousTokens.append(RawSyntax(consumeAnyToken()))
     }
     let unexpectedBeforeEof = extraneousTokens.isEmpty ? nil : RawUnexpectedNodesSyntax(elements: extraneousTokens, arena: self.arena)
-    let eof = self.eat(.eof)
+    let eof = self.eatWithoutRecovery(.eof)
     return .init(statements: items, unexpectedBeforeEof, eofToken: eof, arena: self.arena)
   }
 }

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -138,8 +138,10 @@ extension Parser {
       return RawSyntax(self.parseDeclaration())
     } else if self.lookahead().isStartOfStatement() {
       return RawSyntax(self.parseStatement())
-    } else {
+    } else if self.lookahead().isStartOfExpression() {
       return RawSyntax(self.parseExpression())
+    } else {
+      return RawSyntax(RawMissingExprSyntax(arena: self.arena))
     }
   }
 }

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -140,6 +140,8 @@ extension Parser {
       return RawSyntax(self.parseStatement())
     } else if self.lookahead().isStartOfExpression() {
       return RawSyntax(self.parseExpression())
+    } else if self.lookahead().isStartOfDeclaration(allowRecovery: true) {
+      return RawSyntax(self.parseDeclaration())
     } else {
       return RawSyntax(RawMissingExprSyntax(arena: self.arena))
     }

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -158,10 +158,10 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
   /// If `text` is passed, it will be used to represent the missing token's text.
   /// If `text` is `nil`, the `kind`'s default text will be used.
   /// If that is also `nil`, the token will have empty text.
-  public init(missing kind: RawTokenKind, arena: __shared SyntaxArena) {
+  public init(missing kind: RawTokenKind, text: SyntaxText? = nil, arena: __shared SyntaxArena) {
     self.init(
       kind: kind,
-      text: kind.defaultText ?? "",
+      text: text ?? kind.defaultText ?? "",
       leadingTriviaPieces: [],
       trailingTriviaPieces: [],
       presence: .missing,

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -34,6 +34,18 @@ final class DeclarationTests: XCTestCase {
     )
   }
 
+  func testFuncAfterUnbalancedClosingBrace() {
+    AssertParse(
+      """
+      #^DIAG^#}
+      func foo() {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "Unexpected text '}' found in function")
+      ]
+    )
+  }
+
   func testClassParsing() {
     AssertParse("class Foo {}")
 
@@ -71,6 +83,20 @@ final class DeclarationTests: XCTestCase {
       """
     )
   }
+
+  func testActorAfterUnbalancedClosingBrace() {
+    AssertParse(
+      """
+      #^DIAG^#}
+      actor Foo {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "Unexpected text '}' found in actor")
+      ]
+    )
+  }
+
+
 
   func testProtocolParsing() {
     AssertParse("protocol Foo {}")

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -41,7 +41,7 @@ final class DeclarationTests: XCTestCase {
       func foo() {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text '}' found in function")
+        DiagnosticSpec(message: "Unexpected text '}' before function")
       ]
     )
   }
@@ -91,7 +91,7 @@ final class DeclarationTests: XCTestCase {
       actor Foo {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text '}' found in actor")
+        DiagnosticSpec(message: "Unexpected text '}' before actor")
       ]
     )
   }
@@ -393,7 +393,7 @@ final class DeclarationTests: XCTestCase {
       "(first second #^DIAG^#third fourth: Int)",
       { $0.parseFunctionSignature() },
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'third fourth' found in function parameter")
+        DiagnosticSpec(message: "Unexpected text 'third fourth' in function parameter")
       ]
     )
   }
@@ -535,7 +535,7 @@ final class DeclarationTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(
           message: """
-            Unexpected text '/ ###line 25 "line-directive.swift"' found in struct
+            Unexpected text '/ ###line 25 "line-directive.swift"' in struct
             """
         )
       ]
@@ -550,7 +550,7 @@ final class DeclarationTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'bogus rethrows set' found in variable")
+        DiagnosticSpec(message: "Unexpected text 'bogus rethrows set' in variable")
       ]
     )
   }
@@ -582,7 +582,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'third' found in function parameter")
+        DiagnosticSpec(message: "Unexpected text 'third' in function parameter")
       ]
     )
   }
@@ -603,7 +603,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'third fourth' found in function parameter")
+        DiagnosticSpec(message: "Unexpected text 'third fourth' in function parameter")
       ]
     )
   }
@@ -654,7 +654,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text '[third fourth]' found in function parameter")
+        DiagnosticSpec(message: "Unexpected text '[third fourth]' in function parameter")
       ]
     )
   }

--- a/Tests/SwiftParserTest/Directives.swift
+++ b/Tests/SwiftParserTest/Directives.swift
@@ -84,17 +84,17 @@ final class DirectiveTests: XCTestCase {
     AssertParse(
       """
       #if os(iOS)
-        func foo() {}#^DIAG_1^#
-      #^DIAG_2^#}
+        func foo() {}
+      #^DIAG_1^#}
       #else
         func bar() {}
         func baz() {}
-      } // expected-error{{unexpected '}' in conditional compilation block}}
+      #^DIAG_2^#}
       #endif
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected '#endif' in conditional compilation block"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Extraneous code at top level"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "Unexpected text '}' in conditional compilation block"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -202,7 +202,7 @@ final class ExpressionTests: XCTestCase {
       " >> \( abc #^DIAG^#} ) << "
       """#,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text '}' found in string literal")
+        DiagnosticSpec(message: "Unexpected text '}' in string literal")
       ]
     )
 
@@ -389,7 +389,7 @@ final class ExpressionTests: XCTestCase {
       "[(Int) -> #^DIAG^#throws Int]()",
       diagnostics: [
         // FIXME: We should suggest to move 'throws' in front of '->'
-        DiagnosticSpec(message: "Unexpected text 'throws Int' found in array")
+        DiagnosticSpec(message: "Unexpected text 'throws Int' in array")
       ]
     )
 

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -14,7 +14,7 @@ final class StatementTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(message: "Expected '=' in pattern matching"),
-        DiagnosticSpec(message: "Unexpected text '* ! = x' found in 'if' statement"),
+        DiagnosticSpec(message: "Unexpected text '* ! = x' in 'if' statement"),
       ]
     )
   }
@@ -199,7 +199,7 @@ final class StatementTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "END_SWITCH", message: "Expected '}' to end 'switch' statement"),
-        DiagnosticSpec(locationMarker: "UNEXPECTED", message: "Unexpected text found in conditional compilation block"),
+        DiagnosticSpec(locationMarker: "UNEXPECTED", message: "Unexpected text in conditional compilation block"),
         DiagnosticSpec(locationMarker: "EXTRANEOUS", message: "Extraneous code at top level")
       ]
     )


### PR DESCRIPTION
Depends on https://github.com/apple/swift-syntax/pull/688

---

The basic idea is that `isStartOfDeclaration` now has a `recover` argument and returns `true` if it’s possible to recover to a declaration. Other than that, we needed some recovery infrastructure. The productions themself only needed minor changes to continue along the right path and skip the unexpected tokens.