### PR TITLE
Improve token precedence classifications

### DIFF
--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -22,17 +22,20 @@ public enum TokenPrecedence: Comparable {
   case exprKeyword
   /// A token that starts a bracketet expression which typically occurs inside
   /// a statement.
-  /// `closingDelimiter` must have precedence `weakPunctuator` or `weakBracketed`
   case weakBracketed(closingDelimiter: RawTokenKind)
   /// A punctuator that can occur inside a statement
   case weakPunctuator
+  /// The closing delimiter of `weakBracketed`
+  case weakBracketClose
   /// Keywords that start a new statement.
   case stmtKeyword
-  /// A punctuator that is a strong indicator that it separates two distinct parts of the source code, like two statements
-  case strongPunctuator
   /// The '{' token because it typically marks the body of a declaration.
   /// `closingDelimiter` must have type `strongPunctuator`
-  case strongBracketet(closingDelimiter: RawTokenKind)
+  case strongBracketed(closingDelimiter: RawTokenKind)
+  /// A punctuator that is a strong indicator that it separates two distinct parts of the source code, like two statements
+  case strongPunctuator
+  /// The closing delimiter of `strongBracketed`
+  case strongBracketedClose
   /// Tokens that start a new declaration
   case declKeyword
 
@@ -41,7 +44,7 @@ public enum TokenPrecedence: Comparable {
     switch self {
     case .weakBracketed(closingDelimiter: let closingDelimiter):
       return closingDelimiter
-    case .strongBracketet(closingDelimiter: let closingDelimiter):
+    case .strongBracketed(closingDelimiter: let closingDelimiter):
       return closingDelimiter
     default:
       return nil
@@ -60,14 +63,18 @@ public enum TokenPrecedence: Comparable {
         return 2
       case .weakPunctuator:
         return 3
-      case .stmtKeyword:
+      case .weakBracketClose:
         return 4
-      case .strongPunctuator:
+      case .stmtKeyword:
         return 5
-      case .strongBracketet:
+      case .strongPunctuator:
         return 6
-      case .declKeyword:
+      case .strongBracketed:
         return 7
+      case .strongBracketedClose:
+        return 8
+      case .declKeyword:
+        return 9
       }
     }
 
@@ -131,10 +138,14 @@ public enum TokenPrecedence: Comparable {
       // Chaining punctuators
         .infixQuestionMark, .period, .postfixQuestionMark, .prefixPeriod,.exclamationMark,
       // Misc
-        .backslash, .backtick, .colon, .comma, .ellipsis, .equal, .prefixAmpersand,
+        .backslash, .backtick, .colon, .comma, .ellipsis, .equal, .prefixAmpersand:
+      self = .weakPunctuator
+
+      // MARK: Weak bracket close
+    case
       // Weak brackets
         .rightAngle, .rightParen, .rightSquareBracket:
-      self = .weakPunctuator
+      self = .weakBracketClose
 
       // MARK: Statement keyword punctuator
     case
@@ -152,9 +163,9 @@ public enum TokenPrecedence: Comparable {
 
       // MARK: Strong bracketet
     case .leftBrace:
-      self = .strongBracketet(closingDelimiter: .rightBrace)
+      self = .strongBracketed(closingDelimiter: .rightBrace)
     case .poundElseifKeyword, .poundElseKeyword, .poundIfKeyword:
-      self = .strongBracketet(closingDelimiter: .poundEndifKeyword)
+      self = .strongBracketed(closingDelimiter: .poundEndifKeyword)
 
       // MARK: Strong punctuator
     case
@@ -164,11 +175,13 @@ public enum TokenPrecedence: Comparable {
         .arrow,
       // '@' typically occurs at the start of declarations
         .atSign,
-      // Match the '}' and '#endif' as strongBracketet
-        .poundEndifKeyword, .rightBrace,
       // EOF is here because it is a very stong marker and doesn't belong anywhere else
         .eof:
       self = .strongPunctuator
+
+      // MARK: Strong bracket close
+    case .poundEndifKeyword, .rightBrace:
+      self = .strongBracketedClose
 
       // MARK: Decl keywords
     case

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -635,7 +635,7 @@ final class DeclarationTests: XCTestCase {
 
   func testDontRecoverFromUnbalancedParens() {
     AssertParse(
-      "func foo(first second #^COLON^#[third #^RSQUARE_COLON^#fourth#^EXTRANEOUS^#: Int) {}",
+      "func foo(first second #^COLON^#[third #^END_ARRAY^#fourth: Int) {}",
       substructure: Syntax(FunctionParameterSyntax(
         attributes: nil,
         firstName: TokenSyntax.identifier("first"),
@@ -652,9 +652,8 @@ final class DeclarationTests: XCTestCase {
       )),
       diagnostics: [
         DiagnosticSpec(locationMarker: "COLON", message: "Expected ':' in function parameter"),
-        DiagnosticSpec(locationMarker: "RSQUARE_COLON" , message: "Expected ']' to end array type"),
-        DiagnosticSpec(locationMarker: "RSQUARE_COLON", message: "Expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "EXTRANEOUS", message: "Extraneous ': Int) {}' at top level")
+        DiagnosticSpec(locationMarker: "END_ARRAY" , message: "Expected ']' to end array type"),
+        DiagnosticSpec(locationMarker: "END_ARRAY", message: "Unexpected text 'fourth: Int' found in parameter clause")
       ]
     )
   }

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -150,16 +150,16 @@ final class StatementTests: XCTestCase {
   func testAttributesOnStatements() {
     AssertParse(
       """
-      func test1() {#^END_FUNCTION^#
-        #^EXTRANEOUS^#@s return
+      func test1() {
+        #^TEST_1^#@s return
       }
       func test2() {
-        @unknown return
+        #^TEST_2^#@unknown return
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "END_FUNCTION", message: "Expected '}' to end function"),
-        DiagnosticSpec(locationMarker: "EXTRANEOUS", message: "Extraneous code at top level")
+        DiagnosticSpec(locationMarker: "TEST_1", message: "Unexpected text '@s return' found in function"),
+        DiagnosticSpec(locationMarker: "TEST_2", message: "Unexpected text '@unknown return' found in function")
       ]
     )
   }
@@ -167,40 +167,37 @@ final class StatementTests: XCTestCase {
   func testBogusSwitchStatement() {
     AssertParse(
       """
-      switch x {#^END_SWITCH^#
-        print()
+      switch x {
+        #^DIAG^#print()
       #if true
         print()
       #endif
-        #^EXTRANEOUS^#case .A, .B:
+        case .A, .B:
           break
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "END_SWITCH", message: "Expected '}' to end 'switch' statement"),
-        DiagnosticSpec(locationMarker: "EXTRANEOUS", message: "Extraneous code at top level")
+        DiagnosticSpec(message: "Unexpected text found in 'switch' statement"),
 
       ]
     )
 
     AssertParse(
       """
-      switch x {#^END_SWITCH^#
-      print()
+      switch x {
+      #^DIAG^#print()
       #if ENABLE_C
-      #^UNEXPECTED^#case .NOT_EXIST:
+      case .NOT_EXIST:
         break
       case .C:
         break
       #endif
-      #^EXTRANEOUS^#case .A, .B:
+      case .A, .B:
         break
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "END_SWITCH", message: "Expected '}' to end 'switch' statement"),
-        DiagnosticSpec(locationMarker: "UNEXPECTED", message: "Unexpected text found in conditional compilation block"),
-        DiagnosticSpec(locationMarker: "EXTRANEOUS", message: "Extraneous code at top level")
+        DiagnosticSpec(message: "Unexpected text found in 'switch' statement")
       ]
     )
   }


### PR DESCRIPTION
Motivated by https://github.com/apple/swift-syntax/pull/704 this adjusts token precedences a little bit to produce better diagnostics. Previously, we had different logic how we classified weak brackets (like `(`) and strong brackets (like `{`). Unify the two concepts and allow consuming weak punctuators (like `.` or `:`) while looking for a weak closing bracket and skipping strong punctuators (like `;`) while looking for a strong closing bracket.