### PR TITLE
Fixup Regression in Return Statement Parsing

### DIFF
--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -829,7 +829,7 @@ extension Parser {
     // followed by a '}', '', statement or decl start keyword sequence.
     let expr: RawExprSyntax?
     if
-      self.at(any: [
+      !self.at(any: [
         RawTokenKind.rightBrace, .semicolon, .eof,
         .poundIfKeyword, .poundErrorKeyword, .poundWarningKeyword,
         .poundEndifKeyword, .poundElseKeyword, .poundElseifKeyword

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -75,6 +75,12 @@ final class StatementTests: XCTestCase {
   }
 
   func testReturn() {
+    AssertParse("{ #^ASYNC^#return 0 }",
+                { $0.parseClosureExpression() },
+                substructure: Syntax(ReturnStmtSyntax(returnKeyword: .returnKeyword(),
+                                                      expression: ExprSyntax(IntegerLiteralExprSyntax(digits: .integerLiteral("0"))))),
+                substructureAfterMarker: "ASYNC")
+
     AssertParse("return")
 
     AssertParse(


### PR DESCRIPTION
When we introduced the at(any:) primitive, this condition got inverted so we were parsing

```
{
  return x
}
```

as

```
{
  return
  x
}
```