### PR TITLE
Miscellaneous parser fixes

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -183,7 +183,7 @@ extension Parser {
 
 
     let atSign = self.eat(.atSign)
-    let ident = self.consumeIdentifier()
+    let ident = self.consumeIdentifierOrRethrows()
     let leftParen: RawTokenSyntax?
     let arg: RawSyntax?
     let unexpectedBeforeRightParen: RawUnexpectedNodesSyntax?

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -458,7 +458,7 @@ extension Parser {
             name: name,
             colon: nil,
             arena: self.arena))
-          continue
+          break
         }
 
         let (unexpectedBeforeColon, colon) = self.expect(.colon)

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -721,6 +721,9 @@ extension Parser {
     case .__file__Keyword:
       let tok = self.eat(.__file__Keyword)
       return RawExprSyntax(RawPoundFileExprSyntax(poundFile: tok, arena: self.arena))
+    case .poundFileIDKeyword:
+      let tok = self.eat(.poundFileIDKeyword)
+      return RawExprSyntax(RawPoundFileIDExprSyntax(poundFileID: tok, arena: self.arena))
     case .poundFileKeyword:
       let tok = self.eat(.poundFileKeyword)
       return RawExprSyntax(RawPoundFileExprSyntax(poundFile: tok, arena: self.arena))

--- a/Sources/SwiftParser/Lexer.swift
+++ b/Sources/SwiftParser/Lexer.swift
@@ -2007,6 +2007,8 @@ extension Lexer.Cursor {
   ) -> RawTokenKind? {
     var Tmp = TokStart
     var poundCount = 0
+    var parenCount = 0
+
     while Tmp.advance(matching: UInt8(ascii: "#")) != nil {
       poundCount += 1
     }
@@ -2071,6 +2073,15 @@ extension Lexer.Cursor {
 //        // TODO: Ideally we would recover and continue to lex until the ending
 //        // delimiter.
 //        throw DelimiterLexError(.unprintableASCII, resumeAt: cursor.successor())
+
+      case UInt8(ascii: "("):
+        parenCount += 1
+
+      case UInt8(ascii: ")"):
+        if parenCount == 0 {
+          return nil
+        }
+        parenCount -= 1
 
       default:
         continue DELIMITLOOP

--- a/Sources/SwiftParser/Lexer.swift
+++ b/Sources/SwiftParser/Lexer.swift
@@ -1439,7 +1439,7 @@ extension Lexer.Cursor {
         return .integerLiteral
       }
 
-      self.advance(while: { $0.isDigit || $0 == Unicode.Scalar("_") })
+      self.advance(while: { $0.isHexDigit || $0 == Unicode.Scalar("_") })
 
       if !self.isAtEndOfFile, self.peek() != UInt8(ascii: "p") && self.peek() != UInt8(ascii: "P") {
         if !Unicode.Scalar(PtrOnDot!.peek(at: 1)).isDigit {

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -146,7 +146,7 @@ extension Parser.Lookahead {
 
     repeat {
       self.eat(.atSign)
-      self.consumeIdentifier()
+      self.consumeIdentifierOrRethrows()
       if self.consume(if: .leftParen) != nil {
         while !self.at(.eof), !self.at(.rightParen), !self.at(.poundEndifKeyword) {
           self.skipSingle()

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -330,6 +330,19 @@ extension TokenConsumer {
     }
   }
 
+  mutating func consumeIdentifierOrRethrows() -> Token {
+    switch self.currentToken.tokenKind {
+    case .selfKeyword,
+        .capitalSelfKeyword,
+        .anyKeyword,
+        .identifier,
+        .rethrowsKeyword:
+      return self.consumeAnyToken()
+    default:
+      return self.missingToken(.identifier)
+    }
+  }
+
   mutating func consumeInteger() -> Token {
     switch self.currentToken.tokenKind {
     case .integerLiteral:

--- a/Tests/SwiftParserTest/Attributes.swift
+++ b/Tests/SwiftParserTest/Attributes.swift
@@ -63,6 +63,9 @@ final class AttributeTests: XCTestCase {
       """
       @objc(zeroArg)
       class A { }
+
+      @objc(:::::)
+      func f(_: Int, _: Int, _: Int, _: Int, _: Int) { }
       """
     )
   }

--- a/Tests/SwiftParserTest/Attributes.swift
+++ b/Tests/SwiftParserTest/Attributes.swift
@@ -66,4 +66,13 @@ final class AttributeTests: XCTestCase {
       """
     )
   }
+
+  func testRethrowsAttribute() {
+    AssertParse(
+      """
+      @rethrows
+      protocol P { }
+      """
+    )
+  }
 }

--- a/Tests/SwiftParserTest/Attributes.swift
+++ b/Tests/SwiftParserTest/Attributes.swift
@@ -75,4 +75,22 @@ final class AttributeTests: XCTestCase {
       """
     )
   }
+
+  func testAutoclosureAttribute() {
+    AssertParse(
+      """
+      func f(in: @autoclosure () -> Int) { }
+      func g(in: @autoclosure @escaping () -> Int) { }
+      """
+    )
+  }
+
+  func testDifferentiableAttribute() {
+    AssertParse(
+      """
+      func f(in: @differentiable(reverse) (Int) -> Int) { }
+      func f(in: @differentiable(reverse, wrt: a) (Int) -> Int) { }
+      """
+    )
+  }
 }

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -86,6 +86,7 @@ final class ExpressionTests: XCTestCase {
     AssertParse(
       """
       #file
+      #fileID
       (#line)
       #column
       #function

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -347,6 +347,13 @@ public class LexerTests: XCTestCase {
         lexeme(.pound, "#"),
         lexeme(.eof, ""),
       ]),
+      ("/a)/", [
+        lexeme(.prefixOperator, "/"),
+        lexeme(.identifier, "a"),
+        lexeme(.rightParen, ")"),
+        lexeme(.postfixOperator, "/"),
+        lexeme(.eof, ""),
+      ]),
     ]
     for (fixture, expectation) in fixtures {
       var fixture = fixture

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -130,6 +130,7 @@ public class LexerTests: XCTestCase {
     0xff.0p2
     -0xff.0p2
     +0xff.0p2
+    0x1.921fb4p1
     """
     data.withUTF8 { buf in
       let lexemes = Lexer.lex(buf)
@@ -146,6 +147,7 @@ public class LexerTests: XCTestCase {
         lexeme(.floatingLiteral, "0xff.0p2"),
         lexeme(.prefixOperator, "\n+", leading: 1),
         lexeme(.floatingLiteral, "0xff.0p2"),
+        lexeme(.floatingLiteral, "\n0x1.921fb4p1", leading: 1),
         lexeme(.eof, ""),
       ])
     }


### PR DESCRIPTION
Fix a number of small issues encountered while parsing the standard library:
* Don't lex regex literals with unbalanced close parentheses in them (`/a)/`)
* Lex hexadecimal floating point literals
* Properly parse the `@rethrows` attribute
* Parse `#fileID`
* Parse `@differentiable` on types