### PR TITLE
Link to the parser documentation from the top-level readme and update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,54 +1,84 @@
 # Contributing
 
-## Building SwiftSyntax from `main`
+This guide refers to Swift Development Snapshots. These can be downloaded from [swift.org/download](https://swift.org/download/#snapshots). 
+If you are seeing issues, it is generally a good idea to re-try with the latest Swift Development Snapshot.
 
-Since SwiftSyntax relies on definitions in the main Swift repository to generate the layout of the syntax tree using `gyb`, a checkout of [apple/swift](https://github.com/apple/swift) is still required to build the latest development snapshot of SwiftSyntax.
+## Building
 
-To build the `main` branch of SwiftSyntax, follow the following instructions:
+The easiest option to build SwiftSyntax it to open it in Xcode. 
 
-1. Check `swift-syntax`, `swift-argument-parser` and  `swift` out side by side:
+Alternatively you can also build it from the command line using `build-script.py`. To do this, perform the following steps
+
+1. Check `swift-syntax` and `swift-argument-parser` out side by side:
+     ```
+     - (enclosing directory)
+       - swift-argument-parser
+       - swift-syntax
+2. Execute the following command
+    ```bash
+    swift-syntax/build-script.py build --toolchain /Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-<recent date>.xctoolchain/usr
+    ```
+
+## Testing
+
+Because of SwiftSyntax’s integration with the Swift compiler project, testing certain parts of the project is a little bit more involved than others. 
+
+The `SwiftParser` tests have no depdendencies, other `XCTests` require you to use a matching Swift Development Snapshot, `lit`-based test require a compiler build.
+
+Run the tests that you belive are necessary locally. CI will always run all test before allowing the PR to be merged.
+
+### SwiftParser
+
+If you are only modifying the `SwiftParser` module, you can just run the tests using Xcode by testing the `SwiftParserTest` target. 
+
+If you can’t find it in your Schemes, you need to manually add it using Product -> Scheme -> New Scheme…
+
+### XCTests
+
+The `SwiftSyntaxParser` module (the legacy parser) of this repository depends on the C++ parser library (`_InternalSwiftSyntaxParser.dylib`) to parse source code.
+The syntax node definitions of that parser library need to match those used by your SwiftSyntax checkout.
+Most of the time, the parser library included in the latest Swift Development Snapshot will fulfill this requirement. 
+
+To run the tests in Xcode, select the latest Swift Development Snapshot in Xcode -> Toolchains, select the SwiftSyntax-Package scheme and hit Prodcut -> Test.
+
+You can also run the tests from the command line using
+```bash
+./build-script.py test --toolchain /Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-<recent date>.xctoolchain/usr --skip-lit-tests
+```
+
+If you are seeing issues regarding a mismatched parser library, try the following
+1. Update your Swift Development Snapshot
+2. Revert your swift-syntax checkout to the date of your Swift Development Snapshot
+3. Wait for a new Swift Development Snapshot
+4. If the above options are not possible, build your own Swift toolchain locally and use that toolchain as the `--toolchain` parameter for SwiftSyntax’s `build-script.py` invocations
+  - Note: Building your own toolchain will take more than 1 hour and even longer if you are running into any issues. We do not recomment building your own Swift toolchain unless you are familiar with Swift compiler development.
+
+Tip: Running SwiftSyntax’s self-parse tests takes the majority of testing time. If you want to iterate quickly, you can skip these tests using the following steps:
+1. Product -> Scheme -> Edit Scheme…
+2. Select the Arguments tab in the Run section
+3. Add a `SKIP_SELF_PARSE` environment variable with value `1`
+
+### `lit`-based tests
+
+A few tests of the `SwiftSyntaxParser` module (the legacy parser), which test the interaction between SwiftSyntax and the C++ parser library (`_InternalSwiftSyntaxParser.dylib`) are based LLVM’s `lit` and `FileCheck` tools.
+To run these, build `FileCheck`, e.g. by building the Swift compiler and run the tests using the following command:
+```bash
+./build-script.py test --toolchain /Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-<recent date>.xctoolchain/usr --skip-lit-tests --filecheck-exec /path/to/build/Release+Asserts/llvm-macosx-x86_64/bin/FileCheck
+```
+
+## Generating source code
+
+If you want to modify the code-generated files, perform the following steps:
+
+1. Check out `swift` next to `swift-syntax`
     ```
     - (enclosing directory)
       - swift
       - swift-argument-parser
       - swift-syntax
     ```
-
-2. Make sure you have a recent [Trunk Swift Toolchain](https://swift.org/download/#snapshots) installed.
-3. Define the `TOOLCHAINS` environment variable as below to have the `swift` command point inside the toolchain:
-
+2. Run the following command
     ```bash
-    $ export TOOLCHAINS=swift
+    swift-syntax/build-script.py generate-source-code --toolchain /Library/Developer/Toolchains/swift-DEVELOPMENT-SNAPSHOT-<recent date>.xctoolchain/usr
     ```
-
-4. To make sure everything is set up correctly, check the return statement of `xcrun --find swift`. It should point inside the latest installed trunk development toolchain. If it points inside an Xcode toolchain, check that you exported the `TOOLCHAINS` environment variable correctly. If it points inside a version-specific toolchain (like Swift 5.0-dev), you'll need to remove that toolchain.
-5. Run `swift-syntax/build-script.py build --toolchain /path/to/recent/swift/development/snapshot.xctoolchain/usr`.
-    If despite following those instructions, you get compiler errors, the Swift toolchain might be too old to contain recent changes in Swift's SwiftSyntaxParser C library. In that case, you'll have to build the compiler and SwiftSyntax together with the following command:
-
-    ```bash
-    $ swift/utils/build-script --swiftsyntax --swiftpm --llbuild
-    ```
-
-Swift-CI will automatically run the code generation step whenever a new toolchain (development snapshot or release) is published. It should thus almost never be necessary to perform the above build yourself.
-
-If you also want to run tests locally, read the section below as testing has additional requirements.
-
-## Local Testing
-
-SwiftSyntax uses some test utilities that need to be built as part of the Swift compiler project. To build the most recent version of SwiftSyntax and test it, follow the steps in [swift/README.md](https://github.com/apple/swift/blob/main/README.md) and pass `--llbuild --swiftpm --swiftsyntax` to the build script invocation to build SwiftSyntax and all its dependencies using the current trunk (`main`) compiler.
-
-SwiftSyntax can then be tested using the build script in `apple/swift` by running
-
-```bash
-swift/utils/build-script --swiftsyntax --swiftpm --llbuild -t --skip-test-cmark --skip-test-swift --skip-test-llbuild --skip-test-swiftpm
-```
-
-This command will build SwiftSyntax and all its dependencies, tell the build script to run tests, but skip all tests but the SwiftSyntax tests.
-
-Note that it is not currently supported by SwiftSyntax while building the Swift compiler using Xcode.
-
-## CI Testing
-
-Running `@swift-ci Please test` on the main Swift repository will also test the most recent version of SwiftSyntax.
-
-Testing SwiftSyntax from its own repository is now available by commenting `@swift-ci Please test macOS platform`.
+3. The new source-generated file will be written into your `Sources` directory.

--- a/Documentation/SwiftParser.md
+++ b/Documentation/SwiftParser.md
@@ -1,0 +1,5 @@
+# SwiftParser
+
+Documentation on the new Swift parser can be found in [Sources/SwiftParser/SwiftParser.docc](../Sources/SwiftParser/SwiftParser.docc).
+
+You can either directly view this documentation on GitHub or build a documenation bundle by opening the project in Xcode and clicking Product -> Build Documentation

--- a/Documentation/SwiftParser.md
+++ b/Documentation/SwiftParser.md
@@ -1,5 +1,5 @@
 # SwiftParser
 
-Documentation on the new Swift parser can be found in [Sources/SwiftParser/SwiftParser.docc](../Sources/SwiftParser/SwiftParser.docc).
+Documentation on the Swift parser can be found in [Sources/SwiftParser/SwiftParser.docc](../Sources/SwiftParser/SwiftParser.docc).
 
 You can either directly view this documentation on GitHub or build a documenation bundle by opening the project in Xcode and clicking Product -> Build Documentation

--- a/README.md
+++ b/README.md
@@ -45,7 +45,11 @@ Then, import `SwiftSyntax` in your Swift code.
 
 ## Documentation
 
-Documentation can be found [here](Documentation) and some examples of using SwiftSyntax can be found [here](Examples).
+Documentation can be found in the following places:
+- For the new parser: [Sources/SwiftParser/SwiftParser.docc](Sources/SwiftParser/SwiftParser.docc) 
+  - You can either directly view this documentation on GitHub or build a documenation bundle by opening the project in Xcode and clicking Product -> Build Documentation
+- General documentation: [Documentation](Documentation) 
+- Examples of using SwiftSyntax: [Examples](Examples).
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Then, import `SwiftSyntax` in your Swift code.
 ## Documentation
 
 Documentation can be found in the following places:
-- For the new parser: [Sources/SwiftParser/SwiftParser.docc](Sources/SwiftParser/SwiftParser.docc) 
+- For the parser: [Sources/SwiftParser/SwiftParser.docc](Sources/SwiftParser/SwiftParser.docc) 
   - You can either directly view this documentation on GitHub or build a documenation bundle by opening the project in Xcode and clicking Product -> Build Documentation
 - General documentation: [Documentation](Documentation) 
 - Examples of using SwiftSyntax: [Examples](Examples).


### PR DESCRIPTION
I realized that the SwiftParser documentation was hard to find because we didn’t link to it from anywhere.

I also realized that CONTRIBUTING.md was overly complicated and often assumed a local compiler build, which isn’t necessary most of the time.