### PR TITLE
Revert "SyntaxArena: thread safety"

### DIFF
--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -42,10 +42,8 @@ extension Parser {
     // Extended lifetime is required because `SyntaxArena` in the parser must
     // be alive until `Syntax(raw:)` retains the arena.
     return withExtendedLifetime(parser) {
-      parser.arena.assumingSingleThread {
-        let rawSourceFile =  parser.parseSourceFile()
-        return Syntax(raw: rawSourceFile.raw).as(SourceFileSyntax.self)!
-      }
+      let rawSourceFile =  parser.parseSourceFile()
+      return Syntax(raw: rawSourceFile.raw).as(SourceFileSyntax.self)!
     }
   }
 }

--- a/Sources/SwiftParser/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftParser/Syntax+StringInterpolation.swift
@@ -73,9 +73,7 @@ extension SyntaxExpressibleByStringInterpolation {
       var parser = Parser(buffer)
       // FIXME: When the parser supports incremental parsing, put the
       // interpolatedSyntaxNodes in so we don't have to parse them again.
-      return parser.arena.assumingSingleThread {
-        return Self.parse(from: &parser)
-      }
+      return Self.parse(from: &parser)
     }
   }
 

--- a/Tests/SwiftSyntaxTest/MultithreadingTests.swift
+++ b/Tests/SwiftSyntaxTest/MultithreadingTests.swift
@@ -1,6 +1,5 @@
 import XCTest
-@_spi(RawSyntax) import SwiftSyntax
-
+import SwiftSyntax
 
 public class MultithreadingTests: XCTestCase {
 
@@ -13,29 +12,6 @@ public class MultithreadingTests: XCTestCase {
 
     DispatchQueue.concurrentPerform(iterations: 100) { _ in
       XCTAssertEqual(tuple.leftParen, tuple.leftParen)
-    }
-  }
-
-  public func testConcurrentArena() {
-    let arena = SyntaxArena()
-
-    DispatchQueue.concurrentPerform(iterations: 100) { i in
-      var identStr = " ident\(i) "
-      let tokenRaw = identStr.withSyntaxText { text in
-        RawTokenSyntax(
-          kind: .identifier,
-          wholeText: arena.intern(text),
-          textRange: 1..<(text.count-1),
-          presence: .present,
-          arena: arena)
-      }
-      let identifierExprRaw = RawIdentifierExprSyntax(
-        identifier: tokenRaw,
-        declNameArguments: nil,
-        arena: arena)
-
-      let expr = Syntax(raw: RawSyntax(identifierExprRaw)).as(IdentifierExprSyntax.self)!
-      XCTAssertEqual(expr.identifier.text, "ident\(i)")
     }
   }
 


### PR DESCRIPTION
Reverts apple/swift-syntax#807
https://ci.swift.org/job/oss-swift-pr-test-macoss//1197/console
```
error: 'os_unfair_lock_t' is only available in macOS 10.12 or newer
```