### PR TITLE
Add _noMetadata attribute

### DIFF
--- a/Sources/SwiftParser/gyb_generated/DeclarationAttribute.swift
+++ b/Sources/SwiftParser/gyb_generated/DeclarationAttribute.swift
@@ -119,6 +119,7 @@ extension Parser {
     case _spiOnly = "_spiOnly"
     case _documentation = "_documentation"
     case typeWrapperIgnored = "typeWrapperIgnored"
+    case _noMetadata = "_noMetadata"
     case _spi_available = "_spi_available"
   }
 }

--- a/Sources/SwiftParser/gyb_generated/TypeAttribute.swift
+++ b/Sources/SwiftParser/gyb_generated/TypeAttribute.swift
@@ -27,6 +27,7 @@ extension Parser {
     case unchecked = "unchecked"
     case _typeSequence = "_typeSequence"
     case _local = "_local"
+    case _noMetadata = "_noMetadata"
     case _opaqueReturnTypeOf = "_opaqueReturnTypeOf"
   }
 }

--- a/Sources/generate-swift-syntax-builder/gyb_syntax_support/AttributeKinds.py
+++ b/Sources/generate-swift-syntax-builder/gyb_syntax_support/AttributeKinds.py
@@ -136,6 +136,7 @@ TYPE_ATTR_KINDS = [
     TypeAttribute('unchecked'),
     TypeAttribute('_typeSequence'),
     TypeAttribute('_local'),
+    TypeAttribute('_noMetadata'),
 
     # Generated interface attributes
     TypeAttribute('_opaqueReturnTypeOf'),
@@ -690,6 +691,13 @@ DECL_ATTR_KINDS = [
                         OnVar,
                         ABIStableToAdd, ABIStableToRemove, APIStableToAdd, APIStableToRemove,
                         code=137),
+
+    SimpleDeclAttribute('_noMetadata', 'NoMetadata',
+                        OnGenericTypeParam,
+                        UserInaccessible,
+                        NotSerialized,
+                        ABIStableToAdd, ABIBreakingToRemove, APIStableToAdd, APIStableToRemove,
+                        code=138)
 ]
 
 # Schema for declaration modifiers:


### PR DESCRIPTION
Adds the @_noMetadata attribute that is required for layout based pre-specializations