### PR TITLE
.swiftinterface-Related Fixes

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -773,6 +773,22 @@ extension Parser {
   }
 }
 
+extension Parser {
+  mutating func parseOpaqueReturnTypeOfAttributeArguments() -> RawOpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let (unexpectedBeforeString, mangledName) = self.expect(.stringLiteral)
+    let (unexpectedBeforeComma, comma) = self.expect(.comma)
+    let (unexpectedBeforeOrdinal, ordinal) = self.expect(.integerLiteral)
+    return RawOpaqueReturnTypeOfAttributeArgumentsSyntax(
+      unexpectedBeforeString,
+      mangledName: mangledName,
+      unexpectedBeforeComma,
+      comma: comma,
+      unexpectedBeforeOrdinal,
+      ordinal: ordinal,
+      arena: self.arena)
+  }
+}
+
 // MARK: Lookahead
 
 extension Parser.Lookahead {

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -24,7 +24,7 @@ extension TokenConsumer {
     var attributeProgress = LoopProgressCondition()
     while attributeProgress.evaluate(subparser.currentToken) && subparser.at(.atSign) {
       hasAttribute = true
-      _ = subparser.eatParseAttributeList()
+      _ = subparser.consumeAttributeList()
     }
 
     var modifierProgress = LoopProgressCondition()

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1828,7 +1828,7 @@ extension Parser {
     if !self.at(.inKeyword) {
       if self.at(.leftParen) {
         // Parse the closure arguments.
-        input = RawSyntax(self.parseParameterClause(isClosure: true))
+        input = RawSyntax(self.parseParameterClause(for: .closure))
       } else {
         var params = [RawClosureParamSyntax]()
         var loopProgress = LoopProgressCondition()

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -178,7 +178,14 @@ extension Parser.Lookahead {
     }
 
     while let _ = self.consume(if: .atSign) {
-      self.expectIdentifierOrRethrowsWithoutRecovery()
+      // Consume qualified names that may or may not involve generic arguments.
+      repeat {
+        self.expectIdentifierOrRethrowsWithoutRecovery()
+        // We don't care whether this succeeds or fails to eat generic
+        // parameters.
+        _ = self.consumeGenericArguments()
+      } while self.consume(if: .period) != nil
+
       if self.consume(if: .leftParen) != nil {
         while !self.at(any: [.eof, .rightParen, .poundEndifKeyword]) {
           self.skipSingle()

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -171,8 +171,10 @@ extension Parser.Lookahead {
   public mutating func eat(_ kind: RawTokenKind) -> Token {
     return self.consume(if: kind)!
   }
+}
 
-  mutating func eatParseAttributeList() -> Bool {
+extension Parser.Lookahead {
+  mutating func consumeAttributeList() -> Bool {
     guard self.at(.atSign) else {
       return false
     }

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -712,7 +712,7 @@ extension Parser.Lookahead {
     self.consumeAnyToken()
 
     // Parse an optional generic argument list.
-    if self.currentToken.starts(with: "<") && !self.canParseGenericArguments() {
+    if self.currentToken.starts(with: "<") && !self.consumeGenericArguments() {
       return false
     }
 
@@ -725,13 +725,13 @@ extension Parser.Lookahead {
     }
 
     var lookahead = self.lookahead()
-    guard lookahead.canParseGenericArguments() else {
+    guard lookahead.consumeGenericArguments() else {
       return false
     }
     return lookahead.currentToken.isGenericTypeDisambiguatingToken
   }
 
-  mutating func canParseGenericArguments() -> Bool {
+  mutating func consumeGenericArguments() -> Bool {
     // Parse the opening '<'.
     guard self.currentToken.starts(with: "<") else {
       return false

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -820,6 +820,26 @@ extension Parser {
           arena: self.arena
         )
       )
+    case ._opaqueReturnTypeOf:
+      let (unexpectedBeforeAt, at) = self.expect(.atSign)
+      let ident = self.expectIdentifierWithoutRecovery()
+      let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
+      let argument = self.parseOpaqueReturnTypeOfAttributeArguments()
+      let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
+      return RawSyntax(
+        RawAttributeSyntax(
+          unexpectedBeforeAt,
+          atSignToken: at,
+          attributeName: ident,
+          unexpectedBeforeLeftParen,
+          leftParen: leftParen,
+          argument: RawSyntax(argument),
+          unexpectedBeforeRightParen,
+          rightParen: rightParen,
+          tokenList: nil,
+          arena: self.arena
+        )
+      )
 
     default:
       let (unexpectedBeforeAt, at) = self.expect(.atSign)

--- a/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
@@ -361,6 +361,7 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/BackDeployAttributeSpecListSyntax>
 - <doc:SwiftSyntax/BackDeployVersionListSyntax>
 - <doc:SwiftSyntax/BackDeployVersionArgumentSyntax>
+- <doc:SwiftSyntax/OpaqueReturnTypeOfAttributeArgumentsSyntax>
 - <doc:SwiftSyntax/SwitchCaseListSyntax>
 - <doc:SwiftSyntax/WhereClauseSyntax>
 - <doc:SwiftSyntax/CatchClauseListSyntax>

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -10578,6 +10578,69 @@ public struct RawBackDeployVersionArgumentSyntax: RawSyntaxNodeProtocol {
 }
 
 @_spi(RawSyntax)
+public struct RawOpaqueReturnTypeOfAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
+  var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .opaqueReturnTypeOfAttributeArguments
+  }
+
+  public var raw: RawSyntax
+  init(raw: RawSyntax) {
+    assert(Self.isKindOf(raw))
+    self.raw = raw
+  }
+
+  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+    guard Self.isKindOf(other.raw) else { return nil }
+    self.init(raw: other.raw)
+  }
+
+  public init(
+    _ unexpectedBeforeMangledName: RawUnexpectedNodesSyntax? = nil,
+    mangledName: RawTokenSyntax,
+    _ unexpectedBetweenMangledNameAndComma: RawUnexpectedNodesSyntax? = nil,
+    comma: RawTokenSyntax,
+    _ unexpectedBetweenCommaAndOrdinal: RawUnexpectedNodesSyntax? = nil,
+    ordinal: RawTokenSyntax,
+    arena: __shared SyntaxArena
+  ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .opaqueReturnTypeOfAttributeArguments, uninitializedCount: 6, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeMangledName?.raw
+      layout[1] = mangledName.raw
+      layout[2] = unexpectedBetweenMangledNameAndComma?.raw
+      layout[3] = comma.raw
+      layout[4] = unexpectedBetweenCommaAndOrdinal?.raw
+      layout[5] = ordinal.raw
+    }
+    self.init(raw: raw)
+  }
+
+  public var unexpectedBeforeMangledName: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var mangledName: RawTokenSyntax {
+    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedBetweenMangledNameAndComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var comma: RawTokenSyntax {
+    layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedBetweenCommaAndOrdinal: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var ordinal: RawTokenSyntax {
+    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+}
+
+@_spi(RawSyntax)
 public struct RawLabeledStmtSyntax: RawStmtSyntaxNodeProtocol {
   var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
@@ -1518,6 +1518,15 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
     break
+  case .opaqueReturnTypeOfAttributeArguments:
+    assert(layout.count == 6)
+    _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[3], as: RawTokenSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[5], as: RawTokenSyntax.self)
+    break
   case .labeledStmt:
     assert(layout.count == 6)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)

--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -381,6 +381,8 @@ extension Syntax {
       return node
     case .backDeployVersionArgument(let node):
       return node
+    case .opaqueReturnTypeOfAttributeArguments(let node):
+      return node
     case .labeledStmt(let node):
       return node
     case .continueStmt(let node):
@@ -742,6 +744,7 @@ extension SyntaxKind {
     case .backDeployAttributeSpecList: return BackDeployAttributeSpecListSyntax.self
     case .backDeployVersionList: return BackDeployVersionListSyntax.self
     case .backDeployVersionArgument: return BackDeployVersionArgumentSyntax.self
+    case .opaqueReturnTypeOfAttributeArguments: return OpaqueReturnTypeOfAttributeArgumentsSyntax.self
     case .labeledStmt: return LabeledStmtSyntax.self
     case .continueStmt: return ContinueStmtSyntax.self
     case .whileStmt: return WhileStmtSyntax.self

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
@@ -1293,6 +1293,13 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   override open func visitPost(_ node: BackDeployVersionArgumentSyntax) {
     visitAnyPost(node._syntaxNode)
   }
+  override open func visit(_ node: OpaqueReturnTypeOfAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: OpaqueReturnTypeOfAttributeArgumentsSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
   override open func visit(_ node: LabeledStmtSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -192,6 +192,7 @@ public enum SyntaxEnum {
   case backDeployAttributeSpecList(BackDeployAttributeSpecListSyntax)
   case backDeployVersionList(BackDeployVersionListSyntax)
   case backDeployVersionArgument(BackDeployVersionArgumentSyntax)
+  case opaqueReturnTypeOfAttributeArguments(OpaqueReturnTypeOfAttributeArgumentsSyntax)
   case labeledStmt(LabeledStmtSyntax)
   case continueStmt(ContinueStmtSyntax)
   case whileStmt(WhileStmtSyntax)
@@ -639,6 +640,8 @@ public enum SyntaxEnum {
       return "version list"
     case .backDeployVersionArgument:
       return "version"
+    case .opaqueReturnTypeOfAttributeArguments:
+      return "opaque return type arguments"
     case .labeledStmt:
       return "labeled statement"
     case .continueStmt:
@@ -1179,6 +1182,8 @@ public extension Syntax {
       return .backDeployVersionList(BackDeployVersionListSyntax(self)!)
     case .backDeployVersionArgument:
       return .backDeployVersionArgument(BackDeployVersionArgumentSyntax(self)!)
+    case .opaqueReturnTypeOfAttributeArguments:
+      return .opaqueReturnTypeOfAttributeArguments(OpaqueReturnTypeOfAttributeArgumentsSyntax(self)!)
     case .labeledStmt:
       return .labeledStmt(LabeledStmtSyntax(self)!)
     case .continueStmt:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -4723,6 +4723,35 @@ public enum SyntaxFactory {
     ], arena: .default))
     return BackDeployVersionArgumentSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on OpaqueReturnTypeOfAttributeArgumentsSyntax")
+  public static func makeOpaqueReturnTypeOfAttributeArguments(_ unexpectedBeforeMangledName: UnexpectedNodesSyntax? = nil, mangledName: TokenSyntax, _ unexpectedBetweenMangledNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndOrdinal: UnexpectedNodesSyntax? = nil, ordinal: TokenSyntax) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeMangledName?.raw,
+      mangledName.raw,
+      unexpectedBetweenMangledNameAndComma?.raw,
+      comma.raw,
+      unexpectedBetweenCommaAndOrdinal?.raw,
+      ordinal.raw,
+    ]
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.opaqueReturnTypeOfAttributeArguments,
+      from: layout, arena: .default)
+    let data = SyntaxData.forRoot(raw)
+    return OpaqueReturnTypeOfAttributeArgumentsSyntax(data)
+  }
+
+  @available(*, deprecated, message: "Use initializer on OpaqueReturnTypeOfAttributeArgumentsSyntax")
+  public static func makeBlankOpaqueReturnTypeOfAttributeArguments(presence: SourcePresence = .present) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .opaqueReturnTypeOfAttributeArguments,
+      from: [
+      nil,
+      RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: .default),
+      nil,
+      RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default),
+      nil,
+      RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default),
+    ], arena: .default))
+    return OpaqueReturnTypeOfAttributeArgumentsSyntax(data)
+  }
   @available(*, deprecated, message: "Use initializer on LabeledStmtSyntax")
   public static func makeLabeledStmt(_ unexpectedBeforeLabelName: UnexpectedNodesSyntax? = nil, labelName: TokenSyntax, _ unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? = nil, labelColon: TokenSyntax, _ unexpectedBetweenLabelColonAndStatement: UnexpectedNodesSyntax? = nil, statement: StmtSyntax) -> LabeledStmtSyntax {
     let layout: [RawSyntax?] = [

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
@@ -193,6 +193,7 @@ public enum SyntaxKind {
   case backDeployAttributeSpecList
   case backDeployVersionList
   case backDeployVersionArgument
+  case opaqueReturnTypeOfAttributeArguments
   case labeledStmt
   case continueStmt
   case whileStmt

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -1255,6 +1255,13 @@ open class SyntaxRewriter {
     return Syntax(visitChildren(node))
   }
 
+  /// Visit a `OpaqueReturnTypeOfAttributeArgumentsSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: OpaqueReturnTypeOfAttributeArgumentsSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
   /// Visit a `LabeledStmtSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -3723,6 +3730,16 @@ open class SyntaxRewriter {
   }
 
   /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplOpaqueReturnTypeOfAttributeArgumentsSyntax(_ data: SyntaxData) -> Syntax {
+      let node = OpaqueReturnTypeOfAttributeArgumentsSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplLabeledStmtSyntax(_ data: SyntaxData) -> Syntax {
       let node = LabeledStmtSyntax(data)
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
@@ -5006,6 +5023,8 @@ open class SyntaxRewriter {
       return visitImplBackDeployVersionListSyntax
     case .backDeployVersionArgument:
       return visitImplBackDeployVersionArgumentSyntax
+    case .opaqueReturnTypeOfAttributeArguments:
+      return visitImplOpaqueReturnTypeOfAttributeArgumentsSyntax
     case .labeledStmt:
       return visitImplLabeledStmtSyntax
     case .continueStmt:
@@ -5549,6 +5568,8 @@ open class SyntaxRewriter {
       return visitImplBackDeployVersionListSyntax(data)
     case .backDeployVersionArgument:
       return visitImplBackDeployVersionArgumentSyntax(data)
+    case .opaqueReturnTypeOfAttributeArguments:
+      return visitImplOpaqueReturnTypeOfAttributeArgumentsSyntax(data)
     case .labeledStmt:
       return visitImplLabeledStmtSyntax(data)
     case .continueStmt:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
@@ -724,6 +724,10 @@ public protocol SyntaxTransformVisitor {
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: BackDeployVersionArgumentSyntax) -> ResultType
+  /// Visiting `OpaqueReturnTypeOfAttributeArgumentsSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: OpaqueReturnTypeOfAttributeArgumentsSyntax) -> ResultType
   /// Visiting `LabeledStmtSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -2143,6 +2147,12 @@ extension SyntaxTransformVisitor {
   public func visit(_ node: BackDeployVersionArgumentSyntax) -> ResultType {
     visitAny(Syntax(node))
   }
+  /// Visiting `OpaqueReturnTypeOfAttributeArgumentsSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: OpaqueReturnTypeOfAttributeArgumentsSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
   /// Visiting `LabeledStmtSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
@@ -3029,6 +3039,8 @@ extension SyntaxTransformVisitor {
     case .backDeployVersionList(let derived):
       return visit(derived)
     case .backDeployVersionArgument(let derived):
+      return visit(derived)
+    case .opaqueReturnTypeOfAttributeArguments(let derived):
       return visit(derived)
     case .labeledStmt(let derived):
       return visit(derived)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -1801,6 +1801,16 @@ open class SyntaxVisitor {
   /// The function called after visiting `BackDeployVersionArgumentSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: BackDeployVersionArgumentSyntax) {}
+  /// Visiting `OpaqueReturnTypeOfAttributeArgumentsSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: OpaqueReturnTypeOfAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `OpaqueReturnTypeOfAttributeArgumentsSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: OpaqueReturnTypeOfAttributeArgumentsSyntax) {}
   /// Visiting `LabeledStmtSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -4696,6 +4706,17 @@ open class SyntaxVisitor {
   }
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplOpaqueReturnTypeOfAttributeArgumentsSyntax(_ data: SyntaxData) {
+      let node = OpaqueReturnTypeOfAttributeArgumentsSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && !node.raw.layoutView!.children.isEmpty {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplLabeledStmtSyntax(_ data: SyntaxData) {
       let node = LabeledStmtSyntax(data)
       let needsChildren = (visit(node) == .visitChildren)
@@ -6035,6 +6056,8 @@ open class SyntaxVisitor {
       visitImplBackDeployVersionListSyntax(data)
     case .backDeployVersionArgument:
       visitImplBackDeployVersionArgumentSyntax(data)
+    case .opaqueReturnTypeOfAttributeArguments:
+      visitImplOpaqueReturnTypeOfAttributeArgumentsSyntax(data)
     case .labeledStmt:
       visitImplLabeledStmtSyntax(data)
     case .continueStmt:

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -12009,6 +12009,190 @@ extension BackDeployVersionArgumentSyntax: CustomReflectable {
   }
 }
 
+// MARK: - OpaqueReturnTypeOfAttributeArgumentsSyntax
+
+/// 
+/// The arguments for the '@_opaqueReturnTypeOf()'.
+/// 
+public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `OpaqueReturnTypeOfAttributeArgumentsSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .opaqueReturnTypeOfAttributeArguments else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `OpaqueReturnTypeOfAttributeArgumentsSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .opaqueReturnTypeOfAttributeArguments)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ unexpectedBeforeMangledName: UnexpectedNodesSyntax? = nil,
+    mangledName: TokenSyntax,
+    _ unexpectedBetweenMangledNameAndComma: UnexpectedNodesSyntax? = nil,
+    comma: TokenSyntax,
+    _ unexpectedBetweenCommaAndOrdinal: UnexpectedNodesSyntax? = nil,
+    ordinal: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeMangledName?.raw,
+      mangledName.raw,
+      unexpectedBetweenMangledNameAndComma?.raw,
+      comma.raw,
+      unexpectedBetweenCommaAndOrdinal?.raw,
+      ordinal.raw,
+    ]
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.opaqueReturnTypeOfAttributeArguments,
+      from: layout, arena: .default)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
+  public var unexpectedBeforeMangledName: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 0, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBeforeMangledName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBeforeMangledName` replaced.
+  /// - param newChild: The new `unexpectedBeforeMangledName` to replace the node's
+  ///                   current `unexpectedBeforeMangledName`, if present.
+  public func withUnexpectedBeforeMangledName(
+    _ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 0)
+    return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
+  }
+
+  /// The mangled name of a declaration.
+  public var mangledName: TokenSyntax {
+    get {
+      let childData = data.child(at: 1, parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withMangledName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `mangledName` replaced.
+  /// - param newChild: The new `mangledName` to replace the node's
+  ///                   current `mangledName`, if present.
+  public func withMangledName(
+    _ newChild: TokenSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.stringLiteral(""), arena: .default)
+    let newData = data.replacingChild(raw, at: 1)
+    return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
+  }
+
+  public var unexpectedBetweenMangledNameAndComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenMangledNameAndComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenMangledNameAndComma` replaced.
+  /// - param newChild: The new `unexpectedBetweenMangledNameAndComma` to replace the node's
+  ///                   current `unexpectedBetweenMangledNameAndComma`, if present.
+  public func withUnexpectedBetweenMangledNameAndComma(
+    _ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
+  }
+
+  public var comma: TokenSyntax {
+    get {
+      let childData = data.child(at: 3, parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `comma` replaced.
+  /// - param newChild: The new `comma` to replace the node's
+  ///                   current `comma`, if present.
+  public func withComma(
+    _ newChild: TokenSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default)
+    let newData = data.replacingChild(raw, at: 3)
+    return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
+  }
+
+  public var unexpectedBetweenCommaAndOrdinal: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenCommaAndOrdinal(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndOrdinal` replaced.
+  /// - param newChild: The new `unexpectedBetweenCommaAndOrdinal` to replace the node's
+  ///                   current `unexpectedBetweenCommaAndOrdinal`, if present.
+  public func withUnexpectedBetweenCommaAndOrdinal(
+    _ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
+  }
+
+  /// The ordinal corresponding to the 'some' keyword that introduced this opaque type.
+  public var ordinal: TokenSyntax {
+    get {
+      let childData = data.child(at: 5, parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withOrdinal(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `ordinal` replaced.
+  /// - param newChild: The new `ordinal` to replace the node's
+  ///                   current `ordinal`, if present.
+  public func withOrdinal(
+    _ newChild: TokenSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default)
+    let newData = data.replacingChild(raw, at: 5)
+    return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
+  }
+}
+
+extension OpaqueReturnTypeOfAttributeArgumentsSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "unexpectedBeforeMangledName": unexpectedBeforeMangledName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "mangledName": Syntax(mangledName).asProtocol(SyntaxProtocol.self),
+      "unexpectedBetweenMangledNameAndComma": unexpectedBetweenMangledNameAndComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "comma": Syntax(comma).asProtocol(SyntaxProtocol.self),
+      "unexpectedBetweenCommaAndOrdinal": unexpectedBetweenCommaAndOrdinal.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "ordinal": Syntax(ordinal).asProtocol(SyntaxProtocol.self),
+    ])
+  }
+}
+
 // MARK: - WhereClauseSyntax
 
 public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -10962,6 +10962,84 @@ public struct BackDeployVersionArgument: SyntaxBuildable, ExpressibleAsBackDeplo
     return result
   }
 }
+/// The arguments for the '@_opaqueReturnTypeOf()'.
+public struct OpaqueReturnTypeOfAttributeArguments: SyntaxBuildable, ExpressibleAsOpaqueReturnTypeOfAttributeArguments {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
+  var unexpectedBeforeMangledName: UnexpectedNodes?
+  var mangledName: Token
+  var unexpectedBetweenMangledNameAndComma: UnexpectedNodes?
+  var comma: Token
+  var unexpectedBetweenCommaAndOrdinal: UnexpectedNodes?
+  var ordinal: Token
+  /// Creates a `OpaqueReturnTypeOfAttributeArguments` using the provided parameters.
+  /// - Parameters:
+  ///   - unexpectedBeforeMangledName: 
+  ///   - mangledName: The mangled name of a declaration.
+  ///   - unexpectedBetweenMangledNameAndComma: 
+  ///   - comma: 
+  ///   - unexpectedBetweenCommaAndOrdinal: 
+  ///   - ordinal: The ordinal corresponding to the 'some' keyword that introduced this opaque type.
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeMangledName: ExpressibleAsUnexpectedNodes? = nil, mangledName: Token, unexpectedBetweenMangledNameAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token = Token.`comma`, unexpectedBetweenCommaAndOrdinal: ExpressibleAsUnexpectedNodes? = nil, ordinal: Token) {
+    self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
+    self.unexpectedBeforeMangledName = unexpectedBeforeMangledName?.createUnexpectedNodes()
+    self.mangledName = mangledName
+    self.unexpectedBetweenMangledNameAndComma = unexpectedBetweenMangledNameAndComma?.createUnexpectedNodes()
+    self.comma = comma
+    assert(comma.text == #","#)
+    self.unexpectedBetweenCommaAndOrdinal = unexpectedBetweenCommaAndOrdinal?.createUnexpectedNodes()
+    self.ordinal = ordinal
+  }
+  /// A convenience initializer that allows:
+  ///  - Initializing syntax collections using result builders
+  ///  - Initializing tokens without default text using strings
+  public init (leadingTrivia: Trivia = [], unexpectedBeforeMangledName: ExpressibleAsUnexpectedNodes? = nil, mangledName: String, unexpectedBetweenMangledNameAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token = Token.`comma`, unexpectedBetweenCommaAndOrdinal: ExpressibleAsUnexpectedNodes? = nil, ordinal: String) {
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeMangledName: unexpectedBeforeMangledName, mangledName: Token.`stringLiteral`(mangledName), unexpectedBetweenMangledNameAndComma: unexpectedBetweenMangledNameAndComma, comma: comma, unexpectedBetweenCommaAndOrdinal: unexpectedBetweenCommaAndOrdinal, ordinal: Token.`integerLiteral`(ordinal))
+  }
+  /// Builds a `OpaqueReturnTypeOfAttributeArgumentsSyntax`.
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
+  /// - Returns: The built `OpaqueReturnTypeOfAttributeArgumentsSyntax`.
+  func buildOpaqueReturnTypeOfAttributeArguments(format: Format) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    var result = OpaqueReturnTypeOfAttributeArgumentsSyntax(unexpectedBeforeMangledName?.buildUnexpectedNodes(format: format), mangledName: mangledName.buildToken(format: format), unexpectedBetweenMangledNameAndComma?.buildUnexpectedNodes(format: format), comma: comma.buildToken(format: format), unexpectedBetweenCommaAndOrdinal?.buildUnexpectedNodes(format: format), ordinal: ordinal.buildToken(format: format))
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
+    return format.format(syntax: result)
+  }
+  /// Conformance to `SyntaxBuildable`.
+  public func buildSyntax(format: Format) -> Syntax {
+    let result = buildOpaqueReturnTypeOfAttributeArguments(format: format)
+    return Syntax(result)
+  }
+  /// Conformance to `ExpressibleAsOpaqueReturnTypeOfAttributeArguments`.
+  public func createOpaqueReturnTypeOfAttributeArguments() -> OpaqueReturnTypeOfAttributeArguments {
+    return self
+  }
+  /// Conformance to `ExpressibleAsSyntaxBuildable`.
+  /// `OpaqueReturnTypeOfAttributeArguments` may conform to `ExpressibleAsSyntaxBuildable` via different `ExpressibleAs*` paths.
+  /// Thus, there are multiple default implementations of `createSyntaxBuildable`, some of which perform conversions
+  /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
+  public func createSyntaxBuildable() -> SyntaxBuildable {
+    return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
+}
 public struct LabeledStmt: StmtBuildable, ExpressibleAsLabeledStmt {
   /// The leading trivia attached to this syntax node once built.
   var leadingTrivia: Trivia

--- a/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
@@ -1393,6 +1393,14 @@ public extension ExpressibleAsBackDeployVersionArgument {
     return createBackDeployVersionArgument()
   }
 }
+public protocol ExpressibleAsOpaqueReturnTypeOfAttributeArguments: ExpressibleAsSyntaxBuildable {
+  func createOpaqueReturnTypeOfAttributeArguments() -> OpaqueReturnTypeOfAttributeArguments
+}
+public extension ExpressibleAsOpaqueReturnTypeOfAttributeArguments {
+  func createSyntaxBuildable() -> SyntaxBuildable {
+    return createOpaqueReturnTypeOfAttributeArguments()
+  }
+}
 public protocol ExpressibleAsLabeledStmt: ExpressibleAsStmtBuildable {
   func createLabeledStmt() -> LabeledStmt
 }

--- a/Sources/SwiftSyntaxBuilder/generated/Format.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/Format.swift
@@ -1204,6 +1204,14 @@ extension Format {
     }
     return result
   }
+  func format(syntax: OpaqueReturnTypeOfAttributeArgumentsSyntax) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    var result = syntax
+    let leadingTrivia = result.leadingTrivia ?? []
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
+    return result
+  }
   func format(syntax: LabeledStmtSyntax) -> LabeledStmtSyntax {
     var result = syntax
     let leadingTrivia = result.leadingTrivia ?? []

--- a/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
@@ -17,6 +17,6 @@
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "52d3175a2b84b9bb42a02b8e99bcde4c02f735f3"
+      "832967d1caae86e2c4c75bd8d0cc32544e259d0b"
   }
 }

--- a/Sources/SwiftSyntaxParser/gyb_generated/Serialization.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/Serialization.swift
@@ -195,6 +195,7 @@ extension SyntaxKind {
     case 257: self = .backDeployAttributeSpecList
     case 258: self = .backDeployVersionList
     case 259: self = .backDeployVersionArgument
+    case 274: self = .opaqueReturnTypeOfAttributeArguments
     case 267: self = .labeledStmt
     case 72: self = .continueStmt
     case 73: self = .whileStmt

--- a/Sources/generate-swift-syntax-builder/gyb_generated/AttributeNodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/AttributeNodes.swift
@@ -641,4 +641,28 @@ let ATTRIBUTE_NODES: [Node] = [
                ])
        ]),
 
+  Node(name: "OpaqueReturnTypeOfAttributeArguments",
+       nameForDiagnostics: "opaque return type arguments",
+       description: "The arguments for the '@_opaqueReturnTypeOf()'.",
+       kind: "Syntax",
+       children: [
+         Child(name: "MangledName",
+               kind: "StringLiteralToken",
+               description: "The mangled name of a declaration.",
+               tokenChoices: [
+                 "StringLiteral"
+               ]),
+         Child(name: "Comma",
+               kind: "CommaToken",
+               tokenChoices: [
+                 "Comma"
+               ]),
+         Child(name: "Ordinal",
+               kind: "IntegerLiteralToken",
+               description: "The ordinal corresponding to the 'some' keyword that introduced this opaque type.",
+               tokenChoices: [
+                 "IntegerLiteral"
+               ])
+       ]),
+
 ]

--- a/Sources/generate-swift-syntax-builder/gyb_generated/NodeSerializationCodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/NodeSerializationCodes.swift
@@ -284,4 +284,5 @@ public let SYNTAX_NODE_SERIALIZATION_CODES: [String: Int] = [
   "UnresolvedIsExpr": 271,
   "UnresolvedAsExpr": 272,
   "PackExpansionType": 273,
+  "OpaqueReturnTypeOfAttributeArguments": 274,
 ]

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/AttributeNodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/AttributeNodes.py
@@ -476,5 +476,18 @@ ATTRIBUTE_NODES = [
                    argument
                    '''),
          ]),
-
+    # opaque-return-type-of-arguments -> string-literal ',' integer-literal
+    Node('OpaqueReturnTypeOfAttributeArguments',
+         name_for_diagnostics='opaque return type arguments',
+         kind='Syntax',
+         description='''
+         The arguments for the '@_opaqueReturnTypeOf()'.
+         ''',
+         children=[
+             Child('MangledName', kind='StringLiteralToken',
+                   description='The mangled name of a declaration.'),
+             Child('Comma', kind='CommaToken'),
+             Child('Ordinal', kind='IntegerLiteralToken',
+                   description="The ordinal corresponding to the 'some' keyword that introduced this opaque type."),
+        ]),
 ]

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/NodeSerializationCodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/NodeSerializationCodes.py
@@ -275,6 +275,7 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'UnresolvedIsExpr': 271,
     'UnresolvedAsExpr': 272,
     'PackExpansionType': 273,
+    'OpaqueReturnTypeOfAttributeArguments': 274,
 }
 
 

--- a/Tests/SwiftParserTest/Attributes.swift
+++ b/Tests/SwiftParserTest/Attributes.swift
@@ -96,4 +96,11 @@ final class AttributeTests: XCTestCase {
       """
     )
   }
+
+  func testQualifiedAttribute() {
+    AssertParse(
+      """
+      @_Concurrency.MainActor(unsafe) public struct Image : SwiftUI.View {}
+      """)
+  }
 }

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -383,6 +383,14 @@ final class DeclarationTests: XCTestCase {
   func testEnumParsing() {
     AssertParse(
       """
+      enum Foo {
+        @preconcurrency case custom(@Sendable () throws -> Void)
+      }
+      """
+    )
+
+    AssertParse(
+      """
       enum Content {
         case keyPath(KeyPath<FocusedValues, Value?>)
         case keyPath(KeyPath<FocusedValues, Binding<Value>?>)

--- a/Tests/SwiftParserTest/Types.swift
+++ b/Tests/SwiftParserTest/Types.swift
@@ -59,4 +59,11 @@ final class TypeTests: XCTestCase {
                   DiagnosticSpec(message: "Unexpected text '`' found in closure capture signature")
                 ])
   }
+
+  func testOpaqueReturnTypes() throws {
+    AssertParse("""
+                public typealias Body = @_opaqueReturnTypeOf("$s6CatKit10pspspspspsV5cmereV6lilguyQrvp", 0) __
+                """)
+  }
 }
+


### PR DESCRIPTION
A stack of fixes that get us parsing the declarations in swift interface files correctly.

- Model the argument list to @_opaqueReturnTypeOf and parse it
- Parse attributes involving both qualified names and generics
- Rename some of the methods that got touched here to be more internally consistent.