### PR TITLE
Re-parent the Unexpected Nodes in Function Types

### DIFF
--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -41,26 +41,38 @@ extension Parser {
       let arrow = self.eat(.arrow)
       let returnTy = self.parseType()
 
+      let unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax?
       let leftParen: RawTokenSyntax
+      let unexpectedBetweenLeftParenAndElements: RawUnexpectedNodesSyntax?
       let arguments: RawTupleTypeElementListSyntax
+      let unexpectedBetweenElementsAndRightParen: RawUnexpectedNodesSyntax?
       let rightParen: RawTokenSyntax
       if let input = base.as(RawTupleTypeSyntax.self) {
+        unexpectedBeforeLeftParen = input.unexpectedBeforeLeftParen
         leftParen = input.leftParen
+        unexpectedBetweenLeftParenAndElements = input.unexpectedBetweenLeftParenAndElements
         arguments = input.elements
+        unexpectedBetweenElementsAndRightParen = input.unexpectedBetweenElementsAndRightParen
         rightParen = input.rightParen
       } else {
+        unexpectedBeforeLeftParen = nil
         leftParen = RawTokenSyntax(missing: .leftParen, arena: self.arena)
+        unexpectedBetweenLeftParenAndElements = nil
         arguments = RawTupleTypeElementListSyntax(elements: [
           RawTupleTypeElementSyntax(
             inOut: nil, name: nil, secondName: nil, colon: nil, type: base,
             ellipsis: nil, initializer: nil, trailingComma: nil, arena: self.arena)
         ], arena: self.arena)
+        unexpectedBetweenElementsAndRightParen = nil
         rightParen = RawTokenSyntax(missing: .rightParen, arena: self.arena)
       }
 
       base = RawTypeSyntax(RawFunctionTypeSyntax(
+        unexpectedBeforeLeftParen,
         leftParen: leftParen,
+        unexpectedBetweenLeftParenAndElements,
         arguments: arguments,
+        unexpectedBetweenElementsAndRightParen,
         rightParen: rightParen,
         asyncKeyword: firstEffect,
         throwsOrRethrowsKeyword: secondEffect,

--- a/Tests/SwiftParserTest/Types.swift
+++ b/Tests/SwiftParserTest/Types.swift
@@ -26,4 +26,10 @@ final class TypeTests: XCTestCase {
       { $0.parseType() }
     )
   }
+
+  func testFunctionTypes() throws {
+    AssertParse("t as(#^DIAG^#..)->", diagnostics: [
+      DiagnosticSpec(message: "Unexpected text '..' found in function type")
+    ])
+  }
 }


### PR DESCRIPTION
Function type parsing does this awkward dance where it peels apart tuple
types before arrows and re-inserted them into function type syntax nodes.
Take the unexpected nodes into account during this transformation.

Fixes #680