### PR TITLE
Emulate the Structure of Pattern Binding Conditions

### DIFF
--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -163,7 +163,17 @@ extension Parser {
       // matching-pattern ::= expr
       // Fall back to expression parsing for ambiguous forms. Name lookup will
       // disambiguate.
-      let expr = RawExprSyntax(self.parseSequenceExpression(.basic, inVarOrLet: true))
+      let patternSyntax = self.parseSequenceExpression(.basic, inVarOrLet: true)
+      if let pat = patternSyntax.as(RawUnresolvedPatternExprSyntax.self) {
+        // The most common case here is to parse something that was a lexically
+        // obvious pattern, which will come back wrapped in an immediate
+        // RawUnresolvedPatternExprSyntax.
+        //
+        // FIXME: This is pretty gross. Let's find a way to disambiguate let
+        // binding patterns much earlier.
+        return RawPatternSyntax(pat.pattern)
+      }
+      let expr = RawExprSyntax(patternSyntax)
       return RawPatternSyntax(RawExpressionPatternSyntax(expression: expr, arena: self.arena))
     }
   }

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -217,7 +217,7 @@ extension Parser {
 
     // Parse the basic expression case.  If we have a leading let/var/case
     // keyword or an assignment, then we know this is a binding.
-    if !self.at(.letKeyword) && !self.at(.varKeyword) && !self.at(.caseKeyword) {
+    guard self.at(.letKeyword) || self.at(.varKeyword) || self.at(.caseKeyword) else {
       // If we lack it, then this is theoretically a boolean condition.
       // However, we also need to handle migrating from Swift 2 syntax, in
       // which a comma followed by an expression could actually be a pattern

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -4,6 +4,22 @@ import XCTest
 
 final class StatementTests: XCTestCase {
   func testIf() {
+    AssertParse("""
+                if let baz {}
+                """,
+                substructure: Syntax(IfStmtSyntax(ifKeyword: .ifKeyword(),
+                                                  conditions: ConditionElementListSyntax([
+                                                    ConditionElementSyntax(condition: Syntax(OptionalBindingConditionSyntax(
+                                                      letOrVarKeyword: .letKeyword(),
+                                                      pattern: PatternSyntax(IdentifierPatternSyntax(identifier: .identifier("baz"))),
+                                                      typeAnnotation: nil,
+                                                      initializer: nil)), trailingComma: nil)
+                                                  ]),
+                                                  body: .init(leftBrace: .leftBraceToken(),
+                                                              statements: .init([]),
+                                                              rightBrace: .rightBraceToken()),
+                                                  elseKeyword: nil, elseBody: nil)))
+
     AssertParse("if let x { }")
 
     AssertParse(


### PR DESCRIPTION
The expression parser has to go out of its way to parse all the way down to primary expressions before realizing that the expression pattern it was after isn't actually an expression pattern. This involves setting a bit of ambient state, that we have to plumb down expression parsing.

This is pretty gross, but it emulates what the legacy parser was doing here.

Fixes #724

rdar://99669036