### PR TITLE
Fix Regression in Leading Unexpected Tokens for Declarations

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -577,6 +577,7 @@ extension Parser {
     return RawClassDeclSyntax(
       attributes: attrs.attributes,
       modifiers: attrs.modifiers,
+      unexpectedBeforeClassKeyword,
       classKeyword: classKeyword,
       unexpectedBeforeName,
       identifier: name,
@@ -694,6 +695,7 @@ extension Parser {
     let members = self.parseMemberDeclList()
     return RawEnumDeclSyntax(
       attributes: attrs.attributes, modifiers: attrs.modifiers,
+      unexpectedBeforeEnumKeyword,
       enumKeyword: enumKeyword,
       unexpectedBeforeName,
       identifier: name,
@@ -831,6 +833,7 @@ extension Parser {
     let members = self.parseMemberDeclList()
     return RawStructDeclSyntax(
       attributes: attrs.attributes, modifiers: attrs.modifiers,
+      unexpectedBeforeStructKeyword,
       structKeyword: structKeyword,
       identifier: name,
       genericParameterClause: generics,
@@ -938,6 +941,7 @@ extension Parser {
 
     return RawProtocolDeclSyntax(
       attributes: attrs.attributes, modifiers: attrs.modifiers,
+      unexpectedBeforeProtocolKeyword,
       protocolKeyword: protocolKeyword,
       identifier: name,
       primaryAssociatedTypeClause: primaries,
@@ -1003,6 +1007,7 @@ extension Parser {
 
     return RawAssociatedtypeDeclSyntax(
       attributes: attrs.attributes, modifiers: attrs.modifiers,
+      unexpectedBeforeAssocKeyword,
       associatedtypeKeyword: assocKeyword,
       identifier: name,
       inheritanceClause: inheritance,

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -804,6 +804,55 @@ final class DeclarationTests: XCTestCase {
       }
       """##)
   }
+
+  func testLeadingUnexpectedTokens() {
+    AssertParse("#^DIAG_1^#}class C#^DIAG_2^#",
+                diagnostics: [
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before class"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '{' to start class"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '}' to end class"),
+                ])
+    AssertParse("#^DIAG_1^#}enum C#^DIAG_2^#",
+                diagnostics: [
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before enum"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '{' to start enum"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '}' to end enum"),
+                ])
+    AssertParse("#^DIAG_1^#}protocol C#^DIAG_2^#",
+                diagnostics: [
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before protocol"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '{' to start protocol"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '}' to end protocol"),
+                ])
+    AssertParse("#^DIAG_1^#}actor C#^DIAG_2^#",
+                diagnostics: [
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before actor"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '{' to start actor"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '}' to end actor"),
+                ])
+    AssertParse("#^DIAG_1^#}struct C#^DIAG_2^#",
+                diagnostics: [
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before struct"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '{' to start struct"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '}' to end struct"),
+                ])
+    AssertParse("#^DIAG_1^#}func C#^DIAG_2^#",
+                diagnostics: [
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before function"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected argument list in function declaration"),
+                ])
+    AssertParse("#^DIAG_1^#}init#^DIAG_2^#",
+                diagnostics: [
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before initializer"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected argument list in function declaration"),
+                ])
+    AssertParse("#^DIAG_1^#}subscript#^DIAG_2^#",
+                diagnostics: [
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before subscript"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected argument list in function declaration"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '->' in return clause"),
+                ])
+  }
 }
 
 extension Parser.DeclAttributes {


### PR DESCRIPTION
This was introduced while migrating their introducers from eat to expect in #748 