### PR TITLE
Conditionalize Use of New Internal Parsing APIs

### DIFF
--- a/Sources/SwiftParser/CharacterInfo.swift
+++ b/Sources/SwiftParser/CharacterInfo.swift
@@ -93,7 +93,6 @@ extension Unicode.Scalar {
   }
 }
 
-#if swift(<5.7)
 extension UnsafeRawBufferPointer {
   /// Returns a typed buffer to the memory referenced by this buffer,
   /// assuming that the memory is already bound to the specified type.
@@ -122,7 +121,6 @@ extension UnsafeRawBufferPointer {
     return .init(start: s.assumingMemoryBound(to: T.self), count: n)
   }
 }
-#endif
 
 private var InfoTable: CharacterInfoTable = (
   // 0 NUL        1 SOH         2 STX         3 ETX

--- a/Sources/SwiftSyntax/BumpPtrAllocator.swift
+++ b/Sources/SwiftSyntax/BumpPtrAllocator.swift
@@ -163,7 +163,6 @@ public class BumpPtrAllocator {
 
 // MARK: Compatibilty Shims
 
-#if swift(<5.7)
 extension UnsafeMutableRawPointer {
   /// Obtain the next pointer whose bit pattern is a multiple of alignment.
   ///
@@ -181,4 +180,3 @@ extension UnsafeMutableRawPointer {
     return .init(bitPattern: bits)!
   }
 }
-#endif


### PR DESCRIPTION
Provides a weak solution to #749 by assuming that the toolchain used to build SwiftSyntax is also the toolchain you're linking the internal syntax dylib out of.

@jpsim 