### PR TITLE
Another Grab Bag of Parser Fixes

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -37,6 +37,8 @@ extension Parser {
     switch declAttr {
     case .available:
       return RawSyntax(self.parseAvailabilityAttribute())
+    case ._spi_available:
+      return RawSyntax(self.parseSPIAvailableAttribute())
     case .differentiable:
       return RawSyntax(self.parseDifferentiableAttribute())
     case .derivative:
@@ -125,6 +127,37 @@ extension Parser {
   mutating func parseAvailabilityAttribute() -> RawAttributeSyntax {
     let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
     let (unexpectedBeforeAvailable, available) = self.expectContextualKeyword("available")
+    let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
+
+    let argument: RawSyntax
+    do {
+      if self.peek().tokenKind == .integerLiteral {
+        argument = RawSyntax(self.parseAvailabilitySpecList(from: .available))
+      } else if self.peek().tokenKind  == .floatingLiteral {
+        argument = RawSyntax(self.parseAvailabilitySpecList(from: .available))
+      } else {
+        argument = RawSyntax(self.parseExtendedAvailabilitySpecList())
+      }
+    }
+    let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
+
+    return RawAttributeSyntax(
+      unexpectedBeforeAtSign,
+      atSignToken: atSign,
+      unexpectedBeforeAvailable,
+      attributeName: available,
+      unexpectedBeforeLeftParen,
+      leftParen: leftParen,
+      argument: argument,
+      unexpectedBeforeRightParen,
+      rightParen: rightParen,
+      tokenList: nil,
+      arena: self.arena)
+  }
+
+  mutating func parseSPIAvailableAttribute() -> RawAttributeSyntax {
+    let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
+    let (unexpectedBeforeAvailable, available) = self.expectContextualKeyword("_spi_available")
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
 
     let argument: RawSyntax

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -508,13 +508,13 @@ extension Parser {
         let ident = self.eat(handle)
         let (unexpectedBeforeColon, colon) = self.expect(.colon)
         let availability = self.parseAvailabilitySpecList(from: .available)
-        // FIXME: This is modeled incorrectly in libSyntax.
-        let semi = RawTokenSyntax(missing: .semicolon, arena: self.arena)
+        let (unexpectedBeforeSemi, semi) = self.expect(.semicolon)
         elements.append(RawSyntax(RawAvailabilityEntrySyntax(
           label: ident,
           unexpectedBeforeColon,
           colon: colon,
           availabilityList: availability,
+          unexpectedBeforeSemi,
           semicolon: semi,
           arena: self.arena
         )))

--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -794,6 +794,54 @@ extension Parser {
   }
 }
 
+extension Parser {
+  mutating func parseConventionArguments() -> RawSyntax {
+    if let witnessMethod = self.consumeIfContextualKeyword("witness_method") {
+      let (unexpectedBeforeColon, colon) = self.expect(.colon)
+      let name = self.parseAnyIdentifier()
+      return RawSyntax(RawConventionWitnessMethodAttributeArgumentsSyntax(
+        witnessMethodLabel: witnessMethod,
+        unexpectedBeforeColon,
+        colon: colon,
+        protocolName: name,
+        arena: self.arena))
+    } else {
+      let label = self.consumeAnyToken()
+      let unexpectedBeforeComma: RawUnexpectedNodesSyntax?
+      let comma: RawTokenSyntax?
+      let cTypeLabel: RawTokenSyntax?
+      let unexpectedBeforeColon: RawUnexpectedNodesSyntax?
+      let colon: RawTokenSyntax?
+      let unexpectedBeforeCTypeString: RawUnexpectedNodesSyntax?
+      let cTypeString: RawTokenSyntax?
+      if self.at(.comma) {
+        (unexpectedBeforeComma, comma) = self.expect(.comma)
+        cTypeLabel = self.consumeAnyToken()
+        (unexpectedBeforeColon, colon) = self.expect(.colon)
+        (unexpectedBeforeCTypeString, cTypeString) = self.expect(.stringLiteral)
+      } else {
+        unexpectedBeforeComma = nil
+        comma = nil
+        cTypeLabel = nil
+        unexpectedBeforeColon = nil
+        colon = nil
+        unexpectedBeforeCTypeString = nil
+        cTypeString = nil
+      }
+      return RawSyntax(RawConventionAttributeArgumentsSyntax(
+        conventionLabel: label,
+        unexpectedBeforeComma,
+        comma: comma,
+        cTypeLabel: cTypeLabel,
+        unexpectedBeforeColon,
+        colon: colon,
+        unexpectedBeforeCTypeString,
+        cTypeString: cTypeString,
+        arena: self.arena))
+    }
+  }
+}
+
 // MARK: Lookahead
 
 extension Parser.Lookahead {

--- a/Sources/SwiftParser/Availability.swift
+++ b/Sources/SwiftParser/Availability.swift
@@ -139,7 +139,11 @@ extension Parser {
         case nil:
           // Not sure what this label is but, let's just eat it and
           // keep going.
-          entry = RawSyntax(self.consumeAnyToken())
+          var tokens = [RawTokenSyntax]()
+          while !self.at(any: [.eof, .comma, .rightParen]) {
+            tokens.append(self.consumeAnyToken())
+          }
+          entry = RawSyntax(RawNonEmptyTokenListSyntax(elements: tokens, arena: self.arena))
         }
 
         keepGoing = self.consume(if: .comma)

--- a/Sources/SwiftParser/DeclarationAttribute.swift.gyb
+++ b/Sources/SwiftParser/DeclarationAttribute.swift.gyb
@@ -25,5 +25,6 @@ extension Parser {
 % for attr in DECL_ATTR_KINDS:
     case ${attr.swift_name} = "${attr.name}"
 % end
+    case _spi_available = "_spi_available"
   }
 }

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -47,6 +47,11 @@ extension TokenConsumer {
       }
     }
 
+    if subparser.at(.poundIfKeyword) {
+      var attrLookahead = subparser.lookahead()
+      return attrLookahead.consumeIfConfigOfAttributes()
+    }
+
     let declStartKeyword: DeclarationStart?
     if allowRecovery {
       declStartKeyword = subparser.canRecoverTo(

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1888,27 +1888,21 @@ extension Parser {
     let precedenceAndTypes: RawOperatorPrecedenceAndTypesSyntax?
     if let colon = self.consume(if: .colon) {
       let (unexpectedBeforeIdentifier, identifier) = self.expectIdentifier()
-      let unexpectedBeforeComma: RawUnexpectedNodesSyntax?
-      let comma: RawTokenSyntax?
-      let unexpectedBeforeDesignatedType: RawUnexpectedNodesSyntax?
-      let designatedType: RawTokenSyntax?
-      if self.at(.comma) {
-        (unexpectedBeforeComma, comma) = self.expect(.comma)
-        (unexpectedBeforeDesignatedType, designatedType) = self.expectIdentifier()
-      } else {
-        unexpectedBeforeComma = nil
-        comma = nil
-        unexpectedBeforeDesignatedType = nil
-        designatedType = nil
+      var types = [RawDesignatedTypeElementSyntax]()
+      while let comma = self.consume(if: .comma) {
+        let (unexpectedBeforeDesignatedType, designatedType) = self.expectIdentifier()
+        types.append(RawDesignatedTypeElementSyntax(
+          leadingComma: comma,
+          unexpectedBeforeDesignatedType,
+          name: designatedType,
+          arena: self.arena))
       }
       precedenceAndTypes = RawOperatorPrecedenceAndTypesSyntax(
         colon: colon,
         unexpectedBeforeIdentifier,
         precedenceGroup: identifier,
-        unexpectedBeforeComma,
-        comma: comma,
-        unexpectedBeforeDesignatedType,
-        designatedType: designatedType,
+        designatedTypes: RawDesignatedTypeListSyntax(
+          elements: types, arena: self.arena),
         arena: self.arena)
     } else {
       precedenceAndTypes = nil

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -507,7 +507,13 @@ extension Parser {
     do {
       var loopProgress = LoopProgressCondition()
       while !self.at(any: [.eof, .rightBrace]) && loopProgress.evaluate(currentToken) {
-        let decl = self.parseDeclaration()
+        let decl: RawDeclSyntax
+        if self.at(.poundSourceLocationKeyword) {
+          decl = RawDeclSyntax(self.parsePoundSourceLocationDirective())
+        } else {
+          decl = self.parseDeclaration()
+        }
+
         let semi = self.consume(if: .semicolon)
         elements.append(RawMemberDeclListItemSyntax(
           decl: decl, semicolon: semi, arena: self.arena))

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1882,10 +1882,28 @@ extension Parser {
     // checking.
     let precedenceAndTypes: RawOperatorPrecedenceAndTypesSyntax?
     if let colon = self.consume(if: .colon) {
-      let identifier = self.expectIdentifierWithoutRecovery()
+      let (unexpectedBeforeIdentifier, identifier) = self.expectIdentifier()
+      let unexpectedBeforeComma: RawUnexpectedNodesSyntax?
+      let comma: RawTokenSyntax?
+      let unexpectedBeforeDesignatedType: RawUnexpectedNodesSyntax?
+      let designatedType: RawTokenSyntax?
+      if self.at(.comma) {
+        (unexpectedBeforeComma, comma) = self.expect(.comma)
+        (unexpectedBeforeDesignatedType, designatedType) = self.expectIdentifier()
+      } else {
+        unexpectedBeforeComma = nil
+        comma = nil
+        unexpectedBeforeDesignatedType = nil
+        designatedType = nil
+      }
       precedenceAndTypes = RawOperatorPrecedenceAndTypesSyntax(
         colon: colon,
-        precedenceGroupAndDesignatedTypes: RawIdentifierListSyntax(elements: [ identifier ], arena: self.arena),
+        unexpectedBeforeIdentifier,
+        precedenceGroup: identifier,
+        unexpectedBeforeComma,
+        comma: comma,
+        unexpectedBeforeDesignatedType,
+        designatedType: designatedType,
         arena: self.arena)
     } else {
       precedenceAndTypes = nil

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -197,6 +197,44 @@ extension Parser.Lookahead {
     }
     return true
   }
+
+  mutating func consumeIfConfigOfAttributes() -> Bool {
+    while true {
+      // #if / #else / #elseif
+      self.consumeAnyToken()
+
+      // <expression>
+      self.skipUntilEndOfLine()
+
+      while true {
+        if self.at(.atSign) {
+          _ = self.consumeAttributeList()
+          continue
+        }
+
+        if self.at(.poundIfKeyword) {
+          _ = self.consumeIfConfigOfAttributes()
+          continue
+        }
+
+        break
+      }
+
+      guard self.at(any: [ .poundElseifKeyword, .poundElseKeyword ]) else {
+        break
+      }
+    }
+
+    // If we ran out of tokens, say we consumed the rest.
+    if self.at(.eof) {
+      return true
+    }
+
+    guard self.currentToken.isAtStartOfLine else {
+      return false
+    }
+    return self.consume(if: .poundEndifKeyword) != nil
+  }
 }
 
 // MARK: Lookahead

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -803,7 +803,7 @@ extension Parser {
       let (unexpectedBeforeAt, at) = self.expect(.atSign)
       let (unexpectedBeforeIdent, ident) = self.expectIdentifier()
       let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
-      let (unexpectedBeforeArgument, argument) = self.expectIdentifier()
+      let arguments = self.parseConventionArguments()
       let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
       return RawSyntax(
         RawAttributeSyntax(
@@ -813,8 +813,7 @@ extension Parser {
           attributeName: ident,
           unexpectedBeforeLeftParen,
           leftParen: leftParen,
-          unexpectedBeforeArgument,
-          argument: RawSyntax(argument),
+          argument: arguments,
           unexpectedBeforeRightParen,
           rightParen: rightParen,
           tokenList: nil,

--- a/Sources/SwiftParser/gyb_generated/DeclarationAttribute.swift
+++ b/Sources/SwiftParser/gyb_generated/DeclarationAttribute.swift
@@ -119,5 +119,6 @@ extension Parser {
     case _spiOnly = "_spiOnly"
     case _documentation = "_documentation"
     case typeWrapperIgnored = "typeWrapperIgnored"
+    case _spi_available = "_spi_available"
   }
 }

--- a/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
@@ -234,6 +234,8 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/PatternBindingSyntax>
 - <doc:SwiftSyntax/EnumCaseElementListSyntax>
 - <doc:SwiftSyntax/EnumCaseElementSyntax>
+- <doc:SwiftSyntax/DesignatedTypeListSyntax>
+- <doc:SwiftSyntax/DesignatedTypeElementSyntax>
 - <doc:SwiftSyntax/PrecedenceGroupNameListSyntax>
 - <doc:SwiftSyntax/PrecedenceGroupNameElementSyntax>
 - <doc:SwiftSyntax/ObjCSelectorSyntax>
@@ -328,7 +330,8 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/PatternBindingListSyntax>
 - <doc:SwiftSyntax/EnumCaseElementSyntax>
 - <doc:SwiftSyntax/EnumCaseElementListSyntax>
-- <doc:SwiftSyntax/IdentifierListSyntax>
+- <doc:SwiftSyntax/DesignatedTypeListSyntax>
+- <doc:SwiftSyntax/DesignatedTypeElementSyntax>
 - <doc:SwiftSyntax/OperatorPrecedenceAndTypesSyntax>
 - <doc:SwiftSyntax/PrecedenceGroupAttributeListSyntax>
 - <doc:SwiftSyntax/PrecedenceGroupRelationSyntax>

--- a/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
@@ -362,6 +362,8 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/BackDeployVersionListSyntax>
 - <doc:SwiftSyntax/BackDeployVersionArgumentSyntax>
 - <doc:SwiftSyntax/OpaqueReturnTypeOfAttributeArgumentsSyntax>
+- <doc:SwiftSyntax/ConventionAttributeArgumentsSyntax>
+- <doc:SwiftSyntax/ConventionWitnessMethodAttributeArgumentsSyntax>
 - <doc:SwiftSyntax/SwitchCaseListSyntax>
 - <doc:SwiftSyntax/WhereClauseSyntax>
 - <doc:SwiftSyntax/CatchClauseListSyntax>

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -8637,17 +8637,25 @@ public struct RawOperatorPrecedenceAndTypesSyntax: RawSyntaxNodeProtocol {
   public init(
     _ unexpectedBeforeColon: RawUnexpectedNodesSyntax? = nil,
     colon: RawTokenSyntax,
-    _ unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes: RawUnexpectedNodesSyntax? = nil,
-    precedenceGroupAndDesignatedTypes: RawIdentifierListSyntax,
+    _ unexpectedBetweenColonAndPrecedenceGroup: RawUnexpectedNodesSyntax? = nil,
+    precedenceGroup: RawTokenSyntax,
+    _ unexpectedBetweenPrecedenceGroupAndComma: RawUnexpectedNodesSyntax? = nil,
+    comma: RawTokenSyntax?,
+    _ unexpectedBetweenCommaAndDesignatedType: RawUnexpectedNodesSyntax? = nil,
+    designatedType: RawTokenSyntax?,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .operatorPrecedenceAndTypes, uninitializedCount: 4, arena: arena) { layout in
+      kind: .operatorPrecedenceAndTypes, uninitializedCount: 8, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeColon?.raw
       layout[1] = colon.raw
-      layout[2] = unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes?.raw
-      layout[3] = precedenceGroupAndDesignatedTypes.raw
+      layout[2] = unexpectedBetweenColonAndPrecedenceGroup?.raw
+      layout[3] = precedenceGroup.raw
+      layout[4] = unexpectedBetweenPrecedenceGroupAndComma?.raw
+      layout[5] = comma?.raw
+      layout[6] = unexpectedBetweenCommaAndDesignatedType?.raw
+      layout[7] = designatedType?.raw
     }
     self.init(raw: raw)
   }
@@ -8658,11 +8666,23 @@ public struct RawOperatorPrecedenceAndTypesSyntax: RawSyntaxNodeProtocol {
   public var colon: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
   }
-  public var unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenColonAndPrecedenceGroup: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
-  public var precedenceGroupAndDesignatedTypes: RawIdentifierListSyntax {
-    layoutView.children[3].map(RawIdentifierListSyntax.init(raw:))!
+  public var precedenceGroup: RawTokenSyntax {
+    layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedBetweenPrecedenceGroupAndComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var comma: RawTokenSyntax? {
+    layoutView.children[5].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedBetweenCommaAndDesignatedType: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var designatedType: RawTokenSyntax? {
+    layoutView.children[7].map(RawTokenSyntax.init(raw:))
   }
 }
 

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -10661,6 +10661,152 @@ public struct RawOpaqueReturnTypeOfAttributeArgumentsSyntax: RawSyntaxNodeProtoc
 }
 
 @_spi(RawSyntax)
+public struct RawConventionAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
+  var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .conventionAttributeArguments
+  }
+
+  public var raw: RawSyntax
+  init(raw: RawSyntax) {
+    assert(Self.isKindOf(raw))
+    self.raw = raw
+  }
+
+  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+    guard Self.isKindOf(other.raw) else { return nil }
+    self.init(raw: other.raw)
+  }
+
+  public init(
+    _ unexpectedBeforeConventionLabel: RawUnexpectedNodesSyntax? = nil,
+    conventionLabel: RawTokenSyntax,
+    _ unexpectedBetweenConventionLabelAndComma: RawUnexpectedNodesSyntax? = nil,
+    comma: RawTokenSyntax?,
+    _ unexpectedBetweenCommaAndCTypeLabel: RawUnexpectedNodesSyntax? = nil,
+    cTypeLabel: RawTokenSyntax?,
+    _ unexpectedBetweenCTypeLabelAndColon: RawUnexpectedNodesSyntax? = nil,
+    colon: RawTokenSyntax?,
+    _ unexpectedBetweenColonAndCTypeString: RawUnexpectedNodesSyntax? = nil,
+    cTypeString: RawTokenSyntax?,
+    arena: __shared SyntaxArena
+  ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .conventionAttributeArguments, uninitializedCount: 10, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeConventionLabel?.raw
+      layout[1] = conventionLabel.raw
+      layout[2] = unexpectedBetweenConventionLabelAndComma?.raw
+      layout[3] = comma?.raw
+      layout[4] = unexpectedBetweenCommaAndCTypeLabel?.raw
+      layout[5] = cTypeLabel?.raw
+      layout[6] = unexpectedBetweenCTypeLabelAndColon?.raw
+      layout[7] = colon?.raw
+      layout[8] = unexpectedBetweenColonAndCTypeString?.raw
+      layout[9] = cTypeString?.raw
+    }
+    self.init(raw: raw)
+  }
+
+  public var unexpectedBeforeConventionLabel: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var conventionLabel: RawTokenSyntax {
+    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedBetweenConventionLabelAndComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var comma: RawTokenSyntax? {
+    layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedBetweenCommaAndCTypeLabel: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var cTypeLabel: RawTokenSyntax? {
+    layoutView.children[5].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedBetweenCTypeLabelAndColon: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var colon: RawTokenSyntax? {
+    layoutView.children[7].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedBetweenColonAndCTypeString: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var cTypeString: RawTokenSyntax? {
+    layoutView.children[9].map(RawTokenSyntax.init(raw:))
+  }
+}
+
+@_spi(RawSyntax)
+public struct RawConventionWitnessMethodAttributeArgumentsSyntax: RawSyntaxNodeProtocol {
+  var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .conventionWitnessMethodAttributeArguments
+  }
+
+  public var raw: RawSyntax
+  init(raw: RawSyntax) {
+    assert(Self.isKindOf(raw))
+    self.raw = raw
+  }
+
+  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+    guard Self.isKindOf(other.raw) else { return nil }
+    self.init(raw: other.raw)
+  }
+
+  public init(
+    _ unexpectedBeforeWitnessMethodLabel: RawUnexpectedNodesSyntax? = nil,
+    witnessMethodLabel: RawTokenSyntax,
+    _ unexpectedBetweenWitnessMethodLabelAndColon: RawUnexpectedNodesSyntax? = nil,
+    colon: RawTokenSyntax,
+    _ unexpectedBetweenColonAndProtocolName: RawUnexpectedNodesSyntax? = nil,
+    protocolName: RawTokenSyntax,
+    arena: __shared SyntaxArena
+  ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .conventionWitnessMethodAttributeArguments, uninitializedCount: 6, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeWitnessMethodLabel?.raw
+      layout[1] = witnessMethodLabel.raw
+      layout[2] = unexpectedBetweenWitnessMethodLabelAndColon?.raw
+      layout[3] = colon.raw
+      layout[4] = unexpectedBetweenColonAndProtocolName?.raw
+      layout[5] = protocolName.raw
+    }
+    self.init(raw: raw)
+  }
+
+  public var unexpectedBeforeWitnessMethodLabel: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var witnessMethodLabel: RawTokenSyntax {
+    layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedBetweenWitnessMethodLabelAndColon: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var colon: RawTokenSyntax {
+    layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedBetweenColonAndProtocolName: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var protocolName: RawTokenSyntax {
+    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+}
+
+@_spi(RawSyntax)
 public struct RawLabeledStmtSyntax: RawStmtSyntaxNodeProtocol {
   var layoutView: RawSyntaxLayoutView {
     return raw.layoutView!

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
@@ -1230,21 +1230,26 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[9], as: RawOperatorPrecedenceAndTypesSyntax?.self)
     break
-  case .identifierList:
+  case .designatedTypeList:
     for element in layout {
-      _verify(element, as: RawTokenSyntax.self)
+      _verify(element, as: RawDesignatedTypeElementSyntax.self)
     }
     break
+  case .designatedTypeElement:
+    assert(layout.count == 4)
+    _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[3], as: RawTokenSyntax.self)
+    break
   case .operatorPrecedenceAndTypes:
-    assert(layout.count == 8)
+    assert(layout.count == 6)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
-    _verify(layout[5], as: RawTokenSyntax?.self)
-    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
-    _verify(layout[7], as: RawTokenSyntax?.self)
+    _verify(layout[5], as: RawDesignatedTypeListSyntax.self)
     break
   case .precedenceGroupDecl:
     assert(layout.count == 14)

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
@@ -1531,6 +1531,28 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
     break
+  case .conventionAttributeArguments:
+    assert(layout.count == 10)
+    _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[5], as: RawTokenSyntax?.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[7], as: RawTokenSyntax?.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[9], as: RawTokenSyntax?.self)
+    break
+  case .conventionWitnessMethodAttributeArguments:
+    assert(layout.count == 6)
+    _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[3], as: RawTokenSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[5], as: RawTokenSyntax.self)
+    break
   case .labeledStmt:
     assert(layout.count == 6)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
@@ -1236,11 +1236,15 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .operatorPrecedenceAndTypes:
-    assert(layout.count == 4)
+    assert(layout.count == 8)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
-    _verify(layout[3], as: RawIdentifierListSyntax.self)
+    _verify(layout[3], as: RawTokenSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[5], as: RawTokenSyntax?.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[7], as: RawTokenSyntax?.self)
     break
   case .precedenceGroupDecl:
     assert(layout.count == 14)

--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -383,6 +383,10 @@ extension Syntax {
       return node
     case .opaqueReturnTypeOfAttributeArguments(let node):
       return node
+    case .conventionAttributeArguments(let node):
+      return node
+    case .conventionWitnessMethodAttributeArguments(let node):
+      return node
     case .labeledStmt(let node):
       return node
     case .continueStmt(let node):
@@ -747,6 +751,8 @@ extension SyntaxKind {
     case .backDeployVersionList: return BackDeployVersionListSyntax.self
     case .backDeployVersionArgument: return BackDeployVersionArgumentSyntax.self
     case .opaqueReturnTypeOfAttributeArguments: return OpaqueReturnTypeOfAttributeArgumentsSyntax.self
+    case .conventionAttributeArguments: return ConventionAttributeArgumentsSyntax.self
+    case .conventionWitnessMethodAttributeArguments: return ConventionWitnessMethodAttributeArgumentsSyntax.self
     case .labeledStmt: return LabeledStmtSyntax.self
     case .continueStmt: return ContinueStmtSyntax.self
     case .whileStmt: return WhileStmtSyntax.self

--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -313,7 +313,9 @@ extension Syntax {
       return node
     case .operatorDecl(let node):
       return node
-    case .identifierList(let node):
+    case .designatedTypeList(let node):
+      return node
+    case .designatedTypeElement(let node):
       return node
     case .operatorPrecedenceAndTypes(let node):
       return node
@@ -716,7 +718,8 @@ extension SyntaxKind {
     case .enumCaseDecl: return EnumCaseDeclSyntax.self
     case .enumDecl: return EnumDeclSyntax.self
     case .operatorDecl: return OperatorDeclSyntax.self
-    case .identifierList: return IdentifierListSyntax.self
+    case .designatedTypeList: return DesignatedTypeListSyntax.self
+    case .designatedTypeElement: return DesignatedTypeElementSyntax.self
     case .operatorPrecedenceAndTypes: return OperatorPrecedenceAndTypesSyntax.self
     case .precedenceGroupDecl: return PrecedenceGroupDeclSyntax.self
     case .precedenceGroupAttributeList: return PrecedenceGroupAttributeListSyntax.self

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
@@ -1300,6 +1300,20 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   override open func visitPost(_ node: OpaqueReturnTypeOfAttributeArgumentsSyntax) {
     visitAnyPost(node._syntaxNode)
   }
+  override open func visit(_ node: ConventionAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: ConventionAttributeArgumentsSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: ConventionWitnessMethodAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: ConventionWitnessMethodAttributeArgumentsSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
   override open func visit(_ node: LabeledStmtSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
@@ -1055,11 +1055,18 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   override open func visitPost(_ node: OperatorDeclSyntax) {
     visitAnyPost(node._syntaxNode)
   }
-  override open func visit(_ node: IdentifierListSyntax) -> SyntaxVisitorContinueKind {
+  override open func visit(_ node: DesignatedTypeListSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }
 
-  override open func visitPost(_ node: IdentifierListSyntax) {
+  override open func visitPost(_ node: DesignatedTypeListSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: DesignatedTypeElementSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: DesignatedTypeElementSyntax) {
     visitAnyPost(node._syntaxNode)
   }
   override open func visit(_ node: OperatorPrecedenceAndTypesSyntax) -> SyntaxVisitorContinueKind {

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
@@ -5244,21 +5244,21 @@ extension EnumCaseElementListSyntax: BidirectionalCollection {
   }
 }
 
-/// `IdentifierListSyntax` represents a collection of one or more
-/// `TokenSyntax` nodes. IdentifierListSyntax behaves
+/// `DesignatedTypeListSyntax` represents a collection of one or more
+/// `DesignatedTypeElementSyntax` nodes. DesignatedTypeListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
 /// versions of the collection with different children.
-public struct IdentifierListSyntax: SyntaxCollection, SyntaxHashable {
+public struct DesignatedTypeListSyntax: SyntaxCollection, SyntaxHashable {
   public let _syntaxNode: Syntax
 
   var layoutView: RawSyntaxLayoutView {
     data.raw.layoutView!
   }
 
-  /// Converts the given `Syntax` node to a `IdentifierListSyntax` if possible. Returns 
+  /// Converts the given `Syntax` node to a `DesignatedTypeListSyntax` if possible. Returns 
   /// `nil` if the conversion is not possible.
   public init?(_ syntax: Syntax) {
-    guard syntax.raw.kind == .identifierList else { return nil }
+    guard syntax.raw.kind == .designatedTypeList else { return nil }
     self._syntaxNode = syntax
   }
 
@@ -5266,12 +5266,12 @@ public struct IdentifierListSyntax: SyntaxCollection, SyntaxHashable {
   /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
   /// is undefined.
   internal init(_ data: SyntaxData) {
-    assert(data.raw.kind == .identifierList)
+    assert(data.raw.kind == .designatedTypeList)
     self._syntaxNode = Syntax(data)
   }
 
-  public init(_ children: [TokenSyntax]) {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.identifierList,
+  public init(_ children: [DesignatedTypeElementSyntax]) {
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeList,
       from: children.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
     self.init(data)
@@ -5280,52 +5280,52 @@ public struct IdentifierListSyntax: SyntaxCollection, SyntaxHashable {
   /// The number of elements, `present` or `missing`, in this collection.
   public var count: Int { return raw.layoutView!.children.count }
 
-  /// Creates a new `IdentifierListSyntax` by replacing the underlying layout with
+  /// Creates a new `DesignatedTypeListSyntax` by replacing the underlying layout with
   /// a different set of raw syntax nodes.
   ///
   /// - Parameter layout: The new list of raw syntax nodes underlying this
   ///                     collection.
-  /// - Returns: A new `IdentifierListSyntax` with the new layout underlying it.
+  /// - Returns: A new `DesignatedTypeListSyntax` with the new layout underlying it.
   internal func replacingLayout(
-    _ layout: [RawSyntax?]) -> IdentifierListSyntax {
+    _ layout: [RawSyntax?]) -> DesignatedTypeListSyntax {
     let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
     let newData = data.replacingSelf(newRaw)
-    return IdentifierListSyntax(newData)
+    return DesignatedTypeListSyntax(newData)
   }
 
-  /// Creates a new `IdentifierListSyntax` by appending the provided syntax element
+  /// Creates a new `DesignatedTypeListSyntax` by appending the provided syntax element
   /// to the children.
   ///
   /// - Parameter syntax: The element to append.
-  /// - Returns: A new `IdentifierListSyntax` with that element appended to the end.
+  /// - Returns: A new `DesignatedTypeListSyntax` with that element appended to the end.
   public func appending(
-    _ syntax: TokenSyntax) -> IdentifierListSyntax {
+    _ syntax: DesignatedTypeElementSyntax) -> DesignatedTypeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.append(syntax.raw)
     return replacingLayout(newLayout)
   }
 
-  /// Creates a new `IdentifierListSyntax` by prepending the provided syntax element
+  /// Creates a new `DesignatedTypeListSyntax` by prepending the provided syntax element
   /// to the children.
   ///
   /// - Parameter syntax: The element to prepend.
-  /// - Returns: A new `IdentifierListSyntax` with that element prepended to the
+  /// - Returns: A new `DesignatedTypeListSyntax` with that element prepended to the
   ///            beginning.
   public func prepending(
-    _ syntax: TokenSyntax) -> IdentifierListSyntax {
+    _ syntax: DesignatedTypeElementSyntax) -> DesignatedTypeListSyntax {
     return inserting(syntax, at: 0)
   }
 
-  /// Creates a new `IdentifierListSyntax` by inserting the provided syntax element
+  /// Creates a new `DesignatedTypeListSyntax` by inserting the provided syntax element
   /// at the provided index in the children.
   ///
   /// - Parameters:
   ///   - syntax: The element to insert.
   ///   - index: The index at which to insert the element in the collection.
   ///
-  /// - Returns: A new `IdentifierListSyntax` with that element appended to the end.
-  public func inserting(_ syntax: TokenSyntax,
-                        at index: Int) -> IdentifierListSyntax {
+  /// - Returns: A new `DesignatedTypeListSyntax` with that element appended to the end.
+  public func inserting(_ syntax: DesignatedTypeElementSyntax,
+                        at index: Int) -> DesignatedTypeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid insertion index (0 to 1 past the end)
     precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
@@ -5334,16 +5334,16 @@ public struct IdentifierListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
 
-  /// Creates a new `IdentifierListSyntax` by replacing the syntax element
+  /// Creates a new `DesignatedTypeListSyntax` by replacing the syntax element
   /// at the provided index.
   ///
   /// - Parameters:
   ///   - index: The index at which to replace the element in the collection.
   ///   - syntax: The element to replace with.
   ///
-  /// - Returns: A new `IdentifierListSyntax` with the new element at the provided index.
+  /// - Returns: A new `DesignatedTypeListSyntax` with the new element at the provided index.
   public func replacing(childAt index: Int,
-                        with syntax: TokenSyntax) -> IdentifierListSyntax {
+                        with syntax: DesignatedTypeElementSyntax) -> DesignatedTypeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     /// Make sure the index is a valid index for replacing
     precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
@@ -5352,64 +5352,64 @@ public struct IdentifierListSyntax: SyntaxCollection, SyntaxHashable {
     return replacingLayout(newLayout)
   }
 
-  /// Creates a new `IdentifierListSyntax` by removing the syntax element at the
+  /// Creates a new `DesignatedTypeListSyntax` by removing the syntax element at the
   /// provided index.
   ///
   /// - Parameter index: The index of the element to remove from the collection.
-  /// - Returns: A new `IdentifierListSyntax` with the element at the provided index
+  /// - Returns: A new `DesignatedTypeListSyntax` with the element at the provided index
   ///            removed.
-  public func removing(childAt index: Int) -> IdentifierListSyntax {
+  public func removing(childAt index: Int) -> DesignatedTypeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.remove(at: index)
     return replacingLayout(newLayout)
   }
 
-  /// Creates a new `IdentifierListSyntax` by removing the first element.
+  /// Creates a new `DesignatedTypeListSyntax` by removing the first element.
   ///
-  /// - Returns: A new `IdentifierListSyntax` with the first element removed.
-  public func removingFirst() -> IdentifierListSyntax {
+  /// - Returns: A new `DesignatedTypeListSyntax` with the first element removed.
+  public func removingFirst() -> DesignatedTypeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeFirst()
     return replacingLayout(newLayout)
   }
 
-  /// Creates a new `IdentifierListSyntax` by removing the last element.
+  /// Creates a new `DesignatedTypeListSyntax` by removing the last element.
   ///
-  /// - Returns: A new `IdentifierListSyntax` with the last element removed.
-  public func removingLast() -> IdentifierListSyntax {
+  /// - Returns: A new `DesignatedTypeListSyntax` with the last element removed.
+  public func removingLast() -> DesignatedTypeListSyntax {
     var newLayout = layoutView.formLayoutArray()
     newLayout.removeLast()
     return replacingLayout(newLayout)
   }
 
-  /// Returns a new `IdentifierListSyntax` with its leading trivia replaced
+  /// Returns a new `DesignatedTypeListSyntax` with its leading trivia replaced
   /// by the provided trivia.
-  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> IdentifierListSyntax {
-    return IdentifierListSyntax(data.withLeadingTrivia(leadingTrivia))
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> DesignatedTypeListSyntax {
+    return DesignatedTypeListSyntax(data.withLeadingTrivia(leadingTrivia))
   }
 
-  /// Returns a new `IdentifierListSyntax` with its trailing trivia replaced
+  /// Returns a new `DesignatedTypeListSyntax` with its trailing trivia replaced
   /// by the provided trivia.
-  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> IdentifierListSyntax {
-    return IdentifierListSyntax(data.withTrailingTrivia(trailingTrivia))
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> DesignatedTypeListSyntax {
+    return DesignatedTypeListSyntax(data.withTrailingTrivia(trailingTrivia))
   }
 
-  /// Returns a new `IdentifierListSyntax` with its leading trivia removed.
-  public func withoutLeadingTrivia() -> IdentifierListSyntax {
+  /// Returns a new `DesignatedTypeListSyntax` with its leading trivia removed.
+  public func withoutLeadingTrivia() -> DesignatedTypeListSyntax {
     return withLeadingTrivia([])
   }
 
-  /// Returns a new `IdentifierListSyntax` with its trailing trivia removed.
-  public func withoutTrailingTrivia() -> IdentifierListSyntax {
+  /// Returns a new `DesignatedTypeListSyntax` with its trailing trivia removed.
+  public func withoutTrailingTrivia() -> DesignatedTypeListSyntax {
     return withTrailingTrivia([])
   }
 
-  /// Returns a new `IdentifierListSyntax` with all trivia removed.
-  public func withoutTrivia() -> IdentifierListSyntax {
+  /// Returns a new `DesignatedTypeListSyntax` with all trivia removed.
+  public func withoutTrivia() -> DesignatedTypeListSyntax {
     return withoutLeadingTrivia().withoutTrailingTrivia()
   }
 
-  /// The leading trivia (spaces, newlines, etc.) associated with this `IdentifierListSyntax`.
+  /// The leading trivia (spaces, newlines, etc.) associated with this `DesignatedTypeListSyntax`.
   public var leadingTrivia: Trivia? {
     get {
       return raw.formLeadingTrivia()
@@ -5419,7 +5419,7 @@ public struct IdentifierListSyntax: SyntaxCollection, SyntaxHashable {
     }
   }
 
-  /// The trailing trivia (spaces, newlines, etc.) associated with this `IdentifierListSyntax`.
+  /// The trailing trivia (spaces, newlines, etc.) associated with this `DesignatedTypeListSyntax`.
   public var trailingTrivia: Trivia? {
     get {
       return raw.formTrailingTrivia()
@@ -5430,9 +5430,9 @@ public struct IdentifierListSyntax: SyntaxCollection, SyntaxHashable {
   }
 }
 
-/// Conformance for `IdentifierListSyntax` to the `BidirectionalCollection` protocol.
-extension IdentifierListSyntax: BidirectionalCollection {
-  public typealias Element = TokenSyntax
+/// Conformance for `DesignatedTypeListSyntax` to the `BidirectionalCollection` protocol.
+extension DesignatedTypeListSyntax: BidirectionalCollection {
+  public typealias Element = DesignatedTypeElementSyntax
   public typealias Index = SyntaxChildrenIndex
 
   public struct Iterator: IteratorProtocol {
@@ -5444,13 +5444,13 @@ extension IdentifierListSyntax: BidirectionalCollection {
       self.iterator = rawChildren.makeIterator()
     }
 
-    public mutating func next() -> TokenSyntax? {
+    public mutating func next() -> DesignatedTypeElementSyntax? {
       guard let (raw, info) = self.iterator.next() else {
         return nil
       }
       let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
       let data = SyntaxData(absoluteRaw, parent: parent)
-      return TokenSyntax(data)
+      return DesignatedTypeElementSyntax(data)
     }
   }
 
@@ -5485,11 +5485,11 @@ extension IdentifierListSyntax: BidirectionalCollection {
     return rawChildren.distance(from: start, to: end)
   }
 
-  public subscript(position: SyntaxChildrenIndex) -> TokenSyntax {
+  public subscript(position: SyntaxChildrenIndex) -> DesignatedTypeElementSyntax {
     let (raw, info) = rawChildren[position]
     let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
     let data = SyntaxData(absoluteRaw, parent: Syntax(self))
-    return TokenSyntax(data)
+    return DesignatedTypeElementSyntax(data)
   }
 }
 
@@ -11075,7 +11075,7 @@ extension EnumCaseElementListSyntax: CustomReflectable {
     return Mirror(self, unlabeledChildren: self.map{ $0 })
   }
 }
-extension IdentifierListSyntax: CustomReflectable {
+extension DesignatedTypeListSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, unlabeledChildren: self.map{ $0 })
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -158,7 +158,8 @@ public enum SyntaxEnum {
   case enumCaseDecl(EnumCaseDeclSyntax)
   case enumDecl(EnumDeclSyntax)
   case operatorDecl(OperatorDeclSyntax)
-  case identifierList(IdentifierListSyntax)
+  case designatedTypeList(DesignatedTypeListSyntax)
+  case designatedTypeElement(DesignatedTypeElementSyntax)
   case operatorPrecedenceAndTypes(OperatorPrecedenceAndTypesSyntax)
   case precedenceGroupDecl(PrecedenceGroupDeclSyntax)
   case precedenceGroupAttributeList(PrecedenceGroupAttributeListSyntax)
@@ -575,7 +576,9 @@ public enum SyntaxEnum {
       return "enum"
     case .operatorDecl:
       return "operator"
-    case .identifierList:
+    case .designatedTypeList:
+      return nil
+    case .designatedTypeElement:
       return nil
     case .operatorPrecedenceAndTypes:
       return nil
@@ -1123,8 +1126,10 @@ public extension Syntax {
       return .enumDecl(EnumDeclSyntax(self)!)
     case .operatorDecl:
       return .operatorDecl(OperatorDeclSyntax(self)!)
-    case .identifierList:
-      return .identifierList(IdentifierListSyntax(self)!)
+    case .designatedTypeList:
+      return .designatedTypeList(DesignatedTypeListSyntax(self)!)
+    case .designatedTypeElement:
+      return .designatedTypeElement(DesignatedTypeElementSyntax(self)!)
     case .operatorPrecedenceAndTypes:
       return .operatorPrecedenceAndTypes(OperatorPrecedenceAndTypesSyntax(self)!)
     case .precedenceGroupDecl:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -193,6 +193,8 @@ public enum SyntaxEnum {
   case backDeployVersionList(BackDeployVersionListSyntax)
   case backDeployVersionArgument(BackDeployVersionArgumentSyntax)
   case opaqueReturnTypeOfAttributeArguments(OpaqueReturnTypeOfAttributeArgumentsSyntax)
+  case conventionAttributeArguments(ConventionAttributeArgumentsSyntax)
+  case conventionWitnessMethodAttributeArguments(ConventionWitnessMethodAttributeArgumentsSyntax)
   case labeledStmt(LabeledStmtSyntax)
   case continueStmt(ContinueStmtSyntax)
   case whileStmt(WhileStmtSyntax)
@@ -643,6 +645,10 @@ public enum SyntaxEnum {
       return "version"
     case .opaqueReturnTypeOfAttributeArguments:
       return "opaque return type arguments"
+    case .conventionAttributeArguments:
+      return "@convention(...) arguments"
+    case .conventionWitnessMethodAttributeArguments:
+      return "@convention(...) arguments for witness methods"
     case .labeledStmt:
       return "labeled statement"
     case .continueStmt:
@@ -1187,6 +1193,10 @@ public extension Syntax {
       return .backDeployVersionArgument(BackDeployVersionArgumentSyntax(self)!)
     case .opaqueReturnTypeOfAttributeArguments:
       return .opaqueReturnTypeOfAttributeArguments(OpaqueReturnTypeOfAttributeArgumentsSyntax(self)!)
+    case .conventionAttributeArguments:
+      return .conventionAttributeArguments(ConventionAttributeArgumentsSyntax(self)!)
+    case .conventionWitnessMethodAttributeArguments:
+      return .conventionWitnessMethodAttributeArguments(ConventionWitnessMethodAttributeArgumentsSyntax(self)!)
     case .labeledStmt:
       return .labeledStmt(LabeledStmtSyntax(self)!)
     case .continueStmt:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -3823,33 +3823,56 @@ public enum SyntaxFactory {
     ], arena: .default))
     return OperatorDeclSyntax(data)
   }
-  @available(*, deprecated, message: "Use initializer on IdentifierListSyntax")
-  public static func makeIdentifierList(
-    _ elements: [TokenSyntax]) -> IdentifierListSyntax {
-    let raw = RawSyntax.makeLayout(kind: SyntaxKind.identifierList,
+  @available(*, deprecated, message: "Use initializer on DesignatedTypeListSyntax")
+  public static func makeDesignatedTypeList(
+    _ elements: [DesignatedTypeElementSyntax]) -> DesignatedTypeListSyntax {
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeList,
       from: elements.map { $0.raw }, arena: .default)
     let data = SyntaxData.forRoot(raw)
-    return IdentifierListSyntax(data)
+    return DesignatedTypeListSyntax(data)
   }
 
-  @available(*, deprecated, message: "Use initializer on IdentifierListSyntax")
-  public static func makeBlankIdentifierList(presence: SourcePresence = .present) -> IdentifierListSyntax {
-    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .identifierList,
+  @available(*, deprecated, message: "Use initializer on DesignatedTypeListSyntax")
+  public static func makeBlankDesignatedTypeList(presence: SourcePresence = .present) -> DesignatedTypeListSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .designatedTypeList,
       from: [
     ], arena: .default))
-    return IdentifierListSyntax(data)
+    return DesignatedTypeListSyntax(data)
+  }
+  @available(*, deprecated, message: "Use initializer on DesignatedTypeElementSyntax")
+  public static func makeDesignatedTypeElement(_ unexpectedBeforeLeadingComma: UnexpectedNodesSyntax? = nil, leadingComma: TokenSyntax, _ unexpectedBetweenLeadingCommaAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax) -> DesignatedTypeElementSyntax {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeLeadingComma?.raw,
+      leadingComma.raw,
+      unexpectedBetweenLeadingCommaAndName?.raw,
+      name.raw,
+    ]
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeElement,
+      from: layout, arena: .default)
+    let data = SyntaxData.forRoot(raw)
+    return DesignatedTypeElementSyntax(data)
+  }
+
+  @available(*, deprecated, message: "Use initializer on DesignatedTypeElementSyntax")
+  public static func makeBlankDesignatedTypeElement(presence: SourcePresence = .present) -> DesignatedTypeElementSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .designatedTypeElement,
+      from: [
+      nil,
+      RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default),
+      nil,
+      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+    ], arena: .default))
+    return DesignatedTypeElementSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on OperatorPrecedenceAndTypesSyntax")
-  public static func makeOperatorPrecedenceAndTypes(_ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndPrecedenceGroup: UnexpectedNodesSyntax? = nil, precedenceGroup: TokenSyntax, _ unexpectedBetweenPrecedenceGroupAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndDesignatedType: UnexpectedNodesSyntax? = nil, designatedType: TokenSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+  public static func makeOperatorPrecedenceAndTypes(_ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndPrecedenceGroup: UnexpectedNodesSyntax? = nil, precedenceGroup: TokenSyntax, _ unexpectedBetweenPrecedenceGroupAndDesignatedTypes: UnexpectedNodesSyntax? = nil, designatedTypes: DesignatedTypeListSyntax) -> OperatorPrecedenceAndTypesSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeColon?.raw,
       colon.raw,
       unexpectedBetweenColonAndPrecedenceGroup?.raw,
       precedenceGroup.raw,
-      unexpectedBetweenPrecedenceGroupAndComma?.raw,
-      comma?.raw,
-      unexpectedBetweenCommaAndDesignatedType?.raw,
-      designatedType?.raw,
+      unexpectedBetweenPrecedenceGroupAndDesignatedTypes?.raw,
+      designatedTypes.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorPrecedenceAndTypes,
       from: layout, arena: .default)
@@ -3866,9 +3889,7 @@ public enum SyntaxFactory {
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
       nil,
-      nil,
-      nil,
-      nil,
+      RawSyntax.makeEmptyLayout(kind: SyntaxKind.designatedTypeList, arena: .default),
     ], arena: .default))
     return OperatorPrecedenceAndTypesSyntax(data)
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -4760,6 +4760,72 @@ public enum SyntaxFactory {
     ], arena: .default))
     return OpaqueReturnTypeOfAttributeArgumentsSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on ConventionAttributeArgumentsSyntax")
+  public static func makeConventionAttributeArguments(_ unexpectedBeforeConventionLabel: UnexpectedNodesSyntax? = nil, conventionLabel: TokenSyntax, _ unexpectedBetweenConventionLabelAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndCTypeLabel: UnexpectedNodesSyntax? = nil, cTypeLabel: TokenSyntax?, _ unexpectedBetweenCTypeLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndCTypeString: UnexpectedNodesSyntax? = nil, cTypeString: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeConventionLabel?.raw,
+      conventionLabel.raw,
+      unexpectedBetweenConventionLabelAndComma?.raw,
+      comma?.raw,
+      unexpectedBetweenCommaAndCTypeLabel?.raw,
+      cTypeLabel?.raw,
+      unexpectedBetweenCTypeLabelAndColon?.raw,
+      colon?.raw,
+      unexpectedBetweenColonAndCTypeString?.raw,
+      cTypeString?.raw,
+    ]
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionAttributeArguments,
+      from: layout, arena: .default)
+    let data = SyntaxData.forRoot(raw)
+    return ConventionAttributeArgumentsSyntax(data)
+  }
+
+  @available(*, deprecated, message: "Use initializer on ConventionAttributeArgumentsSyntax")
+  public static func makeBlankConventionAttributeArguments(presence: SourcePresence = .present) -> ConventionAttributeArgumentsSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .conventionAttributeArguments,
+      from: [
+      nil,
+      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+      nil,
+      nil,
+      nil,
+      nil,
+      nil,
+      nil,
+      nil,
+      nil,
+    ], arena: .default))
+    return ConventionAttributeArgumentsSyntax(data)
+  }
+  @available(*, deprecated, message: "Use initializer on ConventionWitnessMethodAttributeArgumentsSyntax")
+  public static func makeConventionWitnessMethodAttributeArguments(_ unexpectedBeforeWitnessMethodLabel: UnexpectedNodesSyntax? = nil, witnessMethodLabel: TokenSyntax, _ unexpectedBetweenWitnessMethodLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndProtocolName: UnexpectedNodesSyntax? = nil, protocolName: TokenSyntax) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeWitnessMethodLabel?.raw,
+      witnessMethodLabel.raw,
+      unexpectedBetweenWitnessMethodLabelAndColon?.raw,
+      colon.raw,
+      unexpectedBetweenColonAndProtocolName?.raw,
+      protocolName.raw,
+    ]
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionWitnessMethodAttributeArguments,
+      from: layout, arena: .default)
+    let data = SyntaxData.forRoot(raw)
+    return ConventionWitnessMethodAttributeArgumentsSyntax(data)
+  }
+
+  @available(*, deprecated, message: "Use initializer on ConventionWitnessMethodAttributeArgumentsSyntax")
+  public static func makeBlankConventionWitnessMethodAttributeArguments(presence: SourcePresence = .present) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .conventionWitnessMethodAttributeArguments,
+      from: [
+      nil,
+      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+      nil,
+      RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
+      nil,
+      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+    ], arena: .default))
+    return ConventionWitnessMethodAttributeArgumentsSyntax(data)
+  }
   @available(*, deprecated, message: "Use initializer on LabeledStmtSyntax")
   public static func makeLabeledStmt(_ unexpectedBeforeLabelName: UnexpectedNodesSyntax? = nil, labelName: TokenSyntax, _ unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? = nil, labelColon: TokenSyntax, _ unexpectedBetweenLabelColonAndStatement: UnexpectedNodesSyntax? = nil, statement: StmtSyntax) -> LabeledStmtSyntax {
     let layout: [RawSyntax?] = [

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -3840,12 +3840,16 @@ public enum SyntaxFactory {
     return IdentifierListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on OperatorPrecedenceAndTypesSyntax")
-  public static func makeOperatorPrecedenceAndTypes(_ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes: UnexpectedNodesSyntax? = nil, precedenceGroupAndDesignatedTypes: IdentifierListSyntax) -> OperatorPrecedenceAndTypesSyntax {
+  public static func makeOperatorPrecedenceAndTypes(_ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndPrecedenceGroup: UnexpectedNodesSyntax? = nil, precedenceGroup: TokenSyntax, _ unexpectedBetweenPrecedenceGroupAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndDesignatedType: UnexpectedNodesSyntax? = nil, designatedType: TokenSyntax?) -> OperatorPrecedenceAndTypesSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeColon?.raw,
       colon.raw,
-      unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes?.raw,
-      precedenceGroupAndDesignatedTypes.raw,
+      unexpectedBetweenColonAndPrecedenceGroup?.raw,
+      precedenceGroup.raw,
+      unexpectedBetweenPrecedenceGroupAndComma?.raw,
+      comma?.raw,
+      unexpectedBetweenCommaAndDesignatedType?.raw,
+      designatedType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorPrecedenceAndTypes,
       from: layout, arena: .default)
@@ -3860,7 +3864,11 @@ public enum SyntaxFactory {
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.identifierList, arena: .default),
+      RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+      nil,
+      nil,
+      nil,
+      nil,
     ], arena: .default))
     return OperatorPrecedenceAndTypesSyntax(data)
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
@@ -194,6 +194,8 @@ public enum SyntaxKind {
   case backDeployVersionList
   case backDeployVersionArgument
   case opaqueReturnTypeOfAttributeArguments
+  case conventionAttributeArguments
+  case conventionWitnessMethodAttributeArguments
   case labeledStmt
   case continueStmt
   case whileStmt

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
@@ -159,7 +159,8 @@ public enum SyntaxKind {
   case enumCaseDecl
   case enumDecl
   case operatorDecl
-  case identifierList
+  case designatedTypeList
+  case designatedTypeElement
   case operatorPrecedenceAndTypes
   case precedenceGroupDecl
   case precedenceGroupAttributeList
@@ -309,7 +310,7 @@ public enum SyntaxKind {
     case .accessorList: return true
     case .patternBindingList: return true
     case .enumCaseElementList: return true
-    case .identifierList: return true
+    case .designatedTypeList: return true
     case .precedenceGroupAttributeList: return true
     case .precedenceGroupNameList: return true
     case .tokenList: return true

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -1017,10 +1017,17 @@ open class SyntaxRewriter {
     return DeclSyntax(visitChildren(node))
   }
 
-  /// Visit a `IdentifierListSyntax`.
+  /// Visit a `DesignatedTypeListSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
-  open func visit(_ node: IdentifierListSyntax) -> Syntax {
+  open func visit(_ node: DesignatedTypeListSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
+  /// Visit a `DesignatedTypeElementSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: DesignatedTypeElementSyntax) -> Syntax {
     return Syntax(visitChildren(node))
   }
 
@@ -3411,8 +3418,18 @@ open class SyntaxRewriter {
   }
 
   /// Implementation detail of visit(_:). Do not call directly.
-  private func visitImplIdentifierListSyntax(_ data: SyntaxData) -> Syntax {
-      let node = IdentifierListSyntax(data)
+  private func visitImplDesignatedTypeListSyntax(_ data: SyntaxData) -> Syntax {
+      let node = DesignatedTypeListSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplDesignatedTypeElementSyntax(_ data: SyntaxData) -> Syntax {
+      let node = DesignatedTypeElementSyntax(data)
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
       visitPre(node._syntaxNode)
       defer { visitPost(node._syntaxNode) }
@@ -5006,8 +5023,10 @@ open class SyntaxRewriter {
       return visitImplEnumDeclSyntax
     case .operatorDecl:
       return visitImplOperatorDeclSyntax
-    case .identifierList:
-      return visitImplIdentifierListSyntax
+    case .designatedTypeList:
+      return visitImplDesignatedTypeListSyntax
+    case .designatedTypeElement:
+      return visitImplDesignatedTypeElementSyntax
     case .operatorPrecedenceAndTypes:
       return visitImplOperatorPrecedenceAndTypesSyntax
     case .precedenceGroupDecl:
@@ -5557,8 +5576,10 @@ open class SyntaxRewriter {
       return visitImplEnumDeclSyntax(data)
     case .operatorDecl:
       return visitImplOperatorDeclSyntax(data)
-    case .identifierList:
-      return visitImplIdentifierListSyntax(data)
+    case .designatedTypeList:
+      return visitImplDesignatedTypeListSyntax(data)
+    case .designatedTypeElement:
+      return visitImplDesignatedTypeElementSyntax(data)
     case .operatorPrecedenceAndTypes:
       return visitImplOperatorPrecedenceAndTypesSyntax(data)
     case .precedenceGroupDecl:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -1262,6 +1262,20 @@ open class SyntaxRewriter {
     return Syntax(visitChildren(node))
   }
 
+  /// Visit a `ConventionAttributeArgumentsSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: ConventionAttributeArgumentsSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
+  /// Visit a `ConventionWitnessMethodAttributeArgumentsSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: ConventionWitnessMethodAttributeArgumentsSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
   /// Visit a `LabeledStmtSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -3747,6 +3761,26 @@ open class SyntaxRewriter {
   }
 
   /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplConventionAttributeArgumentsSyntax(_ data: SyntaxData) -> Syntax {
+      let node = ConventionAttributeArgumentsSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplConventionWitnessMethodAttributeArgumentsSyntax(_ data: SyntaxData) -> Syntax {
+      let node = ConventionWitnessMethodAttributeArgumentsSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplLabeledStmtSyntax(_ data: SyntaxData) -> Syntax {
       let node = LabeledStmtSyntax(data)
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
@@ -5042,6 +5076,10 @@ open class SyntaxRewriter {
       return visitImplBackDeployVersionArgumentSyntax
     case .opaqueReturnTypeOfAttributeArguments:
       return visitImplOpaqueReturnTypeOfAttributeArgumentsSyntax
+    case .conventionAttributeArguments:
+      return visitImplConventionAttributeArgumentsSyntax
+    case .conventionWitnessMethodAttributeArguments:
+      return visitImplConventionWitnessMethodAttributeArgumentsSyntax
     case .labeledStmt:
       return visitImplLabeledStmtSyntax
     case .continueStmt:
@@ -5589,6 +5627,10 @@ open class SyntaxRewriter {
       return visitImplBackDeployVersionArgumentSyntax(data)
     case .opaqueReturnTypeOfAttributeArguments:
       return visitImplOpaqueReturnTypeOfAttributeArgumentsSyntax(data)
+    case .conventionAttributeArguments:
+      return visitImplConventionAttributeArgumentsSyntax(data)
+    case .conventionWitnessMethodAttributeArguments:
+      return visitImplConventionWitnessMethodAttributeArgumentsSyntax(data)
     case .labeledStmt:
       return visitImplLabeledStmtSyntax(data)
     case .continueStmt:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
@@ -728,6 +728,14 @@ public protocol SyntaxTransformVisitor {
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: OpaqueReturnTypeOfAttributeArgumentsSyntax) -> ResultType
+  /// Visiting `ConventionAttributeArgumentsSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: ConventionAttributeArgumentsSyntax) -> ResultType
+  /// Visiting `ConventionWitnessMethodAttributeArgumentsSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: ConventionWitnessMethodAttributeArgumentsSyntax) -> ResultType
   /// Visiting `LabeledStmtSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -2157,6 +2165,18 @@ extension SyntaxTransformVisitor {
   public func visit(_ node: OpaqueReturnTypeOfAttributeArgumentsSyntax) -> ResultType {
     visitAny(Syntax(node))
   }
+  /// Visiting `ConventionAttributeArgumentsSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: ConventionAttributeArgumentsSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
+  /// Visiting `ConventionWitnessMethodAttributeArgumentsSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: ConventionWitnessMethodAttributeArgumentsSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
   /// Visiting `LabeledStmtSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
@@ -3051,6 +3071,10 @@ extension SyntaxTransformVisitor {
     case .backDeployVersionArgument(let derived):
       return visit(derived)
     case .opaqueReturnTypeOfAttributeArguments(let derived):
+      return visit(derived)
+    case .conventionAttributeArguments(let derived):
+      return visit(derived)
+    case .conventionWitnessMethodAttributeArguments(let derived):
       return visit(derived)
     case .labeledStmt(let derived):
       return visit(derived)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
@@ -588,10 +588,14 @@ public protocol SyntaxTransformVisitor {
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: OperatorDeclSyntax) -> ResultType
-  /// Visiting `IdentifierListSyntax` specifically.
+  /// Visiting `DesignatedTypeListSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
-  func visit(_ node: IdentifierListSyntax) -> ResultType
+  func visit(_ node: DesignatedTypeListSyntax) -> ResultType
+  /// Visiting `DesignatedTypeElementSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: DesignatedTypeElementSyntax) -> ResultType
   /// Visiting `OperatorPrecedenceAndTypesSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -1955,10 +1959,16 @@ extension SyntaxTransformVisitor {
   public func visit(_ node: OperatorDeclSyntax) -> ResultType {
     visitAny(Syntax(node))
   }
-  /// Visiting `IdentifierListSyntax` specifically.
+  /// Visiting `DesignatedTypeListSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
-  public func visit(_ node: IdentifierListSyntax) -> ResultType {
+  public func visit(_ node: DesignatedTypeListSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
+  /// Visiting `DesignatedTypeElementSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: DesignatedTypeElementSyntax) -> ResultType {
     visitAny(Syntax(node))
   }
   /// Visiting `OperatorPrecedenceAndTypesSyntax` specifically.
@@ -3002,7 +3012,9 @@ extension SyntaxTransformVisitor {
       return visit(derived)
     case .operatorDecl(let derived):
       return visit(derived)
-    case .identifierList(let derived):
+    case .designatedTypeList(let derived):
+      return visit(derived)
+    case .designatedTypeElement(let derived):
       return visit(derived)
     case .operatorPrecedenceAndTypes(let derived):
       return visit(derived)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -1811,6 +1811,26 @@ open class SyntaxVisitor {
   /// The function called after visiting `OpaqueReturnTypeOfAttributeArgumentsSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: OpaqueReturnTypeOfAttributeArgumentsSyntax) {}
+  /// Visiting `ConventionAttributeArgumentsSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: ConventionAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `ConventionAttributeArgumentsSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: ConventionAttributeArgumentsSyntax) {}
+  /// Visiting `ConventionWitnessMethodAttributeArgumentsSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: ConventionWitnessMethodAttributeArgumentsSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `ConventionWitnessMethodAttributeArgumentsSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: ConventionWitnessMethodAttributeArgumentsSyntax) {}
   /// Visiting `LabeledStmtSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -4727,6 +4747,28 @@ open class SyntaxVisitor {
   }
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplConventionAttributeArgumentsSyntax(_ data: SyntaxData) {
+      let node = ConventionAttributeArgumentsSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && !node.raw.layoutView!.children.isEmpty {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplConventionWitnessMethodAttributeArgumentsSyntax(_ data: SyntaxData) {
+      let node = ConventionWitnessMethodAttributeArgumentsSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && !node.raw.layoutView!.children.isEmpty {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplLabeledStmtSyntax(_ data: SyntaxData) {
       let node = LabeledStmtSyntax(data)
       let needsChildren = (visit(node) == .visitChildren)
@@ -6079,6 +6121,10 @@ open class SyntaxVisitor {
       visitImplBackDeployVersionArgumentSyntax(data)
     case .opaqueReturnTypeOfAttributeArguments:
       visitImplOpaqueReturnTypeOfAttributeArgumentsSyntax(data)
+    case .conventionAttributeArguments:
+      visitImplConventionAttributeArgumentsSyntax(data)
+    case .conventionWitnessMethodAttributeArguments:
+      visitImplConventionWitnessMethodAttributeArgumentsSyntax(data)
     case .labeledStmt:
       visitImplLabeledStmtSyntax(data)
     case .continueStmt:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -1461,16 +1461,26 @@ open class SyntaxVisitor {
   /// The function called after visiting `OperatorDeclSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: OperatorDeclSyntax) {}
-  /// Visiting `IdentifierListSyntax` specifically.
+  /// Visiting `DesignatedTypeListSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
-  open func visit(_ node: IdentifierListSyntax) -> SyntaxVisitorContinueKind {
+  open func visit(_ node: DesignatedTypeListSyntax) -> SyntaxVisitorContinueKind {
     return .visitChildren
   }
 
-  /// The function called after visiting `IdentifierListSyntax` and its descendents.
+  /// The function called after visiting `DesignatedTypeListSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
-  open func visitPost(_ node: IdentifierListSyntax) {}
+  open func visitPost(_ node: DesignatedTypeListSyntax) {}
+  /// Visiting `DesignatedTypeElementSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: DesignatedTypeElementSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `DesignatedTypeElementSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: DesignatedTypeElementSyntax) {}
   /// Visiting `OperatorPrecedenceAndTypesSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -4362,8 +4372,19 @@ open class SyntaxVisitor {
   }
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
-  private func visitImplIdentifierListSyntax(_ data: SyntaxData) {
-      let node = IdentifierListSyntax(data)
+  private func visitImplDesignatedTypeListSyntax(_ data: SyntaxData) {
+      let node = DesignatedTypeListSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && !node.raw.layoutView!.children.isEmpty {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplDesignatedTypeElementSyntax(_ data: SyntaxData) {
+      let node = DesignatedTypeElementSyntax(data)
       let needsChildren = (visit(node) == .visitChildren)
       // Avoid calling into visitChildren if possible.
       if needsChildren && !node.raw.layoutView!.children.isEmpty {
@@ -6051,8 +6072,10 @@ open class SyntaxVisitor {
       visitImplEnumDeclSyntax(data)
     case .operatorDecl:
       visitImplOperatorDeclSyntax(data)
-    case .identifierList:
-      visitImplIdentifierListSyntax(data)
+    case .designatedTypeList:
+      visitImplDesignatedTypeListSyntax(data)
+    case .designatedTypeElement:
+      visitImplDesignatedTypeElementSyntax(data)
     case .operatorPrecedenceAndTypes:
       visitImplOperatorPrecedenceAndTypesSyntax(data)
     case .precedenceGroupDecl:

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -12289,6 +12289,469 @@ extension OpaqueReturnTypeOfAttributeArgumentsSyntax: CustomReflectable {
   }
 }
 
+// MARK: - ConventionAttributeArgumentsSyntax
+
+/// 
+/// The arguments for the '@convention(...)'.
+/// 
+public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `ConventionAttributeArgumentsSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .conventionAttributeArguments else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `ConventionAttributeArgumentsSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .conventionAttributeArguments)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ unexpectedBeforeConventionLabel: UnexpectedNodesSyntax? = nil,
+    conventionLabel: TokenSyntax,
+    _ unexpectedBetweenConventionLabelAndComma: UnexpectedNodesSyntax? = nil,
+    comma: TokenSyntax?,
+    _ unexpectedBetweenCommaAndCTypeLabel: UnexpectedNodesSyntax? = nil,
+    cTypeLabel: TokenSyntax?,
+    _ unexpectedBetweenCTypeLabelAndColon: UnexpectedNodesSyntax? = nil,
+    colon: TokenSyntax?,
+    _ unexpectedBetweenColonAndCTypeString: UnexpectedNodesSyntax? = nil,
+    cTypeString: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeConventionLabel?.raw,
+      conventionLabel.raw,
+      unexpectedBetweenConventionLabelAndComma?.raw,
+      comma?.raw,
+      unexpectedBetweenCommaAndCTypeLabel?.raw,
+      cTypeLabel?.raw,
+      unexpectedBetweenCTypeLabelAndColon?.raw,
+      colon?.raw,
+      unexpectedBetweenColonAndCTypeString?.raw,
+      cTypeString?.raw,
+    ]
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionAttributeArguments,
+      from: layout, arena: .default)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
+  public var unexpectedBeforeConventionLabel: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 0, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBeforeConventionLabel(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBeforeConventionLabel` replaced.
+  /// - param newChild: The new `unexpectedBeforeConventionLabel` to replace the node's
+  ///                   current `unexpectedBeforeConventionLabel`, if present.
+  public func withUnexpectedBeforeConventionLabel(
+    _ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 0)
+    return ConventionAttributeArgumentsSyntax(newData)
+  }
+
+  /// The convention label.
+  public var conventionLabel: TokenSyntax {
+    get {
+      let childData = data.child(at: 1, parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withConventionLabel(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `conventionLabel` replaced.
+  /// - param newChild: The new `conventionLabel` to replace the node's
+  ///                   current `conventionLabel`, if present.
+  public func withConventionLabel(
+    _ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
+    let newData = data.replacingChild(raw, at: 1)
+    return ConventionAttributeArgumentsSyntax(newData)
+  }
+
+  public var unexpectedBetweenConventionLabelAndComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenConventionLabelAndComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenConventionLabelAndComma` replaced.
+  /// - param newChild: The new `unexpectedBetweenConventionLabelAndComma` to replace the node's
+  ///                   current `unexpectedBetweenConventionLabelAndComma`, if present.
+  public func withUnexpectedBetweenConventionLabelAndComma(
+    _ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return ConventionAttributeArgumentsSyntax(newData)
+  }
+
+  public var comma: TokenSyntax? {
+    get {
+      let childData = data.child(at: 3, parent: Syntax(self))
+      if childData == nil { return nil }
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `comma` replaced.
+  /// - param newChild: The new `comma` to replace the node's
+  ///                   current `comma`, if present.
+  public func withComma(
+    _ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 3)
+    return ConventionAttributeArgumentsSyntax(newData)
+  }
+
+  public var unexpectedBetweenCommaAndCTypeLabel: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenCommaAndCTypeLabel(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndCTypeLabel` replaced.
+  /// - param newChild: The new `unexpectedBetweenCommaAndCTypeLabel` to replace the node's
+  ///                   current `unexpectedBetweenCommaAndCTypeLabel`, if present.
+  public func withUnexpectedBetweenCommaAndCTypeLabel(
+    _ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return ConventionAttributeArgumentsSyntax(newData)
+  }
+
+  public var cTypeLabel: TokenSyntax? {
+    get {
+      let childData = data.child(at: 5, parent: Syntax(self))
+      if childData == nil { return nil }
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withCTypeLabel(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `cTypeLabel` replaced.
+  /// - param newChild: The new `cTypeLabel` to replace the node's
+  ///                   current `cTypeLabel`, if present.
+  public func withCTypeLabel(
+    _ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 5)
+    return ConventionAttributeArgumentsSyntax(newData)
+  }
+
+  public var unexpectedBetweenCTypeLabelAndColon: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenCTypeLabelAndColon(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenCTypeLabelAndColon` replaced.
+  /// - param newChild: The new `unexpectedBetweenCTypeLabelAndColon` to replace the node's
+  ///                   current `unexpectedBetweenCTypeLabelAndColon`, if present.
+  public func withUnexpectedBetweenCTypeLabelAndColon(
+    _ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return ConventionAttributeArgumentsSyntax(newData)
+  }
+
+  public var colon: TokenSyntax? {
+    get {
+      let childData = data.child(at: 7, parent: Syntax(self))
+      if childData == nil { return nil }
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withColon(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `colon` replaced.
+  /// - param newChild: The new `colon` to replace the node's
+  ///                   current `colon`, if present.
+  public func withColon(
+    _ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 7)
+    return ConventionAttributeArgumentsSyntax(newData)
+  }
+
+  public var unexpectedBetweenColonAndCTypeString: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenColonAndCTypeString(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndCTypeString` replaced.
+  /// - param newChild: The new `unexpectedBetweenColonAndCTypeString` to replace the node's
+  ///                   current `unexpectedBetweenColonAndCTypeString`, if present.
+  public func withUnexpectedBetweenColonAndCTypeString(
+    _ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return ConventionAttributeArgumentsSyntax(newData)
+  }
+
+  public var cTypeString: TokenSyntax? {
+    get {
+      let childData = data.child(at: 9, parent: Syntax(self))
+      if childData == nil { return nil }
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withCTypeString(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `cTypeString` replaced.
+  /// - param newChild: The new `cTypeString` to replace the node's
+  ///                   current `cTypeString`, if present.
+  public func withCTypeString(
+    _ newChild: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 9)
+    return ConventionAttributeArgumentsSyntax(newData)
+  }
+}
+
+extension ConventionAttributeArgumentsSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "unexpectedBeforeConventionLabel": unexpectedBeforeConventionLabel.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "conventionLabel": Syntax(conventionLabel).asProtocol(SyntaxProtocol.self),
+      "unexpectedBetweenConventionLabelAndComma": unexpectedBetweenConventionLabelAndComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "comma": comma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedBetweenCommaAndCTypeLabel": unexpectedBetweenCommaAndCTypeLabel.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "cTypeLabel": cTypeLabel.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedBetweenCTypeLabelAndColon": unexpectedBetweenCTypeLabelAndColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "colon": colon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedBetweenColonAndCTypeString": unexpectedBetweenColonAndCTypeString.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "cTypeString": cTypeString.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+    ])
+  }
+}
+
+// MARK: - ConventionWitnessMethodAttributeArgumentsSyntax
+
+/// 
+/// The arguments for the '@convention(witness_method: ...)'.
+/// 
+public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `ConventionWitnessMethodAttributeArgumentsSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .conventionWitnessMethodAttributeArguments else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `ConventionWitnessMethodAttributeArgumentsSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .conventionWitnessMethodAttributeArguments)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ unexpectedBeforeWitnessMethodLabel: UnexpectedNodesSyntax? = nil,
+    witnessMethodLabel: TokenSyntax,
+    _ unexpectedBetweenWitnessMethodLabelAndColon: UnexpectedNodesSyntax? = nil,
+    colon: TokenSyntax,
+    _ unexpectedBetweenColonAndProtocolName: UnexpectedNodesSyntax? = nil,
+    protocolName: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeWitnessMethodLabel?.raw,
+      witnessMethodLabel.raw,
+      unexpectedBetweenWitnessMethodLabelAndColon?.raw,
+      colon.raw,
+      unexpectedBetweenColonAndProtocolName?.raw,
+      protocolName.raw,
+    ]
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionWitnessMethodAttributeArguments,
+      from: layout, arena: .default)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
+  public var unexpectedBeforeWitnessMethodLabel: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 0, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBeforeWitnessMethodLabel(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBeforeWitnessMethodLabel` replaced.
+  /// - param newChild: The new `unexpectedBeforeWitnessMethodLabel` to replace the node's
+  ///                   current `unexpectedBeforeWitnessMethodLabel`, if present.
+  public func withUnexpectedBeforeWitnessMethodLabel(
+    _ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 0)
+    return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
+  }
+
+  public var witnessMethodLabel: TokenSyntax {
+    get {
+      let childData = data.child(at: 1, parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withWitnessMethodLabel(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `witnessMethodLabel` replaced.
+  /// - param newChild: The new `witnessMethodLabel` to replace the node's
+  ///                   current `witnessMethodLabel`, if present.
+  public func withWitnessMethodLabel(
+    _ newChild: TokenSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
+    let newData = data.replacingChild(raw, at: 1)
+    return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
+  }
+
+  public var unexpectedBetweenWitnessMethodLabelAndColon: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenWitnessMethodLabelAndColon(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenWitnessMethodLabelAndColon` replaced.
+  /// - param newChild: The new `unexpectedBetweenWitnessMethodLabelAndColon` to replace the node's
+  ///                   current `unexpectedBetweenWitnessMethodLabelAndColon`, if present.
+  public func withUnexpectedBetweenWitnessMethodLabelAndColon(
+    _ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
+  }
+
+  public var colon: TokenSyntax {
+    get {
+      let childData = data.child(at: 3, parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withColon(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `colon` replaced.
+  /// - param newChild: The new `colon` to replace the node's
+  ///                   current `colon`, if present.
+  public func withColon(
+    _ newChild: TokenSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default)
+    let newData = data.replacingChild(raw, at: 3)
+    return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
+  }
+
+  public var unexpectedBetweenColonAndProtocolName: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenColonAndProtocolName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndProtocolName` replaced.
+  /// - param newChild: The new `unexpectedBetweenColonAndProtocolName` to replace the node's
+  ///                   current `unexpectedBetweenColonAndProtocolName`, if present.
+  public func withUnexpectedBetweenColonAndProtocolName(
+    _ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
+  }
+
+  public var protocolName: TokenSyntax {
+    get {
+      let childData = data.child(at: 5, parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withProtocolName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `protocolName` replaced.
+  /// - param newChild: The new `protocolName` to replace the node's
+  ///                   current `protocolName`, if present.
+  public func withProtocolName(
+    _ newChild: TokenSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
+    let newData = data.replacingChild(raw, at: 5)
+    return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
+  }
+}
+
+extension ConventionWitnessMethodAttributeArgumentsSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "unexpectedBeforeWitnessMethodLabel": unexpectedBeforeWitnessMethodLabel.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "witnessMethodLabel": Syntax(witnessMethodLabel).asProtocol(SyntaxProtocol.self),
+      "unexpectedBetweenWitnessMethodLabelAndColon": unexpectedBetweenWitnessMethodLabelAndColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "unexpectedBetweenColonAndProtocolName": unexpectedBetweenColonAndProtocolName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "protocolName": Syntax(protocolName).asProtocol(SyntaxProtocol.self),
+    ])
+  }
+}
+
 // MARK: - WhereClauseSyntax
 
 public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -7208,6 +7208,138 @@ extension EnumCaseElementSyntax: CustomReflectable {
   }
 }
 
+// MARK: - DesignatedTypeElementSyntax
+
+public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `DesignatedTypeElementSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .designatedTypeElement else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `DesignatedTypeElementSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .designatedTypeElement)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ unexpectedBeforeLeadingComma: UnexpectedNodesSyntax? = nil,
+    leadingComma: TokenSyntax,
+    _ unexpectedBetweenLeadingCommaAndName: UnexpectedNodesSyntax? = nil,
+    name: TokenSyntax
+  ) {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeLeadingComma?.raw,
+      leadingComma.raw,
+      unexpectedBetweenLeadingCommaAndName?.raw,
+      name.raw,
+    ]
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeElement,
+      from: layout, arena: .default)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
+  public var unexpectedBeforeLeadingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 0, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBeforeLeadingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBeforeLeadingComma` replaced.
+  /// - param newChild: The new `unexpectedBeforeLeadingComma` to replace the node's
+  ///                   current `unexpectedBeforeLeadingComma`, if present.
+  public func withUnexpectedBeforeLeadingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> DesignatedTypeElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 0)
+    return DesignatedTypeElementSyntax(newData)
+  }
+
+  public var leadingComma: TokenSyntax {
+    get {
+      let childData = data.child(at: 1, parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withLeadingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `leadingComma` replaced.
+  /// - param newChild: The new `leadingComma` to replace the node's
+  ///                   current `leadingComma`, if present.
+  public func withLeadingComma(
+    _ newChild: TokenSyntax?) -> DesignatedTypeElementSyntax {
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default)
+    let newData = data.replacingChild(raw, at: 1)
+    return DesignatedTypeElementSyntax(newData)
+  }
+
+  public var unexpectedBetweenLeadingCommaAndName: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenLeadingCommaAndName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenLeadingCommaAndName` replaced.
+  /// - param newChild: The new `unexpectedBetweenLeadingCommaAndName` to replace the node's
+  ///                   current `unexpectedBetweenLeadingCommaAndName`, if present.
+  public func withUnexpectedBetweenLeadingCommaAndName(
+    _ newChild: UnexpectedNodesSyntax?) -> DesignatedTypeElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return DesignatedTypeElementSyntax(newData)
+  }
+
+  public var name: TokenSyntax {
+    get {
+      let childData = data.child(at: 3, parent: Syntax(self))
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `name` replaced.
+  /// - param newChild: The new `name` to replace the node's
+  ///                   current `name`, if present.
+  public func withName(
+    _ newChild: TokenSyntax?) -> DesignatedTypeElementSyntax {
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
+    let newData = data.replacingChild(raw, at: 3)
+    return DesignatedTypeElementSyntax(newData)
+  }
+}
+
+extension DesignatedTypeElementSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "unexpectedBeforeLeadingComma": unexpectedBeforeLeadingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "leadingComma": Syntax(leadingComma).asProtocol(SyntaxProtocol.self),
+      "unexpectedBetweenLeadingCommaAndName": unexpectedBetweenLeadingCommaAndName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+    ])
+  }
+}
+
 // MARK: - OperatorPrecedenceAndTypesSyntax
 
 /// 
@@ -7236,20 +7368,16 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndPrecedenceGroup: UnexpectedNodesSyntax? = nil,
     precedenceGroup: TokenSyntax,
-    _ unexpectedBetweenPrecedenceGroupAndComma: UnexpectedNodesSyntax? = nil,
-    comma: TokenSyntax?,
-    _ unexpectedBetweenCommaAndDesignatedType: UnexpectedNodesSyntax? = nil,
-    designatedType: TokenSyntax?
+    _ unexpectedBetweenPrecedenceGroupAndDesignatedTypes: UnexpectedNodesSyntax? = nil,
+    designatedTypes: DesignatedTypeListSyntax
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeColon?.raw,
       colon.raw,
       unexpectedBetweenColonAndPrecedenceGroup?.raw,
       precedenceGroup.raw,
-      unexpectedBetweenPrecedenceGroupAndComma?.raw,
-      comma?.raw,
-      unexpectedBetweenCommaAndDesignatedType?.raw,
-      designatedType?.raw,
+      unexpectedBetweenPrecedenceGroupAndDesignatedTypes?.raw,
+      designatedTypes.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorPrecedenceAndTypes,
       from: layout, arena: .default)
@@ -7342,90 +7470,65 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
-  public var unexpectedBetweenPrecedenceGroupAndComma: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenPrecedenceGroupAndDesignatedTypes: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenPrecedenceGroupAndComma(value)
+      self = withUnexpectedBetweenPrecedenceGroupAndDesignatedTypes(value)
     }
   }
 
-  /// Returns a copy of the receiver with its `unexpectedBetweenPrecedenceGroupAndComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenPrecedenceGroupAndComma` to replace the node's
-  ///                   current `unexpectedBetweenPrecedenceGroupAndComma`, if present.
-  public func withUnexpectedBetweenPrecedenceGroupAndComma(
+  /// Returns a copy of the receiver with its `unexpectedBetweenPrecedenceGroupAndDesignatedTypes` replaced.
+  /// - param newChild: The new `unexpectedBetweenPrecedenceGroupAndDesignatedTypes` to replace the node's
+  ///                   current `unexpectedBetweenPrecedenceGroupAndDesignatedTypes`, if present.
+  public func withUnexpectedBetweenPrecedenceGroupAndDesignatedTypes(
     _ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 4)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
-  public var comma: TokenSyntax? {
+  /// 
+  /// The designated types associated with this operator.
+  /// 
+  public var designatedTypes: DesignatedTypeListSyntax {
     get {
       let childData = data.child(at: 5, parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
+      return DesignatedTypeListSyntax(childData!)
     }
     set(value) {
-      self = withComma(value)
+      self = withDesignatedTypes(value)
     }
   }
 
-  /// Returns a copy of the receiver with its `comma` replaced.
-  /// - param newChild: The new `comma` to replace the node's
-  ///                   current `comma`, if present.
-  public func withComma(
-    _ newChild: TokenSyntax?) -> OperatorPrecedenceAndTypesSyntax {
-    let raw = newChild?.raw
+  /// Adds the provided `DesignatedTypeElement` to the node's `designatedTypes`
+  /// collection.
+  /// - param element: The new `DesignatedTypeElement` to add to the node's
+  ///                  `designatedTypes` collection.
+  /// - returns: A copy of the receiver with the provided `DesignatedTypeElement`
+  ///            appended to its `designatedTypes` collection.
+  public func addDesignatedTypeElement(_ element: DesignatedTypeElementSyntax) -> OperatorPrecedenceAndTypesSyntax {
+    var collection: RawSyntax
+    if let col = raw.layoutView!.children[5] {
+      collection = col.layoutView!.appending(element.raw, arena: .default)
+    } else {
+      collection = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeList,
+        from: [element.raw], arena: .default)
+    }
+    let newData = data.replacingChild(collection, at: 5)
+    return OperatorPrecedenceAndTypesSyntax(newData)
+  }
+
+  /// Returns a copy of the receiver with its `designatedTypes` replaced.
+  /// - param newChild: The new `designatedTypes` to replace the node's
+  ///                   current `designatedTypes`, if present.
+  public func withDesignatedTypes(
+    _ newChild: DesignatedTypeListSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.designatedTypeList, arena: .default)
     let newData = data.replacingChild(raw, at: 5)
-    return OperatorPrecedenceAndTypesSyntax(newData)
-  }
-
-  public var unexpectedBetweenCommaAndDesignatedType: UnexpectedNodesSyntax? {
-    get {
-      let childData = data.child(at: 6, parent: Syntax(self))
-      if childData == nil { return nil }
-      return UnexpectedNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withUnexpectedBetweenCommaAndDesignatedType(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndDesignatedType` replaced.
-  /// - param newChild: The new `unexpectedBetweenCommaAndDesignatedType` to replace the node's
-  ///                   current `unexpectedBetweenCommaAndDesignatedType`, if present.
-  public func withUnexpectedBetweenCommaAndDesignatedType(
-    _ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
-    return OperatorPrecedenceAndTypesSyntax(newData)
-  }
-
-  /// 
-  /// The designated types for this operator
-  /// 
-  public var designatedType: TokenSyntax? {
-    get {
-      let childData = data.child(at: 7, parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withDesignatedType(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `designatedType` replaced.
-  /// - param newChild: The new `designatedType` to replace the node's
-  ///                   current `designatedType`, if present.
-  public func withDesignatedType(
-    _ newChild: TokenSyntax?) -> OperatorPrecedenceAndTypesSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 7)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 }
@@ -7437,10 +7540,8 @@ extension OperatorPrecedenceAndTypesSyntax: CustomReflectable {
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenColonAndPrecedenceGroup": unexpectedBetweenColonAndPrecedenceGroup.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "precedenceGroup": Syntax(precedenceGroup).asProtocol(SyntaxProtocol.self),
-      "unexpectedBetweenPrecedenceGroupAndComma": unexpectedBetweenPrecedenceGroupAndComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "comma": comma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "unexpectedBetweenCommaAndDesignatedType": unexpectedBetweenCommaAndDesignatedType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "designatedType": designatedType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedBetweenPrecedenceGroupAndDesignatedTypes": unexpectedBetweenPrecedenceGroupAndDesignatedTypes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "designatedTypes": Syntax(designatedTypes).asProtocol(SyntaxProtocol.self),
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -7234,14 +7234,22 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   public init(
     _ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
-    _ unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes: UnexpectedNodesSyntax? = nil,
-    precedenceGroupAndDesignatedTypes: IdentifierListSyntax
+    _ unexpectedBetweenColonAndPrecedenceGroup: UnexpectedNodesSyntax? = nil,
+    precedenceGroup: TokenSyntax,
+    _ unexpectedBetweenPrecedenceGroupAndComma: UnexpectedNodesSyntax? = nil,
+    comma: TokenSyntax?,
+    _ unexpectedBetweenCommaAndDesignatedType: UnexpectedNodesSyntax? = nil,
+    designatedType: TokenSyntax?
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeColon?.raw,
       colon.raw,
-      unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes?.raw,
-      precedenceGroupAndDesignatedTypes.raw,
+      unexpectedBetweenColonAndPrecedenceGroup?.raw,
+      precedenceGroup.raw,
+      unexpectedBetweenPrecedenceGroupAndComma?.raw,
+      comma?.raw,
+      unexpectedBetweenCommaAndDesignatedType?.raw,
+      designatedType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorPrecedenceAndTypes,
       from: layout, arena: .default)
@@ -7290,21 +7298,21 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
-  public var unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenColonAndPrecedenceGroup: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 2, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes(value)
+      self = withUnexpectedBetweenColonAndPrecedenceGroup(value)
     }
   }
 
-  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes` replaced.
-  /// - param newChild: The new `unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes` to replace the node's
-  ///                   current `unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes`, if present.
-  public func withUnexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes(
+  /// Returns a copy of the receiver with its `unexpectedBetweenColonAndPrecedenceGroup` replaced.
+  /// - param newChild: The new `unexpectedBetweenColonAndPrecedenceGroup` to replace the node's
+  ///                   current `unexpectedBetweenColonAndPrecedenceGroup`, if present.
+  public func withUnexpectedBetweenColonAndPrecedenceGroup(
     _ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 2)
@@ -7312,43 +7320,112 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
   }
 
   /// 
-  /// The precedence group and designated types for this operator
+  /// The precedence group for this operator
   /// 
-  public var precedenceGroupAndDesignatedTypes: IdentifierListSyntax {
+  public var precedenceGroup: TokenSyntax {
     get {
       let childData = data.child(at: 3, parent: Syntax(self))
-      return IdentifierListSyntax(childData!)
+      return TokenSyntax(childData!)
     }
     set(value) {
-      self = withPrecedenceGroupAndDesignatedTypes(value)
+      self = withPrecedenceGroup(value)
     }
   }
 
-  /// Adds the provided `PrecedenceGroupAndDesignatedType` to the node's `precedenceGroupAndDesignatedTypes`
-  /// collection.
-  /// - param element: The new `PrecedenceGroupAndDesignatedType` to add to the node's
-  ///                  `precedenceGroupAndDesignatedTypes` collection.
-  /// - returns: A copy of the receiver with the provided `PrecedenceGroupAndDesignatedType`
-  ///            appended to its `precedenceGroupAndDesignatedTypes` collection.
-  public func addPrecedenceGroupAndDesignatedType(_ element: TokenSyntax) -> OperatorPrecedenceAndTypesSyntax {
-    var collection: RawSyntax
-    if let col = raw.layoutView!.children[3] {
-      collection = col.layoutView!.appending(element.raw, arena: .default)
-    } else {
-      collection = RawSyntax.makeLayout(kind: SyntaxKind.identifierList,
-        from: [element.raw], arena: .default)
-    }
-    let newData = data.replacingChild(collection, at: 3)
+  /// Returns a copy of the receiver with its `precedenceGroup` replaced.
+  /// - param newChild: The new `precedenceGroup` to replace the node's
+  ///                   current `precedenceGroup`, if present.
+  public func withPrecedenceGroup(
+    _ newChild: TokenSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+    let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default)
+    let newData = data.replacingChild(raw, at: 3)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
-  /// Returns a copy of the receiver with its `precedenceGroupAndDesignatedTypes` replaced.
-  /// - param newChild: The new `precedenceGroupAndDesignatedTypes` to replace the node's
-  ///                   current `precedenceGroupAndDesignatedTypes`, if present.
-  public func withPrecedenceGroupAndDesignatedTypes(
-    _ newChild: IdentifierListSyntax?) -> OperatorPrecedenceAndTypesSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.identifierList, arena: .default)
-    let newData = data.replacingChild(raw, at: 3)
+  public var unexpectedBetweenPrecedenceGroupAndComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenPrecedenceGroupAndComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenPrecedenceGroupAndComma` replaced.
+  /// - param newChild: The new `unexpectedBetweenPrecedenceGroupAndComma` to replace the node's
+  ///                   current `unexpectedBetweenPrecedenceGroupAndComma`, if present.
+  public func withUnexpectedBetweenPrecedenceGroupAndComma(
+    _ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return OperatorPrecedenceAndTypesSyntax(newData)
+  }
+
+  public var comma: TokenSyntax? {
+    get {
+      let childData = data.child(at: 5, parent: Syntax(self))
+      if childData == nil { return nil }
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `comma` replaced.
+  /// - param newChild: The new `comma` to replace the node's
+  ///                   current `comma`, if present.
+  public func withComma(
+    _ newChild: TokenSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 5)
+    return OperatorPrecedenceAndTypesSyntax(newData)
+  }
+
+  public var unexpectedBetweenCommaAndDesignatedType: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenCommaAndDesignatedType(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenCommaAndDesignatedType` replaced.
+  /// - param newChild: The new `unexpectedBetweenCommaAndDesignatedType` to replace the node's
+  ///                   current `unexpectedBetweenCommaAndDesignatedType`, if present.
+  public func withUnexpectedBetweenCommaAndDesignatedType(
+    _ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return OperatorPrecedenceAndTypesSyntax(newData)
+  }
+
+  /// 
+  /// The designated types for this operator
+  /// 
+  public var designatedType: TokenSyntax? {
+    get {
+      let childData = data.child(at: 7, parent: Syntax(self))
+      if childData == nil { return nil }
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withDesignatedType(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `designatedType` replaced.
+  /// - param newChild: The new `designatedType` to replace the node's
+  ///                   current `designatedType`, if present.
+  public func withDesignatedType(
+    _ newChild: TokenSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 7)
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 }
@@ -7358,8 +7435,12 @@ extension OperatorPrecedenceAndTypesSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeColon": unexpectedBeforeColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
-      "unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes": unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "precedenceGroupAndDesignatedTypes": Syntax(precedenceGroupAndDesignatedTypes).asProtocol(SyntaxProtocol.self),
+      "unexpectedBetweenColonAndPrecedenceGroup": unexpectedBetweenColonAndPrecedenceGroup.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "precedenceGroup": Syntax(precedenceGroup).asProtocol(SyntaxProtocol.self),
+      "unexpectedBetweenPrecedenceGroupAndComma": unexpectedBetweenPrecedenceGroupAndComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "comma": comma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedBetweenCommaAndDesignatedType": unexpectedBetweenCommaAndDesignatedType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "designatedType": designatedType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
@@ -1375,31 +1375,33 @@ extension Array: ExpressibleAsEnumCaseElementList where Element == ExpressibleAs
     return EnumCaseElementList(self)
   }
 }
-/// `IdentifierList` represents a collection of `Token`
-public struct IdentifierList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsIdentifierList {
+/// `DesignatedTypeList` represents a collection of `DesignatedTypeElement`
+public struct DesignatedTypeList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleAsDesignatedTypeList {
   /// The leading trivia attached to this syntax node once built.
   var leadingTrivia: Trivia = []
   /// The trailing trivia attached to this syntax node once built.
   var trailingTrivia: Trivia = []
-  let elements: [Token]
-  /// Creates a `IdentifierList` with the provided list of elements.
+  let elements: [DesignatedTypeElement]
+  /// Creates a `DesignatedTypeList` with the provided list of elements.
   /// - Parameters:
-  ///   - elements: A list of `Token`
-  public init (_ elements: [Token]) {
-    self.elements = elements
-  }
-  /// Creates a new `IdentifierList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsIdentifierList]) {
-    elements = lists.flatMap {
-      $0.createIdentifierList().elements
+  ///   - elements: A list of `ExpressibleAsDesignatedTypeElement`
+  public init (_ elements: [ExpressibleAsDesignatedTypeElement]) {
+    self.elements = elements.map {
+      $0.createDesignatedTypeElement()
     }
   }
-  public init (arrayLiteral elements: Token...) {
+  /// Creates a new `DesignatedTypeList` by flattening the elements in `lists`
+  public init (combining lists: [ExpressibleAsDesignatedTypeList]) {
+    elements = lists.flatMap {
+      $0.createDesignatedTypeList().elements
+    }
+  }
+  public init (arrayLiteral elements: ExpressibleAsDesignatedTypeElement...) {
     self.init(elements)
   }
-  public func buildIdentifierList(format: Format) -> IdentifierListSyntax {
-    var result = IdentifierListSyntax(elements.map {
-      $0.buildToken(format: format)
+  public func buildDesignatedTypeList(format: Format) -> DesignatedTypeListSyntax {
+    var result = DesignatedTypeListSyntax(elements.map {
+      $0.buildDesignatedTypeElement(format: format)
     })
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
@@ -1410,14 +1412,14 @@ public struct IdentifierList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
     return format.format(syntax: result)
   }
   public func buildSyntax(format: Format) -> Syntax {
-    return Syntax(buildIdentifierList(format: format))
+    return Syntax(buildDesignatedTypeList(format: format))
   }
-  /// Conformance to `ExpressibleAsIdentifierList`.
-  public func createIdentifierList() -> IdentifierList {
+  /// Conformance to `ExpressibleAsDesignatedTypeList`.
+  public func createDesignatedTypeList() -> DesignatedTypeList {
     return self
   }
   /// Conformance to `ExpressibleAsSyntaxBuildable`.
-  /// `IdentifierList` may conform to `ExpressibleAsSyntaxBuildable` via different `ExpressibleAs*` paths.
+  /// `DesignatedTypeList` may conform to `ExpressibleAsSyntaxBuildable` via different `ExpressibleAs*` paths.
   /// Thus, there are multiple default implementations of `createSyntaxBuildable`, some of which perform conversions
   /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
   public func createSyntaxBuildable() -> SyntaxBuildable {
@@ -1434,9 +1436,9 @@ public struct IdentifierList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
     return result
   }
 }
-extension Array: ExpressibleAsIdentifierList where Element == Token {
-  public func createIdentifierList() -> IdentifierList {
-    return IdentifierList(self)
+extension Array: ExpressibleAsDesignatedTypeList where Element == ExpressibleAsDesignatedTypeElement {
+  public func createDesignatedTypeList() -> DesignatedTypeList {
+    return DesignatedTypeList(self)
   }
 }
 /// `PrecedenceGroupAttributeList` represents a collection of `SyntaxBuildable`

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -11052,6 +11052,181 @@ public struct OpaqueReturnTypeOfAttributeArguments: SyntaxBuildable, Expressible
     return result
   }
 }
+/// The arguments for the '@convention(...)'.
+public struct ConventionAttributeArguments: SyntaxBuildable, ExpressibleAsConventionAttributeArguments {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
+  var unexpectedBeforeConventionLabel: UnexpectedNodes?
+  var conventionLabel: Token
+  var unexpectedBetweenConventionLabelAndComma: UnexpectedNodes?
+  var comma: Token?
+  var unexpectedBetweenCommaAndCTypeLabel: UnexpectedNodes?
+  var cTypeLabel: Token?
+  var unexpectedBetweenCTypeLabelAndColon: UnexpectedNodes?
+  var colon: Token?
+  var unexpectedBetweenColonAndCTypeString: UnexpectedNodes?
+  var cTypeString: Token?
+  /// Creates a `ConventionAttributeArguments` using the provided parameters.
+  /// - Parameters:
+  ///   - unexpectedBeforeConventionLabel: 
+  ///   - conventionLabel: The convention label.
+  ///   - unexpectedBetweenConventionLabelAndComma: 
+  ///   - comma: 
+  ///   - unexpectedBetweenCommaAndCTypeLabel: 
+  ///   - cTypeLabel: 
+  ///   - unexpectedBetweenCTypeLabelAndColon: 
+  ///   - colon: 
+  ///   - unexpectedBetweenColonAndCTypeString: 
+  ///   - cTypeString: 
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeConventionLabel: ExpressibleAsUnexpectedNodes? = nil, conventionLabel: Token, unexpectedBetweenConventionLabelAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndCTypeLabel: ExpressibleAsUnexpectedNodes? = nil, cTypeLabel: Token? = nil, unexpectedBetweenCTypeLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndCTypeString: ExpressibleAsUnexpectedNodes? = nil, cTypeString: Token? = nil) {
+    self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
+    self.unexpectedBeforeConventionLabel = unexpectedBeforeConventionLabel?.createUnexpectedNodes()
+    self.conventionLabel = conventionLabel
+    assert(conventionLabel.text == #"block"# || conventionLabel.text == #"c"# || conventionLabel.text == #"objc_method"# || conventionLabel.text == #"thin"# || conventionLabel.text == #"thick"#)
+    self.unexpectedBetweenConventionLabelAndComma = unexpectedBetweenConventionLabelAndComma?.createUnexpectedNodes()
+    self.comma = comma
+    assert(comma == nil || comma!.text == #","#)
+    self.unexpectedBetweenCommaAndCTypeLabel = unexpectedBetweenCommaAndCTypeLabel?.createUnexpectedNodes()
+    self.cTypeLabel = cTypeLabel
+    assert(cTypeLabel == nil || cTypeLabel!.text == #"cType"#)
+    self.unexpectedBetweenCTypeLabelAndColon = unexpectedBetweenCTypeLabelAndColon?.createUnexpectedNodes()
+    self.colon = colon
+    assert(colon == nil || colon!.text == #":"#)
+    self.unexpectedBetweenColonAndCTypeString = unexpectedBetweenColonAndCTypeString?.createUnexpectedNodes()
+    self.cTypeString = cTypeString
+  }
+  /// A convenience initializer that allows:
+  ///  - Initializing syntax collections using result builders
+  ///  - Initializing tokens without default text using strings
+  public init (leadingTrivia: Trivia = [], unexpectedBeforeConventionLabel: ExpressibleAsUnexpectedNodes? = nil, conventionLabel: String, unexpectedBetweenConventionLabelAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndCTypeLabel: ExpressibleAsUnexpectedNodes? = nil, cTypeLabel: String?, unexpectedBetweenCTypeLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndCTypeString: ExpressibleAsUnexpectedNodes? = nil, cTypeString: String?) {
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeConventionLabel: unexpectedBeforeConventionLabel, conventionLabel: Token.`identifier`(conventionLabel), unexpectedBetweenConventionLabelAndComma: unexpectedBetweenConventionLabelAndComma, comma: comma, unexpectedBetweenCommaAndCTypeLabel: unexpectedBetweenCommaAndCTypeLabel, cTypeLabel: cTypeLabel.map {
+      Token.`identifier`($0)
+    }, unexpectedBetweenCTypeLabelAndColon: unexpectedBetweenCTypeLabelAndColon, colon: colon, unexpectedBetweenColonAndCTypeString: unexpectedBetweenColonAndCTypeString, cTypeString: cTypeString.map {
+      Token.`stringLiteral`($0)
+    })
+  }
+  /// Builds a `ConventionAttributeArgumentsSyntax`.
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
+  /// - Returns: The built `ConventionAttributeArgumentsSyntax`.
+  func buildConventionAttributeArguments(format: Format) -> ConventionAttributeArgumentsSyntax {
+    var result = ConventionAttributeArgumentsSyntax(unexpectedBeforeConventionLabel?.buildUnexpectedNodes(format: format), conventionLabel: conventionLabel.buildToken(format: format), unexpectedBetweenConventionLabelAndComma?.buildUnexpectedNodes(format: format), comma: comma?.buildToken(format: format), unexpectedBetweenCommaAndCTypeLabel?.buildUnexpectedNodes(format: format), cTypeLabel: cTypeLabel?.buildToken(format: format), unexpectedBetweenCTypeLabelAndColon?.buildUnexpectedNodes(format: format), colon: colon?.buildToken(format: format), unexpectedBetweenColonAndCTypeString?.buildUnexpectedNodes(format: format), cTypeString: cTypeString?.buildToken(format: format))
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
+    return format.format(syntax: result)
+  }
+  /// Conformance to `SyntaxBuildable`.
+  public func buildSyntax(format: Format) -> Syntax {
+    let result = buildConventionAttributeArguments(format: format)
+    return Syntax(result)
+  }
+  /// Conformance to `ExpressibleAsConventionAttributeArguments`.
+  public func createConventionAttributeArguments() -> ConventionAttributeArguments {
+    return self
+  }
+  /// Conformance to `ExpressibleAsSyntaxBuildable`.
+  /// `ConventionAttributeArguments` may conform to `ExpressibleAsSyntaxBuildable` via different `ExpressibleAs*` paths.
+  /// Thus, there are multiple default implementations of `createSyntaxBuildable`, some of which perform conversions
+  /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
+  public func createSyntaxBuildable() -> SyntaxBuildable {
+    return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
+}
+/// The arguments for the '@convention(witness_method: ...)'.
+public struct ConventionWitnessMethodAttributeArguments: SyntaxBuildable, ExpressibleAsConventionWitnessMethodAttributeArguments {
+  /// The leading trivia attached to this syntax node once built.
+  var leadingTrivia: Trivia
+  /// The trailing trivia attached to this syntax node once built.
+  var trailingTrivia: Trivia
+  var unexpectedBeforeWitnessMethodLabel: UnexpectedNodes?
+  var witnessMethodLabel: Token
+  var unexpectedBetweenWitnessMethodLabelAndColon: UnexpectedNodes?
+  var colon: Token
+  var unexpectedBetweenColonAndProtocolName: UnexpectedNodes?
+  var protocolName: Token
+  /// Creates a `ConventionWitnessMethodAttributeArguments` using the provided parameters.
+  /// - Parameters:
+  ///   - unexpectedBeforeWitnessMethodLabel: 
+  ///   - witnessMethodLabel: 
+  ///   - unexpectedBetweenWitnessMethodLabelAndColon: 
+  ///   - colon: 
+  ///   - unexpectedBetweenColonAndProtocolName: 
+  ///   - protocolName: 
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeWitnessMethodLabel: ExpressibleAsUnexpectedNodes? = nil, witnessMethodLabel: Token, unexpectedBetweenWitnessMethodLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndProtocolName: ExpressibleAsUnexpectedNodes? = nil, protocolName: Token) {
+    self.leadingTrivia = leadingTrivia
+    self.trailingTrivia = trailingTrivia
+    self.unexpectedBeforeWitnessMethodLabel = unexpectedBeforeWitnessMethodLabel?.createUnexpectedNodes()
+    self.witnessMethodLabel = witnessMethodLabel
+    self.unexpectedBetweenWitnessMethodLabelAndColon = unexpectedBetweenWitnessMethodLabelAndColon?.createUnexpectedNodes()
+    self.colon = colon
+    assert(colon.text == #":"#)
+    self.unexpectedBetweenColonAndProtocolName = unexpectedBetweenColonAndProtocolName?.createUnexpectedNodes()
+    self.protocolName = protocolName
+  }
+  /// A convenience initializer that allows:
+  ///  - Initializing syntax collections using result builders
+  ///  - Initializing tokens without default text using strings
+  public init (leadingTrivia: Trivia = [], unexpectedBeforeWitnessMethodLabel: ExpressibleAsUnexpectedNodes? = nil, witnessMethodLabel: String, unexpectedBetweenWitnessMethodLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndProtocolName: ExpressibleAsUnexpectedNodes? = nil, protocolName: String) {
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeWitnessMethodLabel: unexpectedBeforeWitnessMethodLabel, witnessMethodLabel: Token.`identifier`(witnessMethodLabel), unexpectedBetweenWitnessMethodLabelAndColon: unexpectedBetweenWitnessMethodLabelAndColon, colon: colon, unexpectedBetweenColonAndProtocolName: unexpectedBetweenColonAndProtocolName, protocolName: Token.`identifier`(protocolName))
+  }
+  /// Builds a `ConventionWitnessMethodAttributeArgumentsSyntax`.
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
+  /// - Returns: The built `ConventionWitnessMethodAttributeArgumentsSyntax`.
+  func buildConventionWitnessMethodAttributeArguments(format: Format) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    var result = ConventionWitnessMethodAttributeArgumentsSyntax(unexpectedBeforeWitnessMethodLabel?.buildUnexpectedNodes(format: format), witnessMethodLabel: witnessMethodLabel.buildToken(format: format), unexpectedBetweenWitnessMethodLabelAndColon?.buildUnexpectedNodes(format: format), colon: colon.buildToken(format: format), unexpectedBetweenColonAndProtocolName?.buildUnexpectedNodes(format: format), protocolName: protocolName.buildToken(format: format))
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
+    }
+    if !trailingTrivia.isEmpty {
+      result = result.withTrailingTrivia(trailingTrivia + (result.trailingTrivia ?? []))
+    }
+    return format.format(syntax: result)
+  }
+  /// Conformance to `SyntaxBuildable`.
+  public func buildSyntax(format: Format) -> Syntax {
+    let result = buildConventionWitnessMethodAttributeArguments(format: format)
+    return Syntax(result)
+  }
+  /// Conformance to `ExpressibleAsConventionWitnessMethodAttributeArguments`.
+  public func createConventionWitnessMethodAttributeArguments() -> ConventionWitnessMethodAttributeArguments {
+    return self
+  }
+  /// Conformance to `ExpressibleAsSyntaxBuildable`.
+  /// `ConventionWitnessMethodAttributeArguments` may conform to `ExpressibleAsSyntaxBuildable` via different `ExpressibleAs*` paths.
+  /// Thus, there are multiple default implementations of `createSyntaxBuildable`, some of which perform conversions
+  /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
+  public func createSyntaxBuildable() -> SyntaxBuildable {
+    return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    var result = self
+    result.leadingTrivia = leadingTrivia
+    return result
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    var result = self
+    result.trailingTrivia = trailingTrivia
+    return result
+  }
+}
 public struct LabeledStmt: StmtBuildable, ExpressibleAsLabeledStmt {
   /// The leading trivia attached to this syntax node once built.
   var leadingTrivia: Trivia

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -9040,29 +9040,50 @@ public struct OperatorPrecedenceAndTypes: SyntaxBuildable, ExpressibleAsOperator
   var trailingTrivia: Trivia
   var unexpectedBeforeColon: UnexpectedNodes?
   var colon: Token
-  var unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes: UnexpectedNodes?
-  var precedenceGroupAndDesignatedTypes: IdentifierList
+  var unexpectedBetweenColonAndPrecedenceGroup: UnexpectedNodes?
+  var precedenceGroup: Token
+  var unexpectedBetweenPrecedenceGroupAndComma: UnexpectedNodes?
+  var comma: Token?
+  var unexpectedBetweenCommaAndDesignatedType: UnexpectedNodes?
+  var designatedType: Token?
   /// Creates a `OperatorPrecedenceAndTypes` using the provided parameters.
   /// - Parameters:
   ///   - unexpectedBeforeColon: 
   ///   - colon: 
-  ///   - unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes: 
-  ///   - precedenceGroupAndDesignatedTypes: The precedence group and designated types for this operator
-  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes: ExpressibleAsUnexpectedNodes? = nil, precedenceGroupAndDesignatedTypes: ExpressibleAsIdentifierList) {
+  ///   - unexpectedBetweenColonAndPrecedenceGroup: 
+  ///   - precedenceGroup: The precedence group for this operator
+  ///   - unexpectedBetweenPrecedenceGroupAndComma: 
+  ///   - comma: 
+  ///   - unexpectedBetweenCommaAndDesignatedType: 
+  ///   - designatedType: The designated types for this operator
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndPrecedenceGroup: ExpressibleAsUnexpectedNodes? = nil, precedenceGroup: Token, unexpectedBetweenPrecedenceGroupAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndDesignatedType: ExpressibleAsUnexpectedNodes? = nil, designatedType: Token? = nil) {
     self.leadingTrivia = leadingTrivia
     self.trailingTrivia = trailingTrivia
     self.unexpectedBeforeColon = unexpectedBeforeColon?.createUnexpectedNodes()
     self.colon = colon
     assert(colon.text == #":"#)
-    self.unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes = unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes?.createUnexpectedNodes()
-    self.precedenceGroupAndDesignatedTypes = precedenceGroupAndDesignatedTypes.createIdentifierList()
+    self.unexpectedBetweenColonAndPrecedenceGroup = unexpectedBetweenColonAndPrecedenceGroup?.createUnexpectedNodes()
+    self.precedenceGroup = precedenceGroup
+    self.unexpectedBetweenPrecedenceGroupAndComma = unexpectedBetweenPrecedenceGroupAndComma?.createUnexpectedNodes()
+    self.comma = comma
+    assert(comma == nil || comma!.text == #","#)
+    self.unexpectedBetweenCommaAndDesignatedType = unexpectedBetweenCommaAndDesignatedType?.createUnexpectedNodes()
+    self.designatedType = designatedType
+  }
+  /// A convenience initializer that allows:
+  ///  - Initializing syntax collections using result builders
+  ///  - Initializing tokens without default text using strings
+  public init (leadingTrivia: Trivia = [], unexpectedBeforeColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndPrecedenceGroup: ExpressibleAsUnexpectedNodes? = nil, precedenceGroup: String, unexpectedBetweenPrecedenceGroupAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndDesignatedType: ExpressibleAsUnexpectedNodes? = nil, designatedType: String?) {
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeColon: unexpectedBeforeColon, colon: colon, unexpectedBetweenColonAndPrecedenceGroup: unexpectedBetweenColonAndPrecedenceGroup, precedenceGroup: Token.`identifier`(precedenceGroup), unexpectedBetweenPrecedenceGroupAndComma: unexpectedBetweenPrecedenceGroupAndComma, comma: comma, unexpectedBetweenCommaAndDesignatedType: unexpectedBetweenCommaAndDesignatedType, designatedType: designatedType.map {
+      Token.`identifier`($0)
+    })
   }
   /// Builds a `OperatorPrecedenceAndTypesSyntax`.
   /// - Parameter format: The `Format` to use.
   /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
   /// - Returns: The built `OperatorPrecedenceAndTypesSyntax`.
   func buildOperatorPrecedenceAndTypes(format: Format) -> OperatorPrecedenceAndTypesSyntax {
-    var result = OperatorPrecedenceAndTypesSyntax(unexpectedBeforeColon?.buildUnexpectedNodes(format: format), colon: colon.buildToken(format: format), unexpectedBetweenColonAndPrecedenceGroupAndDesignatedTypes?.buildUnexpectedNodes(format: format), precedenceGroupAndDesignatedTypes: precedenceGroupAndDesignatedTypes.buildIdentifierList(format: format))
+    var result = OperatorPrecedenceAndTypesSyntax(unexpectedBeforeColon?.buildUnexpectedNodes(format: format), colon: colon.buildToken(format: format), unexpectedBetweenColonAndPrecedenceGroup?.buildUnexpectedNodes(format: format), precedenceGroup: precedenceGroup.buildToken(format: format), unexpectedBetweenPrecedenceGroupAndComma?.buildUnexpectedNodes(format: format), comma: comma?.buildToken(format: format), unexpectedBetweenCommaAndDesignatedType?.buildUnexpectedNodes(format: format), designatedType: designatedType?.buildToken(format: format))
     if !leadingTrivia.isEmpty {
       result = result.withLeadingTrivia(leadingTrivia + (result.leadingTrivia ?? []))
     }

--- a/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
@@ -1155,8 +1155,20 @@ public extension ExpressibleAsOperatorDecl {
     return createOperatorDecl()
   }
 }
-public protocol ExpressibleAsIdentifierList {
-  func createIdentifierList() -> IdentifierList
+public protocol ExpressibleAsDesignatedTypeList {
+  func createDesignatedTypeList() -> DesignatedTypeList
+}
+public protocol ExpressibleAsDesignatedTypeElement: ExpressibleAsDesignatedTypeList, ExpressibleAsSyntaxBuildable {
+  func createDesignatedTypeElement() -> DesignatedTypeElement
+}
+public extension ExpressibleAsDesignatedTypeElement {
+  /// Conformance to `ExpressibleAsDesignatedTypeList`
+  func createDesignatedTypeList() -> DesignatedTypeList {
+    return DesignatedTypeList([self])
+  }
+  func createSyntaxBuildable() -> SyntaxBuildable {
+    return createDesignatedTypeElement()
+  }
 }
 public protocol ExpressibleAsOperatorPrecedenceAndTypes: ExpressibleAsSyntaxBuildable {
   func createOperatorPrecedenceAndTypes() -> OperatorPrecedenceAndTypes

--- a/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
@@ -1401,6 +1401,22 @@ public extension ExpressibleAsOpaqueReturnTypeOfAttributeArguments {
     return createOpaqueReturnTypeOfAttributeArguments()
   }
 }
+public protocol ExpressibleAsConventionAttributeArguments: ExpressibleAsSyntaxBuildable {
+  func createConventionAttributeArguments() -> ConventionAttributeArguments
+}
+public extension ExpressibleAsConventionAttributeArguments {
+  func createSyntaxBuildable() -> SyntaxBuildable {
+    return createConventionAttributeArguments()
+  }
+}
+public protocol ExpressibleAsConventionWitnessMethodAttributeArguments: ExpressibleAsSyntaxBuildable {
+  func createConventionWitnessMethodAttributeArguments() -> ConventionWitnessMethodAttributeArguments
+}
+public extension ExpressibleAsConventionWitnessMethodAttributeArguments {
+  func createSyntaxBuildable() -> SyntaxBuildable {
+    return createConventionWitnessMethodAttributeArguments()
+  }
+}
 public protocol ExpressibleAsLabeledStmt: ExpressibleAsStmtBuildable {
   func createLabeledStmt() -> LabeledStmt
 }

--- a/Sources/SwiftSyntaxBuilder/generated/Format.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/Format.swift
@@ -982,8 +982,16 @@ extension Format {
     }
     return result
   }
-  func format(syntax: IdentifierListSyntax) -> IdentifierListSyntax {
+  func format(syntax: DesignatedTypeListSyntax) -> DesignatedTypeListSyntax {
     syntax
+  }
+  func format(syntax: DesignatedTypeElementSyntax) -> DesignatedTypeElementSyntax {
+    var result = syntax
+    let leadingTrivia = result.leadingTrivia ?? []
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
+    return result
   }
   func format(syntax: OperatorPrecedenceAndTypesSyntax) -> OperatorPrecedenceAndTypesSyntax {
     var result = syntax

--- a/Sources/SwiftSyntaxBuilder/generated/Format.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/Format.swift
@@ -1212,6 +1212,22 @@ extension Format {
     }
     return result
   }
+  func format(syntax: ConventionAttributeArgumentsSyntax) -> ConventionAttributeArgumentsSyntax {
+    var result = syntax
+    let leadingTrivia = result.leadingTrivia ?? []
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
+    return result
+  }
+  func format(syntax: ConventionWitnessMethodAttributeArgumentsSyntax) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    var result = syntax
+    let leadingTrivia = result.leadingTrivia ?? []
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia.addingSpacingAfterNewlinesIfNeeded())
+    }
+    return result
+  }
   func format(syntax: LabeledStmtSyntax) -> LabeledStmtSyntax {
     var result = syntax
     let leadingTrivia = result.leadingTrivia ?? []

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/ResultBuilders.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/ResultBuilders.swift
@@ -1626,19 +1626,19 @@ public extension EnumCaseElementList {
 }
 
 @resultBuilder
-public struct IdentifierListBuilder {
+public struct DesignatedTypeListBuilder {
 
   /// The type of individual statement expressions in the transformed function,
   /// which defaults to Component if buildExpression() is not provided.
-  public typealias Expression = Token
+  public typealias Expression = ExpressibleAsDesignatedTypeElement
 
   /// The type of a partial result, which will be carried through all of the
   /// build methods.
-  public typealias Component = [Token]
+  public typealias Component = [ExpressibleAsDesignatedTypeElement]
 
   /// The type of the final returned result, which defaults to Component if
   /// buildFinalResult() is not provided.
-  public typealias FinalResult = IdentifierList
+  public typealias FinalResult = DesignatedTypeList
 
   /// Required by every result builder to build combined results from
   /// statement blocks.
@@ -1653,8 +1653,8 @@ public struct IdentifierListBuilder {
   }
   
   /// Add all the elements of `expression` to this result builder, effectively flattening them.
-  public static func buildExpression(_ expression: ExpressibleAsIdentifierList) -> Component {
-    return expression.createIdentifierList().elements
+  public static func buildExpression(_ expression: ExpressibleAsDesignatedTypeList) -> Component {
+    return expression.createDesignatedTypeList().elements
   }
   
   /// Enables support for `if` statements that do not have an `else`.
@@ -1690,12 +1690,12 @@ public struct IdentifierListBuilder {
   /// If declared, this will be called on the partial result from the outermost
   /// block statement to produce the final returned result.
   public static func buildFinalResult(_ component: Component) -> FinalResult {
-    return .init(component)
+    return .init(component.map { $0.createDesignatedTypeElement() })
   }
 }
 
-public extension IdentifierList {
-  init(@IdentifierListBuilder itemsBuilder: () -> IdentifierList) {
+public extension DesignatedTypeList {
+  init(@DesignatedTypeListBuilder itemsBuilder: () -> DesignatedTypeList) {
     self = itemsBuilder()
   }
 }

--- a/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
@@ -17,6 +17,6 @@
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "205b7e115c87de4681e9c3f2aec714b5d4c5bdac"
+      "75e0a772c7bda7709669abec13d24936f29e588c"
   }
 }

--- a/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
@@ -17,6 +17,6 @@
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "75e0a772c7bda7709669abec13d24936f29e588c"
+      "67476b99be2ebd121b659aaeeb014ae1d65cb563"
   }
 }

--- a/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
@@ -17,6 +17,6 @@
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "67476b99be2ebd121b659aaeeb014ae1d65cb563"
+      "4bc138d522588a9a6b316462b4ddb0decbbd7fc3"
   }
 }

--- a/Sources/SwiftSyntaxParser/gyb_generated/Serialization.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/Serialization.swift
@@ -196,6 +196,8 @@ extension SyntaxKind {
     case 258: self = .backDeployVersionList
     case 259: self = .backDeployVersionArgument
     case 274: self = .opaqueReturnTypeOfAttributeArguments
+    case 276: self = .conventionAttributeArguments
+    case 277: self = .conventionWitnessMethodAttributeArguments
     case 267: self = .labeledStmt
     case 72: self = .continueStmt
     case 73: self = .whileStmt

--- a/Sources/SwiftSyntaxParser/gyb_generated/Serialization.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/Serialization.swift
@@ -161,7 +161,8 @@ extension SyntaxKind {
     case 20: self = .enumCaseDecl
     case 21: self = .enumDecl
     case 22: self = .operatorDecl
-    case 226: self = .identifierList
+    case 226: self = .designatedTypeList
+    case 278: self = .designatedTypeElement
     case 127: self = .operatorPrecedenceAndTypes
     case 23: self = .precedenceGroupDecl
     case 183: self = .precedenceGroupAttributeList

--- a/Sources/generate-swift-syntax-builder/gyb_generated/AttributeNodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/AttributeNodes.swift
@@ -115,6 +115,10 @@ let ATTRIBUTE_NODES: [Node] = [
                        kind: "NamedAttributeStringArgument"),
                  Child(name: "BackDeployArguments",
                        kind: "BackDeployAttributeSpecList"),
+                 Child(name: "ConventionArguments",
+                       kind: "ConventionAttributeArguments"),
+                 Child(name: "ConventionWitnessMethodArguments",
+                       kind: "ConventionWitnessMethodAttributeArguments"),
                  Child(name: "TokenList",
                        kind: "TokenList",
                        collectionElementName: "Token")
@@ -651,6 +655,75 @@ let ATTRIBUTE_NODES: [Node] = [
                description: "The ordinal corresponding to the 'some' keyword that introduced this opaque type.",
                tokenChoices: [
                  "IntegerLiteral"
+               ])
+       ]),
+
+  Node(name: "ConventionAttributeArguments",
+       nameForDiagnostics: "@convention(...) arguments",
+       description: "The arguments for the '@convention(...)'.",
+       kind: "Syntax",
+       children: [
+         Child(name: "ConventionLabel",
+               kind: "IdentifierToken",
+               description: "The convention label.",
+               tokenChoices: [
+                 "Identifier"
+               ],
+               textChoices: [
+                 "block",
+                 "c",
+                 "objc_method",
+                 "thin",
+                 "thick"
+               ]),
+         Child(name: "Comma",
+               kind: "CommaToken",
+               isOptional: true,
+               tokenChoices: [
+                 "Comma"
+               ]),
+         Child(name: "CTypeLabel",
+               kind: "IdentifierToken",
+               isOptional: true,
+               tokenChoices: [
+                 "Identifier"
+               ],
+               textChoices: [
+                 "cType"
+               ]),
+         Child(name: "Colon",
+               kind: "ColonToken",
+               isOptional: true,
+               tokenChoices: [
+                 "Colon"
+               ]),
+         Child(name: "CTypeString",
+               kind: "StringLiteralToken",
+               isOptional: true,
+               tokenChoices: [
+                 "StringLiteral"
+               ])
+       ]),
+
+  Node(name: "ConventionWitnessMethodAttributeArguments",
+       nameForDiagnostics: "@convention(...) arguments for witness methods",
+       description: "The arguments for the '@convention(witness_method: ...)'.",
+       kind: "Syntax",
+       children: [
+         Child(name: "WitnessMethodLabel",
+               kind: "IdentifierToken",
+               tokenChoices: [
+                 "Identifier"
+               ]),
+         Child(name: "Colon",
+               kind: "ColonToken",
+               tokenChoices: [
+                 "Colon"
+               ]),
+         Child(name: "ProtocolName",
+               kind: "IdentifierToken",
+               tokenChoices: [
+                 "Identifier"
                ])
        ]),
 

--- a/Sources/generate-swift-syntax-builder/gyb_generated/DeclNodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/DeclNodes.swift
@@ -1297,10 +1297,26 @@ let DECL_NODES: [Node] = [
                isOptional: true)
        ]),
 
-  Node(name: "IdentifierList",
+  Node(name: "DesignatedTypeList",
        nameForDiagnostics: nil,
        kind: "SyntaxCollection",
-       element: "IdentifierToken"),
+       element: "DesignatedTypeElement"),
+
+  Node(name: "DesignatedTypeElement",
+       nameForDiagnostics: nil,
+       kind: "Syntax",
+       children: [
+         Child(name: "LeadingComma",
+               kind: "CommaToken",
+               tokenChoices: [
+                 "Comma"
+               ]),
+         Child(name: "Name",
+               kind: "IdentifierToken",
+               tokenChoices: [
+                 "Identifier"
+               ])
+       ]),
 
   Node(name: "OperatorPrecedenceAndTypes",
        nameForDiagnostics: nil,
@@ -1318,19 +1334,10 @@ let DECL_NODES: [Node] = [
                tokenChoices: [
                  "Identifier"
                ]),
-         Child(name: "Comma",
-               kind: "CommaToken",
-               isOptional: true,
-               tokenChoices: [
-                 "Comma"
-               ]),
-         Child(name: "DesignatedType",
-               kind: "IdentifierToken",
-               description: "The designated types for this operator",
-               isOptional: true,
-               tokenChoices: [
-                 "Identifier"
-               ])
+         Child(name: "DesignatedTypes",
+               kind: "DesignatedTypeList",
+               description: "The designated types associated with this operator.",
+               collectionElementName: "DesignatedTypeElement")
        ]),
 
   Node(name: "PrecedenceGroupDecl",

--- a/Sources/generate-swift-syntax-builder/gyb_generated/DeclNodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/DeclNodes.swift
@@ -1312,10 +1312,25 @@ let DECL_NODES: [Node] = [
                tokenChoices: [
                  "Colon"
                ]),
-         Child(name: "PrecedenceGroupAndDesignatedTypes",
-               kind: "IdentifierList",
-               description: "The precedence group and designated types for this operator",
-               collectionElementName: "PrecedenceGroupAndDesignatedType")
+         Child(name: "PrecedenceGroup",
+               kind: "IdentifierToken",
+               description: "The precedence group for this operator",
+               tokenChoices: [
+                 "Identifier"
+               ]),
+         Child(name: "Comma",
+               kind: "CommaToken",
+               isOptional: true,
+               tokenChoices: [
+                 "Comma"
+               ]),
+         Child(name: "DesignatedType",
+               kind: "IdentifierToken",
+               description: "The designated types for this operator",
+               isOptional: true,
+               tokenChoices: [
+                 "Identifier"
+               ])
        ]),
 
   Node(name: "PrecedenceGroupDecl",

--- a/Sources/generate-swift-syntax-builder/gyb_generated/NodeSerializationCodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/NodeSerializationCodes.swift
@@ -286,4 +286,6 @@ public let SYNTAX_NODE_SERIALIZATION_CODES: [String: Int] = [
   "PackExpansionType": 273,
   "OpaqueReturnTypeOfAttributeArguments": 274,
   "HasSymbolCondition": 275,
+  "ConventionAttributeArguments": 276,
+  "ConventionWitnessMethodAttributeArguments": 277,
 ]

--- a/Sources/generate-swift-syntax-builder/gyb_generated/NodeSerializationCodes.swift
+++ b/Sources/generate-swift-syntax-builder/gyb_generated/NodeSerializationCodes.swift
@@ -237,7 +237,7 @@ public let SYNTAX_NODE_SERIALIZATION_CODES: [String: Int] = [
   "AttributedType": 223,
   "YieldStmt": 224,
   "YieldList": 225,
-  "IdentifierList": 226,
+  "DesignatedTypeList": 226,
   "NamedAttributeStringArgument": 227,
   "DeclName": 228,
   "PoundAssertStmt": 229,
@@ -288,4 +288,5 @@ public let SYNTAX_NODE_SERIALIZATION_CODES: [String: Int] = [
   "HasSymbolCondition": 275,
   "ConventionAttributeArguments": 276,
   "ConventionWitnessMethodAttributeArguments": 277,
+  "DesignatedTypeElement": 278,
 ]

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/AttributeNodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/AttributeNodes.py
@@ -69,6 +69,10 @@ ATTRIBUTE_NODES = [
                              kind='NamedAttributeStringArgument'),
                        Child('BackDeployArguments',
                              kind='BackDeployAttributeSpecList'),
+                       Child('ConventionArguments',
+                             kind='ConventionAttributeArguments'),
+                       Child('ConventionWitnessMethodArguments',
+                             kind='ConventionWitnessMethodAttributeArguments'),
                        # TokenList for custom effects which are parsed by
                        # `FunctionEffects.parse()` in swift.
                        Child('TokenList', kind='TokenList',
@@ -486,5 +490,36 @@ ATTRIBUTE_NODES = [
              Child('Comma', kind='CommaToken'),
              Child('Ordinal', kind='IntegerLiteralToken',
                    description="The ordinal corresponding to the 'some' keyword that introduced this opaque type."),
+        ]),
+
+    # convention-attribute-arguments -> token ',' 'cType'? ':' string-literal
+    Node('ConventionAttributeArguments',
+         name_for_diagnostics='@convention(...) arguments',
+         kind='Syntax',
+         description='''
+         The arguments for the '@convention(...)'.
+         ''',
+         children=[
+             Child('ConventionLabel', kind='IdentifierToken',
+                   text_choices=['block', 'c', 'objc_method', 'thin', 'thick'],
+                   description='The convention label.'),
+             Child('Comma', kind='CommaToken', is_optional=True),
+             Child('CTypeLabel', kind='IdentifierToken',
+                   text_choices=['cType'], is_optional=True),
+             Child('Colon', kind='ColonToken', is_optional=True),
+             Child('CTypeString', kind='StringLiteralToken', is_optional=True),
+        ]),
+
+    # convention-attribute-arguments -> 'witness_method' ':' identifier
+    Node('ConventionWitnessMethodAttributeArguments',
+         name_for_diagnostics='@convention(...) arguments for witness methods',
+         kind='Syntax',
+         description='''
+         The arguments for the '@convention(witness_method: ...)'.
+         ''',
+         children=[
+             Child('WitnessMethodLabel', kind='IdentifierToken'),
+             Child('Colon', kind='ColonToken'),
+             Child('ProtocolName', kind='IdentifierToken'),
         ]),
 ]

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/DeclNodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/DeclNodes.py
@@ -756,10 +756,16 @@ DECL_NODES = [
                    is_optional=True),
          ]),
 
-    Node('IdentifierList', name_for_diagnostics=None, kind='SyntaxCollection',
-         element='IdentifierToken'),
+    # designated-type-list -> (',' identifier)*
+    Node('DesignatedTypeList', name_for_diagnostics=None, kind='SyntaxCollection',
+         element='DesignatedTypeElement'),
+    Node('DesignatedTypeElement', name_for_diagnostics=None, kind='Syntax',
+         children=[
+             Child('LeadingComma', kind='CommaToken'),
+             Child('Name', kind='IdentifierToken'),
+         ]),
 
-    # infix-operator-group -> ':' identifier ','? identifier?
+    # infix-operator-group -> ':' identifier designated-type-list?
     Node('OperatorPrecedenceAndTypes', name_for_diagnostics=None, kind='Syntax',
          description='''
          A clause to specify precedence group in infix operator declarations, and designated types in any operator declaration.
@@ -770,13 +776,11 @@ DECL_NODES = [
                    description='''
                    The precedence group for this operator
                    '''),
-             Child('Comma', kind='CommaToken',
-                   is_optional=True),
-             Child('DesignatedType', kind='IdentifierToken',
+             Child('DesignatedTypes', kind='DesignatedTypeList',
+                   collection_element_name='DesignatedTypeElement',
                    description='''
-                   The designated types for this operator
-                   ''',
-                   is_optional=True),
+                   The designated types associated with this operator.
+                   '''),
          ]),
 
     # precedence-group-decl -> attributes? modifiers? 'precedencegroup'

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/DeclNodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/DeclNodes.py
@@ -766,11 +766,17 @@ DECL_NODES = [
          ''',
          children=[
              Child('Colon', kind='ColonToken'),
-             Child('PrecedenceGroupAndDesignatedTypes', kind='IdentifierList',
-                   collection_element_name='PrecedenceGroupAndDesignatedType',
+             Child('PrecedenceGroup', kind='IdentifierToken',
                    description='''
-                   The precedence group and designated types for this operator
+                   The precedence group for this operator
                    '''),
+             Child('Comma', kind='CommaToken',
+                   is_optional=True),
+             Child('DesignatedType', kind='IdentifierToken',
+                   description='''
+                   The designated types for this operator
+                   ''',
+                   is_optional=True),
          ]),
 
     # precedence-group-decl -> attributes? modifiers? 'precedencegroup'

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/NodeSerializationCodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/NodeSerializationCodes.py
@@ -228,7 +228,7 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'AttributedType': 223,
     'YieldStmt': 224,
     'YieldList': 225,
-    'IdentifierList': 226,
+    'DesignatedTypeList': 226,
     'NamedAttributeStringArgument': 227,
     'DeclName': 228,
     'PoundAssertStmt': 229,
@@ -279,6 +279,7 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'HasSymbolCondition': 275,
     'ConventionAttributeArguments': 276,
     'ConventionWitnessMethodAttributeArguments': 277,
+    'DesignatedTypeElement': 278,
 }
 
 

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/NodeSerializationCodes.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/NodeSerializationCodes.py
@@ -277,6 +277,8 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'PackExpansionType': 273,
     'OpaqueReturnTypeOfAttributeArguments': 274,
     'HasSymbolCondition': 275,
+    'ConventionAttributeArguments': 276,
+    'ConventionWitnessMethodAttributeArguments': 277,
 }
 
 

--- a/Tests/SwiftParserTest/Availability.swift
+++ b/Tests/SwiftParserTest/Availability.swift
@@ -50,4 +50,18 @@ final class AvailabilityTests: XCTestCase {
       """
     )
   }
+
+  func testAvailabilityMacros() throws {
+    AssertParse(
+      """
+      @available(_iOS9, _macOS10_11, tvOS 11.0, *)
+      public func composed() {}
+      """)
+
+    AssertParse(
+      """
+      @_specialize(exported: true, availability: SwiftStdlib 5.1, *; where T == Int)
+      public func testSemanticsAvailability<T>(_ t: T) {}
+      """)
+  }
 }

--- a/Tests/SwiftParserTest/Availability.swift
+++ b/Tests/SwiftParserTest/Availability.swift
@@ -64,4 +64,21 @@ final class AvailabilityTests: XCTestCase {
       public func testSemanticsAvailability<T>(_ t: T) {}
       """)
   }
+
+  func testSPIAvailabilityAttribute() throws {
+    AssertParse(
+      """
+      @_spi_available(*, deprecated, renamed: "another")
+      public class SPIClass1 {}
+
+      @_spi_available(*, unavailable)
+      public class SPIClass2 {}
+
+      @_spi_available(AlienPlatform 5.2, *)
+      public class SPIClass3 {}
+
+      @_spi_available(macOS 10.4, *)
+      public class SPIClass4 {}
+      """)
+  }
 }

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -353,6 +353,7 @@ final class DeclarationTests: XCTestCase {
       prefix operator ^^ : PrefixMagicOperatorProtocol
       infix operator  <*< : MediumPrecedence, InfixMagicOperatorProtocol
       postfix operator ^^ : PostfixMagicOperatorProtocol
+      infix operator ^^ : PostfixMagicOperatorProtocol, Class, Struct
       """)
   }
 

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -347,6 +347,13 @@ final class DeclarationTests: XCTestCase {
 
   func testOperators() {
     AssertParse("infix operator *-* : FunnyPrecedence")
+
+    AssertParse(
+      """
+      prefix operator ^^ : PrefixMagicOperatorProtocol
+      infix operator  <*< : MediumPrecedence, InfixMagicOperatorProtocol
+      postfix operator ^^ : PostfixMagicOperatorProtocol
+      """)
   }
 
   func testObjCAttribute() {

--- a/Tests/SwiftParserTest/Directives.swift
+++ b/Tests/SwiftParserTest/Directives.swift
@@ -111,4 +111,42 @@ final class DirectiveTests: XCTestCase {
     )
   }
 
+  func testHasAttribute() {
+    AssertParse(
+      """
+      @frozen
+      #if hasAttribute(foo)
+      @foo
+      #endif
+      public struct S2 { }
+      """)
+
+    AssertParse(
+      """
+      struct Inner {
+        @frozen
+      #if hasAttribute(foo)
+        #if hasAttribute(bar)
+        @foo @bar
+        #endif
+      #endif
+        public struct S2 { }
+
+      #if hasAttribute(foo)
+        @foo
+      #endif
+        @inlinable
+        func f1() { }
+
+      #if hasAttribute(foo)
+        @foo
+      #else
+        @available(*, deprecated, message: "nope")
+        @frozen
+      #endif
+        public struct S3 { }
+      }
+      """)
+  }
+
 }

--- a/Tests/SwiftParserTest/Directives.swift
+++ b/Tests/SwiftParserTest/Directives.swift
@@ -69,6 +69,19 @@ final class DirectiveTests: XCTestCase {
        #sourceLocation(file: "foo", line: 42)
        """
     )
+
+    AssertParse(
+      """
+      public class C<R> {
+
+      #sourceLocation(file: "f.swift", line: 1)
+        public func f<S>(_ s: S) {
+
+      #sourceLocation(file: "f.swift", line: 2)
+          g(s)
+        }
+      }
+      """)
   }
 
   public func testUnterminatedPoundIf() {

--- a/Tests/SwiftParserTest/Types.swift
+++ b/Tests/SwiftParserTest/Types.swift
@@ -84,5 +84,19 @@ final class TypeTests: XCTestCase {
       let _: (S...) -> Int = \S.i
       """#)
   }
+
+  func testConvention() throws {
+    AssertParse(
+      #"""
+      let _: @convention(thin) (@convention(thick) () -> (),
+                                @convention(thin) () -> (),
+                                @convention(c) () -> (),
+                                @convention(c, cType: "intptr_t (*)(size_t)") (Int) -> Int,
+                                @convention(block) () -> (),
+                                @convention(method) () -> (),
+                                @convention(objc_method) () -> (),
+                                @convention(witness_method: Bendable) (Fork) -> ()) -> ()
+      """#)
+  }
 }
 


### PR DESCRIPTION
- Support #if hasAttribute and conditional directives in attribute parsing
- Support #sourceLocation in member lists
- Support @_spi_available
- Provide more robust modeling for @convention's argument list
- Redo precedencegroup  to strike the "list" of designated types