### PR TITLE
Tests #678: malformed struct

### DIFF
--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -682,6 +682,19 @@ final class DeclarationTests: XCTestCase {
       ]
     )
   }
+  
+  func testMalforedStruct() {
+    AssertParse(
+      """
+      struct n#^OPENINGBRACES^##if@#^ENDIF^##^CLOSINGBRACES^#
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "OPENINGBRACES", message: "Expected '{' to start struct"),
+        DiagnosticSpec(locationMarker: "ENDIF", message: "Expected '#endif' in conditional compilation block"),
+        DiagnosticSpec(locationMarker: "CLOSINGBRACES", message: "Expected '}' to end struct")
+      ]
+    )
+  }
 }
 
 extension Parser.DeclAttributes {


### PR DESCRIPTION
A unit test to cover #678.