### PR TITLE
A Smattering of Trivia Parser Fixes

### DIFF
--- a/Sources/SwiftParser/TriviaParser.swift
+++ b/Sources/SwiftParser/TriviaParser.swift
@@ -109,7 +109,7 @@ public struct TriviaParser {
       // piece start.
       cursor.advance(while: { char in
         switch char {
-        case "\n", "\r", "\t", "\u{000B}", "\u{000C}", "/", "#", "<", ">":
+        case " ", "\n", "\r", "\t", "\u{000B}", "\u{000C}", "/", "#", "<", ">":
           return false
         default:
           return true

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -509,21 +509,39 @@ public class LexerTests: XCTestCase {
     ])
   }
 
-  func testBrokenType() {
-    var data =
-    """
-    () -> (\u{feff})
-    """
-    data.withUTF8 { buf in
-      let lexemes = Lexer.lex(buf)
-      AssertEqualTokens(lexemes, [
-        lexeme(.leftParen, "("),
-        lexeme(.rightParen, ") ", trailing: 1),
-        lexeme(.arrow, "-> ", trailing: 1),
-        lexeme(.leftParen, "(\u{feff}", trailing: 3),
-        lexeme(.rightParen, ")"),
-        lexeme(.eof, ""),
-      ])
+  func testUnicodeReplcementsInStream() {
+    do {
+      var data =
+      """
+      () -> (\u{feff})
+      """
+      data.withUTF8 { buf in
+        let lexemes = Lexer.lex(buf)
+        AssertEqualTokens(lexemes, [
+          lexeme(.leftParen, "("),
+          lexeme(.rightParen, ") ", trailing: 1),
+          lexeme(.arrow, "-> ", trailing: 1),
+          lexeme(.leftParen, "(\u{feff}", trailing: 3),
+          lexeme(.rightParen, ")"),
+          lexeme(.eof, ""),
+        ])
+      }
+    }
+
+    do {
+      var data =
+      """
+      y\u{fffe} + z
+      """
+      data.withUTF8 { buf in
+        let lexemes = Lexer.lex(buf)
+        AssertEqualTokens(lexemes, [
+          lexeme(.identifier, "y\u{fffe} ", trailing: 4),
+          lexeme(.spacedBinaryOperator, "+ ", trailing: 1),
+          lexeme(.identifier, "z"),
+          lexeme(.eof, ""),
+        ])
+      }
     }
   }
 }

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -508,6 +508,24 @@ public class LexerTests: XCTestCase {
       lexeme(.eof, ""),
     ])
   }
+
+  func testBrokenType() {
+    var data =
+    """
+    () -> (\u{feff})
+    """
+    data.withUTF8 { buf in
+      let lexemes = Lexer.lex(buf)
+      AssertEqualTokens(lexemes, [
+        lexeme(.leftParen, "("),
+        lexeme(.rightParen, ") ", trailing: 1),
+        lexeme(.arrow, "-> ", trailing: 1),
+        lexeme(.leftParen, "(\u{feff}", trailing: 3),
+        lexeme(.rightParen, ")"),
+        lexeme(.eof, ""),
+      ])
+    }
+  }
 }
 
 extension Lexer {

--- a/Tests/SwiftParserTest/TriviaParserTests.swift
+++ b/Tests/SwiftParserTest/TriviaParserTests.swift
@@ -39,7 +39,9 @@ final class TriviaParserTests: XCTestCase {
         #!/bin/env swift
         """, position: .trailing),
       [
-        .unexpectedText("#!/bin/env swift"),
+        .unexpectedText("#!/bin/env"),
+        .spaces(1),
+        .unexpectedText("swift"),
       ])
 
     XCTAssertEqual(
@@ -151,16 +153,24 @@ final class TriviaParserTests: XCTestCase {
 
   }
 
-
   func testSyntaxLazyTrivia() throws {
     let source = """
       /* comment only */
 
       """
-    let sourceFileSyntax = try! Parser.parse(source: source)
+    let sourceFileSyntax = try Parser.parse(source: source)
     XCTAssertEqual(sourceFileSyntax.leadingTrivia, [
       .blockComment("/* comment only */"),
       .newlines(1)
     ])
+  }
+
+  func testUnexpectedSplitting() throws {
+    XCTAssertEqual(
+      TriviaParser.parseTrivia("\u{fffe} ", position: .trailing),
+      [
+        .unexpectedText("\u{fffe}"),
+        .spaces(1),
+      ])
   }
 }

--- a/Tests/SwiftParserTest/Types.swift
+++ b/Tests/SwiftParserTest/Types.swift
@@ -13,6 +13,8 @@ final class TypeTests: XCTestCase {
       "@MainActor (a, b) async throws -> c",
       { $0.parseType() }
     )
+
+    AssertParse("() -> (\u{feff})")
   }
 
   func testGenericTypeWithTrivia() throws {


### PR DESCRIPTION
- Split at spaces in the trivia parser
- Add a few more tests from swift-format