### PR TITLE
Add a public API to look up an infix operator by name.

### DIFF
--- a/Sources/SwiftOperators/OperatorTable.swift
+++ b/Sources/SwiftOperators/OperatorTable.swift
@@ -83,13 +83,19 @@ public struct OperatorTable {
 }
 
 extension OperatorTable {
+  /// Returns the ``Operator`` corresponding to the given infix operator, or
+  /// `nil` if it is not defined in the operator table.
+  public func infixOperator(named operatorName: OperatorName) -> Operator? {
+    return infixOperators[operatorName]
+  }
+
   /// Look for the precedence group corresponding to the given operator.
   func lookupOperatorPrecedenceGroupName(
     _ operatorName: OperatorName,
     referencedFrom syntax: Syntax,
     errorHandler: OperatorErrorHandler = { throw $0 }
   ) rethrows -> PrecedenceGroupName? {
-    guard let op = infixOperators[operatorName] else {
+    guard let op = infixOperator(named: operatorName) else {
       try errorHandler(
         .missingOperator(operatorName, referencedFrom: syntax))
       return nil

--- a/Tests/SwiftOperatorsTest/OperatorTableTests.swift
+++ b/Tests/SwiftOperatorsTest/OperatorTableTests.swift
@@ -388,4 +388,21 @@ public class OperatorPrecedenceTests: XCTestCase {
     try opPrecedence.assertExpectedFold(
       "await x + y + z", "await ((x + y) + z)")
   }
+
+  func testInfixOperatorLookup() throws {
+    let opPrecedence = OperatorTable.standardOperators
+    do {
+      let op = try XCTUnwrap(opPrecedence.infixOperator(named: "+"))
+      XCTAssertEqual(op.kind, .infix)
+      XCTAssertEqual(op.name, "+")
+      XCTAssertEqual(op.precedenceGroup, "AdditionPrecedence")
+    }
+    do {
+      let op = try XCTUnwrap(opPrecedence.infixOperator(named: "..."))
+      XCTAssertEqual(op.kind, .infix)
+      XCTAssertEqual(op.name, "...")
+      XCTAssertEqual(op.precedenceGroup, "RangeFormationPrecedence")
+    }
+    XCTAssertNil(opPrecedence.infixOperator(named: "^*^"))
+  }
 }


### PR DESCRIPTION
Rather than limit myself in with an API specifically for the precedence group, returning the full `Operator` value seems more flexible/future-proof.

I added analogs for prefix and postfix operators, and then realized when writing tests that the `defaultOperators` set doesn't include those yet! So I stuck with just the infix API and we can revisit prefix/postfix later—it doesn't seem right to offer those public APIs if they don't have the expected behavior when called on `defaultOperators` yet.