### PR TITLE
Add debug descriptions for `Lexeme` and `LexemeSequence`

### DIFF
--- a/Sources/SwiftParser/Lexer.swift
+++ b/Sources/SwiftParser/Lexer.swift
@@ -22,7 +22,7 @@ public struct Lexer {
   /// A lexeme is the fundamental output unit of lexical analysis. Each lexeme
   /// represents a fully identified, meaningful part of the input text that
   /// will can be consumed by a ``Parser``.
-  public struct Lexeme {
+  public struct Lexeme: CustomDebugStringConvertible {
     public struct Flags: OptionSet {
       public var rawValue: UInt8
 
@@ -100,6 +100,10 @@ public struct Lexer {
     public var trailingTriviaText: SyntaxText {
       SyntaxText(baseAddress: start.advanced(by: leadingTriviaByteLength+textByteLength),
                  count: trailingTriviaByteLength)
+    }
+
+    public var debugDescription: String {
+      return String(syntaxText: SyntaxText(baseAddress: start, count: byteLength))
     }
   }
 }

--- a/Sources/SwiftParser/Lexer.swift
+++ b/Sources/SwiftParser/Lexer.swift
@@ -111,7 +111,7 @@ public struct Lexer {
 extension Lexer {
   /// A sequence of ``Lexer/Lexeme`` tokens starting from a ``Lexer/Cursor``
   /// that points into an input buffer.
-  public struct LexemeSequence: IteratorProtocol, Sequence {
+  public struct LexemeSequence: IteratorProtocol, Sequence, CustomDebugStringConvertible {
     fileprivate let start: Lexer.Cursor
     fileprivate var cursor: Lexer.Cursor
     fileprivate var nextToken: Lexer.Lexeme
@@ -157,6 +157,15 @@ extension Lexer {
 
     func peek() -> Lexer.Lexeme {
       return self.nextToken
+    }
+
+    public var debugDescription: String {
+      let remainingText = self.nextToken.debugDescription + String(syntaxText: SyntaxText(baseAddress: self.cursor.input.baseAddress, count: self.cursor.input.count))
+      if remainingText.count > 100 {
+        return remainingText.prefix(100) + "..."
+      } else {
+        return remainingText
+      }
     }
   }
 

--- a/Sources/SwiftParser/SwiftParser.docc/FixingBugs.md
+++ b/Sources/SwiftParser/SwiftParser.docc/FixingBugs.md
@@ -4,7 +4,7 @@ Guide to write test cases in the parser’s test suite and how to debug failures
 
 The general approach to fixing bugs in the parser is to first write an automated test case that reproduces the test case in isolation. This allows you to invoke the parser with minimal dependencies and allows you to set breakpoints inside of it. 
 
-Once you’ve written a test case (see below), set a breakpoint in `Parser.parseSourceFile` and navigate the debugger to the place where the parser behaves unexpectedly. While the debugger is stopped at an instance function in <doc:SwiftParser/Parser>, `po self.currentToken` can show you the next token that will be parsed.
+Once you’ve written a test case (see below), set a breakpoint in `Parser.parseSourceFile` and navigate the debugger to the place where the parser behaves unexpectedly. While the debugger is stopped at an instance function in <doc:SwiftParser/Parser>, `po self.currentToken` can show you the next token that will be parsed. `po self.lexemes` can show the next tokens that will be parsed.
 
 ## Round-Trip Failure or Parser Crash
 


### PR DESCRIPTION
The debug description of `Lexeme` outputs the current token’s text and the debug description of `LexemeSequence` outputs the source code that’s remaining in the `LexemeSequence`. In practice this means that `po currentToken` output’s the current token’s text and `po lexemes` shows the remaining source code.