### PR TITLE
Improve diagnostics for invalid identifiers

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -183,7 +183,7 @@ extension Parser {
 
 
     let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
-    let ident = self.expectIdentifierOrRethrowsWithoutRecovery()
+    let (unexpectedBeforeIdent, ident) = self.expectIdentifierOrRethrows()
     let leftParen = self.consume(if: .leftParen)
     let arg: RawSyntax?
     let unexpectedBeforeRightParen: RawUnexpectedNodesSyntax?
@@ -204,6 +204,7 @@ extension Parser {
     return RawSyntax(RawAttributeSyntax(
       unexpectedBeforeAtSign,
       atSignToken: atSign,
+      unexpectedBeforeIdent,
       attributeName: ident,
       leftParen: leftParen,
       argument: arg,
@@ -339,7 +340,7 @@ extension Parser {
   }
 
   mutating func parseDifferentiabilityParameters() -> RawDifferentiabilityParamsClauseSyntax {
-    let wrt = self.expectIdentifierWithoutRecovery()
+    let (unexpectedBeforeWrt, wrt) = self.expectIdentifier()
     let (unexpectedBeforeColon, colon) = self.expect(.colon)
 
     guard let leftParen = self.consume(if: .leftParen) else {
@@ -347,6 +348,7 @@ extension Parser {
       let param = self.parseDifferentiabilityParameter().map(RawSyntax.init(_:))
                   ?? RawSyntax(RawMissingSyntax(arena: self.arena))
       return RawDifferentiabilityParamsClauseSyntax(
+        unexpectedBeforeWrt,
         wrtLabel: wrt,
         unexpectedBeforeColon,
         colon: colon,
@@ -692,7 +694,7 @@ extension Parser {
     let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
     let (unexpectedBeforePrivateToken, privateToken) = self.expectContextualKeyword("_private")
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
-    let label = self.expectIdentifierWithoutRecovery()
+    let (unexpectedBeforeLabel, label) = self.expectIdentifier()
     let (unexpectedBeforeColon, colon) = self.expect(.colon)
     let filename = self.consumeAnyToken()
     let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
@@ -704,6 +706,7 @@ extension Parser {
       unexpectedBeforeLeftParen,
       leftParen: leftParen,
       argument: RawSyntax(RawNamedAttributeStringArgumentSyntax(
+        unexpectedBeforeLabel,
         nameTok: label,
         unexpectedBeforeColon,
         colon: colon,

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -114,6 +114,19 @@ public struct ExtaneousCodeAtTopLevel: ParserError {
   }
 }
 
+public struct InvalidIdentifierError: ParserError {
+  public let invalidIdentifier: TokenSyntax
+
+  public var message: String {
+    switch invalidIdentifier.tokenKind {
+    case .unknown(let text) where text.first?.isNumber == true:
+      return "identifier can only start with a letter or underscore, not a number"
+    default:
+      return "'\(invalidIdentifier.text)' is not a valid identifier"
+    }
+  }
+}
+
 public struct MissingTokenError: ParserError {
   public let missingToken: TokenSyntax
 
@@ -134,6 +147,13 @@ public struct MissingTokenError: ParserError {
       break
     }
     return "Expected '\(missingToken.text)' in \(parentTypeName)"
+  }
+
+  public var handledNodes: [Syntax] {
+    if let previous = missingToken.previousToken(viewMode: .all), previous.parent!.is(UnexpectedNodesSyntax.self) {
+      return [Syntax(previous.parent!)]
+    }
+    return []
   }
 }
 

--- a/Sources/SwiftParser/Directives.swift
+++ b/Sources/SwiftParser/Directives.swift
@@ -146,16 +146,17 @@ extension Parser {
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
     let args: RawPoundSourceLocationArgsSyntax?
     if !self.at(.rightParen) {
-      let file = self.expectIdentifierWithoutRecovery()
+      let (unexpectedBeforeFile, file) = self.expectIdentifier()
       let (unexpectedBeforeFileColon, fileColon) = self.expect(.colon)
       let (unexpectedBeforeFileName, fileName) = self.expect(.stringLiteral)
       let (unexpectedBeforeComma, comma) = self.expect(.comma)
 
-      let line = self.expectIdentifierWithoutRecovery()
+      let (unexpectedBeforeLine, line) = self.expectIdentifier()
       let (unexpectedBeforeLineColon, lineColon) = self.expect(.colon)
       let lineNumber = self.expectWithoutRecovery(.integerLiteral)
 
       args = RawPoundSourceLocationArgsSyntax(
+        unexpectedBeforeFile,
         fileArgLabel: file,
         unexpectedBeforeFileColon,
         fileArgColon: fileColon,
@@ -163,6 +164,7 @@ extension Parser {
         fileName: fileName,
         unexpectedBeforeComma,
         comma: comma,
+        unexpectedBeforeLine,
         lineArgLabel: line,
         unexpectedBeforeLineColon,
         lineArgColon: lineColon,

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -128,7 +128,7 @@ extension Parser.Lookahead {
       if case .convention = attr {
         guard
           self.consume(if: .leftParen) != nil,
-          (self.at(.identifier) ? self.expectIdentifierWithoutRecovery() : nil) != nil,
+          self.consume(if: .identifier) != nil,
           self.consume(if: .rightParen) != nil
         else {
           return
@@ -280,10 +280,9 @@ extension Parser.Lookahead {
 
     // Eat attributes, if present.
     while lookahead.consume(if: .atSign) != nil {
-      guard lookahead.at(.identifier) else {
+      guard lookahead.consume(if: .identifier) != nil else {
         return false
       }
-      lookahead.expectIdentifierWithoutRecovery()
       // Eat paren after attribute name; e.g. @foo(x)
       if lookahead.at(.leftParen) {
         lookahead.skipSingle()

--- a/Sources/SwiftParser/Modifiers.swift
+++ b/Sources/SwiftParser/Modifiers.swift
@@ -54,11 +54,11 @@ extension Parser {
         let name = self.eat(handle)
         let details: RawDeclModifierDetailSyntax?
         if let lparen = self.consume(if: .leftParen) {
-          assert(self.atContextualKeyword("set"))
-          let detail = self.expectIdentifierWithoutRecovery()
+          let (unexpectedBeforeDetail, detail) = self.expectContextualKeyword("set")
           let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
           details = RawDeclModifierDetailSyntax(
             leftParen: lparen,
+            unexpectedBeforeDetail,
             detail: detail,
             unexpectedBeforeRParen,
             rightParen: rparen,

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -364,6 +364,40 @@ extension Parser {
       makeMissing: { $0.missingToken(defaultKind, text: nil) }
     )
   }
+
+  @_spi(RawSyntax)
+  public mutating func expectIdentifier() -> (RawUnexpectedNodesSyntax?, Token) {
+    if let (_, handle) = self.canRecoverTo(anyIn: IdentifierTokens.self) {
+      return self.eat(handle)
+    }
+    if let unknown = self.consume(if: .unknown) {
+      return (
+        RawUnexpectedNodesSyntax(elements: [RawSyntax(unknown)], arena: self.arena),
+        self.missingToken(.identifier, text: nil)
+      )
+    }
+    return (
+      nil,
+      self.missingToken(.identifier, text: nil)
+    )
+  }
+
+  @_spi(RawSyntax)
+  public mutating func expectIdentifierOrRethrows() -> (RawUnexpectedNodesSyntax?, Token) {
+    if let (_, handle) = self.canRecoverTo(anyIn: IdentifierOrRethrowsTokens.self) {
+      return self.eat(handle)
+    }
+    if let unknown = self.consume(if: .unknown) {
+      return (
+        RawUnexpectedNodesSyntax(elements: [RawSyntax(unknown)], arena: self.arena),
+        self.missingToken(.identifier, text: nil)
+      )
+    }
+    return (
+      nil,
+      self.missingToken(.identifier, text: nil)
+    )
+  }
 }
 
 // MARK: Spliting Tokens

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -469,6 +469,24 @@ enum IdentifierTokens: RawTokenKindSubset {
   }
 }
 
+enum IdentifierOrRethrowsTokens: RawTokenKindSubset {
+  case anyKeyword
+  case capitalSelfKeyword
+  case identifier
+  case selfKeyword
+  case rethrowsKeyword
+
+  var rawTokenKind: RawTokenKind {
+    switch self {
+    case .anyKeyword: return .anyKeyword
+    case .capitalSelfKeyword: return .capitalSelfKeyword
+    case .identifier: return .identifier
+    case .selfKeyword: return .selfKeyword
+    case .rethrowsKeyword: return .rethrowsKeyword
+    }
+  }
+}
+
 enum Operator: RawTokenKindSubset {
   case spacedBinaryOperator
   case unspacedBinaryOperator

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -664,7 +664,7 @@ extension Parser {
   public mutating func parseSwitchCase() -> RawSwitchCaseSyntax {
     var unknownAttr: RawAttributeSyntax?
     if let at = self.consume(if: .atSign) {
-      let ident = self.expectIdentifierWithoutRecovery()
+      let (unexpectedBeforeIdent, ident) = self.expectIdentifier()
 
       var tokenList = [RawTokenSyntax]()
       var loopProgress = LoopProgressCondition()
@@ -675,6 +675,7 @@ extension Parser {
 
       unknownAttr = RawAttributeSyntax(
         atSignToken: at,
+        unexpectedBeforeIdent,
         attributeName: ident,
         leftParen: nil,
         argument: nil,

--- a/Sources/SwiftParser/TokenConsumer.swift
+++ b/Sources/SwiftParser/TokenConsumer.swift
@@ -282,15 +282,6 @@ extension TokenConsumer {
   }
 
   mutating func expectIdentifierOrRethrowsWithoutRecovery() -> Token {
-    switch self.currentToken.tokenKind {
-    case .selfKeyword,
-        .capitalSelfKeyword,
-        .anyKeyword,
-        .identifier,
-        .rethrowsKeyword:
-      return self.consumeAnyToken()
-    default:
-      return self.missingToken(.identifier, text: nil)
-    }
+    return self.expectAnyWithoutRecovery(IdentifierOrRethrowsTokens.allRawTokenKinds, default: .identifier)
   }
 }

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -16,6 +16,8 @@ import SwiftSyntax
 /// token, tokens with a lower token precedence may be skipped and considered
 /// unexpected.
 public enum TokenPrecedence: Comparable {
+  /// An unknown token. This is known garbage and should always be allowed to be skipped.
+  case unknownToken
   /// Tokens that can be used similar to variable names or literals
   case identifierLike
   /// Keywords and operators that can occur in the middle of an expression
@@ -59,30 +61,32 @@ public enum TokenPrecedence: Comparable {
     func precedence(_ precedence: TokenPrecedence) -> Int {
       /// Should match the order of the cases in the enum.
       switch precedence {
-      case .identifierLike:
+      case .unknownToken:
         return 0
-      case .exprKeyword:
+      case .identifierLike:
         return 1
-      case .weakBracketed:
+      case .exprKeyword:
         return 2
-      case .weakPunctuator:
+      case .weakBracketed:
         return 3
-      case .weakBracketClose:
+      case .weakPunctuator:
         return 4
-      case .stmtKeyword:
+      case .weakBracketClose:
         return 5
-      case .strongPunctuator:
+      case .stmtKeyword:
         return 6
-      case .openingBrace:
+      case .strongPunctuator:
         return 7
-      case .closingBrace:
+      case .openingBrace:
         return 8
-      case .declKeyword:
+      case .closingBrace:
         return 9
-      case .openingPoundIf:
+      case .declKeyword:
         return 10
-      case .closingPoundIf:
+      case .openingPoundIf:
         return 11
+      case .closingPoundIf:
+        return 12
       }
     }
 
@@ -98,6 +102,8 @@ public enum TokenPrecedence: Comparable {
   @_spi(RawSyntax)
   public init(_ tokenKind: RawTokenKind) {
     switch tokenKind {
+    case .unknown:
+      self = .unknownToken
       // MARK: Identifier like
     case
       // Literals
@@ -111,9 +117,7 @@ public enum TokenPrecedence: Comparable {
       // '_' can occur in types to replace a type identifier
         .wildcardKeyword,
       // String segment, string interpolation anchor and pound don't really fit anywhere else
-        .pound, .stringInterpolationAnchor, .stringSegment,
-      // Give unknown tokens the lowest priority to eat it as unexpected if necessary
-        .unknown:
+        .pound, .stringInterpolationAnchor, .stringSegment:
       self = .identifierLike
 
       // MARK: Expr keyword

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -513,20 +513,13 @@ final class DeclarationTests: XCTestCase {
   func testClassWithLeadingNumber() {
     AssertParse(
       """
-      class #^DIAG^#23class {
-        // expected-error@-1 {{class name can only start with a letter or underscore, not a number}}
-        // expected-error@-2 {{'c' is not a valid digit in integer literal}}
-        func 24method() {}
-        // expected-error@-1 {{function name can only start with a letter or underscore, not a number}}
-        // expected-error@-2 {{'m' is not a valid digit in integer literal}}
+      class #^CLASS_NAME^#23class {
+        func #^FUNC_NAME^#24method() {}
       }
       """,
-      // FIXME: These are simply bad diagnostics. We should be complaining that identifiers cannot start with digits.
       diagnostics: [
-        DiagnosticSpec(message: "Expected '' in class"),
-        DiagnosticSpec(message: "Expected '{' to start class"),
-        DiagnosticSpec(message: "Expected '}' to end class"),
-        DiagnosticSpec(message: "Extraneous code at top level"),
+        DiagnosticSpec(locationMarker: "CLASS_NAME", message: "identifier can only start with a letter or underscore, not a number"),
+        DiagnosticSpec(locationMarker: "FUNC_NAME", message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }


### PR DESCRIPTION
The pattern here is that we’ll consume the invalid identifier as an `unknown` token and place it into the unexpected tokens in front of the identifier, which has been synthesized as missing. The diagnostic generator will detect this pattern and emit a matching diagnostic.