### PR TITLE
Fix parsing attributes at the start of an accessor

### DIFF
--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -188,6 +188,28 @@ final class DeclarationTests: XCTestCase {
       async let theVeryLastPhotoWeWant = fetch("4.jpg")
       """
     )
+    
+    AssertParse(
+      """
+      var foo: Int {
+        @available(swift 5.0)
+        func myFun() -> Int {
+          return 42
+        }
+        return myFun()
+      }
+      """
+    )
+    
+    AssertParse(
+      """
+      var foo: Int {
+        mutating set {
+          test += 1
+        }
+      }
+      """
+    )
   }
 
   func testTypealias() {


### PR DESCRIPTION
Previously, it would consume an attribute without adding it to the tree if an identifier is not found. Now, it looks ahead to confirm there is an identifier before consuming.

Added two test cases to verify parseAccessorIntroducer

Fixes: #677