### PR TITLE
Fixes #681 - Missing generic type in attrs

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -381,7 +381,7 @@ extension Parser {
             arena: self.arena))
         } else {
           requirement = RawSyntax(RawSameTypeRequirementSyntax(
-            leftTypeIdentifier: RawTypeSyntax(RawMissingTypeSyntax(arena: self.arena)),
+            leftTypeIdentifier: firstType,
             equalityToken: RawTokenSyntax(missing: .equal, arena: self.arena),
             rightTypeIdentifier: RawTypeSyntax(RawMissingTypeSyntax(arena: self.arena)),
             arena: self.arena

--- a/Tests/SwiftParserTest/Attributes.swift
+++ b/Tests/SwiftParserTest/Attributes.swift
@@ -18,17 +18,18 @@ final class AttributeTests: XCTestCase {
     )
   }
   
-  func testMissingGenericTypeToAttribute() {
-    AssertParse(
+func testMissingGenericTypeToAttribute() {
+  AssertParse(
     """
-    @differentiable(reverse wrt,where T #^DIAG_1^#
+    @differentiable(reverse wrt#^DIAG_1^#,where T#^DIAG_2^##^DIAG_3^#
     func podcastPlaybackSpeed() {
     }
     """,
     diagnostics: [
-      DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected '=' in same type requirement"),
-//      DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected ')' to end attribute"),
+      DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ':' in '@differentiable' argument"),
+      DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '=' in same type requirement"),
+      DiagnosticSpec(locationMarker: "DIAG_3", message: "Expected ')' to end attribute"),
     ]
-    )
-  }
+  )
+}
 }

--- a/Tests/SwiftParserTest/Attributes.swift
+++ b/Tests/SwiftParserTest/Attributes.swift
@@ -18,18 +18,18 @@ final class AttributeTests: XCTestCase {
     )
   }
   
-func testMissingGenericTypeToAttribute() {
-  AssertParse(
-    """
-    @differentiable(reverse wrt#^DIAG_1^#,where T#^DIAG_2^##^DIAG_3^#
-    func podcastPlaybackSpeed() {
-    }
-    """,
-    diagnostics: [
-      DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ':' in '@differentiable' argument"),
-      DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '=' in same type requirement"),
-      DiagnosticSpec(locationMarker: "DIAG_3", message: "Expected ')' to end attribute"),
-    ]
-  )
-}
+  func testMissingGenericTypeToAttribute() {
+    AssertParse(
+      """
+      @differentiable(reverse wrt#^DIAG_1^#,where T#^DIAG_2^##^DIAG_3^#
+      func podcastPlaybackSpeed() {
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ':' in '@differentiable' argument"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '=' in same type requirement"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "Expected ')' to end attribute"),
+      ]
+    )
+  }
 }

--- a/Tests/SwiftParserTest/Attributes.swift
+++ b/Tests/SwiftParserTest/Attributes.swift
@@ -17,4 +17,18 @@ final class AttributeTests: XCTestCase {
       ]
     )
   }
+  
+  func testMissingGenericTypeToAttribute() {
+    AssertParse(
+    """
+    @differentiable(reverse wrt,where T #^DIAG_1^#
+    func podcastPlaybackSpeed() {
+    }
+    """,
+    diagnostics: [
+      DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected '=' in same type requirement"),
+//      DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected ')' to end attribute"),
+    ]
+    )
+  }
 }


### PR DESCRIPTION
I believe this fixes 681. ~However, I think I'm not able to write tests properly.~

~For example, the following fails with error `Expected diagnostic on 1:37 but got 1:28`~
```swift
func testMissingGenericTypeToAttribute() {
  AssertParse(
    """
    @differentiable(reverse wrt,where T #^DIAG_1^#
    func podcastPlaybackSpeed() {
    }
    """,
    diagnostics: [
      DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected '=' in same type requirement"),
    ]
  )
}
```

~I don't think this is true, because the diagnostic marker is not on 1:28. 
It would be great if this PR didn't get merged. Instead, i'd like to fix the test first, so any tips are welcome!~

Edit: Fixed the tests in [d40bae7](https://github.com/apple/swift-syntax/pull/705/commits/d40bae78b1861437810585497ce71630695f022f)