### PR TITLE
Enable the creation of syntax nodes from a string interpolation

### DIFF
--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -24,6 +24,7 @@ add_library(SwiftParser STATIC
   RawTokenKindSubset.swift
   Recovery.swift
   Statements.swift
+  Syntax+StringInterpolation.swift
   TokenConsumer.swift
   TokenPrecedence.swift
   TopLevel.swift

--- a/Sources/SwiftParser/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftParser/Syntax+StringInterpolation.swift
@@ -1,0 +1,124 @@
+@_spi(RawSyntax)
+import SwiftSyntax
+
+/// An individual interpolated syntax node.
+struct InterpolatedSyntaxNode {
+  let node: Syntax
+  let startIndex: Int
+  let endIndex: Int
+}
+
+/// The string interpolation type used for creating syntax nodes.
+public struct SyntaxStringInterpolation {
+  /// The source text in UTF-8.
+  ///
+  /// We use an array of UTF-8 for the representation of the source text
+  /// because that's what the parser uses, and we need the stable indices
+  /// that arrays provide when appending new nodes to this array.
+  var sourceText: [UInt8] = []
+
+  /// Tracks of all of the syntax nodes that were interpolated into the
+  /// syntax.
+  ///
+  /// For each node, we record the syntax node, its start position within the
+  /// source text, and its UTF-8 length.
+  var interpolatedSyntaxNodes: [InterpolatedSyntaxNode] = []
+}
+
+extension SyntaxStringInterpolation: StringInterpolationProtocol {
+  public init(literalCapacity: Int, interpolationCount: Int) {
+    interpolatedSyntaxNodes.reserveCapacity(interpolationCount)
+  }
+
+  /// Append source text to the interpolation.
+  public mutating func appendLiteral(_ text: String) {
+    sourceText.append(contentsOf: text.utf8)
+  }
+
+  /// Append a syntax node to the interpolation.
+  public mutating func appendInterpolation<Node: SyntaxProtocol>(
+    _ node: Node
+  ) {
+    let startIndex = sourceText.count
+    sourceText.append(contentsOf: node.syntaxTextBytes)
+    interpolatedSyntaxNodes.append(
+      .init(
+        node: Syntax(node), startIndex: startIndex, endIndex: sourceText.count
+      )
+    )
+  }
+
+  // Append a value of any CustomStringConvertible type as source text.
+  public mutating func appendInterpolation<T: CustomStringConvertible>(
+    _ value: T
+  ) {
+    sourceText.append(contentsOf: value.description.utf8)
+  }
+}
+
+/// Syntax nodes that can be formed by a string interpolation involve source
+/// code and interpolated syntax nodes.
+protocol SyntaxExpressibleByStringInterpolation:
+    ExpressibleByStringInterpolation, SyntaxProtocol
+    where Self.StringInterpolation == SyntaxStringInterpolation {
+  /// Create an instance of this syntax node by parsing it from the given
+  /// parser.
+  static func parse(from parser: inout Parser) -> Self
+}
+
+extension SyntaxExpressibleByStringInterpolation {
+  /// Initialize a syntax node by parsing the contents of the interpolation.
+  public init(stringInterpolation: SyntaxStringInterpolation) {
+    self = stringInterpolation.sourceText.withUnsafeBufferPointer { buffer in
+      var parser = Parser(buffer)
+      // FIXME: When the parser supports incremental parsing, put the
+      // interpolatedSyntaxNodes in so we don't have to parse them again.
+      return Self.parse(from: &parser)
+    }
+  }
+
+  /// Initialize a syntax node from a string literal.
+  public init(stringLiteral value: String) {
+    var interpolation = SyntaxStringInterpolation()
+    interpolation.appendLiteral(value)
+    self.init(stringInterpolation: interpolation)
+  }
+}
+
+// Parsing support for the main kinds of syntax nodes.
+extension DeclSyntaxProtocol {
+  static func parse(from parser: inout Parser) -> Self {
+    return Syntax(raw: parser.parseDeclaration().raw).as(Self.self)!
+  }
+}
+
+extension ExprSyntaxProtocol {
+  static func parse(from parser: inout Parser) -> Self {
+    return Syntax(raw: parser.parseExpression().raw).as(Self.self)!
+  }
+}
+
+extension StmtSyntaxProtocol {
+  static func parse(from parser: inout Parser) -> Self {
+    return Syntax(raw: parser.parseStatement().raw).as(Self.self)!
+  }
+}
+
+extension TypeSyntaxProtocol {
+  static func parse(from parser: inout Parser) -> Self {
+    return Syntax(raw: parser.parseType().raw).as(Self.self)!
+  }
+}
+
+extension PatternSyntaxProtocol {
+  static func parse(from parser: inout Parser) -> Self {
+    return Syntax(raw: parser.parsePattern().raw).as(Self.self)!
+  }
+}
+
+// String interpolation support for the primary node kinds.
+extension DeclSyntax: SyntaxExpressibleByStringInterpolation { }
+extension ExprSyntax: SyntaxExpressibleByStringInterpolation { }
+extension StmtSyntax: SyntaxExpressibleByStringInterpolation { }
+extension TypeSyntax: SyntaxExpressibleByStringInterpolation { }
+extension PatternSyntax: SyntaxExpressibleByStringInterpolation { }

--- a/Tests/SwiftParserTest/StringInterpolation.swift
+++ b/Tests/SwiftParserTest/StringInterpolation.swift
@@ -1,0 +1,67 @@
+import SwiftSyntax
+import SwiftParser
+
+import XCTest
+
+final class StringInterpolationTests: XCTestCase {
+  func testDeclInterpolation() throws {
+    let funcSyntax: DeclSyntax =
+      """
+      func f(a: Int, b: Int) -> Int {
+        a + b
+      }
+      """
+    XCTAssertTrue(funcSyntax.is(FunctionDeclSyntax.self))
+    XCTAssertEqual(funcSyntax.description,
+      """
+      func f(a: Int, b: Int) -> Int {
+        a + b
+      }
+      """)
+  }
+
+  func testExprInterpolation() throws {
+    let exprSyntax: ExprSyntax =
+      """
+      f(x + g(y), y.z)
+      """
+    XCTAssertTrue(exprSyntax.is(FunctionCallExprSyntax.self))
+
+    let addIt: ExprSyntax = "w + \(exprSyntax)"
+    XCTAssertTrue(addIt.is(SequenceExprSyntax.self))
+  }
+
+  func testStmtSyntax() throws {
+    let collection: ExprSyntax = "[1, 2, 3, 4, 5]"
+    let stmtSyntax: StmtSyntax = "for x in \(collection) { }"
+    XCTAssertTrue(stmtSyntax.is(ForInStmtSyntax.self))
+  }
+
+  func testTypeInterpolation() throws {
+    let tupleSyntax: TypeSyntax = "(Int, name: String)"
+    XCTAssertTrue(tupleSyntax.is(TupleTypeSyntax.self))
+    XCTAssertEqual(tupleSyntax.description, "(Int, name: String)")
+    let fnTypeSyntax: TypeSyntax = "(String) async throws -> \(tupleSyntax)"
+    XCTAssertTrue(fnTypeSyntax.is(FunctionTypeSyntax.self))
+    XCTAssertEqual(fnTypeSyntax.description,
+                   "(String) async throws -> (Int, name: String)")
+  }
+
+  func testPatternInterpolation() throws {
+    let letPattern: PatternSyntax = "let x: Int"
+    XCTAssertTrue(letPattern.is(ValueBindingPatternSyntax.self))
+  }
+
+  func testStructGenerator() throws {
+    let name = "Type"
+    let id = 17
+
+    let structNode: DeclSyntax =
+       """
+       struct \(name) {
+         static var id = \(id)
+       }
+       """
+    XCTAssertTrue(structNode.is(StructDeclSyntax.self))
+  }
+}


### PR DESCRIPTION
Make the main categories of syntax nodes (`DeclSyntax`, `ExprSyntax`, `StmtSyntax`, `TypeSyntax`, and `PatternSyntax`) conform to `ExpressiblyByStringInterpolation`. The string literal portions are source text, and one can interpolate both additional source text and syntax nodes into that source text. The result will be parsed by the parser to produce a node of the given kind. For example, we can produce a `TypeSyntax` like this:

    let tupleSyntax: TypeSyntax = "(Int, name: String)"

And then use that in another production, for example to create a function declaration:

    let fnSyntax: DeclSyntax =
       "func \(name)(String) async throws -> \(tupleSyntax)"

This approach is intended to simplify code generation, by allowing code to generate Swift syntax trees in the most natural way possible---by writing the Swift code that generates them.