### PR TITLE
Improve parsing of access level modifier

### DIFF
--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -159,7 +159,7 @@ extension Parser {
   mutating func parseAccessLevelModifier() -> RawDeclModifierSyntax {
     let (unexpectedBeforeName, name) = expectAny(
       [.privateKeyword, .fileprivateKeyword, .internalKeyword, .publicKeyword],
-      default: .privateKeyword
+      default: .internalKeyword
     )
     let details: RawDeclModifierDetailSyntax?
     if let leftParen = consume(if: .leftParen) {

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -238,7 +238,11 @@ extension Parser {
       )
     }
     var lookahead = self.lookahead()
-    return lookahead.canRecoverTo([], contextualKeywords: [name])
+    return lookahead.canRecoverTo(
+        [],
+        contextualKeywords: [name],
+        recoveryPrecedence: precedence
+    )
   }
 
 

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -83,7 +83,19 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
   }
 
   public var tokenKind: RawTokenKind {
-    return tokenView.rawKind
+    get {
+      return tokenView.rawKind
+    }
+    set {
+      self = RawTokenSyntax(
+        kind: newValue,
+        text: tokenText,
+        leadingTriviaPieces: leadingTriviaPieces,
+        trailingTriviaPieces: trailingTriviaPieces,
+        presence: presence,
+        arena: raw.arena
+      )
+    }
   }
 
   public var tokenText: SyntaxText {
@@ -171,6 +183,15 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
       presence: .missing,
       arena: arena
     )
+  }
+
+  public func isContextualKeyword(_ name: SyntaxText) -> Bool {
+    switch tokenKind {
+    case .identifier, .contextualKeyword:
+      return tokenText == name
+    default:
+      return false
+    }
   }
 }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -83,19 +83,7 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
   }
 
   public var tokenKind: RawTokenKind {
-    get {
-      return tokenView.rawKind
-    }
-    set {
-      self = RawTokenSyntax(
-        kind: newValue,
-        text: tokenText,
-        leadingTriviaPieces: leadingTriviaPieces,
-        trailingTriviaPieces: trailingTriviaPieces,
-        presence: presence,
-        arena: raw.arena
-      )
-    }
+    return tokenView.rawKind
   }
 
   public var tokenText: SyntaxText {
@@ -183,15 +171,6 @@ public struct RawTokenSyntax: RawSyntaxNodeProtocol {
       presence: .missing,
       arena: arena
     )
-  }
-
-  public func isContextualKeyword(_ name: SyntaxText) -> Bool {
-    switch tokenKind {
-    case .identifier, .contextualKeyword:
-      return tokenText == name
-    default:
-      return false
-    }
   }
 }
 

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -219,8 +219,11 @@ final class DeclarationTests: XCTestCase {
         set
       )
       """,
+      // FIXME: It should be single: "Unexpected text '+' found in modifier"
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text '+' found in modifier")
+        DiagnosticSpec(message: "Expected 'set' in modifier"),
+        DiagnosticSpec(message: "Expected ')' to end modifier"),
+        DiagnosticSpec(message: "Extraneous code at top level")
       ]
     )
 
@@ -255,12 +258,15 @@ final class DeclarationTests: XCTestCase {
 
     AssertParse(
       """
