### PR TITLE
Relax Designated Type Parsing; Parse Pack Expansions

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1907,10 +1907,11 @@ extension Parser {
       let (unexpectedBeforeIdentifier, identifier) = self.expectIdentifier()
       var types = [RawDesignatedTypeElementSyntax]()
       while let comma = self.consume(if: .comma) {
-        let (unexpectedBeforeDesignatedType, designatedType) = self.expectIdentifier()
+        // FIXME: The compiler accepts... anything here. This is a bug.
+        // let (unexpectedBeforeDesignatedType, designatedType) = self.expectIdentifier()
+        let designatedType = self.consumeAnyToken()
         types.append(RawDesignatedTypeElementSyntax(
           leadingComma: comma,
-          unexpectedBeforeDesignatedType,
           name: designatedType,
           arena: self.arena))
       }

--- a/Sources/SwiftParser/Types.swift
+++ b/Sources/SwiftParser/Types.swift
@@ -33,6 +33,21 @@ extension Parser {
   ///     type → '(' type ')'
   @_spi(RawSyntax)
   public mutating func parseType() -> RawTypeSyntax {
+    let type = self.parseTypeScalar()
+
+    // Parse pack expansion 'T...'.
+    if self.currentToken.isEllipsis {
+      let ellipsis = self.consumeAnyToken(remapping: .ellipsis)
+      return RawTypeSyntax(
+        RawPackExpansionTypeSyntax(
+          patternType: type,
+          ellipsis: ellipsis,
+          arena: self.arena))
+    }
+    return type
+  }
+
+  mutating func parseTypeScalar() -> RawTypeSyntax {
     let (specifier, attrList) = self.parseTypeAttributeList()
     var base = RawTypeSyntax(self.parseSimpleOrCompositionType())
     if self.lookahead().isAtFunctionTypeArrow() {

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -357,6 +357,7 @@ final class DeclarationTests: XCTestCase {
 
     AssertParse(
       """
+      infix operator  <*<<< : MediumPrecedence, &
       prefix operator ^^ : PrefixMagicOperatorProtocol
       infix operator  <*< : MediumPrecedence, InfixMagicOperatorProtocol
       postfix operator ^^ : PostfixMagicOperatorProtocol

--- a/Tests/SwiftParserTest/Types.swift
+++ b/Tests/SwiftParserTest/Types.swift
@@ -156,5 +156,27 @@ final class TypeTests: XCTestCase {
       }
       """)
   }
+
+  func testPackExpansion() throws {
+    AssertParse(
+      """
+      func f1<@_typeSequence T>() -> T... {}
+      func f2<@_typeSequence T>() -> (T...) {}
+      func f3<@_typeSequence T>() -> G<T... > {}
+      """)
+
+    AssertParse(
+      """
+      enum E<@_typeSequence T> {
+        case f1(_: T...)
+        case f2(_: G<T... >)
+        var x: T... { fatalError() }
+        var x: (T...) { fatalError() }
+        subscript(_: T...) -> Int { fatalError() }
+        subscript() -> T... { fatalError() }
+        subscript() -> (T...) { fatalError() }
+      }
+      """)
+  }
 }
 


### PR DESCRIPTION
- Designated type parsing is pretty buggy, so we need to relax the constraints to match it
- Parse pack expansion ellipses everywhere