### PR TITLE
Fix loop breaking condition for dictionary literal parsing.

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1557,7 +1557,7 @@ extension Parser {
   mutating func parseCollectionElement(_ existing: CollectionKind?) -> CollectionKind {
     let key = self.parseExpression()
     switch existing {
-    case .array(_):
+    case .array:
       return .array(key)
     case nil:
       guard self.at(.colon) else {
@@ -1630,7 +1630,7 @@ extension Parser {
             valueExpression: value,
             trailingComma: comma,
             arena: self.arena)))
-          if key.is(RawMissingExprSyntax.self), colon.isMissing, value.is(RawMissingExprSyntax.self) {
+          if key.is(RawMissingExprSyntax.self) || colon.isMissing || value.is(RawMissingExprSyntax.self) {
             break COLLECTION_LOOP
           }
         }

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -162,9 +162,7 @@ final class ExpressionTests: XCTestCase {
       ([1:#^DIAG^#)
       """,
       diagnostics: [
-        // FIXME: Why is this diagnostic produced?
-        DiagnosticSpec(message: "Expected ':' in dictionary"),
-        DiagnosticSpec(message: "Expected ']' to end dictionary"),
+        DiagnosticSpec(message: "Expected ']' to end dictionary")
       ]
     )
   }


### PR DESCRIPTION
This resolves a FIXME I found in the tests - the loop break previously required the key AND colon AND value to be missing, which I don't think is even possible to satisfy.