### PR TITLE
Emit diagnostics for missing nodes

### DIFF
--- a/Sources/SwiftDiagnostics/Diagnostic.swift
+++ b/Sources/SwiftDiagnostics/Diagnostic.swift
@@ -19,6 +19,10 @@ public struct Diagnostic: CustomDebugStringConvertible {
   /// The node at whose start location the message should be displayed.
   public let node: Syntax
 
+  /// The position at which the location should be anchored.
+  /// By default, this is the start location of `node`.
+  public let position: AbsolutePosition
+
   /// Nodes that should be highlighted in the source code.
   public let highlights: [Syntax]
 
@@ -26,9 +30,10 @@ public struct Diagnostic: CustomDebugStringConvertible {
   /// Each Fix-It offers a different way to resolve the diagnostic. Usually, there's only one.
   public let fixIts: [FixIt]
 
-  public init(node: Syntax, message: DiagnosticMessage, highlights: [Syntax] = [], fixIts: [FixIt] = []) {
-    self.diagMessage = message
+  public init(node: Syntax, position: AbsolutePosition? = nil, message: DiagnosticMessage, highlights: [Syntax] = [], fixIts: [FixIt] = []) {
     self.node = node
+    self.position = position ?? node.positionAfterSkippingLeadingTrivia
+    self.diagMessage = message
     self.highlights = highlights
     self.fixIts = fixIts
   }
@@ -46,7 +51,7 @@ public struct Diagnostic: CustomDebugStringConvertible {
 
   /// The location at which the diagnostic should be displayed.
   public func location(converter: SourceLocationConverter) -> SourceLocation {
-    return node.startLocation(converter: converter)
+    return converter.location(for: position)
   }
 
   public var debugDescription: String {

--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -118,7 +118,39 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     return .skipChildren
   }
 
+  private func handleMissingSyntax<T: SyntaxProtocol>(_ node: T) -> SyntaxVisitorContinueKind {
+    if shouldSkip(node) {
+      return .skipChildren
+    }
+    addDiagnostic(node, position: node.endPosition, MissingNodeError(missingNode: Syntax(node)))
+    return .visitChildren
+  }
+
   // MARK: - Specialized diagnostic generation
+
+  public override func visit(_ node: MissingDeclSyntax) -> SyntaxVisitorContinueKind {
+    return handleMissingSyntax(node)
+  }
+
+  public override func visit(_ node: MissingExprSyntax) -> SyntaxVisitorContinueKind {
+    return handleMissingSyntax(node)
+  }
+
+  public override func visit(_ node: MissingPatternSyntax) -> SyntaxVisitorContinueKind {
+    return handleMissingSyntax(node)
+  }
+
+  public override func visit(_ node: MissingStmtSyntax) -> SyntaxVisitorContinueKind {
+    return handleMissingSyntax(node)
+  }
+
+  public override func visit(_ node: MissingSyntax) -> SyntaxVisitorContinueKind {
+    return handleMissingSyntax(node)
+  }
+
+  public override func visit(_ node: MissingTypeSyntax) -> SyntaxVisitorContinueKind {
+    return handleMissingSyntax(node)
+  }
 
   public override func visit(_ node: ForInStmtSyntax) -> SyntaxVisitorContinueKind {
     if shouldSkip(node) {
@@ -145,7 +177,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
           Syntax(node.unexpectedBetweenWhereClauseAndBody),
           Syntax(unexpectedCondition)
         ] as [Syntax?]).compactMap({ $0 }),
-        handledNodes: [node.inKeyword.id, unexpectedCondition.id]
+        handledNodes: [node.inKeyword.id, node.sequenceExpr.id, unexpectedCondition.id]
       )
     }
     return .visitChildren

--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -67,15 +67,15 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
   // MARK: - Private helper functions
 
   /// Produce a diagnostic.
-  private func addDiagnostic<T: SyntaxProtocol>(_ node: T, _ message: DiagnosticMessage, highlights: [Syntax] = [], fixIts: [FixIt] = [], handledNodes: [SyntaxIdentifier] = []) {
+  private func addDiagnostic<T: SyntaxProtocol>(_ node: T, position: AbsolutePosition? = nil, _ message: DiagnosticMessage, highlights: [Syntax] = [], fixIts: [FixIt] = [], handledNodes: [SyntaxIdentifier] = []) {
     diagnostics.removeAll(where: { handledNodes.contains($0.node.id) })
-    diagnostics.append(Diagnostic(node: Syntax(node), message: message, highlights: highlights, fixIts: fixIts))
+    diagnostics.append(Diagnostic(node: Syntax(node), position: position, message: message, highlights: highlights, fixIts: fixIts))
     self.handledNodes.append(contentsOf: handledNodes)
   }
 
   /// Produce a diagnostic.
-  private func addDiagnostic<T: SyntaxProtocol>(_ node: T, _ message: StaticParserError, highlights: [Syntax] = [], fixIts: [FixIt] = [], handledNodes: [SyntaxIdentifier] = []) {
-    addDiagnostic(node, message as DiagnosticMessage, highlights: highlights, fixIts: fixIts, handledNodes: handledNodes)
+  private func addDiagnostic<T: SyntaxProtocol>(_ node: T,position: AbsolutePosition? = nil,  _ message: StaticParserError, highlights: [Syntax] = [], fixIts: [FixIt] = [], handledNodes: [SyntaxIdentifier] = []) {
+    addDiagnostic(node, position: position, message as DiagnosticMessage, highlights: highlights, fixIts: fixIts, handledNodes: handledNodes)
   }
 
   /// Whether the node should be skipped for diagnostic emission.

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -22,13 +22,19 @@ extension SyntaxProtocol {
   /// default.
   /// Pass inherit: false to prevent this behavior, in which case `nil` will be
   /// returned instead.
-  func nodeTypeNameForDiagnostics(inherit: Bool = true) -> String? {
+  /// If `allowSourceFile` is `false`, `nil` will be returned if the inherited
+  /// node type name is "source file".
+  func nodeTypeNameForDiagnostics(inherit: Bool = true, allowSourceFile: Bool = true) -> String? {
     if let name = Syntax(self).as(SyntaxEnum.self).nameForDiagnostics {
-      return name
+      if Syntax(self).is(SourceFileSyntax.self) && !allowSourceFile {
+        return nil
+      } else {
+        return name
+      }
     }
     if inherit {
       if let parent = self.parent {
-        return parent.nodeTypeNameForDiagnostics(inherit: inherit)
+        return parent.nodeTypeNameForDiagnostics(inherit: inherit, allowSourceFile: allowSourceFile)
       }
     }
     return nil
@@ -132,6 +138,37 @@ public struct InvalidIdentifierError: ParserError {
     default:
       return "'\(invalidIdentifier.text)' is not a valid identifier"
     }
+  }
+}
+
+public struct MissingNodeError: ParserError {
+  public let missingNode: Syntax
+
+  public var message: String {
+    var message: String
+    var hasNamedParent = false
+    if let parent = missingNode.parent,
+        let childName = parent.childNameForDiagnostics(missingNode.index) {
+      message = "Expected \(childName)"
+      if let parent = missingNode.parent,
+          let parentTypeName = parent.nodeTypeNameForDiagnostics(inherit: false) {
+        message += " of \(parentTypeName)"
+        hasNamedParent = true
+      }
+    } else {
+      message = "Expected \(missingNode.nodeTypeNameForDiagnostics() ?? "syntax")"
+      if let lastChild = missingNode.lastToken(viewMode: .fixedUp), lastChild.presence == .present {
+        message += " after '\(lastChild.text)'"
+      } else if let previousToken = missingNode.previousToken(viewMode: .fixedUp), previousToken.presence == .present {
+        message += " after '\(previousToken.text)'"
+      }
+    }
+    if !hasNamedParent {
+      if let parent = missingNode.parent, let parentTypeName = parent.nodeTypeNameForDiagnostics(allowSourceFile: false) {
+        message += " in \(parentTypeName)"
+      }
+    }
+    return message
   }
 }
 

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -150,15 +150,16 @@ public struct MissingNodeError: ParserError {
     if let parent = missingNode.parent,
         let childName = parent.childNameForDiagnostics(missingNode.index) {
       message = "Expected \(childName)"
-      if let parent = missingNode.parent,
-          let parentTypeName = parent.nodeTypeNameForDiagnostics(inherit: false) {
+      if let parentTypeName = parent.nodeTypeNameForDiagnostics(inherit: false) {
         message += " of \(parentTypeName)"
         hasNamedParent = true
       }
     } else {
       message = "Expected \(missingNode.nodeTypeNameForDiagnostics() ?? "syntax")"
-      if let lastChild = missingNode.lastToken(viewMode: .fixedUp), lastChild.presence == .present {
-        message += " after '\(lastChild.text)'"
+      if let missingDecl = missingNode.as(MissingDeclSyntax.self), let lastModifier = missingDecl.modifiers?.last {
+        message += " after '\(lastModifier.name.text)' modifier"
+      } else if let missingDecl = missingNode.as(MissingDeclSyntax.self), missingDecl.attributes != nil {
+        message += " after attribute"
       } else if let previousToken = missingNode.previousToken(viewMode: .fixedUp), previousToken.presence == .present {
         message += " after '\(previousToken.text)'"
       }

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -89,7 +89,7 @@ extension Parser {
         do {
           var elementsProgress = LoopProgressCondition()
           while !self.at(any: [.eof, .poundElseKeyword, .poundElseifKeyword, .poundEndifKeyword]) && elementsProgress.evaluate(currentToken) {
-            guard let element = parseElement(&self), element.raw.byteLength > 0 else {
+            guard let element = parseElement(&self), !element.isEmpty else {
               break
             }
             elements.append(element)

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1617,21 +1617,27 @@ extension Parser {
 
         switch elementKind! {
         case .array(let el):
-          elements.append(RawSyntax(RawArrayElementSyntax(
-            expression: el, trailingComma: comma, arena: self.arena)))
-          if el.is(RawMissingExprSyntax.self) {
+          let element = RawArrayElementSyntax(
+            expression: el, trailingComma: comma, arena: self.arena
+          )
+          if element.raw.byteLength == 0 {
             break COLLECTION_LOOP
+          } else {
+            elements.append(RawSyntax(element))
           }
         case .dictionary(let key, let unexpectedBeforeColon, let colon, let value):
-          elements.append(RawSyntax(RawDictionaryElementSyntax(
+          let element = RawDictionaryElementSyntax(
             keyExpression: key,
             unexpectedBeforeColon,
             colon: colon,
             valueExpression: value,
             trailingComma: comma,
-            arena: self.arena)))
-          if key.is(RawMissingExprSyntax.self), colon.isMissing, value.is(RawMissingExprSyntax.self) {
+            arena: self.arena
+          )
+          if element.raw.byteLength == 0 {
             break COLLECTION_LOOP
+          } else {
+            elements.append(RawSyntax(element))
           }
         }
 

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1620,7 +1620,7 @@ extension Parser {
           let element = RawArrayElementSyntax(
             expression: el, trailingComma: comma, arena: self.arena
           )
-          if element.raw.byteLength == 0 {
+          if element.isEmpty {
             break COLLECTION_LOOP
           } else {
             elements.append(RawSyntax(element))
@@ -1634,7 +1634,7 @@ extension Parser {
             trailingComma: comma,
             arena: self.arena
           )
-          if element.raw.byteLength == 0 {
+          if element.isEmpty {
             break COLLECTION_LOOP
           } else {
             elements.append(RawSyntax(element))

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -865,7 +865,7 @@ extension Parser {
     let expr: RawExprSyntax?
     if
       !self.at(any: [
-        RawTokenKind.rightBrace, .semicolon, .eof,
+        .rightBrace, .caseKeyword, .semicolon, .eof,
         .poundIfKeyword, .poundErrorKeyword, .poundWarningKeyword,
         .poundEndifKeyword, .poundElseKeyword, .poundElseifKeyword
       ])

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -119,7 +119,7 @@ extension Parser {
     let item = self.parseItem(isAtTopLevel: isAtTopLevel)
     let semi = self.consume(if: .semicolon)
 
-    if item.raw.byteLength == 0 && semi == nil {
+    if item.isEmpty && semi == nil {
       return nil
     }
     return .init(item: item, semicolon: semi, errorTokens: nil, arena: self.arena)

--- a/Sources/SwiftSyntax/Misc.swift.gyb
+++ b/Sources/SwiftSyntax/Misc.swift.gyb
@@ -42,6 +42,19 @@ extension Syntax {
 % end
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch self.as(SyntaxEnum.self) {
+    case .token(let node):
+      return node.childNameForDiagnostics(index)
+    case .unknown(let node):
+      return node.childNameForDiagnostics(index)
+% for node in NON_BASE_SYNTAX_NODES:
+    case .${node.swift_syntax_kind}(let node):
+      return node.childNameForDiagnostics(index)
+% end
+    }
+  }
 }
 
 extension SyntaxKind {

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -42,6 +42,10 @@ public extension RawSyntaxNodeProtocol {
   func write<Target>(to target: inout Target) where Target : TextOutputStream {
     raw.write(to: &target)
   }
+
+  var isEmpty: Bool {
+    return raw.byteLength == 0
+  }
 }
 
 /// `RawSyntax` itself conforms to `RawSyntaxNodeProtocol`.

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -131,6 +131,10 @@ public protocol SyntaxProtocol: CustomStringConvertible,
   /// Converts the given `Syntax` node to this type. Returns `nil` if the
   /// conversion is not possible.
   init?(_ syntaxNode: Syntax)
+
+  /// Return a name with which the child at the given `index` can be referred to
+  /// in diagnostics.
+  func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String?
 }
 
 extension SyntaxProtocol {

--- a/Sources/SwiftSyntax/SyntaxBaseNodes.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxBaseNodes.swift.gyb
@@ -120,6 +120,10 @@ public struct ${node.name}: ${node.name}Protocol, SyntaxHashable {
   public func asProtocol(_: ${node.name}Protocol.Protocol) -> ${node.name}Protocol {
     return Syntax(self).asProtocol(${node.name}Protocol.self)!
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return Syntax(self).childNameForDiagnostics(index)
+  }
 }
 
 extension ${node.name}: CustomReflectable {

--- a/Sources/SwiftSyntax/SyntaxChildren.swift
+++ b/Sources/SwiftSyntax/SyntaxChildren.swift
@@ -20,7 +20,7 @@ public struct SyntaxChildrenIndexData: Comparable {
   fileprivate let offset: UInt32
   /// The index of the node in the parent.
   /// See `AbsoluteSyntaxPosition.indexInParent`
-  fileprivate let indexInParent: UInt32
+  let indexInParent: UInt32
   /// Unique value for a node within its own tree.
   /// See `SyntaxIdentifier.indexIntree`
   fileprivate let indexInTree: SyntaxIndexInTree
@@ -61,7 +61,7 @@ public struct SyntaxChildrenIndex: Comparable, ExpressibleByNilLiteral {
   /// SyntaxChildrenIndex` an enumbecause the optional value can be
   /// force-unwrapped when we know that an index is not the end index, saving a
   /// switch case comparison.
-  fileprivate let data: SyntaxChildrenIndexData?
+  let data: SyntaxChildrenIndexData?
 
   fileprivate init(offset: UInt32, indexInParent: UInt32,
                    indexInTree: SyntaxIndexInTree) {

--- a/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
+++ b/Sources/SwiftSyntax/SyntaxCollections.swift.gyb
@@ -217,6 +217,10 @@ public struct ${node.name}: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `${node.name}` to the `BidirectionalCollection` protocol.

--- a/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
+++ b/Sources/SwiftSyntax/SyntaxNodes.swift.gyb.template
@@ -171,6 +171,21 @@ public struct ${node.name}: ${base_type}Protocol, SyntaxHashable {
     return ${node.name}(newData)
   }
 %     end
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+%     for (index, child) in enumerate(node.children):
+    case ${index}:
+%       if child.name_for_diagnostics:
+      return "${child.name_for_diagnostics}"
+%       else:
+      return nil
+%       end
+%     end
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ${node.name}: CustomReflectable {

--- a/Sources/SwiftSyntax/SyntaxOtherNodes.swift
+++ b/Sources/SwiftSyntax/SyntaxOtherNodes.swift
@@ -39,6 +39,10 @@ public struct UnknownSyntax: SyntaxProtocol, SyntaxHashable {
     let data = SyntaxData.forRoot(raw)
     self.init(data)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 extension UnknownSyntax: CustomReflectable {
@@ -191,6 +195,10 @@ public struct TokenSyntax: SyntaxProtocol, SyntaxHashable {
   /// The length of this node including all of its trivia.
   public var totalLength: SourceLength {
     return raw.totalLength
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 

--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -571,6 +571,555 @@ extension Syntax {
       return node
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch self.as(SyntaxEnum.self) {
+    case .token(let node):
+      return node.childNameForDiagnostics(index)
+    case .unknown(let node):
+      return node.childNameForDiagnostics(index)
+    case .unknownDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .unknownExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .unknownStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .unknownType(let node):
+      return node.childNameForDiagnostics(index)
+    case .unknownPattern(let node):
+      return node.childNameForDiagnostics(index)
+    case .missing(let node):
+      return node.childNameForDiagnostics(index)
+    case .missingDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .missingExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .missingStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .missingType(let node):
+      return node.childNameForDiagnostics(index)
+    case .missingPattern(let node):
+      return node.childNameForDiagnostics(index)
+    case .codeBlockItem(let node):
+      return node.childNameForDiagnostics(index)
+    case .codeBlockItemList(let node):
+      return node.childNameForDiagnostics(index)
+    case .codeBlock(let node):
+      return node.childNameForDiagnostics(index)
+    case .unexpectedNodes(let node):
+      return node.childNameForDiagnostics(index)
+    case .inOutExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .poundColumnExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .tupleExprElementList(let node):
+      return node.childNameForDiagnostics(index)
+    case .arrayElementList(let node):
+      return node.childNameForDiagnostics(index)
+    case .dictionaryElementList(let node):
+      return node.childNameForDiagnostics(index)
+    case .stringLiteralSegments(let node):
+      return node.childNameForDiagnostics(index)
+    case .tryExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .awaitExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .moveExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .declNameArgument(let node):
+      return node.childNameForDiagnostics(index)
+    case .declNameArgumentList(let node):
+      return node.childNameForDiagnostics(index)
+    case .declNameArguments(let node):
+      return node.childNameForDiagnostics(index)
+    case .identifierExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .superRefExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .nilLiteralExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .discardAssignmentExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .assignmentExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .sequenceExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .exprList(let node):
+      return node.childNameForDiagnostics(index)
+    case .poundLineExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .poundFileExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .poundFileIDExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .poundFilePathExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .poundFunctionExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .poundDsohandleExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .symbolicReferenceExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .prefixOperatorExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .binaryOperatorExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .arrowExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .infixOperatorExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .floatLiteralExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .tupleExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .arrayExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .dictionaryExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .tupleExprElement(let node):
+      return node.childNameForDiagnostics(index)
+    case .arrayElement(let node):
+      return node.childNameForDiagnostics(index)
+    case .dictionaryElement(let node):
+      return node.childNameForDiagnostics(index)
+    case .integerLiteralExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .booleanLiteralExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .unresolvedTernaryExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .ternaryExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .memberAccessExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .unresolvedIsExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .isExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .unresolvedAsExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .asExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .typeExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .closureCaptureItem(let node):
+      return node.childNameForDiagnostics(index)
+    case .closureCaptureItemList(let node):
+      return node.childNameForDiagnostics(index)
+    case .closureCaptureSignature(let node):
+      return node.childNameForDiagnostics(index)
+    case .closureParam(let node):
+      return node.childNameForDiagnostics(index)
+    case .closureParamList(let node):
+      return node.childNameForDiagnostics(index)
+    case .closureSignature(let node):
+      return node.childNameForDiagnostics(index)
+    case .closureExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .unresolvedPatternExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .multipleTrailingClosureElement(let node):
+      return node.childNameForDiagnostics(index)
+    case .multipleTrailingClosureElementList(let node):
+      return node.childNameForDiagnostics(index)
+    case .functionCallExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .subscriptExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .optionalChainingExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .forcedValueExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .postfixUnaryExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .specializeExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .stringSegment(let node):
+      return node.childNameForDiagnostics(index)
+    case .expressionSegment(let node):
+      return node.childNameForDiagnostics(index)
+    case .stringLiteralExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .regexLiteralExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .keyPathExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .keyPathBaseExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .objcNamePiece(let node):
+      return node.childNameForDiagnostics(index)
+    case .objcName(let node):
+      return node.childNameForDiagnostics(index)
+    case .objcKeyPathExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .objcSelectorExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .postfixIfConfigExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .editorPlaceholderExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .objectLiteralExpr(let node):
+      return node.childNameForDiagnostics(index)
+    case .typeInitializerClause(let node):
+      return node.childNameForDiagnostics(index)
+    case .typealiasDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .associatedtypeDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .functionParameterList(let node):
+      return node.childNameForDiagnostics(index)
+    case .parameterClause(let node):
+      return node.childNameForDiagnostics(index)
+    case .returnClause(let node):
+      return node.childNameForDiagnostics(index)
+    case .functionSignature(let node):
+      return node.childNameForDiagnostics(index)
+    case .ifConfigClause(let node):
+      return node.childNameForDiagnostics(index)
+    case .ifConfigClauseList(let node):
+      return node.childNameForDiagnostics(index)
+    case .ifConfigDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .poundErrorDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .poundWarningDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .poundSourceLocation(let node):
+      return node.childNameForDiagnostics(index)
+    case .poundSourceLocationArgs(let node):
+      return node.childNameForDiagnostics(index)
+    case .declModifierDetail(let node):
+      return node.childNameForDiagnostics(index)
+    case .declModifier(let node):
+      return node.childNameForDiagnostics(index)
+    case .inheritedType(let node):
+      return node.childNameForDiagnostics(index)
+    case .inheritedTypeList(let node):
+      return node.childNameForDiagnostics(index)
+    case .typeInheritanceClause(let node):
+      return node.childNameForDiagnostics(index)
+    case .classDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .actorDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .structDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .protocolDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .extensionDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .memberDeclBlock(let node):
+      return node.childNameForDiagnostics(index)
+    case .memberDeclList(let node):
+      return node.childNameForDiagnostics(index)
+    case .memberDeclListItem(let node):
+      return node.childNameForDiagnostics(index)
+    case .sourceFile(let node):
+      return node.childNameForDiagnostics(index)
+    case .initializerClause(let node):
+      return node.childNameForDiagnostics(index)
+    case .functionParameter(let node):
+      return node.childNameForDiagnostics(index)
+    case .modifierList(let node):
+      return node.childNameForDiagnostics(index)
+    case .functionDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .initializerDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .deinitializerDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .subscriptDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .accessLevelModifier(let node):
+      return node.childNameForDiagnostics(index)
+    case .accessPathComponent(let node):
+      return node.childNameForDiagnostics(index)
+    case .accessPath(let node):
+      return node.childNameForDiagnostics(index)
+    case .importDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .accessorParameter(let node):
+      return node.childNameForDiagnostics(index)
+    case .accessorDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .accessorList(let node):
+      return node.childNameForDiagnostics(index)
+    case .accessorBlock(let node):
+      return node.childNameForDiagnostics(index)
+    case .patternBinding(let node):
+      return node.childNameForDiagnostics(index)
+    case .patternBindingList(let node):
+      return node.childNameForDiagnostics(index)
+    case .variableDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .enumCaseElement(let node):
+      return node.childNameForDiagnostics(index)
+    case .enumCaseElementList(let node):
+      return node.childNameForDiagnostics(index)
+    case .enumCaseDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .enumDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .operatorDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .designatedTypeList(let node):
+      return node.childNameForDiagnostics(index)
+    case .designatedTypeElement(let node):
+      return node.childNameForDiagnostics(index)
+    case .operatorPrecedenceAndTypes(let node):
+      return node.childNameForDiagnostics(index)
+    case .precedenceGroupDecl(let node):
+      return node.childNameForDiagnostics(index)
+    case .precedenceGroupAttributeList(let node):
+      return node.childNameForDiagnostics(index)
+    case .precedenceGroupRelation(let node):
+      return node.childNameForDiagnostics(index)
+    case .precedenceGroupNameList(let node):
+      return node.childNameForDiagnostics(index)
+    case .precedenceGroupNameElement(let node):
+      return node.childNameForDiagnostics(index)
+    case .precedenceGroupAssignment(let node):
+      return node.childNameForDiagnostics(index)
+    case .precedenceGroupAssociativity(let node):
+      return node.childNameForDiagnostics(index)
+    case .tokenList(let node):
+      return node.childNameForDiagnostics(index)
+    case .nonEmptyTokenList(let node):
+      return node.childNameForDiagnostics(index)
+    case .customAttribute(let node):
+      return node.childNameForDiagnostics(index)
+    case .attribute(let node):
+      return node.childNameForDiagnostics(index)
+    case .attributeList(let node):
+      return node.childNameForDiagnostics(index)
+    case .specializeAttributeSpecList(let node):
+      return node.childNameForDiagnostics(index)
+    case .availabilityEntry(let node):
+      return node.childNameForDiagnostics(index)
+    case .labeledSpecializeEntry(let node):
+      return node.childNameForDiagnostics(index)
+    case .targetFunctionEntry(let node):
+      return node.childNameForDiagnostics(index)
+    case .namedAttributeStringArgument(let node):
+      return node.childNameForDiagnostics(index)
+    case .declName(let node):
+      return node.childNameForDiagnostics(index)
+    case .implementsAttributeArguments(let node):
+      return node.childNameForDiagnostics(index)
+    case .objCSelectorPiece(let node):
+      return node.childNameForDiagnostics(index)
+    case .objCSelector(let node):
+      return node.childNameForDiagnostics(index)
+    case .differentiableAttributeArguments(let node):
+      return node.childNameForDiagnostics(index)
+    case .differentiabilityParamsClause(let node):
+      return node.childNameForDiagnostics(index)
+    case .differentiabilityParams(let node):
+      return node.childNameForDiagnostics(index)
+    case .differentiabilityParamList(let node):
+      return node.childNameForDiagnostics(index)
+    case .differentiabilityParam(let node):
+      return node.childNameForDiagnostics(index)
+    case .derivativeRegistrationAttributeArguments(let node):
+      return node.childNameForDiagnostics(index)
+    case .qualifiedDeclName(let node):
+      return node.childNameForDiagnostics(index)
+    case .functionDeclName(let node):
+      return node.childNameForDiagnostics(index)
+    case .backDeployAttributeSpecList(let node):
+      return node.childNameForDiagnostics(index)
+    case .backDeployVersionList(let node):
+      return node.childNameForDiagnostics(index)
+    case .backDeployVersionArgument(let node):
+      return node.childNameForDiagnostics(index)
+    case .opaqueReturnTypeOfAttributeArguments(let node):
+      return node.childNameForDiagnostics(index)
+    case .conventionAttributeArguments(let node):
+      return node.childNameForDiagnostics(index)
+    case .conventionWitnessMethodAttributeArguments(let node):
+      return node.childNameForDiagnostics(index)
+    case .labeledStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .continueStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .whileStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .deferStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .expressionStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .switchCaseList(let node):
+      return node.childNameForDiagnostics(index)
+    case .repeatWhileStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .guardStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .whereClause(let node):
+      return node.childNameForDiagnostics(index)
+    case .forInStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .switchStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .catchClauseList(let node):
+      return node.childNameForDiagnostics(index)
+    case .doStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .returnStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .yieldStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .yieldList(let node):
+      return node.childNameForDiagnostics(index)
+    case .fallthroughStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .breakStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .caseItemList(let node):
+      return node.childNameForDiagnostics(index)
+    case .catchItemList(let node):
+      return node.childNameForDiagnostics(index)
+    case .conditionElement(let node):
+      return node.childNameForDiagnostics(index)
+    case .availabilityCondition(let node):
+      return node.childNameForDiagnostics(index)
+    case .matchingPatternCondition(let node):
+      return node.childNameForDiagnostics(index)
+    case .optionalBindingCondition(let node):
+      return node.childNameForDiagnostics(index)
+    case .unavailabilityCondition(let node):
+      return node.childNameForDiagnostics(index)
+    case .hasSymbolCondition(let node):
+      return node.childNameForDiagnostics(index)
+    case .conditionElementList(let node):
+      return node.childNameForDiagnostics(index)
+    case .declarationStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .throwStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .ifStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .elseIfContinuation(let node):
+      return node.childNameForDiagnostics(index)
+    case .elseBlock(let node):
+      return node.childNameForDiagnostics(index)
+    case .switchCase(let node):
+      return node.childNameForDiagnostics(index)
+    case .switchDefaultLabel(let node):
+      return node.childNameForDiagnostics(index)
+    case .caseItem(let node):
+      return node.childNameForDiagnostics(index)
+    case .catchItem(let node):
+      return node.childNameForDiagnostics(index)
+    case .switchCaseLabel(let node):
+      return node.childNameForDiagnostics(index)
+    case .catchClause(let node):
+      return node.childNameForDiagnostics(index)
+    case .poundAssertStmt(let node):
+      return node.childNameForDiagnostics(index)
+    case .genericWhereClause(let node):
+      return node.childNameForDiagnostics(index)
+    case .genericRequirementList(let node):
+      return node.childNameForDiagnostics(index)
+    case .genericRequirement(let node):
+      return node.childNameForDiagnostics(index)
+    case .sameTypeRequirement(let node):
+      return node.childNameForDiagnostics(index)
+    case .layoutRequirement(let node):
+      return node.childNameForDiagnostics(index)
+    case .genericParameterList(let node):
+      return node.childNameForDiagnostics(index)
+    case .genericParameter(let node):
+      return node.childNameForDiagnostics(index)
+    case .primaryAssociatedTypeList(let node):
+      return node.childNameForDiagnostics(index)
+    case .primaryAssociatedType(let node):
+      return node.childNameForDiagnostics(index)
+    case .genericParameterClause(let node):
+      return node.childNameForDiagnostics(index)
+    case .conformanceRequirement(let node):
+      return node.childNameForDiagnostics(index)
+    case .primaryAssociatedTypeClause(let node):
+      return node.childNameForDiagnostics(index)
+    case .simpleTypeIdentifier(let node):
+      return node.childNameForDiagnostics(index)
+    case .memberTypeIdentifier(let node):
+      return node.childNameForDiagnostics(index)
+    case .classRestrictionType(let node):
+      return node.childNameForDiagnostics(index)
+    case .arrayType(let node):
+      return node.childNameForDiagnostics(index)
+    case .dictionaryType(let node):
+      return node.childNameForDiagnostics(index)
+    case .metatypeType(let node):
+      return node.childNameForDiagnostics(index)
+    case .optionalType(let node):
+      return node.childNameForDiagnostics(index)
+    case .constrainedSugarType(let node):
+      return node.childNameForDiagnostics(index)
+    case .implicitlyUnwrappedOptionalType(let node):
+      return node.childNameForDiagnostics(index)
+    case .compositionTypeElement(let node):
+      return node.childNameForDiagnostics(index)
+    case .compositionTypeElementList(let node):
+      return node.childNameForDiagnostics(index)
+    case .compositionType(let node):
+      return node.childNameForDiagnostics(index)
+    case .packExpansionType(let node):
+      return node.childNameForDiagnostics(index)
+    case .tupleTypeElement(let node):
+      return node.childNameForDiagnostics(index)
+    case .tupleTypeElementList(let node):
+      return node.childNameForDiagnostics(index)
+    case .tupleType(let node):
+      return node.childNameForDiagnostics(index)
+    case .functionType(let node):
+      return node.childNameForDiagnostics(index)
+    case .attributedType(let node):
+      return node.childNameForDiagnostics(index)
+    case .genericArgumentList(let node):
+      return node.childNameForDiagnostics(index)
+    case .genericArgument(let node):
+      return node.childNameForDiagnostics(index)
+    case .genericArgumentClause(let node):
+      return node.childNameForDiagnostics(index)
+    case .namedOpaqueReturnType(let node):
+      return node.childNameForDiagnostics(index)
+    case .typeAnnotation(let node):
+      return node.childNameForDiagnostics(index)
+    case .enumCasePattern(let node):
+      return node.childNameForDiagnostics(index)
+    case .isTypePattern(let node):
+      return node.childNameForDiagnostics(index)
+    case .optionalPattern(let node):
+      return node.childNameForDiagnostics(index)
+    case .identifierPattern(let node):
+      return node.childNameForDiagnostics(index)
+    case .asTypePattern(let node):
+      return node.childNameForDiagnostics(index)
+    case .tuplePattern(let node):
+      return node.childNameForDiagnostics(index)
+    case .wildcardPattern(let node):
+      return node.childNameForDiagnostics(index)
+    case .tuplePatternElement(let node):
+      return node.childNameForDiagnostics(index)
+    case .expressionPattern(let node):
+      return node.childNameForDiagnostics(index)
+    case .tuplePatternElementList(let node):
+      return node.childNameForDiagnostics(index)
+    case .valueBindingPattern(let node):
+      return node.childNameForDiagnostics(index)
+    case .availabilitySpecList(let node):
+      return node.childNameForDiagnostics(index)
+    case .availabilityArgument(let node):
+      return node.childNameForDiagnostics(index)
+    case .availabilityLabeledArgument(let node):
+      return node.childNameForDiagnostics(index)
+    case .availabilityVersionRestriction(let node):
+      return node.childNameForDiagnostics(index)
+    case .versionTuple(let node):
+      return node.childNameForDiagnostics(index)
+    }
+  }
 }
 
 extension SyntaxKind {

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxBaseNodes.swift
@@ -101,6 +101,10 @@ public struct DeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
   public func asProtocol(_: DeclSyntaxProtocol.Protocol) -> DeclSyntaxProtocol {
     return Syntax(self).asProtocol(DeclSyntaxProtocol.self)!
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return Syntax(self).childNameForDiagnostics(index)
+  }
 }
 
 extension DeclSyntax: CustomReflectable {
@@ -199,6 +203,10 @@ public struct ExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
   /// Note that this will incur an existential conversion.
   public func asProtocol(_: ExprSyntaxProtocol.Protocol) -> ExprSyntaxProtocol {
     return Syntax(self).asProtocol(ExprSyntaxProtocol.self)!
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return Syntax(self).childNameForDiagnostics(index)
   }
 }
 
@@ -299,6 +307,10 @@ public struct StmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
   public func asProtocol(_: StmtSyntaxProtocol.Protocol) -> StmtSyntaxProtocol {
     return Syntax(self).asProtocol(StmtSyntaxProtocol.self)!
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return Syntax(self).childNameForDiagnostics(index)
+  }
 }
 
 extension StmtSyntax: CustomReflectable {
@@ -398,6 +410,10 @@ public struct TypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
   public func asProtocol(_: TypeSyntaxProtocol.Protocol) -> TypeSyntaxProtocol {
     return Syntax(self).asProtocol(TypeSyntaxProtocol.self)!
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return Syntax(self).childNameForDiagnostics(index)
+  }
 }
 
 extension TypeSyntax: CustomReflectable {
@@ -496,6 +512,10 @@ public struct PatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
   /// Note that this will incur an existential conversion.
   public func asProtocol(_: PatternSyntaxProtocol.Protocol) -> PatternSyntaxProtocol {
     return Syntax(self).asProtocol(PatternSyntaxProtocol.self)!
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return Syntax(self).childNameForDiagnostics(index)
   }
 }
 

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
@@ -202,6 +202,10 @@ public struct CodeBlockItemListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `CodeBlockItemListSyntax` to the `BidirectionalCollection` protocol.
@@ -450,6 +454,10 @@ public struct UnexpectedNodesSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -700,6 +708,10 @@ public struct TupleExprElementListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `TupleExprElementListSyntax` to the `BidirectionalCollection` protocol.
@@ -948,6 +960,10 @@ public struct ArrayElementListSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -1198,6 +1214,10 @@ public struct DictionaryElementListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `DictionaryElementListSyntax` to the `BidirectionalCollection` protocol.
@@ -1446,6 +1466,10 @@ public struct StringLiteralSegmentsSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -1696,6 +1720,10 @@ public struct DeclNameArgumentListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `DeclNameArgumentListSyntax` to the `BidirectionalCollection` protocol.
@@ -1944,6 +1972,10 @@ public struct ExprListSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -2194,6 +2226,10 @@ public struct ClosureCaptureItemListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `ClosureCaptureItemListSyntax` to the `BidirectionalCollection` protocol.
@@ -2442,6 +2478,10 @@ public struct ClosureParamListSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -2692,6 +2732,10 @@ public struct MultipleTrailingClosureElementListSyntax: SyntaxCollection, Syntax
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `MultipleTrailingClosureElementListSyntax` to the `BidirectionalCollection` protocol.
@@ -2940,6 +2984,10 @@ public struct ObjcNameSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -3190,6 +3238,10 @@ public struct FunctionParameterListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `FunctionParameterListSyntax` to the `BidirectionalCollection` protocol.
@@ -3438,6 +3490,10 @@ public struct IfConfigClauseListSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -3688,6 +3744,10 @@ public struct InheritedTypeListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `InheritedTypeListSyntax` to the `BidirectionalCollection` protocol.
@@ -3936,6 +3996,10 @@ public struct MemberDeclListSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -4186,6 +4250,10 @@ public struct ModifierListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `ModifierListSyntax` to the `BidirectionalCollection` protocol.
@@ -4434,6 +4502,10 @@ public struct AccessPathSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -4684,6 +4756,10 @@ public struct AccessorListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `AccessorListSyntax` to the `BidirectionalCollection` protocol.
@@ -4933,6 +5009,10 @@ public struct PatternBindingListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `PatternBindingListSyntax` to the `BidirectionalCollection` protocol.
@@ -5178,6 +5258,10 @@ public struct EnumCaseElementListSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -5428,6 +5512,10 @@ public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `DesignatedTypeListSyntax` to the `BidirectionalCollection` protocol.
@@ -5676,6 +5764,10 @@ public struct PrecedenceGroupAttributeListSyntax: SyntaxCollection, SyntaxHashab
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -5926,6 +6018,10 @@ public struct PrecedenceGroupNameListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `PrecedenceGroupNameListSyntax` to the `BidirectionalCollection` protocol.
@@ -6174,6 +6270,10 @@ public struct TokenListSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -6424,6 +6524,10 @@ public struct NonEmptyTokenListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `NonEmptyTokenListSyntax` to the `BidirectionalCollection` protocol.
@@ -6673,6 +6777,10 @@ public struct AttributeListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `AttributeListSyntax` to the `BidirectionalCollection` protocol.
@@ -6920,6 +7028,10 @@ public struct SpecializeAttributeSpecListSyntax: SyntaxCollection, SyntaxHashabl
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -7170,6 +7282,10 @@ public struct ObjCSelectorSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `ObjCSelectorSyntax` to the `BidirectionalCollection` protocol.
@@ -7418,6 +7534,10 @@ public struct DifferentiabilityParamListSyntax: SyntaxCollection, SyntaxHashable
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -7668,6 +7788,10 @@ public struct BackDeployVersionListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `BackDeployVersionListSyntax` to the `BidirectionalCollection` protocol.
@@ -7916,6 +8040,10 @@ public struct SwitchCaseListSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -8166,6 +8294,10 @@ public struct CatchClauseListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `CatchClauseListSyntax` to the `BidirectionalCollection` protocol.
@@ -8414,6 +8546,10 @@ public struct CaseItemListSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -8664,6 +8800,10 @@ public struct CatchItemListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `CatchItemListSyntax` to the `BidirectionalCollection` protocol.
@@ -8912,6 +9052,10 @@ public struct ConditionElementListSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -9162,6 +9306,10 @@ public struct GenericRequirementListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `GenericRequirementListSyntax` to the `BidirectionalCollection` protocol.
@@ -9410,6 +9558,10 @@ public struct GenericParameterListSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -9660,6 +9812,10 @@ public struct PrimaryAssociatedTypeListSyntax: SyntaxCollection, SyntaxHashable 
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `PrimaryAssociatedTypeListSyntax` to the `BidirectionalCollection` protocol.
@@ -9908,6 +10064,10 @@ public struct CompositionTypeElementListSyntax: SyntaxCollection, SyntaxHashable
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -10158,6 +10318,10 @@ public struct TupleTypeElementListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `TupleTypeElementListSyntax` to the `BidirectionalCollection` protocol.
@@ -10406,6 +10570,10 @@ public struct GenericArgumentListSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 
@@ -10656,6 +10824,10 @@ public struct TuplePatternElementListSyntax: SyntaxCollection, SyntaxHashable {
       self = withTrailingTrivia(newValue ?? [])
     }
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
 }
 
 /// Conformance for `TuplePatternElementListSyntax` to the `BidirectionalCollection` protocol.
@@ -10904,6 +11076,10 @@ public struct AvailabilitySpecListSyntax: SyntaxCollection, SyntaxHashable {
     set {
       self = withTrailingTrivia(newValue ?? [])
     }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
   }
 }
 

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -394,9 +394,9 @@ public enum SyntaxEnum {
     case .tupleExprElement:
       return nil
     case .arrayElement:
-      return nil
+      return "array element"
     case .dictionaryElement:
-      return nil
+      return "dictionary element"
     case .integerLiteralExpr:
       return "integer literal"
     case .booleanLiteralExpr:
@@ -486,7 +486,7 @@ public enum SyntaxEnum {
     case .parameterClause:
       return "parameter clause"
     case .returnClause:
-      return "return clause"
+      return nil
     case .functionSignature:
       return "function signature"
     case .ifConfigClause:
@@ -528,7 +528,7 @@ public enum SyntaxEnum {
     case .memberDeclList:
       return nil
     case .memberDeclListItem:
-      return "member"
+      return nil
     case .sourceFile:
       return "source file"
     case .initializerClause:

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -42,6 +42,13 @@ public struct UnknownDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let data = SyntaxData.forRoot(raw)
     self.init(data)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension UnknownDeclSyntax: CustomReflectable {
@@ -207,6 +214,21 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return MissingDeclSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -604,6 +626,41 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 13)
     return TypealiasDeclSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "name"
+    case 8:
+      return nil
+    case 9:
+      return "generic parameter clause"
+    case 10:
+      return nil
+    case 11:
+      return nil
+    case 12:
+      return nil
+    case 13:
+      return "generic where clause"
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1013,6 +1070,41 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 13)
     return AssociatedtypeDeclSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "name"
+    case 8:
+      return nil
+    case 9:
+      return "inheritance clause"
+    case 10:
+      return nil
+    case 11:
+      return nil
+    case 12:
+      return nil
+    case 13:
+      return "generic where clause"
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension AssociatedtypeDeclSyntax: CustomReflectable {
@@ -1172,6 +1264,21 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundEndifKeyword, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return IfConfigDeclSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1394,6 +1501,29 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
     let newData = data.replacingChild(raw, at: 7)
     return PoundErrorDeclSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "message"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1621,6 +1751,29 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return PoundWarningDeclSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "message"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension PoundWarningDeclSyntax: CustomReflectable {
@@ -1847,6 +2000,29 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
     let newData = data.replacingChild(raw, at: 7)
     return PoundSourceLocationSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "arguments"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -2294,6 +2470,45 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default)
     let newData = data.replacingChild(raw, at: 15)
     return ClassDeclSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "name"
+    case 8:
+      return nil
+    case 9:
+      return "generic parameter clause"
+    case 10:
+      return nil
+    case 11:
+      return "inheritance clause"
+    case 12:
+      return nil
+    case 13:
+      return "generic where clause"
+    case 14:
+      return nil
+    case 15:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -2750,6 +2965,45 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 15)
     return ActorDeclSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "name"
+    case 8:
+      return nil
+    case 9:
+      return "generic parameter clause"
+    case 10:
+      return nil
+    case 11:
+      return "type inheritance clause"
+    case 12:
+      return nil
+    case 13:
+      return "generic where clause"
+    case 14:
+      return nil
+    case 15:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ActorDeclSyntax: CustomReflectable {
@@ -3204,6 +3458,45 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default)
     let newData = data.replacingChild(raw, at: 15)
     return StructDeclSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "name"
+    case 8:
+      return nil
+    case 9:
+      return "generic parameter clause"
+    case 10:
+      return nil
+    case 11:
+      return "type inheritance clause"
+    case 12:
+      return nil
+    case 13:
+      return "generic where clause"
+    case 14:
+      return nil
+    case 15:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -3660,6 +3953,45 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 15)
     return ProtocolDeclSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "name"
+    case 8:
+      return nil
+    case 9:
+      return "primary associated type clause"
+    case 10:
+      return nil
+    case 11:
+      return "inheritance clause"
+    case 12:
+      return nil
+    case 13:
+      return "generic where clause"
+    case 14:
+      return nil
+    case 15:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ProtocolDeclSyntax: CustomReflectable {
@@ -4068,6 +4400,41 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default)
     let newData = data.replacingChild(raw, at: 13)
     return ExtensionDeclSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "name"
+    case 8:
+      return nil
+    case 9:
+      return "inheritance clause"
+    case 10:
+      return nil
+    case 11:
+      return "generic where clause"
+    case 12:
+      return nil
+    case 13:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -4521,6 +4888,45 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 15)
     return FunctionDeclSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "name"
+    case 8:
+      return nil
+    case 9:
+      return "generic parameter clause"
+    case 10:
+      return nil
+    case 11:
+      return "function signature"
+    case 12:
+      return nil
+    case 13:
+      return "generic where clause"
+    case 14:
+      return nil
+    case 15:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -4978,6 +5384,45 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 15)
     return InitializerDeclSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return "generic parameter clause"
+    case 10:
+      return nil
+    case 11:
+      return "function signature"
+    case 12:
+      return nil
+    case 13:
+      return "generic where clause"
+    case 14:
+      return nil
+    case 15:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension InitializerDeclSyntax: CustomReflectable {
@@ -5250,6 +5695,29 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 7)
     return DeinitializerDeclSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -5698,6 +6166,45 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 15)
     return SubscriptDeclSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "generic parameter clause"
+    case 8:
+      return nil
+    case 9:
+      return nil
+    case 10:
+      return nil
+    case 11:
+      return nil
+    case 12:
+      return nil
+    case 13:
+      return "generic where clause"
+    case 14:
+      return nil
+    case 15:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension SubscriptDeclSyntax: CustomReflectable {
@@ -6033,6 +6540,33 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.accessPath, arena: .default)
     let newData = data.replacingChild(raw, at: 9)
     return ImportDeclSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -6421,6 +6955,41 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 13)
     return AccessorDeclSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "parameter"
+    case 8:
+      return nil
+    case 9:
+      return nil
+    case 10:
+      return nil
+    case 11:
+      return nil
+    case 12:
+      return nil
+    case 13:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension AccessorDeclSyntax: CustomReflectable {
@@ -6708,6 +7277,29 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.patternBindingList, arena: .default)
     let newData = data.replacingChild(raw, at: 7)
     return VariableDeclSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -7003,6 +7595,29 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.enumCaseElementList, arena: .default)
     let newData = data.replacingChild(raw, at: 7)
     return EnumCaseDeclSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "elements"
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -7478,6 +8093,45 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 15)
     return EnumDeclSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "name"
+    case 8:
+      return nil
+    case 9:
+      return "generic parameter clause"
+    case 10:
+      return nil
+    case 11:
+      return "inheritance clause"
+    case 12:
+      return nil
+    case 13:
+      return "generic where clause"
+    case 14:
+      return nil
+    case 15:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension EnumDeclSyntax: CustomReflectable {
@@ -7806,6 +8460,33 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 9)
     return OperatorDeclSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "name"
+    case 8:
+      return nil
+    case 9:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -8239,6 +8920,41 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default)
     let newData = data.replacingChild(raw, at: 13)
     return PrecedenceGroupDeclSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return "modifiers"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "name"
+    case 8:
+      return nil
+    case 9:
+      return nil
+    case 10:
+      return nil
+    case 11:
+      return nil
+    case 12:
+      return nil
+    case 13:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -42,6 +42,13 @@ public struct UnknownExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let data = SyntaxData.forRoot(raw)
     self.init(data)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension UnknownExprSyntax: CustomReflectable {
@@ -79,6 +86,13 @@ public struct MissingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       from: layout, arena: .default)
     let data = SyntaxData.forRoot(raw)
     self.init(data)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -208,6 +222,21 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return InOutExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension InOutExprSyntax: CustomReflectable {
@@ -294,6 +323,17 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundColumnKeyword, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return PoundColumnExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -471,6 +511,25 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return TryExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension TryExprSyntax: CustomReflectable {
@@ -605,6 +664,21 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return AwaitExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension AwaitExprSyntax: CustomReflectable {
@@ -736,6 +810,21 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return MoveExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -870,6 +959,21 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return IdentifierExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension IdentifierExprSyntax: CustomReflectable {
@@ -957,6 +1061,17 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 1)
     return SuperRefExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension SuperRefExprSyntax: CustomReflectable {
@@ -1041,6 +1156,17 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.nilKeyword, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return NilLiteralExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1127,6 +1253,17 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 1)
     return DiscardAssignmentExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension DiscardAssignmentExprSyntax: CustomReflectable {
@@ -1211,6 +1348,17 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return AssignmentExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1315,6 +1463,17 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 1)
     return SequenceExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension SequenceExprSyntax: CustomReflectable {
@@ -1399,6 +1558,17 @@ public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundLineKeyword, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return PoundLineExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1485,6 +1655,17 @@ public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 1)
     return PoundFileExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension PoundFileExprSyntax: CustomReflectable {
@@ -1569,6 +1750,17 @@ public struct PoundFileIDExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundFileIDKeyword, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return PoundFileIDExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1655,6 +1847,17 @@ public struct PoundFilePathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 1)
     return PoundFilePathExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension PoundFilePathExprSyntax: CustomReflectable {
@@ -1740,6 +1943,17 @@ public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 1)
     return PoundFunctionExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension PoundFunctionExprSyntax: CustomReflectable {
@@ -1824,6 +2038,17 @@ public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.poundDsohandleKeyword, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return PoundDsohandleExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1955,6 +2180,21 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return SymbolicReferenceExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -2089,6 +2329,21 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return PrefixOperatorExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension PrefixOperatorExprSyntax: CustomReflectable {
@@ -2175,6 +2430,17 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return BinaryOperatorExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -2352,6 +2618,25 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return ArrowExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -2532,6 +2817,25 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return InfixOperatorExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension InfixOperatorExprSyntax: CustomReflectable {
@@ -2620,6 +2924,17 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.floatingLiteral(""), arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return FloatLiteralExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -2813,6 +3128,25 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return TupleExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -3011,6 +3345,25 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return ArrayExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ArrayExprSyntax: CustomReflectable {
@@ -3190,6 +3543,25 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return DictionaryExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension DictionaryExprSyntax: CustomReflectable {
@@ -3279,6 +3651,17 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 1)
     return IntegerLiteralExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension IntegerLiteralExprSyntax: CustomReflectable {
@@ -3363,6 +3746,17 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.trueKeyword, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return BooleanLiteralExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -3538,6 +3932,25 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return UnresolvedTernaryExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -3808,6 +4221,33 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 9)
     return TernaryExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "condition"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "first choice"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return "second choice"
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension TernaryExprSyntax: CustomReflectable {
@@ -4038,6 +4478,29 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return MemberAccessExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "base"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "name"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension MemberAccessExprSyntax: CustomReflectable {
@@ -4128,6 +4591,17 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return UnresolvedIsExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -4304,6 +4778,25 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return IsExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension IsExprSyntax: CustomReflectable {
@@ -4438,6 +4931,21 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return UnresolvedAsExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -4662,6 +5170,29 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return AsExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension AsExprSyntax: CustomReflectable {
@@ -4752,6 +5283,17 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return TypeExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -4992,6 +5534,29 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return ClosureExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ClosureExprSyntax: CustomReflectable {
@@ -5082,6 +5647,17 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return UnresolvedPatternExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -5432,6 +6008,37 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 11)
     return FunctionCallExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "called expression"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "arguments"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return "trailing closure"
+    case 10:
+      return nil
+    case 11:
+      return "trailing closures"
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -5791,6 +6398,37 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 11)
     return SubscriptExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "called expression"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "arguments"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return "trailing closure"
+    case 10:
+      return nil
+    case 11:
+      return "trailing closures"
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension SubscriptExprSyntax: CustomReflectable {
@@ -5931,6 +6569,21 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return OptionalChainingExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension OptionalChainingExprSyntax: CustomReflectable {
@@ -6062,6 +6715,21 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.exclamationMark, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return ForcedValueExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -6195,6 +6863,21 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return PostfixUnaryExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension PostfixUnaryExprSyntax: CustomReflectable {
@@ -6326,6 +7009,21 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericArgumentClause, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return SpecializeExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -6614,6 +7312,33 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 9)
     return StringLiteralExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension StringLiteralExprSyntax: CustomReflectable {
@@ -6706,6 +7431,17 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.regexLiteral(""), arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return RegexLiteralExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -6883,6 +7619,25 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return KeyPathExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "root"
+    case 4:
+      return nil
+    case 5:
+      return "expression"
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension KeyPathExprSyntax: CustomReflectable {
@@ -6971,6 +7726,17 @@ public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return KeyPathBaseExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -7209,6 +7975,29 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
     let newData = data.replacingChild(raw, at: 7)
     return ObjcKeyPathExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "name"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -7528,6 +8317,37 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 11)
     return ObjcSelectorExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return "name"
+    case 10:
+      return nil
+    case 11:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ObjcSelectorExprSyntax: CustomReflectable {
@@ -7669,6 +8489,21 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return PostfixIfConfigExprSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension PostfixIfConfigExprSyntax: CustomReflectable {
@@ -7755,6 +8590,17 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return EditorPlaceholderExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -7993,6 +8839,29 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
     let newData = data.replacingChild(raw, at: 7)
     return ObjectLiteralExprSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -42,6 +42,13 @@ public struct MissingSyntax: SyntaxProtocol, SyntaxHashable {
     let data = SyntaxData.forRoot(raw)
     self.init(data)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension MissingSyntax: CustomReflectable {
@@ -224,6 +231,25 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 5)
     return CodeBlockItemSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -422,6 +448,25 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return CodeBlockSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "statements"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension CodeBlockSyntax: CustomReflectable {
@@ -555,6 +600,21 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return DeclNameArgumentSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -750,6 +810,25 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return DeclNameArgumentsSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -978,6 +1057,29 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return TupleExprElementSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "label"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "value"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension TupleExprElementSyntax: CustomReflectable {
@@ -1114,6 +1216,21 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return ArrayElementSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "value"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1337,6 +1454,29 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 7)
     return DictionaryElementSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "key"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "value"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1631,6 +1771,33 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 9)
     return ClosureCaptureItemSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ClosureCaptureItemSyntax: CustomReflectable {
@@ -1833,6 +2000,25 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return ClosureCaptureSignatureSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ClosureCaptureSignatureSyntax: CustomReflectable {
@@ -1967,6 +2153,21 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return ClosureParamSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "name"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -2349,6 +2550,41 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 13)
     return ClosureSignatureSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    case 10:
+      return nil
+    case 11:
+      return nil
+    case 12:
+      return nil
+    case 13:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ClosureSignatureSyntax: CustomReflectable {
@@ -2536,6 +2772,25 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
     let newData = data.replacingChild(raw, at: 5)
     return MultipleTrailingClosureElementSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "label"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension MultipleTrailingClosureElementSyntax: CustomReflectable {
@@ -2624,6 +2879,17 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringSegment(""), arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return StringSegmentSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -2909,6 +3175,33 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 9)
     return ExpressionSegmentSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ExpressionSegmentSyntax: CustomReflectable {
@@ -3048,6 +3341,21 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return ObjcNamePieceSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ObjcNamePieceSyntax: CustomReflectable {
@@ -3179,6 +3487,21 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return TypeInitializerClauseSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "value"
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -3375,6 +3698,25 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return ParameterClauseSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "parameters"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ParameterClauseSyntax: CustomReflectable {
@@ -3508,6 +3850,21 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return ReturnClauseSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "return type"
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -3734,6 +4091,29 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return FunctionSignatureSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension FunctionSignatureSyntax: CustomReflectable {
@@ -3915,6 +4295,25 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return IfConfigClauseSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "condition"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -4275,6 +4674,41 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 13)
     return PoundSourceLocationArgsSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "file name"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    case 10:
+      return nil
+    case 11:
+      return nil
+    case 12:
+      return nil
+    case 13:
+      return "line number"
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension PoundSourceLocationArgsSyntax: CustomReflectable {
@@ -4462,6 +4896,25 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return DeclModifierDetailSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension DeclModifierDetailSyntax: CustomReflectable {
@@ -4597,6 +5050,21 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return DeclModifierSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension DeclModifierSyntax: CustomReflectable {
@@ -4729,6 +5197,21 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return InheritedTypeSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -4879,6 +5362,21 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.inheritedTypeList, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return TypeInheritanceClauseSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -5075,6 +5573,25 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return MemberDeclBlockSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension MemberDeclBlockSyntax: CustomReflectable {
@@ -5215,6 +5732,21 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return MemberDeclListItemSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -5366,6 +5898,21 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return SourceFileSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension SourceFileSyntax: CustomReflectable {
@@ -5497,6 +6044,21 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return InitializerClauseSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -6018,6 +6580,53 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 19)
     return FunctionParameterSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "attributes"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "name"
+    case 8:
+      return nil
+    case 9:
+      return "internal name"
+    case 10:
+      return nil
+    case 11:
+      return nil
+    case 12:
+      return nil
+    case 13:
+      return "type"
+    case 14:
+      return nil
+    case 15:
+      return nil
+    case 16:
+      return nil
+    case 17:
+      return "default argument"
+    case 18:
+      return nil
+    case 19:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension FunctionParameterSyntax: CustomReflectable {
@@ -6167,6 +6776,21 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return AccessLevelModifierSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "name"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension AccessLevelModifierSyntax: CustomReflectable {
@@ -6299,6 +6923,21 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return AccessPathComponentSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "name"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -6476,6 +7115,25 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return AccessorParameterSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "name"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -6673,6 +7331,25 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return AccessorBlockSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -6947,6 +7624,33 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 9)
     return PatternBindingSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "type annotation"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension PatternBindingSyntax: CustomReflectable {
@@ -7191,6 +7895,29 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return EnumCaseElementSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "name"
+    case 2:
+      return nil
+    case 3:
+      return "associated values"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension EnumCaseElementSyntax: CustomReflectable {
@@ -7326,6 +8053,21 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return DesignatedTypeElementSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -7530,6 +8272,25 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.designatedTypeList, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return OperatorPrecedenceAndTypesSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -7739,6 +8500,25 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return PrecedenceGroupRelationSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension PrecedenceGroupRelationSyntax: CustomReflectable {
@@ -7873,6 +8653,21 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return PrecedenceGroupNameElementSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "name"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -8062,6 +8857,25 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return PrecedenceGroupAssignmentSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension PrecedenceGroupAssignmentSyntax: CustomReflectable {
@@ -8250,6 +9064,25 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return PrecedenceGroupAssociativitySyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -8545,6 +9378,33 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 9)
     return CustomAttributeSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "name"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -8902,6 +9762,37 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 11)
     return AttributeSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "name"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    case 10:
+      return nil
+    case 11:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension AttributeSyntax: CustomReflectable {
@@ -9155,6 +10046,29 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return AvailabilityEntrySyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "label"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension AvailabilityEntrySyntax: CustomReflectable {
@@ -9391,6 +10305,29 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 7)
     return LabeledSpecializeEntrySyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "label"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "value"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -9630,6 +10567,29 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return TargetFunctionEntrySyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "label"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "declaration name"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension TargetFunctionEntrySyntax: CustomReflectable {
@@ -9818,6 +10778,25 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
     let newData = data.replacingChild(raw, at: 5)
     return NamedAttributeStringArgumentSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "label"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "value"
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension NamedAttributeStringArgumentSyntax: CustomReflectable {
@@ -9959,6 +10938,21 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return DeclNameSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "base name"
+    case 2:
+      return nil
+    case 3:
+      return "arguments"
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -10201,6 +11195,29 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     let newData = data.replacingChild(raw, at: 7)
     return ImplementsAttributeArgumentsSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "type"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "declaration base name"
+    case 6:
+      return nil
+    case 7:
+      return "declaration name arguments"
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ImplementsAttributeArgumentsSyntax: CustomReflectable {
@@ -10343,6 +11360,21 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return ObjCSelectorPieceSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "name"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -10628,6 +11660,33 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
     let newData = data.replacingChild(raw, at: 9)
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension DifferentiableAttributeArgumentsSyntax: CustomReflectable {
@@ -10815,6 +11874,25 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return DifferentiabilityParamsClauseSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "parameters"
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -11015,6 +12093,25 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return DifferentiabilityParamsSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension DifferentiabilityParamsSyntax: CustomReflectable {
@@ -11153,6 +12250,21 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return DifferentiabilityParamSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -11531,6 +12643,41 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
     let newData = data.replacingChild(raw, at: 13)
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    case 10:
+      return nil
+    case 11:
+      return nil
+    case 12:
+      return nil
+    case 13:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension DerivativeRegistrationAttributeArgumentsSyntax: CustomReflectable {
@@ -11780,6 +12927,29 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return QualifiedDeclNameSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "base type"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "base name"
+    case 6:
+      return nil
+    case 7:
+      return "arguments"
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension QualifiedDeclNameSyntax: CustomReflectable {
@@ -11924,6 +13094,21 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return FunctionDeclNameSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "base name"
+    case 2:
+      return nil
+    case 3:
+      return "arguments"
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -12131,6 +13316,25 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
     let newData = data.replacingChild(raw, at: 5)
     return BackDeployAttributeSpecListSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension BackDeployAttributeSpecListSyntax: CustomReflectable {
@@ -12273,6 +13477,21 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return BackDeployVersionArgumentSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -12455,6 +13674,25 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -12733,6 +13971,33 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     let newData = data.replacingChild(raw, at: 9)
     return ConventionAttributeArgumentsSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ConventionAttributeArgumentsSyntax: CustomReflectable {
@@ -12919,6 +14184,25 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
     let newData = data.replacingChild(raw, at: 5)
     return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ConventionWitnessMethodAttributeArgumentsSyntax: CustomReflectable {
@@ -13052,6 +14336,21 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return WhereClauseSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -13294,6 +14593,29 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return YieldListSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension YieldListSyntax: CustomReflectable {
@@ -13430,6 +14752,21 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return ConditionElementSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -13671,6 +15008,29 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return AvailabilityConditionSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension AvailabilityConditionSyntax: CustomReflectable {
@@ -13897,6 +15257,29 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.initializerClause, arena: .default)
     let newData = data.replacingChild(raw, at: 7)
     return MatchingPatternConditionSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -14125,6 +15508,29 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 7)
     return OptionalBindingConditionSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -14370,6 +15776,29 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return UnavailabilityConditionSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension UnavailabilityConditionSyntax: CustomReflectable {
@@ -14596,6 +16025,29 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return HasSymbolConditionSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension HasSymbolConditionSyntax: CustomReflectable {
@@ -14686,6 +16138,17 @@ public struct ElseIfContinuationSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifStmt, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return ElseIfContinuationSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -14816,6 +16279,21 @@ public struct ElseBlockSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return ElseBlockSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -15013,6 +16491,25 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return SwitchCaseSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "label"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension SwitchCaseSyntax: CustomReflectable {
@@ -15146,6 +16643,21 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return SwitchDefaultLabelSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -15325,6 +16837,25 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 5)
     return CaseItemSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -15507,6 +17038,25 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 5)
     return CatchItemSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -15704,6 +17254,25 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return SwitchCaseLabelSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -15903,6 +17472,25 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return CatchClauseSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension CatchClauseSyntax: CustomReflectable {
@@ -16055,6 +17643,21 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return GenericWhereClauseSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension GenericWhereClauseSyntax: CustomReflectable {
@@ -16187,6 +17790,21 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return GenericRequirementSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -16364,6 +17982,25 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return SameTypeRequirementSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "left-hand type"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "right-hand type"
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -16774,6 +18411,45 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 15)
     return LayoutRequirementSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "constrained type"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return "size"
+    case 10:
+      return nil
+    case 11:
+      return nil
+    case 12:
+      return nil
+    case 13:
+      return "alignment"
+    case 14:
+      return nil
+    case 15:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension LayoutRequirementSyntax: CustomReflectable {
@@ -17075,6 +18751,33 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 9)
     return GenericParameterSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "name"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "inherited type"
+    case 8:
+      return nil
+    case 9:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension GenericParameterSyntax: CustomReflectable {
@@ -17213,6 +18916,21 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return PrimaryAssociatedTypeSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "name"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -17455,6 +19173,29 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return GenericParameterClauseSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension GenericParameterClauseSyntax: CustomReflectable {
@@ -17635,6 +19376,25 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return ConformanceRequirementSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -17833,6 +19593,25 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
     let newData = data.replacingChild(raw, at: 5)
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension PrimaryAssociatedTypeClauseSyntax: CustomReflectable {
@@ -17967,6 +19746,21 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return CompositionTypeElementSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -18377,6 +20171,45 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 15)
     return TupleTypeElementSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "name"
+    case 4:
+      return nil
+    case 5:
+      return "internal name"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    case 10:
+      return nil
+    case 11:
+      return nil
+    case 12:
+      return nil
+    case 13:
+      return nil
+    case 14:
+      return nil
+    case 15:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension TupleTypeElementSyntax: CustomReflectable {
@@ -18521,6 +20354,21 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return GenericArgumentSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -18717,6 +20565,25 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return GenericArgumentClauseSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension GenericArgumentClauseSyntax: CustomReflectable {
@@ -18850,6 +20717,21 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return TypeAnnotationSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -19076,6 +20958,29 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return TuplePatternElementSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "label"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension TuplePatternElementSyntax: CustomReflectable {
@@ -19221,6 +21126,21 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return AvailabilityArgumentSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -19406,6 +21326,25 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
     let newData = data.replacingChild(raw, at: 5)
     return AvailabilityLabeledArgumentSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "label"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "value"
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension AvailabilityLabeledArgumentSyntax: CustomReflectable {
@@ -19549,6 +21488,21 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return AvailabilityVersionRestrictionSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "platform"
+    case 2:
+      return nil
+    case 3:
+      return "version"
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -19746,6 +21700,25 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 5)
     return VersionTupleSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
@@ -42,6 +42,13 @@ public struct UnknownPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     let data = SyntaxData.forRoot(raw)
     self.init(data)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension UnknownPatternSyntax: CustomReflectable {
@@ -79,6 +86,13 @@ public struct MissingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       from: layout, arena: .default)
     let data = SyntaxData.forRoot(raw)
     self.init(data)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -300,6 +314,29 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return EnumCasePatternSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "case name"
+    case 6:
+      return nil
+    case 7:
+      return "associated values"
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension EnumCasePatternSyntax: CustomReflectable {
@@ -436,6 +473,21 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return IsTypePatternSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension IsTypePatternSyntax: CustomReflectable {
@@ -568,6 +620,21 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return OptionalPatternSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension OptionalPatternSyntax: CustomReflectable {
@@ -654,6 +721,17 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.selfKeyword, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return IdentifierPatternSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -829,6 +907,25 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return AsTypePatternSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1027,6 +1124,25 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return TuplePatternSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension TuplePatternSyntax: CustomReflectable {
@@ -1162,6 +1278,21 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return WildcardPatternSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension WildcardPatternSyntax: CustomReflectable {
@@ -1248,6 +1379,17 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return ExpressionPatternSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1378,6 +1520,21 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return ValueBindingPatternSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -42,6 +42,13 @@ public struct UnknownStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let data = SyntaxData.forRoot(raw)
     self.init(data)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension UnknownStmtSyntax: CustomReflectable {
@@ -79,6 +86,13 @@ public struct MissingStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       from: layout, arena: .default)
     let data = SyntaxData.forRoot(raw)
     self.init(data)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -253,6 +267,25 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return LabeledStmtSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "name"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension LabeledStmtSyntax: CustomReflectable {
@@ -387,6 +420,21 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return ContinueStmtSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "label"
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -583,6 +631,25 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return WhileStmtSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension WhileStmtSyntax: CustomReflectable {
@@ -717,6 +784,21 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return DeferStmtSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension DeferStmtSyntax: CustomReflectable {
@@ -803,6 +885,17 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return ExpressionStmtSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1023,6 +1116,29 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
     let newData = data.replacingChild(raw, at: 7)
     return RepeatWhileStmtSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "body"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "condition"
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1267,6 +1383,29 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default)
     let newData = data.replacingChild(raw, at: 7)
     return GuardStmtSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "conditions"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "body"
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1769,6 +1908,53 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 19)
     return ForInStmtSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    case 10:
+      return nil
+    case 11:
+      return nil
+    case 12:
+      return nil
+    case 13:
+      return nil
+    case 14:
+      return nil
+    case 15:
+      return nil
+    case 16:
+      return nil
+    case 17:
+      return nil
+    case 18:
+      return nil
+    case 19:
+      return "body"
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ForInStmtSyntax: CustomReflectable {
@@ -2070,6 +2256,33 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 9)
     return SwitchStmtSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension SwitchStmtSyntax: CustomReflectable {
@@ -2272,6 +2485,25 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return DoStmtSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "body"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension DoStmtSyntax: CustomReflectable {
@@ -2407,6 +2639,21 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return ReturnStmtSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ReturnStmtSyntax: CustomReflectable {
@@ -2539,6 +2786,21 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return YieldStmtSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension YieldStmtSyntax: CustomReflectable {
@@ -2625,6 +2887,17 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.fallthroughKeyword, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return FallthroughStmtSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -2757,6 +3030,21 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return BreakStmtSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "label"
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension BreakStmtSyntax: CustomReflectable {
@@ -2843,6 +3131,17 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingDecl, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return DeclarationStmtSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -2973,6 +3272,21 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return ThrowStmtSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -3260,6 +3574,33 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 9)
     return IfStmtSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "body"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return "else body"
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -3583,6 +3924,37 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
     let newData = data.replacingChild(raw, at: 11)
     return PoundAssertStmtSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "condition"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return "message"
+    case 10:
+      return nil
+    case 11:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -42,6 +42,13 @@ public struct UnknownTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let data = SyntaxData.forRoot(raw)
     self.init(data)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension UnknownTypeSyntax: CustomReflectable {
@@ -79,6 +86,13 @@ public struct MissingTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       from: layout, arena: .default)
     let data = SyntaxData.forRoot(raw)
     self.init(data)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -208,6 +222,21 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 3)
     return SimpleTypeIdentifierSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -432,6 +461,29 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 7)
     return MemberTypeIdentifierSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "base type"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return "member type"
+    case 6:
+      return nil
+    case 7:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension MemberTypeIdentifierSyntax: CustomReflectable {
@@ -522,6 +574,17 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.classKeyword, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return ClassRestrictionTypeSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -697,6 +760,25 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return ArrayTypeSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -967,6 +1049,33 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 9)
     return DictionaryTypeSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return "key type"
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return "value type"
+    case 8:
+      return nil
+    case 9:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension DictionaryTypeSyntax: CustomReflectable {
@@ -1150,6 +1259,25 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return MetatypeTypeSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return "base type"
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension MetatypeTypeSyntax: CustomReflectable {
@@ -1284,6 +1412,21 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 3)
     return OptionalTypeSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension OptionalTypeSyntax: CustomReflectable {
@@ -1415,6 +1558,21 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return ConstrainedSugarTypeSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1548,6 +1706,21 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
     let newData = data.replacingChild(raw, at: 3)
     return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension ImplicitlyUnwrappedOptionalTypeSyntax: CustomReflectable {
@@ -1652,6 +1825,17 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.compositionTypeElementList, arena: .default)
     let newData = data.replacingChild(raw, at: 1)
     return CompositionTypeSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1782,6 +1966,21 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.ellipsis, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return PackExpansionTypeSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -1977,6 +2176,25 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
     return TupleTypeSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 
@@ -2357,6 +2575,41 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 13)
     return FunctionTypeSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    case 6:
+      return nil
+    case 7:
+      return nil
+    case 8:
+      return nil
+    case 9:
+      return nil
+    case 10:
+      return nil
+    case 11:
+      return nil
+    case 12:
+      return nil
+    case 13:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension FunctionTypeSyntax: CustomReflectable {
@@ -2564,6 +2817,25 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let newData = data.replacingChild(raw, at: 5)
     return AttributedTypeSyntax(newData)
   }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    case 4:
+      return nil
+    case 5:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
 }
 
 extension AttributedTypeSyntax: CustomReflectable {
@@ -2697,6 +2969,21 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return NamedOpaqueReturnTypeSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
   }
 }
 

--- a/Sources/generate-swift-syntax-builder/gyb_generated/DeclNodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/DeclNodes.swift
@@ -125,7 +125,7 @@ let DECL_NODES: [Node] = [
        ]),
 
   Node(name: "ReturnClause",
-       nameForDiagnostics: "return clause",
+       nameForDiagnostics: nil,
        kind: "Syntax",
        children: [
          Child(name: "Arrow",
@@ -667,7 +667,7 @@ let DECL_NODES: [Node] = [
        elementsSeparatedByNewline: true),
 
   Node(name: "MemberDeclListItem",
-       nameForDiagnostics: "member",
+       nameForDiagnostics: nil,
        description: "A member declaration of a type consisting of a declaration and anoptional semicolon;",
        kind: "Syntax",
        children: [

--- a/Sources/generate-swift-syntax-builder/gyb_generated/ExprNodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/ExprNodes.swift
@@ -479,7 +479,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "ArrayElement",
-       nameForDiagnostics: nil,
+       nameForDiagnostics: "array element",
        kind: "Syntax",
        traits: [
          "WithTrailingComma"
@@ -496,7 +496,7 @@ let EXPR_NODES: [Node] = [
        ]),
 
   Node(name: "DictionaryElement",
-       nameForDiagnostics: nil,
+       nameForDiagnostics: "dictionary element",
        kind: "Syntax",
        traits: [
          "WithTrailingComma"

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/AttributeNodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/AttributeNodes.py
@@ -17,7 +17,8 @@ ATTRIBUTE_NODES = [
          children=[
              Child('AtSignToken', kind='AtSignToken',
                    description='The `@` sign.'),
-             Child('AttributeName', kind='Type', classification='Attribute',
+             Child('AttributeName', kind='Type', name_for_diagnostics='name',
+                   classification='Attribute',
                    description='The name of the attribute.'),
              Child('LeftParen', kind='LeftParenToken',
                    is_optional=True),
@@ -44,7 +45,8 @@ ATTRIBUTE_NODES = [
          children=[
              Child('AtSignToken', kind='AtSignToken',
                    description='The `@` sign.'),
-             Child('AttributeName', kind='Token', classification='Attribute',
+             Child('AttributeName', kind='Token', name_for_diagnostics='name',
+                   classification='Attribute',
                    description='The name of the attribute.'),
              Child('LeftParen', kind='LeftParenToken', is_optional=True,
                    description='''
@@ -124,7 +126,7 @@ ATTRIBUTE_NODES = [
          The availability argument for the _specialize attribute
          ''',
          children=[
-             Child('Label', kind='IdentifierToken',
+             Child('Label', kind='IdentifierToken', name_for_diagnostics='label',
                    description='The label of the argument'),
              Child('Colon', kind='ColonToken',
                    description='The colon separating the label and the value'),
@@ -143,11 +145,11 @@ ATTRIBUTE_NODES = [
          ''',
          traits=['WithTrailingComma'],
          children=[
-             Child('Label', kind='IdentifierToken',
+             Child('Label', kind='IdentifierToken', name_for_diagnostics='label',
                    description='The label of the argument'),
              Child('Colon', kind='ColonToken',
                    description='The colon separating the label and the value'),
-             Child('Value', kind='Token',
+             Child('Value', kind='Token', name_for_diagnostics='value',
                    description='The value for this argument'),
              Child('TrailingComma', kind='CommaToken',
                    is_optional=True, description='''
@@ -165,11 +167,11 @@ ATTRIBUTE_NODES = [
          ''',
          traits=['WithTrailingComma'],
          children=[
-             Child('Label', kind='IdentifierToken',
+             Child('Label', kind='IdentifierToken', name_for_diagnostics='label',
                    description='The label of the argument'),
              Child('Colon', kind='ColonToken',
                    description='The colon separating the label and the value'),
-             Child('Declname', kind='DeclName',
+             Child('Declname', kind='DeclName', name_for_diagnostics='declaration name',
                    description='The value for this argument'),
              Child('TrailingComma', kind='CommaToken',
                    is_optional=True, description='''
@@ -187,24 +189,24 @@ ATTRIBUTE_NODES = [
          "Src.swift"`
          ''',
          children=[
-             Child('NameTok', kind='Token',
+             Child('NameTok', kind='Token', name_for_diagnostics='label',
                    description='The label of the argument'),
              Child('Colon', kind='ColonToken',
                    description='The colon separating the label and the value'),
-             Child('StringOrDeclname', kind='Syntax', node_choices=[
+             Child('StringOrDeclname', kind='Syntax', name_for_diagnostics='value', node_choices=[
                  Child('String', kind='StringLiteralToken'),
                  Child('Declname', kind='DeclName'),
              ]),
          ]),
     Node('DeclName', name_for_diagnostics='declaration name', kind='Syntax', children=[
-         Child('DeclBaseName', kind='Syntax', description='''
+         Child('DeclBaseName', kind='Syntax', name_for_diagnostics='base name', description='''
                The base name of the protocol\'s requirement.
                ''',
                node_choices=[
                    Child('Identifier', kind='IdentifierToken'),
                    Child('Operator', kind='PrefixOperatorToken'),
                ]),
-         Child('DeclNameArguments', kind='DeclNameArguments',
+         Child('DeclNameArguments', kind='DeclNameArguments', name_for_diagnostics='arguments',
                is_optional=True, description='''
                The argument labels of the protocol\'s requirement if it
                is a function requirement.
@@ -220,7 +222,7 @@ ATTRIBUTE_NODES = [
          `Type, methodName(arg1Label:arg2Label:)`
          ''',
          children=[
-             Child('Type', kind='Type', description='''
+             Child('Type', kind='Type', name_for_diagnostics='type', description='''
                    The type for which the method with this attribute
                    implements a requirement.
                    '''),
@@ -228,10 +230,10 @@ ATTRIBUTE_NODES = [
                    description='''
                    The comma separating the type and method name
                    '''),
-             Child('DeclBaseName', kind='Token', description='''
+             Child('DeclBaseName', kind='Token', name_for_diagnostics='declaration base name', description='''
                    The base name of the protocol\'s requirement.
                    '''),
-             Child('DeclNameArguments', kind='DeclNameArguments',
+             Child('DeclNameArguments', name_for_diagnostics='declaration name arguments', kind='DeclNameArguments',
                    is_optional=True, description='''
                    The argument labels of the protocol\'s requirement if it
                    is a function requirement.
@@ -247,7 +249,7 @@ ATTRIBUTE_NODES = [
          labeled argument or just a colon for an unlabeled argument
          ''',
          children=[
-             Child('Name', kind='IdentifierToken', is_optional=True),
+             Child('Name', kind='IdentifierToken', name_for_diagnostics='name', is_optional=True),
              Child('Colon', kind='ColonToken', is_optional=True),
          ]),
 
@@ -293,7 +295,7 @@ ATTRIBUTE_NODES = [
              Child('Colon', kind='ColonToken', description='''
                    The colon separating "wrt" and the parameter list.
                    '''),
-             Child('Parameters', kind='Syntax',
+             Child('Parameters', kind='Syntax', name_for_diagnostics='parameters',
                    node_choices=[
                        Child('Parameter', kind='DifferentiabilityParam'),
                        Child('ParameterList', kind='DifferentiabilityParams'),
@@ -389,14 +391,14 @@ ATTRIBUTE_NODES = [
          `A.B.C.foo(_:_:)`).
          ''',
          children=[
-             Child('BaseType', kind='Type', description='''
+             Child('BaseType', kind='Type', name_for_diagnostics='base type', description='''
                    The base type of the qualified name, optionally specified.
                    ''', is_optional=True),
              Child('Dot', kind='Token',
                    token_choices=[
                        'PeriodToken', 'PrefixPeriodToken'
                    ], is_optional=True),
-             Child('Name', kind='Token', description='''
+             Child('Name', kind='Token', name_for_diagnostics='base name', description='''
                    The base name of the referenced function.
                    ''',
                    token_choices=[
@@ -406,7 +408,7 @@ ATTRIBUTE_NODES = [
                        'PrefixOperatorToken',
                        'PostfixOperatorToken',
                    ]),
-             Child('Arguments', kind='DeclNameArguments',
+             Child('Arguments', name_for_diagnostics='arguments', kind='DeclNameArguments',
                    is_optional=True, description='''
                    The argument labels of the referenced function, optionally
                    specified.
@@ -420,7 +422,7 @@ ATTRIBUTE_NODES = [
          name_for_diagnostics='function declaration name',
          description='A function declaration name (e.g. `foo(_:_:)`).',
          children=[
-             Child('Name', kind='Syntax', description='''
+             Child('Name', kind='Syntax', name_for_diagnostics='base name', description='''
                    The base name of the referenced function.
                    ''',
                    node_choices=[
@@ -429,7 +431,7 @@ ATTRIBUTE_NODES = [
                        Child('SpacedBinaryOperator',
                              kind='SpacedBinaryOperatorToken'),
                    ]),
-             Child('Arguments', kind='DeclNameArguments',
+             Child('Arguments', name_for_diagnostics='arguments', kind='DeclNameArguments',
                    is_optional=True, description='''
                    The argument labels of the referenced function, optionally
                    specified.

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/AvailabilityNodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/AvailabilityNodes.py
@@ -46,11 +46,11 @@ AVAILABILITY_NODES = [
          a value, e.g. `message: "This has been deprecated"`.
          ''',
          children=[
-             Child('Label', kind='IdentifierToken',
+             Child('Label', kind='IdentifierToken', name_for_diagnostics='label',
                    description='The label of the argument'),
              Child('Colon', kind='ColonToken',
                    description='The colon separating label and value'),
-             Child('Value', kind='Syntax',
+             Child('Value', kind='Syntax', name_for_diagnostics='value',
                    node_choices=[
                        Child('String', 'StringLiteralToken'),
                        Child('Version', 'VersionTuple'),
@@ -66,14 +66,14 @@ AVAILABILITY_NODES = [
          certain platform to a version, e.g. `iOS 10` or `swift 3.4`.
          ''',
          children=[
-             Child('Platform', kind='IdentifierToken',
+             Child('Platform', kind='IdentifierToken', name_for_diagnostics='platform',
                    classification='Keyword',
                    description='''
                    The name of the OS on which the availability should be
                    restricted or 'swift' if the availability should be
                    restricted based on a Swift version.
                    '''),
-             Child('Version', kind='VersionTuple', is_optional=True),
+             Child('Version', kind='VersionTuple', name_for_diagnostics='version', is_optional=True),
          ]),
 
     # version-tuple -> integer-literal

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/Child.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/Child.py
@@ -9,7 +9,7 @@ class Child(object):
     A child of a node, that may be declared optional or a token with a
     restricted subset of acceptable kinds or texts.
     """
-    def __init__(self, name, kind, description=None, is_optional=False,
+    def __init__(self, name, kind, name_for_diagnostics=None, description=None, is_optional=False,
                  token_choices=None, text_choices=None, node_choices=None,
                  collection_element_name=None,
                  classification=None, force_classification=False,
@@ -22,6 +22,7 @@ class Child(object):
         identifiers) inherit the syntax classification.
         """
         self.name = name
+        self.name_for_diagnostics = name_for_diagnostics
         self.swift_name = lowercase_first_word(name)
         self.syntax_kind = kind
         self.description = description

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/CommonNodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/CommonNodes.py
@@ -59,7 +59,7 @@ COMMON_NODES = [
          traits=['Braced', 'WithStatements'],
          children=[
              Child('LeftBrace', kind='LeftBraceToken'),
-             Child('Statements', kind='CodeBlockItemList',
+             Child('Statements', kind='CodeBlockItemList', name_for_diagnostics='statements',
                    collection_element_name='Statement', is_indented=True),
              Child('RightBrace', kind='RightBraceToken',
                    requires_leading_newline=True),

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/DeclNodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/DeclNodes.py
@@ -8,7 +8,7 @@ DECL_NODES = [
     Node('TypeInitializerClause', name_for_diagnostics=None, kind='Syntax',
          children=[
              Child('Equal', kind='EqualToken'),
-             Child('Value', kind='Type'),
+             Child('Value', kind='Type', name_for_diagnostics='value'),
          ]),
 
     # typealias-declaration -> attributes? access-level-modifier? 'typealias'
@@ -18,16 +18,16 @@ DECL_NODES = [
     Node('TypealiasDecl', name_for_diagnostics='typealias declaration', kind='Decl',
          traits=['IdentifiedDecl'],
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('TypealiasKeyword', kind='TypealiasToken'),
-             Child('Identifier', kind='IdentifierToken'),
-             Child('GenericParameterClause', kind='GenericParameterClause',
+             Child('Identifier', kind='IdentifierToken',  name_for_diagnostics='name'),
+             Child('GenericParameterClause', kind='GenericParameterClause', name_for_diagnostics='generic parameter clause',
                    is_optional=True),
              Child('Initializer', kind='TypeInitializerClause'),
-             Child('GenericWhereClause', kind='GenericWhereClause',
+             Child('GenericWhereClause', kind='GenericWhereClause', name_for_diagnostics='generic where clause',
                    is_optional=True),
          ]),
 
@@ -39,17 +39,17 @@ DECL_NODES = [
     Node('AssociatedtypeDecl', name_for_diagnostics='associatedtype declaration',
          kind='Decl', traits=['IdentifiedDecl'],
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('AssociatedtypeKeyword', kind='AssociatedtypeToken'),
-             Child('Identifier', kind='IdentifierToken'),
-             Child('InheritanceClause', kind='TypeInheritanceClause',
+             Child('Identifier', kind='IdentifierToken',  name_for_diagnostics='name'),
+             Child('InheritanceClause', kind='TypeInheritanceClause', name_for_diagnostics='inheritance clause',
                    is_optional=True),
              Child('Initializer', kind='TypeInitializerClause',
                    is_optional=True),
-             Child('GenericWhereClause', kind='GenericWhereClause',
+             Child('GenericWhereClause', kind='GenericWhereClause', name_for_diagnostics='generic where clause',
                    is_optional=True),
          ]),
 
@@ -60,16 +60,16 @@ DECL_NODES = [
          traits=['Parenthesized'],
          children=[
              Child('LeftParen', kind='LeftParenToken'),
-             Child('ParameterList', kind='FunctionParameterList',
+             Child('ParameterList', kind='FunctionParameterList', name_for_diagnostics='parameters',
                    collection_element_name='Parameter'),
              Child('RightParen', kind='RightParenToken'),
          ]),
 
     # -> Type
-    Node('ReturnClause', name_for_diagnostics='return clause', kind='Syntax',
+    Node('ReturnClause', name_for_diagnostics=None, kind='Syntax',
          children=[
              Child('Arrow', kind='ArrowToken'),
-             Child('ReturnType', kind='Type'),
+             Child('ReturnType', kind='Type', name_for_diagnostics='return type'),
          ]),
 
     # function-signature ->
@@ -100,7 +100,7 @@ DECL_NODES = [
                        'PoundElseifToken',
                        'PoundElseToken',
                    ]),
-             Child('Condition', kind='Expr', classification='BuildConfigId',
+             Child('Condition', kind='Expr', name_for_diagnostics='condition', classification='BuildConfigId',
                    is_optional=True),
              Child('Elements', kind='Syntax',
                    node_choices=[
@@ -130,7 +130,7 @@ DECL_NODES = [
          children=[
              Child('PoundError', kind='PoundErrorToken'),
              Child('LeftParen', kind='LeftParenToken'),
-             Child('Message', kind='StringLiteralExpr'),
+             Child('Message', kind='StringLiteralExpr', name_for_diagnostics='message'),
              Child('RightParen', kind='RightParenToken')
          ]),
 
@@ -139,7 +139,7 @@ DECL_NODES = [
          children=[
              Child('PoundWarning', kind='PoundWarningToken'),
              Child('LeftParen', kind='LeftParenToken'),
-             Child('Message', kind='StringLiteralExpr'),
+             Child('Message', kind='StringLiteralExpr', name_for_diagnostics='message'),
              Child('RightParen', kind='RightParenToken')
          ]),
 
@@ -148,7 +148,7 @@ DECL_NODES = [
          children=[
              Child('PoundSourceLocation', kind='PoundSourceLocationToken'),
              Child('LeftParen', kind='LeftParenToken'),
-             Child('Args', kind='PoundSourceLocationArgs', is_optional=True),
+             Child('Args', kind='PoundSourceLocationArgs', name_for_diagnostics='arguments', is_optional=True),
              Child('RightParen', kind='RightParenToken')
          ]),
 
@@ -158,12 +158,12 @@ DECL_NODES = [
              Child('FileArgLabel', kind='IdentifierToken',
                    text_choices=['file']),
              Child('FileArgColon', kind='ColonToken'),
-             Child('FileName', kind='StringLiteralToken'),
+             Child('FileName', kind='StringLiteralToken', name_for_diagnostics='file name'),
              Child('Comma', kind='CommaToken'),
              Child('LineArgLabel', kind='IdentifierToken',
                    text_choices=['line']),
              Child('LineArgColon', kind='ColonToken'),
-             Child('LineNumber', kind='IntegerLiteralToken'),
+             Child('LineNumber', name_for_diagnostics='line number', kind='IntegerLiteralToken'),
          ]),
 
     Node('DeclModifierDetail', name_for_diagnostics=None, kind='Syntax',
@@ -218,17 +218,17 @@ DECL_NODES = [
     Node('ClassDecl', name_for_diagnostics='class', kind='Decl',
          traits=['DeclGroup', 'IdentifiedDecl'],
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('ClassKeyword', kind='ClassToken'),
-             Child('Identifier', kind='IdentifierToken'),
-             Child('GenericParameterClause', kind='GenericParameterClause',
+             Child('Identifier', kind='IdentifierToken', name_for_diagnostics='name'),
+             Child('GenericParameterClause', kind='GenericParameterClause', name_for_diagnostics='generic parameter clause',
                    is_optional=True),
-             Child('InheritanceClause', kind='TypeInheritanceClause',
+             Child('InheritanceClause', kind='TypeInheritanceClause', name_for_diagnostics='inheritance clause',
                    is_optional=True),
-             Child('GenericWhereClause', kind='GenericWhereClause',
+             Child('GenericWhereClause', kind='GenericWhereClause', name_for_diagnostics='generic where clause',
                    is_optional=True),
              Child('Members', kind='MemberDeclBlock'),
          ]),
@@ -243,18 +243,18 @@ DECL_NODES = [
     Node('ActorDecl', name_for_diagnostics='actor', kind='Decl',
          traits=['DeclGroup', 'IdentifiedDecl'],
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('ActorKeyword', kind='ContextualKeywordToken',
                    text_choices=['actor']),
-             Child('Identifier', kind='IdentifierToken'),
-             Child('GenericParameterClause', kind='GenericParameterClause',
+             Child('Identifier', kind='IdentifierToken', name_for_diagnostics='name'),
+             Child('GenericParameterClause', kind='GenericParameterClause', name_for_diagnostics='generic parameter clause',
                    is_optional=True),
-             Child('InheritanceClause', kind='TypeInheritanceClause',
+             Child('InheritanceClause', kind='TypeInheritanceClause', name_for_diagnostics='type inheritance clause',
                    is_optional=True),
-             Child('GenericWhereClause', kind='GenericWhereClause',
+             Child('GenericWhereClause', kind='GenericWhereClause', name_for_diagnostics='generic where clause',
                    is_optional=True),
              Child('Members', kind='MemberDeclBlock'),
          ]),
@@ -268,17 +268,17 @@ DECL_NODES = [
     Node('StructDecl', name_for_diagnostics='struct', kind='Decl',
          traits=['DeclGroup', 'IdentifiedDecl'],
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('StructKeyword', kind='StructToken'),
-             Child('Identifier', kind='IdentifierToken'),
-             Child('GenericParameterClause', kind='GenericParameterClause',
+             Child('Identifier', kind='IdentifierToken', name_for_diagnostics='name'),
+             Child('GenericParameterClause', kind='GenericParameterClause', name_for_diagnostics='generic parameter clause',
                    is_optional=True),
-             Child('InheritanceClause', kind='TypeInheritanceClause',
+             Child('InheritanceClause', kind='TypeInheritanceClause', name_for_diagnostics='type inheritance clause',
                    is_optional=True),
-             Child('GenericWhereClause', kind='GenericWhereClause',
+             Child('GenericWhereClause', kind='GenericWhereClause', name_for_diagnostics='generic where clause',
                    is_optional=True),
              Child('Members', kind='MemberDeclBlock'),
          ]),
@@ -286,18 +286,19 @@ DECL_NODES = [
     Node('ProtocolDecl', name_for_diagnostics='protocol', kind='Decl',
          traits=['DeclGroup', 'IdentifiedDecl'],
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('ProtocolKeyword', kind='ProtocolToken'),
-             Child('Identifier', kind='IdentifierToken'),
+             Child('Identifier', kind='IdentifierToken', name_for_diagnostics='name'),
              Child('PrimaryAssociatedTypeClause',
                    kind='PrimaryAssociatedTypeClause',
+                   name_for_diagnostics='primary associated type clause',
                    is_optional=True),
-             Child('InheritanceClause', kind='TypeInheritanceClause',
+             Child('InheritanceClause', kind='TypeInheritanceClause', name_for_diagnostics='inheritance clause',
                    is_optional=True),
-             Child('GenericWhereClause', kind='GenericWhereClause',
+             Child('GenericWhereClause', kind='GenericWhereClause', name_for_diagnostics='generic where clause',
                    is_optional=True),
              Child('Members', kind='MemberDeclBlock'),
          ]),
@@ -311,15 +312,15 @@ DECL_NODES = [
     Node('ExtensionDecl', name_for_diagnostics='extension', kind='Decl',
          traits=['DeclGroup'],
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('ExtensionKeyword', kind='ExtensionToken'),
-             Child('ExtendedType', kind='Type'),
-             Child('InheritanceClause', kind='TypeInheritanceClause',
+             Child('ExtendedType', kind='Type', name_for_diagnostics='name'),
+             Child('InheritanceClause', kind='TypeInheritanceClause', name_for_diagnostics='inheritance clause',
                    is_optional=True),
-             Child('GenericWhereClause', kind='GenericWhereClause',
+             Child('GenericWhereClause', kind='GenericWhereClause', name_for_diagnostics='generic where clause',
                    is_optional=True),
              Child('Members', kind='MemberDeclBlock'),
          ]),
@@ -339,7 +340,7 @@ DECL_NODES = [
          element='MemberDeclListItem', elements_separated_by_newline=True),
 
     # member-decl = decl ';'?
-    Node('MemberDeclListItem', name_for_diagnostics='member', kind='Syntax',
+    Node('MemberDeclListItem', name_for_diagnostics=None, kind='Syntax',
          omit_when_empty=True,
          description='''
          A member declaration of a type consisting of a declaration and an
@@ -374,13 +375,13 @@ DECL_NODES = [
     Node('FunctionParameter', name_for_diagnostics='function parameter', kind='Syntax',
          traits=['WithTrailingComma'],
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
              Child('IsolatedToken', kind='Token',
                    is_optional=True),
              Child('ConstToken', kind='Token',
                    is_optional=True),
-             Child('FirstName', kind='Token',
+             Child('FirstName', kind='Token', name_for_diagnostics='name',
                    token_choices=[
                        'IdentifierToken',
                        'WildcardToken',
@@ -388,7 +389,7 @@ DECL_NODES = [
                    is_optional=True),
              # One of these two names needs be optional, we choose the second
              # name to avoid backtracking.
-             Child('SecondName', kind='Token',
+             Child('SecondName', kind='Token', name_for_diagnostics='internal name',
                    token_choices=[
                        'IdentifierToken',
                        'WildcardToken',
@@ -396,11 +397,11 @@ DECL_NODES = [
                    is_optional=True),
              Child('Colon', kind='ColonToken',
                    is_optional=True),
-             Child('Type', kind='Type',
+             Child('Type', kind='Type', name_for_diagnostics='type',
                    is_optional=True),
              Child('Ellipsis', kind='EllipsisToken',
                    is_optional=True),
-             Child('DefaultArgument', kind='InitializerClause',
+             Child('DefaultArgument', kind='InitializerClause', name_for_diagnostics='default argument',
                    is_optional=True),
              Child('TrailingComma', kind='CommaToken',
                    is_optional=True),
@@ -436,12 +437,12 @@ DECL_NODES = [
     Node('FunctionDecl', name_for_diagnostics='function', kind='Decl',
          traits=['IdentifiedDecl'],
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('FuncKeyword', kind='FuncToken'),
-             Child('Identifier', kind='Token',
+             Child('Identifier', kind='Token', name_for_diagnostics='name',
                    token_choices=[
                        'IdentifierToken',
                        'UnspacedBinaryOperatorToken',
@@ -449,10 +450,10 @@ DECL_NODES = [
                        'PrefixOperatorToken',
                        'PostfixOperatorToken',
                    ]),
-             Child('GenericParameterClause', kind='GenericParameterClause',
+             Child('GenericParameterClause', kind='GenericParameterClause', name_for_diagnostics='generic parameter clause',
                    is_optional=True),
-             Child('Signature', kind='FunctionSignature'),
-             Child('GenericWhereClause', kind='GenericWhereClause',
+             Child('Signature', kind='FunctionSignature', name_for_diagnostics='function signature'),
+             Child('GenericWhereClause', kind='GenericWhereClause', name_for_diagnostics='generic where clause',
                    is_optional=True),
              # the body is not necessary inside a protocol definition
              Child('Body', kind='CodeBlock', is_optional=True),
@@ -460,9 +461,9 @@ DECL_NODES = [
 
     Node('InitializerDecl', name_for_diagnostics='initializer', kind='Decl',
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('InitKeyword', kind='InitToken'),
              Child('OptionalMark', kind='Token',
@@ -472,10 +473,10 @@ DECL_NODES = [
                        'ExclamationMarkToken',
                    ],
                    is_optional=True),
-             Child('GenericParameterClause', kind='GenericParameterClause',
+             Child('GenericParameterClause', kind='GenericParameterClause', name_for_diagnostics='generic parameter clause',
                    is_optional=True),
-             Child('Signature', kind='FunctionSignature'),
-             Child('GenericWhereClause', kind='GenericWhereClause',
+             Child('Signature', kind='FunctionSignature', name_for_diagnostics='function signature',),
+             Child('GenericWhereClause', kind='GenericWhereClause', name_for_diagnostics='generic where clause',
                    is_optional=True),
              # the body is not necessary inside a protocol definition
              Child('Body', kind='CodeBlock', is_optional=True),
@@ -483,9 +484,9 @@ DECL_NODES = [
 
     Node('DeinitializerDecl', name_for_diagnostics='deinitializer', kind='Decl',
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('DeinitKeyword', kind='DeinitToken'),
              Child('Body', kind='CodeBlock', is_optional=True),
@@ -493,16 +494,16 @@ DECL_NODES = [
 
     Node('SubscriptDecl', name_for_diagnostics='subscript', kind='Decl',
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('SubscriptKeyword', kind='SubscriptToken'),
-             Child('GenericParameterClause', kind='GenericParameterClause',
+             Child('GenericParameterClause', kind='GenericParameterClause', name_for_diagnostics='generic parameter clause',
                    is_optional=True),
              Child('Indices', kind='ParameterClause'),
              Child('Result', kind='ReturnClause'),
-             Child('GenericWhereClause', kind='GenericWhereClause',
+             Child('GenericWhereClause', kind='GenericWhereClause', name_for_diagnostics='generic where clause',
                    is_optional=True),
              # the body is not necessary inside a protocol definition
              Child('Accessor', kind='Syntax', is_optional=True,
@@ -519,7 +520,7 @@ DECL_NODES = [
     Node('AccessLevelModifier', name_for_diagnostics='access level modifier',
          kind='Syntax',
          children=[
-             Child('Name', kind='IdentifierToken'),
+             Child('Name', kind='IdentifierToken', name_for_diagnostics='name',),
              Child('Modifier', kind='DeclModifierDetail',
                    is_optional=True),
          ]),
@@ -527,7 +528,7 @@ DECL_NODES = [
     # FIXME: technically misnamed; should be "ImportPathComponent"
     Node('AccessPathComponent', name_for_diagnostics=None, kind='Syntax',
          children=[
-            Child('Name', kind='IdentifierToken'),
+            Child('Name', kind='IdentifierToken', name_for_diagnostics='name',),
             Child('TrailingDot', kind='PeriodToken', is_optional=True),
          ]),
 
@@ -537,9 +538,9 @@ DECL_NODES = [
 
     Node('ImportDecl', name_for_diagnostics='import', kind='Decl',
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('ImportTok', kind='ImportToken'),
              Child('ImportKind', kind='Token', is_optional=True,
@@ -557,15 +558,15 @@ DECL_NODES = [
          traits=['Parenthesized'],
          children=[
              Child('LeftParen', kind='LeftParenToken'),
-             Child('Name', kind='IdentifierToken'),
+             Child('Name', kind='IdentifierToken', name_for_diagnostics='name'),
              Child('RightParen', kind='RightParenToken'),
          ]),
 
     Node('AccessorDecl', name_for_diagnostics='accessor', kind='Decl',
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
-             Child('Modifier', kind='DeclModifier', is_optional=True),
+             Child('Modifier', kind='DeclModifier', name_for_diagnostics='modifiers', is_optional=True),
              Child('AccessorKind', kind='Token',
                    text_choices=[
                       'get', 'set', 'didSet', 'willSet', 'unsafeAddress',
@@ -575,7 +576,7 @@ DECL_NODES = [
                       'mutableAddressWithNativeOwner',
                       '_read', '_modify'
                    ]),
-             Child('Parameter', kind='AccessorParameter', is_optional=True),
+             Child('Parameter', name_for_diagnostics='parameter', kind='AccessorParameter', is_optional=True),
              Child('AsyncKeyword', kind='ContextualKeywordToken',
                    text_choices=['async'], is_optional=True),
              Child('ThrowsKeyword', kind='Token',
@@ -603,7 +604,7 @@ DECL_NODES = [
          traits=['WithTrailingComma'],
          children=[
              Child('Pattern', kind='Pattern'),
-             Child('TypeAnnotation', kind='TypeAnnotation', is_optional=True),
+             Child('TypeAnnotation', kind='TypeAnnotation', name_for_diagnostics='type annotation', is_optional=True),
              Child('Initializer', kind='InitializerClause', is_optional=True),
              Child('Accessor', kind='Syntax', is_optional=True,
                    node_choices=[
@@ -617,9 +618,9 @@ DECL_NODES = [
 
     Node('VariableDecl', name_for_diagnostics='variable', kind='Decl',
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True),
              Child('LetOrVarKeyword', kind='Token',
                    token_choices=[
@@ -636,9 +637,9 @@ DECL_NODES = [
          ''',
          traits=['WithTrailingComma'],
          children=[
-             Child('Identifier', kind='IdentifierToken',
+             Child('Identifier', kind='IdentifierToken', name_for_diagnostics='name',
                    description='The name of this case.'),
-             Child('AssociatedValue', kind='ParameterClause', is_optional=True,
+             Child('AssociatedValue', kind='ParameterClause', name_for_diagnostics='associated values', is_optional=True,
                    description='The set of associated values of the case.'),
              Child('RawValue', kind='InitializerClause', is_optional=True,
                    description='''
@@ -662,12 +663,12 @@ DECL_NODES = [
          enum.
          ''',
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True,
                    description='''
                    The attributes applied to the case declaration.
                    '''),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True,
                    description='''
                    The declaration modifiers applied to the case declaration.
@@ -675,7 +676,7 @@ DECL_NODES = [
              Child('CaseKeyword', kind='CaseToken',
                    description='The `case` keyword for this case.'),
              Child('Elements', kind='EnumCaseElementList',
-                   collection_element_name='Element',
+                   collection_element_name='Element', name_for_diagnostics='elements',
                    description='The elements this case declares.')
          ]),
 
@@ -683,12 +684,12 @@ DECL_NODES = [
          traits=['IdentifiedDecl'],
          description='A Swift `enum` declaration.',
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True,
                    description='''
                    The attributes applied to the enum declaration.
                    '''),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True,
                    description='''
                    The declaration modifiers applied to the enum declaration.
@@ -697,22 +698,22 @@ DECL_NODES = [
                    description='''
                    The `enum` keyword for this declaration.
                    '''),
-             Child('Identifier', kind='IdentifierToken',
+             Child('Identifier', kind='IdentifierToken', name_for_diagnostics='name',
                    description='''
                    The name of this enum.
                    '''),
-             Child('GenericParameters', kind='GenericParameterClause',
+             Child('GenericParameters', kind='GenericParameterClause', name_for_diagnostics='generic parameter clause',
                    is_optional=True,
                    description='''
                    The generic parameters, if any, for this enum.
                    '''),
-             Child('InheritanceClause', kind='TypeInheritanceClause',
+             Child('InheritanceClause', kind='TypeInheritanceClause', name_for_diagnostics='inheritance clause',
                    is_optional=True,
                    description='''
                    The inheritance clause describing conformances or raw
                    values for this enum.
                    '''),
-             Child('GenericWhereClause', kind='GenericWhereClause',
+             Child('GenericWhereClause', kind='GenericWhereClause', name_for_diagnostics='generic where clause',
                    is_optional=True,
                    description='''
                    The `where` clause that applies to the generic parameters of
@@ -729,12 +730,12 @@ DECL_NODES = [
          traits=['IdentifiedDecl'],
          description='A Swift `operator` declaration.',
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True,
                    description='''
                    The attributes applied to the 'operator' declaration.
                    '''),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True,
                    classification='Attribute',
                    description='''
@@ -742,7 +743,7 @@ DECL_NODES = [
                    declaration.
                    '''),
              Child('OperatorKeyword', kind='OperatorToken'),
-             Child('Identifier', kind='Token',
+             Child('Identifier', kind='Token', name_for_diagnostics='name',
                    token_choices=[
                        'UnspacedBinaryOperatorToken',
                        'SpacedBinaryOperatorToken',
@@ -790,19 +791,19 @@ DECL_NODES = [
          traits=['IdentifiedDecl'],
          description='A Swift `precedencegroup` declaration.',
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True,
                    description='''
                    The attributes applied to the 'precedencegroup' declaration.
                    '''),
-             Child('Modifiers', kind='ModifierList',
+             Child('Modifiers', kind='ModifierList', name_for_diagnostics='modifiers',
                    collection_element_name='Modifier', is_optional=True,
                    description='''
                    The declaration modifiers applied to the 'precedencegroup'
                    declaration.
                    '''),
              Child('PrecedencegroupKeyword', kind='PrecedencegroupToken'),
-             Child('Identifier', kind='IdentifierToken',
+             Child('Identifier', kind='IdentifierToken', name_for_diagnostics='name',
                    description='''
                    The name of this precedence group.
                    '''),
@@ -859,7 +860,7 @@ DECL_NODES = [
          element='PrecedenceGroupNameElement'),
     Node('PrecedenceGroupNameElement', name_for_diagnostics=None, kind='Syntax',
          children=[
-             Child('Name', kind='IdentifierToken'),
+             Child('Name', kind='IdentifierToken', name_for_diagnostics='name'),
              Child('TrailingComma', kind='CommaToken',
                    is_optional=True),
          ]),

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/ExprNodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/ExprNodes.py
@@ -263,7 +263,7 @@ EXPR_NODES = [
     Node('TupleExprElement', name_for_diagnostics=None, kind='Syntax',
          traits=['WithTrailingComma'],
          children=[
-             Child('Label', kind='Token',
+             Child('Label', kind='Token', name_for_diagnostics='label',
                    is_optional=True,
                    token_choices=[
                        'IdentifierToken',
@@ -271,26 +271,26 @@ EXPR_NODES = [
                    ]),
              Child('Colon', kind='ColonToken',
                    is_optional=True),
-             Child('Expression', kind='Expr'),
+             Child('Expression', kind='Expr', name_for_diagnostics='value'),
              Child('TrailingComma', kind='CommaToken',
                    is_optional=True),
          ]),
 
     # element inside an array expression: expression ','?
-    Node('ArrayElement', name_for_diagnostics=None, kind='Syntax',
+    Node('ArrayElement', name_for_diagnostics='array element', kind='Syntax',
          traits=['WithTrailingComma'],
          children=[
-             Child('Expression', kind='Expr'),
+             Child('Expression', kind='Expr', name_for_diagnostics='value'),
              Child('TrailingComma', kind='CommaToken', is_optional=True),
          ]),
 
     # element inside an array expression: expression ','?
-    Node('DictionaryElement', name_for_diagnostics=None, kind='Syntax',
+    Node('DictionaryElement', name_for_diagnostics='dictionary element', kind='Syntax',
          traits=['WithTrailingComma'],
          children=[
-             Child('KeyExpression', kind='Expr'),
+             Child('KeyExpression', kind='Expr', name_for_diagnostics='key'),
              Child('Colon', kind='ColonToken'),
-             Child('ValueExpression', kind='Expr'),
+             Child('ValueExpression', kind='Expr', name_for_diagnostics='value'),
              Child('TrailingComma', kind='CommaToken', is_optional=True),
          ]),
 
@@ -330,11 +330,11 @@ EXPR_NODES = [
     # relationships amongst the different infix operators.
     Node('TernaryExpr', name_for_diagnostics='ternay expression', kind='Expr',
          children=[
-             Child("ConditionExpression", kind='Expr'),
+             Child("ConditionExpression", kind='Expr', name_for_diagnostics='condition'),
              Child("QuestionMark", kind='InfixQuestionMarkToken'),
-             Child("FirstChoice", kind='Expr'),
+             Child("FirstChoice", kind='Expr', name_for_diagnostics='first choice'),
              Child("ColonMark", kind='ColonToken'),
-             Child("SecondChoice", kind='Expr')
+             Child("SecondChoice", kind='Expr', name_for_diagnostics='second choice')
          ]),
 
     # expr?.name
@@ -342,13 +342,13 @@ EXPR_NODES = [
          children=[
              # The base needs to be optional to parse expressions in key paths
              # like \.a
-             Child("Base", kind='Expr', is_optional=True),
+             Child("Base", kind='Expr',  name_for_diagnostics='base', is_optional=True),
              Child("Dot", kind='Token',
                    token_choices=[
                        'PeriodToken', 'PrefixPeriodToken'
                    ]),
              # Name could be 'self'
-             Child("Name", kind='Token'),
+             Child("Name", kind='Token', name_for_diagnostics='name'),
              Child('DeclNameArguments', kind='DeclNameArguments',
                    is_optional=True),
          ]),
@@ -437,7 +437,7 @@ EXPR_NODES = [
     Node('ClosureParam', name_for_diagnostics='closure parameter', kind='Syntax',
          traits=['WithTrailingComma'],
          children=[
-             Child('Name', kind='Token',
+             Child('Name', kind='Token', name_for_diagnostics='name',
                    token_choices=[
                        'IdentifierToken',
                        'WildcardToken',
@@ -451,7 +451,7 @@ EXPR_NODES = [
 
     Node('ClosureSignature', name_for_diagnostics='closure signature', kind='Syntax',
          children=[
-             Child('Attributes', kind='AttributeList',
+             Child('Attributes', kind='AttributeList', name_for_diagnostics='attributes',
                    collection_element_name='Attribute', is_optional=True),
              Child('Capture', kind='ClosureCaptureSignature',
                    is_optional=True),
@@ -488,7 +488,7 @@ EXPR_NODES = [
     Node('MultipleTrailingClosureElement', name_for_diagnostics='trailing closure',
          kind='Syntax',
          children=[
-             Child('Label', kind='Token',
+             Child('Label', kind='Token', name_for_diagnostics='label',
                    token_choices=[
                        'IdentifierToken',
                        'WildcardToken'
@@ -504,16 +504,16 @@ EXPR_NODES = [
     #            | expr closure-expr
     Node('FunctionCallExpr', name_for_diagnostics='function call', kind='Expr',
          children=[
-             Child('CalledExpression', kind='Expr'),
+             Child('CalledExpression', kind='Expr', name_for_diagnostics='called expression'),
              Child('LeftParen', kind='LeftParenToken',
                    is_optional=True),
-             Child('ArgumentList', kind='TupleExprElementList',
+             Child('ArgumentList', kind='TupleExprElementList', name_for_diagnostics='arguments',
                    collection_element_name='Argument'),
              Child('RightParen', kind='RightParenToken',
                    is_optional=True),
-             Child('TrailingClosure', kind='ClosureExpr',
+             Child('TrailingClosure', kind='ClosureExpr', name_for_diagnostics='trailing closure',
                    is_optional=True),
-             Child('AdditionalTrailingClosures',
+             Child('AdditionalTrailingClosures', name_for_diagnostics='trailing closures',
                    kind='MultipleTrailingClosureElementList',
                    collection_element_name='AdditionalTrailingClosure',
                    is_optional=True),
@@ -522,14 +522,14 @@ EXPR_NODES = [
     # subscript-expr -> expr '[' call-argument-list ']' closure-expr?
     Node('SubscriptExpr', name_for_diagnostics='subscript', kind='Expr',
          children=[
-             Child('CalledExpression', kind='Expr'),
+             Child('CalledExpression', kind='Expr', name_for_diagnostics='called expression'),
              Child('LeftBracket', kind='LeftSquareBracketToken'),
-             Child('ArgumentList', kind='TupleExprElementList',
+             Child('ArgumentList', kind='TupleExprElementList', name_for_diagnostics='arguments',
                    collection_element_name='Argument'),
              Child('RightBracket', kind='RightSquareBracketToken'),
-             Child('TrailingClosure', kind='ClosureExpr',
+             Child('TrailingClosure', kind='ClosureExpr', name_for_diagnostics='trailing closure',
                    is_optional=True),
-             Child('AdditionalTrailingClosures',
+             Child('AdditionalTrailingClosures', name_for_diagnostics='trailing closures',
                    kind='MultipleTrailingClosureElementList',
                    collection_element_name='AdditionalTrailingClosure',
                    is_optional=True),
@@ -618,13 +618,13 @@ EXPR_NODES = [
     Node('KeyPathExpr', name_for_diagnostics='key path', kind='Expr',
          children=[
              Child('Backslash', kind='BackslashToken'),
-             Child('RootExpr', kind='Expr', is_optional=True,
+             Child('RootExpr', kind='Expr', name_for_diagnostics='root', is_optional=True,
                    node_choices=[
                        Child('IdentifierExpr', kind='IdentifierExpr'),
                        Child('SpecializeExpr', kind='SpecializeExpr'),
                        Child('OptionalChainingExpr', kind='OptionalChainingExpr'),
                    ]),
-             Child('Expression', kind='Expr'),
+             Child('Expression', kind='Expr', name_for_diagnostics='expression'),
          ]),
 
     # The period in the key path serves as the base on which the
@@ -651,7 +651,7 @@ EXPR_NODES = [
          children=[
              Child('KeyPath', kind='PoundKeyPathToken'),
              Child('LeftParen', kind='LeftParenToken'),
-             Child('Name', kind='ObjcName',
+             Child('Name', kind='ObjcName', name_for_diagnostics='name',
                    collection_element_name='NamePiece'),
              Child('RightParen', kind='RightParenToken'),
          ]),
@@ -667,7 +667,7 @@ EXPR_NODES = [
                    is_optional=True),
              Child('Colon', kind='ColonToken',
                    is_optional=True),
-             Child('Name', kind='Expr'),
+             Child('Name', kind='Expr', name_for_diagnostics='name'),
              Child('RightParen', kind='RightParenToken'),
          ]),
 

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/GenericNodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/GenericNodes.py
@@ -36,7 +36,7 @@ GENERIC_NODES = [
     Node('SameTypeRequirement', name_for_diagnostics='same type requirement',
          kind='Syntax',
          children=[
-             Child('LeftTypeIdentifier', kind='Type'),
+             Child('LeftTypeIdentifier', kind='Type', name_for_diagnostics='left-hand type'),
              Child('EqualityToken', kind='Token',
                    token_choices=[
                        'SpacedBinaryOperatorToken',
@@ -44,22 +44,22 @@ GENERIC_NODES = [
                        'PrefixOperatorToken',
                        'PostfixOperatorToken',
                    ]),
-             Child('RightTypeIdentifier', kind='Type'),
+             Child('RightTypeIdentifier', name_for_diagnostics='right-hand type', kind='Type'),
          ]),
 
     # layout-requirement -> type-name : layout-constraint
     # layout-constraint -> identifier '('? integer-literal? ','? integer-literal? ')'?
     Node('LayoutRequirement', name_for_diagnostics='layout requirement', kind='Syntax',
          children=[
-             Child('TypeIdentifier', kind='Type'),
+             Child('TypeIdentifier', kind='Type', name_for_diagnostics='constrained type'),
              Child('Colon', kind='ColonToken'),
              Child('LayoutConstraint', kind='IdentifierToken'),
              Child('LeftParen', kind='LeftParenToken',
                    is_optional=True),
-             Child('Size', kind='IntegerLiteralToken', is_optional=True),
+             Child('Size', kind='IntegerLiteralToken', name_for_diagnostics='size', is_optional=True),
              Child('Comma', kind='CommaToken',
                    is_optional=True),
-             Child('Alignment', kind='IntegerLiteralToken', is_optional=True),
+             Child('Alignment', kind='IntegerLiteralToken', name_for_diagnostics='alignment', is_optional=True),
              Child('RightParen', kind='RightParenToken',
                    is_optional=True),
          ]),
@@ -75,10 +75,10 @@ GENERIC_NODES = [
          children=[
              Child('Attributes', kind='AttributeList',
                    collection_element_name='Attribute', is_optional=True),
-             Child('Name', kind='IdentifierToken'),
+             Child('Name', name_for_diagnostics='name', kind='IdentifierToken'),
              Child('Colon', kind='ColonToken',
                    is_optional=True),
-             Child('InheritedType', kind='Type',
+             Child('InheritedType', name_for_diagnostics='inherited type', kind='Type',
                    is_optional=True),
              Child('TrailingComma', kind='CommaToken',
                    is_optional=True),
@@ -91,7 +91,7 @@ GENERIC_NODES = [
     Node('PrimaryAssociatedType', name_for_diagnostics=None, kind='Syntax',
          traits=['WithTrailingComma'],
          children=[
-             Child('Name', kind='IdentifierToken'),
+             Child('Name', name_for_diagnostics='name', kind='IdentifierToken'),
              Child('TrailingComma', kind='CommaToken',
                    is_optional=True),
          ]),

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/PatternNodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/PatternNodes.py
@@ -16,8 +16,8 @@ PATTERN_NODES = [
              Child('Type', kind='Type',
                    is_optional=True),
              Child('Period', kind='PeriodToken'),
-             Child('CaseName', kind='IdentifierToken'),
-             Child('AssociatedTuple', kind='TuplePattern',
+             Child('CaseName', kind='IdentifierToken', name_for_diagnostics='case name'),
+             Child('AssociatedTuple', kind='TuplePattern', name_for_diagnostics='associated values',
                    is_optional=True),
          ]),
 
@@ -75,7 +75,7 @@ PATTERN_NODES = [
     Node('TuplePatternElement', name_for_diagnostics=None, kind='Syntax',
          traits=['WithTrailingComma'],
          children=[
-             Child('LabelName', kind='IdentifierToken',
+             Child('LabelName', kind='IdentifierToken', name_for_diagnostics='label',
                    is_optional=True),
              Child('LabelColon', kind='ColonToken',
                    is_optional=True),

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/StmtNodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/StmtNodes.py
@@ -5,7 +5,7 @@ STMT_NODES = [
     # labeled-stmt -> label ':' stmt
     Node('LabeledStmt', name_for_diagnostics='labeled statement', kind='Stmt',
          children=[
-             Child('LabelName', kind='IdentifierToken'),
+             Child('LabelName', kind='IdentifierToken', name_for_diagnostics='name'),
              Child('LabelColon', kind='ColonToken'),
              Child('Statement', kind='Stmt'),
          ]),
@@ -14,7 +14,7 @@ STMT_NODES = [
     Node('ContinueStmt', name_for_diagnostics="'continue' statement", kind='Stmt',
          children=[
              Child('ContinueKeyword', kind='ContinueToken'),
-             Child('Label', kind='IdentifierToken',
+             Child('Label', kind='IdentifierToken', name_for_diagnostics='label',
                    is_optional=True),
          ]),
 
@@ -53,9 +53,9 @@ STMT_NODES = [
          traits=['WithCodeBlock'],
          children=[
              Child('RepeatKeyword', kind='RepeatToken'),
-             Child('Body', kind='CodeBlock'),
+             Child('Body', kind='CodeBlock', name_for_diagnostics='body'),
              Child('WhileKeyword', kind='WhileToken'),
-             Child('Condition', kind='Expr'),
+             Child('Condition', kind='Expr', name_for_diagnostics='condition'),
          ]),
 
     # guard-stmt -> 'guard' condition-list 'else' code-block ';'?
@@ -63,10 +63,10 @@ STMT_NODES = [
          traits=['WithCodeBlock'],
          children=[
              Child('GuardKeyword', kind='GuardToken'),
-             Child('Conditions', kind='ConditionElementList',
+             Child('Conditions', kind='ConditionElementList', name_for_diagnostics='conditions',
                    collection_element_name='Condition'),
              Child('ElseKeyword', kind='ElseToken'),
-             Child('Body', kind='CodeBlock'),
+             Child('Body', kind='CodeBlock', name_for_diagnostics='body'),
          ]),
 
     Node('WhereClause', name_for_diagnostics="'where' clause", kind='Syntax',
@@ -96,7 +96,7 @@ STMT_NODES = [
              Child('SequenceExpr', kind='Expr'),
              Child('WhereClause', kind='WhereClause',
                    is_optional=True),
-             Child('Body', kind='CodeBlock'),
+             Child('Body', kind='CodeBlock', name_for_diagnostics='body'),
          ]),
 
     # switch-stmt -> identifier? ':'? 'switch' expr '{'
@@ -122,7 +122,7 @@ STMT_NODES = [
          traits=['WithCodeBlock'],
          children=[
              Child('DoKeyword', kind='DoToken'),
-             Child('Body', kind='CodeBlock'),
+             Child('Body', kind='CodeBlock', name_for_diagnostics='body',),
              Child('CatchClauses', kind='CatchClauseList',
                    collection_element_name='CatchClause', is_optional=True),
          ]),
@@ -165,7 +165,7 @@ STMT_NODES = [
     Node('BreakStmt', name_for_diagnostics="'break' statement", kind='Stmt',
          children=[
              Child('BreakKeyword', kind='BreakToken'),
-             Child('Label', kind='IdentifierToken',
+             Child('Label', kind='IdentifierToken', name_for_diagnostics='label',
                    is_optional=True),
          ]),
 
@@ -280,10 +280,10 @@ STMT_NODES = [
              Child('IfKeyword', kind='IfToken'),
              Child('Conditions', kind='ConditionElementList',
                    collection_element_name='Condition'),
-             Child('Body', kind='CodeBlock'),
+             Child('Body', kind='CodeBlock', name_for_diagnostics='body'),
              Child('ElseKeyword', kind='ElseToken',
                    is_optional=True),
-             Child('ElseBody', kind='Syntax',
+             Child('ElseBody', kind='Syntax', name_for_diagnostics='else body',
                    node_choices=[
                        Child('IfStmt', kind='IfStmt'),
                        Child('CodeBlock', kind='CodeBlock'),
@@ -311,7 +311,7 @@ STMT_NODES = [
          traits=['WithStatements'],
          children=[
              Child('UnknownAttr', kind='Attribute', is_optional=True),
-             Child('Label', kind='Syntax',
+             Child('Label', kind='Syntax', name_for_diagnostics='label',
                    node_choices=[
                        Child('Default', kind='SwitchDefaultLabel'),
                        Child('Case', kind='SwitchCaseLabel'),
@@ -374,11 +374,11 @@ STMT_NODES = [
          children=[
              Child('PoundAssert', kind='PoundAssertToken'),
              Child('LeftParen', kind='LeftParenToken'),
-             Child('Condition', kind='Expr',
+             Child('Condition', kind='Expr', name_for_diagnostics='condition',
                    description='The assertion condition.'),
              Child('Comma', kind='CommaToken', is_optional=True,
                    description='The comma after the assertion condition.'),
-             Child('Message', kind='StringLiteralToken', is_optional=True,
+             Child('Message', kind='StringLiteralToken', name_for_diagnostics='message', is_optional=True,
                    description='The assertion message.'),
              Child('RightParen', kind='RightParenToken'),
          ]),

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/TypeNodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/TypeNodes.py
@@ -18,13 +18,13 @@ TYPE_NODES = [
     # member-type-identifier -> type '.' identifier generic-argument-clause?
     Node('MemberTypeIdentifier', name_for_diagnostics='member type', kind='Type',
          children=[
-             Child('BaseType', kind='Type'),
+             Child('BaseType', kind='Type', name_for_diagnostics='base type'),
              Child('Period', kind='Token',
                    token_choices=[
                        'PeriodToken',
                        'PrefixPeriodToken',
                    ]),
-             Child('Name', kind='Token', classification='TypeIdentifier',
+             Child('Name', kind='Token',  name_for_diagnostics='member type', classification='TypeIdentifier',
                    token_choices=[
                        'IdentifierToken',
                        'CapitalSelfToken',
@@ -51,9 +51,9 @@ TYPE_NODES = [
     Node('DictionaryType', name_for_diagnostics='dictionary type', kind='Type',
          children=[
              Child('LeftSquareBracket', kind='LeftSquareBracketToken'),
-             Child('KeyType', kind='Type'),
+             Child('KeyType', kind='Type', name_for_diagnostics='key type',),
              Child('Colon', kind='ColonToken'),
-             Child('ValueType', kind='Type'),
+             Child('ValueType', kind='Type', name_for_diagnostics='value type'),
              Child('RightSquareBracket', kind='RightSquareBracketToken'),
          ]),
 
@@ -61,7 +61,7 @@ TYPE_NODES = [
     #                | type '.' 'Protocol
     Node('MetatypeType', name_for_diagnostics='metatype', kind='Type',
          children=[
-             Child('BaseType', kind='Type'),
+             Child('BaseType', kind='Type', name_for_diagnostics='base type'),
              Child('Period', kind='PeriodToken'),
              Child('TypeOrProtocol', kind='IdentifierToken',
                    text_choices=[
@@ -129,13 +129,13 @@ TYPE_NODES = [
          children=[
              Child('InOut', kind='InoutToken',
                    is_optional=True),
-             Child('Name', kind='Token',
+             Child('Name', kind='Token', name_for_diagnostics='name',
                    is_optional=True,
                    token_choices=[
                        'IdentifierToken',
                        'WildcardToken'
                    ]),
-             Child('SecondName', kind='Token',
+             Child('SecondName', kind='Token', name_for_diagnostics='internal name',
                    is_optional=True,
                    token_choices=[
                        'IdentifierToken',

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -131,7 +131,7 @@ func AssertDiagnostic<T: SyntaxProtocol>(
        let expectedLine = expectedLocation.line,
        let expectedColumn = expectedLocation.column {
       if actualLine != expectedLine || actualColumn != expectedColumn {
-        XCTFail("Expected diagnostic on \(expectedLine):\(expectedColumn) but got \(actualLine):\(actualColumn)",
+        XCTFail("Expected diagnostic with message '\(spec.message ?? "<nil>")' on \(expectedLine):\(expectedColumn) but got \(actualLine):\(actualColumn)",
                 file: file, line: line
         )
       }

--- a/Tests/SwiftParserTest/Attributes.swift
+++ b/Tests/SwiftParserTest/Attributes.swift
@@ -11,6 +11,7 @@ final class AttributeTests: XCTestCase {
       }
       """,
       diagnostics: [
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected declaration"),
         DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected 'for' in attribute argument"),
         DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ':' in attribute argument"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected ')' to end attribute"),
@@ -27,7 +28,9 @@ final class AttributeTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ':' in '@differentiable' argument"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected parameters of '@differentiable' argument"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '=' in same type requirement"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected right-hand type of same type requirement"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected ')' to end attribute"),
       ]
     )
@@ -36,11 +39,12 @@ final class AttributeTests: XCTestCase {
   func testMissingClosingParenToAttribute() {
     AssertParse(
       """
-      @_specialize(e#^DIAG_1^#
+      @_specialize(e#^DIAG^#
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ':' in attribute argument"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ')' to end attribute"),
+        DiagnosticSpec(message: "Expected declaration"),
+        DiagnosticSpec(message: "Expected ':' in attribute argument"),
+        DiagnosticSpec(message: "Expected ')' to end attribute"),
       ]
     )
   }
@@ -48,9 +52,10 @@ final class AttributeTests: XCTestCase {
   func testMultipleInvalidSpecializeParams() {
     AssertParse(
       """
-      @_specialize(e#^DIAG_1^#, exported#^DIAG_2^#)
+      @_specialize(e#^DIAG_1^#, exported#^DIAG_2^#)#^DIAG_3^#
       """,
       diagnostics: [
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "Expected declaration after ')'"),
         DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ':' in attribute argument"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected ':' in attribute argument"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected 'false' in attribute argument"),

--- a/Tests/SwiftParserTest/Attributes.swift
+++ b/Tests/SwiftParserTest/Attributes.swift
@@ -11,7 +11,7 @@ final class AttributeTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected declaration after attribute"),
         DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected 'for' in attribute argument"),
         DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ':' in attribute argument"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected ')' to end attribute"),
@@ -42,20 +42,20 @@ final class AttributeTests: XCTestCase {
       @_specialize(e#^DIAG^#
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected declaration"),
+        DiagnosticSpec(message: "Expected declaration after attribute"),
         DiagnosticSpec(message: "Expected ':' in attribute argument"),
         DiagnosticSpec(message: "Expected ')' to end attribute"),
       ]
     )
   }
-  
+
   func testMultipleInvalidSpecializeParams() {
     AssertParse(
       """
       @_specialize(e#^DIAG_1^#, exported#^DIAG_2^#)#^DIAG_3^#
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "Expected declaration after ')'"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "Expected declaration after attribute"),
         DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ':' in attribute argument"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected ':' in attribute argument"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected 'false' in attribute argument"),

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -553,7 +553,7 @@ final class DeclarationTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected declaration after 'public' in struct")
+        DiagnosticSpec(message: "Expected declaration after 'public' modifier in struct")
       ]
     )
   }
@@ -904,7 +904,7 @@ final class DeclarationTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(locationMarker: "OPENING_BRACE", message: "Expected '{' to start struct"),
         DiagnosticSpec(locationMarker: "AFTER_POUND_IF", message: "Expected condition of conditional compilation clause"),
-        DiagnosticSpec(locationMarker: "END", message: "Expected declaration after '@' in conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "END", message: "Expected declaration after attribute in conditional compilation clause"),
         DiagnosticSpec(locationMarker: "END", message: "Expected name of attribute"),
         DiagnosticSpec(locationMarker: "END", message: "Expected '#endif' in conditional compilation block"),
         DiagnosticSpec(locationMarker: "END", message: "Expected '}' to end struct")

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -41,6 +41,7 @@ final class DeclarationTests: XCTestCase {
                   DiagnosticSpec(locationMarker: "DIAG1", message: "Expected identifier in function"),
                   DiagnosticSpec(locationMarker: "DIAG1", message: "Expected argument list in function declaration"),
                   DiagnosticSpec(locationMarker: "DIAG2", message: "Expected '=' in same type requirement"),
+                  DiagnosticSpec(locationMarker: "DIAG2", message: "Expected right-hand type of same type requirement"),
                 ])
   }
 
@@ -77,12 +78,14 @@ final class DeclarationTests: XCTestCase {
     AssertParse("class T where t#^DIAG^#",
                 diagnostics: [
                   DiagnosticSpec(message: "Expected '=' in same type requirement"),
+                  DiagnosticSpec(message: "Expected right-hand type of same type requirement"),
                   DiagnosticSpec(message: "Expected '{' to start class"),
                   DiagnosticSpec(message: "Expected '}' to end class"),
                 ])
     AssertParse("class B<where g#^DIAG^#",
                 diagnostics: [
                   DiagnosticSpec(message: "Expected '=' in same type requirement"),
+                  DiagnosticSpec(message: "Expected right-hand type of same type requirement"),
                   DiagnosticSpec(message: "Expected '>' to end generic parameter clause"),
                   DiagnosticSpec(message: "Expected '{' to start class"),
                   DiagnosticSpec(message: "Expected '}' to end class"),
@@ -171,7 +174,8 @@ final class DeclarationTests: XCTestCase {
     AssertParse(
       "_ = foo/* */?.description#^DIAG^#",
       diagnostics: [
-        DiagnosticSpec(message: "Expected ':' after '? ...' in ternary expression")
+        DiagnosticSpec(message: "Expected ':' after '? ...' in ternary expression"),
+        DiagnosticSpec(message: "Expected expression"),
       ]
     )
     
@@ -545,9 +549,12 @@ final class DeclarationTests: XCTestCase {
     AssertParse(
       """
       struct a {
-        public
+        public#^DIAG^#
       }
-      """
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "Expected declaration after 'public' in struct")
+      ]
     )
   }
 
@@ -638,7 +645,12 @@ final class DeclarationTests: XCTestCase {
 
   func testExtraneousRightBraceRecovery() {
     AssertParse(
-      "class ABC { let def = ghi(jkl: mno) } #^DIAG^#}",
+      """
+      class ABC {
+        let def = ghi(jkl: mno)
+      }
+      #^DIAG^#}
+      """,
       diagnostics: [
         DiagnosticSpec(message: "Extraneous '}' at top level")
       ]
@@ -653,7 +665,8 @@ final class DeclarationTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected '->' in return clause")
+        DiagnosticSpec(message: "Expected '->' in subscript"),
+        DiagnosticSpec(message: "Expected return type in subscript"),
       ]
     )
   }
@@ -693,16 +706,13 @@ final class DeclarationTests: XCTestCase {
   func testExpressionMember() {
     AssertParse(
       """
-      struct S {
-        #^DIAG^#/ ###line 25 "line-directive.swift"
+      struct S {#^EXPECTED_DECL^#
+        #^UNEXPECTED_TEXT^#/ ###line 25 "line-directive.swift"
       }
       """,
       diagnostics: [
-        DiagnosticSpec(
-          message: """
-            Unexpected text '/ ###line 25 "line-directive.swift"' in struct
-            """
-        )
+        DiagnosticSpec(locationMarker: "EXPECTED_DECL", message: "Expected declaration after '{' in struct"),
+        DiagnosticSpec(locationMarker: "UNEXPECTED_TEXT", message: #"Unexpected text '/ ###line 25 "line-directive.swift"' in struct"#)
       ]
     )
   }
@@ -887,12 +897,17 @@ final class DeclarationTests: XCTestCase {
   func testMalforedStruct() {
     AssertParse(
       """
-      struct n#^OPENINGBRACES^##if@#^ENDIF^##^CLOSINGBRACES^#
+      struct n#^OPENING_BRACE^#
+      #if#^AFTER_POUND_IF^#
+      @#^END^#
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "OPENINGBRACES", message: "Expected '{' to start struct"),
-        DiagnosticSpec(locationMarker: "ENDIF", message: "Expected '#endif' in conditional compilation block"),
-        DiagnosticSpec(locationMarker: "CLOSINGBRACES", message: "Expected '}' to end struct")
+        DiagnosticSpec(locationMarker: "OPENING_BRACE", message: "Expected '{' to start struct"),
+        DiagnosticSpec(locationMarker: "AFTER_POUND_IF", message: "Expected condition of conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "END", message: "Expected declaration after '@' in conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "END", message: "Expected name of attribute"),
+        DiagnosticSpec(locationMarker: "END", message: "Expected '#endif' in conditional compilation block"),
+        DiagnosticSpec(locationMarker: "END", message: "Expected '}' to end struct")
       ]
     )
   }
@@ -994,7 +1009,8 @@ final class DeclarationTests: XCTestCase {
                 diagnostics: [
                   DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before subscript"),
                   DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected argument list in function declaration"),
-                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '->' in return clause"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '->' in subscript"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected return type in subscript"),
                 ])
   }
 

--- a/Tests/SwiftParserTest/Directives.swift
+++ b/Tests/SwiftParserTest/Directives.swift
@@ -148,9 +148,9 @@ final class DirectiveTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected declaration after 'foo' in conditional compilation clause"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected declaration after 'foo' in conditional compilation clause"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "Expected declaration after 'frozen' in conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected declaration after attribute in conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected declaration after attribute in conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "Expected declaration after attribute in conditional compilation clause"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/Directives.swift
+++ b/Tests/SwiftParserTest/Directives.swift
@@ -133,20 +133,26 @@ final class DirectiveTests: XCTestCase {
         public struct S2 { }
 
       #if hasAttribute(foo)
-        @foo
+        @foo#^DIAG_1^#
       #endif
         @inlinable
         func f1() { }
 
       #if hasAttribute(foo)
-        @foo
+        @foo#^DIAG_2^#
       #else
         @available(*, deprecated, message: "nope")
-        @frozen
+        @frozen#^DIAG_3^#
       #endif
         public struct S3 { }
       }
-      """)
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected declaration after 'foo' in conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected declaration after 'foo' in conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "Expected declaration after 'frozen' in conditional compilation clause"),
+      ]
+    )
   }
 
 }

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -371,7 +371,6 @@ final class ExpressionTests: XCTestCase {
   }
 
   func testSingleQuoteStringLiteral() {
-    // FIXME: This test case should produce a diagnostics
     AssertParse(
       #"""
       'red'

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -162,8 +162,6 @@ final class ExpressionTests: XCTestCase {
       ([1:#^DIAG^#)
       """,
       diagnostics: [
-        // FIXME: Why is this diagnostic produced?
-        DiagnosticSpec(message: "Expected ':' in dictionary"),
         DiagnosticSpec(message: "Expected ']' to end dictionary"),
       ]
     )

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -251,7 +251,7 @@ final class StatementTests: XCTestCase {
       ]
     )
   }
-  
+
   func testIfHasSymbol() {
     AssertParse(
       """

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -45,7 +45,9 @@ final class StatementTests: XCTestCase {
       }
       """,
       diagnostics: [
+        DiagnosticSpec(message: "Expected expression after 'case' in pattern"),
         DiagnosticSpec(message: "Expected '=' in pattern matching"),
+        DiagnosticSpec(message: "Expected expression in pattern matching"),
         DiagnosticSpec(message: "Unexpected text '* ! = x' in 'if' statement"),
       ]
     )
@@ -183,7 +185,6 @@ final class StatementTests: XCTestCase {
   }
 
   func testMissingIfClauseIntroducer() {
-    // FIXME: This test case should produce a diagnostics
     AssertParse("if _ = 42 {}")
   }
 

--- a/Tests/SwiftParserTest/Types.swift
+++ b/Tests/SwiftParserTest/Types.swift
@@ -30,8 +30,10 @@ final class TypeTests: XCTestCase {
   }
 
   func testFunctionTypes() throws {
-    AssertParse("t as(#^DIAG^#..)->", diagnostics: [
-      DiagnosticSpec(message: "Unexpected text '..' in function type")
+    AssertParse("t as(#^DIAG^#..)->#^END^#", diagnostics: [
+      DiagnosticSpec(message: "Expected type after '(' in function type"),
+      DiagnosticSpec(message: "Unexpected text '..' in function type"),
+      DiagnosticSpec(locationMarker: "END", message: "Expected type after '->' in function type"),
     ])
   }
 
@@ -88,9 +90,15 @@ final class TypeTests: XCTestCase {
       #"""
       func takesVariadicFnWithGenericRet<T>(_ fn: (S...) -> T) {}
       let _: (S...) -> Int = \.i
-      let _: (S...) -> Int = \Array.i
-      let _: (S...) -> Int = \S.i
-      """#)
+      let _: (S...) -> Int = \Array.i#^DIAG_1^#
+      let _: (S...) -> Int = \S.i#^DIAG_2^#
+      """#,
+      diagnostics: [
+        // FIXME: This should be a valid parse
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected expression of key path"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected expression of key path"),
+      ]
+    )
   }
 
   func testConvention() throws {


### PR DESCRIPTION
Re-opening https://github.com/apple/swift-syntax/pull/657 without dependencies

---

Previously, we weren’t emitting any errors for the missing layout nodes (RawMissingExprSyntax etc.)