### PR TITLE
Use `swift-argument-parser` in `generate-swift-syntax-builder`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -124,7 +124,7 @@ let package = Package(
     ),
     .executableTarget(
         name: "generate-swift-syntax-builder",
-        dependencies: ["SwiftSyntaxBuilder"],
+        dependencies: ["SwiftSyntaxBuilder", .product(name: "ArgumentParser", package: "swift-argument-parser")],
         exclude: [
           "gyb_helpers",
           "gyb_syntax_support",

--- a/Sources/generate-swift-syntax-builder/GenerateSwiftSyntaxBuilder.swift
+++ b/Sources/generate-swift-syntax-builder/GenerateSwiftSyntaxBuilder.swift
@@ -30,6 +30,9 @@ struct GenerateSwiftSyntaxBuilder: ParsableCommand {
   @Argument(help: "The path to the destination directory where the source files are to be generated")
   var generatedPath: String
 
+  @Flag(help: "Enable verbose output")
+  var verbose: Bool = false
+
   func run() throws {
     let generatedURL = URL(fileURLWithPath: generatedPath)
     let format = Format(indentWidth: 2)
@@ -42,6 +45,9 @@ struct GenerateSwiftSyntaxBuilder: ParsableCommand {
 
     for (sourceFile, name) in sourceTemplates {
       let fileURL = generatedURL.appendingPathComponent(name)
+      if verbose {
+        print("Generating \(fileURL.path)...")
+      }
       let syntax = sourceFile.buildSyntax(format: format)
       try "\(syntax)\n".write(to: fileURL, atomically: true, encoding: .utf8)
     }


### PR DESCRIPTION
This branch updates `generate-swift-syntax-builder` to use `swift-argument-parser` instead of ad-hoc parsing `CommandLine.arguments`.

Since the package already depends on `swift-argument-parser` for `swift-parser-test` I would not expect the introduction of this new target dependency to be an issue, but perhaps still worth checking whether there are any unexpected bootstrapping consequences to this.