### PR TITLE
Add trailing space to attributes in `VariableDecl`

### DIFF
--- a/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/VariableDeclConvenienceInitializers.swift
+++ b/Sources/SwiftSyntaxBuilder/ConvenienceInitializers/VariableDeclConvenienceInitializers.swift
@@ -25,9 +25,9 @@ extension VariableDecl {
   ) {
     self.init(
       leadingTrivia: leadingTrivia,
-      attributes: attributes,
+      attributes: attributes?.createAttributeList().withTrailingTrivia(.space),
       modifiers: modifiers,
-      letOrVarKeyword: attributes != nil ? letOrVarKeyword.withLeadingTrivia(.space) : letOrVarKeyword
+      letOrVarKeyword: letOrVarKeyword
     ) {
       PatternBinding(
         pattern: name,
@@ -48,9 +48,9 @@ extension VariableDecl {
   ) {
     self.init(
       leadingTrivia: leadingTrivia,
-      attributes: attributes,
+      attributes: attributes?.createAttributeList().withTrailingTrivia(.space),
       modifiers: modifiers,
-      letOrVarKeyword: .var.withLeadingTrivia(attributes != nil ? .space : .zero)
+      letOrVarKeyword: .var
     ) {
       PatternBinding(
         pattern: name,

--- a/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
+++ b/Tests/SwiftSyntaxBuilderTest/VariableTests.swift
@@ -150,6 +150,20 @@ final class VariableTests: XCTestCase {
         }
         """
       ),
+      #line: (
+        VariableDecl(
+          attributes: CustomAttribute("WithArgs") {
+            TupleExprElement(expression: "value")
+          },
+          modifiers: [Token.public],
+          .let,
+          name: "z",
+          type: "Float"
+        ),
+        """
+        @WithArgs(value) public let z: Float
+        """
+      ),
     ]
 
     for (line, testCase) in testCases {


### PR DESCRIPTION
A small fix for the generated trivia when using attributes and modifiers together in `VariableDecl`, as detailed in https://github.com/apple/swift-syntax/pull/667#issuecomment-1232598906.