### PR TITLE
Fixes #679: @specialize with invalid attribute

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -493,9 +493,7 @@ extension Parser {
     // Parse optional "exported" and "kind" labeled parameters.
     while !self.at(.eof) && !self.at(.whereKeyword) {
       let ident = self.parseAnyIdentifier()
-      guard let knownParameter = SpecializeParameter(rawValue: ident.tokenText) else {
-        fatalError()
-      }
+      let knownParameter = SpecializeParameter(rawValue: ident.tokenText)
       let (unexpectedBeforeColon, colon) = self.expect(.colon)
 
       switch knownParameter {
@@ -571,6 +569,15 @@ extension Parser {
           colon: colon,
           value: valueLabel,
           trailingComma: comma,
+          arena: self.arena
+        )))
+      case .none:
+        let valueLabel = self.consumeAnyToken()
+        elements.append(RawSyntax(RawLabeledSpecializeEntrySyntax(
+          label: ident,
+          colon: colon,
+          value: valueLabel,
+          trailingComma: nil,
           arena: self.arena
         )))
       }

--- a/Tests/SwiftParserTest/Attributes.swift
+++ b/Tests/SwiftParserTest/Attributes.swift
@@ -32,4 +32,16 @@ final class AttributeTests: XCTestCase {
       ]
     )
   }
+  
+  func testMissingClosingParenToAttribute() {
+    AssertParse(
+      """
+      @_specialize(e#^DIAG_1^#
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ':' in attribute argument"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ')' to end attribute"),
+      ]
+    )
+  }
 }


### PR DESCRIPTION
This closes #679. 

The solution suggests that the `@_specialize` parameter is missing a colon (i.e. `Expected ':' in attribute argument`). This is only true for parameters of `SpecializeParameter` enum. 

However, I believe this behaviour is incorrect in case of supplying a type as a parameter (E.g. `@_specialize(T == Int)`), because it won't have a colon.

The previous example is from [`@_specialize` attribute pitch][pitch], where it seems it's possible to define a parameter with a type only, as opposed to the current unit tests in [`SwiftParserTest`][SwiftParserTest] where the type parameters are only defined with a `where` clause (E.g. `@_specialize(where T.Element == Int)`).

So I'm not 100% sure about the possibility of supplying the type only without a `where` clause.

[pitch]: https://forums.swift.org/t/specialize-attribute/1853
[SwiftParserTest]: https://github.com/apple/swift-syntax/tree/main/Tests/SwiftParserTest