### PR TITLE
Generate missing string closer quote and delimiter

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -935,11 +935,8 @@ extension Parser {
 
       if let openDelimiter = openDelimiter {
         return RawTokenSyntax(
-          kind: .rawStringDelimiter,
+          missing: .rawStringDelimiter,
           text: openDelimiter.tokenText,
-          leadingTriviaPieces: [],
-          trailingTriviaPieces: [],
-          presence: .missing,
           arena: arena
         )
       }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -925,24 +925,21 @@ extension Parser {
       text = text.dropFirst(closeQuote.tokenText.count)
     }
     /// Parse closing raw string delimiter if exist.
-    let closeDelimiter: RawTokenSyntax? = {
-      if let closeDelimiter = self.parseStringLiteralDelimiter(
-        at: .trailing,
-        text: text
-      ) {
-        return closeDelimiter
-      }
-
-      if let openDelimiter = openDelimiter {
-        return RawTokenSyntax(
-          missing: .rawStringDelimiter,
-          text: openDelimiter.tokenText,
-          arena: arena
-        )
-      }
-
-      return nil
-    }()
+    let closeDelimiter: RawTokenSyntax?
+    if let delimiter = self.parseStringLiteralDelimiter(
+      at: .trailing,
+      text: text
+    ) {
+      closeDelimiter = delimiter
+    } else if let openDelimiter = openDelimiter {
+      closeDelimiter = RawTokenSyntax(
+        missing: .rawStringDelimiter,
+        text: openDelimiter.tokenText,
+        arena: arena
+      )
+    } else {
+      closeDelimiter = nil
+    }
     assert((openDelimiter == nil) == (closeDelimiter == nil),
            "existence of open/close delimiter should match")
     if let closeDelimiter = closeDelimiter, !closeDelimiter.isMissing {

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -158,10 +158,14 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
   /// If `text` is passed, it will be used to represent the missing token's text.
   /// If `text` is `nil`, the `kind`'s default text will be used.
   /// If that is also `nil`, the token will have empty text.
-  public init(missing kind: RawTokenKind, arena: __shared SyntaxArena) {
+  public init(
+    missing kind: RawTokenKind,
+    text: SyntaxText? = nil,
+    arena: __shared SyntaxArena
+  ) {
     self.init(
       kind: kind,
-      text: kind.defaultText ?? "",
+      text: text ?? kind.defaultText ?? "",
       leadingTriviaPieces: [],
       trailingTriviaPieces: [],
       presence: .missing,

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -313,31 +313,31 @@ final class ExpressionTests: XCTestCase {
 
     AssertParse(
       ##"""
-      #"#^DQ^##^DD^#
+      #"#^DIAG^#
       """##,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DQ", message: #"Expected '"' in string literal"#),
-        DiagnosticSpec(locationMarker: "DD", message: #"Expected '#' in string literal"#)
+        DiagnosticSpec(message: #"Expected '"' in string literal"#),
+        DiagnosticSpec(message: #"Expected '#' in string literal"#)
       ]
     )
 
     AssertParse(
       ##"""
-      #"""#^DQ^##^DD^#
+      #"""#^DIAG^#
       """##,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DQ", message: #"Expected '"""' in string literal"#),
-        DiagnosticSpec(locationMarker: "DD", message: #"Expected '#' in string literal"#)
+        DiagnosticSpec(message: #"Expected '"""' in string literal"#),
+        DiagnosticSpec(message: #"Expected '#' in string literal"#)
       ]
     )
 
     AssertParse(
       ##"""
-      #"""a#^DQ^##^DD^#
+      #"""a#^DIAG^#
       """##,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DQ", message: #"Expected '"""' in string literal"#),
-        DiagnosticSpec(locationMarker: "DD", message: #"Expected '#' in string literal"#)
+        DiagnosticSpec(message: #"Expected '"""' in string literal"#),
+        DiagnosticSpec(message: #"Expected '#' in string literal"#)
       ]
     )
   }

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -310,6 +310,36 @@ final class ExpressionTests: XCTestCase {
        """"""#^DIAG^#
        """##
      )
+
+    AssertParse(
+      ##"""
+      #"#^DQ^##^DD^#
+      """##,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DQ", message: #"Expected '"' in string literal"#),
+        DiagnosticSpec(locationMarker: "DD", message: #"Expected '#' in string literal"#)
+      ]
+    )
+
+    AssertParse(
+      ##"""
+      #"""#^DQ^##^DD^#
+      """##,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DQ", message: #"Expected '"""' in string literal"#),
+        DiagnosticSpec(locationMarker: "DD", message: #"Expected '#' in string literal"#)
+      ]
+    )
+
+    AssertParse(
+      ##"""
+      #"""a#^DQ^##^DD^#
+      """##,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DQ", message: #"Expected '"""' in string literal"#),
+        DiagnosticSpec(locationMarker: "DD", message: #"Expected '#' in string literal"#)
+      ]
+    )
   }
 
   func testSingleQuoteStringLiteral() {


### PR DESCRIPTION
This PR fix #668 #669.

If closer quote and delimiter is missing but opener ones are present,
generate missing token to fix round trip bug and emit missing diagnostics.