### PR TITLE
Roll Back ArgumentParser Dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -201,7 +201,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   // Building standalone.
   package.dependencies += [
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.4")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.1")),
   ]
 } else {
   package.dependencies += [


### PR DESCRIPTION
This matches the version number found in the rest of the Swift projects and also matches update-checkout which is pinned to version 1.0.3.