### PR TITLE
Update swift-argument-parser to the latest release

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -176,7 +176,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   // Building standalone.
   package.dependencies += [
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.1")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.4")),
   ]
 } else {
   package.dependencies += [


### PR DESCRIPTION
https://github.com/apple/swift-argument-parser/releases/tag/1.1.4

This will allow consumers of SwiftSyntax that use swift-argument-parser to also be on the latest version.