### PR TITLE
#keyPath Expressions Don't Actually Allow Compound Names

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1282,11 +1282,12 @@ extension Parser {
     // Parse the sequence of unqualified-names.
     var elements = [RawObjcNamePieceSyntax]()
     do {
-      var flags: DeclNameOptions = .compoundNames
+      var flags: DeclNameOptions = []
       var keepGoing: RawTokenSyntax? = nil
       repeat {
         // Parse the next name.
-        let (name, _) = self.parseDeclNameRef(flags)
+        let (name, args) = self.parseDeclNameRef(flags)
+        assert(args == nil, "Found arguments but did not pass argument flag?")
 
         // After the first component, we can start parsing keywords.
         flags.formUnion(.keywords)

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -412,6 +412,12 @@ final class ExpressionTests: XCTestCase {
         DiagnosticSpec(message: "Expected '}' to end function"),
       ]
     )
+
+    AssertParse("#keyPath(#^DIAG^#(b:)",
+                diagnostics: [
+                  DiagnosticSpec(message: "Expected '' in '#keyPath' expression"),
+                  DiagnosticSpec(message: "Expected ')' to end '#keyPath' expression"),
+                ])
   }
 
   func testMissingArrowInArrowExpr() {


### PR DESCRIPTION
Somebody added this flag to improve diagnostic QoI. Instead, eat unexpected arguments in compound names as unexpected tokens and keep parsing.

Fixes #674

rdar://99430606