### PR TITLE
[Recovery 3/7] Use higher level parsing primitives

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -183,7 +183,7 @@ extension Parser {
 
 
     let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
-    let ident = self.consumeIdentifierOrRethrows()
+    let ident = self.expectIdentifierOrRethrowsWithoutRecovery()
     let leftParen = self.consume(if: .leftParen)
     let arg: RawSyntax?
     let unexpectedBeforeRightParen: RawUnexpectedNodesSyntax?
@@ -309,7 +309,7 @@ extension Parser {
       .identifier == self.currentToken.tokenKind,
       DifferentiabilityKind(rawValue: self.currentToken.tokenText) != nil
     {
-      diffKind = self.consumeIdentifier()
+      diffKind = self.expectIdentifierWithoutRecovery()
       diffKindComma = self.consume(if: .comma)
     } else {
       diffKind = nil
@@ -342,7 +342,7 @@ extension Parser {
   }
 
   mutating func parseDifferentiabilityParameters() -> RawDifferentiabilityParamsClauseSyntax {
-    let wrt = self.consumeIdentifier()
+    let wrt = self.expectIdentifierWithoutRecovery()
     let (unexpectedBeforeColon, colon) = self.expect(.colon)
 
     guard let leftParen = self.consume(if: .leftParen) else {
@@ -685,7 +685,7 @@ extension Parser {
     assert(self.currentToken.tokenText == "_private")
     let privateToken = self.consumeAnyToken()
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
-    let label = self.consumeIdentifier()
+    let label = self.expectIdentifierWithoutRecovery()
     let (unexpectedBeforeColon, colon) = self.expect(.colon)
     let filename = self.consumeAnyToken()
     let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -191,7 +191,7 @@ extension Parser {
     if leftParen != nil {
       var args = [RawTokenSyntax]()
       var loopProgress = LoopProgressCondition()
-      while !self.at(.eof), !self.at(.rightParen) && loopProgress.evaluate(currentToken) {
+      while !self.at(any: [.eof, .rightParen]) && loopProgress.evaluate(currentToken) {
         args.append(self.consumeAnyToken())
       }
       arg = RawSyntax(RawTokenListSyntax(elements: args, arena: self.arena))
@@ -360,7 +360,7 @@ extension Parser {
 
     var elements = [RawDifferentiabilityParamSyntax]()
     var loopProgress = LoopProgressCondition()
-    while !self.at(.eof) && !self.at(.rightParen) && loopProgress.evaluate(currentToken) {
+    while !self.at(any: [.eof, .rightParen]) && loopProgress.evaluate(currentToken) {
       guard let param = self.parseDifferentiabilityParameter() else {
         break
       }
@@ -459,7 +459,7 @@ extension Parser {
   mutating func parseObjectiveCSelector() -> RawObjCSelectorSyntax {
     var elements = [RawObjCSelectorPieceSyntax]()
     var loopProgress = LoopProgressCondition()
-    while !self.at(.eof) && !self.at(.rightParen) && loopProgress.evaluate(currentToken) {
+    while !self.at(any: [.eof, .rightParen]) && loopProgress.evaluate(currentToken) {
       // Empty selector piece.
       if let colon = self.consume(if: .colon) {
         elements.append(RawObjCSelectorPieceSyntax(
@@ -528,7 +528,7 @@ extension Parser {
     var elements = [RawSyntax]()
     // Parse optional "exported" and "kind" labeled parameters.
     var loopProgress = LoopProgressCondition()
-    while !self.at(.eof) && !self.at(.rightParen) && !self.at(.whereKeyword) && loopProgress.evaluate(currentToken) {
+    while !self.at(any: [.eof, .rightParen, .whereKeyword]) && loopProgress.evaluate(currentToken) {
       let ident = self.parseAnyIdentifier()
       let knownParameter = SpecializeParameter(rawValue: ident.tokenText)
       let (unexpectedBeforeColon, colon) = self.expect(.colon)

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -470,7 +470,7 @@ extension Parser {
         continue
       }
 
-      if self.currentToken.isIdentifier || self.currentToken.isKeyword {
+      if self.at(.identifier) || self.currentToken.isKeyword {
         let name = self.consumeAnyToken()
 
         // If we hit a ')' we may have a zero-argument selector.

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -182,25 +182,21 @@ extension Parser {
     }
 
 
-    let (unexpectedBeforeAtSign, atSign) = self.eat(.atSign)
+    let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
     let ident = self.consumeIdentifierOrRethrows()
-    let unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax?
-    let leftParen: RawTokenSyntax?
+    let leftParen = self.consume(if: .leftParen)
     let arg: RawSyntax?
     let unexpectedBeforeRightParen: RawUnexpectedNodesSyntax?
     let rightParen: RawTokenSyntax?
-    if self.at(.leftParen) {
+    if leftParen != nil {
       var args = [RawTokenSyntax]()
-      (unexpectedBeforeLeftParen, leftParen) = self.eat(.leftParen)
       var loopProgress = LoopProgressCondition()
-      while !self.at(.eof) && !self.at(.rightParen) && loopProgress.evaluate(currentToken) {
+      while !self.at(.eof), !self.at(.rightParen) && loopProgress.evaluate(currentToken) {
         args.append(self.consumeAnyToken())
       }
       arg = RawSyntax(RawTokenListSyntax(elements: args, arena: self.arena))
       (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
     } else {
-      unexpectedBeforeLeftParen = nil
-      leftParen = nil
       arg = nil
       unexpectedBeforeRightParen = nil
       rightParen = nil
@@ -209,7 +205,6 @@ extension Parser {
       unexpectedBeforeAtSign,
       atSignToken: atSign,
       attributeName: ident,
-      unexpectedBeforeLeftParen,
       leftParen: leftParen,
       argument: arg,
       unexpectedBeforeRightParen,
@@ -219,25 +214,25 @@ extension Parser {
   }
 
   mutating func parseCustomAttribute() -> RawCustomAttributeSyntax {
-    let (unexpectedBeforeAtSign, atSign) = self.eat(.atSign)
+    let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
     let attrName = self.parseType()
 
     // Custom attributes are stricter than normal attributes about their
     // argument lists "immediately" following the attribute name.
-    guard self.at(.leftParen) && !self.currentToken.isAtStartOfLine && self.lookahead().isCustomAttributeArgument() else {
+    guard let leftParen = self.consume(if: .leftParen, where: { (lexeme, parser) in
+      !lexeme.isAtStartOfLine && parser.lookahead().isCustomAttributeArgument()
+    }) else {
       return RawCustomAttributeSyntax(
         atSignToken: atSign, attributeName: attrName,
         leftParen: nil, argumentList: nil, rightParen: nil,
         arena: self.arena)
     }
-    let (unexpectedBeforeLeftParen, leftParen) = self.eat(.leftParen)
     let arguments = self.parseArgumentListElements()
     let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
     return RawCustomAttributeSyntax(
       unexpectedBeforeAtSign,
       atSignToken: atSign,
       attributeName: attrName,
-      unexpectedBeforeLeftParen,
       leftParen: leftParen,
       argumentList: RawTupleExprElementListSyntax(elements: arguments, arena: self.arena),
       unexpectedBeforeRightParen,
@@ -248,7 +243,7 @@ extension Parser {
 
 extension Parser {
   mutating func parseAvailabilityAttribute() -> RawAttributeSyntax {
-    let (unexpectedBeforeAtSign, atSign) = self.eat(.atSign)
+    let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
     assert(self.currentToken.tokenText == "available")
     let available = self.consumeAnyToken()
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
@@ -281,7 +276,7 @@ extension Parser {
 
 extension Parser {
   mutating func parseDifferentiableAttribute() -> RawAttributeSyntax {
-    let (unexpectedBeforeAtSign, atSign) = self.eat(.atSign)
+    let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
     assert(self.currentToken.tokenText == "differentiable")
     let differentiable = self.consumeAnyToken()
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
@@ -351,7 +346,7 @@ extension Parser {
     let wrt = self.consumeIdentifier()
     let (unexpectedBeforeColon, colon) = self.expect(.colon)
 
-    guard self.at(.leftParen) else {
+    guard let leftParen = self.consume(if: .leftParen) else {
       // If no opening '(' for parameter list, parse a single parameter.
       let param = self.parseDifferentiabilityParameter().map(RawSyntax.init(_:))
                   ?? RawSyntax(RawMissingSyntax(arena: self.arena))
@@ -364,7 +359,6 @@ extension Parser {
       )
     }
 
-    let (unexpectedBeforeLeftParen, leftParen) = self.eat(.leftParen)
     var elements = [RawDifferentiabilityParamSyntax]()
     var loopProgress = LoopProgressCondition()
     while !self.at(.eof) && !self.at(.rightParen) && loopProgress.evaluate(currentToken) {
@@ -377,7 +371,6 @@ extension Parser {
 
     let parameters = RawDifferentiabilityParamListSyntax(elements: elements, arena: self.arena)
     let list = RawDifferentiabilityParamsSyntax(
-      unexpectedBeforeLeftParen,
       leftParen: leftParen,
       diffParams: parameters,
       unexpectedBeforeRightParen,
@@ -394,27 +387,40 @@ extension Parser {
   }
 
   mutating func parseDifferentiabilityParameter() -> RawDifferentiabilityParamSyntax? {
-    switch self.currentToken.tokenKind {
-    case .identifier:
-      let token = self.consumeIdentifier()
+    enum ExpectedTokenKind: RawTokenKindSubset {
+      case identifier
+      case integerLiteral
+      case selfKeyword
+
+      var rawTokenKind: RawTokenKind {
+        switch self {
+        case .identifier: return .identifier
+        case .integerLiteral: return .integerLiteral
+        case .selfKeyword: return .selfKeyword
+        }
+      }
+    }
+
+    switch self.at(anyIn: ExpectedTokenKind.self) {
+    case (.identifier, let handle)?:
+      let token = self.eat(handle)
       let comma = self.consume(if: .comma)
       return RawDifferentiabilityParamSyntax(
         parameter: RawSyntax(token), trailingComma: comma, arena: self.arena)
-    case .integerLiteral:
-      let token = self.consumeAnyToken()
+    case (.integerLiteral, let handle)?:
+      let token = self.eat(handle)
       let comma = self.consume(if: .comma)
       return RawDifferentiabilityParamSyntax(
         parameter: RawSyntax(token), trailingComma: comma, arena: self.arena)
-    case .selfKeyword:
-      let (unexpectedBeforeToken, token) = self.eat(.selfKeyword)
+    case (.selfKeyword, let handle)?:
+      let token = self.eat(handle)
       let comma = self.consume(if: .comma)
       return RawDifferentiabilityParamSyntax(
-        unexpectedBeforeToken,
         parameter: RawSyntax(token),
         trailingComma: comma,
         arena: self.arena
       )
-    default:
+    case nil:
       return nil
     }
   }
@@ -422,22 +428,18 @@ extension Parser {
 
 extension Parser {
   mutating func parseObjectiveCAttribute() -> RawAttributeSyntax {
-    let (unexpectedBeforeAtSign, atSign) = self.eat(.atSign)
+    let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
     assert(self.currentToken.tokenText == "objc")
     let objc = self.consumeAnyToken()
 
-    let unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax?
-    let leftParen: RawTokenSyntax?
+    let leftParen = self.consume(if: .leftParen)
     let argument: RawObjCSelectorSyntax?
     let unexpectedBeforeRightParen: RawUnexpectedNodesSyntax?
     let rightParen: RawTokenSyntax?
-    if self.at(.leftParen) {
-      (unexpectedBeforeLeftParen, leftParen) = self.eat(.leftParen)
+    if leftParen != nil {
       argument = self.parseObjectiveCSelector()
       (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
     } else {
-      unexpectedBeforeLeftParen = nil
-      leftParen = nil
       argument = nil
       unexpectedBeforeRightParen = nil
       rightParen = nil
@@ -447,7 +449,6 @@ extension Parser {
       unexpectedBeforeAtSign,
       atSignToken: atSign,
       attributeName: objc,
-      unexpectedBeforeLeftParen,
       leftParen: leftParen,
       argument: argument.map(RawSyntax.init),
       unexpectedBeforeRightParen,
@@ -461,11 +462,9 @@ extension Parser {
     var loopProgress = LoopProgressCondition()
     while !self.at(.eof) && !self.at(.rightParen) && loopProgress.evaluate(currentToken) {
       // Empty selector piece.
-      if self.at(.colon) {
-        let (unexpectedBeforeColon, colon) = self.eat(.colon)
+      if let colon = self.consume(if: .colon) {
         elements.append(RawObjCSelectorPieceSyntax(
           name: nil,
-          unexpectedBeforeColon,
           colon: colon,
           arena: self.arena
         ))
@@ -498,7 +497,7 @@ extension Parser {
 
 extension Parser {
   mutating func parseSpecializeAttribute() -> RawAttributeSyntax {
-    let (unexpectedBeforeAtSign, atSign) = self.eat(.atSign)
+    let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
     assert(self.currentToken.tokenText == "_specialize")
     let specializeToken = self.consumeAnyToken()
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
@@ -683,7 +682,7 @@ extension Parser {
 
 extension Parser {
   mutating func parsePrivateImportAttribute() -> RawAttributeSyntax {
-    let (unexpectedBeforeAtSign, atSign) = self.eat(.atSign)
+    let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
     assert(self.currentToken.tokenText == "_private")
     let privateToken = self.consumeAnyToken()
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
@@ -713,7 +712,7 @@ extension Parser {
 
 extension Parser {
   mutating func parseDynamicReplacementAttribute() -> RawAttributeSyntax {
-    let (unexpectedBeforeAtSign, atSign) = self.eat(.atSign)
+    let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
     assert(self.currentToken.tokenText == "_dynamicReplacement")
     let dynamicReplacementToken = self.consumeAnyToken()
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
@@ -751,7 +750,7 @@ extension Parser {
 
 extension Parser {
   mutating func parseSPIAttribute() -> RawAttributeSyntax {
-    let (unexpectedBeforeAtSign, atSign) = self.eat(.atSign)
+    let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
     assert(self.currentToken.tokenText == "_spi")
     let spiToken = self.consumeAnyToken()
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -784,9 +784,9 @@ extension Parser.Lookahead {
         .rightSquareBracket,
         .rightAngle:
       return false
-    case _ where lookahead.currentToken.isContextualKeyword("async"):
+    case _ where lookahead.atContextualKeyword("async"):
       return false
-    case _ where lookahead.currentToken.isContextualKeyword("reasync"):
+    case _ where lookahead.atContextualKeyword("reasync"):
       return false
     default:
       return true

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -798,7 +798,7 @@ extension Parser.Lookahead {
       return false
     }
 
-    if self.at(.leftParen) && !self.currentToken.isAtStartOfLine && self.lookahead().isCustomAttributeArgument() {
+    if self.at(.leftParen, where: { !$0.isAtStartOfLine }) && self.lookahead().isCustomAttributeArgument() {
       self.skipSingle()
     }
 

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -219,9 +219,8 @@ extension Parser {
 
     // Custom attributes are stricter than normal attributes about their
     // argument lists "immediately" following the attribute name.
-    guard let leftParen = self.consume(if: .leftParen, where: { (lexeme, parser) in
-      !lexeme.isAtStartOfLine && parser.lookahead().isCustomAttributeArgument()
-    }) else {
+    guard self.lookahead().isCustomAttributeArgument(),
+            let leftParen = self.consume(if: .leftParen, where: { !$0.isAtStartOfLine }) else {
       return RawCustomAttributeSyntax(
         atSignToken: atSign, attributeName: attrName,
         leftParen: nil, argumentList: nil, rightParen: nil,

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -208,7 +208,7 @@ extension Parser {
   ///     platform-name → tvOS
   mutating func parsePlatformVersionConstraintSpec() -> RawAvailabilityVersionRestrictionSyntax {
     // Register the platform name as a keyword token.
-    let plaform = self.consume(remapping: .contextualKeyword)
+    let plaform = self.consumeAnyToken(remapping: .contextualKeyword)
     let version = self.parseVersionTuple()
     return RawAvailabilityVersionRestrictionSyntax(
       platform: plaform, version: version, arena: self.arena)

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -131,12 +131,10 @@ extension Parser {
           ))
         case .deprecated:
           let argumentLabel = self.consumeAnyToken()
-          if self.at(.colon) {
-            let (unexpectedBeforeColon, colon) = self.eat(.colon)
+          if let colon = self.consume(if: .colon) {
             let version = self.parseVersionTuple()
             entry = RawSyntax(RawAvailabilityLabeledArgumentSyntax(
               label: argumentLabel,
-              unexpectedBeforeColon,
               colon: colon,
               value: RawSyntax(version),
               arena: self.arena

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -48,13 +48,10 @@ extension Parser {
 
         // Before continuing to parse the next specification, we check that it's
         // also in the shorthand syntax and recover from it.
-        if
-          keepGoing != nil,
-          self.at(.identifier),
-          AvailabilityArgumentKind(rawValue: self.currentToken.tokenText) != nil
-        {
+        if keepGoing != nil,
+           let (_, handle) = self.at(anyIn: AvailabilityArgumentKind.self) {
           var tokens = [RawTokenSyntax]()
-          tokens.append(self.consumeAnyToken())
+          tokens.append(self.eat(handle))
           var recoveryProgress = LoopProgressCondition()
           while !self.at(any: [.eof, .comma, .rightParen]) && recoveryProgress.evaluate(currentToken) {
             tokens.append(self.consumeAnyToken())
@@ -70,7 +67,7 @@ extension Parser {
     return RawAvailabilitySpecListSyntax(elements: elements, arena: self.arena)
   }
 
-  enum AvailabilityArgumentKind: SyntaxText {
+  enum AvailabilityArgumentKind: SyntaxText, ContextualKeywords {
     case message
     case renamed
     case introduced
@@ -92,21 +89,11 @@ extension Parser {
     do {
       var loopProgressCondition = LoopProgressCondition()
       while keepGoing != nil && loopProgressCondition.evaluate(currentToken) {
-        guard self.currentToken.tokenKind == .identifier,
-              let argKind = AvailabilityArgumentKind(rawValue: self.currentToken.tokenText) else {
-          // Not sure what this label is but, let's just eat it and
-          // keep going.
-          let arg = self.consumeAnyToken()
-          keepGoing = self.consume(if: .comma)
-          elements.append(RawAvailabilityArgumentSyntax(
-            entry: RawSyntax(arg), trailingComma: keepGoing, arena: self.arena))
-          continue
-        }
-
         let entry: RawSyntax
-        switch argKind {
-        case .message, .renamed:
-          let argumentLabel = self.consumeAnyToken()
+        switch self.at(anyIn: AvailabilityArgumentKind.self) {
+        case (.message, let handle)?,
+            (.renamed, let handle)?:
+          let argumentLabel = self.eat(handle)
           let (unexpectedBeforeColon, colon) = self.expect(.colon)
           // FIXME: Make sure this is a string literal with no interpolation.
           let stringValue = self.consumeAnyToken()
@@ -118,8 +105,9 @@ extension Parser {
             value: RawSyntax(stringValue),
             arena: self.arena
           ))
-        case .introduced, .obsoleted:
-          let argumentLabel = self.consumeAnyToken()
+        case (.introduced, let handle)?,
+            (.obsoleted, let handle)?:
+          let argumentLabel = self.eat(handle)
           let (unexpectedBeforeColon, colon) = self.expect(.colon)
           let version = self.parseVersionTuple()
           entry = RawSyntax(RawAvailabilityLabeledArgumentSyntax(
@@ -129,8 +117,8 @@ extension Parser {
             value: RawSyntax(version),
             arena: self.arena
           ))
-        case .deprecated:
-          let argumentLabel = self.consumeAnyToken()
+        case (.deprecated, let handle)?:
+          let argumentLabel = self.eat(handle)
           if let colon = self.consume(if: .colon) {
             let version = self.parseVersionTuple()
             entry = RawSyntax(RawAvailabilityLabeledArgumentSyntax(
@@ -142,11 +130,16 @@ extension Parser {
           } else {
             entry = RawSyntax(argumentLabel)
           }
-        case .unavailable, .noasync:
-          let argument = self.consumeAnyToken()
+        case (.unavailable, let handle)?,
+            (.noasync, let handle)?:
+          let argument = self.eat(handle)
           // FIXME: Can we model this in SwiftSyntax by making the
           // 'labeled' argument part optional?
           entry = RawSyntax(argument)
+        case nil:
+          // Not sure what this label is but, let's just eat it and
+          // keep going.
+          entry = RawSyntax(self.consumeAnyToken())
         }
 
         keepGoing = self.consume(if: .comma)
@@ -173,7 +166,7 @@ extension Parser {
     }
 
     if self.at(any: [.identifier, .wildcardKeyword]) {
-      if self.currentToken.tokenText == "swift" || self.currentToken.tokenText == "_PackageDescription" {
+      if self.atContextualKeyword("swift") || self.atContextualKeyword("_PackageDescription") {
         return RawSyntax(self.parsePlatformAgnosticVersionConstraintSpec())
       }
     }

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -219,9 +219,9 @@ extension Parser {
     let platform = self.consumeAnyToken()
 
     let version: RawVersionTupleSyntax?
-    if case .integerLiteral = self.currentToken.tokenKind {
+    if self.at(.integerLiteral) {
       version = self.parseVersionTuple()
-    } else if case .floatingLiteral = self.currentToken.tokenKind {
+    } else if self.at(.floatingLiteral) {
       version = self.parseVersionTuple()
     } else {
       version = nil
@@ -240,7 +240,7 @@ extension Parser {
   ///     platform-version → decimal-digits '.' decimal-digits
   ///     platform-version → decimal-digits '.' decimal-digits '.' decimal-digits
   mutating func parseVersionTuple() -> RawVersionTupleSyntax {
-    if self.currentToken.tokenKind == .integerLiteral {
+    if self.at(.integerLiteral) {
       let majorMinor = self.consumeAnyToken()
       return RawVersionTupleSyntax(
         majorMinor: RawSyntax(majorMinor), patchPeriod: nil, patchVersion: nil,

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -132,10 +132,15 @@ extension Parser {
         case .deprecated:
           let argumentLabel = self.consumeAnyToken()
           if self.at(.colon) {
-            let colon = self.eat(.colon)
+            let (unexpectedBeforeColon, colon) = self.eat(.colon)
             let version = self.parseVersionTuple()
             entry = RawSyntax(RawAvailabilityLabeledArgumentSyntax(
-              label: argumentLabel, colon: colon, value: RawSyntax(version), arena: self.arena))
+              label: argumentLabel,
+              unexpectedBeforeColon,
+              colon: colon,
+              value: RawSyntax(version),
+              arena: self.arena
+            ))
           } else {
             entry = RawSyntax(argumentLabel)
           }

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -35,8 +35,8 @@ extension Parser {
       repeat {
         let entry: RawSyntax
         switch source {
-        case .available where self.currentToken.isIdentifier,
-            .unavailable where self.currentToken.isIdentifier:
+        case .available where self.at(.identifier),
+            .unavailable where self.at(.identifier):
           entry = RawSyntax(self.parseAvailabilityMacro())
         default:
           entry = self.parseAvailabilitySpec()
@@ -50,7 +50,7 @@ extension Parser {
         // also in the shorthand syntax and recover from it.
         if
           keepGoing != nil,
-          self.currentToken.isIdentifier,
+          self.at(.identifier),
           AvailabilityArgumentKind(rawValue: self.currentToken.tokenText) != nil
         {
           var tokens = [RawTokenSyntax]()

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -158,8 +158,7 @@ extension Parser {
   ///     availability-argument → platform-name platform-version
   ///     availability-argument → *
   mutating func parseAvailabilitySpec() -> RawSyntax {
-    if self.currentToken.isBinaryOperator && self.currentToken.tokenText == "*" {
-      let star = self.consumeAnyToken()
+    if let star = self.consumeIfContextualPunctuator("*") {
       // FIXME: Use makeAvailabilityVersionRestriction here - but swift-format
       // doesn't expect it.
       return RawSyntax(star)

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -420,7 +420,7 @@ extension Parser {
         case (.colon, let handle)?:
           let colon = self.eat(handle)
           // A conformance-requirement.
-          if self.currentToken.isIdentifier, let layoutConstraint = LayoutConstraint(rawValue: self.currentToken.tokenText) {
+          if self.at(.identifier), let layoutConstraint = LayoutConstraint(rawValue: self.currentToken.tokenText) {
             // Parse a layout constraint.
             let constraint = self.expectIdentifierWithoutRecovery()
 
@@ -1304,7 +1304,7 @@ extension Parser {
     let identifier: RawTokenSyntax
     if self.currentToken.isAnyOperator || self.at(any: [.exclamationMark, .prefixAmpersand]) {
       var name = self.currentToken.tokenText
-      if name.count > 1 && name.hasSuffix("<") && self.peek().isIdentifier {
+      if name.count > 1 && name.hasSuffix("<") && self.peek().tokenKind == .identifier {
         name = SyntaxText(rebasing: name.dropLast())
       }
       identifier = self.consumePrefix(name, as: .spacedBinaryOperator)
@@ -1539,7 +1539,7 @@ extension Parser {
     }
 
     guard
-      self.currentToken.isIdentifier,
+      self.at(.identifier),
       let kind = AccessorKind(rawValue: self.currentToken.tokenText)
     else {
       return AccessorIntroducer(

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -219,7 +219,7 @@ extension Parser {
   public mutating func parseGenericParameters() -> RawGenericParameterClauseSyntax {
     assert(self.currentToken.starts(with: "<"))
 
-    let langle = self.consume(remapping: .leftAngle)
+    let langle = self.consumeAnyToken(remapping: .leftAngle)
     var elements = [RawGenericParameterSyntax]()
     do {
       var keepGoing: RawTokenSyntax? = nil
@@ -258,7 +258,7 @@ extension Parser {
 
     let rangle: RawTokenSyntax
     if self.currentToken.starts(with: ">") {
-      rangle = self.consume(remapping: .rightAngle)
+      rangle = self.consumeAnyToken(remapping: .rightAngle)
     } else {
       rangle = RawTokenSyntax(missing: .rightAngle, arena: self.arena)
     }
@@ -771,7 +771,7 @@ extension Parser {
 extension Parser {
   @_spi(RawSyntax)
   public mutating func parsePrimaryAssociatedTypes() -> RawPrimaryAssociatedTypeClauseSyntax {
-    let langle = self.consume(remapping: .leftAngle)
+    let langle = self.consumeAnyToken(remapping: .leftAngle)
     var associatedTypes = [RawPrimaryAssociatedTypeSyntax]()
     do {
       var keepGoing: RawTokenSyntax? = nil
@@ -786,7 +786,7 @@ extension Parser {
           arena: self.arena))
       } while keepGoing != nil && loopProgress.evaluate(currentToken)
     }
-    let rangle = self.consume(remapping: .rightAngle)
+    let rangle = self.consumeAnyToken(remapping: .rightAngle)
     return RawPrimaryAssociatedTypeClauseSyntax(
       leftAngleBracket: langle,
       primaryAssociatedTypeList: RawPrimaryAssociatedTypeListSyntax(elements: associatedTypes, arena: self.arena),
@@ -1130,7 +1130,7 @@ extension Parser {
 
         let ellipsis: RawTokenSyntax?
         if self.currentToken.isEllipsis {
-          ellipsis = self.consume(remapping: .ellipsis)
+          ellipsis = self.consumeAnyToken(remapping: .ellipsis)
         } else {
           ellipsis = nil
         }
@@ -1249,7 +1249,7 @@ extension Parser {
 
     let async: RawTokenSyntax?
     if self.currentToken.isContextualKeyword("async") {
-      async = self.consume(remapping: .contextualKeyword)
+      async = self.consumeAnyToken(remapping: .contextualKeyword)
     } else {
       async = nil
     }
@@ -1447,7 +1447,7 @@ extension Parser {
         attributes: attrs, modifier: modifier, introducer: nil)
     }
 
-    let introducer = self.consume(remapping: .contextualKeyword)
+    let introducer = self.consumeAnyToken(remapping: .contextualKeyword)
     return AccessorIntroducer(
       attributes: attrs, modifier: modifier, introducer: (kind, introducer))
   }
@@ -1456,12 +1456,12 @@ extension Parser {
   public mutating func parseEffectsSpecifier() -> RawTokenSyntax? {
     // 'async'
     if self.currentToken.isContextualKeyword("async") {
-      return self.consume(remapping: .contextualKeyword)
+      return self.consumeAnyToken(remapping: .contextualKeyword)
     }
 
     // 'reasync'
     if self.currentToken.isContextualKeyword("reasync") {
-      return self.consume(remapping: .contextualKeyword)
+      return self.consumeAnyToken(remapping: .contextualKeyword)
     }
 
     // 'throws'/'rethrows'
@@ -1756,7 +1756,7 @@ extension Parser {
           )))
         case "higherThan", "lowerThan":
           // "lowerThan" and "higherThan" are contextual keywords.
-          let level = self.consume(remapping: .contextualKeyword)
+          let level = self.consumeAnyToken(remapping: .contextualKeyword)
           let (unexpectedBeforeColon, colon) = self.expect(.colon)
           var names = [RawPrecedenceGroupNameElementSyntax]()
           do {

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1033,7 +1033,7 @@ extension Parser {
   ///     actor-member → declaration | compiler-control-statement
   @_spi(RawSyntax)
   public mutating func parseActorDeclaration(_ attrs: DeclAttributes) -> RawActorDeclSyntax {
-    assert(self.currentToken.isContextualKeyword("actor"))
+    assert(self.atContextualKeyword("actor"))
     let actorKeyword = self.expectIdentifierWithoutRecovery()
     let name = self.expectIdentifierWithoutRecovery()
 
@@ -1331,7 +1331,7 @@ extension Parser {
     let input = self.parseParameterClause()
 
     let async: RawTokenSyntax?
-    if self.currentToken.isContextualKeyword("async") {
+    if self.atContextualKeyword("async") {
       async = self.consumeAnyToken(remapping: .contextualKeyword)
     } else {
       async = nil
@@ -1512,9 +1512,9 @@ extension Parser {
     // Parse the contextual keywords for 'mutating' and 'nonmutating' before
     // get and set.
     let modifier: RawDeclModifierSyntax?
-    if self.currentToken.isContextualKeyword("mutating") ||
-        self.currentToken.isContextualKeyword("nonmutating") ||
-        self.currentToken.isContextualKeyword("__consuming") {
+    if self.atContextualKeyword("mutating") ||
+        self.atContextualKeyword("nonmutating") ||
+        self.atContextualKeyword("__consuming") {
       modifier = RawDeclModifierSyntax(
         name: self.consumeAnyToken(), detail: nil,
         arena: self.arena)
@@ -1535,12 +1535,12 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseEffectsSpecifier() -> RawTokenSyntax? {
     // 'async'
-    if self.currentToken.isContextualKeyword("async") {
+    if self.atContextualKeyword("async") {
       return self.consumeAnyToken(remapping: .contextualKeyword)
     }
 
     // 'reasync'
-    if self.currentToken.isContextualKeyword("reasync") {
+    if self.atContextualKeyword("reasync") {
       return self.consumeAnyToken(remapping: .contextualKeyword)
     }
 

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -227,7 +227,7 @@ extension Parser {
       repeat {
         let attributes = self.parseAttributeList()
 
-        let name = self.consumeIdentifier()
+        let name = self.expectIdentifierWithoutRecovery()
         if name.isMissing && elements.isEmpty {
           break
         }
@@ -326,7 +326,7 @@ extension Parser {
           // A conformance-requirement.
           if self.currentToken.isIdentifier, let layoutConstraint = LayoutConstraint(rawValue: self.currentToken.tokenText) {
             // Parse a layout constraint.
-            let constraint = self.consumeIdentifier()
+            let constraint = self.expectIdentifierWithoutRecovery()
 
             let unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax?
             let leftParen: RawTokenSyntax?
@@ -462,7 +462,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseClassDeclaration(_ attrs: DeclAttributes) -> RawClassDeclSyntax {
     let (unexpectedBeforeClassKeyword, classKeyword) = self.expect(.classKeyword)
-    let name = self.consumeIdentifier()
+    let name = self.expectIdentifierWithoutRecovery()
     if name.isMissing {
       return RawClassDeclSyntax(
         attributes: attrs.attributes,
@@ -578,7 +578,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseEnumDeclaration(_ attrs: DeclAttributes) -> RawEnumDeclSyntax {
     let (unexpectedBeforeEnumKeyword, enumKeyword) = self.expect(.enumKeyword)
-    let name = self.consumeIdentifier()
+    let name = self.expectIdentifierWithoutRecovery()
     if name.isMissing {
       return RawEnumDeclSyntax(
         attributes: attrs.attributes,
@@ -654,7 +654,7 @@ extension Parser {
       var keepGoing: RawTokenSyntax? = nil
       var loopProgress = LoopProgressCondition()
       repeat {
-        let name = self.consumeIdentifier()
+        let name = self.expectIdentifierWithoutRecovery()
 
         let associatedValue: RawParameterClauseSyntax?
         if self.at(.leftParen) && !self.currentToken.isAtStartOfLine {
@@ -713,7 +713,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseStructDeclaration(_ attrs: DeclAttributes) -> RawStructDeclSyntax {
     let (unexpectedBeforeStructKeyword, structKeyword) = self.expect(.structKeyword)
-    let name = self.consumeIdentifier()
+    let name = self.expectIdentifierWithoutRecovery()
     if name.isMissing {
       return RawStructDeclSyntax(
         attributes: attrs.attributes,
@@ -778,7 +778,7 @@ extension Parser {
       var loopProgress = LoopProgressCondition()
       repeat {
         // Parse the name of the parameter.
-        let name = self.consumeIdentifier()
+        let name = self.expectIdentifierWithoutRecovery()
         keepGoing = self.consume(if: .comma)
         associatedTypes.append(RawPrimaryAssociatedTypeSyntax(
           name: name,
@@ -816,7 +816,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseProtocolDeclaration(_ attrs: DeclAttributes) -> RawProtocolDeclSyntax {
     let (unexpectedBeforeProtocolKeyword, protocolKeyword) = self.expect(.protocolKeyword)
-    let name = self.consumeIdentifier()
+    let name = self.expectIdentifierWithoutRecovery()
     if name.isMissing {
       return RawProtocolDeclSyntax(
         attributes: attrs.attributes,
@@ -884,7 +884,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseAssociatedTypeDeclaration(_ attrs: DeclAttributes) -> RawAssociatedtypeDeclSyntax {
     let (unexpectedBeforeAssocKeyword, assocKeyword) = self.expect(.associatedtypeKeyword)
-    let name = self.consumeIdentifier()
+    let name = self.expectIdentifierWithoutRecovery()
     if name.isMissing {
       return RawAssociatedtypeDeclSyntax(
         attributes: attrs.attributes,
@@ -952,8 +952,8 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseActorDeclaration(_ attrs: DeclAttributes) -> RawActorDeclSyntax {
     assert(self.currentToken.isContextualKeyword("actor"))
-    let actorKeyword = self.consumeIdentifier()
-    let name = self.consumeIdentifier()
+    let actorKeyword = self.expectIdentifierWithoutRecovery()
+    let name = self.expectIdentifierWithoutRecovery()
 
     let generics: RawGenericParameterClauseSyntax?
     if self.currentToken.starts(with: "<") {
@@ -1210,7 +1210,7 @@ extension Parser {
       }
       identifier = self.consumePrefix(name, as: .spacedBinaryOperator)
     } else {
-      identifier = self.consumeIdentifier()
+      identifier = self.expectIdentifierWithoutRecovery()
     }
 
     let genericParams: RawGenericParameterClauseSyntax?
@@ -1554,7 +1554,7 @@ extension Parser {
         //     set-name    ::= '(' identifier ')'
         let parameter: RawAccessorParameterSyntax?
         if [ AccessorKind.set, .willSet, .didSet ].firstIndex(of: kind) != nil, let lparen = self.consume(if: .leftParen) {
-          let name = self.consumeIdentifier()
+          let name = self.expectIdentifierWithoutRecovery()
           let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
           parameter = RawAccessorParameterSyntax(
             leftParen: lparen,
@@ -1616,7 +1616,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseTypealiasDeclaration(_ attrs: DeclAttributes) -> RawTypealiasDeclSyntax {
     let (unexpectedBeforeTypealiasKeyword, typealiasKeyword) = self.expect(.typealiasKeyword)
-    let name = self.consumeIdentifier()
+    let name = self.expectIdentifierWithoutRecovery()
 
     // Parse a generic parameter list if it is present.
     let generics: RawGenericParameterClauseSyntax?
@@ -1679,7 +1679,7 @@ extension Parser {
     // checking.
     let precedenceAndTypes: RawOperatorPrecedenceAndTypesSyntax?
     if let colon = self.consume(if: .colon) {
-      let identifier = self.consumeIdentifier()
+      let identifier = self.expectIdentifierWithoutRecovery()
       precedenceAndTypes = RawOperatorPrecedenceAndTypesSyntax(
         colon: colon,
         precedenceGroupAndDesignatedTypes: RawIdentifierListSyntax(elements: [ identifier ], arena: self.arena),
@@ -1724,7 +1724,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parsePrecedenceGroupDeclaration(_ attrs: DeclAttributes) -> RawPrecedenceGroupDeclSyntax {
     let (unexpectedBeforeGroup, group) = self.expect(.precedencegroupKeyword)
-    let identifier = self.consumeIdentifier()
+    let identifier = self.expectIdentifierWithoutRecovery()
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
     var elements = [RawSyntax]()
     do {
@@ -1732,9 +1732,9 @@ extension Parser {
       LOOP: while !self.at(any: [.eof, .rightBrace]) && attributesProgress.evaluate(currentToken) {
         switch self.currentToken.tokenText {
         case "associativity":
-          let associativity = self.consumeIdentifier()
+          let associativity = self.expectIdentifierWithoutRecovery()
           let (unexpectedBeforeColon, colon) = self.expect(.colon)
-          let value = self.consumeIdentifier()
+          let value = self.expectIdentifierWithoutRecovery()
           elements.append(RawSyntax(RawPrecedenceGroupAssociativitySyntax(
             associativityKeyword: associativity,
             unexpectedBeforeColon,
@@ -1743,7 +1743,7 @@ extension Parser {
             arena: self.arena
           )))
         case "assignment":
-          let assignmentKeyword = self.consumeIdentifier()
+          let assignmentKeyword = self.expectIdentifierWithoutRecovery()
           let (unexpectedBeforeColon, colon) = self.expect(.colon)
           let (unexpectedBeforeFlag, flag) = self.expectAny([.trueKeyword, .falseKeyword], default: .trueKeyword)
           elements.append(RawSyntax(RawPrecedenceGroupAssignmentSyntax(
@@ -1763,7 +1763,7 @@ extension Parser {
             var keepGoing: RawTokenSyntax? = nil
             var namesProgress = LoopProgressCondition()
             repeat {
-              let name = self.consumeIdentifier()
+              let name = self.expectIdentifierWithoutRecovery()
               keepGoing = self.consume(if: .comma)
               names.append(RawPrecedenceGroupNameElementSyntax(
                 name: name, trailingComma: keepGoing,

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -123,11 +123,13 @@ extension Parser {
   ///     import-path → identifier | identifier '.' import-path
   @_spi(RawSyntax)
   public mutating func parseImportDeclaration(_ attrs: DeclAttributes) -> RawImportDeclSyntax {
-    let importKeyword = self.eat(.importKeyword)
+    let (unexpectedBeforeImportKeyword, importKeyword) = self.eat(.importKeyword)
     let kind = self.parseImportKind()
     let path = self.parseImportAccessPath()
     return RawImportDeclSyntax(
-      attributes: attrs.attributes, modifiers: attrs.modifiers,
+      attributes: attrs.attributes,
+      modifiers: attrs.modifiers,
+      unexpectedBeforeImportKeyword,
       importTok: importKeyword,
       importKind: kind,
       path: path,
@@ -182,7 +184,7 @@ extension Parser {
   ///     extension-member → declaration | compiler-control-statement
   @_spi(RawSyntax)
   public mutating func parseExtensionDeclaration(_ attrs: DeclAttributes) -> RawExtensionDeclSyntax {
-    let extensionKeyword = self.eat(.extensionKeyword)
+    let (unexpectedBeforeExtensionKeyword, extensionKeyword) = self.eat(.extensionKeyword)
     let type = self.parseType()
 
     let inheritance: RawTypeInheritanceClauseSyntax?
@@ -200,7 +202,9 @@ extension Parser {
     }
     let members = self.parseMemberDeclList()
     return RawExtensionDeclSyntax(
-      attributes: attrs.attributes, modifiers: attrs.modifiers,
+      attributes: attrs.attributes,
+      modifiers: attrs.modifiers,
+      unexpectedBeforeExtensionKeyword,
       extensionKeyword: extensionKeyword,
       extendedType: type,
       inheritanceClause: inheritance,
@@ -299,7 +303,7 @@ extension Parser {
 
   @_spi(RawSyntax)
   public mutating func parseGenericWhereClause() -> RawGenericWhereClauseSyntax {
-    let whereKeyword = self.eat(.whereKeyword)
+    let (unexpectedBeforeWhereKeyword, whereKeyword) = self.eat(.whereKeyword)
 
     var elements = [RawGenericRequirementSyntax]()
     do {
@@ -320,7 +324,7 @@ extension Parser {
         let requirement: RawSyntax
         if self.at(.colon) {
           // A conformance-requirement.
-          let colon = self.eat(.colon)
+          let (unexpectedBeforeColon, colon) = self.eat(.colon)
           if self.currentToken.isIdentifier, let layoutConstraint = LayoutConstraint(rawValue: self.currentToken.tokenText) {
             // Parse a layout constraint.
             let constraint = self.consumeIdentifier()
@@ -356,7 +360,9 @@ extension Parser {
 
             requirement = RawSyntax(RawLayoutRequirementSyntax(
               typeIdentifier: firstType,
-              colon: colon, layoutConstraint: constraint,
+              unexpectedBeforeColon,
+              colon: colon,
+              layoutConstraint: constraint,
               unexpectedBeforeLeftParen,
               leftParen: leftParen,
               size: size,
@@ -370,6 +376,7 @@ extension Parser {
             let secondType = self.parseType()
             requirement = RawSyntax(RawConformanceRequirementSyntax(
               leftTypeIdentifier: firstType,
+              unexpectedBeforeColon,
               colon: colon,
               rightTypeIdentifier: secondType,
               arena: self.arena))
@@ -398,6 +405,7 @@ extension Parser {
     }
 
     return RawGenericWhereClauseSyntax(
+      unexpectedBeforeWhereKeyword,
       whereKeyword: whereKeyword,
       requirementList: RawGenericRequirementListSyntax(elements: elements, arena: self.arena),
       arena: self.arena)
@@ -456,12 +464,13 @@ extension Parser {
   ///     class-member → declaration | compiler-control-statement
   @_spi(RawSyntax)
   public mutating func parseClassDeclaration(_ attrs: DeclAttributes) -> RawClassDeclSyntax {
-    let classKeyword = self.eat(.classKeyword)
+    let (unexpectedBeforeClassKeyword, classKeyword) = self.eat(.classKeyword)
     let name = self.consumeIdentifier()
     if name.isMissing {
       return RawClassDeclSyntax(
         attributes: attrs.attributes,
         modifiers: attrs.modifiers,
+        unexpectedBeforeClassKeyword,
         classKeyword: classKeyword,
         identifier: name,
         genericParameterClause: nil,
@@ -520,7 +529,7 @@ extension Parser {
   ///     type-inheritance-list → attributes? type-identifier | attributes? type-identifier ',' type-inheritance-list
   @_spi(RawSyntax)
   public mutating func parseInheritance() -> RawTypeInheritanceClauseSyntax {
-    let colon = self.eat(.colon)
+    let (unexpectedBeforeColon, colon) = self.eat(.colon)
     var elements = [RawInheritedTypeSyntax]()
     do {
       var keepGoing: RawTokenSyntax? = nil
@@ -528,10 +537,12 @@ extension Parser {
       repeat {
         let type: RawTypeSyntax
         if self.at(.classKeyword) {
-          let classKeyword = self.eat(.classKeyword)
+          let (unexpectedBeforeClassKeyword, classKeyword) = self.eat(.classKeyword)
           type = RawTypeSyntax(RawClassRestrictionTypeSyntax(
+            unexpectedBeforeClassKeyword,
             classKeyword: classKeyword,
-            arena: self.arena))
+            arena: self.arena
+          ))
         } else {
           type = self.parseType()
         }
@@ -542,9 +553,11 @@ extension Parser {
       } while keepGoing != nil && loopProgress.evaluate(currentToken)
     }
     return RawTypeInheritanceClauseSyntax(
+      unexpectedBeforeColon,
       colon: colon,
       inheritedTypeCollection: RawInheritedTypeListSyntax(elements: elements, arena: self.arena),
-      arena: self.arena)
+      arena: self.arena
+    )
   }
 }
 
@@ -569,12 +582,13 @@ extension Parser {
   ///     raw-value-style-enum-member → declaration | raw-value-style-enum-case-clause | compiler-control-statement
   @_spi(RawSyntax)
   public mutating func parseEnumDeclaration(_ attrs: DeclAttributes) -> RawEnumDeclSyntax {
-    let enumKeyword = self.eat(.enumKeyword)
+    let (unexpectedBeforeEnumKeyword, enumKeyword) = self.eat(.enumKeyword)
     let name = self.consumeIdentifier()
     if name.isMissing {
       return RawEnumDeclSyntax(
         attributes: attrs.attributes,
         modifiers: attrs.modifiers,
+        unexpectedBeforeEnumKeyword,
         enumKeyword: enumKeyword,
         identifier: name,
         genericParameters: nil,
@@ -639,7 +653,7 @@ extension Parser {
   ///     raw-value-literal → numeric-literal | static-string-literal | boolean-literal
   @_spi(RawSyntax)
   public mutating func parseDeclEnumCase(_ attrs: DeclAttributes) -> RawEnumCaseDeclSyntax {
-    let caseKeyword = self.eat(.caseKeyword)
+    let (unexpectedBeforeCaseKeyword, caseKeyword) = self.eat(.caseKeyword)
     var elements = [RawEnumCaseElementSyntax]()
     do {
       var keepGoing: RawTokenSyntax? = nil
@@ -657,9 +671,14 @@ extension Parser {
         // See if there's a raw value expression.
         let rawValue: RawInitializerClauseSyntax?
         if self.at(.equal) {
-          let eq = self.eat(.equal)
+          let (unexpectedBeforeEq, eq) = self.eat(.equal)
           let value = self.parseExpression()
-          rawValue = RawInitializerClauseSyntax(equal: eq, value: value, arena: self.arena)
+          rawValue = RawInitializerClauseSyntax(
+            unexpectedBeforeEq,
+            equal: eq,
+            value: value,
+            arena: self.arena
+          )
         } else {
           rawValue = nil
         }
@@ -677,6 +696,7 @@ extension Parser {
 
     return RawEnumCaseDeclSyntax(
       attributes: attrs.attributes, modifiers: attrs.modifiers,
+      unexpectedBeforeCaseKeyword,
       caseKeyword: caseKeyword,
       elements: RawEnumCaseElementListSyntax(elements: elements, arena: self.arena),
       arena: self.arena)
@@ -699,12 +719,13 @@ extension Parser {
   ///     struct-member → declaration | compiler-control-statement
   @_spi(RawSyntax)
   public mutating func parseStructDeclaration(_ attrs: DeclAttributes) -> RawStructDeclSyntax {
-    let structKeyword = self.eat(.structKeyword)
+    let (unexpectedBeforeStructKeyword, structKeyword) = self.eat(.structKeyword)
     let name = self.consumeIdentifier()
     if name.isMissing {
       return RawStructDeclSyntax(
         attributes: attrs.attributes,
         modifiers: attrs.modifiers,
+        unexpectedBeforeStructKeyword,
         structKeyword: structKeyword,
         identifier: name,
         genericParameterClause: nil,
@@ -801,12 +822,13 @@ extension Parser {
   ///     protocol-member-declaration → typealias-declaration
   @_spi(RawSyntax)
   public mutating func parseProtocolDeclaration(_ attrs: DeclAttributes) -> RawProtocolDeclSyntax {
-    let protocolKeyword = self.eat(.protocolKeyword)
+    let (unexpectedBeforeProtocolKeyword, protocolKeyword) = self.eat(.protocolKeyword)
     let name = self.consumeIdentifier()
     if name.isMissing {
       return RawProtocolDeclSyntax(
         attributes: attrs.attributes,
         modifiers: attrs.modifiers,
+        unexpectedBeforeProtocolKeyword,
         protocolKeyword: protocolKeyword,
         identifier: name,
         primaryAssociatedTypeClause: nil,
@@ -868,11 +890,13 @@ extension Parser {
   ///     protocol-associated-type-declaration → attributes? access-level-modifier? 'associatedtype' typealias-name type-inheritance-clause? typealias-assignment? generic-where-clause?
   @_spi(RawSyntax)
   public mutating func parseAssociatedTypeDeclaration(_ attrs: DeclAttributes) -> RawAssociatedtypeDeclSyntax {
-    let assocKeyword = self.eat(.associatedtypeKeyword)
+    let (unexpectedBeforeAssocKeyword, assocKeyword) = self.eat(.associatedtypeKeyword)
     let name = self.consumeIdentifier()
     if name.isMissing {
       return RawAssociatedtypeDeclSyntax(
-        attributes: attrs.attributes, modifiers: attrs.modifiers,
+        attributes: attrs.attributes,
+        modifiers: attrs.modifiers,
+        unexpectedBeforeAssocKeyword,
         associatedtypeKeyword: assocKeyword,
         identifier: name,
         inheritanceClause: nil,
@@ -892,11 +916,14 @@ extension Parser {
     // Parse default type, if any.
     let defaultType: RawTypeInitializerClauseSyntax?
     if self.at(.equal) {
-      let equal = self.eat(.equal)
+      let (unexpectedBeforeEqual, equal) = self.eat(.equal)
       let type = self.parseType()
       defaultType = RawTypeInitializerClauseSyntax(
-        equal: equal, value: type,
-        arena: self.arena)
+        unexpectedBeforeEqual,
+        equal: equal,
+        value: type,
+        arena: self.arena
+      )
     } else {
       defaultType = nil
     }
@@ -990,7 +1017,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseInitializerDeclaration(_ attrs: DeclAttributes) -> RawInitializerDeclSyntax {
     assert(self.at(.initKeyword))
-    let initKeyword = self.eat(.initKeyword)
+    let (unexpectedBeforeInitKeyword, initKeyword) = self.eat(.initKeyword)
 
     // Parse the '!' or '?' for a failable initializer.
     let failable: RawTokenSyntax?
@@ -1022,7 +1049,9 @@ extension Parser {
     let items = self.parseOptionalCodeBlock()
 
     return RawInitializerDeclSyntax(
-      attributes: attrs.attributes, modifiers: attrs.modifiers,
+      attributes: attrs.attributes,
+      modifiers: attrs.modifiers,
+      unexpectedBeforeInitKeyword,
       initKeyword: initKeyword,
       optionalMark: failable,
       genericParameterClause: generics,
@@ -1040,12 +1069,16 @@ extension Parser {
   /// deinitializer-declaration → attributes? 'deinit' code-block
   @_spi(RawSyntax)
   public mutating func parseDeinitializerDeclaration(_ attrs: DeclAttributes) -> RawDeinitializerDeclSyntax {
-    let deinitKeyword = self.eat(.deinitKeyword)
+    let (unexpectedBeforeDeinitKeyword, deinitKeyword) = self.eat(.deinitKeyword)
     let items = self.parseOptionalCodeBlock()
     return RawDeinitializerDeclSyntax(
-      attributes: attrs.attributes, modifiers: attrs.modifiers,
-      deinitKeyword: deinitKeyword, body: items,
-      arena: self.arena)
+      attributes: attrs.attributes,
+      modifiers: attrs.modifiers,
+      unexpectedBeforeDeinitKeyword,
+      deinitKeyword: deinitKeyword,
+      body: items,
+      arena: self.arena
+    )
   }
 }
 
@@ -1156,7 +1189,7 @@ extension Parser {
   /// If a `throws` keyword appears right in front of the `arrow`, it is returned as `misplacedThrowsKeyword` so it can be synthesized in front of the arrow.
   @_spi(RawSyntax)
   public mutating func parseFunctionReturnClause() -> (returnClause: RawReturnClauseSyntax, misplacedThrowsKeyword: RawTokenSyntax?) {
-    let arrow = self.eat(.arrow)
+    let (unexpectedBeforeArrow, arrow) = self.eat(.arrow)
     var misplacedThrowsKeyword: RawTokenSyntax? = nil
     let unexpectedBeforeReturnType: RawUnexpectedNodesSyntax?
     if let throwsKeyword = self.consume(ifAny: .rethrowsKeyword, .throwsKeyword) {
@@ -1167,6 +1200,7 @@ extension Parser {
     }
     let result = self.parseType()
     let returnClause = RawReturnClauseSyntax(
+      unexpectedBeforeArrow,
       arrow: arrow,
       unexpectedBeforeReturnType,
       returnType: result,
@@ -1178,7 +1212,7 @@ extension Parser {
 extension Parser {
   @_spi(RawSyntax)
   public mutating func parseFuncDeclaration(_ attrs: DeclAttributes) -> RawFunctionDeclSyntax {
-    let funcKeyword = self.eat(.funcKeyword)
+    let (unexpectedBeforeFuncKeyword, funcKeyword) = self.eat(.funcKeyword)
     let identifier: RawTokenSyntax
     if self.currentToken.isAnyOperator || self.at(.exclamationMark) || self.at(.prefixAmpersand) {
       var name = self.currentToken.tokenText
@@ -1208,7 +1242,9 @@ extension Parser {
 
     let body = self.parseOptionalCodeBlock()
     return RawFunctionDeclSyntax(
-      attributes: attrs.attributes, modifiers: attrs.modifiers,
+      attributes: attrs.attributes,
+      modifiers: attrs.modifiers,
+      unexpectedBeforeFuncKeyword,
       funcKeyword: funcKeyword,
       identifier: identifier,
       genericParameterClause: genericParams,
@@ -1269,7 +1305,7 @@ extension Parser {
   ///     subscript-result → '->' attributes? type
   @_spi(RawSyntax)
   public mutating func parseSubscriptDeclaration(_ attrs: DeclAttributes) -> RawSubscriptDeclSyntax {
-    let subscriptKeyword = self.eat(.subscriptKeyword)
+    let (unexpectedBeforeSubscriptKeyword, subscriptKeyword) = self.eat(.subscriptKeyword)
     let genericParameterClause: RawGenericParameterClauseSyntax?
     if self.currentToken.starts(with: "<") {
       genericParameterClause = self.parseGenericParameters()
@@ -1307,7 +1343,9 @@ extension Parser {
     }
     
     return RawSubscriptDeclSyntax(
-      attributes: attrs.attributes, modifiers: attrs.modifiers,
+      attributes: attrs.attributes,
+      modifiers: attrs.modifiers,
+      unexpectedBeforeSubscriptKeyword,
       subscriptKeyword: subscriptKeyword,
       genericParameterClause: genericParameterClause,
       indices: indices,
@@ -1330,12 +1368,13 @@ extension Parser {
   ///     initializer → = expression
   @_spi(RawSyntax)
   public mutating func parseLetOrVarDeclaration(_ attrs: DeclAttributes) -> RawVariableDeclSyntax {
+    let unexpectedBeforeIntroducer: RawUnexpectedNodesSyntax?
     let introducer: RawTokenSyntax
     if self.at(.letKeyword) {
-      introducer = self.eat(.letKeyword)
+      (unexpectedBeforeIntroducer, introducer) = self.eat(.letKeyword)
     } else {
       assert(self.at(.varKeyword))
-      introducer = self.eat(.varKeyword)
+      (unexpectedBeforeIntroducer, introducer) = self.eat(.varKeyword)
     }
 
     var elements = [RawPatternBindingSyntax]()
@@ -1349,11 +1388,14 @@ extension Parser {
         // Parse an initializer if present.
         let initializer: RawInitializerClauseSyntax?
         if self.at(.equal) {
-          let equal = self.eat(.equal)
+          let (unexpectedBeforeEqual, equal) = self.eat(.equal)
           let value = self.parseExpression()
           initializer = RawInitializerClauseSyntax(
-            equal: equal, value: value,
-            arena: self.arena)
+            unexpectedBeforeEqual,
+            equal: equal,
+            value: value,
+            arena: self.arena
+          )
         } else {
           initializer = nil
         }
@@ -1377,7 +1419,9 @@ extension Parser {
     }
 
     return RawVariableDeclSyntax(
-      attributes: attrs.attributes, modifiers: attrs.modifiers,
+      attributes: attrs.attributes,
+      modifiers: attrs.modifiers,
+      unexpectedBeforeIntroducer,
       letOrVarKeyword: introducer,
       bindings: RawPatternBindingListSyntax(elements: elements, arena: self.arena),
       arena: self.arena)
@@ -1492,7 +1536,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseGetSet() -> RawSyntax {
     // Parse getter and setter.
-    let lbrace = self.eat(.leftBrace)
+    let (unexpectedBeforeLBrace, lbrace) = self.eat(.leftBrace)
     // Collect all explicit accessors to a list.
     var elements = [RawAccessorDeclSyntax]()
     do {
@@ -1505,6 +1549,7 @@ extension Parser {
           guard elements.isEmpty else {
             let (unexpectedBeforeRBrace, rbrace) = self.expect(.rightBrace)
             return RawSyntax(RawAccessorBlockSyntax(
+              unexpectedBeforeLBrace,
               leftBrace: lbrace,
               accessors: RawAccessorListSyntax(elements: elements, arena: self.arena),
               unexpectedBeforeRBrace,
@@ -1521,6 +1566,7 @@ extension Parser {
           }
           let (unexpectedBeforeRBrace, rbrace) = self.expect(.rightBrace)
           return RawSyntax(RawCodeBlockSyntax(
+            unexpectedBeforeLBrace,
             leftBrace: lbrace,
             statements: RawCodeBlockItemListSyntax(elements: body, arena: self.arena),
             unexpectedBeforeRBrace,
@@ -1534,10 +1580,11 @@ extension Parser {
         //     set-name    ::= '(' identifier ')'
         let parameter: RawAccessorParameterSyntax?
         if self.at(.leftParen) && [ AccessorKind.set, .willSet, .didSet ].firstIndex(of: kind) != nil {
-          let lparen = self.eat(.leftParen)
+          let (unexpectedBeforeLParen, lparen) = self.eat(.leftParen)
           let name = self.consumeIdentifier()
           let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
           parameter = RawAccessorParameterSyntax(
+            unexpectedBeforeLParen,
             leftParen: lparen,
             name: name,
             unexpectedBeforeRParen,
@@ -1576,6 +1623,7 @@ extension Parser {
 
     let (unexpectedBeforeRBrace, rbrace) = self.expect(.rightBrace)
     return RawSyntax(RawAccessorBlockSyntax(
+      unexpectedBeforeLBrace,
       leftBrace: lbrace,
       accessors: RawAccessorListSyntax(elements: elements, arena: self.arena),
       unexpectedBeforeRBrace,
@@ -1595,7 +1643,7 @@ extension Parser {
   ///     typealias-assignment → '=' type
   @_spi(RawSyntax)
   public mutating func parseTypealiasDeclaration(_ attrs: DeclAttributes) -> RawTypealiasDeclSyntax {
-    let typealiasKeyword = self.eat(.typealiasKeyword)
+    let (unexpectedBeforeTypealiasKeyword, typealiasKeyword) = self.eat(.typealiasKeyword)
     let name = self.consumeIdentifier()
 
     // Parse a generic parameter list if it is present.
@@ -1625,7 +1673,9 @@ extension Parser {
     }
 
     return RawTypealiasDeclSyntax(
-      attributes: attrs.attributes, modifiers: attrs.modifiers,
+      attributes: attrs.attributes,
+      modifiers: attrs.modifiers,
+      unexpectedBeforeTypealiasKeyword,
       typealiasKeyword: typealiasKeyword,
       identifier: name,
       genericParameterClause: generics,
@@ -1648,7 +1698,7 @@ extension Parser {
   ///     infix-operator-group → ':' precedence-group-name
   @_spi(RawSyntax)
   public mutating func parseOperatorDeclaration(_ attrs: DeclAttributes) -> RawOperatorDeclSyntax {
-    let operatorKeyword = self.eat(.operatorKeyword)
+    let (unexpectedBeforeOperatorKeyword, operatorKeyword) = self.eat(.operatorKeyword)
     let identifier = self.consumeAnyToken()
 
     // Parse (or diagnose) a specified precedence group and/or
@@ -1657,9 +1707,10 @@ extension Parser {
     // checking.
     let precedenceAndTypes: RawOperatorPrecedenceAndTypesSyntax?
     if self.at(.colon) {
-      let colon = self.eat(.colon)
+      let (unexpectedBeforeColon, colon) = self.eat(.colon)
       let identifier = self.consumeIdentifier()
       precedenceAndTypes = RawOperatorPrecedenceAndTypesSyntax(
+        unexpectedBeforeColon,
         colon: colon,
         precedenceGroupAndDesignatedTypes: RawIdentifierListSyntax(elements: [ identifier ], arena: self.arena),
         arena: self.arena)
@@ -1667,7 +1718,9 @@ extension Parser {
       precedenceAndTypes = nil
     }
     return RawOperatorDeclSyntax(
-      attributes: attrs.attributes, modifiers: attrs.modifiers,
+      attributes: attrs.attributes,
+      modifiers: attrs.modifiers,
+      unexpectedBeforeOperatorKeyword,
       operatorKeyword: operatorKeyword,
       identifier: identifier,
       operatorPrecedenceAndTypes: precedenceAndTypes,
@@ -1700,7 +1753,7 @@ extension Parser {
   ///     precedence-group-name → identifier
   @_spi(RawSyntax)
   public mutating func parsePrecedenceGroupDeclaration(_ attrs: DeclAttributes) -> RawPrecedenceGroupDeclSyntax {
-    let group = self.eat(.precedencegroupKeyword)
+    let (unexpectedBeforeGroup, group) = self.eat(.precedencegroupKeyword)
     let identifier = self.consumeIdentifier()
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
     var elements = [RawSyntax]()
@@ -1722,18 +1775,21 @@ extension Parser {
         case "assignment":
           let assignmentKeyword = self.consumeIdentifier()
           let (unexpectedBeforeColon, colon) = self.expect(.colon)
+          let unexpectedBeforeFlag: RawUnexpectedNodesSyntax?
           let flag: RawTokenSyntax
           if self.at(.trueKeyword) {
-            flag = self.eat(.trueKeyword)
+            (unexpectedBeforeFlag, flag) = self.eat(.trueKeyword)
           } else if self.at(.falseKeyword) {
-            flag = self.eat(.falseKeyword)
+            (unexpectedBeforeFlag, flag) = self.eat(.falseKeyword)
           } else {
+            unexpectedBeforeFlag = nil
             flag = RawTokenSyntax(missing: .trueKeyword, arena: self.arena)
           }
           elements.append(RawSyntax(RawPrecedenceGroupAssignmentSyntax(
             assignmentKeyword: assignmentKeyword,
             unexpectedBeforeColon,
             colon: colon,
+            unexpectedBeforeFlag,
             flag: flag,
             arena: self.arena
           )))
@@ -1767,6 +1823,7 @@ extension Parser {
     let (unexpectedBeforeRBrace, rbrace) = self.expect(.rightBrace)
     return RawPrecedenceGroupDeclSyntax(
       attributes: attrs.attributes, modifiers: attrs.modifiers,
+      unexpectedBeforeGroup,
       precedencegroupKeyword: group,
       identifier: identifier,
       unexpectedBeforeLBrace,
@@ -1780,8 +1837,8 @@ extension Parser {
 
 extension Parser {
   enum PoundDiagnosticKind {
-    case error(RawTokenSyntax)
-    case warning(RawTokenSyntax)
+    case error(unexpectedBeforePoundError: RawUnexpectedNodesSyntax?, poundError: RawTokenSyntax)
+    case warning(unexpectedBeforePoundWarning: RawUnexpectedNodesSyntax?, poundWarning: RawTokenSyntax)
   }
 
   @_spi(RawSyntax)
@@ -1790,9 +1847,11 @@ extension Parser {
 
     let directive: PoundDiagnosticKind
     if self.at(.poundErrorKeyword) {
-      directive = .error(self.eat(.poundErrorKeyword))
+      let (unexpected, token) = self.eat(.poundErrorKeyword)
+      directive = .error(unexpectedBeforePoundError: unexpected, poundError: token)
     } else {
-      directive = .error(self.eat(.poundWarningKeyword))
+      let (unexpected, token) = self.eat(.poundWarningKeyword)
+      directive = .warning(unexpectedBeforePoundWarning: unexpected, poundWarning: token)
     }
 
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
@@ -1812,8 +1871,9 @@ extension Parser {
     let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
 
     switch directive {
-    case .error(let tok):
+    case .error(let unexpectedBeforeTok, let tok):
       return RawDeclSyntax(RawPoundErrorDeclSyntax(
+        unexpectedBeforeTok,
         poundError: tok,
         unexpectedBeforeLeftParen,
         leftParen: leftParen,
@@ -1821,8 +1881,9 @@ extension Parser {
         unexpectedBeforeRightParen,
         rightParen: rightParen,
         arena: self.arena))
-    case .warning(let tok):
+    case .warning(let unexpectedBeforeTok, let tok):
       return RawDeclSyntax(RawPoundWarningDeclSyntax(
+        unexpectedBeforeTok,
         poundWarning: tok,
         unexpectedBeforeLeftParen,
         leftParen: leftParen,

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -739,7 +739,7 @@ extension Parser {
         let name = self.expectIdentifierWithoutRecovery()
 
         let associatedValue: RawParameterClauseSyntax?
-        if self.at(.leftParen) && !self.currentToken.isAtStartOfLine {
+        if self.at(.leftParen, where: { !$0.isAtStartOfLine }) {
           associatedValue = self.parseParameterClause()
         } else {
           associatedValue = nil

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1093,9 +1093,10 @@ extension Parser {
 
     // Parse the '!' or '?' for a failable initializer.
     let failable: RawTokenSyntax?
-    if self.at(any: [.exclamationMark, .postfixQuestionMark])
-        || (self.currentToken.isAnyOperator && self.currentToken.tokenText == "!") {
-      failable = self.consumeAnyToken()
+    if let parsedFailable = self.consume(ifAny: [.exclamationMark, .postfixQuestionMark]) {
+      failable = parsedFailable
+    } else if let parsedFailable = self.consumeIfContextualPunctuator("!") {
+      failable = parsedFailable
     } else {
       failable = nil
     }
@@ -1211,7 +1212,7 @@ extension Parser {
         }
 
         let ellipsis: RawTokenSyntax?
-        if self.currentToken.isEllipsis {
+        if self.atContextualPunctuator("...") {
           ellipsis = self.consumeAnyToken(remapping: .ellipsis)
         } else {
           ellipsis = nil

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -207,23 +207,7 @@ extension Parser {
 
   @_spi(RawSyntax)
   public mutating func parseImportKind() -> RawTokenSyntax? {
-    guard self.currentToken.tokenKind.isKeyword else {
-      return nil
-    }
-
-    switch self.currentToken.tokenKind {
-    case .typealiasKeyword,
-        .structKeyword,
-        .classKeyword,
-        .enumKeyword,
-        .protocolKeyword,
-        .varKeyword,
-        .letKeyword,
-        .funcKeyword:
-      return self.consumeAnyToken()
-    default:
-      return nil
-    }
+    return self.consume(ifAny: [.typealiasKeyword, .structKeyword, .classKeyword, .enumKeyword, .protocolKeyword, .varKeyword, .letKeyword, .funcKeyword])
   }
 
   @_spi(RawSyntax)
@@ -305,10 +289,9 @@ extension Parser {
         let colon = self.consume(if: .colon)
         let inherited: RawTypeSyntax?
         if colon != nil {
-          switch self.currentToken.tokenKind {
-          case .identifier, .protocolKeyword, .anyKeyword:
+          if self.at(any: [.identifier, .protocolKeyword, .anyKeyword]) {
             inherited = self.parseType()
-          default:
+          } else {
             inherited = nil
           }
         } else {
@@ -1935,7 +1918,7 @@ extension Parser {
     
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
     let stringLiteral: RawStringLiteralExprSyntax
-    if self.currentToken.tokenKind == .stringLiteral {
+    if self.at(.stringLiteral) {
       stringLiteral = self.parseStringLiteral()
     } else {
       stringLiteral = RawStringLiteralExprSyntax(

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1181,7 +1181,7 @@ extension Parser {
     let (unexpectedBeforeArrow, arrow) = self.expect(.arrow)
     var misplacedThrowsKeyword: RawTokenSyntax? = nil
     let unexpectedBeforeReturnType: RawUnexpectedNodesSyntax?
-    if let throwsKeyword = self.consume(ifAny: .rethrowsKeyword, .throwsKeyword) {
+    if let throwsKeyword = self.consume(ifAny: [.rethrowsKeyword, .throwsKeyword]) {
       misplacedThrowsKeyword = throwsKeyword
       unexpectedBeforeReturnType = RawUnexpectedNodesSyntax(elements: [RawSyntax(throwsKeyword)], arena: self.arena)
     } else {
@@ -1254,7 +1254,7 @@ extension Parser {
       async = nil
     }
 
-    var throwsKeyword = self.consume(ifAny: .throwsKeyword, .rethrowsKeyword)
+    var throwsKeyword = self.consume(ifAny: [.throwsKeyword, .rethrowsKeyword])
 
     let output: RawReturnClauseSyntax?
     if self.at(.arrow) {
@@ -1465,12 +1465,12 @@ extension Parser {
     }
 
     // 'throws'/'rethrows'
-    if let throwsRethrows = self.consume(ifAny: .throwsKeyword, .rethrowsKeyword) {
+    if let throwsRethrows = self.consume(ifAny: [.throwsKeyword, .rethrowsKeyword]) {
       return throwsRethrows
     }
 
     // diagnose 'throw'/'try'.
-    if let throwTry = self.consume(ifAny: .throwKeyword, .tryKeyword, where: { !$0.isAtStartOfLine }) {
+    if let throwTry = self.consume(ifAny: [.throwKeyword, .tryKeyword], where: { !$0.isAtStartOfLine }) {
       return throwTry
     }
 

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -49,7 +49,22 @@ extension Parser {
   ///     declarations → declaration declarations?
   @_spi(RawSyntax)
   public mutating func parseDeclaration() -> RawDeclSyntax {
-    if self.at(.poundIfKeyword) {
+    enum PoundIfTokenKind: RawTokenKindSubset {
+      case poundIfKeyword
+      case poundWarningKeyword
+      case poundErrorKeyword
+
+      var rawTokenKind: RawTokenKind {
+        switch self {
+        case .poundIfKeyword: return .poundIfKeyword
+        case .poundWarningKeyword: return .poundWarningKeyword
+        case .poundErrorKeyword: return .poundErrorKeyword
+        }
+      }
+    }
+
+    switch self.at(anyIn: PoundIfTokenKind.self) {
+    case (.poundIfKeyword, _)?:
       return RawDeclSyntax(self.parsePoundIfDirective { parser in
         let parsedDecl = parser.parseDeclaration()
         let semicolon = parser.consume(if: .semicolon)
@@ -58,52 +73,106 @@ extension Parser {
           semicolon: semicolon,
           arena: parser.arena)
       }
-      syntax: { parser, elements in
+                           syntax: { parser, elements in
         return RawSyntax(RawMemberDeclListSyntax(elements: elements, arena: parser.arena))
       })
-    } else if self.at(any: [.poundWarningKeyword, .poundErrorKeyword]) {
+    case (.poundWarningKeyword, _)?, (.poundErrorKeyword, _)?:
       return self.parsePoundDiagnosticDeclaration()
+    case nil:
+      break
+    }
+
+    enum DeclStartTokenKind: RawTokenKindSubset {
+      case importKeyword
+      case classKeyword
+      case enumKeyword
+      case caseKeyword
+      case structKeyword
+      case protocolKeyword
+      case associatedtypeKeyword
+      case typealiasKeyword
+      case extensionKeyword
+      case funcKeyword
+      case subscriptKeyword
+      case letKeyword
+      case varKeyword
+      case initKeyword
+      case deinitKeyword
+      case operatorKeyword
+      case precedencegroupKeyword
+      case actor
+
+      var contextualKeyword: SyntaxText? {
+        switch self {
+        case .actor: return "actor"
+        default: return nil
+        }
+      }
+
+      var rawTokenKind: RawTokenKind {
+        switch self {
+        case .importKeyword: return .importKeyword
+        case .classKeyword: return .classKeyword
+        case .enumKeyword: return .enumKeyword
+        case .caseKeyword: return .caseKeyword
+        case .structKeyword: return .structKeyword
+        case .protocolKeyword: return .protocolKeyword
+        case .associatedtypeKeyword: return .associatedtypeKeyword
+        case .typealiasKeyword: return .typealiasKeyword
+        case .extensionKeyword: return .extensionKeyword
+        case .funcKeyword: return .funcKeyword
+        case .subscriptKeyword: return .subscriptKeyword
+        case .letKeyword: return .letKeyword
+        case .varKeyword: return .varKeyword
+        case .initKeyword: return .initKeyword
+        case .deinitKeyword: return .deinitKeyword
+        case .operatorKeyword: return .operatorKeyword
+        case .precedencegroupKeyword: return .precedencegroupKeyword
+        case .actor: return .identifier
+        }
+      }
     }
 
     let attrs = DeclAttributes(
       attributes: self.parseAttributeList(),
       modifiers: self.parseModifierList())
-    switch self.currentToken.tokenKind {
-    case .importKeyword:
+    switch self.at(anyIn: DeclStartTokenKind.self) {
+    case (.importKeyword, _)?:
       return RawDeclSyntax(self.parseImportDeclaration(attrs))
-    case .classKeyword:
+    case (.classKeyword, _)?:
       return RawDeclSyntax(self.parseClassDeclaration(attrs))
-    case .enumKeyword:
+    case (.enumKeyword, _)?:
       return RawDeclSyntax(self.parseEnumDeclaration(attrs))
-    case .caseKeyword:
+    case (.caseKeyword, _)?:
       return RawDeclSyntax(self.parseDeclEnumCase(attrs))
-    case .structKeyword:
+    case (.structKeyword, _)?:
       return RawDeclSyntax(self.parseStructDeclaration(attrs))
-    case .protocolKeyword:
+    case (.protocolKeyword, _)?:
       return RawDeclSyntax(self.parseProtocolDeclaration(attrs))
-    case .associatedtypeKeyword:
+    case (.associatedtypeKeyword, _)?:
       return RawDeclSyntax(self.parseAssociatedTypeDeclaration(attrs))
-    case .typealiasKeyword:
+    case (.typealiasKeyword, _)?:
       return RawDeclSyntax(self.parseTypealiasDeclaration(attrs))
-    case .extensionKeyword:
+    case (.extensionKeyword, _)?:
       return RawDeclSyntax(self.parseExtensionDeclaration(attrs))
-    case .funcKeyword:
+    case (.funcKeyword, _)?:
       return RawDeclSyntax(self.parseFuncDeclaration(attrs))
-    case .subscriptKeyword:
+    case (.subscriptKeyword, _)?:
       return RawDeclSyntax(self.parseSubscriptDeclaration(attrs))
-    case .letKeyword, .varKeyword:
+    case (.letKeyword, _)?,
+      (.varKeyword, _)?:
       return RawDeclSyntax(self.parseLetOrVarDeclaration(attrs))
-    case .initKeyword:
+    case (.initKeyword, _)?:
       return RawDeclSyntax(self.parseInitializerDeclaration(attrs))
-    case .deinitKeyword:
+    case (.deinitKeyword, _)?:
       return RawDeclSyntax(self.parseDeinitializerDeclaration(attrs))
-    case .operatorKeyword:
+    case (.operatorKeyword, _)?:
       return RawDeclSyntax(self.parseOperatorDeclaration(attrs))
-    case .precedencegroupKeyword:
+    case (.precedencegroupKeyword, _)?:
       return RawDeclSyntax(self.parsePrecedenceGroupDeclaration(attrs))
-    case _ where self.currentToken.isContextualKeyword("actor"):
+    case (.actor, _)?:
       return RawDeclSyntax(self.parseActorDeclaration(attrs))
-    default:
+    case nil:
       return RawDeclSyntax(RawMissingDeclSyntax(
         attributes: attrs.attributes,
         modifiers: attrs.modifiers,
@@ -321,8 +390,35 @@ extension Parser {
           continue
         }
 
+        enum ExpectedTokenKind: RawTokenKindSubset {
+          case colon
+          case spacedBinaryOperator
+          case unspacedBinaryOperator
+          case postfixOperator
+          case prefixOperator
+
+          func accepts(lexeme: Lexer.Lexeme) -> Bool {
+            switch self {
+            case .colon: return true
+            default: return lexeme.tokenText == "=="
+            }
+          }
+
+          var rawTokenKind: RawTokenKind {
+            switch self {
+            case .colon: return .colon
+            case .spacedBinaryOperator: return .spacedBinaryOperator
+            case .unspacedBinaryOperator: return .unspacedBinaryOperator
+            case .postfixOperator: return .postfixOperator
+            case .prefixOperator: return .prefixOperator
+            }
+          }
+        }
+
         let requirement: RawSyntax
-        if let colon = self.consume(if: .colon) {
+        switch self.at(anyIn: ExpectedTokenKind.self) {
+        case (.colon, let handle)?:
+          let colon = self.eat(handle)
           // A conformance-requirement.
           if self.currentToken.isIdentifier, let layoutConstraint = LayoutConstraint(rawValue: self.currentToken.tokenText) {
             // Parse a layout constraint.
@@ -378,7 +474,10 @@ extension Parser {
               rightTypeIdentifier: secondType,
               arena: self.arena))
           }
-        } else if (self.currentToken.isAnyOperator && self.currentToken.tokenText == "==") || self.at(.equal) {
+        case (.spacedBinaryOperator, _)?,
+          (.unspacedBinaryOperator, _)?,
+          (.postfixOperator, _)?,
+          (.prefixOperator, _)?:
           let equal = self.consumeAnyToken()
           let secondType = self.parseType()
           requirement = RawSyntax(RawSameTypeRequirementSyntax(
@@ -386,7 +485,7 @@ extension Parser {
             equalityToken: equal,
             rightTypeIdentifier: secondType,
             arena: self.arena))
-        } else {
+        case nil:
           requirement = RawSyntax(RawSameTypeRequirementSyntax(
             leftTypeIdentifier: firstType,
             equalityToken: RawTokenSyntax(missing: .equal, arena: self.arena),
@@ -1804,18 +1903,30 @@ extension Parser {
 
   @_spi(RawSyntax)
   public mutating func parsePoundDiagnosticDeclaration() -> RawDeclSyntax {
-    assert(self.at(any: [.poundErrorKeyword, .poundWarningKeyword]))
+    enum ExpectedTokenKind: RawTokenKindSubset {
+      case poundErrorKeyword
+      case poundWarningKeyword
 
-    let directive: PoundDiagnosticKind
-    if let poundError = self.consume(if: .poundErrorKeyword) {
-      directive = .error(poundError: poundError)
-    } else if let poundWarning = self.consume(if: .poundWarningKeyword) {
-      directive = .warning(poundWarning: poundWarning)
-    } else {
-      assert(false, "Should not happen based on assertion at start of function")
-      directive = .error(poundError: RawTokenSyntax(missing: .poundErrorKeyword, arena: self.arena))
+      var rawTokenKind: RawTokenKind {
+        switch self {
+        case .poundErrorKeyword: return .poundErrorKeyword
+        case .poundWarningKeyword: return .poundWarningKeyword
+        }
+      }
     }
 
+
+    let directive: PoundDiagnosticKind
+
+    switch self.at(anyIn: ExpectedTokenKind.self) {
+    case (.poundErrorKeyword, let handle)?:
+      directive = .error(poundError: self.eat(handle))
+    case (.poundWarningKeyword, let handle)?:
+      directive = .warning(poundWarning: self.eat(handle))
+    case nil:
+      directive = .error(poundError: RawTokenSyntax(missing: .poundErrorKeyword, arena: self.arena))
+    }
+    
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
     let stringLiteral: RawStringLiteralExprSyntax
     if self.currentToken.tokenKind == .stringLiteral {

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -339,10 +339,10 @@ extension Parser {
             // is optional.
             if layoutConstraint.hasArguments && (layoutConstraint != .trivialLayout || self.at(.leftParen)) {
               (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
-              size = self.consumeInteger()
+              size = self.expectWithoutRecovery(.integerLiteral)
               comma = self.consume(if: .comma)
               if comma != nil {
-                alignment = self.consumeInteger()
+                alignment = self.expectWithoutRecovery(.integerLiteral)
               } else {
                 alignment = nil
               }

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -68,7 +68,7 @@ extension Parser {
   ) -> RawIfConfigDeclSyntax {
     var clauses = [RawIfConfigClauseSyntax]()
     do {
-      var (unexpectedBeforePoundIf, poundIf) = self.eat(.poundIfKeyword)
+      var (unexpectedBeforePoundIf, poundIf) = self.expect(.poundIfKeyword)
       var loopProgress = LoopProgressCondition()
       repeat {
         // Parse the condition.
@@ -128,7 +128,7 @@ extension Parser {
   ///     literal-expression → '#line'
   @_spi(RawSyntax)
   public mutating func parsePoundLineDirective() -> RawPoundLineExprSyntax {
-    let (unexpectedBeforeToken, token) = self.eat(.poundLineKeyword)
+    let (unexpectedBeforeToken, token) = self.expect(.poundLineKeyword)
     return RawPoundLineExprSyntax(
       unexpectedBeforeToken,
       poundLine: token,

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -89,10 +89,7 @@ extension Parser {
         var elements = [Element]()
         do {
           var elementsProgress = LoopProgressCondition()
-          while !self.at(.eof)
-                  && !self.at(.poundElseKeyword)
-                  && !self.at(.poundElseifKeyword)
-                  && !self.at(.poundEndifKeyword)
+          while !self.at(any: [.eof, .poundElseKeyword, .poundElseifKeyword, .poundEndifKeyword])
                   && elementsProgress.evaluate(currentToken) {
             guard let element = parseElement(&self) else {
               break
@@ -107,7 +104,7 @@ extension Parser {
           condition: condition,
           elements: syntax(&self, elements),
           arena: self.arena))
-      } while (self.at(.poundElseifKeyword) || self.at(.poundElseKeyword)) && loopProgress.evaluate(currentToken)
+      } while self.at(any: [.poundElseifKeyword, .poundElseKeyword]) && loopProgress.evaluate(currentToken)
     }
 
     let (unexpectedBeforePoundEndIf, poundEndIf) = self.expect(.poundEndifKeyword)

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -155,7 +155,7 @@ extension Parser {
 
       let line = self.expectIdentifierWithoutRecovery()
       let (unexpectedBeforeLineColon, lineColon) = self.expect(.colon)
-      let lineNumber = self.consumeInteger()
+      let lineNumber = self.expectWithoutRecovery(.integerLiteral)
 
       args = RawPoundSourceLocationArgsSyntax(
         fileArgLabel: file,

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -148,12 +148,12 @@ extension Parser {
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
     let args: RawPoundSourceLocationArgsSyntax?
     if !self.at(.rightParen) {
-      let file = self.consumeIdentifier()
+      let file = self.expectIdentifierWithoutRecovery()
       let (unexpectedBeforeFileColon, fileColon) = self.expect(.colon)
       let (unexpectedBeforeFileName, fileName) = self.expect(.stringLiteral)
       let (unexpectedBeforeComma, comma) = self.expect(.comma)
 
-      let line = self.consumeIdentifier()
+      let line = self.expectIdentifierWithoutRecovery()
       let (unexpectedBeforeLineColon, lineColon) = self.expect(.colon)
       let lineNumber = self.consumeInteger()
 

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -147,22 +147,56 @@ extension Parser {
   mutating func parseSequenceExpressionOperator(
     _ flavor: ExprFlavor, inVarOrLet: Bool
   ) -> (operator: RawExprSyntax, rhs: RawExprSyntax?)? {
-    switch self.currentToken.tokenKind {
-    case .spacedBinaryOperator, .unspacedBinaryOperator:
+    enum ExpectedTokenKind: RawTokenKindSubset {
+      case spacedBinaryOperator
+      case unspacedBinaryOperator
+      case infixQuestionMark
+      case equal
+      case isKeyword
+      case asKeyword
+      case identifier
+      case arrow
+      case throwsKeyword
+
+      var rawTokenKind: RawTokenKind {
+        switch self {
+        case .spacedBinaryOperator: return .spacedBinaryOperator
+        case .unspacedBinaryOperator: return .unspacedBinaryOperator
+        case .infixQuestionMark: return .infixQuestionMark
+        case .equal: return .equal
+        case .isKeyword: return .isKeyword
+        case .asKeyword: return .asKeyword
+        case .identifier: return .identifier
+        case .arrow: return .arrow
+        case .throwsKeyword: return .throwsKeyword
+        }
+      }
+
+      func accepts(lexeme: Lexer.Lexeme, parser: Parser) -> Bool {
+        switch self {
+        case .identifier:
+          return lexeme.isContextualKeyword("async") && (parser.peek().tokenKind == .arrow || parser.peek().tokenKind == .throwsKeyword)
+        default:
+          return true
+        }
+      }
+    }
+
+    switch self.at(anyIn: ExpectedTokenKind.self) {
+    case (.spacedBinaryOperator, let handle)?, (.unspacedBinaryOperator, let handle)?:
       // Parse the operator.
-      let operatorToken = self.consumeAnyToken()
+      let operatorToken = self.eat(handle)
       let op = RawBinaryOperatorExprSyntax(operatorToken: operatorToken, arena: arena)
       return (RawExprSyntax(op), nil)
 
-    case .infixQuestionMark:
+    case (.infixQuestionMark, let handle)?:
       // Save the '?'.
-      let (unexpectedBeforeQuestion, question) = self.eat(.infixQuestionMark)
+      let question = self.eat(handle)
       let firstChoice = self.parseSequenceExpression(flavor, inVarOrLet: inVarOrLet)
       // Make sure there's a matching ':' after the middle expr.
       let (unexpectedBeforeColon, colon) = self.expect(.colon)
 
       let op = RawUnresolvedTernaryExprSyntax(
-        unexpectedBeforeQuestion,
         questionMark: question,
         firstChoice: firstChoice,
         unexpectedBeforeColon,
@@ -180,19 +214,21 @@ extension Parser {
       }
       return (RawExprSyntax(op), rhs)
 
-    case .equal where !inVarOrLet:
-      let (unexpectedBeforeEq, eq) = self.eat(.equal)
-      let op = RawAssignmentExprSyntax(
-        unexpectedBeforeEq,
-        assignToken: eq,
-        arena: self.arena
-      )
-      return (RawExprSyntax(op), nil)
-
-    case .isKeyword:
-      let (unexpectedBeforeIsKeyword, isKeyword) = self.eat(.isKeyword)
+    case (.equal, let handle)?:
+      if inVarOrLet {
+        return nil
+      } else {
+        let eq = self.eat(handle)
+        let op = RawAssignmentExprSyntax(
+          assignToken: eq,
+          arena: self.arena
+        )
+        return (RawExprSyntax(op), nil)
+      }
+      
+    case (.isKeyword, let handle)?:
+      let isKeyword = self.eat(handle)
       let op = RawUnresolvedIsExprSyntax(
-        unexpectedBeforeIsKeyword,
         isTok: isKeyword,
         arena: self.arena
       )
@@ -203,8 +239,8 @@ extension Parser {
 
       return (RawExprSyntax(op), RawExprSyntax(rhs))
 
-    case .asKeyword:
-      let (unexpectedBeforeAsKeyword, asKeyword) = self.eat(.asKeyword)
+    case (.asKeyword, let handle)?:
+      let asKeyword = self.eat(handle)
       let failable: RawTokenSyntax?
       if self.at(.postfixQuestionMark) || self.at(.exclamationMark) {
         failable = self.consumeAnyToken()
@@ -212,7 +248,6 @@ extension Parser {
         failable = nil
       }
       let op = RawUnresolvedAsExprSyntax(
-        unexpectedBeforeAsKeyword,
         asTok: asKeyword,
         questionOrExclamationMark: failable,
         arena: self.arena
@@ -224,14 +259,7 @@ extension Parser {
 
       return (RawExprSyntax(op), RawExprSyntax(rhs))
 
-    case .identifier:
-      guard
-        self.currentToken.isContextualKeyword("async"),
-        (self.peek().tokenKind == .arrow || self.peek().tokenKind == .throwsKeyword) else {
-        return nil
-      }
-      fallthrough
-    case .arrow, .throwsKeyword:
+    case (.identifier, _)?, (.arrow, _)?, (.throwsKeyword, _)?:
       let asyncKeyword: RawTokenSyntax?
       if self.currentToken.isContextualKeyword("async") {
         asyncKeyword = self.consume(remapping: .contextualKeyword)
@@ -251,7 +279,7 @@ extension Parser {
 
       return (RawExprSyntax(op), nil)
 
-    default:
+    case nil:
       // Not an operator.
       return nil
     }
@@ -289,13 +317,12 @@ extension Parser {
       }
     }
 
-    guard self.at(.tryKeyword) else {
+    guard let tryKeyword = self.consume(if: .tryKeyword) else {
       return self.parseUnaryExpression(flavor,
                                        forDirective: forDirective,
                                        inVarOrLet: inVarOrLet)
     }
 
-    let (unexpectedBeforeTryKeyword, tryKeyword) = self.eat(.tryKeyword)
     let mark: RawTokenSyntax?
     if self.at(.exclamationMark) || self.at(.postfixQuestionMark) {
       mark = self.consumeAnyToken()
@@ -306,7 +333,6 @@ extension Parser {
     let expression = self.parseSequenceExpressionElement(flavor,
                                                          inVarOrLet: inVarOrLet)
     return RawExprSyntax(RawTryExprSyntax(
-      unexpectedBeforeTryKeyword,
       tryKeyword: tryKeyword,
       questionOrExclamationMark: mark,
       expression: expression,
@@ -328,27 +354,39 @@ extension Parser {
     forDirective: Bool = false,
     inVarOrLet: Bool = false
   ) -> RawExprSyntax {
+    enum ExpectedTokenKind: RawTokenKindSubset {
+      case prefixAmpersand
+      case backslash
+      case prefixOperator
+
+      var rawTokenKind: RawTokenKind {
+        switch self {
+        case .prefixAmpersand: return .prefixAmpersand
+        case .backslash: return .backslash
+        case .prefixOperator: return .prefixOperator
+        }
+      }
+    }
+
     // First check to see if we have the start of a regex literal `/.../`.
     //    tryLexRegexLiteral(/*forUnappliedOperator*/ false)
-    switch self.currentToken.tokenKind {
-    case .prefixAmpersand:
-      let (unexpectedBeforeAmp, amp) = self.eat(.prefixAmpersand)
+    switch self.at(anyIn: ExpectedTokenKind.self) {
+    case (.prefixAmpersand, let handle)?:
+      let amp = self.eat(handle)
       let expr = self.parseUnaryExpression(flavor, forDirective: forDirective, inVarOrLet: inVarOrLet)
       return RawExprSyntax(RawInOutExprSyntax(
-        unexpectedBeforeAmp,
         ampersand: amp,
         expression: RawExprSyntax(expr),
         arena: self.arena
       ))
 
-    case .backslash:
+    case (.backslash, _)?:
       return RawExprSyntax(self.parseKeyPathExpression(forDirective: forDirective, inVarOrLet: inVarOrLet))
 
-    case .prefixOperator:
-      let (unexpectedBeforeOp, op) = self.eat(.prefixOperator)
+    case (.prefixOperator, let handle)?:
+      let op = self.eat(handle)
       let postfix = self.parseUnaryExpression(flavor, forDirective: forDirective, inVarOrLet: inVarOrLet)
       return RawExprSyntax(RawPrefixOperatorExprSyntax(
-        unexpectedBeforeOp,
         operatorToken: op,
         postfixExpression: postfix,
         arena: self.arena
@@ -408,12 +446,10 @@ extension Parser {
     }
 
     // Handle "x.self" expr.
-    if self.at(.selfKeyword) {
-      let (unexpectedBeforeSelfKeyword, selfKeyword) = self.eat(.selfKeyword)
+    if let selfKeyword = self.consume(if: .selfKeyword) {
       return RawExprSyntax(RawMemberAccessExprSyntax(
         base: start,
         dot: period,
-        unexpectedBeforeSelfKeyword,
         name: selfKeyword,
         declNameArguments: nil,
         arena: self.arena
@@ -506,9 +542,7 @@ extension Parser {
       }
 
       // If there is an expr-call-suffix, parse it and form a call.
-      if self.at(.leftParen) && !self.currentToken.isAtStartOfLine {
-        // Parse the argument list.
-        let (unexpectedBeforeLParen, lparen) = self.eat(.leftParen)
+      if let lparen = self.consume(if: .leftParen, where: { (lexeme, parser) in !lexeme.isAtStartOfLine }) {
         let args = self.parseArgumentListElements()
         let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
 
@@ -524,7 +558,6 @@ extension Parser {
 
         leadingExpr = RawExprSyntax(RawFunctionCallExprSyntax(
           calledExpression: leadingExpr,
-          unexpectedBeforeLParen,
           leftParen: lparen,
           argumentList: RawTupleExprElementListSyntax(elements: args, arena: self.arena),
           unexpectedBeforeRParen,
@@ -537,8 +570,7 @@ extension Parser {
 
       // Check for a [expr] suffix.
       // Note that this cannot be the start of a new line.
-      if self.at(.leftSquareBracket) && !self.currentToken.isAtStartOfLine {
-        let (unexpectedBeforeLSquare, lsquare) = self.eat(.leftSquareBracket)
+      if let lsquare = self.consume(if: .leftSquareBracket, where: { (lexeme, _) in !lexeme.isAtStartOfLine }) {
         let args = self.parseArgumentListElements()
         let (unexpectedBeforeRSquare, rsquare) = self.expect(.rightSquareBracket)
 
@@ -554,7 +586,6 @@ extension Parser {
 
         leadingExpr = RawExprSyntax(RawSubscriptExprSyntax(
           calledExpression: leadingExpr,
-          unexpectedBeforeLSquare,
           leftBracket: lsquare,
           argumentList: RawTupleExprElementListSyntax(elements: args, arena: self.arena),
           unexpectedBeforeRSquare,
@@ -606,16 +637,14 @@ extension Parser {
       }
 
       // Check for a postfix-operator suffix.
-      if self.currentToken.tokenKind  == .postfixOperator {
+      if let op = self.consume(if: .postfixOperator) {
         // KeyPaths are more restricted in what can go after a ., and so we treat
         // them specially.
         //        if (periodHasKeyPathBehavior && startsWithSymbol(Tok, '.'))
         //          break
 
-        let (unexpectedBeforeOp, op) = self.eat(.postfixOperator)
         leadingExpr = RawExprSyntax(RawPostfixUnaryExprSyntax(
           expression: leadingExpr,
-          unexpectedBeforeOp,
           operatorToken: op,
           arena: self.arena
         ))
@@ -635,7 +664,7 @@ extension Parser {
           //       .someMember
           var loopProgress = LoopProgressCondition()
           repeat {
-            backtrack.eatWithoutRecovery(.poundIfKeyword)
+            backtrack.eat(.poundIfKeyword)
             while !backtrack.at(.eof) && !backtrack.currentToken.isAtStartOfLine {
               backtrack.skipSingle()
             }
@@ -674,7 +703,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseKeyPathExpression(forDirective: Bool, inVarOrLet: Bool) -> RawKeyPathExprSyntax {
     // Consume '\'.
-    let (unexpectedBeforeBackslash, backslash) = self.eat(.backslash)
+    let (unexpectedBeforeBackslash, backslash) = self.expect(.backslash)
 
     // For uniformity, \.foo is parsed as if it were MAGIC.foo, so we need to
     // make sure the . is there, but parsing the ? in \.? as .? doesn't make
@@ -732,124 +761,189 @@ extension Parser {
   ///     primary-expression → key-path-string-expression
   @_spi(RawSyntax)
   public mutating func parsePrimaryExpression(inVarOrLet: Bool) -> RawExprSyntax {
-    switch self.currentToken.tokenKind {
-    case .integerLiteral:
-      let (unexpectedBeforeDigits, digits) = self.eat(.integerLiteral)
+    enum ExpectedTokenKind: RawTokenKindSubset {
+      case integerLiteral
+      case floatingLiteral
+      case stringLiteral
+      case regexLiteral
+      case nilKeyword
+      case trueKeyword
+      case falseKeyword
+      case __file__Keyword
+      case poundFileIDKeyword
+      case poundFileKeyword
+      case poundFilePathKeyword
+      case poundFunctionKeyword
+      case __function__Keyword
+      case poundLineKeyword
+      case __line__Keyword
+      case poundColumnKeyword
+      case __column__Keyword
+      case poundDsohandleKeyword
+      case __dso_handle__Keyword
+      case identifier
+      case selfKeyword
+      case capitalSelfKeyword
+      case anyKeyword
+      case dollarIdentifier
+      case wildcardKeyword
+      case poundSelectorKeyword
+      case poundKeyPathKeyword
+      case poundColorLiteralKeyword
+      case poundImageLiteralKeyword
+      case poundFileLiteralKeyword
+      case leftBrace
+      case period
+      case prefixPeriod
+      case superKeyword
+      case leftParen
+      case leftSquareBracket
+
+      var rawTokenKind: SwiftSyntax.RawTokenKind {
+        switch self {
+        case .integerLiteral: return .integerLiteral
+        case .floatingLiteral: return .floatingLiteral
+        case .stringLiteral: return .stringLiteral
+        case .regexLiteral: return .regexLiteral
+        case .nilKeyword: return .nilKeyword
+        case .trueKeyword: return .trueKeyword
+        case .falseKeyword: return .falseKeyword
+        case .__file__Keyword: return .__file__Keyword
+        case .poundFileIDKeyword: return .poundFileIDKeyword
+        case .poundFileKeyword: return .poundFileKeyword
+        case .poundFilePathKeyword: return .poundFilePathKeyword
+        case .poundFunctionKeyword: return .poundFunctionKeyword
+        case .__function__Keyword: return .__function__Keyword
+        case .poundLineKeyword: return .poundLineKeyword
+        case .__line__Keyword: return .__line__Keyword
+        case .poundColumnKeyword: return .poundColumnKeyword
+        case .__column__Keyword: return .__column__Keyword
+        case .poundDsohandleKeyword: return .poundDsohandleKeyword
+        case .__dso_handle__Keyword: return .__dso_handle__Keyword
+        case .identifier: return .identifier
+        case .selfKeyword: return .selfKeyword
+        case .capitalSelfKeyword: return .capitalSelfKeyword
+        case .anyKeyword: return .anyKeyword
+        case .dollarIdentifier: return .dollarIdentifier
+        case .wildcardKeyword: return .wildcardKeyword
+        case .poundSelectorKeyword: return .poundSelectorKeyword
+        case .poundKeyPathKeyword: return .poundKeyPathKeyword
+        case .poundColorLiteralKeyword: return .poundColorLiteralKeyword
+        case .poundImageLiteralKeyword: return .poundImageLiteralKeyword
+        case .poundFileLiteralKeyword: return .poundFileLiteralKeyword
+        case .leftBrace: return .leftBrace
+        case .period: return .period
+        case .prefixPeriod: return .prefixPeriod
+        case .superKeyword: return .superKeyword
+        case .leftParen: return .leftParen
+        case .leftSquareBracket: return .leftSquareBracket
+        }
+      }
+    }
+
+    switch self.at(anyIn: ExpectedTokenKind.self) {
+    case (.integerLiteral, let handle)?:
+      let digits = self.eat(handle)
       return RawExprSyntax(RawIntegerLiteralExprSyntax(
-        unexpectedBeforeDigits,
         digits: digits,
         arena: self.arena
       ))
-    case .floatingLiteral:
-      let (unexpectedBeforeDigits, digits) = self.eat(.floatingLiteral)
+    case (.floatingLiteral, let handle)?:
+      let digits = self.eat(handle)
       return RawExprSyntax(RawFloatLiteralExprSyntax(
-        unexpectedBeforeDigits,
         floatingDigits: digits,
         arena: self.arena
       ))
-    case .stringLiteral:
+    case (.stringLiteral, _)?:
       return RawExprSyntax(self.parseStringLiteral())
-    case .regexLiteral:
+    case (.regexLiteral, _)?:
       return RawExprSyntax(self.parseRegexLiteral())
-    case .nilKeyword:
-      let (unexpectedBeforeNilKeyword, nilKeyword) = self.eat(.nilKeyword)
+    case (.nilKeyword, let handle)?:
+      let nilKeyword = self.eat(handle)
       return RawExprSyntax(RawNilLiteralExprSyntax(
-        unexpectedBeforeNilKeyword,
         nilKeyword: nilKeyword,
         arena: self.arena
       ))
-    case .trueKeyword, .falseKeyword:
-      let (unexpectedBeforeTok, tok) = self.eat(self.currentToken.tokenKind)
+    case (.trueKeyword, let handle)?,
+      (.falseKeyword, let handle)?:
+      let tok = self.eat(handle)
       return RawExprSyntax(RawBooleanLiteralExprSyntax(
-        unexpectedBeforeTok,
         booleanLiteral: tok,
         arena: self.arena
       ))
-    case .__file__Keyword:
-      let (unexpectedBeforeTok, tok) = self.eat(.__file__Keyword)
+    case (.__file__Keyword, let handle)?:
+      let tok = self.eat(handle)
       return RawExprSyntax(RawPoundFileExprSyntax(
-        unexpectedBeforeTok,
         poundFile: tok,
         arena: self.arena
       ))
-    case .poundFileIDKeyword:
-      let (unexpectedBeforeTok, tok) = self.eat(.poundFileIDKeyword)
+    case (.poundFileIDKeyword, let handle)?:
+      let tok = self.eat(handle)
       return RawExprSyntax(RawPoundFileIDExprSyntax(
-        unexpectedBeforeTok,
         poundFileID: tok,
         arena: self.arena
       ))
-    case .poundFileKeyword:
-      let (unexpectedBeforeTok, tok) = self.eat(.poundFileKeyword)
+    case (.poundFileKeyword, let handle)?:
+      let tok = self.eat(handle)
       return RawExprSyntax(RawPoundFileExprSyntax(
-        unexpectedBeforeTok,
         poundFile: tok,
         arena: self.arena
       ))
-    case .poundFilePathKeyword:
-      let (unexpectedBeforeTok, tok) = self.eat(.poundFilePathKeyword)
+    case (.poundFilePathKeyword, let handle)?:
+      let tok = self.eat(handle)
       return RawExprSyntax(RawPoundFilePathExprSyntax(
-        unexpectedBeforeTok,
         poundFilePath: tok,
         arena: self.arena
       ))
-    case .poundFunctionKeyword:
-      let (unexpectedBeforeTok, tok) = self.eat(.poundFunctionKeyword)
+    case (.poundFunctionKeyword, let handle)?:
+      let tok = self.eat(handle)
       return RawExprSyntax(RawPoundFunctionExprSyntax(
-        unexpectedBeforeTok,
         poundFunction: tok,
         arena: self.arena
       ))
-    case .__function__Keyword:
-      let (unexpectedBeforeTok, tok) = self.eat(.__function__Keyword)
+    case (.__function__Keyword, let handle)?:
+      let tok = self.eat(handle)
       return RawExprSyntax(RawPoundFunctionExprSyntax(
-        unexpectedBeforeTok,
         poundFunction: tok,
         arena: self.arena
       ))
-    case .poundLineKeyword:
-      let (unexpectedBeforeTok, tok) = self.eat(.poundLineKeyword)
+    case (.poundLineKeyword, let handle)?:
+      let tok = self.eat(handle)
       return RawExprSyntax(RawPoundLineExprSyntax(
-        unexpectedBeforeTok,
         poundLine: tok,
         arena: self.arena
       ))
-    case .__line__Keyword:
-      let (unexpectedBeforeTok, tok) = self.eat(.__line__Keyword)
+    case (.__line__Keyword, let handle)?:
+      let tok = self.eat(handle)
       return RawExprSyntax(RawPoundLineExprSyntax(
-        unexpectedBeforeTok,
         poundLine: tok,
         arena: self.arena
       ))
-    case .poundColumnKeyword:
-      let (unexpectedBeforeTok, tok) = self.eat(.poundColumnKeyword)
+    case (.poundColumnKeyword, let handle)?:
+      let tok = self.eat(handle)
       return RawExprSyntax(RawPoundColumnExprSyntax(
-        unexpectedBeforeTok,
         poundColumn: tok,
         arena: self.arena
       ))
-    case .__column__Keyword:
-      let (unexpectedBeforeTok, tok) = self.eat(.__column__Keyword)
+    case (.__column__Keyword, let handle)?:
+      let tok = self.eat(handle)
       return RawExprSyntax(RawPoundColumnExprSyntax(
-        unexpectedBeforeTok,
         poundColumn: tok,
         arena: self.arena
       ))
-    case .poundDsohandleKeyword:
-      let (unexpectedBeforeTok, tok) = self.eat(.poundDsohandleKeyword)
+    case (.poundDsohandleKeyword, let handle)?:
+      let tok = self.eat(handle)
       return RawExprSyntax(RawPoundDsohandleExprSyntax(
-        unexpectedBeforeTok,
         poundDsohandle: tok,
         arena: self.arena
       ))
-    case .__dso_handle__Keyword:
-      let (unexpectedBeforeTok, tok) = self.eat(.__dso_handle__Keyword)
+    case (.__dso_handle__Keyword, let handle)?:
+      let tok = self.eat(handle)
       return RawExprSyntax(RawPoundDsohandleExprSyntax(
-        unexpectedBeforeTok,
         poundDsohandle: tok,
         arena: self.arena
       ))
-    case .identifier, .selfKeyword:
+    case (.identifier, _)?, (.selfKeyword, _)?:
       // If we have "case let x." or "case let x(", we parse x as a normal
       // name, not a binding, because it is the start of an enum pattern or
       // call pattern.
@@ -870,43 +964,42 @@ extension Parser {
       }
 
       return RawExprSyntax(self.parseIdentifierExpression())
-    case .capitalSelfKeyword:     // Self
+    case (.capitalSelfKeyword, _)?:     // Self
       return RawExprSyntax(self.parseIdentifierExpression())
-    case .anyKeyword: // Any
+    case (.anyKeyword, _)?: // Any
       let anyType = RawTypeSyntax(self.parseAnyType())
       return RawExprSyntax(RawTypeExprSyntax(type: anyType, arena: self.arena))
-    case .dollarIdentifier:
+    case (.dollarIdentifier, _)?:
       return RawExprSyntax(self.parseAnonymousClosureArgument())
-    case .wildcardKeyword: // _
-      let (unexpectedBeforeWild, wild) = self.eat(.wildcardKeyword)
+    case (.wildcardKeyword, let handle)?: // _
+      let wild = self.eat(handle)
       return RawExprSyntax(RawDiscardAssignmentExprSyntax(
-        unexpectedBeforeWild,
         wildcard: wild,
         arena: self.arena
       ))
-    case .poundSelectorKeyword:
+    case (.poundSelectorKeyword, _)?:
       return RawExprSyntax(self.parseObjectiveCSelectorLiteral())
-    case .poundKeyPathKeyword:
+    case (.poundKeyPathKeyword, _)?:
       return RawExprSyntax(self.parseObjectiveCKeyPathExpression())
 
-    case .poundColorLiteralKeyword,
-         .poundImageLiteralKeyword,
-         .poundFileLiteralKeyword:
+    case (.poundColorLiteralKeyword, _)?,
+         (.poundImageLiteralKeyword, _)?,
+         (.poundFileLiteralKeyword, _)?:
       return RawExprSyntax(self.parseObjectLiteralExpression())
 
-    case .leftBrace:     // expr-closure
+    case (.leftBrace, _)?:     // expr-closure
       return RawExprSyntax(self.parseClosureExpression())
-    case .period,              //=.foo
-         .prefixPeriod:      // .foo
+    case (.period, _)?,              //=.foo
+         (.prefixPeriod, _)?:      // .foo
       let dot = self.consume(remapping: .prefixPeriod)
       let (name, args) = self.parseDeclNameRef([ .keywords, .compoundNames ])
       return RawExprSyntax(RawMemberAccessExprSyntax(
         base: nil, dot: dot, name: name, declNameArguments: args,
         arena: self.arena))
-    case .superKeyword: // 'super'
+    case (.superKeyword, _)?: // 'super'
       return RawExprSyntax(self.parseSuperExpression())
 
-    case .leftParen:
+    case (.leftParen, _)?:
       // Build a tuple expression syntax node.
       // AST differentiates paren and tuple expression where the former allows
       // only one element without label. However, libSyntax tree doesn't have this
@@ -914,10 +1007,10 @@ extension Parser {
       // element without label.
       return RawExprSyntax(self.parseTupleExpression())
 
-    case .leftSquareBracket:
+    case (.leftSquareBracket, _)?:
       return self.parseCollectionLiteral()
 
-    default:
+    case nil:
       return RawExprSyntax(RawMissingExprSyntax(arena: self.arena))
     }
   }
@@ -1385,7 +1478,7 @@ extension Parser {
   ///     regular-expression-literal → '\' `Any valid regular expression characters` '\'
   @_spi(RawSyntax)
   public mutating func parseRegexLiteral() -> RawRegexLiteralExprSyntax {
-    let (unexpectedBeforeLiteral, literal) = self.eat(.regexLiteral)
+    let (unexpectedBeforeLiteral, literal) = self.expect(.regexLiteral)
     return RawRegexLiteralExprSyntax(
       unexpectedBeforeLiteral,
       regex: literal,
@@ -1403,7 +1496,7 @@ extension Parser {
   ///     key-path-string-expression → '#keyPath' '(' expression ')'
   @_spi(RawSyntax)
   public mutating func parseObjectiveCKeyPathExpression() -> RawObjcKeyPathExprSyntax {
-    let (unexpectedBeforeKeyword, keyword) = self.eat(.poundKeyPathKeyword)
+    let (unexpectedBeforeKeyword, keyword) = self.expect(.poundKeyPathKeyword)
     // Parse the leading '('.
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
 
@@ -1451,7 +1544,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseSuperExpression() -> RawSuperRefExprSyntax {
     // Parse the 'super' reference.
-    let (unexpectedBeforeSuperKeyword, superKeyword) = self.eat(.superKeyword)
+    let (unexpectedBeforeSuperKeyword, superKeyword) = self.expect(.superKeyword)
     return RawSuperRefExprSyntax(
       unexpectedBeforeSuperKeyword,
       superKeyword: superKeyword,
@@ -1470,7 +1563,7 @@ extension Parser {
   ///     tuple-element-list → tuple-element | tuple-element ',' tuple-element-list
   @_spi(RawSyntax)
   public mutating func parseTupleExpression() -> RawTupleExprSyntax {
-    let (unexpectedBeforeLParen, lparen) = self.eat(.leftParen)
+    let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
     let elements = self.parseArgumentListElements()
     let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
     return RawTupleExprSyntax(
@@ -1526,29 +1619,23 @@ extension Parser {
   ///     dictionary-literal-items → dictionary-literal-item ','? | dictionary-literal-item ',' dictionary-literal-items
   @_spi(RawSyntax)
   public mutating func parseCollectionLiteral() -> RawExprSyntax {
-    let (unexpectedBeforeLSquare, lsquare) = self.eat(.leftSquareBracket)
+    let (unexpectedBeforeLSquare, lsquare) = self.expect(.leftSquareBracket)
 
-    if self.at(.rightSquareBracket) {
-      let (unexpectedBeforeRSquare, rsquare) = self.eat(.rightSquareBracket)
+    if let rsquare = self.consume(if: .rightSquareBracket) {
       return RawExprSyntax(RawArrayExprSyntax(
         unexpectedBeforeLSquare,
         leftSquare: lsquare,
         elements: RawArrayElementListSyntax(elements: [], arena: self.arena),
-        unexpectedBeforeRSquare,
         rightSquare: rsquare,
         arena: self.arena))
     }
 
-    if self.at(.colon) && self.peek().tokenKind == .rightSquareBracket {
-      let (unexpectedBeforeColon, colon) = self.eat(.colon)
-      let (unexpectedBeforeRSquare, rsquare) = self.eat(.rightSquareBracket)
+    if let (colon, rsquare) = self.consume(if: .colon, followedBy: .rightSquareBracket) {
       // FIXME: We probably want a separate node for the empty case.
       return RawExprSyntax(RawDictionaryExprSyntax(
         unexpectedBeforeLSquare,
         leftSquare: lsquare,
-        unexpectedBeforeColon,
         content: RawSyntax(colon),
-        unexpectedBeforeRSquare,
         rightSquare: rsquare,
         arena: self.arena
       ))
@@ -1625,7 +1712,7 @@ extension Parser {
 extension Parser {
   @_spi(RawSyntax)
   public mutating func parseDefaultArgument() -> RawInitializerClauseSyntax {
-    let (unexpectedBeforeEq, eq) = self.eat(.equal)
+    let (unexpectedBeforeEq, eq) = self.expect(.equal)
     let expr = self.parseExpression()
     return RawInitializerClauseSyntax(
       unexpectedBeforeEq,
@@ -1660,27 +1747,17 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseObjectiveCSelectorLiteral() -> RawObjcSelectorExprSyntax {
     // Consume '#selector'.
-    let (unexpectedBeforeSelector, selector) = self.eat(.poundSelectorKeyword)
+    let (unexpectedBeforeSelector, selector) = self.expect(.poundSelectorKeyword)
     // Parse the leading '('.
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
 
     // Parse possible 'getter:' or 'setter:' modifiers, and determine
     // the kind of selector we're working with.
-    let kind: RawTokenSyntax?
-    let unexpectedBeforeColon: RawUnexpectedNodesSyntax?
-    let colon: RawTokenSyntax?
-    if
-      self.peek().tokenKind == .colon,
-      self.currentToken.isContextualKeyword("getter") || self.currentToken.isContextualKeyword("setter")
-    {
-      // Parse the modifier.
-      kind = self.consume(remapping: .contextualKeyword)
-      (unexpectedBeforeColon, colon) = self.eat(.colon)
-    } else {
-      kind = nil
-      unexpectedBeforeColon = nil
-      colon = nil
-    }
+    let kindAndColon = self.consume(
+      if: { $0.isContextualKeyword("getter") || $0.isContextualKeyword("setter")},
+      followedBy: { $0.tokenKind == .colon }
+    )
+    let (kind, colon) = (kindAndColon?.0, kindAndColon?.1)
 
     // Parse the subexpression.
     let subexpr = self.parseExpression()
@@ -1692,7 +1769,6 @@ extension Parser {
       unexpectedBeforeLParen,
       leftParen: lparen,
       kind: kind,
-      unexpectedBeforeColon,
       colon: colon,
       name: subexpr,
       unexpectedBeforeRParen,
@@ -1711,7 +1787,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseClosureExpression() -> RawClosureExprSyntax {
     // Parse the opening left brace.
-    let (unexpectedBeforeLBrace, lbrace) = self.eat(.leftBrace)
+    let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
     // Parse the closure-signature, if present.
     let signature = self.parseClosureSignatureIfPresent()
 
@@ -1777,8 +1853,7 @@ extension Parser {
     let attrs = self.parseAttributeList()
 
     let captures: RawClosureCaptureSignatureSyntax?
-    if self.at(.leftSquareBracket) {
-      let (unexpectedBeforeLSquare, lsquare) = self.eat(.leftSquareBracket)
+    if let lsquare = self.consume(if: .leftSquareBracket) {
       // At this point, we know we have a closure signature. Parse the capture list
       // and parameters.
       var elements = [RawClosureCaptureItemSyntax]()
@@ -1798,7 +1873,7 @@ extension Parser {
           if self.peek().tokenKind == .equal {
             // The name is a new declaration.
             name = self.consumeIdentifier()
-            (unexpectedBeforeAssignToken, assignToken) = self.eat(.equal)
+            (unexpectedBeforeAssignToken, assignToken) = self.expect(.equal)
             expression = self.parseExpression()
           } else {
             // This is the simple case - the identifier is both the name and
@@ -1829,7 +1904,6 @@ extension Parser {
       unexpectedNodes.append(contentsOf: unexpectedBeforeRSquare?.elements ?? [])
 
       captures = RawClosureCaptureSignatureSyntax(
-        unexpectedBeforeLSquare,
         leftSquare: lsquare,
         items: elements.isEmpty ? nil : RawClosureCaptureItemListSyntax(elements: elements, arena: self.arena),
         unexpectedNodes.isEmpty ? nil : RawUnexpectedNodesSyntax(elements: unexpectedNodes, arena: self.arena),
@@ -1874,15 +1948,11 @@ extension Parser {
       throwsTok = self.parseEffectsSpecifier()
 
       // Parse the optional explicit return type.
-      if self.at(.arrow) {
-        // Consume the '->'.
-        let (unexpectedBeforeArrow, arrow) = self.eat(.arrow)
-
+      if let arrow = self.consume(if: .arrow) {
         // Parse the type.
         let returnTy = self.parseType()
 
         output = RawReturnClauseSyntax(
-          unexpectedBeforeArrow,
           arrow: arrow,
           returnType: returnTy,
           arena: self.arena
@@ -1964,17 +2034,8 @@ extension Parser {
     var keepGoing: RawTokenSyntax? = nil
     var loopProgress = LoopProgressCondition()
     repeat {
-      let label: RawTokenSyntax?
-      let unexpectedBeforeColon: RawUnexpectedNodesSyntax?
-      let colon: RawTokenSyntax?
-      if self.currentToken.canBeArgumentLabel && self.peek().tokenKind == .colon {
-        label = self.consumeAnyToken()
-        (unexpectedBeforeColon, colon) = self.eat(.colon)
-      } else {
-        label = nil
-        unexpectedBeforeColon = nil
-        colon = nil
-      }
+      let labelAndColon = self.consume(if: { $0.canBeArgumentLabel }, followedBy: { $0.tokenKind == .colon })
+      let (label, colon) = (labelAndColon?.0, labelAndColon?.1)
 
       // See if we have an operator decl ref '(<op>)'. The operator token in
       // this case lexes as a binary operator because it neither leads nor
@@ -1991,7 +2052,6 @@ extension Parser {
       keepGoing = self.consume(if: .comma)
       result.append(RawTupleExprElementSyntax(
         label: label,
-        unexpectedBeforeColon,
         colon: colon,
         expression: expr,
         trailingComma: keepGoing,
@@ -2013,7 +2073,7 @@ extension Parser {
   ///     tuple-element-list → tuple-element | tuple-element ',' tuple-element-list
   @_spi(RawSyntax)
   public mutating func parseArgumentList(_ flavor: ExprFlavor) -> RawTupleExprSyntax {
-    let (unexpectedBeforeLParen, lparen) = self.eat(.leftParen)
+    let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
     let args = self.parseArgumentListElements()
     let (unexpectedBeforeRightParen, rparen) = self.expect(.rightParen)
 
@@ -2126,7 +2186,7 @@ extension Parser.Lookahead {
     // to see if it is immediately followed by a token which indicates we should
     // consider it part of the preceding expression
     var backtrack = self.lookahead()
-    backtrack.eatWithoutRecovery(.leftBrace)
+    backtrack.eat(.leftBrace)
     var loopProgress = LoopProgressCondition()
     while !backtrack.at(.eof) && !backtrack.at(.rightBrace) && loopProgress.evaluate(backtrack.currentToken) {
       backtrack.consumeAnyToken()
@@ -2178,8 +2238,7 @@ extension Parser.Lookahead {
     // Consume attributes.
     var lookahead = self.lookahead()
     var attributesProgress = LoopProgressCondition()
-    while lookahead.at(.atSign) && attributesProgress.evaluate(lookahead.currentToken) {
-      lookahead.eatWithoutRecovery(.atSign)
+    while let _ = lookahead.consume(if: .atSign), attributesProgress.evaluate(lookahead.currentToken) {
       guard lookahead.currentToken.isIdentifier else {
         break
       }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1981,9 +1981,9 @@ extension Parser {
         if let lparen = self.consume(if: .leftParen) {
           specifiers.append(lparen)
           if self.currentToken.tokenText == "safe" {
-            specifiers.append(self.expectWithoutRecovery(.identifier, where: { $0.tokenText == "safe" }))
+            specifiers.append(self.expectContextualKeywordWithoutRecovery("safe"))
           } else {
-            specifiers.append(self.expectWithoutRecovery(.identifier, where: { $0.tokenText == "unsafe" }))
+            specifiers.append(self.expectContextualKeywordWithoutRecovery("unsafe"))
           }
           specifiers.append(self.expectWithoutRecovery(.rightParen))
         }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -241,7 +241,7 @@ extension Parser {
 
     case (.asKeyword, let handle)?:
       let asKeyword = self.eat(handle)
-      let failable = self.consume(ifAny: .postfixQuestionMark, .exclamationMark)
+      let failable = self.consume(ifAny: [.postfixQuestionMark, .exclamationMark])
       let op = RawUnresolvedAsExprSyntax(
         asTok: asKeyword,
         questionOrExclamationMark: failable,
@@ -324,7 +324,7 @@ extension Parser {
                                        inVarOrLet: inVarOrLet)
     }
 
-    let mark = self.consume(ifAny: .exclamationMark, .postfixQuestionMark)
+    let mark = self.consume(ifAny: [.exclamationMark, .postfixQuestionMark])
 
     let expression = self.parseSequenceExpressionElement(flavor,
                                                          inVarOrLet: inVarOrLet)

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -432,8 +432,7 @@ extension Parser {
 
     let period = self.consumeAnyToken(remapping: .period)
     // Handle "x.42" - a tuple index.
-    if self.currentToken.tokenKind == .integerLiteral {
-      let name = self.consumeAnyToken()
+    if let name = self.consume(if: .integerLiteral) {
       return RawExprSyntax(RawMemberAccessExprSyntax(
         base: start, dot: period, name: name, declNameArguments: nil,
         arena: self.arena))
@@ -1720,12 +1719,13 @@ extension Parser {
 extension Parser {
   @_spi(RawSyntax)
   public mutating func parseAnonymousClosureArgument() -> RawIdentifierExprSyntax {
-    guard self.currentToken.tokenKind == .dollarIdentifier else {
-      fatalError("Production invoked with non-dollar token!")
-    }
-    let ident = self.consumeAnyToken()
+    let (unexpectedBeforeIdent, ident) = self.expect(.dollarIdentifier)
     return RawIdentifierExprSyntax(
-      identifier: ident, declNameArguments: nil, arena: self.arena)
+      unexpectedBeforeIdent,
+      identifier: ident,
+      declNameArguments: nil,
+      arena: self.arena
+    )
   }
 }
 
@@ -2317,7 +2317,7 @@ extension Parser.Lookahead {
       return false
     }
 
-    if case .integerLiteral = self.currentToken.tokenKind {
+    if self.at(.integerLiteral) {
       return true
     }
 

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1993,9 +1993,9 @@ extension Parser {
         if let lparen = self.consume(if: .leftParen) {
           specifiers.append(lparen)
           if self.currentToken.tokenText == "safe" {
-            specifiers.append(self.expectWithoutLookahead(.identifier, "safe"))
+            specifiers.append(self.expectWithoutLookahead(.identifier, where: { $0.tokenText == "safe" }))
           } else {
-            specifiers.append(self.expectWithoutLookahead(.identifier, "unsafe"))
+            specifiers.append(self.expectWithoutLookahead(.identifier, where: { $0.tokenText == "unsafe" }))
           }
           specifiers.append(self.expectWithoutLookahead(.rightParen))
         }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1835,7 +1835,7 @@ extension Parser {
     // If we have a leading token that may be part of the closure signature, do a
     // speculative parse to validate it and look for 'in'.
     guard self.at(any: [.atSign, .leftParen, .leftSquareBracket, .wildcardKeyword])
-            || self.currentToken.isIdentifier else {
+            || self.at(.identifier) else {
       // No closure signature.
       return nil
     }
@@ -1923,7 +1923,7 @@ extension Parser {
           repeat {
             let unexpected: RawUnexpectedNodesSyntax?
             let name: RawTokenSyntax
-            if self.currentToken.isIdentifier {
+            if self.at(.identifier) {
               unexpected = nil
               name = self.expectIdentifierWithoutRecovery()
             } else {
@@ -1987,7 +1987,7 @@ extension Parser {
           }
           specifiers.append(self.expectWithoutRecovery(.rightParen))
         }
-      } else if self.currentToken.isIdentifier || self.at(.selfKeyword) {
+      } else if self.at(.identifier) || self.at(.selfKeyword) {
         let next = self.peek()
         // "x = 42", "x," and "x]" are all strong captures of x.
         guard next.tokenKind == .equal || next.tokenKind == .comma
@@ -1999,7 +1999,7 @@ extension Parser {
         return nil
       }
 
-      guard self.currentToken.isIdentifier || self.at(.selfKeyword) else {
+      guard self.at(.identifier) || self.at(.selfKeyword) else {
         return nil
       }
     }
@@ -2233,7 +2233,7 @@ extension Parser.Lookahead {
     var lookahead = self.lookahead()
     var attributesProgress = LoopProgressCondition()
     while let _ = lookahead.consume(if: .atSign), attributesProgress.evaluate(lookahead.currentToken) {
-      guard lookahead.currentToken.isIdentifier else {
+      guard lookahead.at(.identifier) else {
         break
       }
       _ = lookahead.canParseCustomAttribute()
@@ -2274,12 +2274,13 @@ extension Parser.Lookahead {
         }
       }
       // Okay, we have a closure signature.
-    } else if lookahead.currentToken.isIdentifier || lookahead.at(.wildcardKeyword) {
+    } else if lookahead.at(.identifier) || lookahead.at(.wildcardKeyword) {
       // Parse identifier (',' identifier)*
       lookahead.consumeAnyToken()
+
       var parametersProgress = LoopProgressCondition()
       while lookahead.consume(if: .comma) != nil && parametersProgress.evaluate(lookahead.currentToken) {
-        if lookahead.currentToken.isIdentifier || lookahead.at(.wildcardKeyword) {
+        if lookahead.at(.identifier) || lookahead.at(.wildcardKeyword) {
           lookahead.consumeAnyToken()
           continue
         }
@@ -2320,9 +2321,9 @@ extension Parser.Lookahead {
       return true
     }
 
-    if !self.peek().isIdentifier,
-        self.peek().tokenKind != .capitalSelfKeyword,
-        self.peek().tokenKind != .selfKeyword,
+    if self.peek().tokenKind != .identifier,
+       self.peek().tokenKind != .capitalSelfKeyword,
+       self.peek().tokenKind != .selfKeyword,
        !self.peek().tokenKind.isKeyword {
       return false
     }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -156,12 +156,13 @@ extension Parser {
 
     case .infixQuestionMark:
       // Save the '?'.
-      let question = self.eat(.infixQuestionMark)
+      let (unexpectedBeforeQuestion, question) = self.eat(.infixQuestionMark)
       let firstChoice = self.parseSequenceExpression(flavor, inVarOrLet: inVarOrLet)
       // Make sure there's a matching ':' after the middle expr.
       let (unexpectedBeforeColon, colon) = self.expect(.colon)
 
       let op = RawUnresolvedTernaryExprSyntax(
+        unexpectedBeforeQuestion,
         questionMark: question,
         firstChoice: firstChoice,
         unexpectedBeforeColon,
@@ -180,13 +181,21 @@ extension Parser {
       return (RawExprSyntax(op), rhs)
 
     case .equal where !inVarOrLet:
-      let eq = self.eat(.equal)
-      let op = RawAssignmentExprSyntax(assignToken: eq, arena: self.arena)
+      let (unexpectedBeforeEq, eq) = self.eat(.equal)
+      let op = RawAssignmentExprSyntax(
+        unexpectedBeforeEq,
+        assignToken: eq,
+        arena: self.arena
+      )
       return (RawExprSyntax(op), nil)
 
     case .isKeyword:
-      let isKeyword = self.eat(.isKeyword)
-      let op = RawUnresolvedIsExprSyntax(isTok: isKeyword, arena: self.arena)
+      let (unexpectedBeforeIsKeyword, isKeyword) = self.eat(.isKeyword)
+      let op = RawUnresolvedIsExprSyntax(
+        unexpectedBeforeIsKeyword,
+        isTok: isKeyword,
+        arena: self.arena
+      )
 
       // Parse the right type expression operand as part of the 'is' production.
       let type = self.parseType()
@@ -195,7 +204,7 @@ extension Parser {
       return (RawExprSyntax(op), RawExprSyntax(rhs))
 
     case .asKeyword:
-      let asKeyword = self.eat(.asKeyword)
+      let (unexpectedBeforeAsKeyword, asKeyword) = self.eat(.asKeyword)
       let failable: RawTokenSyntax?
       if self.at(.postfixQuestionMark) || self.at(.exclamationMark) {
         failable = self.consumeAnyToken()
@@ -203,7 +212,11 @@ extension Parser {
         failable = nil
       }
       let op = RawUnresolvedAsExprSyntax(
-        asTok: asKeyword, questionOrExclamationMark: failable, arena: self.arena)
+        unexpectedBeforeAsKeyword,
+        asTok: asKeyword,
+        questionOrExclamationMark: failable,
+        arena: self.arena
+      )
 
       // Parse the right type expression operand as part of the 'as' production.
       let type = self.parseType()
@@ -282,7 +295,7 @@ extension Parser {
                                        inVarOrLet: inVarOrLet)
     }
 
-    let tryKeyword = self.eat(.tryKeyword)
+    let (unexpectedBeforeTryKeyword, tryKeyword) = self.eat(.tryKeyword)
     let mark: RawTokenSyntax?
     if self.at(.exclamationMark) || self.at(.postfixQuestionMark) {
       mark = self.consumeAnyToken()
@@ -293,6 +306,7 @@ extension Parser {
     let expression = self.parseSequenceExpressionElement(flavor,
                                                          inVarOrLet: inVarOrLet)
     return RawExprSyntax(RawTryExprSyntax(
+      unexpectedBeforeTryKeyword,
       tryKeyword: tryKeyword,
       questionOrExclamationMark: mark,
       expression: expression,
@@ -318,21 +332,27 @@ extension Parser {
     //    tryLexRegexLiteral(/*forUnappliedOperator*/ false)
     switch self.currentToken.tokenKind {
     case .prefixAmpersand:
-      let amp = self.eat(.prefixAmpersand)
+      let (unexpectedBeforeAmp, amp) = self.eat(.prefixAmpersand)
       let expr = self.parseUnaryExpression(flavor, forDirective: forDirective, inVarOrLet: inVarOrLet)
       return RawExprSyntax(RawInOutExprSyntax(
-        ampersand: amp, expression: RawExprSyntax(expr),
-        arena: self.arena))
+        unexpectedBeforeAmp,
+        ampersand: amp,
+        expression: RawExprSyntax(expr),
+        arena: self.arena
+      ))
 
     case .backslash:
       return RawExprSyntax(self.parseKeyPathExpression(forDirective: forDirective, inVarOrLet: inVarOrLet))
 
     case .prefixOperator:
-      let op = self.eat(.prefixOperator)
+      let (unexpectedBeforeOp, op) = self.eat(.prefixOperator)
       let postfix = self.parseUnaryExpression(flavor, forDirective: forDirective, inVarOrLet: inVarOrLet)
       return RawExprSyntax(RawPrefixOperatorExprSyntax(
-        operatorToken: op, postfixExpression: postfix,
-        arena: self.arena))
+        unexpectedBeforeOp,
+        operatorToken: op,
+        postfixExpression: postfix,
+        arena: self.arena
+      ))
 
     default:
       // If the next token is not an operator, just parse this as expr-postfix.
@@ -389,10 +409,15 @@ extension Parser {
 
     // Handle "x.self" expr.
     if self.at(.selfKeyword) {
-      let selfKeyword = self.eat(.selfKeyword)
+      let (unexpectedBeforeSelfKeyword, selfKeyword) = self.eat(.selfKeyword)
       return RawExprSyntax(RawMemberAccessExprSyntax(
-        base: start, dot: period, name: selfKeyword, declNameArguments: nil,
-        arena: self.arena))
+        base: start,
+        dot: period,
+        unexpectedBeforeSelfKeyword,
+        name: selfKeyword,
+        declNameArguments: nil,
+        arena: self.arena
+      ))
     }
 
     let (ident, args) = self.parseDeclNameRef([ .keywords, .compoundNames ])
@@ -483,7 +508,7 @@ extension Parser {
       // If there is an expr-call-suffix, parse it and form a call.
       if self.at(.leftParen) && !self.currentToken.isAtStartOfLine {
         // Parse the argument list.
-        let lparen = self.eat(.leftParen)
+        let (unexpectedBeforeLParen, lparen) = self.eat(.leftParen)
         let args = self.parseArgumentListElements()
         let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
 
@@ -499,6 +524,7 @@ extension Parser {
 
         leadingExpr = RawExprSyntax(RawFunctionCallExprSyntax(
           calledExpression: leadingExpr,
+          unexpectedBeforeLParen,
           leftParen: lparen,
           argumentList: RawTupleExprElementListSyntax(elements: args, arena: self.arena),
           unexpectedBeforeRParen,
@@ -512,7 +538,7 @@ extension Parser {
       // Check for a [expr] suffix.
       // Note that this cannot be the start of a new line.
       if self.at(.leftSquareBracket) && !self.currentToken.isAtStartOfLine {
-        let lsquare = self.eat(.leftSquareBracket)
+        let (unexpectedBeforeLSquare, lsquare) = self.eat(.leftSquareBracket)
         let args = self.parseArgumentListElements()
         let (unexpectedBeforeRSquare, rsquare) = self.expect(.rightSquareBracket)
 
@@ -528,6 +554,7 @@ extension Parser {
 
         leadingExpr = RawExprSyntax(RawSubscriptExprSyntax(
           calledExpression: leadingExpr,
+          unexpectedBeforeLSquare,
           leftBracket: lsquare,
           argumentList: RawTupleExprElementListSyntax(elements: args, arena: self.arena),
           unexpectedBeforeRSquare,
@@ -585,10 +612,13 @@ extension Parser {
         //        if (periodHasKeyPathBehavior && startsWithSymbol(Tok, '.'))
         //          break
 
-        let op = self.eat(.postfixOperator)
+        let (unexpectedBeforeOp, op) = self.eat(.postfixOperator)
         leadingExpr = RawExprSyntax(RawPostfixUnaryExprSyntax(
-          expression: leadingExpr, operatorToken: op,
-          arena: self.arena))
+          expression: leadingExpr,
+          unexpectedBeforeOp,
+          operatorToken: op,
+          arena: self.arena
+        ))
         continue
       }
 
@@ -605,7 +635,7 @@ extension Parser {
           //       .someMember
           var loopProgress = LoopProgressCondition()
           repeat {
-            backtrack.eat(.poundIfKeyword)
+            backtrack.eatWithoutRecovery(.poundIfKeyword)
             while !backtrack.at(.eof) && !backtrack.currentToken.isAtStartOfLine {
               backtrack.skipSingle()
             }
@@ -644,7 +674,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseKeyPathExpression(forDirective: Bool, inVarOrLet: Bool) -> RawKeyPathExprSyntax {
     // Consume '\'.
-    let backslash = self.eat(.backslash)
+    let (unexpectedBeforeBackslash, backslash) = self.eat(.backslash)
 
     // For uniformity, \.foo is parsed as if it were MAGIC.foo, so we need to
     // make sure the . is there, but parsing the ? in \.? as .? doesn't make
@@ -673,6 +703,7 @@ extension Parser {
     }
 
     return RawKeyPathExprSyntax(
+      unexpectedBeforeBackslash,
       backslash: backslash,
       rootExpr: root,
       expression: expression,
@@ -703,57 +734,121 @@ extension Parser {
   public mutating func parsePrimaryExpression(inVarOrLet: Bool) -> RawExprSyntax {
     switch self.currentToken.tokenKind {
     case .integerLiteral:
-      let digits = self.eat(.integerLiteral)
-      return RawExprSyntax(RawIntegerLiteralExprSyntax(digits: digits, arena: self.arena))
+      let (unexpectedBeforeDigits, digits) = self.eat(.integerLiteral)
+      return RawExprSyntax(RawIntegerLiteralExprSyntax(
+        unexpectedBeforeDigits,
+        digits: digits,
+        arena: self.arena
+      ))
     case .floatingLiteral:
-      let digits = self.eat(.floatingLiteral)
-      return RawExprSyntax(RawFloatLiteralExprSyntax(floatingDigits: digits, arena: self.arena))
+      let (unexpectedBeforeDigits, digits) = self.eat(.floatingLiteral)
+      return RawExprSyntax(RawFloatLiteralExprSyntax(
+        unexpectedBeforeDigits,
+        floatingDigits: digits,
+        arena: self.arena
+      ))
     case .stringLiteral:
       return RawExprSyntax(self.parseStringLiteral())
     case .regexLiteral:
       return RawExprSyntax(self.parseRegexLiteral())
     case .nilKeyword:
-      let nilKeyword = self.eat(.nilKeyword)
-      return RawExprSyntax(RawNilLiteralExprSyntax(nilKeyword: nilKeyword, arena: self.arena))
+      let (unexpectedBeforeNilKeyword, nilKeyword) = self.eat(.nilKeyword)
+      return RawExprSyntax(RawNilLiteralExprSyntax(
+        unexpectedBeforeNilKeyword,
+        nilKeyword: nilKeyword,
+        arena: self.arena
+      ))
     case .trueKeyword, .falseKeyword:
-      let tok = self.eat(self.currentToken.tokenKind)
-      return RawExprSyntax(RawBooleanLiteralExprSyntax(booleanLiteral: tok, arena: self.arena))
+      let (unexpectedBeforeTok, tok) = self.eat(self.currentToken.tokenKind)
+      return RawExprSyntax(RawBooleanLiteralExprSyntax(
+        unexpectedBeforeTok,
+        booleanLiteral: tok,
+        arena: self.arena
+      ))
     case .__file__Keyword:
-      let tok = self.eat(.__file__Keyword)
-      return RawExprSyntax(RawPoundFileExprSyntax(poundFile: tok, arena: self.arena))
+      let (unexpectedBeforeTok, tok) = self.eat(.__file__Keyword)
+      return RawExprSyntax(RawPoundFileExprSyntax(
+        unexpectedBeforeTok,
+        poundFile: tok,
+        arena: self.arena
+      ))
     case .poundFileIDKeyword:
-      let tok = self.eat(.poundFileIDKeyword)
-      return RawExprSyntax(RawPoundFileIDExprSyntax(poundFileID: tok, arena: self.arena))
+      let (unexpectedBeforeTok, tok) = self.eat(.poundFileIDKeyword)
+      return RawExprSyntax(RawPoundFileIDExprSyntax(
+        unexpectedBeforeTok,
+        poundFileID: tok,
+        arena: self.arena
+      ))
     case .poundFileKeyword:
-      let tok = self.eat(.poundFileKeyword)
-      return RawExprSyntax(RawPoundFileExprSyntax(poundFile: tok, arena: self.arena))
+      let (unexpectedBeforeTok, tok) = self.eat(.poundFileKeyword)
+      return RawExprSyntax(RawPoundFileExprSyntax(
+        unexpectedBeforeTok,
+        poundFile: tok,
+        arena: self.arena
+      ))
     case .poundFilePathKeyword:
-      let tok = self.eat(.poundFilePathKeyword)
-      return RawExprSyntax(RawPoundFilePathExprSyntax(poundFilePath: tok, arena: self.arena))
+      let (unexpectedBeforeTok, tok) = self.eat(.poundFilePathKeyword)
+      return RawExprSyntax(RawPoundFilePathExprSyntax(
+        unexpectedBeforeTok,
+        poundFilePath: tok,
+        arena: self.arena
+      ))
     case .poundFunctionKeyword:
-      let tok = self.eat(.poundFunctionKeyword)
-      return RawExprSyntax(RawPoundFunctionExprSyntax(poundFunction: tok, arena: self.arena))
+      let (unexpectedBeforeTok, tok) = self.eat(.poundFunctionKeyword)
+      return RawExprSyntax(RawPoundFunctionExprSyntax(
+        unexpectedBeforeTok,
+        poundFunction: tok,
+        arena: self.arena
+      ))
     case .__function__Keyword:
-      let tok = self.eat(.__function__Keyword)
-      return RawExprSyntax(RawPoundFunctionExprSyntax(poundFunction: tok, arena: self.arena))
+      let (unexpectedBeforeTok, tok) = self.eat(.__function__Keyword)
+      return RawExprSyntax(RawPoundFunctionExprSyntax(
+        unexpectedBeforeTok,
+        poundFunction: tok,
+        arena: self.arena
+      ))
     case .poundLineKeyword:
-      let tok = self.eat(.poundLineKeyword)
-      return RawExprSyntax(RawPoundLineExprSyntax(poundLine: tok, arena: self.arena))
+      let (unexpectedBeforeTok, tok) = self.eat(.poundLineKeyword)
+      return RawExprSyntax(RawPoundLineExprSyntax(
+        unexpectedBeforeTok,
+        poundLine: tok,
+        arena: self.arena
+      ))
     case .__line__Keyword:
-      let tok = self.eat(.__line__Keyword)
-      return RawExprSyntax(RawPoundLineExprSyntax(poundLine: tok, arena: self.arena))
+      let (unexpectedBeforeTok, tok) = self.eat(.__line__Keyword)
+      return RawExprSyntax(RawPoundLineExprSyntax(
+        unexpectedBeforeTok,
+        poundLine: tok,
+        arena: self.arena
+      ))
     case .poundColumnKeyword:
-      let tok = self.eat(.poundColumnKeyword)
-      return RawExprSyntax(RawPoundColumnExprSyntax(poundColumn: tok, arena: self.arena))
+      let (unexpectedBeforeTok, tok) = self.eat(.poundColumnKeyword)
+      return RawExprSyntax(RawPoundColumnExprSyntax(
+        unexpectedBeforeTok,
+        poundColumn: tok,
+        arena: self.arena
+      ))
     case .__column__Keyword:
-      let tok = self.eat(.__column__Keyword)
-      return RawExprSyntax(RawPoundColumnExprSyntax(poundColumn: tok, arena: self.arena))
+      let (unexpectedBeforeTok, tok) = self.eat(.__column__Keyword)
+      return RawExprSyntax(RawPoundColumnExprSyntax(
+        unexpectedBeforeTok,
+        poundColumn: tok,
+        arena: self.arena
+      ))
     case .poundDsohandleKeyword:
-      let tok = self.eat(.poundDsohandleKeyword)
-      return RawExprSyntax(RawPoundDsohandleExprSyntax(poundDsohandle: tok, arena: self.arena))
+      let (unexpectedBeforeTok, tok) = self.eat(.poundDsohandleKeyword)
+      return RawExprSyntax(RawPoundDsohandleExprSyntax(
+        unexpectedBeforeTok,
+        poundDsohandle: tok,
+        arena: self.arena
+      ))
     case .__dso_handle__Keyword:
-      let tok = self.eat(.__dso_handle__Keyword)
-      return RawExprSyntax(RawPoundDsohandleExprSyntax(poundDsohandle: tok, arena: self.arena))
+      let (unexpectedBeforeTok, tok) = self.eat(.__dso_handle__Keyword)
+      return RawExprSyntax(RawPoundDsohandleExprSyntax(
+        unexpectedBeforeTok,
+        poundDsohandle: tok,
+        arena: self.arena
+      ))
     case .identifier, .selfKeyword:
       // If we have "case let x." or "case let x(", we parse x as a normal
       // name, not a binding, because it is the start of an enum pattern or
@@ -783,9 +878,12 @@ extension Parser {
     case .dollarIdentifier:
       return RawExprSyntax(self.parseAnonymousClosureArgument())
     case .wildcardKeyword: // _
-      let wild = self.eat(.wildcardKeyword)
+      let (unexpectedBeforeWild, wild) = self.eat(.wildcardKeyword)
       return RawExprSyntax(RawDiscardAssignmentExprSyntax(
-        wildcard: wild, arena: self.arena))
+        unexpectedBeforeWild,
+        wildcard: wild,
+        arena: self.arena
+      ))
     case .poundSelectorKeyword:
       return RawExprSyntax(self.parseObjectiveCSelectorLiteral())
     case .poundKeyPathKeyword:
@@ -1287,8 +1385,12 @@ extension Parser {
   ///     regular-expression-literal → '\' `Any valid regular expression characters` '\'
   @_spi(RawSyntax)
   public mutating func parseRegexLiteral() -> RawRegexLiteralExprSyntax {
-    let literal = self.eat(.regexLiteral)
-    return RawRegexLiteralExprSyntax(regex: literal, arena: self.arena)
+    let (unexpectedBeforeLiteral, literal) = self.eat(.regexLiteral)
+    return RawRegexLiteralExprSyntax(
+      unexpectedBeforeLiteral,
+      regex: literal,
+      arena: self.arena
+    )
   }
 }
 
@@ -1301,7 +1403,7 @@ extension Parser {
   ///     key-path-string-expression → '#keyPath' '(' expression ')'
   @_spi(RawSyntax)
   public mutating func parseObjectiveCKeyPathExpression() -> RawObjcKeyPathExprSyntax {
-    let keyword = self.eat(.poundKeyPathKeyword)
+    let (unexpectedBeforeKeyword, keyword) = self.eat(.poundKeyPathKeyword)
     // Parse the leading '('.
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
 
@@ -1329,6 +1431,7 @@ extension Parser {
     // Parse the closing ')'.
     let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
     return RawObjcKeyPathExprSyntax(
+      unexpectedBeforeKeyword,
       keyPath: keyword,
       unexpectedBeforeLParen,
       leftParen: lparen,
@@ -1348,8 +1451,12 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseSuperExpression() -> RawSuperRefExprSyntax {
     // Parse the 'super' reference.
-    let superKeyword = self.eat(.superKeyword)
-    return RawSuperRefExprSyntax(superKeyword: superKeyword, arena: self.arena)
+    let (unexpectedBeforeSuperKeyword, superKeyword) = self.eat(.superKeyword)
+    return RawSuperRefExprSyntax(
+      unexpectedBeforeSuperKeyword,
+      superKeyword: superKeyword,
+      arena: self.arena
+    )
   }
 }
 
@@ -1363,10 +1470,11 @@ extension Parser {
   ///     tuple-element-list → tuple-element | tuple-element ',' tuple-element-list
   @_spi(RawSyntax)
   public mutating func parseTupleExpression() -> RawTupleExprSyntax {
-    let lparen = self.eat(.leftParen)
+    let (unexpectedBeforeLParen, lparen) = self.eat(.leftParen)
     let elements = self.parseArgumentListElements()
     let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
     return RawTupleExprSyntax(
+      unexpectedBeforeLParen,
       leftParen: lparen,
       elementList: RawTupleExprElementListSyntax(elements: elements, arena: self.arena),
       unexpectedBeforeRParen,
@@ -1418,25 +1526,32 @@ extension Parser {
   ///     dictionary-literal-items → dictionary-literal-item ','? | dictionary-literal-item ',' dictionary-literal-items
   @_spi(RawSyntax)
   public mutating func parseCollectionLiteral() -> RawExprSyntax {
-    let lsquare = self.eat(.leftSquareBracket)
+    let (unexpectedBeforeLSquare, lsquare) = self.eat(.leftSquareBracket)
 
     if self.at(.rightSquareBracket) {
-      let rsquare = self.eat(.rightSquareBracket)
+      let (unexpectedBeforeRSquare, rsquare) = self.eat(.rightSquareBracket)
       return RawExprSyntax(RawArrayExprSyntax(
+        unexpectedBeforeLSquare,
         leftSquare: lsquare,
         elements: RawArrayElementListSyntax(elements: [], arena: self.arena),
+        unexpectedBeforeRSquare,
         rightSquare: rsquare,
         arena: self.arena))
     }
 
     if self.at(.colon) && self.peek().tokenKind == .rightSquareBracket {
-      let colon = self.eat(.colon)
-      let rsquare = self.eat(.rightSquareBracket)
+      let (unexpectedBeforeColon, colon) = self.eat(.colon)
+      let (unexpectedBeforeRSquare, rsquare) = self.eat(.rightSquareBracket)
       // FIXME: We probably want a separate node for the empty case.
       return RawExprSyntax(RawDictionaryExprSyntax(
-          leftSquare: lsquare,
-          content: RawSyntax(colon),
-          rightSquare: rsquare, arena: self.arena))
+        unexpectedBeforeLSquare,
+        leftSquare: lsquare,
+        unexpectedBeforeColon,
+        content: RawSyntax(colon),
+        unexpectedBeforeRSquare,
+        rightSquare: rsquare,
+        arena: self.arena
+      ))
     }
 
     var elementKind: CollectionKind? = nil
@@ -1510,10 +1625,14 @@ extension Parser {
 extension Parser {
   @_spi(RawSyntax)
   public mutating func parseDefaultArgument() -> RawInitializerClauseSyntax {
-    let eq = self.eat(.equal)
+    let (unexpectedBeforeEq, eq) = self.eat(.equal)
     let expr = self.parseExpression()
     return RawInitializerClauseSyntax(
-      equal: eq, value: expr, arena: self.arena)
+      unexpectedBeforeEq,
+      equal: eq,
+      value: expr,
+      arena: self.arena
+    )
   }
 }
 
@@ -1541,13 +1660,14 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseObjectiveCSelectorLiteral() -> RawObjcSelectorExprSyntax {
     // Consume '#selector'.
-    let selector = self.eat(.poundSelectorKeyword)
+    let (unexpectedBeforeSelector, selector) = self.eat(.poundSelectorKeyword)
     // Parse the leading '('.
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
 
     // Parse possible 'getter:' or 'setter:' modifiers, and determine
     // the kind of selector we're working with.
     let kind: RawTokenSyntax?
+    let unexpectedBeforeColon: RawUnexpectedNodesSyntax?
     let colon: RawTokenSyntax?
     if
       self.peek().tokenKind == .colon,
@@ -1555,9 +1675,10 @@ extension Parser {
     {
       // Parse the modifier.
       kind = self.consume(remapping: .contextualKeyword)
-      colon = self.eat(.colon)
+      (unexpectedBeforeColon, colon) = self.eat(.colon)
     } else {
       kind = nil
+      unexpectedBeforeColon = nil
       colon = nil
     }
 
@@ -1566,10 +1687,12 @@ extension Parser {
     // Parse the closing ')'.
     let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
     return RawObjcSelectorExprSyntax(
+      unexpectedBeforeSelector,
       poundSelector: selector,
       unexpectedBeforeLParen,
       leftParen: lparen,
       kind: kind,
+      unexpectedBeforeColon,
       colon: colon,
       name: subexpr,
       unexpectedBeforeRParen,
@@ -1588,7 +1711,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseClosureExpression() -> RawClosureExprSyntax {
     // Parse the opening left brace.
-    let lbrace = self.eat(.leftBrace)
+    let (unexpectedBeforeLBrace, lbrace) = self.eat(.leftBrace)
     // Parse the closure-signature, if present.
     let signature = self.parseClosureSignatureIfPresent()
 
@@ -1604,6 +1727,7 @@ extension Parser {
     // Parse the closing '}'.
     let (unexpectedBeforeRBrace, rbrace) = self.expect(.rightBrace)
     return RawClosureExprSyntax(
+      unexpectedBeforeLBrace,
       leftBrace: lbrace,
       signature: signature,
       statements: RawCodeBlockItemListSyntax(elements: elements, arena: arena),
@@ -1654,7 +1778,7 @@ extension Parser {
 
     let captures: RawClosureCaptureSignatureSyntax?
     if self.at(.leftSquareBracket) {
-      let lsquare = self.eat(.leftSquareBracket)
+      let (unexpectedBeforeLSquare, lsquare) = self.eat(.leftSquareBracket)
       // At this point, we know we have a closure signature. Parse the capture list
       // and parameters.
       var elements = [RawClosureCaptureItemSyntax]()
@@ -1668,17 +1792,19 @@ extension Parser {
           // The thing being capture specified is an identifier, or as an identifier
           // followed by an expression.
           let name: RawTokenSyntax?
+          let unexpectedBeforeAssignToken: RawUnexpectedNodesSyntax?
           let assignToken: RawTokenSyntax?
           let expression: RawExprSyntax
           if self.peek().tokenKind == .equal {
             // The name is a new declaration.
             name = self.consumeIdentifier()
-            assignToken = self.eat(.equal)
+            (unexpectedBeforeAssignToken, assignToken) = self.eat(.equal)
             expression = self.parseExpression()
           } else {
             // This is the simple case - the identifier is both the name and
             // the expression to capture.
             name = nil
+            unexpectedBeforeAssignToken = nil
             assignToken = nil
             expression = RawExprSyntax(self.parseIdentifierExpression())
           }
@@ -1687,6 +1813,7 @@ extension Parser {
           elements.append(RawClosureCaptureItemSyntax(
             specifier: specifier,
             name: name,
+            unexpectedBeforeAssignToken,
             assignToken: assignToken,
             expression: expression,
             trailingComma: keepGoing,
@@ -1702,6 +1829,7 @@ extension Parser {
       unexpectedNodes.append(contentsOf: unexpectedBeforeRSquare?.elements ?? [])
 
       captures = RawClosureCaptureSignatureSyntax(
+        unexpectedBeforeLSquare,
         leftSquare: lsquare,
         items: elements.isEmpty ? nil : RawClosureCaptureItemListSyntax(elements: elements, arena: self.arena),
         unexpectedNodes.isEmpty ? nil : RawUnexpectedNodesSyntax(elements: unexpectedNodes, arena: self.arena),
@@ -1748,13 +1876,17 @@ extension Parser {
       // Parse the optional explicit return type.
       if self.at(.arrow) {
         // Consume the '->'.
-        let arrow = self.eat(.arrow)
+        let (unexpectedBeforeArrow, arrow) = self.eat(.arrow)
 
         // Parse the type.
         let returnTy = self.parseType()
 
         output = RawReturnClauseSyntax(
-          arrow: arrow, returnType: returnTy, arena: self.arena)
+          unexpectedBeforeArrow,
+          arrow: arrow,
+          returnType: returnTy,
+          arena: self.arena
+        )
       }
     }
 
@@ -1833,12 +1965,14 @@ extension Parser {
     var loopProgress = LoopProgressCondition()
     repeat {
       let label: RawTokenSyntax?
+      let unexpectedBeforeColon: RawUnexpectedNodesSyntax?
       let colon: RawTokenSyntax?
       if self.currentToken.canBeArgumentLabel && self.peek().tokenKind == .colon {
         label = self.consumeAnyToken()
-        colon = self.eat(.colon)
+        (unexpectedBeforeColon, colon) = self.eat(.colon)
       } else {
         label = nil
+        unexpectedBeforeColon = nil
         colon = nil
       }
 
@@ -1856,7 +1990,13 @@ extension Parser {
       }
       keepGoing = self.consume(if: .comma)
       result.append(RawTupleExprElementSyntax(
-        label: label, colon: colon, expression: expr, trailingComma: keepGoing, arena: self.arena))
+        label: label,
+        unexpectedBeforeColon,
+        colon: colon,
+        expression: expr,
+        trailingComma: keepGoing,
+        arena: self.arena
+      ))
     } while keepGoing != nil && loopProgress.evaluate(currentToken)
     return result
   }
@@ -1873,12 +2013,13 @@ extension Parser {
   ///     tuple-element-list → tuple-element | tuple-element ',' tuple-element-list
   @_spi(RawSyntax)
   public mutating func parseArgumentList(_ flavor: ExprFlavor) -> RawTupleExprSyntax {
-    let lparen = self.eat(.leftParen)
+    let (unexpectedBeforeLParen, lparen) = self.eat(.leftParen)
     let args = self.parseArgumentListElements()
     let (unexpectedBeforeRightParen, rparen) = self.expect(.rightParen)
 
     // FIXME: Introduce new SyntaxKind for ArgumentList (rdar://81786229)
     return RawTupleExprSyntax(
+      unexpectedBeforeLParen,
       leftParen: lparen,
       elementList: RawTupleExprElementListSyntax(elements: args, arena: self.arena),
       unexpectedBeforeRightParen,
@@ -1985,7 +2126,7 @@ extension Parser.Lookahead {
     // to see if it is immediately followed by a token which indicates we should
     // consider it part of the preceding expression
     var backtrack = self.lookahead()
-    backtrack.eat(.leftBrace)
+    backtrack.eatWithoutRecovery(.leftBrace)
     var loopProgress = LoopProgressCondition()
     while !backtrack.at(.eof) && !backtrack.at(.rightBrace) && loopProgress.evaluate(backtrack.currentToken) {
       backtrack.consumeAnyToken()
@@ -2038,7 +2179,7 @@ extension Parser.Lookahead {
     var lookahead = self.lookahead()
     var attributesProgress = LoopProgressCondition()
     while lookahead.at(.atSign) && attributesProgress.evaluate(lookahead.currentToken) {
-      lookahead.eat(.atSign)
+      lookahead.eatWithoutRecovery(.atSign)
       guard lookahead.currentToken.isIdentifier else {
         break
       }

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -260,7 +260,7 @@ extension Parser {
       }
     case (.arrow, _)?, (.throwsKeyword, _)?:
       let asyncKeyword: RawTokenSyntax?
-      if self.currentToken.isContextualKeyword("async") {
+      if self.atContextualKeyword("async") {
         asyncKeyword = self.consumeAnyToken(remapping: .contextualKeyword)
       } else {
         asyncKeyword = nil
@@ -297,7 +297,7 @@ extension Parser {
     forDirective: Bool = false,
     inVarOrLet: Bool = false
   ) -> RawExprSyntax {
-    if self.currentToken.isContextualKeyword("await") {
+    if self.atContextualKeyword("await") {
       let awaitTok = self.consumeAnyToken()
       let sub = self.parseSequenceExpressionElement(flavor,
                                                     inVarOrLet: inVarOrLet)
@@ -948,7 +948,7 @@ extension Parser {
       }
 
       // 'any' followed by another identifier is an existential type.
-      if self.currentToken.isContextualKeyword("any"),
+      if self.atContextualKeyword("any"),
          self.peek().tokenKind == .identifier,
          self.peek().isAtStartOfLine
       {
@@ -1748,7 +1748,7 @@ extension Parser {
     // Parse possible 'getter:' or 'setter:' modifiers, and determine
     // the kind of selector we're working with.
     let kindAndColon = self.consume(
-      if: { $0.isContextualKeyword("getter") || $0.isContextualKeyword("setter")},
+      if: { $0.isContextualKeyword(["getter", "setter"])},
       followedBy: { $0.tokenKind == .colon }
     )
     let (kind, colon) = (kindAndColon?.0, kindAndColon?.1)
@@ -1974,9 +1974,9 @@ extension Parser {
     do {
       // Check for the strength specifier: "weak", "unowned", or
       // "unowned(safe/unsafe)".
-      if self.currentToken.isContextualKeyword("weak") {
+      if self.atContextualKeyword("weak") {
         specifiers.append(self.expectIdentifierWithoutRecovery())
-      } else if self.currentToken.isContextualKeyword("unowned") {
+      } else if self.atContextualKeyword("unowned") {
         specifiers.append(self.expectIdentifierWithoutRecovery())
         if let lparen = self.consume(if: .leftParen) {
           specifiers.append(lparen)

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -263,7 +263,7 @@ extension Parser {
     case (.arrow, _)?, (.throwsKeyword, _)?:
       let asyncKeyword: RawTokenSyntax?
       if self.currentToken.isContextualKeyword("async") {
-        asyncKeyword = self.consume(remapping: .contextualKeyword)
+        asyncKeyword = self.consumeAnyToken(remapping: .contextualKeyword)
       } else {
         asyncKeyword = nil
       }
@@ -432,7 +432,7 @@ extension Parser {
 //          break
 //        }
 
-    let period = self.consume(remapping: .period)
+    let period = self.consumeAnyToken(remapping: .period)
     // Handle "x.42" - a tuple index.
     if self.currentToken.tokenKind == .integerLiteral {
       let name = self.consumeAnyToken()
@@ -987,7 +987,7 @@ extension Parser {
       return RawExprSyntax(self.parseClosureExpression())
     case (.period, _)?,              //=.foo
          (.prefixPeriod, _)?:      // .foo
-      let dot = self.consume(remapping: .prefixPeriod)
+      let dot = self.consumeAnyToken(remapping: .prefixPeriod)
       let (name, args) = self.parseDeclNameRef([ .keywords, .compoundNames ])
       return RawExprSyntax(RawMemberAccessExprSyntax(
         base: nil, dot: dot, name: name, declNameArguments: args,

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1412,7 +1412,7 @@ extension Parser {
           } else {
             runexpected = nil
           }
-          let rparen = subparser.expectWithoutLookahead(.rightParen)
+          let rparen = subparser.expectWithoutRecovery(.rightParen)
 
           segments.append(RawSyntax(RawExpressionSegmentSyntax(
             backslash: slashToken,
@@ -1983,11 +1983,11 @@ extension Parser {
         if let lparen = self.consume(if: .leftParen) {
           specifiers.append(lparen)
           if self.currentToken.tokenText == "safe" {
-            specifiers.append(self.expectWithoutLookahead(.identifier, where: { $0.tokenText == "safe" }))
+            specifiers.append(self.expectWithoutRecovery(.identifier, where: { $0.tokenText == "safe" }))
           } else {
-            specifiers.append(self.expectWithoutLookahead(.identifier, where: { $0.tokenText == "unsafe" }))
+            specifiers.append(self.expectWithoutRecovery(.identifier, where: { $0.tokenText == "unsafe" }))
           }
-          specifiers.append(self.expectWithoutLookahead(.rightParen))
+          specifiers.append(self.expectWithoutRecovery(.rightParen))
         }
       } else if self.currentToken.isIdentifier || self.at(.selfKeyword) {
         let next = self.peek()

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -548,7 +548,7 @@ extension Parser {
       }
 
       // If there is an expr-call-suffix, parse it and form a call.
-      if let lparen = self.consume(if: .leftParen, where: { (lexeme, parser) in !lexeme.isAtStartOfLine }) {
+      if let lparen = self.consume(if: .leftParen, where: { !$0.isAtStartOfLine }) {
         let args = self.parseArgumentListElements()
         let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
 
@@ -576,7 +576,7 @@ extension Parser {
 
       // Check for a [expr] suffix.
       // Note that this cannot be the start of a new line.
-      if let lsquare = self.consume(if: .leftSquareBracket, where: { (lexeme, _) in !lexeme.isAtStartOfLine }) {
+      if let lsquare = self.consume(if: .leftSquareBracket, where: { !$0.isAtStartOfLine }) {
         let args = self.parseArgumentListElements()
         let (unexpectedBeforeRSquare, rsquare) = self.expect(.rightSquareBracket)
 

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -172,10 +172,10 @@ extension Parser {
         }
       }
 
-      func accepts(lexeme: Lexer.Lexeme, parser: Parser) -> Bool {
+      func accepts(lexeme: Lexer.Lexeme) -> Bool {
         switch self {
         case .identifier:
-          return lexeme.isContextualKeyword("async") && (parser.peek().tokenKind == .arrow || parser.peek().tokenKind == .throwsKeyword)
+          return lexeme.isContextualKeyword("async")
         default:
           return true
         }
@@ -259,7 +259,13 @@ extension Parser {
 
       return (RawExprSyntax(op), RawExprSyntax(rhs))
 
-    case (.identifier, _)?, (.arrow, _)?, (.throwsKeyword, _)?:
+    case (.identifier, _)?:
+      if self.peek().tokenKind == .arrow || self.peek().tokenKind == .throwsKeyword {
+        fallthrough
+      } else {
+        return nil
+      }
+    case (.arrow, _)?, (.throwsKeyword, _)?:
       let asyncKeyword: RawTokenSyntax?
       if self.currentToken.isContextualKeyword("async") {
         asyncKeyword = self.consume(remapping: .contextualKeyword)

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -154,7 +154,7 @@ extension Parser {
       case equal
       case isKeyword
       case asKeyword
-      case identifier
+      case async
       case arrow
       case throwsKeyword
 
@@ -166,18 +166,16 @@ extension Parser {
         case .equal: return .equal
         case .isKeyword: return .isKeyword
         case .asKeyword: return .asKeyword
-        case .identifier: return .identifier
+        case .async: return .identifier
         case .arrow: return .arrow
         case .throwsKeyword: return .throwsKeyword
         }
       }
 
-      func accepts(lexeme: Lexer.Lexeme) -> Bool {
+      var contextualKeyword: SyntaxText? {
         switch self {
-        case .identifier:
-          return lexeme.isContextualKeyword("async")
-        default:
-          return true
+        case .async: return "async"
+        default: return nil
         }
       }
     }
@@ -254,7 +252,7 @@ extension Parser {
 
       return (RawExprSyntax(op), RawExprSyntax(rhs))
 
-    case (.identifier, _)?:
+    case (.async, _)?:
       if self.peek().tokenKind == .arrow || self.peek().tokenKind == .throwsKeyword {
         fallthrough
       } else {

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1868,7 +1868,7 @@ extension Parser {
           let expression: RawExprSyntax
           if self.peek().tokenKind == .equal {
             // The name is a new declaration.
-            name = self.consumeIdentifier()
+            name = self.expectIdentifierWithoutRecovery()
             (unexpectedBeforeAssignToken, assignToken) = self.expect(.equal)
             expression = self.parseExpression()
           } else {
@@ -1927,7 +1927,7 @@ extension Parser {
             let name: RawTokenSyntax
             if self.currentToken.isIdentifier {
               unexpected = nil
-              name = self.consumeIdentifier()
+              name = self.expectIdentifierWithoutRecovery()
             } else {
               (unexpected, name) = self.expect(.wildcardKeyword)
             }
@@ -1977,9 +1977,9 @@ extension Parser {
       // Check for the strength specifier: "weak", "unowned", or
       // "unowned(safe/unsafe)".
       if self.currentToken.isContextualKeyword("weak") {
-        specifiers.append(self.consumeIdentifier())
+        specifiers.append(self.expectIdentifierWithoutRecovery())
       } else if self.currentToken.isContextualKeyword("unowned") {
-        specifiers.append(self.consumeIdentifier())
+        specifiers.append(self.expectIdentifierWithoutRecovery())
         if let lparen = self.consume(if: .leftParen) {
           specifiers.append(lparen)
           if self.currentToken.tokenText == "safe" {

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -139,13 +139,24 @@ extension Parser.Lookahead {
     return
   }
 
+  /// Consumes the current token, and asserts that the kind of token that was
+  /// consumed matches the given kind.
+  ///
+  /// If the token kind did not match, this function will abort. It is useful
+  /// to insert structural invariants during parsing.
+  ///
+  /// - Parameter kind: The kind of token to consume.
+  /// - Returns: A token of the given kind.
+  public mutating func eat(_ kind: RawTokenKind) -> Token {
+    return self.consume(if: kind)!
+  }
+
   mutating func eatParseAttributeList() -> Bool {
     guard self.at(.atSign) else {
       return false
     }
 
-    repeat {
-      self.eatWithoutRecovery(.atSign)
+    while let _ = self.consume(if: .atSign) {
       self.consumeIdentifierOrRethrows()
       if self.consume(if: .leftParen) != nil {
         while !self.at(.eof), !self.at(.rightParen), !self.at(.poundEndifKeyword) {
@@ -153,7 +164,7 @@ extension Parser.Lookahead {
         }
         self.consume(if: .rightParen)
       }
-    } while self.at(.atSign)
+    }
     return true
   }
 }
@@ -310,9 +321,9 @@ extension Parser.Lookahead {
         self.isParenthesizedUnowned() {
       var lookahead = self.lookahead()
       lookahead.consumeIdentifier()
-      lookahead.eatWithoutRecovery(.leftParen)
+      lookahead.eat(.leftParen)
       lookahead.consumeIdentifier()
-      lookahead.eatWithoutRecovery(.rightParen)
+      lookahead.eat(.rightParen)
       return lookahead.isStartOfDeclaration()
     }
 
@@ -381,7 +392,7 @@ extension Parser.Lookahead {
 
     // Eat the "{".
     var lookahead = self.lookahead()
-    lookahead.eatWithoutRecovery(.leftBrace)
+    lookahead.eat(.leftBrace)
 
     // Eat attributes, if present.
     while lookahead.consume(if: .atSign) != nil {

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -101,7 +101,7 @@ extension Parser.Lookahead {
 extension Parser.Lookahead {
   mutating func skipTypeAttribute() {
     // These are keywords that we accept as attribute names.
-    guard self.currentToken.isIdentifier || self.at(any: [.inKeyword, .inoutKeyword]) else {
+    guard self.at(.identifier) || self.at(any: [.inKeyword, .inoutKeyword]) else {
       return
     }
 
@@ -112,7 +112,7 @@ extension Parser.Lookahead {
       if case .convention = attr {
         guard
           self.consume(if: .leftParen) != nil,
-          (self.currentToken.isIdentifier ? self.expectIdentifierWithoutRecovery() : nil) != nil,
+          (self.at(.identifier) ? self.expectIdentifierWithoutRecovery() : nil) != nil,
           self.consume(if: .rightParen) != nil
         else {
           return
@@ -300,7 +300,7 @@ extension Parser.Lookahead {
     }
 
     // Otherwise, the only hard case left is the identifier case.
-    guard self.currentToken.isIdentifier else {
+    guard self.at(.identifier) else {
       return true
     }
 
@@ -314,7 +314,7 @@ extension Parser.Lookahead {
 
     // If this can't possibly be a contextual keyword, then this identifier is
     // not interesting.  Bail out.
-    guard self.currentToken.isContextualDeclKeyword() else {
+    guard self.at(anyIn: ContextualDeclKeyword.self) != nil else {
       return false
     }
 
@@ -333,7 +333,7 @@ extension Parser.Lookahead {
     }
 
     if self.currentToken.isContextualKeyword("actor") {
-      if tok2.isIdentifier {
+      if tok2.tokenKind == .identifier {
         return true
       }
       // actor may be somewhere in the modifier list. Eat the tokens until we get
@@ -343,7 +343,7 @@ extension Parser.Lookahead {
       repeat {
         lookahead.consumeAnyToken()
       } while lookahead.isStartOfDeclaration()
-      return lookahead.currentToken.isIdentifier
+      return lookahead.at(.identifier)
     }
 
     // If the next token is obviously not the start of a decl, bail early.
@@ -367,7 +367,7 @@ extension Parser.Lookahead {
     guard lookahead.consume(if: .leftParen) != nil else {
       return false
     }
-    return lookahead.currentToken.isIdentifier
+    return lookahead.at(.identifier)
         && lookahead.peek().tokenKind == .rightParen
         && (lookahead.currentToken.tokenText == "safe" || lookahead.currentToken.tokenText == "unsafe")
   }
@@ -401,7 +401,7 @@ extension Parser.Lookahead {
 
     // Eat attributes, if present.
     while lookahead.consume(if: .atSign) != nil {
-      guard lookahead.currentToken.isIdentifier else {
+      guard lookahead.at(.identifier) else {
         return false
       }
       lookahead.expectIdentifierWithoutRecovery()

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -107,7 +107,7 @@ extension Parser.Lookahead {
       if case .convention = attr {
         guard
           self.consume(if: .leftParen) != nil,
-          (self.currentToken.isIdentifier ? self.consumeIdentifier() : nil) != nil,
+          (self.currentToken.isIdentifier ? self.expectIdentifierWithoutRecovery() : nil) != nil,
           self.consume(if: .rightParen) != nil
         else {
           return
@@ -157,7 +157,7 @@ extension Parser.Lookahead {
     }
 
     while let _ = self.consume(if: .atSign) {
-      self.consumeIdentifierOrRethrows()
+      self.expectIdentifierOrRethrowsWithoutRecovery()
       if self.consume(if: .leftParen) != nil {
         while !self.at(any: [.eof, .rightParen, .poundEndifKeyword]) {
           self.skipSingle()
@@ -320,9 +320,9 @@ extension Parser.Lookahead {
     if self.currentToken.tokenText == "unowned" && tok2.tokenKind == .leftParen &&
         self.isParenthesizedUnowned() {
       var lookahead = self.lookahead()
-      lookahead.consumeIdentifier()
+      lookahead.expectIdentifierWithoutRecovery()
       lookahead.eat(.leftParen)
-      lookahead.consumeIdentifier()
+      lookahead.expectIdentifierWithoutRecovery()
       lookahead.eat(.rightParen)
       return lookahead.isStartOfDeclaration()
     }
@@ -348,7 +348,7 @@ extension Parser.Lookahead {
 
     // Otherwise, do a recursive parse.
     var next = self.lookahead()
-    next.consumeIdentifier()
+    next.expectIdentifierWithoutRecovery()
     return next.isStartOfDeclaration()
   }
 
@@ -358,7 +358,7 @@ extension Parser.Lookahead {
 
     // Look ahead to parse the parenthesized expression.
     var lookahead = self.lookahead()
-    lookahead.consumeIdentifier()
+    lookahead.expectIdentifierWithoutRecovery()
     guard lookahead.consume(if: .leftParen) != nil else {
       return false
     }
@@ -399,7 +399,7 @@ extension Parser.Lookahead {
       guard lookahead.currentToken.isIdentifier else {
         return false
       }
-      lookahead.consumeIdentifier()
+      lookahead.expectIdentifierWithoutRecovery()
       // Eat paren after attribute name; e.g. @foo(x)
       if lookahead.at(.leftParen) {
         lookahead.skipSingle()

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -61,13 +61,18 @@ extension Parser.Lookahead {
 }
 
 extension Parser.Lookahead {
-  public mutating func missingToken(_ kind: RawTokenKind) {
+  @_spi(RawSyntax)
+  public mutating func missingToken(_ kind: RawTokenKind, text: SyntaxText?) {
     // do nothing
   }
 
   public mutating func consumeAnyToken() {
     tokensConsumed += 1
     self.currentToken = self.lexemes.advance()
+  }
+
+  public mutating func consumeAnyToken(remapping: RawTokenKind) {
+    self.consumeAnyToken()
   }
 
   /// Consumes a given token, or splits the current token into a leading token

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -145,7 +145,7 @@ extension Parser.Lookahead {
     }
 
     repeat {
-      self.eat(.atSign)
+      self.eatWithoutRecovery(.atSign)
       self.consumeIdentifierOrRethrows()
       if self.consume(if: .leftParen) != nil {
         while !self.at(.eof), !self.at(.rightParen), !self.at(.poundEndifKeyword) {
@@ -310,9 +310,9 @@ extension Parser.Lookahead {
         self.isParenthesizedUnowned() {
       var lookahead = self.lookahead()
       lookahead.consumeIdentifier()
-      lookahead.eat(.leftParen)
+      lookahead.eatWithoutRecovery(.leftParen)
       lookahead.consumeIdentifier()
-      lookahead.eat(.rightParen)
+      lookahead.eatWithoutRecovery(.rightParen)
       return lookahead.isStartOfDeclaration()
     }
 
@@ -381,7 +381,7 @@ extension Parser.Lookahead {
 
     // Eat the "{".
     var lookahead = self.lookahead()
-    lookahead.eat(.leftBrace)
+    lookahead.eatWithoutRecovery(.leftBrace)
 
     // Eat attributes, if present.
     while lookahead.consume(if: .atSign) != nil {

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -106,9 +106,9 @@ extension Parser.Lookahead {
     }
 
     // Determine which attribute it is.
-    if let attr = Parser.TypeAttribute(rawValue: self.currentToken.tokenText) {
+    if let (attr, handle) = self.at(anyIn: Parser.TypeAttribute.self) {
       // Ok, it is a valid attribute, eat it, and then process it.
-      self.consumeAnyToken()
+      self.eat(handle)
       if case .convention = attr {
         guard
           self.consume(if: .leftParen) != nil,
@@ -121,12 +121,12 @@ extension Parser.Lookahead {
       return
     }
 
-    if Parser.DeclarationAttribute(rawValue: self.currentToken.tokenText) != nil {
+    if let (_, handle) = self.at(anyIn: Parser.DeclarationAttribute.self) {
       // This is a valid decl attribute so they should have put it on the decl
       // instead of the type.
       //
       // Recover by eating @foo(...)
-      self.consumeAnyToken()
+      self.eat(handle)
       if self.at(.leftParen) {
         var backtrack = self.lookahead()
         backtrack.skipSingle()
@@ -177,7 +177,7 @@ extension Parser.Lookahead {
 // MARK: Lookahead
 
 extension Parser.Lookahead {
-  private static let declAttributeNames: Set<SyntaxText> = [
+  private static let declAttributeNames: [SyntaxText] = [
     "autoclosure",
     "convention",
     "noescape",
@@ -274,7 +274,7 @@ extension Parser.Lookahead {
     // shared by SIL, e.g 'private' in 'sil private @foo :'. We need to make sure
     // this isn't considered a valid Swift decl start.
     if self.currentToken.tokenKind.isKeyword {
-      if Self.declAttributeNames.contains(self.currentToken.tokenText) {
+      if self.at(any: [], contextualKeywords: Self.declAttributeNames) {
         var subparser = self.lookahead()
         subparser.consumeAnyToken()
 
@@ -322,7 +322,7 @@ extension Parser.Lookahead {
 
     // If this is 'unowned', check to see if it is valid.
     let tok2 = self.peek()
-    if self.currentToken.tokenText == "unowned" && tok2.tokenKind == .leftParen &&
+    if self.atContextualKeyword("unowned") && tok2.tokenKind == .leftParen &&
         self.isParenthesizedUnowned() {
       var lookahead = self.lookahead()
       lookahead.expectIdentifierWithoutRecovery()
@@ -358,7 +358,7 @@ extension Parser.Lookahead {
   }
 
   func isParenthesizedUnowned() -> Bool {
-    assert(self.currentToken.tokenText == "unowned" && self.peek().tokenKind == .leftParen,
+    assert(self.atContextualKeyword("unowned") && self.peek().tokenKind == .leftParen,
            "Invariant violated")
 
     // Look ahead to parse the parenthesized expression.
@@ -369,7 +369,7 @@ extension Parser.Lookahead {
     }
     return lookahead.at(.identifier)
         && lookahead.peek().tokenKind == .rightParen
-        && (lookahead.currentToken.tokenText == "safe" || lookahead.currentToken.tokenText == "unsafe")
+        && (lookahead.atContextualKeyword("safe") || lookahead.atContextualKeyword("unsafe"))
   }
 }
 

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -306,9 +306,9 @@ extension Parser.Lookahead {
 
     // If this is an operator declaration, handle it.
     if case .operatorKeyword = self.peek().tokenKind,
-        (self.currentToken.isContextualKeyword("prefix") ||
-         self.currentToken.isContextualKeyword("postfix") ||
-         self.currentToken.isContextualKeyword("infix")) {
+        (self.atContextualKeyword("prefix") ||
+         self.atContextualKeyword("postfix") ||
+         self.atContextualKeyword("infix")) {
       return true
     }
 
@@ -332,7 +332,7 @@ extension Parser.Lookahead {
       return lookahead.isStartOfDeclaration()
     }
 
-    if self.currentToken.isContextualKeyword("actor") {
+    if self.atContextualKeyword("actor") {
       if tok2.tokenKind == .identifier {
         return true
       }
@@ -386,7 +386,7 @@ extension Parser.Lookahead {
     // If we have a 'didSet' or a 'willSet' label, disambiguate immediately as
     // an accessor block.
     let nextToken = self.peek()
-    if nextToken.isContextualKeyword("didSet") || nextToken.isContextualKeyword("willSet") {
+    if nextToken.isContextualKeyword(["didSet", "willSet"]) {
       return true
     }
 
@@ -412,8 +412,7 @@ extension Parser.Lookahead {
     }
 
     // Check if we have 'didSet'/'willSet' after attributes.
-    return lookahead.currentToken.isContextualKeyword("didSet") ||
-           lookahead.currentToken.isContextualKeyword("willSet")
+    return lookahead.at(any: [], contextualKeywords: ["didSet", "willSet"])
   }
 }
 

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -96,7 +96,7 @@ extension Parser.Lookahead {
 extension Parser.Lookahead {
   mutating func skipTypeAttribute() {
     // These are keywords that we accept as attribute names.
-    guard self.currentToken.isIdentifier || self.at(.inKeyword) || self.at(.inoutKeyword) else {
+    guard self.currentToken.isIdentifier || self.at(any: [.inKeyword, .inoutKeyword]) else {
       return
     }
 
@@ -127,7 +127,7 @@ extension Parser.Lookahead {
         backtrack.skipSingle()
         // If we found '->', or 'throws' after paren, it's likely a parameter
         // of function type.
-        guard backtrack.at(.arrow) || backtrack.at(.throwsKeyword) || backtrack.at(.rethrowsKeyword) || backtrack.at(.throwKeyword) else {
+        guard backtrack.at(any: [.arrow, .throwsKeyword, .rethrowsKeyword, .throwKeyword]) else {
           self.skipSingle()
           return
         }
@@ -159,7 +159,7 @@ extension Parser.Lookahead {
     while let _ = self.consume(if: .atSign) {
       self.consumeIdentifierOrRethrows()
       if self.consume(if: .leftParen) != nil {
-        while !self.at(.eof), !self.at(.rightParen), !self.at(.poundEndifKeyword) {
+        while !self.at(any: [.eof, .rightParen, .poundEndifKeyword]) {
           self.skipSingle()
         }
         self.consume(if: .rightParen)
@@ -258,7 +258,7 @@ extension Parser.Lookahead {
       _ = subparser.eatParseAttributeList()
       // If this attribute is the last element in the block,
       // consider it is a start of incomplete decl.
-      if subparser.at(.rightBrace) || subparser.at(.eof) || subparser.at(.poundEndifKeyword) {
+      if subparser.at(any: [.rightBrace, .eof, .poundEndifKeyword]) {
         return true
       }
       return subparser.isStartOfDeclaration()
@@ -275,7 +275,7 @@ extension Parser.Lookahead {
 
         // Eat paren after modifier name; e.g. private(set)
         if subparser.consume(if: .leftParen) != nil {
-          while !subparser.at(.eof) && !subparser.at(.rightBrace) && !subparser.at(.poundEndifKeyword) {
+          while !subparser.at(any: [.eof, .rightBrace, .poundEndifKeyword]) {
             if subparser.consume(if: .rightParen) != nil {
               break
             }
@@ -416,8 +416,7 @@ extension Parser.Lookahead {
 
 extension Parser.Lookahead {
   mutating func skipUntil(_ t1: RawTokenKind, _ t2: RawTokenKind) {
-    while !self.at(.eof) && !self.at(t1) && !self.at(t2)
-            && !self.at(.poundEndifKeyword) && !self.at(.poundElseKeyword) && !self.at(.poundElseifKeyword) {
+    while !self.at(any: [.eof, t1, t2, .poundEndifKeyword, .poundElseKeyword, .poundElseifKeyword]) {
       self.skipSingle()
     }
   }
@@ -452,7 +451,7 @@ extension Parser.Lookahead {
       // skipUntil also implicitly stops at tok::pound_endif.
       self.skipUntil(.poundElseKeyword, .poundElseifKeyword)
 
-      if self.at(.poundElseKeyword) || self.at(.poundElseifKeyword) {
+      if self.at(any: [.poundElseKeyword, .poundElseifKeyword]) {
         self.skipSingle()
       } else {
         self.consume(if: .poundElseifKeyword)

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -77,7 +77,7 @@ extension Parser {
         let details: RawDeclModifierDetailSyntax?
         if let lparen = self.consume(if: .leftParen) {
           assert(self.currentToken.isContextualKeyword("set"))
-          let detail = self.consumeIdentifier()
+          let detail = self.expectIdentifierWithoutRecovery()
           let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
           details = RawDeclModifierDetailSyntax(
             leftParen: lparen,

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -13,7 +13,7 @@
 @_spi(RawSyntax) import SwiftSyntax
 
 extension Parser {
-  enum DeclModifier: SyntaxText {
+  enum DeclModifier: SyntaxText, ContextualKeywords {
     case unowned = "unowned"
 
     case final = "final"
@@ -120,34 +120,34 @@ extension Parser {
       case (.identifier, _)?:
         // Context sensitive keywords.
         // FIXME: Sink this into the GYB
-        switch DeclModifier(rawValue: self.currentToken.tokenText) {
-        case .unowned:
+        switch self.at(anyIn: DeclModifier.self) {
+        case (.unowned, _)?:
           elements.append(self.parseUnownedModifier())
-        case .final,
-            .required,
-            .optional,
-            .lazy,
-            .dynamic,
-            .infix,
-            .prefix,
-            .postfix,
-            .compilerInitialized,
-            .consuming,
-            .mutating,
-            .nonmutating,
-            .convenience,
-            .override,
-            .open,
-            .weak,
-            .indirect,
-            .isolated,
-            .async,
-            .nonisolated,
-            .distributed,
-            .const,
-            .local:
+        case (.final, _)?,
+            (.required, _)?,
+            (.optional, _)?,
+            (.lazy, _)?,
+            (.dynamic, _)?,
+            (.infix, _)?,
+            (.prefix, _)?,
+            (.postfix, _)?,
+            (.compilerInitialized, _)?,
+            (.consuming, _)?,
+            (.mutating, _)?,
+            (.nonmutating, _)?,
+            (.convenience, _)?,
+            (.override, _)?,
+            (.open, _)?,
+            (.weak, _)?,
+            (.indirect, _)?,
+            (.isolated, _)?,
+            (.async, _)?,
+            (.nonisolated, _)?,
+            (.distributed, _)?,
+            (.const, _)?,
+            (.local, _)?:
           elements.append(self.parseSimpleModifier())
-        default:
+        case nil:
           break MODIFIER_LOOP
         }
 
@@ -186,8 +186,7 @@ extension Parser {
   }
 
   mutating func parseUnownedModifier() -> RawDeclModifierSyntax {
-    assert(self.currentToken.tokenText == "unowned")
-    let keyword = self.consumeAnyToken(remapping: .contextualKeyword)
+    let (unexpectedBeforeKeyword, keyword) = self.expectContextualKeyword("unowned")
 
     let detail: RawDeclModifierDetailSyntax?
     if self.at(.leftParen) {
@@ -196,6 +195,11 @@ extension Parser {
       detail = nil
     }
 
-    return RawDeclModifierSyntax(name: keyword, detail: detail, arena: self.arena)
+    return RawDeclModifierSyntax(
+      unexpectedBeforeKeyword,
+      name: keyword,
+      detail: detail,
+      arena: self.arena
+    )
   }
 }

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -161,7 +161,7 @@ extension Parser {
 
 extension Parser {
   mutating func parseSimpleModifier() -> RawDeclModifierSyntax {
-    let keyword = self.consume(remapping: .contextualKeyword)
+    let keyword = self.consumeAnyToken(remapping: .contextualKeyword)
     return RawDeclModifierSyntax(name: keyword, detail: nil, arena: self.arena)
   }
 
@@ -180,14 +180,14 @@ extension Parser {
   }
 
   mutating func parseSingleArgumentModifier() -> RawDeclModifierSyntax {
-    let keyword = self.consume(remapping: .contextualKeyword)
+    let keyword = self.consumeAnyToken(remapping: .contextualKeyword)
     let detail = self.parseModifierDetail()
     return RawDeclModifierSyntax(name: keyword, detail: detail, arena: self.arena)
   }
 
   mutating func parseUnownedModifier() -> RawDeclModifierSyntax {
     assert(self.currentToken.tokenText == "unowned")
-    let keyword = self.consume(remapping: .contextualKeyword)
+    let keyword = self.consumeAnyToken(remapping: .contextualKeyword)
 
     let detail: RawDeclModifierDetailSyntax?
     if self.at(.leftParen) {

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -76,7 +76,7 @@ extension Parser {
         let name = self.eat(handle)
         let details: RawDeclModifierDetailSyntax?
         if let lparen = self.consume(if: .leftParen) {
-          assert(self.currentToken.isContextualKeyword("set"))
+          assert(self.atContextualKeyword("set"))
           let detail = self.expectIdentifierWithoutRecovery()
           let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
           details = RawDeclModifierDetailSyntax(
@@ -106,7 +106,7 @@ extension Parser {
         // treat 'class' as a modifier in the case of a following CC
         // token, we cannot be sure there is no intention to override
         // or witness something static.
-        if lookahead.isStartOfDeclaration() || lookahead.currentToken.isContextualKeyword("override") {
+        if lookahead.isStartOfDeclaration() || lookahead.atContextualKeyword("override") {
           let classKeyword = self.eat(handle)
           elements.append(RawDeclModifierSyntax(
             name: classKeyword,

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -53,13 +53,13 @@ extension Parser {
     // Consume the base name.
     let ident: RawTokenSyntax
     if self.currentToken.isIdentifier || self.at(any: [.selfKeyword, .capitalSelfKeyword]) {
-      ident = self.consumeIdentifier()
+      ident = self.expectIdentifierWithoutRecovery()
     } else if flags.contains(.operators) && self.currentToken.isAnyOperator {
       ident = self.consume(remapping: .identifier)
     } else if flags.contains(.keywords) && self.currentToken.tokenKind.isKeyword {
       ident = self.consume(remapping: .identifier)
     } else {
-      ident = self.consumeIdentifier()
+      ident = self.expectIdentifierWithoutRecovery()
     }
 
     // Parse an argument list, if the flags allow it and it's present.
@@ -332,31 +332,6 @@ extension Lexer.Lexeme {
 }
 
 extension TokenConsumer {
-  mutating func consumeIdentifier() -> Token {
-    switch self.currentToken.tokenKind {
-    case .selfKeyword,
-        .capitalSelfKeyword,
-        .anyKeyword,
-        .identifier:
-      return self.consumeAnyToken()
-    default:
-      return self.missingToken(.identifier)
-    }
-  }
-
-  mutating func consumeIdentifierOrRethrows() -> Token {
-    switch self.currentToken.tokenKind {
-    case .selfKeyword,
-        .capitalSelfKeyword,
-        .anyKeyword,
-        .identifier,
-        .rethrowsKeyword:
-      return self.consumeAnyToken()
-    default:
-      return self.missingToken(.identifier)
-    }
-  }
-
   mutating func consumeInteger() -> Token {
     switch self.currentToken.tokenKind {
     case .integerLiteral:

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -331,13 +331,3 @@ extension Lexer.Lexeme {
   }
 }
 
-extension TokenConsumer {
-  mutating func consumeInteger() -> Token {
-    switch self.currentToken.tokenKind {
-    case .integerLiteral:
-      return self.consumeAnyToken()
-    default:
-      return self.missingToken(.integerLiteral)
-    }
-  }
-}

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -105,7 +105,7 @@ extension Parser {
         // Check to see if there is an argument label.
         assert(self.currentToken.canBeArgumentLabel && self.peek().tokenKind == .colon)
         let name = self.consumeAnyToken()
-        let (unexpectedBeforeColon, colon) = self.eat(.colon)
+        let (unexpectedBeforeColon, colon) = self.expect(.colon)
         elements.append(RawDeclNameArgumentSyntax(
           name: name,
           unexpectedBeforeColon,
@@ -114,7 +114,7 @@ extension Parser {
         ))
       }
     }
-    let (unexpectedBeforeRParen, rparen) = self.eat(.rightParen)
+    let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
     return RawDeclNameArgumentsSyntax(
       unexpectedBeforeLParen,
       leftParen: lparen,
@@ -185,6 +185,15 @@ extension Lexer.Lexeme {
     switch self.tokenKind {
     case .identifier, .contextualKeyword:
       return self.tokenText == name
+    default:
+      return false
+    }
+  }
+
+  func isContextualKeyword(_ names: [SyntaxText]) -> Bool {
+    switch self.tokenKind {
+    case .identifier, .contextualKeyword:
+      return names.contains(self.tokenText)
     default:
       return false
     }

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -211,9 +211,8 @@ extension Lexer.Lexeme {
     // NOTE: If this returns 'true', that token must be handled in
     //       'parseEffectsSpecifiers()'.
 
-    if (self.isContextualKeyword("async") ||
-        (self.isContextualKeyword("await") && !self.isAtStartOfLine) ||
-        self.isContextualKeyword("reasync")) {
+    if self.isContextualKeyword(["async", "reasync"]) ||
+        (self.isContextualKeyword("await") && !self.isAtStartOfLine) {
       return true
     }
 

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -55,9 +55,9 @@ extension Parser {
     if self.currentToken.isIdentifier || self.at(any: [.selfKeyword, .capitalSelfKeyword]) {
       ident = self.expectIdentifierWithoutRecovery()
     } else if flags.contains(.operators) && self.currentToken.isAnyOperator {
-      ident = self.consume(remapping: .identifier)
+      ident = self.consumeAnyToken(remapping: .identifier)
     } else if flags.contains(.keywords) && self.currentToken.tokenKind.isKeyword {
-      ident = self.consume(remapping: .identifier)
+      ident = self.consumeAnyToken(remapping: .identifier)
     } else {
       ident = self.expectIdentifierWithoutRecovery()
     }

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -14,7 +14,7 @@
 
 extension Parser {
   mutating func parseAnyIdentifier() -> RawTokenSyntax {
-    if self.currentToken.isIdentifier || self.currentToken.isAnyOperator {
+    if self.at(.identifier) || self.currentToken.isAnyOperator {
       return self.consumeAnyToken()
     } else {
       return RawTokenSyntax(missing: .identifier, arena: arena)
@@ -52,7 +52,7 @@ extension Parser {
   mutating func parseDeclNameRef(_ flags: DeclNameOptions = []) -> (RawTokenSyntax, RawDeclNameArgumentsSyntax?) {
     // Consume the base name.
     let ident: RawTokenSyntax
-    if self.currentToken.isIdentifier || self.at(any: [.selfKeyword, .capitalSelfKeyword]) {
+    if self.at(.identifier) || self.at(any: [.selfKeyword, .capitalSelfKeyword]) {
       ident = self.expectIdentifierWithoutRecovery()
     } else if flags.contains(.operators) && self.currentToken.isAnyOperator {
       ident = self.consumeAnyToken(remapping: .identifier)
@@ -199,42 +199,6 @@ extension Lexer.Lexeme {
     }
   }
 
-  func isContextualDeclKeyword() -> Bool {
-    guard self.isIdentifier else {
-      return false
-    }
-    switch self.tokenText {
-    case "final",
-      "required",
-      "optional",
-      "lazy",
-      "dynamic",
-      "infix",
-      "prefix",
-      "postfix",
-      "_compilerInitialized",
-      "__consuming",
-      "mutating",
-      "nonmutating",
-      "convenience",
-      "override",
-      "open",
-      "weak",
-      "unowned",
-      "indirect",
-      "actor",
-      "isolated",
-      "async",
-      "nonisolated",
-      "distributed",
-      "_const",
-      "_local":
-      return true
-    default:
-      return false
-    }
-  }
-
   func isContextualPunctuator(_ name: SyntaxText) -> Bool {
     return self.isAnyOperator && self.tokenText == name
   }
@@ -245,10 +209,6 @@ extension Lexer.Lexeme {
 
   var isPunctuation: Bool {
     self.tokenKind.isPunctuation
-  }
-
-  var isIdentifier: Bool {
-    return self.tokenKind == .identifier
   }
 
   var isEllipsis: Bool {

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -207,15 +207,6 @@ extension Lexer.Lexeme {
     self.tokenKind.isKeyword
   }
 
-  var isPunctuation: Bool {
-    self.tokenKind.isPunctuation
-  }
-
-  var isEllipsis: Bool {
-    return self.isAnyOperator && self.tokenText == "..."
-  }
-
-
   var isEffectsSpecifier: Bool {
     // NOTE: If this returns 'true', that token must be handled in
     //       'parseEffectsSpecifiers()'.
@@ -283,7 +274,7 @@ extension Lexer.Lexeme {
   }
 
   func starts(with symbol: SyntaxText) -> Bool {
-    guard self.isAnyOperator || self.isPunctuation else {
+    guard self.isAnyOperator || self.tokenKind.isPunctuation else {
       return false
     }
 

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -52,7 +52,7 @@ extension Parser {
   mutating func parseDeclNameRef(_ flags: DeclNameOptions = []) -> (RawTokenSyntax, RawDeclNameArgumentsSyntax?) {
     // Consume the base name.
     let ident: RawTokenSyntax
-    if self.currentToken.isIdentifier || self.at(.selfKeyword) || self.at(.capitalSelfKeyword) {
+    if self.currentToken.isIdentifier || self.at(any: [.selfKeyword, .capitalSelfKeyword]) {
       ident = self.consumeIdentifier()
     } else if flags.contains(.operators) && self.currentToken.isAnyOperator {
       ident = self.consume(remapping: .identifier)
@@ -101,7 +101,7 @@ extension Parser {
     var elements = [RawDeclNameArgumentSyntax]()
     do {
       var loopProgress = LoopProgressCondition()
-      while !self.at(.eof) && !self.at(.rightParen) && loopProgress.evaluate(currentToken) {
+      while !self.at(any: [.eof, .rightParen]) && loopProgress.evaluate(currentToken) {
         // Check to see if there is an argument label.
         assert(self.currentToken.canBeArgumentLabel && self.peek().tokenKind == .colon)
         let name = self.consumeAnyToken()
@@ -133,7 +133,7 @@ extension Parser.Lookahead {
     }
 
     var loopProgress = LoopProgressCondition()
-    while !lookahead.at(.eof) && !lookahead.at(.rightParen) && loopProgress.evaluate(lookahead.currentToken) {
+    while !lookahead.at(any: [.eof, .rightParen]) && loopProgress.evaluate(lookahead.currentToken) {
       // Check to see if there is an argument label.
       guard lookahead.currentToken.canBeArgumentLabel && lookahead.peek().tokenKind == .colon else {
         return false

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -105,16 +105,21 @@ extension Parser {
         // Check to see if there is an argument label.
         assert(self.currentToken.canBeArgumentLabel && self.peek().tokenKind == .colon)
         let name = self.consumeAnyToken()
-        let colon = self.eat(.colon)
+        let (unexpectedBeforeColon, colon) = self.eat(.colon)
         elements.append(RawDeclNameArgumentSyntax(
-          name: name, colon: colon, arena: arena))
+          name: name,
+          unexpectedBeforeColon,
+          colon: colon,
+          arena: arena
+        ))
       }
     }
-    let rparen = self.eat(.rightParen)
+    let (unexpectedBeforeRParen, rparen) = self.eat(.rightParen)
     return RawDeclNameArgumentsSyntax(
       unexpectedBeforeLParen,
       leftParen: lparen,
       arguments: RawDeclNameArgumentListSyntax(elements: elements, arena: self.arena),
+      unexpectedBeforeRParen,
       rightParen: rparen,
       arena: arena)
   }

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -73,7 +73,7 @@ extension Parser {
     }
 
     // Is the current token a left paren?
-    guard self.at(.leftParen) && !self.currentToken.isAtStartOfLine else {
+    guard self.at(.leftParen, where: { !$0.isAtStartOfLine }) else {
       return nil
     }
 

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -196,7 +196,7 @@ extension Parser {
   /// - Returns: The token that was consumed with its kind re-mapped to the
   ///            given `TokenKind`.
   @_spi(RawSyntax)
-  public mutating func consume(remapping kind: RawTokenKind) -> RawTokenSyntax {
+  public mutating func consumeAnyToken(remapping kind: RawTokenKind) -> RawTokenSyntax {
     self.currentToken.tokenKind = kind
     return self.consumeAnyToken()
   }
@@ -277,7 +277,7 @@ extension Parser {
     let tokenText = current.tokenText
 
     if tokenText == prefix {
-      return self.consume(remapping: tokenKind)
+      return self.consumeAnyToken(remapping: tokenKind)
     }
     assert(tokenText.hasPrefix(prefix))
 

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -203,61 +203,9 @@ extension Parser {
 
 }
 
-// MARK: Consuming Tokens with Lookahead
+// MARK: Expecting Tokens with Recovery
 
 extension Parser {
-  /// If the current token has `kind1` and is followed by `kind2` consume both tokens and return them.
-  /// Otherwise, return `nil`.
-  @_spi(RawSyntax)
-  public mutating func consume(if kind1: RawTokenKind, followedBy kind2: RawTokenKind) -> (Token, Token)? {
-    if self.at(kind1) && self.peek().tokenKind == kind2 {
-      return (consumeAnyToken(), consumeAnyToken())
-    } else {
-      return nil
-    }
-  }
-
-  /// If the current token satisfies `condition1` and the next token satisfies
-  /// `condition2` consume both tokens and return them.
-  /// Otherwise, return `nil`.
-  @_spi(RawSyntax)
-  public mutating func consume(
-    if condition1: (Lexer.Lexeme) -> Bool,
-    followedBy condition2: (Lexer.Lexeme) -> Bool
-  ) -> (Token, Token)? {
-    if condition1(self.currentToken) && condition2(self.peek()) {
-      return (consumeAnyToken(), consumeAnyToken())
-    } else {
-      return nil
-    }
-  }
-}
-
-// MARK: Expecting Tokens
-
-extension Parser {
-  /// Attempts to consume a token of the given kind, synthesizing a missing
-  /// token if the current token's kind does not match.
-  ///
-  /// This method does not try to eat unexpected until it finds the token of the specified `kind`.
-  /// In general, `expect` or `expectAny` should be preferred.
-  ///
-  /// - Parameter kind: The kind of token to consume.
-  /// - Returns: A token of the given kind.
-  @_spi(RawSyntax)
-  public mutating func expectWithoutLookahead(_ kind: RawTokenKind, _ text: SyntaxText? = nil) -> RawTokenSyntax {
-    if self.currentToken.tokenKind == kind {
-      if let text = text {
-        if self.currentToken.tokenText == text {
-          return self.consumeAnyToken()
-        }
-      } else {
-        return self.consumeAnyToken()
-      }
-    }
-    return RawTokenSyntax(missing: kind, arena: self.arena)
-  }
-
   /// Attempts to consume a token of the given kind.
   /// If it cannot be found, the parser tries
   ///  1. To each unexpected tokens that have lower ``TokenPrecedence`` than the

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -217,7 +217,7 @@ extension Parser {
       for _ in 0..<lookahead.tokensConsumed {
         unexpectedNodes.append(RawSyntax(self.consumeAnyToken()))
       }
-      let token = eat(kind)
+      let token = eatWithoutRecovery(kind)
       return (RawUnexpectedNodesSyntax(elements: unexpectedNodes, arena: self.arena), token)
     }
     return (nil, RawTokenSyntax(missing: kind, arena: self.arena))
@@ -273,6 +273,13 @@ extension Parser {
       }
     }
     return RawTokenSyntax(missing: kind, arena: self.arena)
+  }
+
+  @_spi(RawSyntax)
+  public mutating func eat(_ kind: RawTokenKind) -> (unexpected: RawUnexpectedNodesSyntax?, token: Token) {
+    let (unexpected, token) = expect(kind)
+    assert(!token.isMissing)
+    return (unexpected, token)
   }
 }
 

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -281,8 +281,7 @@ extension Parser.Lookahead {
           return true // isolated :
         }
         backtrack.consumeAnyToken()
-        backtrack.consumeAnyToken()
-        return backtrack.currentToken.canBeArgumentLabel && nextTok.tokenKind == .colon
+        return backtrack.currentToken.canBeArgumentLabel && backtrack.peek().tokenKind == .colon
       }
     }
 

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -162,7 +162,7 @@ extension Parser {
   /// for-in loops and guard clauses.
   mutating func parseMatchingPattern() -> RawPatternSyntax {
     // Parse productions that can only be patterns.
-    if let letOrVar = self.consume(ifAny: .varKeyword, .letKeyword) {
+    if let letOrVar = self.consume(ifAny: [.varKeyword, .letKeyword]) {
       let value = self.parseMatchingPattern()
       return RawPatternSyntax(RawValueBindingPatternSyntax(
         letOrVarKeyword: letOrVar, valuePattern: value, arena: self.arena))

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -282,9 +282,9 @@ extension Parser.Lookahead {
     // If the next token can be an argument label, we might have a name.
     if nextTok.canBeArgumentLabel {
       // If the first name wasn't "isolated", we're done.
-      if !self.currentToken.isContextualKeyword("isolated") &&
-          !self.currentToken.isContextualKeyword("some") &&
-          !self.currentToken.isContextualKeyword("any") {
+      if !self.atContextualKeyword("isolated") &&
+          !self.atContextualKeyword("some") &&
+          !self.atContextualKeyword("any") {
         return true
       }
 

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -45,51 +45,60 @@ extension Parser {
   ///
   ///     expression-pattern → expression
   mutating func parsePattern() -> RawPatternSyntax {
-    switch self.currentToken.tokenKind {
-    case .leftParen:
-      let (unexpectedBeforeLParen, lparen) = self.eat(.leftParen)
+    enum ExpectedTokens: RawTokenKindSubset {
+      case leftParen
+      case wildcardKeyword
+      case identifier
+      case letKeyword
+      case varKeyword
+
+      var rawTokenKind: RawTokenKind {
+        switch self {
+        case .leftParen: return .leftParen
+        case .wildcardKeyword: return .wildcardKeyword
+        case .identifier: return .identifier
+        case .letKeyword: return .letKeyword
+        case .varKeyword: return .varKeyword
+        }
+      }
+
+    }
+
+    switch self.at(anyIn: ExpectedTokens.self) {
+    case (.leftParen, let handle)?:
+      let lparen = self.eat(handle)
       let elements = self.parsePatternTupleElements()
       let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
       return RawPatternSyntax(RawTuplePatternSyntax(
-        unexpectedBeforeLParen,
         leftParen: lparen,
         elements: elements,
         unexpectedBeforeRParen,
         rightParen: rparen,
         arena: self.arena
       ))
-    case .wildcardKeyword:
-      let (unexpectedBeforeWildcard, wildcard) = self.eat(.wildcardKeyword)
+    case (.wildcardKeyword, let handle)?:
+      let wildcard = self.eat(handle)
       return RawPatternSyntax(RawWildcardPatternSyntax(
-        unexpectedBeforeWildcard,
         wildcard: wildcard,
         typeAnnotation: nil,
         arena: self.arena
       ))
-    case .identifier:
-      let (unexpectedBeforeIdentifier, identifier) = self.eat(self.currentToken.tokenKind)
+    case (.identifier, let handle)?:
+      let identifier = self.eat(handle)
       return RawPatternSyntax(RawIdentifierPatternSyntax(
-        unexpectedBeforeIdentifier,
         identifier: identifier,
         arena: self.arena
       ))
-    case .letKeyword, .varKeyword:
-      let unexpectedBeforeLetOrVar: RawUnexpectedNodesSyntax?
-      let letOrVar: RawTokenSyntax
-      if self.at(.letKeyword) {
-        (unexpectedBeforeLetOrVar, letOrVar) = self.eat(.letKeyword)
-      } else {
-        assert(self.at(.varKeyword))
-        (unexpectedBeforeLetOrVar, letOrVar) = self.eat(.varKeyword)
-      }
+    case (.letKeyword, let handle)?,
+      (.varKeyword, let handle)?:
+      let letOrVar = self.eat(handle)
       let value = self.parsePattern()
       return RawPatternSyntax(RawValueBindingPatternSyntax(
-        unexpectedBeforeLetOrVar,
         letOrVarKeyword: letOrVar,
         valuePattern: value,
         arena: self.arena
       ))
-    default:
+    case nil:
       return RawPatternSyntax(RawMissingPatternSyntax(arena: self.arena))
     }
   }
@@ -104,14 +113,12 @@ extension Parser {
     let pattern = self.parsePattern()
 
     // Now parse an optional type annotation.
-    guard self.at(.colon) else {
+    guard let colon = self.consume(if: .colon) else {
       return (pattern, nil)
     }
 
-    let (unexpectedBeforeColon, colon) = self.eat(.colon)
     let result = self.parseType()
     let type = RawTypeAnnotationSyntax(
-      unexpectedBeforeColon,
       colon: colon,
       type: result,
       arena: self.arena
@@ -136,23 +143,13 @@ extension Parser {
               && keepGoing
               && loopProgress.evaluate(currentToken) {
         // If the tuple element has a label, parse it.
-        let label: RawTokenSyntax?
-        let unexpectedBeforeColon: RawUnexpectedNodesSyntax?
-        let colon: RawTokenSyntax?
-        if self.currentToken.tokenKind == .identifier, self.peek().tokenKind == .colon {
-          label = self.consumeAnyToken()
-          (unexpectedBeforeColon, colon) = self.eat(.colon)
-        } else {
-          label = nil
-          unexpectedBeforeColon = nil
-          colon = nil
-        }
+        let labelAndColon = self.consume(if: .identifier, followedBy: .colon)
+        let (label, colon) = (labelAndColon?.0, labelAndColon?.1)
         let pattern = self.parsePattern()
         let trailingComma = self.consume(if: .comma)
         keepGoing = trailingComma != nil
         elements.append(RawTuplePatternElementSyntax(
           labelName: label,
-          unexpectedBeforeColon,
           labelColon: colon,
           pattern: pattern,
           trailingComma: trailingComma,
@@ -173,12 +170,9 @@ extension Parser {
       let value = self.parseMatchingPattern()
       return RawPatternSyntax(RawValueBindingPatternSyntax(
         letOrVarKeyword: letOrVar, valuePattern: value, arena: self.arena))
-    } else if self.at(.isKeyword) {
-      // matching-pattern ::= 'is' type
-      let (unexpectedBeforeIsKeyword, isKeyword) = self.eat(.isKeyword)
+    } else if let isKeyword = self.consume(if: .isKeyword) {
       let type = self.parseType()
       return RawPatternSyntax(RawIsTypePatternSyntax(
-        unexpectedBeforeIsKeyword,
         isKeyword: isKeyword,
         type: type,
         arena: self.arena

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -47,10 +47,11 @@ extension Parser {
   mutating func parsePattern() -> RawPatternSyntax {
     switch self.currentToken.tokenKind {
     case .leftParen:
-      let lparen = self.eat(.leftParen)
+      let (unexpectedBeforeLParen, lparen) = self.eat(.leftParen)
       let elements = self.parsePatternTupleElements()
       let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
       return RawPatternSyntax(RawTuplePatternSyntax(
+        unexpectedBeforeLParen,
         leftParen: lparen,
         elements: elements,
         unexpectedBeforeRParen,
@@ -58,24 +59,36 @@ extension Parser {
         arena: self.arena
       ))
     case .wildcardKeyword:
-      let wildcard = self.eat(.wildcardKeyword)
+      let (unexpectedBeforeWildcard, wildcard) = self.eat(.wildcardKeyword)
       return RawPatternSyntax(RawWildcardPatternSyntax(
-        wildcard: wildcard, typeAnnotation: nil, arena: self.arena))
+        unexpectedBeforeWildcard,
+        wildcard: wildcard,
+        typeAnnotation: nil,
+        arena: self.arena
+      ))
     case .identifier:
-      let identifier = self.eat(self.currentToken.tokenKind)
+      let (unexpectedBeforeIdentifier, identifier) = self.eat(self.currentToken.tokenKind)
       return RawPatternSyntax(RawIdentifierPatternSyntax(
-        identifier: identifier, arena: self.arena))
+        unexpectedBeforeIdentifier,
+        identifier: identifier,
+        arena: self.arena
+      ))
     case .letKeyword, .varKeyword:
+      let unexpectedBeforeLetOrVar: RawUnexpectedNodesSyntax?
       let letOrVar: RawTokenSyntax
       if self.at(.letKeyword) {
-        letOrVar = self.eat(.letKeyword)
+        (unexpectedBeforeLetOrVar, letOrVar) = self.eat(.letKeyword)
       } else {
         assert(self.at(.varKeyword))
-        letOrVar = self.eat(.varKeyword)
+        (unexpectedBeforeLetOrVar, letOrVar) = self.eat(.varKeyword)
       }
       let value = self.parsePattern()
       return RawPatternSyntax(RawValueBindingPatternSyntax(
-        letOrVarKeyword: letOrVar, valuePattern: value, arena: self.arena))
+        unexpectedBeforeLetOrVar,
+        letOrVarKeyword: letOrVar,
+        valuePattern: value,
+        arena: self.arena
+      ))
     default:
       return RawPatternSyntax(RawMissingPatternSyntax(arena: self.arena))
     }
@@ -95,10 +108,14 @@ extension Parser {
       return (pattern, nil)
     }
 
-    let colon = self.eat(.colon)
+    let (unexpectedBeforeColon, colon) = self.eat(.colon)
     let result = self.parseType()
     let type = RawTypeAnnotationSyntax(
-      colon: colon, type: result, arena: self.arena)
+      unexpectedBeforeColon,
+      colon: colon,
+      type: result,
+      arena: self.arena
+    )
     return (pattern, type)
   }
 
@@ -120,12 +137,14 @@ extension Parser {
               && loopProgress.evaluate(currentToken) {
         // If the tuple element has a label, parse it.
         let label: RawTokenSyntax?
+        let unexpectedBeforeColon: RawUnexpectedNodesSyntax?
         let colon: RawTokenSyntax?
         if self.currentToken.tokenKind == .identifier, self.peek().tokenKind == .colon {
           label = self.consumeAnyToken()
-          colon = self.eat(.colon)
+          (unexpectedBeforeColon, colon) = self.eat(.colon)
         } else {
           label = nil
+          unexpectedBeforeColon = nil
           colon = nil
         }
         let pattern = self.parsePattern()
@@ -133,6 +152,7 @@ extension Parser {
         keepGoing = trailingComma != nil
         elements.append(RawTuplePatternElementSyntax(
           labelName: label,
+          unexpectedBeforeColon,
           labelColon: colon,
           pattern: pattern,
           trailingComma: trailingComma,
@@ -155,10 +175,14 @@ extension Parser {
         letOrVarKeyword: letOrVar, valuePattern: value, arena: self.arena))
     } else if self.at(.isKeyword) {
       // matching-pattern ::= 'is' type
-      let isKeyword = self.eat(.isKeyword)
+      let (unexpectedBeforeIsKeyword, isKeyword) = self.eat(.isKeyword)
       let type = self.parseType()
       return RawPatternSyntax(RawIsTypePatternSyntax(
-        isKeyword: isKeyword, type: type, arena: self.arena))
+        unexpectedBeforeIsKeyword,
+        isKeyword: isKeyword,
+        type: type,
+        arena: self.arena
+      ))
     } else {
       // matching-pattern ::= expr
       // Fall back to expression parsing for ambiguous forms. Name lookup will

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -138,11 +138,8 @@ extension Parser {
     do {
       var keepGoing = true
       var loopProgress = LoopProgressCondition()
-      while !self.at(.eof)
-              && !self.at(.rightParen)
-              && keepGoing
-              && loopProgress.evaluate(currentToken) {
-        // If the tuple element has a label, parse it.
+      while !self.at(any: [.eof, .rightParen]) && keepGoing && loopProgress.evaluate(currentToken) {
+         // If the tuple element has a label, parse it.
         let labelAndColon = self.consume(if: .identifier, followedBy: .colon)
         let (label, colon) = (labelAndColon?.0, labelAndColon?.1)
         let pattern = self.parsePattern()
@@ -165,8 +162,7 @@ extension Parser {
   /// for-in loops and guard clauses.
   mutating func parseMatchingPattern() -> RawPatternSyntax {
     // Parse productions that can only be patterns.
-    if self.at(.varKeyword) || self.at(.letKeyword) {
-      let letOrVar = self.consumeAnyToken()
+    if let letOrVar = self.consume(ifAny: .varKeyword, .letKeyword) {
       let value = self.parseMatchingPattern()
       return RawPatternSyntax(RawValueBindingPatternSyntax(
         letOrVarKeyword: letOrVar, valuePattern: value, arena: self.arena))

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -40,6 +40,37 @@ extension RawTokenKindSubset {
   }
 }
 
+// MARK: - Subsets
+
+enum ContextualDeclKeyword: SyntaxText, ContextualKeywords {
+  case __consuming = "__consuming"
+  case _compilerInitialized = "_compilerInitialized"
+  case _const = "_const"
+  case _local = "_local"
+  case actor = "actor"
+  case async = "async"
+  case convenience = "convenience"
+  case distributed = "distributed"
+  case dynamic = "dynamic"
+  case final = "final"
+  case indirect = "indirect"
+  case infix = "infix"
+  case isolated = "isolated"
+  case lazy = "lazy"
+  case mutating = "mutating"
+  case nonisolated = "nonisolated"
+  case nonmutating = "nonmutating"
+  case open = "open"
+  case optional = "optional"
+  case override = "override"
+  case postfix = "postfix"
+  case prefix = "prefix"
+  case required = "required"
+  case unowned = "unowned"
+  case weak = "weak"
+}
+
+
 enum IdentifierTokens: RawTokenKindSubset {
   case anyKeyword
   case capitalSelfKeyword

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -40,6 +40,20 @@ extension RawTokenKindSubset {
   }
 }
 
+/// A set of contextual keywords.
+/// This should be an enum that has `SyntaxText` as its underlying value.
+protocol ContextualKeywords: RawRepresentable, RawTokenKindSubset {}
+
+extension ContextualKeywords where RawValue == SyntaxText {
+  var rawTokenKind: RawTokenKind {
+    return .identifier
+  }
+
+  var contextualKeyword: SyntaxText? {
+    return self.rawValue
+  }
+}
+
 // MARK: - Subsets
 
 enum ContextualDeclKeyword: SyntaxText, ContextualKeywords {

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -17,12 +17,20 @@
 protocol RawTokenKindSubset: CaseIterable {
   var rawTokenKind: RawTokenKind { get }
 
+  /// If this returns a non-nil value, only tokens with this token text are matched.
+  /// Must only return a non-nil value if `rawTokenKind` is `identifier` or `contextualKeyword`.
+  var contextualKeyword: SyntaxText? { get }
+
   /// Allows more flexible rejection of further token kinds based on the token's
   /// contents. Useful to e.g. look for contextual keywords.
   func accepts(lexeme: Lexer.Lexeme) -> Bool
 }
 
 extension RawTokenKindSubset {
+  var contextualKeyword: SyntaxText? {
+    return nil
+  }
+
   func accepts(lexeme: Lexer.Lexeme) -> Bool {
     return true
   }

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -1,0 +1,29 @@
+//===--- RawTokenKindSubset.swift -----------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RawSyntax) import SwiftSyntax
+
+/// Allows callers of `at(anyOf:)` to expect being positioned at a subset of all
+/// `RawTokenKind`s.
+protocol RawTokenKindSubset: CaseIterable {
+  var rawTokenKind: RawTokenKind { get }
+
+  /// Allows more flexible rejection of further token kinds based on the token's
+  /// contents or lookahead. Useful to e.g. look for contextual keywords.
+  func accepts(lexeme: Lexer.Lexeme, parser: Parser) -> Bool
+}
+
+extension RawTokenKindSubset {
+  func accepts(lexeme: Lexer.Lexeme, parser: Parser) -> Bool {
+    return true
+  }
+}

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -18,12 +18,12 @@ protocol RawTokenKindSubset: CaseIterable {
   var rawTokenKind: RawTokenKind { get }
 
   /// Allows more flexible rejection of further token kinds based on the token's
-  /// contents or lookahead. Useful to e.g. look for contextual keywords.
-  func accepts(lexeme: Lexer.Lexeme, parser: Parser) -> Bool
+  /// contents. Useful to e.g. look for contextual keywords.
+  func accepts(lexeme: Lexer.Lexeme) -> Bool
 }
 
 extension RawTokenKindSubset {
-  func accepts(lexeme: Lexer.Lexeme, parser: Parser) -> Bool {
+  func accepts(lexeme: Lexer.Lexeme) -> Bool {
     return true
   }
 }

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -26,4 +26,24 @@ extension RawTokenKindSubset {
   func accepts(lexeme: Lexer.Lexeme) -> Bool {
     return true
   }
+
+  static var allRawTokenKinds: [RawTokenKind] {
+    return self.allCases.map { $0.rawTokenKind }
+  }
+}
+
+enum IdentifierTokens: RawTokenKindSubset {
+  case anyKeyword
+  case capitalSelfKeyword
+  case identifier
+  case selfKeyword
+
+  var rawTokenKind: RawTokenKind {
+    switch self {
+    case .anyKeyword: return .anyKeyword
+    case .capitalSelfKeyword: return .capitalSelfKeyword
+    case .identifier: return .identifier
+    case .selfKeyword: return .selfKeyword
+    }
+  }
 }

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -42,7 +42,7 @@ extension Parser.Lookahead {
           self.currentToken.isAtStartOfLine {
         break
       }
-      if self.atAny(kinds) {
+      if self.at(any: kinds) {
         return true
       }
       let currentTokenPrecedence = TokenPrecedence(self.currentToken.tokenKind)

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -54,7 +54,7 @@ extension Parser.Lookahead {
         guard self.canRecoverTo(closingDelimiter) else {
           break
         }
-        self.eat(closingDelimiter)
+        self.eatWithoutRecovery(closingDelimiter)
       }
     }
 

--- a/Sources/SwiftParser/Recovery.swift
+++ b/Sources/SwiftParser/Recovery.swift
@@ -54,7 +54,7 @@ extension Parser.Lookahead {
         guard self.canRecoverTo(closingDelimiter) else {
           break
         }
-        self.eatWithoutRecovery(closingDelimiter)
+        self.eat(closingDelimiter)
       }
     }
 

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -661,13 +661,13 @@ extension Parser {
   public mutating func parseSwitchCase() -> RawSwitchCaseSyntax {
     var unknownAttr: RawAttributeSyntax?
     if let at = self.consume(if: .atSign) {
-      let ident = self.consumeIdentifier()
+      let ident = self.expectIdentifierWithoutRecovery()
 
       var tokenList = [RawTokenSyntax]()
       var loopProgress = LoopProgressCondition()
       while let atSign = self.consume(if: .atSign), loopProgress.evaluate(currentToken) {
         tokenList.append(atSign)
-        tokenList.append(self.consumeIdentifier())
+        tokenList.append(self.expectIdentifierWithoutRecovery())
       }
 
       unknownAttr = RawAttributeSyntax(
@@ -991,7 +991,7 @@ extension Parser {
       return nil
     }
 
-    return self.consumeIdentifier()
+    return self.expectIdentifierWithoutRecovery()
   }
 }
 
@@ -1074,7 +1074,7 @@ extension Parser.Lookahead {
       // question colon expression or something else, we look ahead to the second
       // token.
       var backtrack = self.lookahead()
-      backtrack.consumeIdentifier()
+      backtrack.expectIdentifierWithoutRecovery()
       backtrack.eat(.colon)
 
       // We treating IDENTIFIER: { as start of statement to provide missed 'do'
@@ -1095,7 +1095,7 @@ extension Parser.Lookahead {
       }
       var backtrack = self.lookahead()
       backtrack.eat(.atSign)
-      backtrack.consumeIdentifier()
+      backtrack.expectIdentifierWithoutRecovery()
       return backtrack.isStartOfStatement()
     default:
       return false
@@ -1120,7 +1120,7 @@ extension Parser.Lookahead {
       }
 
       lookahead.eat(.atSign)
-      lookahead.consumeIdentifier()
+      lookahead.expectIdentifierWithoutRecovery()
     }
 
     return lookahead.at(any: [.caseKeyword, .defaultKeyword])

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -984,7 +984,7 @@ extension Parser {
     }
 
     guard
-      self.currentToken.isIdentifier &&
+      self.at(.identifier) &&
         !self.lookahead().isStartOfStatement() &&
         !self.lookahead().isStartOfDeclaration()
     else {
@@ -1115,7 +1115,7 @@ extension Parser.Lookahead {
     var lookahead = self.lookahead()
     var loopProgress = LoopProgressCondition()
     while lookahead.at(.atSign) && loopProgress.evaluate(lookahead.currentToken) {
-      guard lookahead.peek().isIdentifier else {
+      guard lookahead.peek().tokenKind == .identifier else {
         return false
       }
 

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -60,7 +60,6 @@ extension Parser {
       }
       return RawStmtSyntax(RawLabeledStmtSyntax(
         labelName: label.label,
-        label.unexpectedBeforeColon,
         labelColon: label.colon,
         statement: RawStmtSyntax(stmt),
         arena: self.arena
@@ -125,7 +124,7 @@ extension Parser {
   ///     else-clause  → 'else' code-block | else if-statement
   @_spi(RawSyntax)
   public mutating func parseIfStatement() -> RawIfStmtSyntax {
-    let (unexpectedBeforeIfKeyword, ifKeyword) = self.eat(.ifKeyword)
+    let (unexpectedBeforeIfKeyword, ifKeyword) = self.expect(.ifKeyword)
     // A scope encloses the condition and true branch for any variables bound
     // by a conditional binding. The else branch does *not* see these variables.
     let conditions = self.parseConditionList()
@@ -163,7 +162,7 @@ extension Parser {
   ///     guard-statement → 'guard' condition-list 'else' code-block
   @_spi(RawSyntax)
   public mutating func parseGuardStatement() -> RawGuardStmtSyntax {
-    let (unexpectedBeforeGuardKeyword, guardKeyword) = self.eat(.guardKeyword)
+    let (unexpectedBeforeGuardKeyword, guardKeyword) = self.expect(.guardKeyword)
     let conditions = self.parseConditionList()
     let (unexpectedBeforeElseKeyword, elseKeyword) = self.expect(.elseKeyword)
     let body = self.parseCodeBlock()
@@ -258,11 +257,9 @@ extension Parser {
 
     // Now parse an optional type annotation.
     let annotation: RawTypeAnnotationSyntax?
-    if self.at(.colon) {
-      let (unexpectedBeforeColon, colon) = self.eat(.colon)
+    if let colon = self.consume(if: .colon) {
       let type = self.parseType()
       annotation = RawTypeAnnotationSyntax(
-        unexpectedBeforeColon,
         colon: colon,
         type: type,
         arena: self.arena
@@ -275,11 +272,9 @@ extension Parser {
     //  `let newBinding = <expr>`, or
     //  `let newBinding`, which is shorthand for `let newBinding = newBinding`
     let initializer: RawInitializerClauseSyntax?
-    if self.at(.equal) {
-      let (unexpectedBeforeEq, eq) = self.eat(.equal)
+    if let eq = self.consume(if: .equal) {
       let value = self.parseExpression(.basic)
       initializer = RawInitializerClauseSyntax(
-        unexpectedBeforeEq,
         equal: eq,
         value: value,
         arena: self.arena
@@ -361,7 +356,7 @@ extension Parser {
   ///     throw-statement → 'throw' expression
   @_spi(RawSyntax)
   public mutating func parseThrowStatement() -> RawThrowStmtSyntax {
-    let (unexpectedBeforeThrowKeyword, throwKeyword) = self.eat(.throwKeyword)
+    let (unexpectedBeforeThrowKeyword, throwKeyword) = self.expect(.throwKeyword)
     let expr = self.parseExpression()
     return RawThrowStmtSyntax(
       unexpectedBeforeThrowKeyword,
@@ -383,7 +378,7 @@ extension Parser {
   ///     defer-statement → 'defer' code-block
   @_spi(RawSyntax)
   public mutating func parseDeferStatement() -> RawDeferStmtSyntax {
-    let (unexpectedBeforeDeferKeyword, deferKeyword) = self.eat(.deferKeyword)
+    let (unexpectedBeforeDeferKeyword, deferKeyword) = self.expect(.deferKeyword)
     let items = self.parseCodeBlock()
     return RawDeferStmtSyntax(
       unexpectedBeforeDeferKeyword,
@@ -405,7 +400,7 @@ extension Parser {
   ///     do-statement → 'do' code-block catch-clauses?
   @_spi(RawSyntax)
   public mutating func parseDoStatement() -> RawDoStmtSyntax {
-    let (unexpectedBeforeDoKeyword, doKeyword) = self.eat(.doKeyword)
+    let (unexpectedBeforeDoKeyword, doKeyword) = self.expect(.doKeyword)
     let body = self.parseCodeBlock()
 
     // If the next token is 'catch', this is a 'do'/'catch' statement.
@@ -439,7 +434,7 @@ extension Parser {
   ///     catch-pattern-list → catch-pattern | catch-pattern ',' catch-pattern-list
   @_spi(RawSyntax)
   public mutating func parseCatchClause() -> RawCatchClauseSyntax {
-    let (unexpectedBeforeCatchKeyword, catchKeyword) = self.eat(.catchKeyword)
+    let (unexpectedBeforeCatchKeyword, catchKeyword) = self.expect(.catchKeyword)
     var catchItems = [RawCatchItemSyntax]()
     if !self.at(.leftBrace) {
       var keepGoing: RawTokenSyntax? = nil
@@ -473,7 +468,7 @@ extension Parser {
   ///     while-statement → 'while' condition-list code-block
   @_spi(RawSyntax)
   public mutating func parseWhileStatement() -> RawWhileStmtSyntax {
-    let (unexpectedBeforeWhileKeyword, whileKeyword) = self.eat(.whileKeyword)
+    let (unexpectedBeforeWhileKeyword, whileKeyword) = self.expect(.whileKeyword)
     let conditions = self.parseConditionList()
     let body = self.parseCodeBlock()
     return RawWhileStmtSyntax(
@@ -495,7 +490,7 @@ extension Parser {
   ///     repeat-while-statement → 'repeat' code-block 'while' expression
   @_spi(RawSyntax)
   public mutating func parseRepeatWhileStatement() -> RawRepeatWhileStmtSyntax {
-    let (unexpectedBeforeRepeatKeyword, repeatKeyword) = self.eat(.repeatKeyword)
+    let (unexpectedBeforeRepeatKeyword, repeatKeyword) = self.expect(.repeatKeyword)
     let body = self.parseCodeBlock()
     let (unexpectedBeforeWhileKeyword, whileKeyword) = self.expect(.whileKeyword)
     let condition = self.parseExpression()
@@ -521,7 +516,7 @@ extension Parser {
   ///     for-in-statement → 'for' 'case'? pattern 'in' expression where-clause? code-block
   @_spi(RawSyntax)
   public mutating func parseForEachStatement() -> RawForInStmtSyntax {
-    let (unexpectedBeforeForKeyword, forKeyword) = self.eat(.forKeyword)
+    let (unexpectedBeforeForKeyword, forKeyword) = self.expect(.forKeyword)
     let tryKeyword = self.consume(if: .tryKeyword)
 
     let awaitKeyword: RawTokenSyntax?
@@ -539,11 +534,9 @@ extension Parser {
     if caseKeyword != nil {
       pattern = self.parseMatchingPattern()
       // Now parse an optional type annotation.
-      if self.at(.colon) {
-        let (unexpectedBeforeColon, colon) = self.eat(.colon)
+      if let colon = self.consume(if: .colon) {
         let resultType = self.parseType()
         type = RawTypeAnnotationSyntax(
-          unexpectedBeforeColon,
           colon: colon,
           type: resultType,
           arena: self.arena
@@ -561,11 +554,9 @@ extension Parser {
 
     // Parse the 'where' expression if present.
     let whereClause: RawWhereClauseSyntax?
-    if self.at(.whereKeyword) {
-      let (unexpectedBeforeWhereKeyword, whereKeyword) = self.eat(.whereKeyword)
+    if let whereKeyword = self.consume(if: .whereKeyword) {
       let guardExpr = self.parseExpression(.basic)
       whereClause = RawWhereClauseSyntax(
-        unexpectedBeforeWhereKeyword,
         whereKeyword: whereKeyword,
         guardResult: guardExpr,
         arena: self.arena
@@ -606,7 +597,7 @@ extension Parser {
   ///     switch-cases → switch-case switch-cases?
   @_spi(RawSyntax)
   public mutating func parseSwitchStatement() -> RawSwitchStmtSyntax {
-    let (unexpectedBeforeSwitchKeyword, switchKeyword) = self.eat(.switchKeyword)
+    let (unexpectedBeforeSwitchKeyword, switchKeyword) = self.expect(.switchKeyword)
 
     let subject = self.parseExpression(.basic)
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
@@ -675,19 +666,17 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseSwitchCase() -> RawSwitchCaseSyntax {
     var unknownAttr: RawAttributeSyntax?
-    if self.at(.atSign) {
-      let (unexpectedBeforeAt, at) = self.eat(.atSign)
+    if let at = self.consume(if: .atSign) {
       let ident = self.consumeIdentifier()
 
       var tokenList = [RawTokenSyntax]()
       var loopProgress = LoopProgressCondition()
-      while self.at(.atSign) && loopProgress.evaluate(currentToken) {
-        tokenList.append(self.eatWithoutRecovery(.atSign))
+      while let atSign = self.consume(if: .atSign), loopProgress.evaluate(currentToken) {
+        tokenList.append(atSign)
         tokenList.append(self.consumeIdentifier())
       }
 
       unknownAttr = RawAttributeSyntax(
-        unexpectedBeforeAt,
         atSignToken: at,
         attributeName: ident,
         leftParen: nil,
@@ -739,7 +728,7 @@ extension Parser {
   ///     case-item-list → pattern where-clause? | pattern where-clause? ',' case-item-list
   @_spi(RawSyntax)
   public mutating func parseSwitchCaseLabel() -> RawSwitchCaseLabelSyntax {
-    let (unexpectedBeforeCaseKeyword, caseKeyword) = self.eat(.caseKeyword)
+    let (unexpectedBeforeCaseKeyword, caseKeyword) = self.expect(.caseKeyword)
     var caseItems = [RawCaseItemSyntax]()
     do {
       var keepGoing: RawTokenSyntax? = nil
@@ -770,7 +759,7 @@ extension Parser {
   ///     default-label → attributes? 'default' ':'
   @_spi(RawSyntax)
   public mutating func parseSwitchDefaultLabel() -> RawSwitchDefaultLabelSyntax {
-    let (unexpectedBeforeDefaultKeyword, defaultKeyword) = self.eat(.defaultKeyword)
+    let (unexpectedBeforeDefaultKeyword, defaultKeyword) = self.expect(.defaultKeyword)
     let (unexpectedBeforeColon, colon) = self.expect(.colon)
     return RawSwitchDefaultLabelSyntax(
       unexpectedBeforeDefaultKeyword,
@@ -812,11 +801,9 @@ extension Parser {
     // Parse the optional 'where' guard, with this particular pattern's bound
     // vars in scope.
     let whereClause: RawWhereClauseSyntax?
-    if self.at(.whereKeyword) {
-      let (unexpectedBeforeWhereKeyword, whereKeyword) = self.eat(.whereKeyword)
+    if let whereKeyword = self.consume(if: .whereKeyword) {
       let guardExpr = self.parseExpression(flavor)
       whereClause = RawWhereClauseSyntax(
-        unexpectedBeforeWhereKeyword,
         whereKeyword: whereKeyword,
         guardResult: guardExpr,
         arena: self.arena
@@ -839,7 +826,7 @@ extension Parser {
   ///     return-statement → 'return' expression?
   @_spi(RawSyntax)
   public mutating func parseReturnStatement() -> RawReturnStmtSyntax {
-    let (unexpectedBeforeRet, ret) = self.eat(.returnKeyword)
+    let (unexpectedBeforeRet, ret) = self.expect(.returnKeyword)
 
     // Handle the ambiguity between consuming the expression and allowing the
     // enclosing stmt-brace to get it by eagerly eating it unless the return is
@@ -880,8 +867,7 @@ extension Parser {
     let yield = self.consume(remapping: .yield)
 
     let yields: RawSyntax
-    if self.at(.leftParen) {
-      let (unexpectedBeforeLParen, lparen) = self.eat(.leftParen)
+    if let lparen = self.consume(if: .leftParen) {
       let exprList: RawExprListSyntax
       do {
         var keepGoing = true
@@ -899,7 +885,6 @@ extension Parser {
       }
       let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
       yields = RawSyntax(RawYieldListSyntax(
-        unexpectedBeforeLParen,
         leftParen: lparen,
         elementList: exprList, trailingComma: nil,
         unexpectedBeforeRParen,
@@ -919,16 +904,13 @@ extension Parser {
   @_spi(RawSyntax)
   public struct StatementLabel {
     public var label: RawTokenSyntax
-    public var unexpectedBeforeColon: RawUnexpectedNodesSyntax?
     public var colon: RawTokenSyntax
 
     public init(
       label: RawTokenSyntax,
-      unexpectedBeforeColon: RawUnexpectedNodesSyntax?,
       colon: RawTokenSyntax
     ) {
       self.label = label
-      self.unexpectedBeforeColon = unexpectedBeforeColon
       self.colon = colon
     }
   }
@@ -942,17 +924,14 @@ extension Parser {
   ///     label-name → identifier
   @_spi(RawSyntax)
   public mutating func parseOptionalStatementLabel() -> StatementLabel? {
-    guard self.currentToken.isIdentifier && self.peek().tokenKind == .colon else {
+    if let (label, colon) = self.consume(if: .identifier, followedBy: .colon) {
+      return StatementLabel(
+        label: label,
+        colon: colon
+      )
+    } else {
       return nil
     }
-
-    let label = self.consumeIdentifier()
-    let (unexpectedBeforeColon, colon) = self.eat(.colon)
-    return StatementLabel(
-      label: label,
-      unexpectedBeforeColon: unexpectedBeforeColon,
-      colon: colon
-    )
   }
 }
 
@@ -965,7 +944,7 @@ extension Parser {
   ///     break-statement → 'break' label-name?
   @_spi(RawSyntax)
   public mutating func parseBreakStatement() -> RawBreakStmtSyntax {
-    let (unexpectedBeforeBreakKeyword, breakKeyword) = self.eat(.breakKeyword)
+    let (unexpectedBeforeBreakKeyword, breakKeyword) = self.expect(.breakKeyword)
     let label = self.parseOptionalControlTransferTarget()
     return RawBreakStmtSyntax(
       unexpectedBeforeBreakKeyword,
@@ -983,7 +962,7 @@ extension Parser {
   ///     continue-statement → 'continue' label-name?
   @_spi(RawSyntax)
   public mutating func parseContinueStatement() -> RawContinueStmtSyntax {
-    let (unexpectedBeforeContinueKeyword, continueKeyword) = self.eat(.continueKeyword)
+    let (unexpectedBeforeContinueKeyword, continueKeyword) = self.expect(.continueKeyword)
     let label = self.parseOptionalControlTransferTarget()
     return RawContinueStmtSyntax(
       unexpectedBeforeContinueKeyword,
@@ -1001,7 +980,7 @@ extension Parser {
   ///     fallthrough-statement → 'fallthrough'
   @_spi(RawSyntax)
   public mutating func parseFallthroughStatement() -> RawFallthroughStmtSyntax {
-    let (unexpectedBeforeFallthroughKeyword, fallthroughKeyword) = self.eat(.fallthroughKeyword)
+    let (unexpectedBeforeFallthroughKeyword, fallthroughKeyword) = self.expect(.fallthroughKeyword)
     return RawFallthroughStmtSyntax(
       unexpectedBeforeFallthroughKeyword,
       fallthroughKeyword: fallthroughKeyword,
@@ -1031,7 +1010,7 @@ extension Parser {
 extension Parser {
   @_spi(RawSyntax)
   public mutating func parsePoundAssertStatement() -> RawPoundAssertStmtSyntax {
-    let (unexpectedBeforePoundAssert, poundAssert) = self.eat(.poundAssertKeyword)
+    let (unexpectedBeforePoundAssert, poundAssert) = self.expect(.poundAssertKeyword)
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
     let condition = self.parseExpression()
     let comma = self.consume(if: .comma)
@@ -1108,7 +1087,7 @@ extension Parser.Lookahead {
       // token.
       var backtrack = self.lookahead()
       backtrack.consumeIdentifier()
-      backtrack.eatWithoutRecovery(.colon)
+      backtrack.eat(.colon)
 
       // We treating IDENTIFIER: { as start of statement to provide missed 'do'
       // diagnostics. This case will be handled in parseStmt().
@@ -1127,7 +1106,7 @@ extension Parser.Lookahead {
         return false
       }
       var backtrack = self.lookahead()
-      backtrack.eatWithoutRecovery(.atSign)
+      backtrack.eat(.atSign)
       backtrack.consumeIdentifier()
       return backtrack.isStartOfStatement()
     default:
@@ -1152,7 +1131,7 @@ extension Parser.Lookahead {
         return false
       }
 
-      lookahead.eatWithoutRecovery(.atSign)
+      lookahead.eat(.atSign)
       lookahead.consumeIdentifier()
     }
 

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -100,7 +100,7 @@ extension Parser {
     case .poundAssertKeyword:
       // FIXME: This drops `optLabel`.
       return RawStmtSyntax(self.parsePoundAssertStatement())
-    case _ where self.currentToken.isContextualKeyword("yield"):
+    case _ where self.atContextualKeyword("yield"):
       fallthrough
     case .yield:
       // FIXME: This drops `optLabel`.
@@ -518,7 +518,7 @@ extension Parser {
     let tryKeyword = self.consume(if: .tryKeyword)
 
     let awaitKeyword: RawTokenSyntax?
-    if self.currentToken.isContextualKeyword("await") {
+    if self.atContextualKeyword("await") {
       awaitKeyword = self.consumeAnyToken()
     } else {
       awaitKeyword = nil
@@ -1066,7 +1066,7 @@ extension Parser.Lookahead {
       // "identifier ':' for/while/do/switch" is a label on a loop/switch.
       guard self.peek().tokenKind == .colon else {
         // "yield" in the right context begins a yield statement.
-        if self.currentToken.isContextualKeyword("yield") {
+        if self.atContextualKeyword("yield") {
           return true
         }
         return false

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -59,8 +59,12 @@ extension Parser {
         return RawStmtSyntax(stmt)
       }
       return RawStmtSyntax(RawLabeledStmtSyntax(
-        labelName: label.label, labelColon: label.colon, statement: RawStmtSyntax(stmt),
-        arena: self.arena))
+        labelName: label.label,
+        label.unexpectedBeforeColon,
+        labelColon: label.colon,
+        statement: RawStmtSyntax(stmt),
+        arena: self.arena
+      ))
     }
 
     let optLabel = self.parseOptionalStatementLabel()
@@ -121,7 +125,7 @@ extension Parser {
   ///     else-clause  → 'else' code-block | else if-statement
   @_spi(RawSyntax)
   public mutating func parseIfStatement() -> RawIfStmtSyntax {
-    let ifKeyword = self.eat(.ifKeyword)
+    let (unexpectedBeforeIfKeyword, ifKeyword) = self.eat(.ifKeyword)
     // A scope encloses the condition and true branch for any variables bound
     // by a conditional binding. The else branch does *not* see these variables.
     let conditions = self.parseConditionList()
@@ -141,6 +145,7 @@ extension Parser {
     }
 
     return RawIfStmtSyntax(
+      unexpectedBeforeIfKeyword,
       ifKeyword: ifKeyword,
       conditions: conditions,
       body: body,
@@ -158,11 +163,12 @@ extension Parser {
   ///     guard-statement → 'guard' condition-list 'else' code-block
   @_spi(RawSyntax)
   public mutating func parseGuardStatement() -> RawGuardStmtSyntax {
-    let guardKeyword = self.eat(.guardKeyword)
+    let (unexpectedBeforeGuardKeyword, guardKeyword) = self.eat(.guardKeyword)
     let conditions = self.parseConditionList()
     let (unexpectedBeforeElseKeyword, elseKeyword) = self.expect(.elseKeyword)
     let body = self.parseCodeBlock()
     return RawGuardStmtSyntax(
+      unexpectedBeforeGuardKeyword,
       guardKeyword: guardKeyword,
       conditions: conditions,
       unexpectedBeforeElseKeyword,
@@ -253,11 +259,14 @@ extension Parser {
     // Now parse an optional type annotation.
     let annotation: RawTypeAnnotationSyntax?
     if self.at(.colon) {
-      let colon = self.eat(.colon)
+      let (unexpectedBeforeColon, colon) = self.eat(.colon)
       let type = self.parseType()
       annotation = RawTypeAnnotationSyntax(
-        colon: colon, type: type,
-        arena: self.arena)
+        unexpectedBeforeColon,
+        colon: colon,
+        type: type,
+        arena: self.arena
+      )
     } else {
       annotation = nil
     }
@@ -267,11 +276,14 @@ extension Parser {
     //  `let newBinding`, which is shorthand for `let newBinding = newBinding`
     let initializer: RawInitializerClauseSyntax?
     if self.at(.equal) {
-      let eq = self.eat(.equal)
+      let (unexpectedBeforeEq, eq) = self.eat(.equal)
       let value = self.parseExpression(.basic)
       initializer = RawInitializerClauseSyntax(
-        equal: eq, value: value,
-        arena: self.arena)
+        unexpectedBeforeEq,
+        equal: eq,
+        value: value,
+        arena: self.arena
+      )
     } else {
       initializer = nil
     }
@@ -349,11 +361,14 @@ extension Parser {
   ///     throw-statement → 'throw' expression
   @_spi(RawSyntax)
   public mutating func parseThrowStatement() -> RawThrowStmtSyntax {
-    let throwKeyword = self.eat(.throwKeyword)
+    let (unexpectedBeforeThrowKeyword, throwKeyword) = self.eat(.throwKeyword)
     let expr = self.parseExpression()
     return RawThrowStmtSyntax(
-      throwKeyword: throwKeyword, expression: expr,
-      arena: self.arena)
+      unexpectedBeforeThrowKeyword,
+      throwKeyword: throwKeyword,
+      expression: expr,
+      arena: self.arena
+    )
   }
 }
 
@@ -368,11 +383,14 @@ extension Parser {
   ///     defer-statement → 'defer' code-block
   @_spi(RawSyntax)
   public mutating func parseDeferStatement() -> RawDeferStmtSyntax {
-    let deferKeyword = self.eat(.deferKeyword)
+    let (unexpectedBeforeDeferKeyword, deferKeyword) = self.eat(.deferKeyword)
     let items = self.parseCodeBlock()
     return RawDeferStmtSyntax(
-      deferKeyword: deferKeyword, body: items,
-      arena: self.arena)
+      unexpectedBeforeDeferKeyword,
+      deferKeyword: deferKeyword,
+      body: items,
+      arena: self.arena
+    )
   }
 }
 
@@ -387,7 +405,7 @@ extension Parser {
   ///     do-statement → 'do' code-block catch-clauses?
   @_spi(RawSyntax)
   public mutating func parseDoStatement() -> RawDoStmtSyntax {
-    let doKeyword = self.eat(.doKeyword)
+    let (unexpectedBeforeDoKeyword, doKeyword) = self.eat(.doKeyword)
     let body = self.parseCodeBlock()
 
     // If the next token is 'catch', this is a 'do'/'catch' statement.
@@ -401,6 +419,7 @@ extension Parser {
     }
 
     return RawDoStmtSyntax(
+      unexpectedBeforeDoKeyword,
       doKeyword: doKeyword,
       body: body,
       catchClauses: elements.isEmpty ? nil : RawCatchClauseListSyntax(elements: elements, arena: self.arena),
@@ -420,7 +439,7 @@ extension Parser {
   ///     catch-pattern-list → catch-pattern | catch-pattern ',' catch-pattern-list
   @_spi(RawSyntax)
   public mutating func parseCatchClause() -> RawCatchClauseSyntax {
-    let catchKeyword = self.eat(.catchKeyword)
+    let (unexpectedBeforeCatchKeyword, catchKeyword) = self.eat(.catchKeyword)
     var catchItems = [RawCatchItemSyntax]()
     if !self.at(.leftBrace) {
       var keepGoing: RawTokenSyntax? = nil
@@ -435,6 +454,7 @@ extension Parser {
     }
     let body = self.parseCodeBlock()
     return RawCatchClauseSyntax(
+      unexpectedBeforeCatchKeyword,
       catchKeyword: catchKeyword,
       catchItems: catchItems.isEmpty ? nil : RawCatchItemListSyntax(elements: catchItems, arena:  self.arena),
       body: body,
@@ -453,12 +473,16 @@ extension Parser {
   ///     while-statement → 'while' condition-list code-block
   @_spi(RawSyntax)
   public mutating func parseWhileStatement() -> RawWhileStmtSyntax {
-    let whileKeyword = self.eat(.whileKeyword)
+    let (unexpectedBeforeWhileKeyword, whileKeyword) = self.eat(.whileKeyword)
     let conditions = self.parseConditionList()
     let body = self.parseCodeBlock()
     return RawWhileStmtSyntax(
-      whileKeyword: whileKeyword, conditions: conditions, body: body,
-      arena: self.arena)
+      unexpectedBeforeWhileKeyword,
+      whileKeyword: whileKeyword,
+      conditions: conditions,
+      body: body,
+      arena: self.arena
+    )
   }
 }
 
@@ -471,11 +495,12 @@ extension Parser {
   ///     repeat-while-statement → 'repeat' code-block 'while' expression
   @_spi(RawSyntax)
   public mutating func parseRepeatWhileStatement() -> RawRepeatWhileStmtSyntax {
-    let repeatKeyword = self.eat(.repeatKeyword)
+    let (unexpectedBeforeRepeatKeyword, repeatKeyword) = self.eat(.repeatKeyword)
     let body = self.parseCodeBlock()
     let (unexpectedBeforeWhileKeyword, whileKeyword) = self.expect(.whileKeyword)
     let condition = self.parseExpression()
     return RawRepeatWhileStmtSyntax(
+      unexpectedBeforeRepeatKeyword,
       repeatKeyword: repeatKeyword,
       body: body,
       unexpectedBeforeWhileKeyword,
@@ -496,7 +521,7 @@ extension Parser {
   ///     for-in-statement → 'for' 'case'? pattern 'in' expression where-clause? code-block
   @_spi(RawSyntax)
   public mutating func parseForEachStatement() -> RawForInStmtSyntax {
-    let forKeyword = self.eat(.forKeyword)
+    let (unexpectedBeforeForKeyword, forKeyword) = self.eat(.forKeyword)
     let tryKeyword = self.consume(if: .tryKeyword)
 
     let awaitKeyword: RawTokenSyntax?
@@ -515,11 +540,14 @@ extension Parser {
       pattern = self.parseMatchingPattern()
       // Now parse an optional type annotation.
       if self.at(.colon) {
-        let colon = self.eat(.colon)
+        let (unexpectedBeforeColon, colon) = self.eat(.colon)
         let resultType = self.parseType()
         type = RawTypeAnnotationSyntax(
-          colon: colon, type: resultType,
-          arena: self.arena)
+          unexpectedBeforeColon,
+          colon: colon,
+          type: resultType,
+          arena: self.arena
+        )
       } else {
         type = nil
       }
@@ -534,11 +562,14 @@ extension Parser {
     // Parse the 'where' expression if present.
     let whereClause: RawWhereClauseSyntax?
     if self.at(.whereKeyword) {
-      let whereKeyword = self.eat(.whereKeyword)
+      let (unexpectedBeforeWhereKeyword, whereKeyword) = self.eat(.whereKeyword)
       let guardExpr = self.parseExpression(.basic)
       whereClause = RawWhereClauseSyntax(
-        whereKeyword: whereKeyword, guardResult: guardExpr,
-        arena: self.arena)
+        unexpectedBeforeWhereKeyword,
+        whereKeyword: whereKeyword,
+        guardResult: guardExpr,
+        arena: self.arena
+      )
     } else {
       whereClause = nil
     }
@@ -546,6 +577,7 @@ extension Parser {
     // stmt-brace
     let body = self.parseCodeBlock()
     return RawForInStmtSyntax(
+      unexpectedBeforeForKeyword,
       forKeyword: forKeyword,
       tryKeyword: tryKeyword,
       awaitKeyword: awaitKeyword,
@@ -574,7 +606,7 @@ extension Parser {
   ///     switch-cases → switch-case switch-cases?
   @_spi(RawSyntax)
   public mutating func parseSwitchStatement() -> RawSwitchStmtSyntax {
-    let switchKeyword = self.eat(.switchKeyword)
+    let (unexpectedBeforeSwitchKeyword, switchKeyword) = self.eat(.switchKeyword)
 
     let subject = self.parseExpression(.basic)
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
@@ -583,6 +615,7 @@ extension Parser {
 
     let (unexpectedBeforeRBrace, rbrace) = self.expect(.rightBrace)
     return RawSwitchStmtSyntax(
+      unexpectedBeforeSwitchKeyword,
       switchKeyword: switchKeyword,
       expression: subject,
       unexpectedBeforeLBrace,
@@ -643,21 +676,26 @@ extension Parser {
   public mutating func parseSwitchCase() -> RawSwitchCaseSyntax {
     var unknownAttr: RawAttributeSyntax?
     if self.at(.atSign) {
-      let at = self.eat(.atSign)
+      let (unexpectedBeforeAt, at) = self.eat(.atSign)
       let ident = self.consumeIdentifier()
 
       var tokenList = [RawTokenSyntax]()
       var loopProgress = LoopProgressCondition()
       while self.at(.atSign) && loopProgress.evaluate(currentToken) {
-        tokenList.append(self.eat(.atSign))
+        tokenList.append(self.eatWithoutRecovery(.atSign))
         tokenList.append(self.consumeIdentifier())
       }
 
       unknownAttr = RawAttributeSyntax(
-        atSignToken: at, attributeName: ident,
-        leftParen: nil, argument: nil, rightParen: nil,
+        unexpectedBeforeAt,
+        atSignToken: at,
+        attributeName: ident,
+        leftParen: nil,
+        argument: nil,
+        rightParen: nil,
         tokenList: tokenList.isEmpty ? nil : RawTokenListSyntax(elements: tokenList, arena: self.arena),
-        arena: self.arena)
+        arena: self.arena
+      )
     } else {
       unknownAttr = nil
     }
@@ -701,7 +739,7 @@ extension Parser {
   ///     case-item-list → pattern where-clause? | pattern where-clause? ',' case-item-list
   @_spi(RawSyntax)
   public mutating func parseSwitchCaseLabel() -> RawSwitchCaseLabelSyntax {
-    let caseKeyword = self.eat(.caseKeyword)
+    let (unexpectedBeforeCaseKeyword, caseKeyword) = self.eat(.caseKeyword)
     var caseItems = [RawCaseItemSyntax]()
     do {
       var keepGoing: RawTokenSyntax? = nil
@@ -716,6 +754,7 @@ extension Parser {
     }
     let (unexpectedBeforeColon, colon) = self.expect(.colon)
     return RawSwitchCaseLabelSyntax(
+      unexpectedBeforeCaseKeyword,
       caseKeyword: caseKeyword,
       caseItems: RawCaseItemListSyntax(elements: caseItems, arena: self.arena),
       unexpectedBeforeColon,
@@ -731,9 +770,10 @@ extension Parser {
   ///     default-label → attributes? 'default' ':'
   @_spi(RawSyntax)
   public mutating func parseSwitchDefaultLabel() -> RawSwitchDefaultLabelSyntax {
-    let defaultKeyword = self.eat(.defaultKeyword)
+    let (unexpectedBeforeDefaultKeyword, defaultKeyword) = self.eat(.defaultKeyword)
     let (unexpectedBeforeColon, colon) = self.expect(.colon)
     return RawSwitchDefaultLabelSyntax(
+      unexpectedBeforeDefaultKeyword,
       defaultKeyword: defaultKeyword,
       unexpectedBeforeColon,
       colon: colon,
@@ -773,11 +813,14 @@ extension Parser {
     // vars in scope.
     let whereClause: RawWhereClauseSyntax?
     if self.at(.whereKeyword) {
-      let whereKeyword = self.eat(.whereKeyword)
+      let (unexpectedBeforeWhereKeyword, whereKeyword) = self.eat(.whereKeyword)
       let guardExpr = self.parseExpression(flavor)
       whereClause = RawWhereClauseSyntax(
-        whereKeyword: whereKeyword, guardResult: guardExpr,
-        arena: self.arena)
+        unexpectedBeforeWhereKeyword,
+        whereKeyword: whereKeyword,
+        guardResult: guardExpr,
+        arena: self.arena
+      )
     } else {
       whereClause = nil
     }
@@ -796,7 +839,7 @@ extension Parser {
   ///     return-statement → 'return' expression?
   @_spi(RawSyntax)
   public mutating func parseReturnStatement() -> RawReturnStmtSyntax {
-    let ret = self.eat(.returnKeyword)
+    let (unexpectedBeforeRet, ret) = self.eat(.returnKeyword)
 
     // Handle the ambiguity between consuming the expression and allowing the
     // enclosing stmt-brace to get it by eagerly eating it unless the return is
@@ -814,8 +857,11 @@ extension Parser {
       expr = nil
     }
     return RawReturnStmtSyntax(
-      returnKeyword: ret, expression: expr,
-      arena: self.arena)
+      unexpectedBeforeRet,
+      returnKeyword: ret,
+      expression: expr,
+      arena: self.arena
+    )
   }
 }
 
@@ -835,7 +881,7 @@ extension Parser {
 
     let yields: RawSyntax
     if self.at(.leftParen) {
-      let lparen = self.eat(.leftParen)
+      let (unexpectedBeforeLParen, lparen) = self.eat(.leftParen)
       let exprList: RawExprListSyntax
       do {
         var keepGoing = true
@@ -853,6 +899,7 @@ extension Parser {
       }
       let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
       yields = RawSyntax(RawYieldListSyntax(
+        unexpectedBeforeLParen,
         leftParen: lparen,
         elementList: exprList, trailingComma: nil,
         unexpectedBeforeRParen,
@@ -872,10 +919,16 @@ extension Parser {
   @_spi(RawSyntax)
   public struct StatementLabel {
     public var label: RawTokenSyntax
+    public var unexpectedBeforeColon: RawUnexpectedNodesSyntax?
     public var colon: RawTokenSyntax
 
-    public init(label: RawTokenSyntax, colon: RawTokenSyntax) {
+    public init(
+      label: RawTokenSyntax,
+      unexpectedBeforeColon: RawUnexpectedNodesSyntax?,
+      colon: RawTokenSyntax
+    ) {
       self.label = label
+      self.unexpectedBeforeColon = unexpectedBeforeColon
       self.colon = colon
     }
   }
@@ -894,8 +947,12 @@ extension Parser {
     }
 
     let label = self.consumeIdentifier()
-    let colon = self.eat(.colon)
-    return StatementLabel(label: label, colon: colon)
+    let (unexpectedBeforeColon, colon) = self.eat(.colon)
+    return StatementLabel(
+      label: label,
+      unexpectedBeforeColon: unexpectedBeforeColon,
+      colon: colon
+    )
   }
 }
 
@@ -908,11 +965,14 @@ extension Parser {
   ///     break-statement → 'break' label-name?
   @_spi(RawSyntax)
   public mutating func parseBreakStatement() -> RawBreakStmtSyntax {
-    let breakKeyword = self.eat(.breakKeyword)
+    let (unexpectedBeforeBreakKeyword, breakKeyword) = self.eat(.breakKeyword)
     let label = self.parseOptionalControlTransferTarget()
     return RawBreakStmtSyntax(
-      breakKeyword: breakKeyword, label: label,
-      arena: self.arena)
+      unexpectedBeforeBreakKeyword,
+      breakKeyword: breakKeyword,
+      label: label,
+      arena: self.arena
+    )
   }
 
   /// Parse a continue statement.
@@ -923,11 +983,14 @@ extension Parser {
   ///     continue-statement → 'continue' label-name?
   @_spi(RawSyntax)
   public mutating func parseContinueStatement() -> RawContinueStmtSyntax {
-    let continueKeyword = self.eat(.continueKeyword)
+    let (unexpectedBeforeContinueKeyword, continueKeyword) = self.eat(.continueKeyword)
     let label = self.parseOptionalControlTransferTarget()
     return RawContinueStmtSyntax(
-      continueKeyword: continueKeyword, label: label,
-      arena: self.arena)
+      unexpectedBeforeContinueKeyword,
+      continueKeyword: continueKeyword,
+      label: label,
+      arena: self.arena
+    )
   }
 
   /// Parse a fallthrough statement.
@@ -938,10 +1001,12 @@ extension Parser {
   ///     fallthrough-statement → 'fallthrough'
   @_spi(RawSyntax)
   public mutating func parseFallthroughStatement() -> RawFallthroughStmtSyntax {
-    let fallthroughKeyword = self.eat(.fallthroughKeyword)
+    let (unexpectedBeforeFallthroughKeyword, fallthroughKeyword) = self.eat(.fallthroughKeyword)
     return RawFallthroughStmtSyntax(
+      unexpectedBeforeFallthroughKeyword,
       fallthroughKeyword: fallthroughKeyword,
-      arena: self.arena)
+      arena: self.arena
+    )
   }
 
   // label-name → identifier
@@ -966,7 +1031,7 @@ extension Parser {
 extension Parser {
   @_spi(RawSyntax)
   public mutating func parsePoundAssertStatement() -> RawPoundAssertStmtSyntax {
-    let poundAssert = self.eat(.poundAssertKeyword)
+    let (unexpectedBeforePoundAssert, poundAssert) = self.eat(.poundAssertKeyword)
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
     let condition = self.parseExpression()
     let comma = self.consume(if: .comma)
@@ -978,6 +1043,7 @@ extension Parser {
     }
     let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
     return RawPoundAssertStmtSyntax(
+      unexpectedBeforePoundAssert,
       poundAssert: poundAssert,
       unexpectedBeforeLParen,
       leftParen: lparen,
@@ -1042,7 +1108,7 @@ extension Parser.Lookahead {
       // token.
       var backtrack = self.lookahead()
       backtrack.consumeIdentifier()
-      backtrack.eat(.colon)
+      backtrack.eatWithoutRecovery(.colon)
 
       // We treating IDENTIFIER: { as start of statement to provide missed 'do'
       // diagnostics. This case will be handled in parseStmt().
@@ -1061,7 +1127,7 @@ extension Parser.Lookahead {
         return false
       }
       var backtrack = self.lookahead()
-      backtrack.eat(.atSign)
+      backtrack.eatWithoutRecovery(.atSign)
       backtrack.consumeIdentifier()
       return backtrack.isStartOfStatement()
     default:
@@ -1086,7 +1152,7 @@ extension Parser.Lookahead {
         return false
       }
 
-      lookahead.eat(.atSign)
+      lookahead.eatWithoutRecovery(.atSign)
       lookahead.consumeIdentifier()
     }
 

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -854,8 +854,7 @@ extension Parser {
   ///     yield-statement → 'yield' '('? expr-list? ')'?
   @_spi(RawSyntax)
   public mutating func parseYieldStatement() -> RawYieldStmtSyntax {
-    assert(self.currentToken.tokenText == "yield")
-    let yield = self.consumeAnyToken(remapping: .yield)
+    let (unexpectedBeforeYield, yield) = self.expectContextualKeyword("yield")
 
     let yields: RawSyntax
     if let lparen = self.consume(if: .leftParen) {
@@ -883,8 +882,11 @@ extension Parser {
     }
 
     return RawYieldStmtSyntax(
-      yieldKeyword: yield, yields: yields,
-      arena: self.arena)
+      unexpectedBeforeYield,
+      yieldKeyword: yield,
+      yields: yields,
+      arena: self.arena
+    )
   }
 }
 

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -855,7 +855,7 @@ extension Parser {
   @_spi(RawSyntax)
   public mutating func parseYieldStatement() -> RawYieldStmtSyntax {
     assert(self.currentToken.tokenText == "yield")
-    let yield = self.consume(remapping: .yield)
+    let yield = self.consumeAnyToken(remapping: .yield)
 
     let yields: RawSyntax
     if let lparen = self.consume(if: .leftParen) {

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -824,11 +824,11 @@ extension Parser {
     // followed by a '}', '', statement or decl start keyword sequence.
     let expr: RawExprSyntax?
     if
-      [
+      self.at(any: [
         RawTokenKind.rightBrace, .semicolon, .eof,
         .poundIfKeyword, .poundErrorKeyword, .poundWarningKeyword,
         .poundEndifKeyword, .poundElseKeyword, .poundElseifKeyword
-      ].firstIndex(of: self.currentToken.tokenKind) == nil
+      ])
         && !self.lookahead().isStartOfStatement() && !self.lookahead().isStartOfDeclaration() {
       expr = self.parseExpression()
     } else {
@@ -1106,7 +1106,7 @@ extension Parser.Lookahead {
 
   func isBooleanExpr() -> Bool {
     var lookahead = self.lookahead()
-    return !lookahead.canParseTypedPattern() || lookahead.currentToken.tokenKind != .equal
+    return !lookahead.canParseTypedPattern() || !lookahead.at(.equal)
   }
 
   /// Returns whether the parser's current position is the start of a switch case,

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -152,7 +152,7 @@ extension TokenConsumer {
   ///
   /// - Parameter kind: The kind of token to consume.
   /// - Returns: A token of the given kind.
-  public mutating func expectWithoutLookahead(
+  public mutating func expectWithoutRecovery(
     _ kind: RawTokenKind,
     where condition: (Lexer.Lexeme) -> Bool = { _ in true }
   ) -> Token {

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -66,6 +66,13 @@ extension TokenConsumer {
     return self.currentToken.isContextualKeyword(name)
   }
 
+  /// Returns whether the current token is an operator with the given `name`.
+  @_spi(RawSyntax)
+  public func atContextualPunctuator(_ name: SyntaxText) -> Bool {
+    return self.currentToken.isContextualPunctuator(name)
+  }
+
+
   /// Returns whether the kind of the current token is any of the given
   /// kinds or a contextual keyword with text in `contextualKeywords` and
   /// additionally satisfies `condition`.
@@ -147,6 +154,15 @@ extension TokenConsumer {
   public mutating func consumeIfContextualKeyword(_ name: SyntaxText) -> Token? {
     if self.atContextualKeyword(name) {
       return self.consumeAnyToken(remapping: .contextualKeyword)
+    }
+    return nil
+  }
+
+  /// Consumes and returns the current token is an operator with the given `name`.
+  @_spi(RawSyntax)
+  public mutating func consumeIfContextualPunctuator(_ name: SyntaxText) -> Token? {
+    if self.atContextualPunctuator(name) {
+      return self.consumeAnyToken()
     }
     return nil
   }

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -82,9 +82,9 @@ extension TokenConsumer {
   @_spi(RawSyntax)
   public mutating func consume(
     if kind: RawTokenKind,
-    where condition: (Lexer.Lexeme, Self) -> Bool = { (_, _) in true}
+    where condition: (Lexer.Lexeme) -> Bool = { _ in true}
   ) -> Token? {
-    if self.at(kind) && condition(self.currentToken, self) {
+    if self.at(kind) && condition(self.currentToken) {
       return self.consumeAnyToken()
     }
     return nil
@@ -98,7 +98,7 @@ extension TokenConsumer {
   /// - Returns: A token of the given kind if one was consumed, else `nil`.
   public mutating func consume(
     ifAny kinds: RawTokenKind...,
-    where condition: (Lexer.Lexeme, Self) -> Bool = { (_, _) in true }
+    where condition: (Lexer.Lexeme) -> Bool = { _ in true }
   ) -> Token? {
     for kind in kinds {
       if let consumed = self.consume(if: kind, where: condition) {

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -70,16 +70,4 @@ extension TokenConsumer {
     }
     return nil
   }
-
-  /// Consumes the current token, and asserts that the kind of token that was
-  /// consumed matches the given kind.
-  ///
-  /// If the token kind did not match, this function will abort. It is useful
-  /// to insert structural invariants during parsing.
-  ///
-  /// - Parameter kind: The kind of token to consume.
-  /// - Returns: A token of the given kind.
-  public mutating func eatWithoutRecovery(_ kind: RawTokenKind) -> Token {
-    return self.consume(if: kind)!
-  }
 }

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -79,7 +79,7 @@ extension TokenConsumer {
   ///
   /// - Parameter kind: The kind of token to consume.
   /// - Returns: A token of the given kind.
-  public mutating func eat(_ kind: RawTokenKind) -> Token {
+  public mutating func eatWithoutRecovery(_ kind: RawTokenKind) -> Token {
     return self.consume(if: kind)!
   }
 }

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -42,8 +42,8 @@ extension TokenConsumer {
   ///
   /// - Parameter kinds: The kinds to test for.
   /// - Returns: `true` if the current token's kind is in `kinds`.
-  public func atAny(_ kind: [RawTokenKind]) -> Bool {
-    return kind.contains(self.currentToken.tokenKind)
+  public func at(any kinds: [RawTokenKind]) -> Bool {
+    return kinds.contains(self.currentToken.tokenKind)
   }
 
   /// Checks whether the parser is currently positioned at any token in `Subset`.

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -129,7 +129,7 @@ extension TokenConsumer {
   /// - Parameter kind: The kinds of token to consume.
   /// - Returns: A token of the given kind if one was consumed, else `nil`.
   public mutating func consume(
-    ifAny kinds: RawTokenKind...,
+    ifAny kinds: [RawTokenKind],
     where condition: (Lexer.Lexeme) -> Bool = { _ in true }
   ) -> Token? {
     for kind in kinds {

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -31,7 +31,7 @@ extension Parser {
       extraneousTokens.append(RawSyntax(consumeAnyToken()))
     }
     let unexpectedBeforeEof = extraneousTokens.isEmpty ? nil : RawUnexpectedNodesSyntax(elements: extraneousTokens, arena: self.arena)
-    let eof = self.eat(.eof)
+    let eof = self.eatWithoutRecovery(.eof)
     return .init(statements: items, unexpectedBeforeEof, eofToken: eof, arena: self.arena)
   }
 }

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -31,7 +31,7 @@ extension Parser {
       extraneousTokens.append(RawSyntax(consumeAnyToken()))
     }
     let unexpectedBeforeEof = extraneousTokens.isEmpty ? nil : RawUnexpectedNodesSyntax(elements: extraneousTokens, arena: self.arena)
-    let eof = self.eatWithoutRecovery(.eof)
+    let eof = self.consume(if: .eof)!
     return .init(statements: items, unexpectedBeforeEof, eofToken: eof, arena: self.arena)
   }
 }

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -27,7 +27,7 @@ extension Parser {
   public mutating func parseSourceFile() -> RawSourceFileSyntax {
     let items = self.parseTopLevelCodeBlockItems()
     var extraneousTokens = [RawSyntax]()
-    while currentToken.tokenKind != .eof {
+    while !self.at(.eof) {
       extraneousTokens.append(RawSyntax(consumeAnyToken()))
     }
     let unexpectedBeforeEof = extraneousTokens.isEmpty ? nil : RawUnexpectedNodesSyntax(elements: extraneousTokens, arena: self.arena)

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -784,13 +784,7 @@ extension Parser {
   public mutating func parseTypeAttributeListPresent() -> RawAttributeListSyntax {
     var elements = [RawSyntax]()
     var modifiersProgress = LoopProgressCondition()
-    while let token = self.consume(ifAny: [.inoutKeyword, .identifier], where: {
-      if $0.tokenKind  == .identifier {
-        return $0.isContextualKeyword(["__shared", "__owned", "isolated", "_const"])
-      } else {
-        return true
-      }
-    }), modifiersProgress.evaluate(currentToken) {
+    while let token = self.consume(ifAny: [.inoutKeyword], contextualKeywords: ["__shared", "__owned", "isolated", "_const"]), modifiersProgress.evaluate(currentToken) {
       elements.append(RawSyntax(token))
     }
 

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -188,7 +188,7 @@ extension Parser {
     // '.Type', '.Protocol', '?', '!', and '[]' still leave us with type-simple.
     var loopCondition = LoopProgressCondition()
     while loopCondition.evaluate(currentToken) {
-      if self.at(.period) || self.at(.prefixPeriod) {
+      if self.at(any: [.period, .prefixPeriod]) {
         if self.peek().isContextualKeyword("Type") || self.peek().isContextualKeyword("Protocol") {
           let period = self.consumeAnyToken()
           let type = self.consumeIdentifier()
@@ -382,7 +382,7 @@ extension Parser {
     do {
       var keepGoing = true
       var loopProgress = LoopProgressCondition()
-      while !self.at(.eof) && !self.at(.rightParen) && keepGoing && loopProgress.evaluate(currentToken) {
+      while !self.at(any: [.eof, .rightParen]) && keepGoing && loopProgress.evaluate(currentToken) {
         let first: RawTokenSyntax?
         let second: RawTokenSyntax?
         let unexpectedBeforeColon: RawUnexpectedNodesSyntax?
@@ -527,7 +527,7 @@ extension Parser.Lookahead {
     // '.Type', '.Protocol', '?', and '!' still leave us with type-simple.
     var loopCondition = LoopProgressCondition()
     while loopCondition.evaluate(currentToken) {
-      if (self.at(.period) || self.at(.prefixPeriod)) &&
+      if self.at(any: [.period, .prefixPeriod]) &&
           (self.peek().isContextualKeyword("Type")
            || self.peek().isContextualKeyword("Protocol")) {
         self.consumeAnyToken()
@@ -565,8 +565,7 @@ extension Parser.Lookahead {
 
   mutating func canParseTupleBodyType() -> Bool {
     guard
-      !self.at(.rightParen) &&
-        !self.at(.rightBrace) &&
+      !self.at(any: [.rightParen, .rightBrace]) &&
         !self.currentToken.isEllipsis &&
         !self.isStartOfDeclaration()
     else {
@@ -599,9 +598,9 @@ extension Parser.Lookahead {
         // better if we skip over them.
         if self.consume(if: .equal) != nil {
           var skipProgress = LoopProgressCondition()
-          while !self.at(.eof) && !self.at(.rightParen)
-                  && !self.at(.rightBrace) && !self.currentToken.isEllipsis
-                  && !self.at(.comma) && !self.isStartOfDeclaration()
+          while !self.at(any: [.eof, .rightParen, .rightBrace, .comma])
+                  && !self.currentToken.isEllipsis
+                  && !self.isStartOfDeclaration()
                   && skipProgress.evaluate(currentToken) {
             self.skipSingle()
           }
@@ -631,7 +630,7 @@ extension Parser.Lookahead {
 
       // Treat 'Foo.<anything>' as an attempt to write a dotted type
       // unless <anything> is 'Type' or 'Protocol'.
-      if (self.at(.period) || self.at(.prefixPeriod)) &&
+      if self.at(any: [.period, .prefixPeriod]) &&
           !self.peek().isContextualKeyword("Type") &&
           !self.peek().isContextualKeyword("Protocol") {
         self.consumeAnyToken()
@@ -721,7 +720,7 @@ extension Parser.Lookahead {
 
   mutating func canParseSimpleTypeIdentifier() -> Bool {
     // Parse an identifier.
-    guard self.currentToken.isIdentifier || self.at(.capitalSelfKeyword) || self.at(.anyKeyword) else {
+    guard self.currentToken.isIdentifier || self.at(any: [.capitalSelfKeyword, .anyKeyword]) else {
       return false
     }
     self.consumeAnyToken()
@@ -781,7 +780,7 @@ extension Parser {
       }
     })
 
-    if self.at(.atSign) || self.at(.inoutKeyword) {
+    if self.at(any: [.atSign, .inoutKeyword]) {
       return (specifier, self.parseTypeAttributeListPresent())
     }
 

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -720,7 +720,7 @@ extension Parser.Lookahead {
 
   mutating func canParseSimpleTypeIdentifier() -> Bool {
     // Parse an identifier.
-    guard self.currentToken.isIdentifier || self.at(any: [.capitalSelfKeyword, .anyKeyword]) else {
+    guard self.at(.identifier) || self.at(any: [.capitalSelfKeyword, .anyKeyword]) else {
       return false
     }
     self.consumeAnyToken()
@@ -784,7 +784,7 @@ extension Parser {
       return (specifier, self.parseTypeAttributeListPresent())
     }
 
-    if self.currentToken.isIdentifier {
+    if self.at(.identifier) {
       if self.currentToken.tokenText == "__shared"
           || self.currentToken.tokenText == "__owned"
           || self.currentToken.isContextualKeyword("isolated")

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -773,7 +773,7 @@ extension Parser.Lookahead {
 extension Parser {
   @_spi(RawSyntax)
   public mutating func parseTypeAttributeList() -> (RawTokenSyntax?, RawAttributeListSyntax?) {
-    let specifier = self.consume(ifAny: .inoutKeyword, .identifier, where: {
+    let specifier = self.consume(ifAny: [.inoutKeyword, .identifier], where: {
       switch $0.tokenKind {
       case .identifier: return $0.isContextualKeyword(["__shared", "__owned"])
       default: return true
@@ -800,7 +800,7 @@ extension Parser {
   public mutating func parseTypeAttributeListPresent() -> RawAttributeListSyntax {
     var elements = [RawSyntax]()
     var modifiersProgress = LoopProgressCondition()
-    while let token = self.consume(ifAny: .inoutKeyword, .identifier, where: {
+    while let token = self.consume(ifAny: [.inoutKeyword, .identifier], where: {
       if $0.tokenKind  == .identifier {
         return $0.isContextualKeyword(["__shared", "__owned", "isolated", "_const"])
       } else {

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -774,9 +774,9 @@ extension Parser.Lookahead {
 extension Parser {
   @_spi(RawSyntax)
   public mutating func parseTypeAttributeList() -> (RawTokenSyntax?, RawAttributeListSyntax?) {
-    let specifier = self.consume(ifAny: .inoutKeyword, .identifier, where: { (lexeme, parser) in
-      switch lexeme.tokenKind {
-      case .identifier: return lexeme.isContextualKeyword(["__shared", "__owned"])
+    let specifier = self.consume(ifAny: .inoutKeyword, .identifier, where: {
+      switch $0.tokenKind {
+      case .identifier: return $0.isContextualKeyword(["__shared", "__owned"])
       default: return true
       }
     })
@@ -801,9 +801,9 @@ extension Parser {
   public mutating func parseTypeAttributeListPresent() -> RawAttributeListSyntax {
     var elements = [RawSyntax]()
     var modifiersProgress = LoopProgressCondition()
-    while let token = self.consume(ifAny: .inoutKeyword, .identifier, where: { (lexeme, parser) in
-      if lexeme.tokenKind  == .identifier {
-        return lexeme.isContextualKeyword(["__shared", "__owned", "isolated", "_const"])
+    while let token = self.consume(ifAny: .inoutKeyword, .identifier, where: {
+      if $0.tokenKind  == .identifier {
+        return $0.isContextualKeyword(["__shared", "__owned", "isolated", "_const"])
       } else {
         return true
       }

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -38,7 +38,7 @@ extension Parser {
     if self.lookahead().isAtFunctionTypeArrow() {
       let firstEffect = self.parseEffectsSpecifier()
       let secondEffect = self.parseEffectsSpecifier()
-      let arrow = self.eat(.arrow)
+      let (unexpectedBeforeArrow, arrow) = self.eat(.arrow)
       let returnTy = self.parseType()
 
       let unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax?
@@ -76,6 +76,7 @@ extension Parser {
         rightParen: rightParen,
         asyncKeyword: firstEffect,
         throwsOrRethrowsKeyword: secondEffect,
+        unexpectedBeforeArrow,
         arrow: arrow,
         returnType: returnTy,
         arena: self.arena))
@@ -219,9 +220,13 @@ extension Parser {
   ///     optional-type → type '?'
   @_spi(RawSyntax)
   public mutating func parseOptionalType(_ base: RawTypeSyntax) -> RawOptionalTypeSyntax {
-    let mark = self.eat(.postfixQuestionMark)
+    let (unexpectedBeforeMark, mark) = self.eat(.postfixQuestionMark)
     return RawOptionalTypeSyntax(
-      wrappedType: base, questionMark: mark, arena: self.arena)
+      wrappedType: base,
+      unexpectedBeforeMark,
+      questionMark: mark,
+      arena: self.arena
+    )
   }
 
   /// Parse an optional type.
@@ -232,9 +237,13 @@ extension Parser {
   ///     implicitly-unwrapped-optional-type → type '!'
   @_spi(RawSyntax)
   public mutating func parseImplicitlyUnwrappedOptionalType(_ base: RawTypeSyntax) -> RawImplicitlyUnwrappedOptionalTypeSyntax {
-    let mark = self.eat(.exclamationMark)
+    let (unexpectedBeforeMark, mark) = self.eat(.exclamationMark)
     return RawImplicitlyUnwrappedOptionalTypeSyntax(
-      wrappedType: base, exclamationMark: mark, arena: self.arena)
+      wrappedType: base,
+      unexpectedBeforeMark,
+      exclamationMark: mark,
+      arena: self.arena
+    )
   }
 
   @_spi(RawSyntax)
@@ -279,9 +288,13 @@ extension Parser {
   ///     any-type → Any
   @_spi(RawSyntax)
   public mutating func parseAnyType() -> RawSimpleTypeIdentifierSyntax {
-    let name = self.eat(.anyKeyword)
+    let (unexpectedBeforeName, name) = self.eat(.anyKeyword)
     return RawSimpleTypeIdentifierSyntax(
-      name: name, genericArgumentClause: nil, arena: self.arena)
+      unexpectedBeforeName,
+      name: name,
+      genericArgumentClause: nil,
+      arena: self.arena
+    )
   }
 
   /// Parse a type placeholder.
@@ -292,10 +305,14 @@ extension Parser {
   ///     placeholder-type → wildcard
   @_spi(RawSyntax)
   public mutating func parsePlaceholderType() -> RawSimpleTypeIdentifierSyntax {
-    let name = self.eat(.wildcardKeyword)
+    let (unexpectedBeforeName, name) = self.eat(.wildcardKeyword)
     // FIXME: Need a better syntax node than this
     return RawSimpleTypeIdentifierSyntax(
-      name: name, genericArgumentClause: nil, arena: self.arena)
+      unexpectedBeforeName,
+      name: name,
+      genericArgumentClause: nil,
+      arena: self.arena
+    )
   }
 }
 
@@ -360,7 +377,7 @@ extension Parser {
   ///     element-name → identifier
   @_spi(RawSyntax)
   public mutating func parseTupleTypeBody() -> RawTupleTypeSyntax {
-    let lparen = self.eat(.leftParen)
+    let (unexpectedBeforeLParen, lparen) = self.eat(.leftParen)
     var elements = [RawTupleTypeElementSyntax]()
     do {
       var keepGoing = true
@@ -409,6 +426,7 @@ extension Parser {
     }
     let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
     return RawTupleTypeSyntax(
+      unexpectedBeforeLParen,
       leftParen: lparen,
       elements: RawTupleTypeElementListSyntax(elements: elements, arena: self.arena),
       unexpectedBeforeRParen,
@@ -428,15 +446,17 @@ extension Parser {
   ///     dictionary-type → '[' type ':' type ']'
   @_spi(RawSyntax)
   public mutating func parseCollectionType() -> RawTypeSyntax {
-    let lsquare = self.eat(.leftSquareBracket)
+    let (unexpectedBeforeLSquare, lsquare) = self.eat(.leftSquareBracket)
     let firstType = self.parseType()
     if self.at(.colon) {
-      let colon = self.eat(.colon)
+      let (unexpectedBeforeColon, colon) = self.eat(.colon)
       let secondType = self.parseType()
       let (unexpectedBeforeRSquareBracket, rSquareBracket) = self.expect(.rightSquareBracket)
       return RawTypeSyntax(RawDictionaryTypeSyntax(
+        unexpectedBeforeLSquare,
         leftSquareBracket: lsquare,
         keyType: firstType,
+        unexpectedBeforeColon,
         colon: colon,
         valueType: secondType,
         unexpectedBeforeRSquareBracket,
@@ -446,6 +466,7 @@ extension Parser {
     } else {
       let (unexpectedBeforeRSquareBracket, rSquareBracket) = self.expect(.rightSquareBracket)
       return RawTypeSyntax(RawArrayTypeSyntax(
+        unexpectedBeforeLSquare,
         leftSquareBracket: lsquare,
         elementType: firstType,
         unexpectedBeforeRSquareBracket,
@@ -569,7 +590,7 @@ extension Parser.Lookahead {
             return false
           }
         }
-        self.eat(.colon)
+        self.eatWithoutRecovery(.colon)
 
         // Parse a type.
         guard self.canParseType() else {
@@ -668,7 +689,7 @@ extension Parser.Lookahead {
   }
 
   mutating func canParseOldStyleProtocolComposition() -> Bool {
-    self.eat(.protocolKeyword)
+    self.eatWithoutRecovery(.protocolKeyword)
 
     // Check for the starting '<'.
     guard self.currentToken.starts(with: "<") else {
@@ -757,7 +778,7 @@ extension Parser {
   public mutating func parseTypeAttributeList() -> (RawTokenSyntax?, RawAttributeListSyntax?) {
     let specifier: RawTokenSyntax?
     if self.at(.inoutKeyword) {
-      specifier = self.eat(.inoutKeyword)
+      specifier = self.eatWithoutRecovery(.inoutKeyword)
     } else if self.currentToken.isIdentifier {
       if self.currentToken.tokenText == "__shared" {
         specifier = self.consumeAnyToken()
@@ -797,7 +818,7 @@ extension Parser {
            || self.currentToken.isContextualKeyword("_const")
     ) && modifiersProgress.evaluate(currentToken) {
       if self.at(.inoutKeyword) {
-        let inoutKeyword = self.eat(.inoutKeyword)
+        let inoutKeyword = self.eatWithoutRecovery(.inoutKeyword)
         elements.append(RawSyntax(inoutKeyword))
       } else {
         let ident = self.consumeIdentifier()
@@ -823,7 +844,7 @@ extension Parser {
       return RawSyntax(self.parseDifferentiableAttribute())
 
     case .convention:
-      let at = self.eat(.atSign)
+      let (unexpectedBeforeAt, at) = self.eat(.atSign)
       let ident = self.consumeIdentifier()
       let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
       let argument = self.consumeIdentifier()
@@ -831,6 +852,7 @@ extension Parser {
       let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
       return RawSyntax(
         RawAttributeSyntax(
+          unexpectedBeforeAt,
           atSignToken: at,
           attributeName: ident,
           unexpectedBeforeLeftParen,
@@ -844,10 +866,11 @@ extension Parser {
       )
 
     default:
-      let at = self.eat(.atSign)
+      let (unexpectedBeforeAt, at) = self.eat(.atSign)
       let ident = self.consumeIdentifier()
       return RawSyntax(
         RawAttributeSyntax(
+          unexpectedBeforeAt,
           atSignToken: at,
           attributeName: ident,
           leftParen: nil,

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -191,7 +191,7 @@ extension Parser {
       if self.at(any: [.period, .prefixPeriod]) {
         if self.peek().isContextualKeyword("Type") || self.peek().isContextualKeyword("Protocol") {
           let period = self.consumeAnyToken()
-          let type = self.consumeIdentifier()
+          let type = self.expectIdentifierWithoutRecovery()
           base = RawTypeSyntax(RawMetatypeTypeSyntax(
             baseType: base, period: period, typeOrProtocol: type, arena: self.arena))
         }
@@ -531,7 +531,7 @@ extension Parser.Lookahead {
           (self.peek().isContextualKeyword("Type")
            || self.peek().isContextualKeyword("Protocol")) {
         self.consumeAnyToken()
-        self.consumeIdentifier()
+        self.expectIdentifierWithoutRecovery()
         continue
       }
       if self.currentToken.isOptionalToken {
@@ -829,9 +829,9 @@ extension Parser {
 
     case .convention:
       let (unexpectedBeforeAt, at) = self.expect(.atSign)
-      let ident = self.consumeIdentifier()
+      let ident = self.expectIdentifierWithoutRecovery()
       let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
-      let argument = self.consumeIdentifier()
+      let argument = self.expectIdentifierWithoutRecovery()
 
       let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
       return RawSyntax(
@@ -851,7 +851,7 @@ extension Parser {
 
     default:
       let (unexpectedBeforeAt, at) = self.expect(.atSign)
-      let ident = self.consumeIdentifier()
+      let ident = self.expectIdentifierWithoutRecovery()
       return RawSyntax(
         RawAttributeSyntax(
           unexpectedBeforeAt,

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -248,7 +248,7 @@ extension Parser {
 
   @_spi(RawSyntax)
   public mutating func parseTypeIdentifier() -> RawTypeSyntax {
-    if self.currentToken.tokenKind == .anyKeyword {
+    if self.at(.anyKeyword) {
       return RawTypeSyntax(self.parseAnyType())
     }
 
@@ -389,9 +389,10 @@ extension Parser {
         let colon: RawTokenSyntax?
         if self.lookahead().startsParameterName(false) {
           first = self.parseArgumentLabel()
-          if self.currentToken.tokenKind == .colon {
-            (unexpectedBeforeColon, colon) = self.expect(.colon)
+          if let parsedColon = self.consume(if: .colon) {
             second = nil
+            unexpectedBeforeColon = nil
+            colon = parsedColon
           } else if self.currentToken.canBeArgumentLabel && self.peek().tokenKind == .colon {
             second = self.parseArgumentLabel()
             (unexpectedBeforeColon, colon) = self.expect(.colon)

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -785,10 +785,7 @@ extension Parser {
     }
 
     if self.at(.identifier) {
-      if self.currentToken.tokenText == "__shared"
-          || self.currentToken.tokenText == "__owned"
-          || self.currentToken.isContextualKeyword("isolated")
-          || self.currentToken.isContextualKeyword("_const") {
+      if self.at(any: [], contextualKeywords: ["__shared", "__owned", "isolated", "_const"]) {
         return (specifier, self.parseTypeAttributeListPresent())
 
       }

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -204,13 +204,15 @@ func AssertParse<Node: RawSyntaxNodeProtocol>(
   _ markedSource: String,
   _ parseSyntax: (inout Parser) -> Node,
   substructure expectedSubstructure: Syntax? = nil,
+  substructureAfterMarker: String = "START",
   diagnostics expectedDiagnostics: [DiagnosticSpec] = [],
   fixedSource expectedFixedSource: String? = nil,
   file: StaticString = #file,
   line: UInt = #line
 ) {
   // Verify the parser can round-trip the source
-  let (markerLocations, source) = extractMarkers(markedSource)
+  var (markerLocations, source) = extractMarkers(markedSource)
+  markerLocations["START"] = 0
   var src = source
   src.withUTF8 { buf in
     var parser = Parser(buf)
@@ -227,9 +229,9 @@ func AssertParse<Node: RawSyntaxNodeProtocol>(
 
       // Substructure
       if let expectedSubstructure = expectedSubstructure {
-        let subtreeMatcher = SubtreeMatcher(Syntax(tree), markers: [:])
+        let subtreeMatcher = SubtreeMatcher(Syntax(tree), markers: markerLocations)
         do {
-          try subtreeMatcher.assertSameStructure(Syntax(expectedSubstructure), file: file, line: line)
+          try subtreeMatcher.assertSameStructure(afterMarker: substructureAfterMarker, Syntax(expectedSubstructure), file: file, line: line)
         } catch {
           XCTFail("Matching for a subtree failed with error: \(error)", file: file, line: line)
         }

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -723,6 +723,15 @@ final class DeclarationTests: XCTestCase {
     AssertParse("deinit {}", { $0.parseDeinitializerDeclaration(.empty) })
     AssertParse("deinit", { $0.parseDeinitializerDeclaration(.empty) })
   }
+
+  func testAttributedMember() {
+    AssertParse(#"""
+    struct Foo {
+      @Argument(help: "xxx")
+      var generatedPath: String
+    }
+    """#)
+  }
 }
 
 extension Parser.DeclAttributes {

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -732,6 +732,12 @@ final class DeclarationTests: XCTestCase {
     }
     """#)
   }
+
+  func testAnyAsParameterLabel() {
+    AssertParse(
+      "func at(any kinds: [RawTokenKind]) {}"
+    )
+  }
 }
 
 extension Parser.DeclAttributes {

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -449,7 +449,7 @@ final class ExpressionTests: XCTestCase {
       """
     )
   }
-  
+
   func testClosureExpression() {
     AssertParse(
       """
@@ -458,6 +458,15 @@ final class ExpressionTests: XCTestCase {
       diagnostics: [
         DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '..' found in function type"),
       ]
+    )
+  }
+
+  func testParseArrowExpr() {
+    AssertParse(
+      "Foo #^ASYNC^#async ->",
+      { $0.parseSequenceExpression(.basic, forDirective: false) },
+      substructure: Syntax(TokenSyntax.contextualKeyword("async")),
+      substructureAfterMarker: "ASYNC"
     )
   }
 }


### PR DESCRIPTION
Depends on https://github.com/apple/swift-syntax/pull/743

Diff of this PR: https://github.com/ahoppen/swift-syntax/compare/ahoppen/20-common-paradigm..ahoppen/30-higher-level-primitives
