### PR TITLE
Correct Typo in the Lexer

### DIFF
--- a/Sources/SwiftParser/Lexer.swift
+++ b/Sources/SwiftParser/Lexer.swift
@@ -237,7 +237,7 @@ extension Lexer.Cursor {
     }
 
     switch self.peek() {
-    case UInt8(ascii: " "), UInt8(ascii: #"""#), UInt8(ascii: "\n"), UInt8(ascii: "\t"), // whitespace
+    case UInt8(ascii: " "), UInt8(ascii: "\r"), UInt8(ascii: "\n"), UInt8(ascii: "\t"), // whitespace
       UInt8(ascii: ")"), UInt8(ascii: "]"), UInt8(ascii: "}"),              // closing delimiters
       UInt8(ascii: ","), UInt8(ascii: ";"), UInt8(ascii: ":"):              // expression separators
       return false
@@ -1617,7 +1617,7 @@ extension Lexer.Cursor {
 //      }
     } while self.advance(if: { $0.isOperatorContinuationCodePoint })
 
-    if (self.input.baseAddress!-TokStart.input.baseAddress! > 2) {
+    if self.input.baseAddress!-TokStart.input.baseAddress! > 2 {
       // If there is a "//" or "/*" in the middle of an identifier token,
       // it starts a comment.
       var Ptr = TokStart
@@ -1638,8 +1638,8 @@ extension Lexer.Cursor {
     let rightBound = self.isRightBound(leftBound)
 
     // Match various reserved words.
-    if (self.input.baseAddress! - TokStart.input.baseAddress! == 1) {
-      switch (TokStart.peek()) {
+    if self.input.baseAddress! - TokStart.input.baseAddress! == 1 {
+      switch TokStart.peek() {
       case UInt8(ascii: "="):
         // Refrain from emitting this message in operator name position.
 //        if (NextToken.isNot(tok::kw_operator) && leftBound != rightBound) {
@@ -1652,7 +1652,7 @@ extension Lexer.Cursor {
         // always emit 'tok::equal' to avoid trickle down parse errors
         return .equal
       case UInt8(ascii: "&"):
-        if (leftBound == rightBound || leftBound) {
+        if leftBound == rightBound || leftBound {
           break
         }
         return .prefixAmpersand
@@ -1661,7 +1661,7 @@ extension Lexer.Cursor {
           return .period
         }
 
-        if (rightBound) {
+        if rightBound {
           return .prefixPeriod
         }
 

--- a/Tests/SwiftParserTest/LexerTests.swift
+++ b/Tests/SwiftParserTest/LexerTests.swift
@@ -544,6 +544,22 @@ public class LexerTests: XCTestCase {
       }
     }
   }
+
+  func testOperators() {
+    var data =
+    """
+    myString==""
+    """
+    data.withUTF8 { buf in
+      let lexemes = Lexer.lex(buf)
+      AssertEqualTokens(lexemes, [
+        lexeme(.identifier, "myString"),
+        lexeme(.unspacedBinaryOperator, "=="),
+        lexeme(.stringLiteral, #""""#),
+        lexeme(.eof, ""),
+      ])
+    }
+  }
 }
 
 extension Lexer {


### PR DESCRIPTION
This should have been a CR, but was instead checking for ". This appears to be a typo.

Fixes #780

rdar://99804977