### PR TITLE
[Performance] Minimize RawTokenKindSubset.allCases usage

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -311,6 +311,15 @@ extension Parser {
       case integerLiteral
       case selfKeyword
 
+      init?(lexeme: Lexer.Lexeme) {
+        switch lexeme.tokenKind {
+        case .identifier: self = .identifier
+        case .integerLiteral: self = .integerLiteral
+        case .selfKeyword: self = .selfKeyword
+        default: return nil
+        }
+      }
+
       var rawTokenKind: RawTokenKind {
         switch self {
         case .identifier: return .identifier

--- a/Sources/SwiftParser/DeclarationModifier.swift.gyb
+++ b/Sources/SwiftParser/DeclarationModifier.swift.gyb
@@ -25,6 +25,18 @@ enum DeclarationModifier: SyntaxText, ContextualKeywords, RawTokenKindSubset {
   case ${attr.swift_name} = "${attr.name}"
 % end
 
+  init?(lexeme: Lexer.Lexeme) {
+    switch lexeme.tokenKind {
+% for attr in DECL_MODIFIER_KINDS:
+%   if attr.swift_name.endswith('Keyword'):
+    case .${attr.swift_name}: self = .${attr.swift_name}
+%   end
+% end
+    case .identifier: self.init(rawValue: lexeme.tokenText)
+    default: return nil
+    }
+  }
+
   var rawTokenKind: RawTokenKind {
     switch self {
 % for attr in DECL_MODIFIER_KINDS:

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -393,10 +393,14 @@ extension Parser {
           case postfixOperator
           case prefixOperator
 
-          func accepts(lexeme: Lexer.Lexeme) -> Bool {
-            switch self {
-            case .colon: return true
-            default: return lexeme.tokenText == "=="
+          init?(lexeme: Lexer.Lexeme) {
+            switch (lexeme.tokenKind, lexeme.tokenText) {
+            case (.colon, _): self = .colon
+            case (.spacedBinaryOperator, "=="): self = .spacedBinaryOperator
+            case (.unspacedBinaryOperator, "=="): self = .unspacedBinaryOperator
+            case (.postfixOperator, "=="): self = .postfixOperator
+            case (.prefixOperator, "=="): self = .prefixOperator
+            default: return nil
             }
           }
 
@@ -2044,6 +2048,14 @@ extension Parser {
     enum ExpectedTokenKind: RawTokenKindSubset {
       case poundErrorKeyword
       case poundWarningKeyword
+
+      init?(lexeme: Lexer.Lexeme) {
+        switch lexeme.tokenKind {
+        case .poundErrorKeyword: self = .poundErrorKeyword
+        case .poundWarningKeyword: self = .poundWarningKeyword
+        default: return nil
+        }
+      }
 
       var rawTokenKind: RawTokenKind {
         switch self {

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -173,6 +173,21 @@ extension Parser {
       case arrow
       case throwsKeyword
 
+      init?(lexeme: Lexer.Lexeme) {
+        switch lexeme.tokenKind {
+        case .spacedBinaryOperator: self = .spacedBinaryOperator
+        case .unspacedBinaryOperator: self = .unspacedBinaryOperator
+        case .infixQuestionMark: self = .infixQuestionMark
+        case .equal: self = .equal
+        case .isKeyword: self = .isKeyword
+        case .asKeyword: self = .asKeyword
+        case .identifier where lexeme.tokenText == "async": self = .async
+        case .arrow: self = .arrow
+        case .throwsKeyword: self = .throwsKeyword
+        default: return nil
+        }
+      }
+
       var rawTokenKind: RawTokenKind {
         switch self {
         case .spacedBinaryOperator: return .spacedBinaryOperator

--- a/Sources/SwiftParser/Lookahead.swift
+++ b/Sources/SwiftParser/Lookahead.swift
@@ -283,20 +283,6 @@ extension Parser.Lookahead {
     "_opaqueReturnTypeOf",
   ]
 
-  func isParenthesizedUnowned() -> Bool {
-    assert(self.atContextualKeyword("unowned") && self.peek().tokenKind == .leftParen,
-           "Invariant violated")
-
-    // Look ahead to parse the parenthesized expression.
-    var lookahead = self.lookahead()
-    lookahead.expectIdentifierWithoutRecovery()
-    guard lookahead.consume(if: .leftParen) != nil else {
-      return false
-    }
-    return lookahead.at(.identifier)
-        && lookahead.peek().tokenKind == .rightParen
-        && (lookahead.atContextualKeyword("safe") || lookahead.atContextualKeyword("unsafe"))
-  }
 }
 
 extension Parser.Lookahead {
@@ -364,6 +350,18 @@ extension Parser.Lookahead {
       case poundIfKeyword
       case poundElseKeyword
       case poundElseifKeyword
+
+      init?(lexeme: Lexer.Lexeme) {
+        switch lexeme.tokenKind {
+        case .leftParen: self = .leftParen
+        case .leftBrace: self = .leftBrace
+        case .leftSquareBracket: self = .leftSquareBracket
+        case .poundIfKeyword: self = .poundIfKeyword
+        case .poundElseKeyword: self = .poundElseKeyword
+        case .poundElseifKeyword: self = .poundElseifKeyword
+        default: return nil
+        }
+      }
 
       var rawTokenKind: RawTokenKind {
         switch self {

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -227,7 +227,7 @@ extension Lexer.Lexeme {
   }
 
   func isContextualPunctuator(_ name: SyntaxText) -> Bool {
-    return Operator(self) != nil && self.tokenText == name
+    return Operator(lexeme: self) != nil && self.tokenText == name
   }
 
   var isKeyword: Bool {
@@ -235,7 +235,7 @@ extension Lexer.Lexeme {
   }
 
   func starts(with symbol: SyntaxText) -> Bool {
-    guard Operator(self) != nil || self.tokenKind.isPunctuation else {
+    guard Operator(lexeme: self) != nil || self.tokenKind.isPunctuation else {
       return false
     }
 

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -52,6 +52,17 @@ extension Parser {
       case letKeyword
       case varKeyword
 
+      init?(lexeme: Lexer.Lexeme) {
+        switch lexeme.tokenKind {
+        case .leftParen: self = .leftParen
+        case .wildcardKeyword: self = .wildcardKeyword
+        case .identifier: self = .identifier
+        case .letKeyword: self = .letKeyword
+        case .varKeyword: self = .varKeyword
+        default: return nil
+        }
+      }
+
       var rawTokenKind: RawTokenKind {
         switch self {
         case .leftParen: return .leftParen
@@ -212,6 +223,17 @@ extension Parser.Lookahead {
       case letKeyword
       case varKeyword
       case leftParen
+
+      init?(lexeme: Lexer.Lexeme) {
+        switch lexeme.tokenKind {
+        case .identifier: self = .identifier
+        case .wildcardKeyword: self = .wildcardKeyword
+        case .letKeyword: self = .letKeyword
+        case .varKeyword: self = .varKeyword
+        case .leftParen: self = .leftParen
+        default: return nil
+        }
+      }
 
       var rawTokenKind: RawTokenKind {
         switch self {

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -1086,7 +1086,7 @@ extension Parser.Lookahead {
       }
 
       lookahead.eat(.atSign)
-      lookahead.expectIdentifierWithoutRecovery()
+      lookahead.eat(.identifier)
     }
 
     if allowRecovery {

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -637,7 +637,7 @@ extension Parser.Lookahead {
         return true
       }
 
-      if EffectsSpecifier(self.peek()) != nil {
+      if EffectsSpecifier(lexeme: self.peek()) != nil {
         var backtrack = self.lookahead()
         backtrack.consumeAnyToken()
         backtrack.consumeAnyToken()

--- a/Sources/SwiftParser/gyb_generated/DeclarationModifier.swift
+++ b/Sources/SwiftParser/gyb_generated/DeclarationModifier.swift
@@ -48,6 +48,19 @@ enum DeclarationModifier: SyntaxText, ContextualKeywords, RawTokenKindSubset {
   case _const = "_const"
   case _local = "_local"
 
+  init?(lexeme: Lexer.Lexeme) {
+    switch lexeme.tokenKind {
+    case .staticKeyword: self = .staticKeyword
+    case .classKeyword: self = .classKeyword
+    case .privateKeyword: self = .privateKeyword
+    case .fileprivateKeyword: self = .fileprivateKeyword
+    case .internalKeyword: self = .internalKeyword
+    case .publicKeyword: self = .publicKeyword
+    case .identifier: self.init(rawValue: lexeme.tokenText)
+    default: return nil
+    }
+  }
+
   var rawTokenKind: RawTokenKind {
     switch self {
     case .staticKeyword: return .staticKeyword


### PR DESCRIPTION
`allCases` is not trivial because it creates an Array. We should avoid creating temporary array if possible.

This recovers recent performance regression (2.22s -> 1.31s)

Instead of using `allCases.map { $0.rawTokenKind }.contains(self.currentToken.tokenKind)`, make `RawTokenKindSubset.init(lexeme:)` requirement and `switch` the `tokenKind` in it.