### PR TITLE
Use XCTFail over XCTAssertNil for substructure matching

### DIFF
--- a/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
+++ b/Sources/_SwiftSyntaxTestSupport/Syntax+Assertions.swift
@@ -112,8 +112,9 @@ public struct SubtreeMatcher {
   /// `init(markedText:)` has the same structure as `expected`.
   public func assertSameStructure(afterMarker: String? = nil, _ expected: Syntax, includeTrivia: Bool = false,
                                   file: StaticString = #filePath, line: UInt = #line) throws {
-    let diff = try findFirstDifference(afterMarker: afterMarker, baseline: expected, includeTrivia: includeTrivia)
-    XCTAssertNil(diff, diff!.debugDescription, file: file, line: line)
+    if let diff = try findFirstDifference(afterMarker: afterMarker, baseline: expected, includeTrivia: includeTrivia) {
+      XCTFail(diff.debugDescription, file: file, line: line)
+    }
   }
 }
 


### PR DESCRIPTION
There's no reason to print the nil assertion message when matching tree substructures - we just want the diff message itself.