### PR TITLE
Fixup Bare Slash Literal Lexing

### DIFF
--- a/Sources/SwiftParser/Lexer.swift
+++ b/Sources/SwiftParser/Lexer.swift
@@ -2015,6 +2015,20 @@ extension Lexer.Cursor {
       return nil
     }
 
+    // For `/.../` regex literals, we need to ban space and tab at the start of
+    // a regex to avoid ambiguity with operator chains, e.g:
+    //
+    // Builder {
+    //   0
+    //   / 1 /
+    //   2
+    // }
+    //
+    if poundCount == 0 && !Tmp.isAtEndOfFile &&
+        (Tmp.peek() == UInt8(ascii: " ") || Tmp.peek() == UInt8(ascii: "\t")) {
+      return nil
+    }
+
     var isMultiline = false
     while !Tmp.isAtEndOfFile {
       switch Tmp.peek() {

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -474,6 +474,31 @@ public class LexerTests: XCTestCase {
       ])
     }
   }
+
+  func testNotARegex() {
+    var data =
+    """
+    min(reduced.count / 2, chunkSize / 2)
+    """
+    let lexemes = data.withUTF8 { buf in
+      Lexer.lex(buf)
+    }
+    AssertEqualTokens(lexemes, [
+      lexeme(.identifier, "min"),
+      lexeme(.leftParen, "("),
+      lexeme(.identifier, "reduced"),
+      lexeme(.period, "."),
+      lexeme(.identifier, "count ", trailing: 1),
+      lexeme(.spacedBinaryOperator, "/ ", trailing: 1),
+      lexeme(.integerLiteral, "2"),
+      lexeme(.comma, ", ", trailing: 1),
+      lexeme(.identifier, "chunkSize ", trailing: 1),
+      lexeme(.spacedBinaryOperator, "/ ", trailing: 1),
+      lexeme(.integerLiteral, "2"),
+      lexeme(.rightParen, ")"),
+      lexeme(.eof, ""),
+    ])
+  }
 }
 
 extension Lexer {


### PR DESCRIPTION
Break the ambiguity with bare slash regex literals that have any amount of whitespace after the slash delimiter. These now lex as spaced binary operators as appropriate.

Fixes #627

rdar://98736315