### PR TITLE
Fix issues that are preventing us from switching the stress tester to the new parser

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -117,7 +117,7 @@ extension Parser {
         leftParen: nil, argumentList: nil, rightParen: nil,
         arena: self.arena)
     }
-    let arguments = self.parseArgumentListElements()
+    let arguments = self.parseArgumentListElements(inLetOrVar: false)
     let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
     return RawCustomAttributeSyntax(
       unexpectedBeforeAtSign,

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -302,7 +302,7 @@ extension Parser {
         let attributes = self.parseAttributeList()
 
         let (unexpectedBeforeName, name) = self.expectIdentifier()
-        if unexpectedBeforeName == nil && name.isMissing && elements.isEmpty {
+        if attributes == nil && unexpectedBeforeName == nil && name.isMissing && elements.isEmpty {
           break
         }
 

--- a/Sources/SwiftParser/Names.swift
+++ b/Sources/SwiftParser/Names.swift
@@ -57,7 +57,7 @@ extension Parser {
     if self.at(.identifier) || self.at(any: [.selfKeyword, .capitalSelfKeyword]) {
       ident = self.expectIdentifierWithoutRecovery()
     } else if flags.contains(.operators), let (_, _) = self.at(anyIn: Operator.self) {
-      ident = self.consumeAnyToken(remapping: .identifier)
+      ident = self.consumeAnyToken(remapping: .unspacedBinaryOperator)
     } else if flags.contains(.keywords) && self.currentToken.tokenKind.isKeyword {
       ident = self.consumeAnyToken(remapping: .identifier)
     } else {

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -177,6 +177,7 @@ func AssertDiagnostic<T: SyntaxProtocol>(
 func AssertParse(
   _ markedSource: String,
   substructure expectedSubstructure: Syntax? = nil,
+  substructureAfterMarker: String = "START",
   diagnostics expectedDiagnostics: [DiagnosticSpec] = [],
   fixedSource expectedFixedSource: String? = nil,
   file: StaticString = #file,
@@ -185,6 +186,7 @@ func AssertParse(
   return AssertParse(markedSource,
                      { $0.parseSourceFile() },
                      substructure: expectedSubstructure,
+                     substructureAfterMarker: substructureAfterMarker,
                      diagnostics: expectedDiagnostics,
                      fixedSource: expectedFixedSource,
                      file: file,

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -1059,6 +1059,21 @@ final class DeclarationTests: XCTestCase {
       }
       """)
   }
+
+  func testStandaloneAtSignInGenericParameter() {
+    AssertParse(
+      """
+      struct U<@#^DIAG^#
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "Expected name of attribute"),
+        DiagnosticSpec(message: "Expected identifier in generic parameter"),
+        DiagnosticSpec(message: "Expected '>' to end generic parameter clause"),
+        DiagnosticSpec(message: "Expected '{' to start struct"),
+        DiagnosticSpec(message: "Expected '}' to end struct"),
+      ]
+    )
+  }
 }
 
 extension Parser.DeclAttributes {

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -577,4 +577,12 @@ final class ExpressionTests: XCTestCase {
       _ = ##""" foo # "# "##
       """###)
   }
+
+  func testOperatorReference() {
+    AssertParse(
+      "reduce(0, #^PLUS^#+)",
+      substructure: Syntax(TokenSyntax.unspacedBinaryOperator("+")),
+      substructureAfterMarker: "PLUS"
+    )
+  }
 }

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -265,4 +265,13 @@ final class StatementTests: XCTestCase {
       """
     )
   }
+
+  func testIdentifierPattern() {
+    AssertParse(
+      "switch x { case let .y(z): break }",
+      substructure: Syntax(IdentifierPatternSyntax(
+        identifier: .identifier("z")
+      ))
+    )
+  }
 }


### PR DESCRIPTION

- Don’t remap operators in DeclNameRef to identifiers
  - Fixes #833 rdar://100319818
- Propagate `inLetOrVar` in more cases
  - Fixes #831 rdar://100301666
- Fix generic parameter round trip failure
  - Fixes #835 rdar://100321071