### PR TITLE
Provide API for working with syntax text that includes malformed UTF-8.

### DIFF
--- a/Sources/SwiftParser/CompilerSupport.swift
+++ b/Sources/SwiftParser/CompilerSupport.swift
@@ -47,7 +47,7 @@ public func _parserConsistencyCheck(
 
     // Round-trip test.
     if flags & 0x01 != 0 {
-      if Syntax(raw: rawSourceFile.raw).syntaxTextBytes != [UInt8](buffer) {
+      if rawSourceFile.raw.syntaxTextBytes != [UInt8](buffer) {
         print(
           "\(String(cString: filename)): error: file failed to round-trip")
         return 1

--- a/Sources/SwiftParser/CompilerSupport.swift
+++ b/Sources/SwiftParser/CompilerSupport.swift
@@ -47,9 +47,7 @@ public func _parserConsistencyCheck(
 
     // Round-trip test.
     if flags & 0x01 != 0 {
-      var bufferArray = [UInt8](buffer)
-      bufferArray.append(0)
-      if "\(rawSourceFile)" != String(cString: bufferArray) {
+      if Syntax(raw: rawSourceFile.raw).syntaxTextBytes != [UInt8](buffer) {
         print(
           "\(String(cString: filename)): error: file failed to round-trip")
         return 1

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -267,6 +267,21 @@ extension RawSyntax {
   }
 }
 
+extension RawTriviaPiece {
+  func withSyntaxText(body: (SyntaxText) throws -> Void) rethrows {
+    if let syntaxText = storedText {
+      try body(syntaxText)
+      return
+    }
+
+    var description = ""
+    write(to: &description)
+    try description.withUTF8 { buffer in
+      try body(SyntaxText(baseAddress: buffer.baseAddress, count: buffer.count))
+    }
+  }
+}
+
 extension RawSyntax {
   /// Enumerate all of the syntax text present in this node, and all
   /// of its children, to give a source-accurate view of the bytes.

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -299,6 +299,16 @@ extension RawSyntax {
       }
     }
   }
+
+  /// Retrieve the syntax text as an array of bytes that models the input
+  /// source even in the presence of invalid UTF-8.
+  public var syntaxTextBytes: [UInt8] {
+    var result: [UInt8] = []
+    withEachSyntaxText { syntaxText in
+      result.append(contentsOf: syntaxText)
+    }
+    return result
+  }
 }
 
 extension RawSyntax: TextOutputStreamable, CustomStringConvertible {

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -99,11 +99,7 @@ extension Syntax {
   /// Retrieve the syntax text as an array of bytes that models the input
   /// source even in the presence of invalid UTF-8.
   public var syntaxTextBytes: [UInt8] {
-    var result: [UInt8] = []
-    withEachSyntaxText { syntaxText in
-      result.append(contentsOf: syntaxText)
-    }
-    return result
+    return raw.syntaxTextBytes
   }
 }
 
@@ -495,6 +491,12 @@ public extension SyntaxProtocol {
   /// invalid UTF-8.
   var description: String {
     return data.raw.description
+  }
+
+  /// Retrieve the syntax text as an array of bytes that models the input
+  /// source even in the presence of invalid UTF-8.
+  var syntaxTextBytes: [UInt8] {
+    return data.raw.syntaxTextBytes
   }
 
   /// Prints the raw value of this node to the provided stream.

--- a/Sources/SwiftSyntax/gyb_generated/Trivia.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Trivia.swift
@@ -422,6 +422,21 @@ public enum RawTriviaPiece: Equatable {
   }
 }
 
+extension RawTriviaPiece {
+  func withSyntaxText(body: (SyntaxText) throws -> Void) rethrows {
+    if let syntaxText = storedText {
+      try body(syntaxText)
+      return
+    }
+
+    var description = ""
+    write(to: &description)
+    try description.withUTF8 { buffer in
+      try body(SyntaxText(baseAddress: buffer.baseAddress, count: buffer.count))
+    }
+  }
+}
+
 extension RawTriviaPiece: TextOutputStreamable {
   public func write<Target: TextOutputStream>(to target: inout Target) {
     TriviaPiece(raw: self).write(to: &target)

--- a/Sources/SwiftSyntax/gyb_generated/Trivia.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Trivia.swift
@@ -422,21 +422,6 @@ public enum RawTriviaPiece: Equatable {
   }
 }
 
-extension RawTriviaPiece {
-  func withSyntaxText(body: (SyntaxText) throws -> Void) rethrows {
-    if let syntaxText = storedText {
-      try body(syntaxText)
-      return
-    }
-
-    var description = ""
-    write(to: &description)
-    try description.withUTF8 { buffer in
-      try body(SyntaxText(baseAddress: buffer.baseAddress, count: buffer.count))
-    }
-  }
-}
-
 extension RawTriviaPiece: TextOutputStreamable {
   public func write<Target: TextOutputStream>(to target: inout Target) {
     TriviaPiece(raw: self).write(to: &target)

--- a/Sources/swift-parser-test/swift-parser-test.swift
+++ b/Sources/swift-parser-test/swift-parser-test.swift
@@ -36,22 +36,20 @@ func printerr(_ message: String, terminator: String = "\n") {
   FileHandle.standardError.write((message + terminator).data(using: .utf8)!)
 }
 
-private func withTemporaryFile<T>(contents: String, body: (URL) throws -> T) throws -> T {
+private func withTemporaryFile<T>(contents: [UInt8], body: (URL) throws -> T) throws -> T {
   var tempFileURL = FileManager.default.temporaryDirectory
   tempFileURL.appendPathComponent("swift-parser-test-\(UUID().uuidString).swift")
-  try contents.write(to: tempFileURL, atomically: false, encoding: .utf8)
+  try Data(contents).write(to: tempFileURL)
   defer {
     try? FileManager.default.removeItem(at: tempFileURL)
   }
   return try body(tempFileURL)
 }
 
-private func getContentsOfSourceFile(at path: String) throws -> String {
+private func getContentsOfSourceFile(at path: String) throws -> [UInt8] {
   let sourceURL = URL(fileURLWithPath: path)
-  guard let source = try String(data: Data(contentsOf: sourceURL), encoding: .utf8) else {
-    throw CommonError.readingSourceFileFailed(sourceURL)
-  }
-  return source
+  let source = try Data(contentsOf: sourceURL)
+  return [UInt8](source)
 }
 
 @main
@@ -96,16 +94,24 @@ class VerifyRoundTrip: ParsableCommand {
   func run() throws {
     let source = try getContentsOfSourceFile(at: sourceFile)
 
-    try Self.run(source: source, swiftVersion: swiftVersion, enableBareSlashRegex: enableBareSlashRegex)
+    try source.withUnsafeBufferPointer { sourceBuffer in
+      try Self.run(
+        source: sourceBuffer, swiftVersion: swiftVersion,
+        enableBareSlashRegex: enableBareSlashRegex
+      )
+    }
   }
 
-  static func run(source: String, swiftVersion: String?, enableBareSlashRegex: Bool?) throws {
+  static func run(
+    source: UnsafeBufferPointer<UInt8>, swiftVersion: String?,
+    enableBareSlashRegex: Bool?
+  ) throws {
     let tree = try Parser.parse(
       source: source,
       languageVersion: swiftVersion,
       enableBareSlashRegexLiteral: enableBareSlashRegex
     )
-    if tree.description != source {
+    if tree.syntaxTextBytes != [UInt8](source) {
       throw Error.roundTripFailed
     }
   }
@@ -126,17 +132,19 @@ class PrintDiags: ParsableCommand {
   func run() throws {
     let source = try getContentsOfSourceFile(at: sourceFile)
 
-    let tree = try Parser.parse(
-      source: source,
-      languageVersion: swiftVersion,
-      enableBareSlashRegexLiteral: enableBareSlashRegex
-    )
-    let diags = ParseDiagnosticsGenerator.diagnostics(for: tree)
-    if diags.isEmpty {
-      print("No diagnostics produced")
-    }
-    for diag in diags {
-      print("\(diag.debugDescription)")
+    try source.withUnsafeBufferPointer { sourceBuffer in
+      let tree = try Parser.parse(
+        source: sourceBuffer,
+        languageVersion: swiftVersion,
+        enableBareSlashRegexLiteral: enableBareSlashRegex
+      )
+      let diags = ParseDiagnosticsGenerator.diagnostics(for: tree)
+      if diags.isEmpty {
+        print("No diagnostics produced")
+      }
+      for diag in diags {
+        print("\(diag.debugDescription)")
+      }
     }
   }
 }
@@ -156,12 +164,14 @@ class DumpTree: ParsableCommand {
   func run() throws {
     let source = try getContentsOfSourceFile(at: sourceFile)
 
-    let tree = try Parser.parse(
-      source: source,
-      languageVersion: swiftVersion,
-      enableBareSlashRegexLiteral: enableBareSlashRegex
-    )
-    print(tree.recursiveDescription)
+    try source.withUnsafeBufferPointer { sourceBuffer in
+      let tree = try Parser.parse(
+        source: sourceBuffer,
+        languageVersion: swiftVersion,
+        enableBareSlashRegexLiteral: enableBareSlashRegex
+      )
+      print(tree.recursiveDescription)
+    }
   }
 }
 
@@ -204,7 +214,7 @@ class Reduce: ParsableCommand {
 
   /// Invoke `swift-parser-test verify-round-trip` with the same arguments as this `reduce` subcommand.
   /// Returns the exit code of the invocation.
-  private func runVerifyRoundTripInSeparateProcess(source: String) throws -> ProcessExit {
+  private func runVerifyRoundTripInSeparateProcess(source: [UInt8]) throws -> ProcessExit {
     return try withTemporaryFile(contents: source) { tempFileURL in
       let process = Process()
       process.executableURL = URL(fileURLWithPath: ProcessInfo.processInfo.arguments[0])
@@ -250,16 +260,18 @@ class Reduce: ParsableCommand {
 
   /// Runs the `verify-round-trip` subcommand in process.
   /// Returns `true` if `source` round-tripped successfully, `false` otherwise.
-  private func runVerifyRoundTripInCurrentProcess(source: String) throws -> Bool {
+  private func runVerifyRoundTripInCurrentProcess(source: [UInt8]) throws -> Bool {
     do {
-      try VerifyRoundTrip.run(source: source, swiftVersion: self.swiftVersion, enableBareSlashRegex: self.enableBareSlashRegex)
+      try source.withUnsafeBufferPointer { sourceBuffer in
+        try VerifyRoundTrip.run(source: sourceBuffer, swiftVersion: self.swiftVersion, enableBareSlashRegex: self.enableBareSlashRegex)
+      }
     } catch {
       return false
     }
     return true
   }
 
-  private func reduce(source: String, testPasses: (String) throws -> Bool) throws -> String {
+  private func reduce(source: [UInt8], testPasses: ([UInt8]) throws -> Bool) throws -> [UInt8] {
     var reduced = source
     var chunkSize = source.count / 4
     while chunkSize > 0 {
@@ -280,17 +292,17 @@ class Reduce: ParsableCommand {
   }
 
   /// Reduces a test case with `source` by iteratively attempting to remove `chunkSize` characters - ie. removing the chunk if `testPasses` returns `false`.
-  private func reduceImpl(source: String, chunkSize: Int, testPasses: (String) throws -> Bool) rethrows -> String {
-    var reduced = ""
+  private func reduceImpl(source: [UInt8], chunkSize: Int, testPasses: ([UInt8]) throws -> Bool) rethrows -> [UInt8] {
+    var reduced: [UInt8] = []
     // Characters that stil need to be checked whether they can be removed.
     var remaining = source
     while !remaining.isEmpty {
       let index = remaining.index(remaining.startIndex, offsetBy: chunkSize, limitedBy: remaining.endIndex) ?? remaining.endIndex
-      let testChunk = String(remaining[..<index])
-      remaining = String(remaining[index...])
+      let testChunk = [UInt8](remaining[..<index])
+      remaining = [UInt8](remaining[index...])
       if try testPasses(reduced + remaining) {
         // The test doesn't fail anymore if we remove testChunk. Add it again.
-        reduced.append(testChunk)
+        reduced.append(contentsOf: testChunk)
       }
     }
     return reduced
@@ -299,7 +311,7 @@ class Reduce: ParsableCommand {
   func run() throws {
     let source = try getContentsOfSourceFile(at: sourceFile)
 
-    let testPasses: (String) throws -> Bool
+    let testPasses: ([UInt8]) throws -> Bool
     switch try runVerifyRoundTripInSeparateProcess(source: source) {
     case .success:
       throw Error.testDoesNotFail

--- a/Sources/swift-parser-test/swift-parser-test.swift
+++ b/Sources/swift-parser-test/swift-parser-test.swift
@@ -20,17 +20,6 @@ import ArgumentParser
 import WinSDK
 #endif
 
-enum CommonError: Swift.Error {
-  case readingSourceFileFailed(URL)
-
-  public var description: String {
-    switch self {
-    case .readingSourceFileFailed(let url):
-      return "Reading the source file at \(url) failed"
-    }
-  }
-}
-
 /// Print the given message to stderr
 func printerr(_ message: String, terminator: String = "\n") {
   FileHandle.standardError.write((message + terminator).data(using: .utf8)!)


### PR DESCRIPTION
The `description` operation on a syntax node cannot represent invalid UTF-8. Document this limitation, and introduce `syntaxTextBytes`, which produces an array of bytes that accurately represents the source, even in the presence of malformed UTF-8.

Switch the parser consistency check's round-tripping validation over to use `syntaxTextBytes`, so that we correctly verify round-tripping of malformed UTF-8.