### PR TITLE
Remove a Bogus Early-Exit From Closure Specifier Computation

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1921,10 +1921,6 @@ extension Parser {
       } else {
         return nil
       }
-
-      guard self.at(.identifier) || self.at(.selfKeyword) else {
-        return nil
-      }
     }
     // Squash all tokens, if any, as the specifier of the captured item.
     return RawTokenListSyntax(elements: specifiers, arena: self.arena)

--- a/Tests/SwiftParserTest/Types.swift
+++ b/Tests/SwiftParserTest/Types.swift
@@ -58,6 +58,13 @@ final class TypeTests: XCTestCase {
                 diagnostics: [
                   DiagnosticSpec(message: "Unexpected text '`' in closure capture signature")
                 ])
+
+    AssertParse("{[weak#^DIAG^#^]in}",
+                { $0.parseClosureExpression() },
+                diagnostics: [
+                  DiagnosticSpec(message: "Expected '' in closure capture item"),
+                  DiagnosticSpec(message: "Unexpected text '^' in closure capture signature"),
+                ])
   }
 
   func testOpaqueReturnTypes() throws {


### PR DESCRIPTION
This doesn't need to early-exit by checking for tokens like this.

Fixes #768