-      private(#^LEFT^#get, didSet#^RIGHT^#
+      private(#^DIAG^#get#^TOP^#, didSet
       """,
+      // FIXME: Consuming `get` as top level token is undesirable.
       diagnostics: [
-        DiagnosticSpec(locationMarker: "LEFT", message: "Unexpected text 'get, didSet' found in modifier"),
-        DiagnosticSpec(locationMarker: "RIGHT", message: "Expected 'set' in modifier"),
-        DiagnosticSpec(locationMarker: "RIGHT", message: "Expected ')' to end modifier")
+        // FIXME: It should be located at right of didSet
+        DiagnosticSpec(message: "Expected 'set' in modifier"),
+        DiagnosticSpec(message: "Expected ')' to end modifier"),
+        // FIXME: It should be from modifier, not top level
+        DiagnosticSpec(locationMarker: "TOP", message: "Extraneous ', didSet' at top level")
       ]
     )
   }

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -225,22 +225,23 @@ final class DeclarationTests: XCTestCase {
 
     AssertParse(
       """
-      private(#^DLEFT^#get, set#^DRIGHT^#, didSet)
+      private(#^DIAG^#get#^DTOP^#, set, didSet)
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DLEFT", message: "Unexpected text 'get,' found in modifier"),
-        DiagnosticSpec(locationMarker: "DRIGHT", message: "Unexpected text ', didSet' found in modifier")
+        DiagnosticSpec(message: "Expected 'set' in modifier"),
+        DiagnosticSpec(message: "Expected ')' to end modifier"),
+        DiagnosticSpec(locationMarker: "DTOP", message: "Extraneous ', set, didSet)' at top level")
       ]
     )
 
     AssertParse(
       """
-      private(#^DSET^#get, didSet#^DRPAREN^#
+      private(#^DIAG^#get#^DTOP^#, didSet
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DSET", message: "Expected 'set' in modifier"),
-        DiagnosticSpec(locationMarker: "DSET", message: "Unexpected text 'get, didSet' found in modifier"),
-        DiagnosticSpec(locationMarker: "DRPAREN", message: "Expected ')' to end modifier"),
+        DiagnosticSpec(message: "Expected 'set' in modifier"),
+        DiagnosticSpec(message: "Expected ')' to end modifier"),
+        DiagnosticSpec(locationMarker: "DTOP", message: "Extraneous ', didSet' at top level")
       ]
     )
   }

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -215,30 +215,64 @@ final class DeclarationTests: XCTestCase {
   func testAccessLevelModifier() {
     AssertParse(
       """
+      private(set) var a = 0
+      """
+    )
+
+    AssertParse(
+      """
+      private(#^DIAG^#get) var a = 0
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "Expected 'set' in modifier"),
+        DiagnosticSpec(message: "Unexpected text 'get' in modifier")
+      ]
+    )
+
+    AssertParse(
+      """
       private(#^DIAG^#+
         set
-      )
+      ) var a = 0
       """,
-      // FIXME: It should be single: "Unexpected text '+' found in modifier"
       diagnostics: [
         DiagnosticSpec(message: "Expected 'set' in modifier"),
         DiagnosticSpec(message: "Expected ')' to end modifier"),
-        DiagnosticSpec(message: "Extraneous code at top level")
+        // FIXME: It should print `+` as detail of text.
+        DiagnosticSpec(message: "Unexpected text in variable")
       ]
     )
 
     AssertParse(
       """
-      private(#^DIAG^#get: set)
+      private(#^DIAG^#get, set) var a = 0
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'get:' found in modifier")
+        DiagnosticSpec(message: "Unexpected text 'get,' in modifier")
       ]
     )
 
     AssertParse(
       """
-      private(#^DIAG^#
+      private(#^DIAG^#get: set) var a = 0
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "Unexpected text 'get:' in modifier")
+      ]
+    )
+
+    AssertParse(
+      """
+      #^DIAG^#private(
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "Extraneous 'private(' at top level")
+      ]
+    )
+
+    AssertParse(
+      """
+      private(#^DIAG^#var a = 0
       """,
       diagnostics: [
         DiagnosticSpec(message: "Expected 'set' in modifier"),
@@ -248,25 +282,22 @@ final class DeclarationTests: XCTestCase {
 
     AssertParse(
       """
-      private(#^LEFT^#get, set#^RIGHT^#, didSet)
+      private(#^LEFT^#get, set#^RIGHT^#, didSet) var a = 0
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "LEFT", message: "Unexpected text 'get,' found in modifier"),
-        DiagnosticSpec(locationMarker: "RIGHT", message: "Unexpected text ', didSet' found in modifier")
+        DiagnosticSpec(locationMarker: "LEFT", message: "Unexpected text 'get,' in modifier"),
+        DiagnosticSpec(locationMarker: "RIGHT", message: "Unexpected text ', didSet' in modifier")
       ]
     )
 
     AssertParse(
       """
-      private(#^DIAG^#get#^TOP^#, didSet
+      private(#^DIAG^#get, didSet var a = 0
       """,
-      // FIXME: Consuming `get` as top level token is undesirable.
       diagnostics: [
-        // FIXME: It should be located at right of didSet
         DiagnosticSpec(message: "Expected 'set' in modifier"),
         DiagnosticSpec(message: "Expected ')' to end modifier"),
-        // FIXME: It should be from modifier, not top level
-        DiagnosticSpec(locationMarker: "TOP", message: "Extraneous ', didSet' at top level")
+        DiagnosticSpec(message: "Unexpected text 'get, didSet' in variable")
       ]
     )
   }

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -215,6 +215,26 @@ final class DeclarationTests: XCTestCase {
   func testAccessLevelModifier() {
     AssertParse(
       """
+      private(#^DIAG^#+
+        set
+      )
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "Unexpected text '+' found in modifier")
+      ]
+    )
+
+    AssertParse(
+      """
+      private(#^DIAG^#get: set)
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "Unexpected text 'get:' found in modifier")
+      ]
+    )
+
+    AssertParse(
+      """
       private(#^DIAG^#
       """,
       diagnostics: [
@@ -225,23 +245,22 @@ final class DeclarationTests: XCTestCase {
 
     AssertParse(
       """
-      private(#^DIAG^#get#^DTOP^#, set, didSet)
+      private(#^LEFT^#get, set#^RIGHT^#, didSet)
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected 'set' in modifier"),
-        DiagnosticSpec(message: "Expected ')' to end modifier"),
-        DiagnosticSpec(locationMarker: "DTOP", message: "Extraneous ', set, didSet)' at top level")
+        DiagnosticSpec(locationMarker: "LEFT", message: "Unexpected text 'get,' found in modifier"),
+        DiagnosticSpec(locationMarker: "RIGHT", message: "Unexpected text ', didSet' found in modifier")
       ]
     )
 
     AssertParse(
       """
-      private(#^DIAG^#get#^DTOP^#, didSet
+      private(#^LEFT^#get, didSet#^RIGHT^#
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected 'set' in modifier"),
-        DiagnosticSpec(message: "Expected ')' to end modifier"),
-        DiagnosticSpec(locationMarker: "DTOP", message: "Extraneous ', didSet' at top level")
+        DiagnosticSpec(locationMarker: "LEFT", message: "Unexpected text 'get, didSet' found in modifier"),
+        DiagnosticSpec(locationMarker: "RIGHT", message: "Expected 'set' in modifier"),
+        DiagnosticSpec(locationMarker: "RIGHT", message: "Expected ')' to end modifier")
       ]
     )
   }

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -212,6 +212,39 @@ final class DeclarationTests: XCTestCase {
     )
   }
 
+  func testAccessLevelModifier() {
+    AssertParse(
+      """
+      private(#^DIAG^#
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "Expected 'set' in modifier"),
+        DiagnosticSpec(message: "Expected ')' to end modifier")
+      ]
+    )
+
+    AssertParse(
+      """
+      private(#^DLEFT^#get, set#^DRIGHT^#, didSet)
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DLEFT", message: "Unexpected text 'get,' found in modifier"),
+        DiagnosticSpec(locationMarker: "DRIGHT", message: "Unexpected text ', didSet' found in modifier")
+      ]
+    )
+
+    AssertParse(
+      """
+      private(#^DSET^#get, didSet#^DRPAREN^#
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DSET", message: "Expected 'set' in modifier"),
+        DiagnosticSpec(locationMarker: "DSET", message: "Unexpected text 'get, didSet' found in modifier"),
+        DiagnosticSpec(locationMarker: "DRPAREN", message: "Expected ')' to end modifier"),
+      ]
+    )
+  }
+
   func testTypealias() {
     AssertParse("typealias Foo = Int")
 


### PR DESCRIPTION
This PR fix #631.
It can round-trip correctly without crashing.

Not only that, I tried to improve recovering logic here.

For example, the logic recover such wrong inputs intuitively way.

```swift
private(get, set, didSet)
```

See my test cases for detail.
How do you think?