### PR TITLE
Parse an Optional Code Block in Deinits

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1034,7 +1034,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseDeinitializerDeclaration(_ attrs: DeclAttributes) -> RawDeinitializerDeclSyntax {
     let deinitKeyword = self.eat(.deinitKeyword)
-    let items = self.parseCodeBlock()
+    let items = self.parseOptionalCodeBlock()
     return RawDeinitializerDeclSyntax(
       attributes: attrs.attributes, modifiers: attrs.modifiers,
       deinitKeyword: deinitKeyword, body: items,

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -708,6 +708,11 @@ final class DeclarationTests: XCTestCase {
       ]
     )
   }
+
+  func testDeinitializers() {
+    AssertParse("deinit {}", { $0.parseDeinitializerDeclaration(.empty) })
+    AssertParse("deinit", { $0.parseDeinitializerDeclaration(.empty) })
+  }
 }
 
 extension Parser.DeclAttributes {


### PR DESCRIPTION
The body of a deinitializer is not strictly required a la
declarations in swiftinterface file.