### PR TITLE
Add prefix/postfix operators to the built-in operator tables

### DIFF
--- a/Sources/SwiftOperators/Operator.swift
+++ b/Sources/SwiftOperators/Operator.swift
@@ -39,7 +39,7 @@ public struct Operator {
 
   public init(
     kind: OperatorKind, name: OperatorName,
-    precedenceGroup: PrecedenceGroupName?,
+    precedenceGroup: PrecedenceGroupName? = nil,
     syntax: OperatorDeclSyntax? = nil
   ) {
     self.kind = kind

--- a/Sources/SwiftOperators/OperatorTable+Defaults.swift
+++ b/Sources/SwiftOperators/OperatorTable+Defaults.swift
@@ -26,6 +26,7 @@ extension OperatorTable {
     ]
 
     let operators: [Operator] = [
+      Operator(kind: .prefix, name: "!"),
       Operator(kind: .infix, name: "&&",
                precedenceGroup: "LogicalConjunctionPrecedence"),
       Operator(kind: .infix, name: "||",
@@ -121,6 +122,21 @@ extension OperatorTable {
     ]
 
     let operators: [Operator] = [
+      // Standard postfix operators.
+      Operator(kind: .postfix, name: "++"),
+      Operator(kind: .postfix, name: "--"),
+      Operator(kind: .postfix, name: "..."),
+
+      // Standard prefix operators.
+      Operator(kind: .prefix, name: "++"),
+      Operator(kind: .prefix, name: "--"),
+      Operator(kind: .prefix, name: "!"),
+      Operator(kind: .prefix, name: "~"),
+      Operator(kind: .prefix, name: "+"),
+      Operator(kind: .prefix, name: "-"),
+      Operator(kind: .prefix, name: "..."),
+      Operator(kind: .prefix, name: "..<"),
+
       // "Exponentiative"
       Operator(
         kind: .infix,

--- a/Sources/SwiftOperators/OperatorTable.swift
+++ b/Sources/SwiftOperators/OperatorTable.swift
@@ -89,6 +89,18 @@ extension OperatorTable {
     return infixOperators[operatorName]
   }
 
+  /// Returns the ``Operator`` corresponding to the given prefix operator, or
+  /// `nil` if it is not defined in the operator table.
+  public func prefixOperator(named operatorName: OperatorName) -> Operator? {
+    return prefixOperators[operatorName]
+  }
+
+  /// Returns the ``Operator`` corresponding to the given prefix operator, or
+  /// `nil` if it is not defined in the operator table.
+  public func postfixOperator(named operatorName: OperatorName) -> Operator? {
+    return postfixOperators[operatorName]
+  }
+
   /// Look for the precedence group corresponding to the given operator.
   func lookupOperatorPrecedenceGroupName(
     _ operatorName: OperatorName,

--- a/Tests/SwiftOperatorsTest/OperatorTableTests.swift
+++ b/Tests/SwiftOperatorsTest/OperatorTableTests.swift
@@ -405,4 +405,22 @@ public class OperatorPrecedenceTests: XCTestCase {
     }
     XCTAssertNil(opPrecedence.infixOperator(named: "^*^"))
   }
+
+  func testUnaryOperatorLookup() throws {
+    let opPrecedence = OperatorTable.standardOperators
+    do {
+      let op = try XCTUnwrap(opPrecedence.prefixOperator(named: "-"))
+      XCTAssertEqual(op.kind, .prefix)
+      XCTAssertEqual(op.name, "-")
+      XCTAssertNil(op.precedenceGroup)
+    }
+
+    do {
+      let op = try XCTUnwrap(opPrecedence.postfixOperator(named: "..."))
+      XCTAssertEqual(op.kind, .postfix)
+      XCTAssertEqual(op.name, "...")
+      XCTAssertNil(op.precedenceGroup)
+    }
+
+  }
 }

--- a/Tests/SwiftOperatorsTest/SyntaxSynthesisTests.swift
+++ b/Tests/SwiftOperatorsTest/SyntaxSynthesisTests.swift
@@ -52,6 +52,7 @@ public class SyntaxSynthesisTests: XCTestCase {
       precedencegroup LogicalDisjunctionPrecedence {
           associativity: left
       }
+      prefix operator !
       infix operator &&: LogicalConjunctionPrecedence
       infix operator ||: LogicalDisjunctionPrecedence
 


### PR DESCRIPTION
Also add lookup functions `prefixOperator` and `postfixOperator`.