### PR TITLE
SyntaxArena: thread safety

### DIFF
--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -42,8 +42,10 @@ extension Parser {
     // Extended lifetime is required because `SyntaxArena` in the parser must
     // be alive until `Syntax(raw:)` retains the arena.
     return withExtendedLifetime(parser) {
-      let rawSourceFile =  parser.parseSourceFile()
-      return Syntax(raw: rawSourceFile.raw).as(SourceFileSyntax.self)!
+      parser.arena.assumingSingleThread {
+        let rawSourceFile =  parser.parseSourceFile()
+        return Syntax(raw: rawSourceFile.raw).as(SourceFileSyntax.self)!
+      }
     }
   }
 }

--- a/Sources/SwiftParser/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftParser/Syntax+StringInterpolation.swift
@@ -73,7 +73,9 @@ extension SyntaxExpressibleByStringInterpolation {
       var parser = Parser(buffer)
       // FIXME: When the parser supports incremental parsing, put the
       // interpolatedSyntaxNodes in so we don't have to parse them again.
-      return Self.parse(from: &parser)
+      return parser.arena.assumingSingleThread {
+        return Self.parse(from: &parser)
+      }
     }
   }
 

--- a/Tests/SwiftSyntaxTest/MultithreadingTests.swift
+++ b/Tests/SwiftSyntaxTest/MultithreadingTests.swift
@@ -29,8 +29,13 @@ public class MultithreadingTests: XCTestCase {
           presence: .present,
           arena: arena)
       }
-      let token = Syntax(raw: RawSyntax(tokenRaw)).as(TokenSyntax.self)!
-      XCTAssertEqual(token.text, "ident\(i)")
+      let identifierExprRaw = RawIdentifierExprSyntax(
+        identifier: tokenRaw,
+        declNameArguments: nil,
+        arena: arena)
+
+      let expr = Syntax(raw: RawSyntax(identifierExprRaw)).as(IdentifierExprSyntax.self)!
+      XCTAssertEqual(expr.identifier.text, "ident\(i)")
     }
   }
 

--- a/Tests/SwiftSyntaxTest/MultithreadingTests.swift
+++ b/Tests/SwiftSyntaxTest/MultithreadingTests.swift
@@ -1,5 +1,6 @@
 import XCTest
-import SwiftSyntax
+@_spi(RawSyntax) import SwiftSyntax
+
 
 public class MultithreadingTests: XCTestCase {
 
@@ -12,6 +13,24 @@ public class MultithreadingTests: XCTestCase {
 
     DispatchQueue.concurrentPerform(iterations: 100) { _ in
       XCTAssertEqual(tuple.leftParen, tuple.leftParen)
+    }
+  }
+
+  public func testConcurrentArena() {
+    let arena = SyntaxArena()
+
+    DispatchQueue.concurrentPerform(iterations: 100) { i in
+      var identStr = " ident\(i) "
+      let tokenRaw = identStr.withSyntaxText { text in
+        RawTokenSyntax(
+          kind: .identifier,
+          wholeText: arena.intern(text),
+          textRange: 1..<(text.count-1),
+          presence: .present,
+          arena: arena)
+      }
+      let token = Syntax(raw: RawSyntax(tokenRaw)).as(TokenSyntax.self)!
+      XCTAssertEqual(token.text, "ident\(i)")
     }
   }
 


### PR DESCRIPTION
Use mutex to guard concurrent mutation to the arena.
But make a "single thread" mode so that we don't regress performance too much when we know the arena is not used by other threads.

(non `Darwin`/`Glibc` environment e.g. Windows implementation is currently a dummy)

https://github.com/apple/swift-syntax/issues/785
rdar://99812330