### PR TITLE
Improve diagnostic message if unexpected tokens are found at the start of a layout node

### DIFF
--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -51,7 +51,7 @@ final class DeclarationTests: XCTestCase {
       func foo() {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text '}' found in function")
+        DiagnosticSpec(message: "Unexpected text '}' before function")
       ]
     )
   }
@@ -115,7 +115,7 @@ final class DeclarationTests: XCTestCase {
       actor Foo {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text '}' found in actor")
+        DiagnosticSpec(message: "Unexpected text '}' before actor")
       ]
     )
   }
@@ -417,7 +417,7 @@ final class DeclarationTests: XCTestCase {
       "(first second #^DIAG^#third fourth: Int)",
       { $0.parseFunctionSignature() },
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'third fourth' found in function parameter")
+        DiagnosticSpec(message: "Unexpected text 'third fourth' in function parameter")
       ]
     )
   }
@@ -559,7 +559,7 @@ final class DeclarationTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(
           message: """
-            Unexpected text '/ ###line 25 "line-directive.swift"' found in struct
+            Unexpected text '/ ###line 25 "line-directive.swift"' in struct
             """
         )
       ]
@@ -574,7 +574,7 @@ final class DeclarationTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'bogus rethrows set' found in variable")
+        DiagnosticSpec(message: "Unexpected text 'bogus rethrows set' in variable")
       ]
     )
   }
@@ -606,7 +606,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'third' found in function parameter")
+        DiagnosticSpec(message: "Unexpected text 'third' in function parameter")
       ]
     )
   }
@@ -627,7 +627,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'third fourth' found in function parameter")
+        DiagnosticSpec(message: "Unexpected text 'third fourth' in function parameter")
       ]
     )
   }
@@ -678,7 +678,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text '[third fourth]' found in function parameter")
+        DiagnosticSpec(message: "Unexpected text '[third fourth]' in function parameter")
       ]
     )
   }
@@ -703,7 +703,7 @@ final class DeclarationTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(locationMarker: "COLON", message: "Expected ':' in function parameter"),
         DiagnosticSpec(locationMarker: "END_ARRAY" , message: "Expected ']' to end array type"),
-        DiagnosticSpec(locationMarker: "END_ARRAY", message: "Unexpected text 'fourth: Int' found in parameter clause")
+        DiagnosticSpec(locationMarker: "END_ARRAY", message: "Unexpected text 'fourth: Int' in parameter clause")
       ]
     )
   }

--- a/Tests/SwiftParserTest/Directives.swift
+++ b/Tests/SwiftParserTest/Directives.swift
@@ -92,8 +92,8 @@ final class DirectiveTests: XCTestCase {
       #endif
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' found in conditional compilation clause"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Unexpected text '}' found in conditional compilation block"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "Unexpected text '}' in conditional compilation block"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -203,7 +203,7 @@ final class ExpressionTests: XCTestCase {
       " >> \( abc #^DIAG^#} ) << "
       """#,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text '}' found in string literal")
+        DiagnosticSpec(message: "Unexpected text '}' in string literal")
       ]
     )
 
@@ -426,7 +426,7 @@ final class ExpressionTests: XCTestCase {
       "[(Int) -> #^DIAG^#throws Int]()",
       diagnostics: [
         // FIXME: We should suggest to move 'throws' in front of '->'
-        DiagnosticSpec(message: "Unexpected text 'throws Int' found in array")
+        DiagnosticSpec(message: "Unexpected text 'throws Int' in array")
       ]
     )
 
@@ -456,7 +456,7 @@ final class ExpressionTests: XCTestCase {
       let :(#^DIAG_1^#..)->
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '..' found in function type"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '..' in function type"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -30,7 +30,7 @@ final class StatementTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(message: "Expected '=' in pattern matching"),
-        DiagnosticSpec(message: "Unexpected text '* ! = x' found in 'if' statement"),
+        DiagnosticSpec(message: "Unexpected text '* ! = x' in 'if' statement"),
       ]
     )
   }
@@ -174,8 +174,8 @@ final class StatementTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "TEST_1", message: "Unexpected text '@s return' found in function"),
-        DiagnosticSpec(locationMarker: "TEST_2", message: "Unexpected text '@unknown return' found in function")
+        DiagnosticSpec(locationMarker: "TEST_1", message: "Unexpected text '@s return' in function"),
+        DiagnosticSpec(locationMarker: "TEST_2", message: "Unexpected text '@unknown return' in function")
       ]
     )
   }
@@ -193,8 +193,8 @@ final class StatementTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "FOO", message: "Unexpected text 'foo()' found in conditional compilation clause"),
-        DiagnosticSpec(locationMarker: "BAR", message: "Unexpected text 'bar()' found in conditional compilation block"),
+        DiagnosticSpec(locationMarker: "FOO", message: "Unexpected text 'foo()' before conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "BAR", message: "Unexpected text 'bar()' in conditional compilation block"),
       ]
     )
 
@@ -213,7 +213,7 @@ final class StatementTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'print()' found in conditional compilation clause")
+        DiagnosticSpec(message: "Unexpected text 'print()' before conditional compilation clause")
       ]
     )
   }

--- a/Tests/SwiftParserTest/Types.swift
+++ b/Tests/SwiftParserTest/Types.swift
@@ -29,7 +29,7 @@ final class TypeTests: XCTestCase {
 
   func testFunctionTypes() throws {
     AssertParse("t as(#^DIAG^#..)->", diagnostics: [
-      DiagnosticSpec(message: "Unexpected text '..' found in function type")
+      DiagnosticSpec(message: "Unexpected text '..' in function type")
     ])
   }
 
@@ -49,14 +49,14 @@ final class TypeTests: XCTestCase {
                 { $0.parseClosureExpression() },
                 diagnostics: [
                   DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected '' in closure capture item"),
-                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text 'class' found in closure capture signature"),
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text 'class' in closure capture signature"),
                   DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '}' to end closure"),
                 ])
 
     AssertParse("{[n#^DIAG^#`]in}",
                 { $0.parseClosureExpression() },
                 diagnostics: [
-                  DiagnosticSpec(message: "Unexpected text '`' found in closure capture signature")
+                  DiagnosticSpec(message: "Unexpected text '`' in closure capture signature")
                 ])
   }
 }


### PR DESCRIPTION
This helps us produce better error messages once we implement recovery in front of declarations.

Unfortunately, we don’t have a test case that exercises the new paths yet.