### PR TITLE
Translate test case from swift/test/Parse to SwiftParserTest

### DIFF
--- a/Tests/SwiftParserTest/translated/ActorTests.swift
+++ b/Tests/SwiftParserTest/translated/ActorTests.swift
@@ -1,0 +1,34 @@
+// This test file has been translated from swift/test/Parse/actor.swift
+
+import XCTest
+
+final class ActorTests: XCTestCase {
+  func testActor1() {
+    AssertParse(
+      """
+      actor MyActor1#^DIAG^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected '{' in actor
+        DiagnosticSpec(message: "expected member block in actor"),
+      ]
+    )
+  }
+
+  func testActor2() {
+    AssertParse(
+      """
+      actor MyActor2 { 
+          init() {
+          }
+      func hello() { }#^DIAG^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 1: to match this opening '{'
+        DiagnosticSpec(message: "expected '}' to end actor"),
+        // TODO: Old parser expected error on line 5: expected '}' in actor
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/AlwaysEmitConformanceMetadataAttrTests.swift
+++ b/Tests/SwiftParserTest/translated/AlwaysEmitConformanceMetadataAttrTests.swift
@@ -1,0 +1,23 @@
+// This test file has been translated from swift/test/Parse/alwaysEmitConformanceMetadata_attr.swift
+
+import XCTest
+
+final class AlwaysEmitConformanceMetadataAttrTests: XCTestCase {
+  func testAlwaysEmitConformanceMetadataAttr1() {
+    AssertParse(
+      """
+      import Swift
+      """
+    )
+  }
+
+  func testAlwaysEmitConformanceMetadataAttr2() {
+    AssertParse(
+      """
+      @_alwaysEmitConformanceMetadata
+      protocol Test {}
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/AsyncSyntaxTests.swift
+++ b/Tests/SwiftParserTest/translated/AsyncSyntaxTests.swift
@@ -1,0 +1,68 @@
+// This test file has been translated from swift/test/Parse/async-syntax.swift
+
+import XCTest
+
+final class AsyncSyntaxTests: XCTestCase {
+  func testAsyncSyntax1() {
+    AssertParse(
+      """
+      func asyncGlobal1() async { }
+      func asyncGlobal2() async throws { }
+      """
+    )
+  }
+
+  func testAsyncSyntax2() {
+    AssertParse(
+      """
+      typealias AsyncFunc1 = () async -> ()
+      typealias AsyncFunc2 = () async throws -> ()
+      typealias AsyncFunc3 = (_ a: Bool, _ b: Bool) async throws -> ()
+      """
+    )
+  }
+
+  func testAsyncSyntax3() {
+    AssertParse(
+      """
+      func testTypeExprs() {
+        let _ = [() async -> ()]()
+        let _ = [() async throws -> ()]()
+      }
+      """
+    )
+  }
+
+  func testAsyncSyntax4() {
+    AssertParse(
+      """
+      func testAwaitOperator() async {
+        let _ = await asyncGlobal1()
+      }
+      """
+    )
+  }
+
+  func testAsyncSyntax5() {
+    AssertParse(
+      """
+      func testAsyncClosure() {
+        let _ = { () async in 5 }
+        let _ = { () throws in 5 }
+        let _ = { () async throws in 5 }
+      }
+      """
+    )
+  }
+
+  func testAsyncSyntax6() {
+    AssertParse(
+      """
+      func testAwait() async {
+        let _ = await asyncGlobal1()
+      }
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/AsyncTests.swift
+++ b/Tests/SwiftParserTest/translated/AsyncTests.swift
@@ -1,0 +1,216 @@
+// This test file has been translated from swift/test/Parse/async.swift
+
+import XCTest
+
+final class AsyncTests: XCTestCase {
+  func testAsync1() {
+    AssertParse(
+      """
+      // Parsing function declarations with 'async'
+      func asyncGlobal1() async { }
+      func asyncGlobal2() async throws { }
+      """
+    )
+  }
+
+  func testAsync2() {
+    AssertParse(
+      """
+      func asyncGlobal3() throws async { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'async' must precede 'throws', Fix-It replacements: 28 - 34 = '', 21 - 21 = 'async '
+      ]
+    )
+  }
+
+  func testAsync3() {
+    AssertParse(
+      """
+      func asyncGlobal3(fn: () throws -> Int) rethrows async { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'async' must precede 'rethrows', Fix-It replacements: 50 - 56 = '', 41 - 41 = 'async '
+      ]
+    )
+  }
+
+  func testAsync4() {
+    AssertParse(
+      """
+      func asyncGlobal4() -> Int async { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'async' may only occur before '->', Fix-It replacements: 28 - 34 = '', 21 - 21 = 'async '
+      ]
+    )
+  }
+
+  func testAsync5() {
+    AssertParse(
+      """
+      func asyncGlobal5() -> Int async throws #^DIAG^#{ }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'async' may only occur before '->', Fix-It replacements: 28 - 34 = '', 21 - 21 = 'async '
+        // TODO: Old parser expected error on line 1: 'throws' may only occur before '->', Fix-It replacements: 34 - 41 = '', 21 - 21 = 'throws '
+        DiagnosticSpec(message: "expected '->'"),
+      ]
+    )
+  }
+
+  func testAsync6() {
+    AssertParse(
+      """
+      func asyncGlobal6() -> Int #^DIAG^#throws async { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'throws' may only occur before '->', Fix-It replacements: 28 - 35 = '', 21 - 21 = 'throws '
+        // TODO: Old parser expected error on line 1: 'async' may only occur before '->', Fix-It replacements: 35 - 41 = '', 21 - 21 = 'async '
+        DiagnosticSpec(message: "extraneous 'throws async { }' at top level"),
+      ]
+    )
+  }
+
+  func testAsync7() {
+    AssertParse(
+      """
+      func asyncGlobal7() throws -> Int async { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'async' may only occur before '->', Fix-It replacements: 35 - 41 = '', 21 - 21 = 'async '
+      ]
+    )
+  }
+
+  func testAsync8() {
+    AssertParse(
+      """
+      func asyncGlobal8() async throws async -> async Int async {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'async' has already been specified, Fix-It replacements: 34 - 40 = ''
+        // TODO: Old parser expected error on line 1: 'async' has already been specified, Fix-It replacements: 43 - 49 = ''
+        // TODO: Old parser expected error on line 1: 'async' has already been specified, Fix-It replacements: 53 - 59 = ''
+      ]
+    )
+  }
+
+  func testAsync9() {
+    AssertParse(
+      """
+      class X {
+        init() async { }
+        deinit async #^DIAG_1^#{ } 
+        func f() async { }
+        subscript(x: Int) #^DIAG_2^#async #^DIAG_3^#-> Int { 
+          get {
+            return 0
+          }
+          set async { 
+          }
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: deinitializers cannot have a name
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '{ }' in function"),
+        // TODO: Old parser expected error on line 5: expected '->' for subscript element type
+        // TODO: Old parser expected error on line 5: single argument function types require parentheses
+        // TODO: Old parser expected error on line 5: cannot find type 'async' in scope
+        // TODO: Old parser expected note on line 5: cannot use module 'async' as a type
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '->' and return type in subscript"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected declaration after 'async' modifier in class"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text in class"),
+        // TODO: Old parser expected error on line 9: 'set' accessor cannot have specifier 'async'
+      ]
+    )
+  }
+
+  func testAsync10() {
+    AssertParse(
+      """
+      // Parsing function types with 'async'.
+      typealias AsyncFunc1 = () async -> ()
+      typealias AsyncFunc2 = () async throws -> ()
+      typealias AsyncFunc3 = () throws async -> ()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: 'async' must precede 'throws', Fix-It replacements: 34 - 40 = '', 27 - 27 = 'async '
+      ]
+    )
+  }
+
+  func testAsync11() {
+    AssertParse(
+      """
+      // Parsing type expressions with 'async'.
+      func testTypeExprs() {
+        let _ = [() async -> ()]()
+        let _ = [() async throws -> ()]()
+        let _ = [() throws #^DIAG^#async -> ()]()  
+        let _ = [() -> async ()]() 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: 'async' must precede 'throws', Fix-It replacements: 22 - 28 = '', 15 - 15 = 'async '
+        DiagnosticSpec(message: "unexpected text 'async' in array element"),
+        // TODO: Old parser expected error on line 6: 'async' may only occur before '->', Fix-It replacements: 18 - 24 = '', 15 - 15 = 'async '
+      ]
+    )
+  }
+
+  func testAsync12() {
+    AssertParse(
+      """
+      // Parsing await syntax.
+      struct MyFuture {
+        func await() -> Int { 0 }
+      }
+      """
+    )
+  }
+
+  func testAsync13() {
+    AssertParse(
+      """
+      func testAwaitExpr() async {
+        let _ = await asyncGlobal1()
+        let myFuture = MyFuture()
+        let _ = myFuture.await()
+      }
+      """
+    )
+  }
+
+  func testAsync14() {
+    AssertParse(
+      """
+      func getIntSomeday() async -> Int { 5 }
+      """
+    )
+  }
+
+  func testAsync15() {
+    AssertParse(
+      """
+      func testAsyncLet() async {
+        async let x = await getIntSomeday()
+        _ = await x
+      }
+      """
+    )
+  }
+
+  func testAsync16() {
+    AssertParse(
+      """
+      async func asyncIncorrectly() { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'async' must be written after the parameter list of a function, Fix-It replacements: 1 - 7 = '', 30 - 30 = ' async'
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
@@ -176,11 +176,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """
       if #available(iDishwasherOS 10.51) { 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
-        // TODO: Old parser expected error on line 1: must handle potential future platforms with '*'
-      ]
+      """
     )
   }
 
@@ -189,10 +185,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """
       if #available(iDishwasherOS 10.51, *) { 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
-      ]
+      """
     )
   }
 
@@ -201,10 +194,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """
       if #available(macos 10.51, *) { 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'macos'; did you mean 'macOS'?, Fix-It replacements: 15 - 20 = 'macOS'
-      ]
+      """
     )
   }
 
@@ -213,10 +203,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """
       if #available(mscos 10.51, *) { 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'mscos'; did you mean 'macOS'?, Fix-It replacements: 15 - 20 = 'macOS'
-      ]
+      """
     )
   }
 
@@ -225,10 +212,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """
       if #available(macoss 10.51, *) { 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'macoss'; did you mean 'macOS'?, Fix-It replacements: 15 - 21 = 'macOS'
-      ]
+      """
     )
   }
 
@@ -237,10 +221,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """
       if #available(mac 10.51, *) { 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'mac'; did you mean 'macOS'?, Fix-It replacements: 15 - 18 = 'macOS'
-      ]
+      """
     )
   }
 
@@ -249,10 +230,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """
       if #available(OSX 10.51, OSX 10.52, *) {  
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: version for 'macOS' already specified
-      ]
+      """
     )
   }
 
@@ -260,10 +238,7 @@ final class AvailabilityQueryTests: XCTestCase {
     AssertParse(
       """
       if #available(OSX 10.52) { }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: must handle potential future platforms with '*', Fix-It replacements: 24 - 24 = ', *'
-      ]
+      """
     )
   }
 
@@ -271,10 +246,7 @@ final class AvailabilityQueryTests: XCTestCase {
     AssertParse(
       """
       if #available(OSX 10.51, iOS 8.0) { }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: must handle potential future platforms with '*', Fix-It replacements: 33 - 33 = ', *'
-      ]
+      """
     )
   }
 
@@ -380,11 +352,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """
       if #available(OSX 10.51, iOS 8.0, iDishwasherOS 10.51) { 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
-        // TODO: Old parser expected error on line 1: must handle potential future platforms with '*'
-      ]
+      """
     )
   }
 
@@ -393,11 +361,7 @@ final class AvailabilityQueryTests: XCTestCase {
       """
       if #available(iDishwasherOS 10.51, OSX 10.51) { 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
-        // TODO: Old parser expected error on line 1: must handle potential future platforms with '*'
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
@@ -1,0 +1,467 @@
+// This test file has been translated from swift/test/Parse/availability_query.swift
+
+import XCTest
+
+final class AvailabilityQueryTests: XCTestCase {
+  func testAvailabilityQuery1() {
+    AssertParse(
+      """
+      if #available(OSX 10.51, *) {
+      }
+      """
+    )
+  }
+
+  func testAvailabilityQuery2() {
+    AssertParse(
+      """
+      // Disallow use as an expression.
+      if (#^DIAG^##available(OSX 10.51, *)) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: #available may only be used as condition of an 'if', 'guard'
+        DiagnosticSpec(message: "expected value in tuple"),
+        DiagnosticSpec(message: "unexpected text '#available(OSX 10.51, *)' in tuple"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery3() {
+    AssertParse(
+      """
+      let x = #^DIAG^##available(OSX 10.51, *)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: #available may only be used as condition of
+        DiagnosticSpec(message: "expected expression in variable"),
+        DiagnosticSpec(message: "extraneous '#available(OSX 10.51, *)' at top level"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery4() {
+    AssertParse(
+      """
+      (#^DIAG^##available(OSX 10.51, *) ? 1 : 0)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: #available may only be used as condition of an
+        DiagnosticSpec(message: "expected value in tuple"),
+        DiagnosticSpec(message: "unexpected text '#available(OSX 10.51, *) ? 1 : 0' in tuple"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery5() {
+    AssertParse(
+      """
+      if !#^DIAG_1^##available(OSX 10.52, *) { 
+      }
+      if let _ = Optional(5), !#^DIAG_2^##available(OSX 10.52, *) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: #available cannot be used as an expression, did you mean to use '#unavailable'?, Fix-It replacements: 4 - 15 = '#unavailable'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in prefix operator expression"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '#available(OSX 10.52, *)' in 'if' statement"),
+        // TODO: Old parser expected error on line 3: #available cannot be used as an expression, did you mean to use '#unavailable'?, Fix-It replacements: 25 - 36 = '#unavailable'
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in prefix operator expression"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '#available(OSX 10.52, *)' in 'if' statement"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery6() {
+    AssertParse(
+      """
+      if #available(OSX 10.51, *) #^DIAG^#&& #available(OSX 10.52, *) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected ',' joining parts of a multi-clause condition, Fix-It replacements: 28 - 31 = ','
+        DiagnosticSpec(message: "unexpected text '&& #available(OSX 10.52, *)' in 'if' statement"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery7() {
+    AssertParse(
+      """
+      if #available #^DIAG_1^#{ 
+      }#^DIAG_2^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected availability condition
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '(' in '#availabile' condition"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ')' to end '#availabile' condition"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected code block in 'if' statement"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery8() {
+    AssertParse(
+      """
+      if #available( { 
+      }#^DIAG^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected platform name
+        // TODO: Old parser expected error on line 1: expected ')'
+        // TODO: Old parser expected note on line 1: to match this opening '('
+        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+        DiagnosticSpec(message: "expected code block in 'if' statement"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery9() {
+    AssertParse(
+      """
+      if #available() { #^DIAG^#
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected platform name
+        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+        DiagnosticSpec(message: "expected '{' in 'if' statement"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery10() {
+    AssertParse(
+      """
+      if #available(OSX #^DIAG^#{ 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected version number
+        // TODO: Old parser expected error on line 1: expected ')'
+        // TODO: Old parser expected note on line 1: to match this opening '('
+        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery11() {
+    AssertParse(
+      """
+      if #available(OSX) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected version number
+      ]
+    )
+  }
+
+  func testAvailabilityQuery12() {
+    AssertParse(
+      """
+      if #available(OSX 10.51 #^DIAG^#{ 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected ')'
+        // TODO: Old parser expected note on line 1: to match this opening '('
+        // TODO: Old parser expected error on line 1: must handle potential future platforms with '*', Fix-It replacements: 24 - 24 = ', *'
+        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery13() {
+    AssertParse(
+      """
+      if #available(iDishwasherOS 10.51) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
+        // TODO: Old parser expected error on line 1: must handle potential future platforms with '*'
+      ]
+    )
+  }
+
+  func testAvailabilityQuery14() {
+    AssertParse(
+      """
+      if #available(iDishwasherOS 10.51, *) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
+      ]
+    )
+  }
+
+  func testAvailabilityQuery15() {
+    AssertParse(
+      """
+      if #available(macos 10.51, *) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'macos'; did you mean 'macOS'?, Fix-It replacements: 15 - 20 = 'macOS'
+      ]
+    )
+  }
+
+  func testAvailabilityQuery16() {
+    AssertParse(
+      """
+      if #available(mscos 10.51, *) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'mscos'; did you mean 'macOS'?, Fix-It replacements: 15 - 20 = 'macOS'
+      ]
+    )
+  }
+
+  func testAvailabilityQuery17() {
+    AssertParse(
+      """
+      if #available(macoss 10.51, *) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'macoss'; did you mean 'macOS'?, Fix-It replacements: 15 - 21 = 'macOS'
+      ]
+    )
+  }
+
+  func testAvailabilityQuery18() {
+    AssertParse(
+      """
+      if #available(mac 10.51, *) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'mac'; did you mean 'macOS'?, Fix-It replacements: 15 - 18 = 'macOS'
+      ]
+    )
+  }
+
+  func testAvailabilityQuery19() {
+    AssertParse(
+      """
+      if #available(OSX 10.51, OSX 10.52, *) {  
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: version for 'macOS' already specified
+      ]
+    )
+  }
+
+  func testAvailabilityQuery20() {
+    AssertParse(
+      """
+      if #available(OSX 10.52) { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: must handle potential future platforms with '*', Fix-It replacements: 24 - 24 = ', *'
+      ]
+    )
+  }
+
+  func testAvailabilityQuery21() {
+    AssertParse(
+      """
+      if #available(OSX 10.51, iOS 8.0) { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: must handle potential future platforms with '*', Fix-It replacements: 33 - 33 = ', *'
+      ]
+    )
+  }
+
+  func testAvailabilityQuery22() {
+    AssertParse(
+      """
+      if #available(iOS 8.0, *) {
+      }
+      """
+    )
+  }
+
+  func testAvailabilityQuery23() {
+    AssertParse(
+      """
+      if #available(iOSApplicationExtension, unavailable) { // expected-error 2{{expected version number}}
+      }
+      """
+    )
+  }
+
+  func testAvailabilityQuery24() {
+    AssertParse(
+      """
+      // Want to make sure we can parse this. Perhaps we should not let this validate, though.
+      if #available(*) {
+      }
+      """
+    )
+  }
+
+  func testAvailabilityQuery25() {
+    AssertParse(
+      """
+      if #available(* #^DIAG^#{ 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected ')' in availability query
+        // TODO: Old parser expected note on line 1: to match this opening '('
+        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery26() {
+    AssertParse(
+      """
+      // Multiple platforms
+      if #available(OSX 10.51, iOS 8.0, *) {
+      }
+      """
+    )
+  }
+
+  func testAvailabilityQuery27() {
+    AssertParse(
+      """
+      if #available(OSX 10.51, { 
+      }#^DIAG^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected ')'
+        // TODO: Old parser expected note on line 1: to match this opening '('
+        // TODO: Old parser expected error on line 1: expected platform name
+        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+        DiagnosticSpec(message: "expected code block in 'if' statement"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery28() {
+    AssertParse(
+      """
+      if #available(OSX 10.51,) { #^DIAG^#
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected platform name
+        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+        DiagnosticSpec(message: "expected '{' in 'if' statement"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery29() {
+    AssertParse(
+      """
+      if #available(OSX 10.51, iOS #^DIAG^#{ 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected ')'
+        // TODO: Old parser expected note on line 1: to match this opening '('
+        // TODO: Old parser expected error on line 1: expected version number
+        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery30() {
+    AssertParse(
+      """
+      if #available(OSX 10.51, iOS 8.0, iDishwasherOS 10.51) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
+        // TODO: Old parser expected error on line 1: must handle potential future platforms with '*'
+      ]
+    )
+  }
+
+  func testAvailabilityQuery31() {
+    AssertParse(
+      """
+      if #available(iDishwasherOS 10.51, OSX 10.51) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
+        // TODO: Old parser expected error on line 1: must handle potential future platforms with '*'
+      ]
+    )
+  }
+
+  func testAvailabilityQuery32() {
+    AssertParse(
+      """
+      if #available(OSX 10.51 #^DIAG^#|| iOS 8.0) {
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '||' cannot be used in an availability condition
+        DiagnosticSpec(message: "unexpected text '|| iOS 8.0' in '#availabile' condition"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery33() {
+    AssertParse(
+      """
+      // Emit Fix-It removing un-needed >=, for the moment.
+      """
+    )
+  }
+
+  func testAvailabilityQuery34() {
+    AssertParse(
+      """
+      if #available(OSX #^DIAG^#>= 10.51, *) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: version comparison not needed, Fix-It replacements: 19 - 22 = ''
+        DiagnosticSpec(message: "unexpected text '>= 10.51, *' in '#availabile' condition"),
+      ]
+    )
+  }
+
+  func testAvailabilityQuery35() {
+    AssertParse(
+      """
+      // Bool then #available.
+      if 1 != 2, #available(iOS 8.0, *) {}
+      """
+    )
+  }
+
+  func testAvailabilityQuery36() {
+    AssertParse(
+      """
+      // Pattern then #available(iOS 8.0, *) {
+      if case 42 = 42, #available(iOS 8.0, *) {}
+      if let _ = Optional(42), #available(iOS 8.0, *) {}
+      """
+    )
+  }
+
+  func testAvailabilityQuery37() {
+    AssertParse(
+      #"""
+      // Allow "macOS" as well.
+      if #available(macOS 10.51, *) {
+      }
+      """#
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -1,0 +1,478 @@
+// This test file has been translated from swift/test/Parse/availability_query_unavailability.swift
+
+import XCTest
+
+final class AvailabilityQueryUnavailabilityTests: XCTestCase {
+  func testAvailabilityQueryUnavailability1() {
+    AssertParse(
+      """
+      // This file is mostly an inverted version of availability_query.swift
+      if #unavailable(OSX 10.51) {
+      }
+      """
+    )
+  }
+
+  func testAvailabilityQueryUnavailability2() {
+    AssertParse(
+      """
+      // Disallow explicit wildcards.
+      if #unavailable(OSX 10.51, *) {} 
+      // Disallow use as an expression.
+      if (#^DIAG_1^##unavailable(OSX 10.51)) {}  
+      let x = #^DIAG_2^##unavailable(OSX 10.51)  
+      (#unavailable(OSX 10.51) ? 1 : 0) 
+      if !#unavailable(OSX 10.52) { 
+      }
+      if let _ = Optional(5), #^DIAG_3^#!#^DIAG_4^##unavailable(OSX 10.52) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: platform wildcard '*' is always implicit in #unavailable, Fix-It replacements: 28 - 29 = ''
+        // TODO: Old parser expected error on line 4: #unavailable may only be used as condition of an 'if', 'guard'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected value in tuple"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '#unavailable(OSX 10.51)' in tuple"),
+        // TODO: Old parser expected error on line 5: #unavailable may only be used as condition of
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text before variable"),
+        // TODO: Old parser expected error on line 6: #unavailable may only be used as condition of an
+        // TODO: Old parser expected error on line 7: #unavailable may only be used as condition of an
+        // TODO: Old parser expected error on line 9: #unavailable may only be used as condition
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected pattern in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected expression in prefix operator expression"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "extraneous code at top level"),
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability3() {
+    AssertParse(
+      """
+      if #unavailable(OSX 10.51) #^DIAG^#&& #unavailable(OSX 10.52) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected ',' joining parts of a multi-clause condition, Fix-It replacements: 27 - 30 = ','
+        DiagnosticSpec(message: "unexpected text '&& #unavailable(OSX 10.52)' in 'if' statement"),
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability4() {
+    AssertParse(
+      """
+      if #unavailable #^DIAG_1^#{ 
+      }#^DIAG_2^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected availability condition
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '(' in '#unavailable' condition"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected code block in 'if' statement"),
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability5() {
+    AssertParse(
+      """
+      if #unavailable( { 
+      }#^DIAG^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected platform name
+        // TODO: Old parser expected error on line 1: expected ')'
+        // TODO: Old parser expected note on line 1: to match this opening '('
+        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(message: "expected code block in 'if' statement"),
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability6() {
+    AssertParse(
+      """
+      if #unavailable() { #^DIAG^#
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected platform name
+        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(message: "expected '{' in 'if' statement"),
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability7() {
+    AssertParse(
+      """
+      if #unavailable(OSX #^DIAG^#{ 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected version number
+        // TODO: Old parser expected error on line 1: expected ')'
+        // TODO: Old parser expected note on line 1: to match this opening '('
+        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability8() {
+    AssertParse(
+      """
+      if #unavailable(OSX) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected version number
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability9() {
+    AssertParse(
+      """
+      if #unavailable(OSX 10.51 #^DIAG^#{ 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected ')'
+        // TODO: Old parser expected note on line 1: to match this opening '('
+        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability10() {
+    AssertParse(
+      """
+      if #unavailable(iDishwasherOS 10.51) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability11() {
+    AssertParse(
+      """
+      if #unavailable(iDishwasherOS 10.51) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability12() {
+    AssertParse(
+      """
+      if #unavailable(macos 10.51) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'macos'; did you mean 'macOS'?, Fix-It replacements: 17 - 22 = 'macOS'
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability13() {
+    AssertParse(
+      """
+      if #unavailable(mscos 10.51) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'mscos'; did you mean 'macOS'?, Fix-It replacements: 17 - 22 = 'macOS'
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability14() {
+    AssertParse(
+      """
+      if #unavailable(macoss 10.51) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'macoss'; did you mean 'macOS'?, Fix-It replacements: 17 - 23 = 'macOS'
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability15() {
+    AssertParse(
+      """
+      if #unavailable(mac 10.51) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'mac'; did you mean 'macOS'?, Fix-It replacements: 17 - 20 = 'macOS'
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability16() {
+    AssertParse(
+      """
+      if #unavailable(OSX 10.51, OSX 10.52) {  
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: version for 'macOS' already specified
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability17() {
+    AssertParse(
+      """
+      if #unavailable(OSX 10.51, iOS 8.0, *) { }  
+      if #unavailable(iOS 8.0) {
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: platform wildcard '*' is always implicit in #unavailable, Fix-It replacements: 37 - 38 = ''
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability18() {
+    AssertParse(
+      """
+      if #unavailable(iOSApplicationExtension, unavailable) { // expected-error 2{{expected version number}}
+      }
+      """
+    )
+  }
+
+  func testAvailabilityQueryUnavailability19() {
+    AssertParse(
+      """
+      // Should this be a valid spelling since `#unvailable(*)` cannot be written?
+      if #unavailable() { #^DIAG^#
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected platform name
+        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(message: "expected '{' in 'if' statement"),
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability20() {
+    AssertParse(
+      """
+      if #unavailable(OSX 10 #^DIAG^#{ 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected ')' in availability query
+        // TODO: Old parser expected note on line 1: to match this opening '('
+        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability21() {
+    AssertParse(
+      """
+      // Multiple platforms
+      if #unavailable(OSX 10.51, iOS 8.0) {
+      }
+      """
+    )
+  }
+
+  func testAvailabilityQueryUnavailability22() {
+    AssertParse(
+      """
+      if #unavailable(OSX 10.51, { 
+      }#^DIAG^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected ')'
+        // TODO: Old parser expected note on line 1: to match this opening '('
+        // TODO: Old parser expected error on line 1: expected platform name
+        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(message: "expected code block in 'if' statement"),
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability23() {
+    AssertParse(
+      """
+      if #unavailable(OSX 10.51,) { #^DIAG^#
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected platform name
+        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(message: "expected '{' in 'if' statement"),
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability24() {
+    AssertParse(
+      """
+      if #unavailable(OSX 10.51, iOS #^DIAG^#{ 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected ')'
+        // TODO: Old parser expected note on line 1: to match this opening '('
+        // TODO: Old parser expected error on line 1: expected version number
+        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability25() {
+    AssertParse(
+      """
+      if #unavailable(OSX 10.51, iOS 8.0, iDishwasherOS 10.51) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability26() {
+    AssertParse(
+      """
+      if #unavailable(iDishwasherOS 10.51, OSX 10.51) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability27() {
+    AssertParse(
+      """
+      if #unavailable(OSX 10.51 #^DIAG^#|| iOS 8.0) {
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '||' cannot be used in an availability condition
+        DiagnosticSpec(message: "unexpected text '|| iOS 8.0' in '#unavailable' condition"),
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability28() {
+    AssertParse(
+      """
+      // Emit Fix-It removing un-needed >=, for the moment.
+      if #unavailable(OSX #^DIAG^#>= 10.51) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: version comparison not needed, Fix-It replacements: 21 - 24 = ''
+        DiagnosticSpec(message: "unexpected text '>= 10.51' in '#unavailable' condition"),
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability29() {
+    AssertParse(
+      """
+      // Bool then #unavailable.
+      if 1 != 2, #unavailable(iOS 8.0) {}
+      """
+    )
+  }
+
+  func testAvailabilityQueryUnavailability30() {
+    AssertParse(
+      """
+      // Pattern then #unavailable(iOS 8.0) {
+      if case 42 = 42, #unavailable(iOS 8.0) {}
+      if let _ = Optional(42), #unavailable(iOS 8.0) {}
+      """
+    )
+  }
+
+  func testAvailabilityQueryUnavailability31() {
+    AssertParse(
+      #"""
+      // Allow "macOS" as well.
+      if #unavailable(macOS 10.51) {
+      }
+      """#
+    )
+  }
+
+  func testAvailabilityQueryUnavailability32() {
+    AssertParse(
+      """
+      // Prevent availability and unavailability being present in the same statement.
+      if #unavailable(macOS 10.51), #available(macOS 10.52, *) { 
+      }
+      if #available(macOS 10.51, *), #unavailable(macOS 10.52) { 
+      }
+      if #available(macOS 10.51, *), #available(macOS 10.55, *), #unavailable(macOS 10.53) { 
+      }
+      if #unavailable(macOS 10.51), #unavailable(macOS 10.55), #available(macOS 10.53, *) { 
+      }
+      if case 42 = 42, #available(macOS 10.51, *), #unavailable(macOS 10.52) { 
+      }
+      if #available(macOS 10.51, *), case 42 = 42, #unavailable(macOS 10.52) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: #available and #unavailable cannot be in the same statement
+        // TODO: Old parser expected error on line 4: #available and #unavailable cannot be in the same statement
+        // TODO: Old parser expected error on line 6: #available and #unavailable cannot be in the same statement
+        // TODO: Old parser expected error on line 8: #available and #unavailable cannot be in the same statement
+        // TODO: Old parser expected error on line 10: #available and #unavailable cannot be in the same statement
+        // TODO: Old parser expected error on line 12: #available and #unavailable cannot be in the same statement
+      ]
+    )
+  }
+
+  func testAvailabilityQueryUnavailability33() {
+    AssertParse(
+      """
+      // Allow availability and unavailability to mix if they are not in the same statement.
+      if #unavailable(macOS 11) {
+        if #available(macOS 10, *) { }
+      }
+      if #available(macOS 10, *) {
+        if #unavailable(macOS 11) { }
+      }
+      """
+    )
+  }
+
+  func testAvailabilityQueryUnavailability34() {
+    AssertParse(
+      """
+      // Diagnose wrong spellings of unavailability
+      if #available(*) #^DIAG_1^#== false { 
+      }
+      if !#^DIAG_2^##available(*) { 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: #available cannot be used as an expression, did you mean to use '#unavailable'?, Fix-It replacements: 4 - 14 = '#unavailable', 18 - 27 = ''
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '== false' in 'if' statement"),
+        // TODO: Old parser expected error on line 4: #available cannot be used as an expression, did you mean to use '#unavailable'?, Fix-It replacements: 4 - 15 = '#unavailable'
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in prefix operator expression"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '#available(*)' in 'if' statement"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -149,10 +149,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """
       if #unavailable(iDishwasherOS 10.51) { 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
-      ]
+      """
     )
   }
 
@@ -161,10 +158,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """
       if #unavailable(iDishwasherOS 10.51) { 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
-      ]
+      """
     )
   }
 
@@ -173,10 +167,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """
       if #unavailable(macos 10.51) { 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'macos'; did you mean 'macOS'?, Fix-It replacements: 17 - 22 = 'macOS'
-      ]
+      """
     )
   }
 
@@ -185,10 +176,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """
       if #unavailable(mscos 10.51) { 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'mscos'; did you mean 'macOS'?, Fix-It replacements: 17 - 22 = 'macOS'
-      ]
+      """
     )
   }
 
@@ -197,10 +185,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """
       if #unavailable(macoss 10.51) { 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'macoss'; did you mean 'macOS'?, Fix-It replacements: 17 - 23 = 'macOS'
-      ]
+      """
     )
   }
 
@@ -209,10 +194,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """
       if #unavailable(mac 10.51) { 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'mac'; did you mean 'macOS'?, Fix-It replacements: 17 - 20 = 'macOS'
-      ]
+      """
     )
   }
 
@@ -221,10 +203,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """
       if #unavailable(OSX 10.51, OSX 10.52) {  
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: version for 'macOS' already specified
-      ]
+      """
     )
   }
 
@@ -234,10 +213,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       if #unavailable(OSX 10.51, iOS 8.0, *) { }  
       if #unavailable(iOS 8.0) {
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: platform wildcard '*' is always implicit in #unavailable, Fix-It replacements: 37 - 38 = ''
-      ]
+      """
     )
   }
 
@@ -339,10 +315,7 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       """
       if #unavailable(OSX 10.51, iOS 8.0, iDishwasherOS 10.51) { 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unrecognized platform name 'iDishwasherOS'
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/BraceRecoveryEofTests.swift
+++ b/Tests/SwiftParserTest/translated/BraceRecoveryEofTests.swift
@@ -1,0 +1,21 @@
+// This test file has been translated from swift/test/Parse/brace_recovery_eof.swift
+
+import XCTest
+
+final class BraceRecoveryEofTests: XCTestCase {
+  func testBraceRecoveryEof1() {
+    AssertParse(
+      """
+      // Make sure source ranges satisfy the verifier.
+      for foo in [1, 2] { 
+        _ = foo#^DIAG^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: to match this opening '{'
+        DiagnosticSpec(message: "expected '}' to end 'for' statement"),
+        // TODO: Old parser expected error on line 4: expected '}' at end of brace statement
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/BuiltinBridgeObjectTests.swift
+++ b/Tests/SwiftParserTest/translated/BuiltinBridgeObjectTests.swift
@@ -1,0 +1,41 @@
+// This test file has been translated from swift/test/Parse/builtin_bridge_object.swift
+
+import XCTest
+
+final class BuiltinBridgeObjectTests: XCTestCase {
+  func testBuiltinBridgeObject1() {
+    AssertParse(
+      """
+      precedencegroup AssignmentPrecedence { assignment: true }
+      """
+    )
+  }
+
+  func testBuiltinBridgeObject2() {
+    AssertParse(
+      """
+      var word: Builtin.Word
+      """
+    )
+  }
+
+  func testBuiltinBridgeObject3() {
+    AssertParse(
+      """
+      class C {}
+      """
+    )
+  }
+
+  func testBuiltinBridgeObject4() {
+    AssertParse(
+      """
+      var c: C
+      let bo = Builtin.castToBridgeObject(c, word)
+      c = Builtin.castReferenceFromBridgeObject(bo)
+      word = Builtin.castBitPatternFromBridgeObject(bo)
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/BuiltinWordTests.swift
+++ b/Tests/SwiftParserTest/translated/BuiltinWordTests.swift
@@ -39,11 +39,7 @@ final class BuiltinWordTests: XCTestCase {
       word = Builtin.truncOrBitCast_Int64_Word(i64)
       word = Builtin.truncOrBitCast_Int32_Word(i32) 
       word = Builtin.truncOrBitCast_Int16_Word(i16)
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: 
-        // TODO: Old parser expected error on line 4: 
-      ]
+      """
     )
   }
 
@@ -54,11 +50,7 @@ final class BuiltinWordTests: XCTestCase {
       i32 = Builtin.truncOrBitCast_Word_Int32(word)
       i64 = Builtin.truncOrBitCast_Word_Int64(word) 
       i128 = Builtin.truncOrBitCast_Word_Int128(word)
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: 
-        // TODO: Old parser expected error on line 4: 
-      ]
+      """
     )
   }
 
@@ -69,11 +61,7 @@ final class BuiltinWordTests: XCTestCase {
       word = Builtin.zextOrBitCast_Int64_Word(i64) 
       word = Builtin.zextOrBitCast_Int32_Word(i32)
       word = Builtin.zextOrBitCast_Int16_Word(i16)
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 
-        // TODO: Old parser expected error on line 2: 
-      ]
+      """
     )
   }
 
@@ -84,11 +72,7 @@ final class BuiltinWordTests: XCTestCase {
       i32 = Builtin.zextOrBitCast_Word_Int32(word) 
       i64 = Builtin.zextOrBitCast_Word_Int64(word)
       i128 = Builtin.zextOrBitCast_Word_Int128(word)
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 
-        // TODO: Old parser expected error on line 2: 
-      ]
+      """
     )
   }
 
@@ -99,12 +83,7 @@ final class BuiltinWordTests: XCTestCase {
       word = Builtin.trunc_Int64_Word(i64) 
       word = Builtin.trunc_Int32_Word(i32) 
       word = Builtin.trunc_Int16_Word(i16)
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: 
-        // TODO: Old parser expected error on line 3: 
-        // TODO: Old parser expected error on line 4: 
-      ]
+      """
     )
   }
 
@@ -115,12 +94,7 @@ final class BuiltinWordTests: XCTestCase {
       i32 = Builtin.trunc_Word_Int32(word) 
       i64 = Builtin.trunc_Word_Int64(word) 
       i128 = Builtin.trunc_Word_Int128(word)
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: 
-        // TODO: Old parser expected error on line 3: 
-        // TODO: Old parser expected error on line 4: 
-      ]
+      """
     )
   }
 
@@ -131,12 +105,7 @@ final class BuiltinWordTests: XCTestCase {
       word = Builtin.zext_Int64_Word(i64) 
       word = Builtin.zext_Int32_Word(i32) 
       word = Builtin.zext_Int16_Word(i16)
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 
-        // TODO: Old parser expected error on line 2: 
-        // TODO: Old parser expected error on line 3: 
-      ]
+      """
     )
   }
 
@@ -147,12 +116,7 @@ final class BuiltinWordTests: XCTestCase {
       i32 = Builtin.zext_Word_Int32(word) 
       i64 = Builtin.zext_Word_Int64(word) 
       i128 = Builtin.zext_Word_Int128(word)
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 
-        // TODO: Old parser expected error on line 2: 
-        // TODO: Old parser expected error on line 3: 
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/BuiltinWordTests.swift
+++ b/Tests/SwiftParserTest/translated/BuiltinWordTests.swift
@@ -1,0 +1,159 @@
+// This test file has been translated from swift/test/Parse/builtin_word.swift
+
+import XCTest
+
+final class BuiltinWordTests: XCTestCase {
+  func testBuiltinWord1() {
+    AssertParse(
+      """
+      precedencegroup AssignmentPrecedence { assignment: true }
+      """
+    )
+  }
+
+  func testBuiltinWord2() {
+    AssertParse(
+      """
+      var word: Builtin.Word
+      var i16: Builtin.Int16
+      var i32: Builtin.Int32
+      var i64: Builtin.Int64
+      var i128: Builtin.Int128
+      """
+    )
+  }
+
+  func testBuiltinWord3() {
+    AssertParse(
+      """
+      // Check that trunc/?ext operations are appropriately available given the
+      // abstract range of potential Word sizes.
+      """
+    )
+  }
+
+  func testBuiltinWord4() {
+    AssertParse(
+      """
+      word = Builtin.truncOrBitCast_Int128_Word(i128)
+      word = Builtin.truncOrBitCast_Int64_Word(i64)
+      word = Builtin.truncOrBitCast_Int32_Word(i32) 
+      word = Builtin.truncOrBitCast_Int16_Word(i16)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: 
+        // TODO: Old parser expected error on line 4: 
+      ]
+    )
+  }
+
+  func testBuiltinWord5() {
+    AssertParse(
+      """
+      i16 = Builtin.truncOrBitCast_Word_Int16(word)
+      i32 = Builtin.truncOrBitCast_Word_Int32(word)
+      i64 = Builtin.truncOrBitCast_Word_Int64(word) 
+      i128 = Builtin.truncOrBitCast_Word_Int128(word)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: 
+        // TODO: Old parser expected error on line 4: 
+      ]
+    )
+  }
+
+  func testBuiltinWord6() {
+    AssertParse(
+      """
+      word = Builtin.zextOrBitCast_Int128_Word(i128) 
+      word = Builtin.zextOrBitCast_Int64_Word(i64) 
+      word = Builtin.zextOrBitCast_Int32_Word(i32)
+      word = Builtin.zextOrBitCast_Int16_Word(i16)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 
+        // TODO: Old parser expected error on line 2: 
+      ]
+    )
+  }
+
+  func testBuiltinWord7() {
+    AssertParse(
+      """
+      i16 = Builtin.zextOrBitCast_Word_Int16(word) 
+      i32 = Builtin.zextOrBitCast_Word_Int32(word) 
+      i64 = Builtin.zextOrBitCast_Word_Int64(word)
+      i128 = Builtin.zextOrBitCast_Word_Int128(word)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 
+        // TODO: Old parser expected error on line 2: 
+      ]
+    )
+  }
+
+  func testBuiltinWord8() {
+    AssertParse(
+      """
+      word = Builtin.trunc_Int128_Word(i128)
+      word = Builtin.trunc_Int64_Word(i64) 
+      word = Builtin.trunc_Int32_Word(i32) 
+      word = Builtin.trunc_Int16_Word(i16)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 
+        // TODO: Old parser expected error on line 3: 
+        // TODO: Old parser expected error on line 4: 
+      ]
+    )
+  }
+
+  func testBuiltinWord9() {
+    AssertParse(
+      """
+      i16 = Builtin.trunc_Word_Int16(word)
+      i32 = Builtin.trunc_Word_Int32(word) 
+      i64 = Builtin.trunc_Word_Int64(word) 
+      i128 = Builtin.trunc_Word_Int128(word)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 
+        // TODO: Old parser expected error on line 3: 
+        // TODO: Old parser expected error on line 4: 
+      ]
+    )
+  }
+
+  func testBuiltinWord10() {
+    AssertParse(
+      """
+      word = Builtin.zext_Int128_Word(i128) 
+      word = Builtin.zext_Int64_Word(i64) 
+      word = Builtin.zext_Int32_Word(i32) 
+      word = Builtin.zext_Int16_Word(i16)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 
+        // TODO: Old parser expected error on line 2: 
+        // TODO: Old parser expected error on line 3: 
+      ]
+    )
+  }
+
+  func testBuiltinWord11() {
+    AssertParse(
+      """
+      i16 = Builtin.zext_Word_Int16(word) 
+      i32 = Builtin.zext_Word_Int32(word) 
+      i64 = Builtin.zext_Word_Int64(word) 
+      i128 = Builtin.zext_Word_Int128(word)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 
+        // TODO: Old parser expected error on line 2: 
+        // TODO: Old parser expected error on line 3: 
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/ConflictMarkersTests.swift
+++ b/Tests/SwiftParserTest/translated/ConflictMarkersTests.swift
@@ -1,0 +1,217 @@
+// This test file has been translated from swift/test/Parse/conflict_markers.swift
+
+import XCTest
+
+final class ConflictMarkersTests: XCTestCase {
+  func testConflictMarkers1() {
+    AssertParse(
+      """
+      // Conflict marker parsing should never conflict with operator parsing.
+      """
+    )
+  }
+
+  func testConflictMarkers2() {
+    AssertParse(
+      """
+      prefix operator <<<<<<<
+      infix operator <<<<<<<
+      """
+    )
+  }
+
+  func testConflictMarkers3() {
+    AssertParse(
+      """
+      prefix func <<<<<<< (x : String) {}
+      func <<<<<<< (x : String, y : String) {}
+      """
+    )
+  }
+
+  func testConflictMarkers4() {
+    AssertParse(
+      """
+      prefix operator >>>>>>>
+      infix operator >>>>>>>
+      """
+    )
+  }
+
+  func testConflictMarkers5() {
+    AssertParse(
+      """
+      prefix func >>>>>>> (x : String) {}
+      func >>>>>>> (x : String, y : String) {}
+      """
+    )
+  }
+
+  func testConflictMarkers6() {
+    AssertParse(
+      """
+      // diff3-style conflict markers
+      """
+    )
+  }
+
+  func testConflictMarkers7() {
+    AssertParse(
+      #"""
+      #^DIAG_1^#<<<<<<< HEAD:conflict_markers.swift 
+      var a : String = "A"
+      var b : String = "b"
+      =======#^DIAG_2^#
+      var a : String = "a"
+      var b : String = "B"
+      >>>>>>> #^DIAG_3^#18844bc65229786b96b89a9fc7739c0fc897905e:conflict_markers.swift
+      print(a + b)
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: source control conflict marker in source file
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '<<<<<<< HEAD:conflict_markers.swift' before variable"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 8: cannot find 'a' in scope
+        // TODO: Old parser expected error on line 8: cannot find 'b' in scope
+      ]
+    )
+  }
+
+  func testConflictMarkers8() {
+    AssertParse(
+      #"""
+      #^DIAG_1^#<<<<<<< HEAD:conflict_markers.swift 
+      ======= 
+      var d : String = "D"
+      >>>>>>> #^DIAG_2^#18844bc65229786b96b89a9fc7739c0fc897905e:conflict_markers.swift
+      print(d)
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: source control conflict marker in source file
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text before variable"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 5: cannot find 'd' in scope
+      ]
+    )
+  }
+
+  func testConflictMarkers9() {
+    AssertParse(
+      #"""
+      <<<<<<<"HEAD:fake_conflict_markers.swift" // No error
+      >>>>>>>"18844bc65229786b96b89a9fc7739c0fc897905e:fake_conflict_markers.swift" // No error
+      """#
+    )
+  }
+
+  func testConflictMarkers10() {
+    AssertParse(
+      #"""
+      #^DIAG_1^#<<<<<<< HEAD:conflict_markers.swift 
+      <<<<<<<"HEAD:fake_conflict_markers.swift"
+      var fake_b : String = "a"
+      >>>>>>>"18844bc65229786b96b89a9fc7739c0fc897905e:fake_conflict_markers.swift"
+      =======
+      <<<<<<<"HEAD:fake_conflict_markers.swift"
+      var fake_c : String = "a"
+      >>>>>>>"18844bc65229786b96b89a9fc7739c0fc897905e:fake_conflict_markers.swift"
+      >>>>>>> #^DIAG_2^#18844bc65229786b96b89a9fc7739c0fc897905e:conflict_markers.swift
+      print(fake_b + fake_c)
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: source control conflict marker in source file
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text before variable"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 10: cannot find 'fake_b' in scope
+        // TODO: Old parser expected error on line 10: cannot find 'fake_c' in scope
+      ]
+    )
+  }
+
+  func testConflictMarkers11() {
+    AssertParse(
+      """
+      // Disambiguating conflict markers from operator applications.
+      """
+    )
+  }
+
+  func testConflictMarkers12() {
+    AssertParse(
+      #"""
+      _ = {
+      // Conflict marker.
+      let a = "a", b = "b"
+      a 
+      <<<<<<< b 
+      a
+      >>>>>>> b
+      // Not a conflict marker.
+      a
+        <<<<<<< b
+      a
+        >>>>>>> b
+      }()
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 4: expression of type 'String' is unused
+        // TODO: Old parser expected error on line 5: source control conflict marker in source file
+      ]
+    )
+  }
+
+  func testConflictMarkers13() {
+    AssertParse(
+      """
+      // Perforce-style conflict markers
+      """
+    )
+  }
+
+  func testConflictMarkers14() {
+    AssertParse(
+      #"""
+      #^DIAG^#>>>> ORIGINAL 
+      var a : String = "A"
+      var b : String = "B"
+      ==== THEIRS
+      var a : String = "A"
+      var b : String = "b"
+      ==== YOURS
+      var a : String = "a"
+      var b : String = "B"
+      <<<<
+      print(a + b)
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: source control conflict marker in source file
+        DiagnosticSpec(message: "unexpected text '>>>> ORIGINAL' before variable"),
+        // TODO: Old parser expected error on line 11: cannot find 'a' in scope
+        // TODO: Old parser expected error on line 11: cannot find 'b' in scope
+      ]
+    )
+  }
+
+  func testConflictMarkers15() {
+    AssertParse(
+      #"""
+      #^DIAG^#>>>> ORIGINAL 
+      ==== THEIRS
+      ==== YOURS
+      var d : String = "D"
+      <<<<
+      print(d)
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: source control conflict marker in source file
+        DiagnosticSpec(message: "unexpected text before variable"),
+        // TODO: Old parser expected error on line 6: cannot find 'd' in scope
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/ConflictMarkersTests.swift
+++ b/Tests/SwiftParserTest/translated/ConflictMarkersTests.swift
@@ -73,8 +73,6 @@ final class ConflictMarkersTests: XCTestCase {
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in variable"),
         DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in variable"),
         DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous code at top level"),
-        // TODO: Old parser expected error on line 8: cannot find 'a' in scope
-        // TODO: Old parser expected error on line 8: cannot find 'b' in scope
       ]
     )
   }
@@ -93,7 +91,6 @@ final class ConflictMarkersTests: XCTestCase {
         DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text before variable"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in variable"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "extraneous code at top level"),
-        // TODO: Old parser expected error on line 5: cannot find 'd' in scope
       ]
     )
   }
@@ -126,8 +123,6 @@ final class ConflictMarkersTests: XCTestCase {
         DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text before variable"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "extraneous code at top level"),
-        // TODO: Old parser expected error on line 10: cannot find 'fake_b' in scope
-        // TODO: Old parser expected error on line 10: cannot find 'fake_c' in scope
       ]
     )
   }
@@ -158,7 +153,6 @@ final class ConflictMarkersTests: XCTestCase {
       }()
       """#,
       diagnostics: [
-        // TODO: Old parser expected warning on line 4: expression of type 'String' is unused
         // TODO: Old parser expected error on line 5: source control conflict marker in source file
       ]
     )
@@ -190,8 +184,6 @@ final class ConflictMarkersTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: source control conflict marker in source file
         DiagnosticSpec(message: "unexpected text '>>>> ORIGINAL' before variable"),
-        // TODO: Old parser expected error on line 11: cannot find 'a' in scope
-        // TODO: Old parser expected error on line 11: cannot find 'b' in scope
       ]
     )
   }
@@ -209,7 +201,6 @@ final class ConflictMarkersTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 1: source control conflict marker in source file
         DiagnosticSpec(message: "unexpected text before variable"),
-        // TODO: Old parser expected error on line 6: cannot find 'd' in scope
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/ConsecutiveStatementsTests.swift
+++ b/Tests/SwiftParserTest/translated/ConsecutiveStatementsTests.swift
@@ -1,0 +1,144 @@
+// This test file has been translated from swift/test/Parse/consecutive_statements.swift
+
+import XCTest
+
+final class ConsecutiveStatementsTests: XCTestCase {
+  func testConsecutiveStatements1() {
+    AssertParse(
+      """
+      func statement_starts() {
+        var f : (Int) -> ()
+        f = { (x : Int) -> () in }
+        f(0)
+        f (0)
+        f 
+        (0) 
+        var a = [1,2,3]
+        a[0] = 1
+        a [0] = 1
+        a 
+        [0, 1, 2] 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 6: variable is unused
+        // TODO: Old parser expected warning on line 7: integer literal is unused
+        // TODO: Old parser expected warning on line 11: variable is unused
+        // TODO: Old parser expected warning on line 12: expression of type '[Int]' is unused
+      ]
+    )
+  }
+
+  func testConsecutiveStatements2() {
+    AssertParse(
+      """
+      // Within a function
+      func test(i: inout Int, j: inout Int) {
+        // Okay
+        let q : Int; i = j; j = i; _ = q
+        if i != j { i = j }
+        // Errors
+        i = j j = i 
+        let r : Int i = j 
+        let s : Int let t : Int 
+        _ = r; _ = s; _ = t
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 7: consecutive statements, Fix-It replacements: 8 - 8 = ';'
+        // TODO: Old parser expected error on line 8: consecutive statements, Fix-It replacements: 14 - 14 = ';'
+        // TODO: Old parser expected error on line 9: consecutive statements, Fix-It replacements: 14 - 14 = ';'
+      ]
+    )
+  }
+
+  func testConsecutiveStatements3() {
+    AssertParse(
+      """
+      struct X {
+        // In a sequence of declarations.
+        var a, b : Int func d() -> Int {} 
+        var prop : Int { return 4
+        } var other : Float 
+        // Within property accessors
+        subscript(i: Int) -> Float {
+          get {
+            var x = i x = i + x return Float(x) 
+          }
+          set {
+            var x = i x = i + 1 
+            _ = x
+          }
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: consecutive declarations, Fix-It replacements: 17 - 17 = ';'
+        // TODO: Old parser expected error on line 5: consecutive declarations, Fix-It replacements: 4 - 4 = ';'
+        // TODO: Old parser expected error on line 9: consecutive statements, Fix-It replacements: 16 - 16 = ';'
+        // TODO: Old parser expected error on line 9: consecutive statements, Fix-It replacements: 26 - 26 = ';'
+        // TODO: Old parser expected error on line 12: consecutive statements, Fix-It replacements: 16 - 16 = ';'
+      ]
+    )
+  }
+
+  func testConsecutiveStatements4() {
+    AssertParse(
+      """
+      class C {
+        // In a sequence of declarations.
+        var a, b : Int func d() -> Int {} 
+        init() {
+          a = 0
+          b = 0
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: consecutive declarations, Fix-It replacements: 17 - 17 = ';'
+      ]
+    )
+  }
+
+  func testConsecutiveStatements5() {
+    AssertParse(
+      """
+      protocol P {
+        func a() func b() 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: consecutive declarations, Fix-It replacements: 11 - 11 = ';'
+      ]
+    )
+  }
+
+  func testConsecutiveStatements6() {
+    AssertParse(
+      """
+      enum Color {
+        case Red case Blue 
+        func a() {} func b() {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: consecutive declarations, Fix-It replacements: 11 - 11 = ';'
+        // TODO: Old parser expected error on line 3: consecutive declarations, Fix-It replacements: 14 - 14 = ';'
+      ]
+    )
+  }
+
+  func testConsecutiveStatements7() {
+    AssertParse(
+      """
+      // At the top level
+      var i, j : Int i = j j = i
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: consecutive statements, Fix-It replacements: 15 - 15 = ';'
+        // TODO: Old parser expected error on line 2: consecutive statements, Fix-It replacements: 21 - 21 = ';'
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/ConsecutiveStatementsTests.swift
+++ b/Tests/SwiftParserTest/translated/ConsecutiveStatementsTests.swift
@@ -19,13 +19,7 @@ final class ConsecutiveStatementsTests: XCTestCase {
         a 
         [0, 1, 2] 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 6: variable is unused
-        // TODO: Old parser expected warning on line 7: integer literal is unused
-        // TODO: Old parser expected warning on line 11: variable is unused
-        // TODO: Old parser expected warning on line 12: expression of type '[Int]' is unused
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/DebuggerTests.swift
+++ b/Tests/SwiftParserTest/translated/DebuggerTests.swift
@@ -7,10 +7,7 @@ final class DebuggerTests: XCTestCase {
     AssertParse(
       """
       import Nonexistent_Module
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: no such module
-      ]
+      """
     )
   }
 
@@ -35,10 +32,7 @@ final class DebuggerTests: XCTestCase {
     AssertParse(
       """
       var x: Double = z
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot convert value of type 'Int' to specified type 'Double'
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/DebuggerTests.swift
+++ b/Tests/SwiftParserTest/translated/DebuggerTests.swift
@@ -1,0 +1,45 @@
+// This test file has been translated from swift/test/Parse/debugger.swift
+
+import XCTest
+
+final class DebuggerTests: XCTestCase {
+  func testDebugger1() {
+    AssertParse(
+      """
+      import Nonexistent_Module
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: no such module
+      ]
+    )
+  }
+
+  func testDebugger2() {
+    AssertParse(
+      """
+      var ($x0, $x1) = (4, 3)
+      var z = $x0 + $x1
+      """
+    )
+  }
+
+  func testDebugger3() {
+    AssertParse(
+      """
+      z // no error.
+      """
+    )
+  }
+
+  func testDebugger4() {
+    AssertParse(
+      """
+      var x: Double = z
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot convert value of type 'Int' to specified type 'Double'
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/DelayedExtensionTests.swift
+++ b/Tests/SwiftParserTest/translated/DelayedExtensionTests.swift
@@ -9,11 +9,7 @@ final class DelayedExtensionTests: XCTestCase {
       extension X { } 
       _ = 1
       f()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot find type 'X' in scope
-        // TODO: Old parser expected error on line 3: cannot find 'f' in scope
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/DelayedExtensionTests.swift
+++ b/Tests/SwiftParserTest/translated/DelayedExtensionTests.swift
@@ -1,0 +1,20 @@
+// This test file has been translated from swift/test/Parse/delayed_extension.swift
+
+import XCTest
+
+final class DelayedExtensionTests: XCTestCase {
+  func testDelayedExtension1() {
+    AssertParse(
+      """
+      extension X { } 
+      _ = 1
+      f()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot find type 'X' in scope
+        // TODO: Old parser expected error on line 3: cannot find 'f' in scope
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
+++ b/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
@@ -1,0 +1,201 @@
+// This test file has been translated from swift/test/Parse/deprecated_where.swift
+
+import XCTest
+
+final class DeprecatedWhereTests: XCTestCase {
+  func testDeprecatedWhere1() {
+    AssertParse(
+      """
+      protocol Mashable { }
+      protocol Womparable { }
+      """
+    )
+  }
+
+  func testDeprecatedWhere2() {
+    AssertParse(
+      """
+      // FuncDecl: Choose 0
+      func f1<T>(x: T) {}
+      """
+    )
+  }
+
+  func testDeprecatedWhere3() {
+    AssertParse(
+      """
+      // FuncDecl: Choose 1
+      // 1: Inherited constraint
+      func f2<T: Mashable>(x: T) {} // no-warning
+      // 2: Non-trailing where
+      func f3<T where T: Womparable>(x: T) {} 
+      // 3: Has return type
+      func f4<T>(x: T) -> Int { return 2 } // no-warning
+      // 4: Trailing where
+      func f5<T>(x: T) where T : Equatable {} // no-warning
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 10 - 30 = '', 37 - 37 = ' where T: Womparable'
+      ]
+    )
+  }
+
+  func testDeprecatedWhere4() {
+    AssertParse(
+      """
+      // FuncDecl: Choose 2
+      // 1,2
+      func f12<T: Mashable where T: Womparable>(x: T) {} 
+      // 1,3
+      func f13<T: Mashable>(x: T) -> Int { return 2 } // no-warning
+      // 1,4
+      func f14<T: Mashable>(x: T) where T: Equatable {} // no-warning
+      // 2,3
+      func f23<T where T: Womparable>(x: T) -> Int { return 2 } 
+      // 2,4
+      func f24<T where T: Womparable>(x: T) where T: Equatable {} 
+      // 3,4
+      func f34<T>(x: T) -> Int where T: Equatable { return 2 } // no-warning
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 21 - 41 = '', 48 - 48 = ' where T: Womparable'
+        // TODO: Old parser expected error on line 9: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 11 - 31 = '', 45 - 45 = ' where T: Womparable'
+        // TODO: Old parser expected error on line 11: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 11 - 31 = '', 39 - 44 = 'where T: Womparable,'
+      ]
+    )
+  }
+
+  func testDeprecatedWhere5() {
+    AssertParse(
+      """
+      // FuncDecl: Choose 3
+      // 1,2,3
+      func f123<T: Mashable where T: Womparable>(x: T) -> Int { return 2 } 
+      // 1,2,4
+      func f124<T: Mashable where T: Womparable>(x: T) where T: Equatable {} 
+      // 2,3,4
+      func f234<T where T: Womparable>(x: T) -> Int where T: Equatable { return 2 }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 22 - 42 = '', 56 - 56 = ' where T: Womparable'
+        // TODO: Old parser expected error on line 5: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 22 - 42 = '', 50 - 55 = 'where T: Womparable,'
+        // TODO: Old parser expected error on line 7: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 12 - 32 = '', 47 - 52 = 'where T: Womparable,'
+      ]
+    )
+  }
+
+  func testDeprecatedWhere6() {
+    AssertParse(
+      """
+      // FuncDecl: Choose 4
+      // 1,2,3,4
+      func f1234<T: Mashable where T: Womparable>(x: T) -> Int where T: Equatable { return 2 }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 23 - 43 = '', 58 - 63 = 'where T: Womparable,'
+      ]
+    )
+  }
+
+  func testDeprecatedWhere7() {
+    AssertParse(
+      """
+      // NominalTypeDecl: Choose 0
+      struct S0<T> {}
+      """
+    )
+  }
+
+  func testDeprecatedWhere8() {
+    AssertParse(
+      """
+      // NominalTypeDecl: Choose 1
+      // 1: Inherited constraint
+      struct S1<T: Mashable> {} // no-warning
+      // 2: Non-trailing where
+      struct S2<T where T: Womparable> {} 
+      // 3: Trailing where
+      struct S3<T> where T : Equatable {} // no-warning
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 12 - 32 = '', 33 - 33 = ' where T: Womparable'
+      ]
+    )
+  }
+
+  func testDeprecatedWhere9() {
+    AssertParse(
+      """
+      // NominalTypeDecl: Choose 2
+      // 1,2
+      struct S12<T: Mashable where T: Womparable> {} 
+      // 1,3
+      struct S13<T: Mashable> where T: Equatable {} // no-warning
+      // 2,3
+      struct S23<T where T: Womparable> where T: Equatable {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 23 - 43 = '', 44 - 44 = ' where T: Womparable'
+        // TODO: Old parser expected error on line 7: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 13 - 33 = '', 35 - 40 = 'where T: Womparable,'
+      ]
+    )
+  }
+
+  func testDeprecatedWhere10() {
+    AssertParse(
+      """
+      // NominalTypeDecl: Choose 3
+      // 1,2,3
+      struct S123<T: Mashable where T: Womparable> where T: Equatable {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 24 - 44 = '', 46 - 51 = 'where T: Womparable,'
+      ]
+    )
+  }
+
+  func testDeprecatedWhere11() {
+    AssertParse(
+      """
+      protocol ProtoA {}
+      protocol ProtoB {}
+      protocol ProtoC {}
+      protocol ProtoD {}
+      func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) {} 
+      func testCombinedConstraints<T: ProtoA & ProtoB where T: ProtoC>(x: T) where T: ProtoD {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 48 - 64 = '', 71 - 71 = ' where T: ProtoC'
+        // TODO: Old parser expected error on line 6: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 48 - 64 = '', 72 - 77 = 'where T: ProtoC,'
+      ]
+    )
+  }
+
+  func testDeprecatedWhere12() {
+    AssertParse(
+      """
+      func testCombinedConstraintsOld<T: #^DIAG_1^#protocol#^DIAG_2^#<ProtoA, ProtoB> where T: ProtoC>(x: T) {} 
+      func testCombinedConstraintsOld<T: #^DIAG_3^#protocol#^DIAG_4^#<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 60 - 76 = '', 83 - 83 = ' where T: ProtoC'
+        // TODO: Old parser expected error on line 1: 'protocol<...>' composition syntax has been removed
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected inherited type in generic parameter"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '>' to end generic parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected argument list in function declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '<ProtoA, ProtoB> where T: ProtoC>(x: T) {}' before function"),
+        // TODO: Old parser expected error on line 2: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 60 - 76 = '', 84 - 89 = 'where T: ProtoC,'
+        // TODO: Old parser expected error on line 2: 'protocol<...>' composition syntax has been removed
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected inherited type in generic parameter"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected '>' to end generic parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected argument list in function declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected identifier in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected member block in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "extraneous '<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {}' at top level"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/DiagnoseAvailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseAvailabilityTests.swift
@@ -204,11 +204,7 @@ final class DiagnoseAvailabilityTests: XCTestCase {
         """)
       func multilineMessage() {}
       multilineMessage()
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected note on line 4: 'multilineMessage()' has been explicitly marked unavailable here
-        // TODO: Old parser expected error on line 5: 'multilineMessage()' is unavailable: foobar message.
-      ]
+      """#
     )
   }
 
@@ -218,11 +214,7 @@ final class DiagnoseAvailabilityTests: XCTestCase {
       @available(*, unavailable, message: " ")
       func emptyMessage() {}
       emptyMessage()
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: 'emptyMessage()' has been explicitly marked unavailable here
-        // TODO: Old parser expected error on line 3: 'emptyMessage()' is unavailable:  
-      ]
+      """#
     )
   }
 

--- a/Tests/SwiftParserTest/translated/DiagnoseAvailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseAvailabilityTests.swift
@@ -1,0 +1,255 @@
+// This test file has been translated from swift/test/Parse/diagnose_availability.swift
+
+import XCTest
+
+final class DiagnoseAvailabilityTests: XCTestCase {
+  func testDiagnoseAvailability1() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/46814
+      // Misleading/wrong error message for malformed '@available'
+      """
+    )
+  }
+
+  func testDiagnoseAvailability2() {
+    AssertParse(
+      """
+      @available(OSX 10.6, *) // no error
+      func availableSince10_6() {}
+      """
+    )
+  }
+
+  func testDiagnoseAvailability3() {
+    AssertParse(
+      """
+      @available(OSX, introduced: 10.0, deprecated: 10.12) // no error
+      func introducedFollowedByDeprecated() {}
+      """
+    )
+  }
+
+  func testDiagnoseAvailability4() {
+    AssertParse(
+      """
+      @available(OSX 10.0, deprecated: 10.12)
+      func shorthandFollowedByDeprecated() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'deprecated' can't be combined with shorthand specification 'OSX 10.0'
+        // TODO: Old parser expected note on line 1: did you mean to specify an introduction version?, Fix-It replacements: 15 - 15 = ', introduced:'
+        // TODO: Old parser expected error on line 1: expected declaration
+      ]
+    )
+  }
+
+  func testDiagnoseAvailability5() {
+    AssertParse(
+      """
+      @available(OSX 10.0, introduced: 10.12)
+      func shorthandFollowedByIntroduced() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'introduced' can't be combined with shorthand specification 'OSX 10.0'
+        // TODO: Old parser expected error on line 1: expected declaration
+      ]
+    )
+  }
+
+  func testDiagnoseAvailability6() {
+    AssertParse(
+      """
+      @available(iOS 6.0, OSX 10.8, *) // no error
+      func availableOnMultiplePlatforms() {}
+      """
+    )
+  }
+
+  func testDiagnoseAvailability7() {
+    AssertParse(
+      """
+      @available(iOS 6.0, OSX 10.0, deprecated: 10.12)
+      func twoShorthandsFollowedByDeprecated() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'deprecated' can't be combined with shorthand specification 'OSX 10.0'
+        // TODO: Old parser expected error on line 1: expected declaration
+      ]
+    )
+  }
+
+  func testDiagnoseAvailability8() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/51114
+      // Missing/wrong warning message for '*' or 'swift' platform.
+      """
+    )
+  }
+
+  func testDiagnoseAvailability9() {
+    AssertParse(
+      """
+      @available(*, deprecated: 4.2)
+      func allPlatformsDeprecatedVersion() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unexpected version number in 'available' attribute for non-specific platform '*', Fix-It replacements: 25 - 30 = ''
+      ]
+    )
+  }
+
+  func testDiagnoseAvailability10() {
+    AssertParse(
+      """
+      @available(*, deprecated, obsoleted: 4.2)
+      func allPlatformsDeprecatedAndObsoleted() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unexpected version number in 'available' attribute for non-specific platform '*', Fix-It replacements: 36 - 41 = ''
+      ]
+    )
+  }
+
+  func testDiagnoseAvailability11() {
+    AssertParse(
+      """
+      @available(*, introduced: 4.0, deprecated: 4.1, obsoleted: 4.2)
+      func allPlatformsDeprecatedAndObsoleted2() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unexpected version number in 'available' attribute for non-specific platform '*', Fix-It replacements: 25 - 30 = '', 42 - 47 = '', 58 - 63 = ''
+      ]
+    )
+  }
+
+  func testDiagnoseAvailability12() {
+    AssertParse(
+      """
+      @available(swift, unavailable)
+      func swiftUnavailable() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: 'unavailable' cannot be used in 'available' attribute for platform 'swift'
+      ]
+    )
+  }
+
+  func testDiagnoseAvailability13() {
+    AssertParse(
+      """
+      @available(swift, unavailable, introduced: 4.2)
+      func swiftUnavailableIntroduced() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: 'unavailable' cannot be used in 'available' attribute for platform 'swift'
+      ]
+    )
+  }
+
+  func testDiagnoseAvailability14() {
+    AssertParse(
+      """
+      @available(swift, deprecated)
+      func swiftDeprecated() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: expected version number with 'deprecated' in 'available' attribute for platform 'swift'
+      ]
+    )
+  }
+
+  func testDiagnoseAvailability15() {
+    AssertParse(
+      """
+      @available(swift, deprecated, obsoleted: 4.2)
+      func swiftDeprecatedObsoleted() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: expected version number with 'deprecated' in 'available' attribute for platform 'swift'
+      ]
+    )
+  }
+
+  func testDiagnoseAvailability16() {
+    AssertParse(
+      #"""
+      @available(swift, message: "missing valid option")
+      func swiftMessage() {}
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: expected 'introduced', 'deprecated', or 'obsoleted' in 'available' attribute for platform 'swift'
+      ]
+    )
+  }
+
+  func testDiagnoseAvailability17() {
+    AssertParse(
+      #"""
+      @available(*, unavailable, message: "\("message")")
+      func interpolatedMessage() {}
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'message' cannot be an interpolated string literal
+      ]
+    )
+  }
+
+  func testDiagnoseAvailability18() {
+    AssertParse(
+      #"""
+      @available(*, unavailable, message: """
+        foobar message.
+        """)
+      func multilineMessage() {}
+      multilineMessage()
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected note on line 4: 'multilineMessage()' has been explicitly marked unavailable here
+        // TODO: Old parser expected error on line 5: 'multilineMessage()' is unavailable: foobar message.
+      ]
+    )
+  }
+
+  func testDiagnoseAvailability19() {
+    AssertParse(
+      #"""
+      @available(*, unavailable, message: " ")
+      func emptyMessage() {}
+      emptyMessage()
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: 'emptyMessage()' has been explicitly marked unavailable here
+        // TODO: Old parser expected error on line 3: 'emptyMessage()' is unavailable:  
+      ]
+    )
+  }
+
+  func testDiagnoseAvailability20() {
+    AssertParse(
+      ##"""
+      @available(*, unavailable, message: #"""
+        foobar message.
+        """#)
+      func extendedEscapedMultilineMessage() {}
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'message' cannot be an extended escaping string literal
+      ]
+    )
+  }
+
+  func testDiagnoseAvailability21() {
+    AssertParse(
+      ##"""
+      @available(*, unavailable, renamed: #"available()"#)
+      func extendedEscapedRenamed() {}
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'renamed' cannot be an extended escaping string literal
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/DiagnoseAvailabilityWindowsTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseAvailabilityWindowsTests.swift
@@ -8,10 +8,7 @@ final class DiagnoseAvailabilityWindowsTests: XCTestCase {
       #"""
       @available(Windows, unavailable, message: "unsupported")
       func unavailable() {}
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: 'unavailable()' has been explicitly marked unavailable here
-      ]
+      """#
     )
   }
 
@@ -19,10 +16,7 @@ final class DiagnoseAvailabilityWindowsTests: XCTestCase {
     AssertParse(
       """
       unavailable()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'unavailable()' is unavailable in Windows: unsupported
-      ]
+      """
     )
   }
 
@@ -39,11 +33,7 @@ final class DiagnoseAvailabilityWindowsTests: XCTestCase {
     AssertParse(
       """
       introduced_deprecated()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'introduced_deprecated()' is only available in * 10.0.17763 or newe
-        // TODO: Old parser expected note on line 1: add 'if #available' version check
-      ]
+      """
     )
   }
 
@@ -60,11 +50,7 @@ final class DiagnoseAvailabilityWindowsTests: XCTestCase {
     AssertParse(
       """
       windows10()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'windows10()' is only available in * 10 or newer
-        // TODO: Old parser expected note on line 1: add 'if #available' version check
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/DiagnoseAvailabilityWindowsTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseAvailabilityWindowsTests.swift
@@ -1,0 +1,82 @@
+// This test file has been translated from swift/test/Parse/diagnose_availability_windows.swift
+
+import XCTest
+
+final class DiagnoseAvailabilityWindowsTests: XCTestCase {
+  func testDiagnoseAvailabilityWindows1() {
+    AssertParse(
+      #"""
+      @available(Windows, unavailable, message: "unsupported")
+      func unavailable() {}
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: 'unavailable()' has been explicitly marked unavailable here
+      ]
+    )
+  }
+
+  func testDiagnoseAvailabilityWindows2() {
+    AssertParse(
+      """
+      unavailable()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'unavailable()' is unavailable in Windows: unsupported
+      ]
+    )
+  }
+
+  func testDiagnoseAvailabilityWindows3() {
+    AssertParse(
+      """
+      @available(Windows, introduced: 10.0.17763, deprecated: 10.0.19140)
+      func introduced_deprecated() {}
+      """
+    )
+  }
+
+  func testDiagnoseAvailabilityWindows4() {
+    AssertParse(
+      """
+      introduced_deprecated()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'introduced_deprecated()' is only available in * 10.0.17763 or newe
+        // TODO: Old parser expected note on line 1: add 'if #available' version check
+      ]
+    )
+  }
+
+  func testDiagnoseAvailabilityWindows5() {
+    AssertParse(
+      """
+      @available(Windows 10, *)
+      func windows10() {}
+      """
+    )
+  }
+
+  func testDiagnoseAvailabilityWindows6() {
+    AssertParse(
+      """
+      windows10()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'windows10()' is only available in * 10 or newer
+        // TODO: Old parser expected note on line 1: add 'if #available' version check
+      ]
+    )
+  }
+
+  func testDiagnoseAvailabilityWindows7() {
+    AssertParse(
+      """
+      func conditional_compilation() {
+        if #available(Windows 10, *) {
+        }
+      }
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/DiagnoseDynamicReplacementTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseDynamicReplacementTests.swift
@@ -1,0 +1,61 @@
+// This test file has been translated from swift/test/Parse/diagnose_dynamicReplacement.swift
+
+import XCTest
+
+final class DiagnoseDynamicReplacementTests: XCTestCase {
+  func testDiagnoseDynamicReplacement1() {
+    AssertParse(
+      """
+      dynamic func dynamic_replaceable() {
+      }
+      """
+    )
+  }
+
+  func testDiagnoseDynamicReplacement2() {
+    AssertParse(
+      """
+      @_dynamicReplacement#^DIAG^#
+      func test_dynamic_replacement_for() {
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected '(' in '_dynamicReplacement' attribute
+        DiagnosticSpec(message: "expected '(' in attribute"),
+        DiagnosticSpec(message: "expected argument for '@_dynamicReplacement' attribute"),
+        DiagnosticSpec(message: "expected ')' to end attribute"),
+      ]
+    )
+  }
+
+  func testDiagnoseDynamicReplacement3() {
+    AssertParse(
+      """
+      @_dynamicReplacement(#^DIAG^#
+      func test_dynamic_replacement_for2() {
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected 'for' in '_dynamicReplacement' attribute
+        DiagnosticSpec(message: "expected argument for '@_dynamicReplacement' attribute"),
+        DiagnosticSpec(message: "expected ')' to end attribute"),
+      ]
+    )
+  }
+
+  func testDiagnoseDynamicReplacement4() {
+    AssertParse(
+      """
+      @_dynamicReplacement(for: dynamically_replaceable() #^DIAG^#
+      func test_dynamic_replacement_for3() {
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 1: to match this opening '('
+        DiagnosticSpec(message: "expected ')' to end attribute"),
+        // TODO: Old parser expected error on line 2: expected ')' after function name for @_dynamicReplacement
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/DiagnoseInitializerAsTypedPatternTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseInitializerAsTypedPatternTests.swift
@@ -1,0 +1,122 @@
+// This test file has been translated from swift/test/Parse/diagnose_initializer_as_typed_pattern.swift
+
+import XCTest
+
+final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
+  func testDiagnoseInitializerAsTypedPattern1() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/44070
+      """
+    )
+  }
+
+  func testDiagnoseInitializerAsTypedPattern2() {
+    AssertParse(
+      """
+      class X {}
+      func foo() {}
+      """
+    )
+  }
+
+  func testDiagnoseInitializerAsTypedPattern3() {
+    AssertParse(
+      """
+      let a:[X]()  
+      let b: [X]()  
+      let c :[X]()  
+      let d : [X]()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' = '
+        // TODO: Old parser expected error on line 2: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' ='
+        // TODO: Old parser expected error on line 3: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 7 - 8 = '= '
+        // TODO: Old parser expected error on line 4: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 7 - 8 = '='
+      ]
+    )
+  }
+
+  func testDiagnoseInitializerAsTypedPattern4() {
+    AssertParse(
+      """
+      let e: X()#^DIAG^#, ee: Int
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' ='
+        DiagnosticSpec(message: "extraneous ', ee: Int' at top level"),
+      ]
+    )
+  }
+
+  func testDiagnoseInitializerAsTypedPattern5() {
+    AssertParse(
+      """
+      let f:/*comment*/[X]()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' = '
+      ]
+    )
+  }
+
+  func testDiagnoseInitializerAsTypedPattern6() {
+    AssertParse(
+      """
+      var _1 = 1, _2 = 2
+      """
+    )
+  }
+
+  func testDiagnoseInitializerAsTypedPattern7() {
+    AssertParse(
+      """
+      // paren follows the type, but it's part of a separate (valid) expression
+      let ff: X
+      (_1, _2) = (_2, _1)
+      let fff: X
+       (_1, _2) = (_2, _1)
+      """
+    )
+  }
+
+  func testDiagnoseInitializerAsTypedPattern8() {
+    AssertParse(
+      """
+      let g: X(x)  
+      let h: X(x, y)  
+      let i: X() { foo() }  
+      let j: X(x) { foo() }  
+      let k: X(x, y) { foo() }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' ='
+        // TODO: Old parser expected error on line 2: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' ='
+        // TODO: Old parser expected error on line 3: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' ='
+        // TODO: Old parser expected error on line 4: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' ='
+        // TODO: Old parser expected error on line 5: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' ='
+      ]
+    )
+  }
+
+  func testDiagnoseInitializerAsTypedPattern9() {
+    AssertParse(
+      """
+      func nonTopLevel() {
+        let a:[X]()   
+        let i: X() { foo() }  
+        let j: X(x) { foo() }  
+        let k: X(x, y) { foo() }  
+        _ = (a, i, j, k)
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 8 - 9 = ' = '
+        // TODO: Old parser expected error on line 3: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 8 - 9 = ' ='
+        // TODO: Old parser expected error on line 4: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 8 - 9 = ' ='
+        // TODO: Old parser expected error on line 5: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 8 - 9 = ' ='
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/DiagnosticMissingFuncKeywordTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnosticMissingFuncKeywordTests.swift
@@ -1,0 +1,134 @@
+// This test file has been translated from swift/test/Parse/diagnostic_missing_func_keyword.swift
+
+import XCTest
+
+final class DiagnosticMissingFuncKeywordTests: XCTestCase {
+  func testDiagnosticMissingFuncKeyword1() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/52877
+      """
+    )
+  }
+
+  func testDiagnosticMissingFuncKeyword2() {
+    AssertParse(
+      """
+      protocol Brew { #^DIAG_1^#
+        tripel() -> Int 
+        quadrupel#^DIAG_2^#: Int { get } 
+        static + (lhs: Self, rhs: Self) -> Self 
+        * (lhs: Self, rhs: Self) -> Self 
+        ipa: Int { get }; apa: Float { get }
+        stout: Int { get } porter: Float { get }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 1: in declaration of 'Brew'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected declaration in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '}' to end protocol"),
+        // TODO: Old parser expected error on line 2: expected 'func' keyword in instance method declaration, Fix-It replacements: 3 - 3 = 'func '
+        // TODO: Old parser expected error on line 3: expected 'var' keyword in property declaration, Fix-It replacements: 3 - 3 = 'var '
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 4: expected 'func' keyword in operator function declaration, Fix-It replacements: 10 - 10 = 'func '
+        // TODO: Old parser expected error on line 5: expected 'func' keyword in operator function declaration, Fix-It replacements: 3 - 3 = 'func '
+        // TODO: Old parser expected error on line 5: operator '*' declared in protocol must be 'static', Fix-It replacements: 3 - 3 = 'static '
+        // TODO: Old parser expected error on line 6: expected 'var' keyword in property declaration, Fix-It replacements: 3 - 3 = 'var '
+        // TODO: Old parser expected error on line 6: expected 'var' keyword in property declaration, Fix-It replacements: 21 - 21 = 'var '
+        // TODO: Old parser expected error on line 7: expected 'var' keyword in property declaration, Fix-It replacements: 3 - 3 = 'var '
+        // TODO: Old parser expected error on line 7: expected declaration
+        // TODO: Old parser expected error on line 7: consecutive declarations on a line must be separated by ';'
+      ]
+    )
+  }
+
+  func testDiagnosticMissingFuncKeyword3() {
+    AssertParse(
+      """
+      infix operator %%
+      """
+    )
+  }
+
+  func testDiagnosticMissingFuncKeyword4() {
+    AssertParse(
+      """
+      struct Bar {#^DIAG_1^#
+        #^DIAG_2^#fisr = 0x5F3759DF 
+        %%<T: Brew> (lhs: T, rhs: T) -> T { 
+          lhs + lhs + rhs + rhs
+        }
+        _: Int = 42 
+        (light, dark) = (100, 200)
+        a, b: Int 
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected declaration in struct"),
+        // TODO: Old parser expected error on line 2: expected 'var' keyword in property declaration, Fix-It replacements: 3 - 3 = 'var '
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text in struct"),
+        // TODO: Old parser expected error on line 3: expected 'func' keyword in operator function declaration, Fix-It replacements: 3 - 3 = 'func '
+        // TODO: Old parser expected error on line 3: operator '%%' declared in type 'Bar' must be 'static'
+        // TODO: Old parser expected error on line 3: member operator '%%' must have at least one argument of type 'Bar'
+        // TODO: Old parser expected error on line 6: expected 'var' keyword in property declaration, Fix-It replacements: 3 - 3 = 'var '
+        // TODO: Old parser expected error on line 6: property declaration does not bind any variables
+        // TODO: Old parser expected error on line 7: expected 'var' keyword in property declaration, Fix-It replacements: 3 - 3 = 'var '
+        // TODO: Old parser expected error on line 8: expected 'var' keyword in property declaration, Fix-It replacements: 3 - 3 = 'var '
+      ]
+    )
+  }
+
+  func testDiagnosticMissingFuncKeyword5() {
+    AssertParse(
+      """
+      class Baz {#^DIAG_1^#
+        instanceMethod() {} 
+        #^DIAG_2^#static staticMethod() {} 
+        instanceProperty: Int { 0 } 
+        static staticProperty: Int { 0 } 
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected declaration in class"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '}' to end class"),
+        // TODO: Old parser expected error on line 2: expected 'func' keyword in instance method declaration, Fix-It replacements: 3 - 3 = 'func '
+        // TODO: Old parser expected error on line 3: expected 'func' keyword in static method declaration, Fix-It replacements: 10 - 10 = 'func '
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 4: expected 'var' keyword in property declaration, Fix-It replacements: 3 - 3 = 'var '
+        // TODO: Old parser expected error on line 5: expected 'var' keyword in static property declaration, Fix-It replacements: 10 - 10 = 'var '
+      ]
+    )
+  }
+
+  func testDiagnosticMissingFuncKeyword6() {
+    AssertParse(
+      """
+      class C1 {
+        class classMethod#^DIAG^#() {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '{' in class
+        DiagnosticSpec(message: "unexpected text '()' in class"),
+      ]
+    )
+  }
+
+  func testDiagnosticMissingFuncKeyword7() {
+    AssertParse(
+      """
+      class C2 {
+        class classProperty: Int { #^DIAG^#0 } 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: inheritance from non-protocol, non-class type 'Int'
+        // TODO: Old parser expected note on line 2: in declaration of 'classProperty'
+        // TODO: Old parser expected error on line 2: expected declaration
+        DiagnosticSpec(message: "expected declaration in class"),
+        DiagnosticSpec(message: "unexpected text '0' in class"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/DiagnosticMissingFuncKeywordTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnosticMissingFuncKeywordTests.swift
@@ -68,10 +68,7 @@ final class DiagnosticMissingFuncKeywordTests: XCTestCase {
         // TODO: Old parser expected error on line 2: expected 'var' keyword in property declaration, Fix-It replacements: 3 - 3 = 'var '
         DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text in struct"),
         // TODO: Old parser expected error on line 3: expected 'func' keyword in operator function declaration, Fix-It replacements: 3 - 3 = 'func '
-        // TODO: Old parser expected error on line 3: operator '%%' declared in type 'Bar' must be 'static'
-        // TODO: Old parser expected error on line 3: member operator '%%' must have at least one argument of type 'Bar'
         // TODO: Old parser expected error on line 6: expected 'var' keyword in property declaration, Fix-It replacements: 3 - 3 = 'var '
-        // TODO: Old parser expected error on line 6: property declaration does not bind any variables
         // TODO: Old parser expected error on line 7: expected 'var' keyword in property declaration, Fix-It replacements: 3 - 3 = 'var '
         // TODO: Old parser expected error on line 8: expected 'var' keyword in property declaration, Fix-It replacements: 3 - 3 = 'var '
       ]
@@ -122,8 +119,6 @@ final class DiagnosticMissingFuncKeywordTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: inheritance from non-protocol, non-class type 'Int'
-        // TODO: Old parser expected note on line 2: in declaration of 'classProperty'
         // TODO: Old parser expected error on line 2: expected declaration
         DiagnosticSpec(message: "expected declaration in class"),
         DiagnosticSpec(message: "unexpected text '0' in class"),

--- a/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
+++ b/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
@@ -201,7 +201,6 @@ final class DollarIdentifierTests: XCTestCase {
         // TODO: Old parser expected error on line 27: cannot declare entity named '$Struct'; the '$' prefix is reserved
         // TODO: Old parser expected error on line 32: cannot declare entity named '$Protocol'; the '$' prefix is reserved
         // TODO: Old parser expected error on line 33: cannot declare entity named '$Precedence'; the '$' prefix is reserved
-        // TODO: Old parser expected error on line 34: cycle in 'higherThan' relation
         // TODO: Old parser expected error on line 37: use of unknown directive '#$UnknownDirective'
         DiagnosticSpec(message: "extraneous '#$UnknownDirective()' at top level"),
       ]

--- a/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
+++ b/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
@@ -1,0 +1,263 @@
+// This test file has been translated from swift/test/Parse/dollar_identifier.swift
+
+import XCTest
+
+final class DollarIdentifierTests: XCTestCase {
+  func testDollarIdentifier1() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/44270
+      // Dollar was accidentally allowed as an identifier in Swift 3.
+      // SE-0144: Reject this behavior in the future.
+      """
+    )
+  }
+
+  func testDollarIdentifier2() {
+    AssertParse(
+      """
+      func dollarVar() {
+        var #^DIAG_1^#$ #^DIAG_2^#: Int = 42 
+        $ += 1 
+        print($) 
+      }
+      func dollarLet() {
+        let #^DIAG_3^#$ = 42 
+        print($) 
+      }
+      func dollarClass() {
+        class #^DIAG_4^#$ {} 
+      }
+      func dollarEnum() {
+        enum #^DIAG_5^#$ {} 
+      }
+      func dollarStruct() {
+        struct #^DIAG_6^#$ {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 7 - 8 = '`$`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected pattern in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text in function"),
+        // TODO: Old parser expected error on line 3: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 3 - 4 = '`$`'
+        // TODO: Old parser expected error on line 4: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 9 - 10 = '`$`'
+        // TODO: Old parser expected error on line 7: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 7 - 8 = '`$`'
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected pattern in variable"),
+        // TODO: Old parser expected error on line 8: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 9 - 10 = '`$`'
+        // TODO: Old parser expected error on line 11: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 9 - 10 = '`$`'
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected identifier in class"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected member block in class"),
+        // TODO: Old parser expected error on line 14: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 8 - 9 = '`$`'
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected identifier in enum"),
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected member block in enum"),
+        // TODO: Old parser expected error on line 17: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 10 - 11 = '`$`'
+        DiagnosticSpec(locationMarker: "DIAG_6", message: "expected identifier in struct"),
+        DiagnosticSpec(locationMarker: "DIAG_6", message: "expected member block in struct"),
+      ]
+    )
+  }
+
+  func testDollarIdentifier3() {
+    AssertParse(
+      """
+      func dollarFunc() {
+        func #^DIAG_1^#$(#^DIAG_2^#$ dollarParam: Int) {}
+        $($#^DIAG_3^#: 24)
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 8 - 9 = '`$`'
+        // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 10 - 11 = '`$`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '$' before parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected type in function parameter"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '$ dollarParam: Int' in parameter clause"),
+        // TODO: Old parser expected error on line 3: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 3 - 4 = '`$`'
+        // TODO: Old parser expected error on line 3: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 5 - 6 = '`$`'
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text ': 24' in function call"),
+      ]
+    )
+  }
+
+  func testDollarIdentifier4() {
+    AssertParse(
+      """
+      func escapedDollarVar() {
+        var `$` : Int = 42 // no error
+        `$` += 1
+        print(`$`)
+      }
+      func escapedDollarLet() {
+        let `$` = 42 // no error
+        print(`$`)
+      }
+      func escapedDollarClass() {
+        class `$` {} // no error
+      }
+      func escapedDollarEnum() {
+        enum `$` {} // no error
+      }
+      func escapedDollarStruct() {
+        struct `$` {} // no error
+      }
+      """
+    )
+  }
+
+  func testDollarIdentifier5() {
+    AssertParse(
+      """
+      func escapedDollarFunc() {
+        func `$`(`$`: Int) {} // no error
+        `$`(`$`: 25) // no error
+      }
+      """
+    )
+  }
+
+  func testDollarIdentifier6() {
+    AssertParse(
+      """
+      func escapedDollarAnd() {
+        // FIXME: Bad diagnostics.
+        #^DIAG^#`$0` = 1 
+        `$$` = 2
+        `$abc` = 3
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: expected expression
+        DiagnosticSpec(message: "unexpected text in function"),
+      ]
+    )
+  }
+
+  func testDollarIdentifier7() {
+    AssertParse(
+      """
+      // Test that we disallow user-defined $-prefixed identifiers. However, the error
+      // should not be emitted on $-prefixed identifiers that are not considered
+      // declarations.
+      """
+    )
+  }
+
+  func testDollarIdentifier8() {
+    AssertParse(
+      """
+      func $declareWithDollar() { 
+        var $foo: Int { 
+          get { 0 }
+          set($value) {} 
+        }
+        func $bar() { } 
+        func wibble(
+          $a: Int, 
+          $b c: Int) { } 
+        let _: (Int) -> Int = {
+          [$capture = 0] 
+          $a in 
+          $capture
+        }
+        let ($a: _, _) = (0, 0) 
+        $label: if true { 
+          break $label
+        }
+        switch 0 {
+        @$dollar case _: 
+          break
+        }
+        if #available($Dummy 9999, *) {} 
+        @_swift_native_objc_runtime_base($Dollar)
+        class $Class {} 
+        enum $Enum {} 
+        struct $Struct { 
+          @_projectedValueProperty($dummy)
+          let property: Never
+        }
+      }
+      protocol $Protocol {} 
+      precedencegroup $Precedence { 
+        higherThan: $Precedence 
+      }
+      infix operator **: $Precedence
+      #^DIAG^##$UnknownDirective()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot declare entity named '$declareWithDollar'
+        // TODO: Old parser expected error on line 2: cannot declare entity named '$foo'
+        // TODO: Old parser expected error on line 4: cannot declare entity named '$value'
+        // TODO: Old parser expected error on line 6: cannot declare entity named '$bar'
+        // TODO: Old parser expected error on line 8: cannot declare entity named '$a'
+        // TODO: Old parser expected error on line 9: cannot declare entity named '$b'
+        // TODO: Old parser expected error on line 11: cannot declare entity named '$capture'
+        // TODO: Old parser expected error on line 12: inferred projection type 'Int' is not a property wrapper
+        // TODO: Old parser expected error on line 15: cannot declare entity named '$a'
+        // TODO: Old parser expected error on line 16: cannot declare entity named '$label'
+        // TODO: Old parser expected error on line 20: unknown attribute '$dollar'
+        // TODO: Old parser expected warning on line 23: unrecognized platform name '$Dummy'
+        // TODO: Old parser expected error on line 25: cannot declare entity named '$Class'; the '$' prefix is reserved
+        // TODO: Old parser expected error on line 26: cannot declare entity named '$Enum'; the '$' prefix is reserved
+        // TODO: Old parser expected error on line 27: cannot declare entity named '$Struct'; the '$' prefix is reserved
+        // TODO: Old parser expected error on line 32: cannot declare entity named '$Protocol'; the '$' prefix is reserved
+        // TODO: Old parser expected error on line 33: cannot declare entity named '$Precedence'; the '$' prefix is reserved
+        // TODO: Old parser expected error on line 34: cycle in 'higherThan' relation
+        // TODO: Old parser expected error on line 37: use of unknown directive '#$UnknownDirective'
+        DiagnosticSpec(message: "extraneous '#$UnknownDirective()' at top level"),
+      ]
+    )
+  }
+
+  func testDollarIdentifier9() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/55672
+      """
+    )
+  }
+
+  func testDollarIdentifier10() {
+    AssertParse(
+      """
+      @propertyWrapper
+      struct Wrapper {
+        var wrappedValue: Int
+        var projectedValue: String { String(wrappedValue) }
+      }
+      """
+    )
+  }
+
+  func testDollarIdentifier11() {
+    AssertParse(
+      """
+      struct S {
+        @Wrapper var café = 42
+      }
+      """
+    )
+  }
+
+  func testDollarIdentifier12() {
+    AssertParse(
+      """
+      let _ = S().$café // Okay
+      """
+    )
+  }
+
+  func testDollarIdentifier13() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/55538
+      infix operator $ 
+      infix operator `$`
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '$' is considered an identifier and must not appear within an operator name
+        // TODO: Old parser expected error on line 3: '$' is considered an identifier and must not appear within an operator name
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/EffectfulPropertiesTests.swift
+++ b/Tests/SwiftParserTest/translated/EffectfulPropertiesTests.swift
@@ -1,0 +1,333 @@
+// This test file has been translated from swift/test/Parse/effectful_properties.swift
+
+import XCTest
+
+final class EffectfulPropertiesTests: XCTestCase {
+  func testEffectfulProperties1() {
+    AssertParse(
+      """
+      struct MyProps {
+        var prop1 : Int {
+          get async { }
+        }
+        var prop2 : Int {
+          get throws { }
+        }
+        var prop3 : Int {
+          get async throws { }
+        }
+        var prop1mut : Int {
+          mutating get async { }
+        }
+        var prop2mut : Int {
+          mutating get throws { }
+        }
+        var prop3mut : Int {
+          mutating get async throws { }
+        }
+      }
+      """
+    )
+  }
+
+  func testEffectfulProperties2() {
+    AssertParse(
+      """
+      struct X1 {
+        subscript(_ i : Int) -> Int {
+            get async {}
+          }
+      }
+      """
+    )
+  }
+
+  func testEffectfulProperties3() {
+    AssertParse(
+      """
+      class X2 {
+        subscript(_ i : Int) -> Int {
+            get throws {}
+          }
+      }
+      """
+    )
+  }
+
+  func testEffectfulProperties4() {
+    AssertParse(
+      """
+      struct X3 {
+        subscript(_ i : Int) -> Int {
+            get async throws {}
+          }
+      }
+      """
+    )
+  }
+
+  func testEffectfulProperties5() {
+    AssertParse(
+      """
+      struct BadSubscript1 {
+        subscript(_ i : Int) -> Int {
+            get async throws {}
+            set {} 
+          }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
+      ]
+    )
+  }
+
+  func testEffectfulProperties6() {
+    AssertParse(
+      """
+      struct BadSubscript2 {
+        subscript(_ i : Int) -> Int {
+            get throws {}
+            set throws {}
+          }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
+        // TODO: Old parser expected error on line 4: 'set' accessor cannot have specifier 'throws'
+      ]
+    )
+  }
+
+  func testEffectfulProperties7() {
+    AssertParse(
+      """
+      struct S {
+        var prop2 : Int {
+          mutating get async throws { 0 }
+          nonmutating set {} 
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
+      ]
+    )
+  }
+
+  func testEffectfulProperties8() {
+    AssertParse(
+      """
+      var prop3 : Bool {
+        _read { yield prop3 }
+        // expected-note@+1 2 {{previous definition of getter here}}
+        get throws { false }
+        get async { true } 
+        get {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '_read' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
+        // TODO: Old parser expected error on line 2: variable cannot provide both a 'read' accessor and a getter
+        // TODO: Old parser expected note on line 4: getter defined here
+        // TODO: Old parser expected error on line 5: variable already has a getter
+        // TODO: Old parser expected error on line 6: variable already has a getter
+      ]
+    )
+  }
+
+  func testEffectfulProperties9() {
+    AssertParse(
+      """
+      enum E {
+        private(set) var prop4 : Double {
+          set {} 
+          get async throws { 1.1 }
+          _modify { yield &prop4 } 
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
+        // TODO: Old parser expected error on line 5: '_modify' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
+      ]
+    )
+  }
+
+  func testEffectfulProperties10() {
+    AssertParse(
+      """
+      protocol P {
+        associatedtype T
+        var prop1 : T { get async throws }
+        var prop2 : T { get async throws set } 
+        var prop3 : T { get throws set } 
+        var prop4 : T { get async }
+        var prop5 : T { mutating get async throws }
+        var prop6 : T { mutating get throws }
+        var prop7 : T { mutating get async nonmutating set } 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
+        // TODO: Old parser expected error on line 5: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
+        // TODO: Old parser expected error on line 9: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
+      ]
+    )
+  }
+
+  func testEffectfulProperties11() {
+    AssertParse(
+      """
+      ///////////////////
+      // invalid syntax
+      """
+    )
+  }
+
+  func testEffectfulProperties12() {
+    AssertParse(
+      """
+      var bad1 : Int {
+        get rethrows { 0 }  
+        set rethrows { }   
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: only function declarations may be marked 'rethrows'; did you mean 'throws'?
+        // TODO: Old parser expected error on line 3: 'set' accessor is not allowed on property with 'get' accessor that is 'async' or 'throws'
+        // TODO: Old parser expected error on line 3: 'set' accessor cannot have specifier 'rethrows'
+      ]
+    )
+  }
+
+  func testEffectfulProperties13() {
+    AssertParse(
+      """
+      var bad2 : Int {
+        get reasync { 0 }  
+        set reasync { }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '{' to start getter definition
+      ]
+    )
+  }
+
+  func testEffectfulProperties14() {
+    AssertParse(
+      """
+      var bad3 : Int {
+        _read async { yield 0 } 
+        set(theValue) async { } 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '_read' accessor cannot have specifier 'async'
+        // TODO: Old parser expected error on line 3: 'set' accessor cannot have specifier 'async'
+      ]
+    )
+  }
+
+  func testEffectfulProperties15() {
+    AssertParse(
+      """
+      var bad4 : Int = 0 {
+        willSet(theValue) reasync rethrows #^DIAG^#async throws {}
+        didSet throws bogus {}
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'willSet' accessor cannot have specifier 'throws'
+        // TODO: Old parser expected error on line 2: 'willSet' accessor cannot have specifier 'async'
+        // TODO: Old parser expected error on line 2: 'willSet' accessor cannot have specifier 'rethrows'
+        // TODO: Old parser expected error on line 2: 'willSet' accessor cannot have specifier 'reasync'
+        DiagnosticSpec(message: "unexpected text in variable"),
+        // TODO: Old parser expected error on line 3: expected '{' to start 'didSet' definition
+        // TODO: Old parser expected error on line 3: 'didSet' accessor cannot have specifier 'throws'
+      ]
+    )
+  }
+
+  func testEffectfulProperties16() {
+    AssertParse(
+      """
+      var bad5 : Int {
+        get #^DIAG^#bogus rethrows {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '{' to start getter definition
+        DiagnosticSpec(message: "unexpected text 'bogus rethrows {}' in variable"),
+      ]
+    )
+  }
+
+  func testEffectfulProperties17() {
+    AssertParse(
+      """
+      var bad6 : Int {
+        get rethrows #^DIAG^#-> Int { 0 }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '{' to start getter definition
+        // TODO: Old parser expected error on line 2: only function declarations may be marked 'rethrows'; did you mean 'throws'?
+        DiagnosticSpec(message: "unexpected text '-> Int { 0 }' in variable"),
+      ]
+    )
+  }
+
+  func testEffectfulProperties18() {
+    AssertParse(
+      """
+      var bad7 : Double {
+        get throws async { 3.14 } 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'async' must precede 'throws'
+      ]
+    )
+  }
+
+  func testEffectfulProperties19() {
+    AssertParse(
+      """
+      var bad8 : Double {
+        get {}
+        _modify throws async { yield &bad8 }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: '_modify' accessor cannot have specifier 'async'
+        // TODO: Old parser expected error on line 3: '_modify' accessor cannot have specifier 'throws'
+      ]
+    )
+  }
+
+  func testEffectfulProperties20() {
+    AssertParse(
+      """
+      protocol BadP {
+        var prop2 : Int { get #^DIAG_1^#bogus rethrows set } 
+        var prop3 : Int { get rethrows #^DIAG_2^#bogus set }
+        var prop4 : Int { get reasync #^DIAG_3^#bogus set }
+        var prop5 : Int { get throws async } 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected get or set in a protocol property
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text 'bogus rethrows set' in variable"),
+        // TODO: Old parser expected error on line 3: only function declarations may be marked 'rethrows'; did you mean 'throws'?
+        // TODO: Old parser expected error on line 3: expected get or set in a protocol property
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text 'bogus set' in variable"),
+        // TODO: Old parser expected error on line 4: expected get or set in a protocol property
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text 'bogus set' in variable"),
+        // TODO: Old parser expected error on line 5: 'async' must precede 'throws'
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/EnumElementPatternSwift4Tests.swift
+++ b/Tests/SwiftParserTest/translated/EnumElementPatternSwift4Tests.swift
@@ -67,14 +67,6 @@ final class EnumElementPatternSwift4Tests: XCTestCase {
         // TODO: Old parser expected note on line 3: while parsing this '<' as a type parameter bracket
         // TODO: Old parser expected error on line 5: cannot specialize a non-generic definition
         // TODO: Old parser expected note on line 5: while parsing this '<' as a type parameter bracket
-        // TODO: Old parser expected error on line 7: pattern with associated values does not match enum case 'C'
-        // TODO: Old parser expected note on line 7: remove associated values to make the pattern match, Fix-It replacements: 10 - 12 = ''
-        // TODO: Old parser expected error on line 9: pattern with associated values does not match enum case 'D'
-        // TODO: Old parser expected note on line 9: remove associated values to make the pattern match, Fix-It replacements: 10 - 23 = ''
-        // TODO: Old parser expected error on line 16: pattern with associated values does not match enum case 'C'
-        // TODO: Old parser expected note on line 16: remove associated values to make the pattern match, Fix-It replacements: 12 - 14 = ''
-        // TODO: Old parser expected error on line 17: pattern with associated values does not match enum case 'D'
-        // TODO: Old parser expected note on line 17: remove associated values to make the pattern match, Fix-It replacements: 12 - 25 = ''
       ]
     )
   }
@@ -100,13 +92,7 @@ final class EnumElementPatternSwift4Tests: XCTestCase {
       } catch E.B(let payload) { 
         let _: () = payload
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: pattern with associated values does not match enum case 'A'
-        // TODO: Old parser expected note on line 3: remove associated values to make the pattern match, Fix-It replacements: 12 - 14 = ''
-        // TODO: Old parser expected error on line 5: pattern with associated values does not match enum case 'B'
-        // TODO: Old parser expected note on line 5: remove associated values to make the pattern match, Fix-It replacements: 12 - 25 = ''
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/EnumElementPatternSwift4Tests.swift
+++ b/Tests/SwiftParserTest/translated/EnumElementPatternSwift4Tests.swift
@@ -1,0 +1,113 @@
+// This test file has been translated from swift/test/Parse/enum_element_pattern_swift4.swift
+
+import XCTest
+
+final class EnumElementPatternSwift4Tests: XCTestCase {
+  func testEnumElementPatternSwift41() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/46040
+      // See test/Compatibility/enum_element_pattern.swift for Swift3 behavior.
+      // As for FIXME cases: see https://github.com/apple/swift/issues/46054
+      """
+    )
+  }
+
+  func testEnumElementPatternSwift42() {
+    AssertParse(
+      """
+      enum E {
+        case A, B, C, D
+        static func testE(e: E) {
+          switch e {
+          case A<UndefinedTy>(): 
+            break
+          case B<Int>(): 
+            break
+          default:
+            break;
+          }
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: cannot specialize a non-generic definition
+        // TODO: Old parser expected note on line 5: while parsing this '<' as a type parameter bracket
+        // TODO: Old parser expected error on line 7: cannot specialize a non-generic definition
+        // TODO: Old parser expected note on line 7: while parsing this '<' as a type parameter bracket
+      ]
+    )
+  }
+
+  func testEnumElementPatternSwift43() {
+    AssertParse(
+      """
+      func testE(e: E) {
+        switch e {
+        case E.A<UndefinedTy>(): 
+          break
+        case E.B<Int>(): 
+          break
+        case .C(): 
+          break
+        case .D(let payload): 
+          let _: () = payload
+          break
+        default:
+          break
+        }
+        guard
+          case .C() = e, 
+          case .D(let payload) = e 
+        else { return }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: cannot specialize a non-generic definition
+        // TODO: Old parser expected note on line 3: while parsing this '<' as a type parameter bracket
+        // TODO: Old parser expected error on line 5: cannot specialize a non-generic definition
+        // TODO: Old parser expected note on line 5: while parsing this '<' as a type parameter bracket
+        // TODO: Old parser expected error on line 7: pattern with associated values does not match enum case 'C'
+        // TODO: Old parser expected note on line 7: remove associated values to make the pattern match, Fix-It replacements: 10 - 12 = ''
+        // TODO: Old parser expected error on line 9: pattern with associated values does not match enum case 'D'
+        // TODO: Old parser expected note on line 9: remove associated values to make the pattern match, Fix-It replacements: 10 - 23 = ''
+        // TODO: Old parser expected error on line 16: pattern with associated values does not match enum case 'C'
+        // TODO: Old parser expected note on line 16: remove associated values to make the pattern match, Fix-It replacements: 12 - 14 = ''
+        // TODO: Old parser expected error on line 17: pattern with associated values does not match enum case 'D'
+        // TODO: Old parser expected note on line 17: remove associated values to make the pattern match, Fix-It replacements: 12 - 25 = ''
+      ]
+    )
+  }
+
+  func testEnumElementPatternSwift44() {
+    AssertParse(
+      """
+      extension E : Error {}
+      func canThrow() throws {
+        throw E.A
+      }
+      """
+    )
+  }
+
+  func testEnumElementPatternSwift45() {
+    AssertParse(
+      """
+      do {
+        try canThrow()
+      } catch E.A() { 
+        // ..
+      } catch E.B(let payload) { 
+        let _: () = payload
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: pattern with associated values does not match enum case 'A'
+        // TODO: Old parser expected note on line 3: remove associated values to make the pattern match, Fix-It replacements: 12 - 14 = ''
+        // TODO: Old parser expected error on line 5: pattern with associated values does not match enum case 'B'
+        // TODO: Old parser expected note on line 5: remove associated values to make the pattern match, Fix-It replacements: 12 - 25 = ''
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/EnumTests.swift
+++ b/Tests/SwiftParserTest/translated/EnumTests.swift
@@ -1,0 +1,1448 @@
+// This test file has been translated from swift/test/Parse/enum.swift
+
+import XCTest
+
+final class EnumTests: XCTestCase {
+  func testEnum1() {
+    AssertParse(
+      """
+      // FIXME: this test only passes on platforms which have Float80.
+      // <rdar://problem/19508460> Floating point enum raw values are not portable
+      """
+    )
+  }
+
+  func testEnum2() {
+    AssertParse(
+      """
+      // Windows does not support FP80
+      // XFAIL: OS=windows-msvc
+      """
+    )
+  }
+
+  func testEnum3() {
+    AssertParse(
+      """
+      enum Empty {}
+      """
+    )
+  }
+
+  func testEnum4() {
+    AssertParse(
+      """
+      enum Boolish {
+        case falsy
+        case truthy
+        init() { self = .falsy }
+      }
+      """
+    )
+  }
+
+  func testEnum5() {
+    AssertParse(
+      """
+      var b = Boolish.falsy
+      b = .truthy
+      """
+    )
+  }
+
+  func testEnum6() {
+    AssertParse(
+      """
+      enum Optionable<T> {
+        case Nought
+        case Mere(T)
+      }
+      """
+    )
+  }
+
+  func testEnum7() {
+    AssertParse(
+      """
+      var o = Optionable<Int>.Nought
+      o = .Mere(0)
+      """
+    )
+  }
+
+  func testEnum8() {
+    AssertParse(
+      """
+      enum Color { case Red, Green, Grayscale(Int), Blue }
+      """
+    )
+  }
+
+  func testEnum9() {
+    AssertParse(
+      """
+      var c = Color.Red
+      c = .Green
+      c = .Grayscale(255)
+      c = .Blue
+      """
+    )
+  }
+
+  func testEnum10() {
+    AssertParse(
+      """
+      let partialApplication = Color.Grayscale
+      """
+    )
+  }
+
+  func testEnum11() {
+    AssertParse(
+      """
+      // Cases are excluded from non-enums.
+      #^DIAG^#case FloatingCase
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: enum 'case' is not allowed outside of an enum
+        DiagnosticSpec(message: "extraneous 'case FloatingCase' at top level"),
+      ]
+    )
+  }
+
+  func testEnum12() {
+    AssertParse(
+      """
+      struct SomeStruct {
+        case StructCase 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: enum 'case' is not allowed outside of an enum
+      ]
+    )
+  }
+
+  func testEnum13() {
+    AssertParse(
+      """
+      class SomeClass {
+        case ClassCase 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: enum 'case' is not allowed outside of an enum
+      ]
+    )
+  }
+
+  func testEnum14() {
+    AssertParse(
+      """
+      enum EnumWithExtension1 {
+        case A1
+      }
+      extension EnumWithExtension1 {
+        case A2 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: enum 'case' is not allowed outside of an enum
+      ]
+    )
+  }
+
+  func testEnum15() {
+    AssertParse(
+      """
+      // Attributes for enum cases.
+      """
+    )
+  }
+
+  func testEnum16() {
+    AssertParse(
+      """
+      enum EnumCaseAttributes {
+        @xyz case EmptyAttributes  
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: unknown attribute 'xyz'
+      ]
+    )
+  }
+
+  func testEnum17() {
+    AssertParse(
+      """
+      // Recover when a switch 'case' label is spelled inside an enum (or outside).
+      enum SwitchEnvy {
+        case X#^DIAG_1^#: 
+        case X(Y)#^DIAG_2^#: 
+        case X, Y#^DIAG_3^#: 
+        case X #^DIAG_4^#where true: 
+        case X(Y), Z(W)#^DIAG_5^#: 
+        case X(Y) #^DIAG_6^#where true: 
+        case #^DIAG_7^#0: 
+        case #^DIAG_8^#_: 
+        case #^DIAG_9^#(_, var x#^DIAG_10^#, #^DIAG_11^#0)#^DIAG_12^#: 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: 'case' label can only appear inside a 'switch' statement
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text ':' before enum case"),
+        // TODO: Old parser expected error on line 4: 'case' label can only appear inside a 'switch' statement
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text ':' before enum case"),
+        // TODO: Old parser expected error on line 5: 'case' label can only appear inside a 'switch' statement
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text ':' before enum case"),
+        // TODO: Old parser expected error on line 6: 'case' label can only appear inside a 'switch' statement
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "unexpected text 'where true:' before enum case"),
+        // TODO: Old parser expected error on line 7: 'case' label can only appear inside a 'switch' statement
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "unexpected text ':' before enum case"),
+        // TODO: Old parser expected error on line 8: 'case' label can only appear inside a 'switch' statement
+        DiagnosticSpec(locationMarker: "DIAG_6", message: "unexpected text 'where true:' before enum case"),
+        // TODO: Old parser expected error on line 9: 'case' label can only appear inside a 'switch' statement
+        DiagnosticSpec(locationMarker: "DIAG_7", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "DIAG_7", message: "unexpected text '0:' before enum case"),
+        // TODO: Old parser expected error on line 10: 'case' label can only appear inside a 'switch' statement
+        DiagnosticSpec(locationMarker: "DIAG_8", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "DIAG_8", message: "unexpected text '_:' before enum case"),
+        // TODO: Old parser expected error on line 11: 'case' label can only appear inside a 'switch' statement
+        DiagnosticSpec(locationMarker: "DIAG_9", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "DIAG_10", message: "expected ':' and type in function parameter"),
+        DiagnosticSpec(locationMarker: "DIAG_11", message: "expected type in function parameter"),
+        DiagnosticSpec(locationMarker: "DIAG_11", message: "unexpected text '0' in parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_12", message: "expected declaration in enum"),
+        DiagnosticSpec(locationMarker: "DIAG_12", message: "unexpected text ':' in enum"),
+      ]
+    )
+  }
+
+  func testEnum18() {
+    AssertParse(
+      """
+      enum HasMethodsPropertiesAndCtors {
+        case TweedleDee
+        case TweedleDum
+        func method() {}
+        func staticMethod() {}
+        init() {}
+        subscript(x:Int) -> Int {
+          return 0
+        }
+        var property : Int {
+          return 0
+        }
+      }
+      """
+    )
+  }
+
+  func testEnum19() {
+    AssertParse(
+      """
+      enum ImproperlyHasIVars {
+        case Flopsy
+        case Mopsy
+        var ivar : Int 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: enums must not contain stored properties
+      ]
+    )
+  }
+
+  func testEnum20() {
+    AssertParse(
+      """
+      // We used to crash on this.  rdar://14678675
+      enum rdar14678675 {
+        case U1, #^DIAG^#
+        case U2 
+        case U3
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: expected identifier after comma in enum 'case' declaration
+        DiagnosticSpec(message: "expected identifier in enum case"),
+      ]
+    )
+  }
+
+  func testEnum21() {
+    AssertParse(
+      """
+      enum Recovery1 {
+        case#^DIAG_1^#: 
+      }
+      enum Recovery2 {
+        case UE1#^DIAG_2^#: 
+      }
+      enum Recovery3 {
+        case UE2(Void)#^DIAG_3^#: 
+      }
+      enum Recovery4 { 
+        case Self #^DIAG_4^#Self 
+      }
+      enum Recovery5 {
+        case #^DIAG_5^#.UE3 
+        case #^DIAG_6^#.UE4, .UE5
+      }
+      enum Recovery6 {
+        case Snout, #^DIAG_7^#_; 
+        case #^DIAG_8^#_; 
+        case Tusk, #^DIAG_9^#
+      }#^DIAG_10^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
+        // TODO: Old parser expected error on line 2: expected pattern
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text before enum"),
+        // TODO: Old parser expected error on line 5: 'case' label can only appear inside a 'switch' statement
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text before enum"),
+        // TODO: Old parser expected error on line 8: 'case' label can only appear inside a 'switch' statement
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text before enum"),
+        // TODO: Old parser expected note on line 10: in declaration of 'Recovery4'
+        // TODO: Old parser expected error on line 11: keyword 'Self' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 11: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 12 = '`Self`'
+        // TODO: Old parser expected error on line 11: consecutive declarations on a line must be separated by ';', Fix-It replacements: 12 - 12 = ';'
+        // TODO: Old parser expected error on line 11: expected declaration
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "unexpected text before enum"),
+        // TODO: Old parser expected error on line 14: extraneous '.' in enum 'case' declaration, Fix-It replacements: 8 - 9 = ''
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "unexpected text '.UE3' before enum case"),
+        // TODO: Old parser expected error on line 15: extraneous '.' in enum 'case' declaration, Fix-It replacements: 8 - 9 = ''
+        // TODO: Old parser expected error on line 15: extraneous '.' in enum 'case' declaration, Fix-It replacements: 14 - 15 = ''
+        DiagnosticSpec(locationMarker: "DIAG_6", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "DIAG_6", message: "unexpected text before enum"),
+        // TODO: Old parser expected error on line 18: keyword '_' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 18: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 15 - 16 = '`_`'
+        // TODO: Old parser expected note on line 18: '_' previously declared here
+        DiagnosticSpec(locationMarker: "DIAG_7", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "DIAG_7", message: "unexpected text '_;' before enum case"),
+        // TODO: Old parser expected error on line 19: keyword '_' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 19: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 9 = '`_`'
+        // TODO: Old parser expected error on line 19: invalid redeclaration of '_'
+        DiagnosticSpec(locationMarker: "DIAG_8", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "DIAG_8", message: "unexpected text '_;' before enum case"),
+        // TODO: Old parser expected error on line 20: expected identifier after comma in enum 'case' declaration
+        DiagnosticSpec(locationMarker: "DIAG_9", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "DIAG_10", message: "expected '}' to end enum"),
+        DiagnosticSpec(locationMarker: "DIAG_10", message: "expected '}' to end enum"),
+        DiagnosticSpec(locationMarker: "DIAG_10", message: "expected '}' to end enum"),
+        DiagnosticSpec(locationMarker: "DIAG_10", message: "expected '}' to end enum"),
+        DiagnosticSpec(locationMarker: "DIAG_10", message: "expected '}' to end enum"),
+      ]
+    )
+  }
+
+  func testEnum22() {
+    AssertParse(
+      """
+      enum RawTypeEmpty : Int {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: an enum with no cases cannot declare a raw type
+        // TODO: Old parser expected error on line 1: 'RawTypeEmpty' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized
+      ]
+    )
+  }
+
+  func testEnum23() {
+    AssertParse(
+      """
+      enum Raw : Int {
+        case Ankeny, Burnside
+      }
+      """
+    )
+  }
+
+  func testEnum24() {
+    AssertParse(
+      """
+      enum MultiRawType : Int64, Int32 { 
+        case Couch, Davis
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: multiple enum raw types 'Int64' and 'Int32'
+      ]
+    )
+  }
+
+  func testEnum25() {
+    AssertParse(
+      """
+      protocol RawTypeNotFirstProtocol {}
+      enum RawTypeNotFirst : RawTypeNotFirstProtocol, Int { 
+        case E
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: raw type 'Int' must appear first in the enum inheritance clause, Fix-It replacements: 24 - 24 = 'Int, ', 47 - 52 = ''
+      ]
+    )
+  }
+
+  func testEnum26() {
+    AssertParse(
+      """
+      enum ExpressibleByRawTypeNotLiteral : Array<Int> { 
+        case Ladd, Elliott, Sixteenth, Harrison
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: raw type 'Array<Int>' is not expressible by a string, integer, or floating-point literal
+        // TODO: Old parser expected error on line 1: 'ExpressibleByRawTypeNotLiteral' declares raw type 'Array<Int>', but does not conform to RawRepresentable and conformance could not be synthesized
+      ]
+    )
+  }
+
+  func testEnum27() {
+    AssertParse(
+      """
+      enum RawTypeCircularityA : RawTypeCircularityB, ExpressibleByIntegerLiteral { 
+        case Morrison, Belmont, Madison, Hawthorne
+        init(integerLiteral value: Int) {
+          self = .Morrison
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'RawTypeCircularityA' has a raw type that depends on itself
+      ]
+    )
+  }
+
+  func testEnum28() {
+    AssertParse(
+      """
+      enum RawTypeCircularityB : RawTypeCircularityA, ExpressibleByIntegerLiteral { 
+        case Willamette, Columbia, Sandy, Multnomah
+        init(integerLiteral value: Int) { 
+          self = .Willamette
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 1: enum 'RawTypeCircularityB' declared here
+      ]
+    )
+  }
+
+  func testEnum29() {
+    AssertParse(
+      """
+      struct ExpressibleByFloatLiteralOnly : ExpressibleByFloatLiteral {
+          init(floatLiteral: Double) {}
+      }
+      enum ExpressibleByRawTypeNotIntegerLiteral : ExpressibleByFloatLiteralOnly { 
+        case Everett 
+        case Flanders
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: 'ExpressibleByRawTypeNotIntegerLiteral' declares raw type 'ExpressibleByFloatLiteralOnly', but does not conform to RawRepresentable and conformance could not be synthesized
+        // TODO: Old parser expected error on line 4: RawRepresentable conformance cannot be synthesized because raw type 'ExpressibleByFloatLiteralOnly' is not Equatable
+        // TODO: Old parser expected error on line 5: enum cases require explicit raw values when the raw type is not expressible by integer or string literal
+      ]
+    )
+  }
+
+  func testEnum30() {
+    AssertParse(
+      """
+      enum RawTypeWithIntValues : Int {
+        case Glisan = 17, Hoyt = 219, Irving, Johnson = 97209
+      }
+      """
+    )
+  }
+
+  func testEnum31() {
+    AssertParse(
+      """
+      enum RawTypeWithNegativeValues : Int {
+        case Glisan = -17, Hoyt = -219, Irving, Johnson = -97209
+        case AutoIncAcrossZero = -1, Zero, One
+      }
+      """
+    )
+  }
+
+  func testEnum32() {
+    AssertParse(
+      #"""
+      enum RawTypeWithUnicodeScalarValues : UnicodeScalar { 
+        case Kearney = "K"
+        case Lovejoy 
+        case Marshall = "M"
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'RawTypeWithUnicodeScalarValues' declares raw type 'UnicodeScalar' (aka 'Unicode.Scalar'), but does not conform to RawRepresentable and conformance could not be synthesized
+        // TODO: Old parser expected error on line 3: enum cases require explicit raw values when the raw type is not expressible by integer or string literal
+      ]
+    )
+  }
+
+  func testEnum33() {
+    AssertParse(
+      #"""
+      enum RawTypeWithCharacterValues : Character { 
+        case First = "い"
+        case Second 
+        case Third = "は"
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'RawTypeWithCharacterValues' declares raw type 'Character', but does not conform to RawRepresentable and conformance could not be synthesized
+        // TODO: Old parser expected error on line 3: enum cases require explicit raw values when the raw type is not expressible by integer or string literal
+      ]
+    )
+  }
+
+  func testEnum34() {
+    AssertParse(
+      #"""
+      enum RawTypeWithCharacterValues_Correct : Character {
+        case First = "😅" // ok
+        case Second = "👩‍👩‍👧‍👦" // ok
+        case Third = "👋🏽" // ok
+        case Fourth = "\u{1F3F4}\u{E0067}\u{E0062}\u{E0065}\u{E006E}\u{E0067}\u{E007F}" // ok
+      }
+      """#
+    )
+  }
+
+  func testEnum35() {
+    AssertParse(
+      #"""
+      enum RawTypeWithCharacterValues_Error1 : Character { 
+        case First = "abc" 
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'RawTypeWithCharacterValues_Error1' declares raw type 'Character', but does not conform to RawRepresentable and conformance could not be synthesized
+        // TODO: Old parser expected error on line 2: cannot convert value of type 'String' to raw type 'Character'
+      ]
+    )
+  }
+
+  func testEnum36() {
+    AssertParse(
+      """
+      enum RawTypeWithFloatValues : Float { 
+        case Northrup = 1.5
+        case Overton 
+        case Pettygrove = 2.25
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'RawTypeWithFloatValues' declares raw type 'Float', but does not conform to RawRepresentable and conformance could not be synthesized
+        // TODO: Old parser expected error on line 3: enum case must declare a raw value when the preceding raw value is not an integer
+      ]
+    )
+  }
+
+  func testEnum37() {
+    AssertParse(
+      #"""
+      enum RawTypeWithStringValues : String {
+        case Primrose // okay
+        case Quimby = "Lucky Lab"
+        case Raleigh // okay
+        case Savier = "McMenamin's", Thurman = "Kenny and Zuke's"
+      }
+      """#
+    )
+  }
+
+  func testEnum38() {
+    AssertParse(
+      """
+      enum RawValuesWithoutRawType {
+        case Upshur = 22 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: enum case cannot have a raw value if the enum does not have a raw type
+      ]
+    )
+  }
+
+  func testEnum39() {
+    AssertParse(
+      """
+      enum RawTypeWithRepeatValues : Int {
+        case Vaughn = 22 
+        case Wilson = 22 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: raw value previously used here
+        // TODO: Old parser expected error on line 3: raw value for enum case is not unique
+      ]
+    )
+  }
+
+  func testEnum40() {
+    AssertParse(
+      """
+      enum RawTypeWithRepeatValues2 : Double {
+        case Vaughn = 22   
+        case Wilson = 22.0 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: raw value previously used here
+        // TODO: Old parser expected error on line 3: raw value for enum case is not unique
+      ]
+    )
+  }
+
+  func testEnum41() {
+    AssertParse(
+      """
+      enum RawTypeWithRepeatValues3 : Double {
+        // 2^63-1
+        case Vaughn = 9223372036854775807   
+        case Wilson = 9223372036854775807.0 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 3: raw value previously used here
+        // TODO: Old parser expected error on line 4: raw value for enum case is not unique
+      ]
+    )
+  }
+
+  func testEnum42() {
+    AssertParse(
+      """
+      enum RawTypeWithRepeatValues4 : Double {
+        // 2^64-1
+        case Vaughn = 18446744073709551615   
+        case Wilson = 18446744073709551615.0 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 3: raw value previously used here
+        // TODO: Old parser expected error on line 4: raw value for enum case is not unique
+      ]
+    )
+  }
+
+  func testEnum43() {
+    AssertParse(
+      """
+      enum RawTypeWithRepeatValues5 : Double {
+        // FIXME: should reject.
+        // 2^65-1
+        case Vaughn = 36893488147419103231
+        case Wilson = 36893488147419103231.0
+      }
+      """
+    )
+  }
+
+  func testEnum44() {
+    AssertParse(
+      """
+      enum RawTypeWithRepeatValues6 : Double {
+        // FIXME: should reject.
+        // 2^127-1
+        case Vaughn = 170141183460469231731687303715884105727
+        case Wilson = 170141183460469231731687303715884105727.0
+      }
+      """
+    )
+  }
+
+  func testEnum45() {
+    AssertParse(
+      """
+      enum RawTypeWithRepeatValues7 : Double {
+        // FIXME: should reject.
+        // 2^128-1
+        case Vaughn = 340282366920938463463374607431768211455
+        case Wilson = 340282366920938463463374607431768211455.0
+      }
+      """
+    )
+  }
+
+  func testEnum46() {
+    AssertParse(
+      #"""
+      enum RawTypeWithRepeatValues8 : String {
+        case Vaughn = "XYZ" 
+        case Wilson = "XYZ" 
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: raw value previously used here
+        // TODO: Old parser expected error on line 3: raw value for enum case is not unique
+      ]
+    )
+  }
+
+  func testEnum47() {
+    AssertParse(
+      """
+      enum RawTypeWithNonRepeatValues : Double {
+        case SantaClara = 3.7
+        case SanFernando = 7.4
+        case SanAntonio = -3.7
+        case SanCarlos = -7.4
+      }
+      """
+    )
+  }
+
+  func testEnum48() {
+    AssertParse(
+      """
+      enum RawTypeWithRepeatValuesAutoInc : Double {
+        case Vaughn = 22 
+        case Wilson    
+        case Yeon = 23 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: raw value auto-incremented from here
+        // TODO: Old parser expected note on line 3: raw value previously used here
+        // TODO: Old parser expected error on line 4: raw value for enum case is not unique
+      ]
+    )
+  }
+
+  func testEnum49() {
+    AssertParse(
+      """
+      enum RawTypeWithRepeatValuesAutoInc2 : Double {
+        case Vaughn = 23 
+        case Wilson = 22 
+        case Yeon 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: raw value previously used here
+        // TODO: Old parser expected note on line 3: raw value auto-incremented from here
+        // TODO: Old parser expected error on line 4: raw value for enum case is not unique
+      ]
+    )
+  }
+
+  func testEnum50() {
+    AssertParse(
+      """
+      enum RawTypeWithRepeatValuesAutoInc3 : Double {
+        case Vaughn 
+        case Wilson 
+        case Yeon = 1 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: raw value implicitly auto-incremented from zero
+        // TODO: Old parser expected note on line 3: raw value previously used here
+        // TODO: Old parser expected error on line 4: raw value for enum case is not unique
+      ]
+    )
+  }
+
+  func testEnum51() {
+    AssertParse(
+      #"""
+      enum RawTypeWithRepeatValuesAutoInc4 : String {
+        case A = "B" 
+        case B 
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: raw value previously used here
+        // TODO: Old parser expected error on line 3: raw value for enum case is not unique
+      ]
+    )
+  }
+
+  func testEnum52() {
+    AssertParse(
+      #"""
+      enum RawTypeWithRepeatValuesAutoInc5 : String {
+        case A 
+        case B = "A" 
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: raw value previously used here
+        // TODO: Old parser expected error on line 3: raw value for enum case is not unique
+      ]
+    )
+  }
+
+  func testEnum53() {
+    AssertParse(
+      #"""
+      enum RawTypeWithRepeatValuesAutoInc6 : String {
+        case A
+        case B 
+        case C = "B" 
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected note on line 3: raw value previously used here
+        // TODO: Old parser expected error on line 4: raw value for enum case is not unique
+      ]
+    )
+  }
+
+  func testEnum54() {
+    AssertParse(
+      """
+      enum NonliteralRawValue : Int {
+        case Yeon = 100 + 20 + 3 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: raw value for enum case must be a literal
+      ]
+    )
+  }
+
+  func testEnum55() {
+    AssertParse(
+      """
+      enum RawTypeWithPayload : Int { 
+        case Powell(Int) 
+        case Terwilliger(Int) = 17 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'RawTypeWithPayload' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized
+        // TODO: Old parser expected note on line 1: declared raw type 'Int' here
+        // TODO: Old parser expected note on line 1: declared raw type 'Int' here
+        // TODO: Old parser expected error on line 2: enum with raw type cannot have cases with arguments
+        // TODO: Old parser expected error on line 3: enum with raw type cannot have cases with arguments
+      ]
+    )
+  }
+
+  func testEnum56() {
+    AssertParse(
+      #"""
+      enum RawTypeMismatch : Int { 
+        case Barbur = "foo" 
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'RawTypeMismatch' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized
+        // TODO: Old parser expected error on line 2: 
+      ]
+    )
+  }
+
+  func testEnum57() {
+    AssertParse(
+      """
+      enum DuplicateMembers1 {
+        case Foo 
+        case Foo 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: 'Foo' previously declared here
+        // TODO: Old parser expected error on line 3: invalid redeclaration of 'Foo'
+      ]
+    )
+  }
+
+  func testEnum58() {
+    AssertParse(
+      """
+      enum DuplicateMembers2 {
+        case Foo, Bar 
+        case Foo 
+        case Bar 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: 'Foo' previously declared here
+        // TODO: Old parser expected note on line 2: 'Bar' previously declared here
+        // TODO: Old parser expected error on line 3: invalid redeclaration of 'Foo'
+        // TODO: Old parser expected error on line 4: invalid redeclaration of 'Bar'
+      ]
+    )
+  }
+
+  func testEnum59() {
+    AssertParse(
+      """
+      enum DuplicateMembers3 {
+        case Foo 
+        case Foo(Int) 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: 'Foo' previously declared here
+        // TODO: Old parser expected error on line 3: invalid redeclaration of 'Foo'
+      ]
+    )
+  }
+
+  func testEnum60() {
+    AssertParse(
+      """
+      enum DuplicateMembers4 : Int { 
+        case Foo = 1 
+        case Foo = 2 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'DuplicateMembers4' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized
+        // TODO: Old parser expected note on line 2: 'Foo' previously declared here
+        // TODO: Old parser expected error on line 3: invalid redeclaration of 'Foo'
+      ]
+    )
+  }
+
+  func testEnum61() {
+    AssertParse(
+      """
+      enum DuplicateMembers5 : Int { 
+        case Foo = 1 
+        case Foo = 1 + 1 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'DuplicateMembers5' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized
+        // TODO: Old parser expected note on line 2: 'Foo' previously declared here
+        // TODO: Old parser expected error on line 3: invalid redeclaration of 'Foo'
+        // TODO: Old parser expected error on line 3: raw value for enum case must be a literal
+      ]
+    )
+  }
+
+  func testEnum62() {
+    AssertParse(
+      """
+      enum DuplicateMembers6 {
+        case Foo // expected-note 2{{'Foo' previously declared here}}
+        case Foo 
+        case Foo 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: invalid redeclaration of 'Foo'
+        // TODO: Old parser expected error on line 4: invalid redeclaration of 'Foo'
+      ]
+    )
+  }
+
+  func testEnum63() {
+    AssertParse(
+      #"""
+      enum DuplicateMembers7 : String { 
+        case Foo 
+        case Foo = "Bar" 
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'DuplicateMembers7' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized
+        // TODO: Old parser expected note on line 2: 'Foo' previously declared here
+        // TODO: Old parser expected error on line 3: invalid redeclaration of 'Foo'
+      ]
+    )
+  }
+
+  func testEnum64() {
+    AssertParse(
+      #"""
+      // Refs to duplicated enum cases shouldn't crash the compiler.
+      // rdar://problem/20922401
+      func check20922401() -> String {
+        let x: DuplicateMembers1 = .Foo 
+        switch x {
+          case .Foo:
+            return "Foo"
+        }
+      }
+      """#
+    )
+  }
+
+  func testEnum65() {
+    AssertParse(
+      """
+      enum PlaygroundRepresentation : UInt8 {
+        case Class = 1
+        case Struct = 2
+        case Tuple = 3
+        case Enum = 4
+        case Aggregate = 5
+        case Container = 6
+        case IDERepr = 7
+        case Gap = 8
+        case ScopeEntry = 9
+        case ScopeExit = 10
+        case Error = 11
+        case IndexContainer = 12
+        case KeyContainer = 13
+        case MembershipContainer = 14
+        case Unknown = 0xFF
+        static func fromByte(byte : UInt8) -> PlaygroundRepresentation {
+          let repr = PlaygroundRepresentation(rawValue: byte)
+          if repr == .none { return .Unknown } else { return repr! }
+        }
+      }
+      """
+    )
+  }
+
+  func testEnum66() {
+    AssertParse(
+      """
+      struct ManyLiteralable : ExpressibleByIntegerLiteral, ExpressibleByStringLiteral, Equatable {
+        init(stringLiteral: String) {}
+        init(integerLiteral: Int) {}
+        init(unicodeScalarLiteral: String) {}
+        init(extendedGraphemeClusterLiteral: String) {}
+      }
+      func ==(lhs: ManyLiteralable, rhs: ManyLiteralable) -> Bool { return true }
+      """
+    )
+  }
+
+  func testEnum67() {
+    AssertParse(
+      """
+      enum ManyLiteralA : ManyLiteralable {
+        case A 
+        case B = 0 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: raw value previously used here
+        // TODO: Old parser expected note on line 2: raw value implicitly auto-incremented from zero
+        // TODO: Old parser expected error on line 3: raw value for enum case is not unique
+      ]
+    )
+  }
+
+  func testEnum68() {
+    AssertParse(
+      #"""
+      enum ManyLiteralB : ManyLiteralable { 
+        case A = "abc"
+        case B 
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'ManyLiteralB' declares raw type 'ManyLiteralable', but does not conform to RawRepresentable and conformance could not be synthesized
+        // TODO: Old parser expected error on line 3: enum case must declare a raw value when the preceding raw value is not an integer
+      ]
+    )
+  }
+
+  func testEnum69() {
+    AssertParse(
+      #"""
+      enum ManyLiteralC : ManyLiteralable {
+        case A
+        case B = "0"
+      }
+      """#
+    )
+  }
+
+  func testEnum70() {
+    AssertParse(
+      """
+      // rdar://problem/22476643
+      public protocol RawValueA: RawRepresentable
+      {
+        var rawValue: Double { get }
+      }
+      """
+    )
+  }
+
+  func testEnum71() {
+    AssertParse(
+      """
+      enum RawValueATest: Double, RawValueA {
+        case A, B
+      }
+      """
+    )
+  }
+
+  func testEnum72() {
+    AssertParse(
+      """
+      public protocol RawValueB
+      {
+        var rawValue: Double { get }
+      }
+      """
+    )
+  }
+
+  func testEnum73() {
+    AssertParse(
+      """
+      enum RawValueBTest: Double, RawValueB {
+        case A, B
+      }
+      """
+    )
+  }
+
+  func testEnum74() {
+    AssertParse(
+      """
+      enum foo : String { 
+        case bar = nil 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'foo' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized
+        // TODO: Old parser expected error on line 2: cannot convert 'nil' to raw type 'String'
+      ]
+    )
+  }
+
+  func testEnum75() {
+    AssertParse(
+      """
+      // Static member lookup from instance methods
+      """
+    )
+  }
+
+  func testEnum76() {
+    AssertParse(
+      """
+      struct EmptyStruct {}
+      """
+    )
+  }
+
+  func testEnum77() {
+    AssertParse(
+      """
+      enum EnumWithStaticMember {
+        static let staticVar = EmptyStruct()
+        func foo() {
+          let _ = staticVar 
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: static member 'staticVar' cannot be used on instance of type 'EnumWithStaticMember'
+      ]
+    )
+  }
+
+  func testEnum78() {
+    AssertParse(
+      """
+      // SE-0036:
+      """
+    )
+  }
+
+  func testEnum79() {
+    AssertParse(
+      """
+      struct SE0036_Auxiliary {}
+      """
+    )
+  }
+
+  func testEnum80() {
+    AssertParse(
+      """
+      enum SE0036 {
+        case A
+        case B(SE0036_Auxiliary)
+        case C(SE0036_Auxiliary)
+        static func staticReference() {
+          _ = A
+          _ = self.A
+          _ = SE0036.A
+        }
+        func staticReferenceInInstanceMethod() {
+          _ = A 
+          _ = self.A 
+          _ = SE0036.A
+        }
+        static func staticReferenceInSwitchInStaticMethod() {
+          switch SE0036.A {
+          case A: break
+          case B(_): break
+          case C(let x): _ = x; break
+          }
+        }
+        func staticReferenceInSwitchInInstanceMethod() {
+          switch self {
+          case A: break 
+          case B(_): break 
+          case C(let x): _ = x; break 
+          }
+        }
+        func explicitReferenceInSwitch() {
+          switch SE0036.A {
+          case SE0036.A: break
+          case SE0036.B(_): break
+          case SE0036.C(let x): _ = x; break
+          }
+        }
+        func dotReferenceInSwitchInInstanceMethod() {
+          switch self {
+          case .A: break
+          case .B(_): break
+          case .C(let x): _ = x; break
+          }
+        }
+        static func dotReferenceInSwitchInStaticMethod() {
+          switch SE0036.A {
+          case .A: break
+          case .B(_): break
+          case .C(let x): _ = x; break
+          }
+        }
+        init() {
+          self = .A
+          self = A 
+          self = SE0036.A
+          self = .B(SE0036_Auxiliary())
+          self = B(SE0036_Auxiliary()) 
+          self = SE0036.B(SE0036_Auxiliary())
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 11: enum case 'A' cannot be used as an instance member, Fix-It replacements: 9 - 9 = 'SE0036.'
+        // TODO: Old parser expected error on line 12: enum case 'A' cannot be used as an instance member, Fix-It replacements: 9 - 13 = 'SE0036'
+        // TODO: Old parser expected error on line 24: enum case 'A' cannot be used as an instance member, Fix-It replacements: 10 - 10 = '.'
+        // TODO: Old parser expected error on line 25: '_' can only appear in a pattern or on the left side of an assignment
+        // TODO: Old parser expected error on line 26: enum case 'C' cannot be used as an instance member, Fix-It replacements: 10 - 10 = '.'
+        // TODO: Old parser expected error on line 52: enum case 'A' cannot be used as an instance member, Fix-It replacements: 12 - 12 = 'SE0036.'
+        // TODO: Old parser expected error on line 55: enum case 'B' cannot be used as an instance member, Fix-It replacements: 12 - 12 = 'SE0036.'
+      ]
+    )
+  }
+
+  func testEnum81() {
+    AssertParse(
+      """
+      enum SE0036_Generic<T> {
+        case A(x: T)
+        func foo() {
+          switch self {
+          case A(_): break 
+          }
+          switch self {
+          case .A(let a): print(a)
+          }
+          switch self {
+          case SE0036_Generic.A(let a): print(a)
+          }
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: '_' can only appear in a pattern or on the left side of an assignment
+      ]
+    )
+  }
+
+  func testEnum82() {
+    AssertParse(
+      """
+      enum #^DIAG_1^#switch {}#^DIAG_2^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: keyword 'switch' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 6 - 12 = '`switch`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in enum"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected member block in enum"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '{}' in 'switch' statement"),
+      ]
+    )
+  }
+
+  func testEnum83() {
+    AssertParse(
+      """
+      enum SE0155 {
+        case emptyArgs() 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 2: enum element with associated values must have at least one associated value
+        // TODO: Old parser expected note on line 2: did you mean to remove the empty associated value list?, Fix-It replacements: 17 - 19 = ''
+        // TODO: Old parser expected note on line 2: did you mean to explicitly add a 'Void' associated value?, Fix-It replacements: 18 - 18 = 'Void'
+      ]
+    )
+  }
+
+  func testEnum84() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/53662
+      """
+    )
+  }
+
+  func testEnum85() {
+    AssertParse(
+      """
+      enum E_53662 {
+        case identifier
+        case #^DIAG_1^#operator 
+        case #^DIAG_2^#identifier2
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: keyword 'operator' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 3: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 16 = '`operator`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected declaration in enum"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text 'identifier2' in enum"),
+      ]
+    )
+  }
+
+  func testEnum86() {
+    AssertParse(
+      """
+      enum E_53662_var {
+        case identifier
+        case #^DIAG_1^#var #^DIAG_2^#
+        case identifier2
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: keyword 'var' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 3: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 11 = '`var`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected pattern in variable"),
+      ]
+    )
+  }
+
+  func testEnum87() {
+    AssertParse(
+      """
+      enum E_53662_underscore {
+        case identifier
+        case #^DIAG^#_ 
+        case identifier2
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: keyword '_' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 3: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 9 = '`_`'
+        DiagnosticSpec(message: "expected identifier in enum case"),
+        DiagnosticSpec(message: "unexpected text '_' before enum case"),
+      ]
+    )
+  }
+
+  func testEnum88() {
+    AssertParse(
+      """
+      enum E_53662_Comma {
+        case a, b, c, #^DIAG_1^#func#^DIAG_2^#, d 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: keyword 'func' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 2: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 17 - 21 = '`func`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected argument list in function declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected declaration in enum"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text ', d' in enum"),
+      ]
+    )
+  }
+
+  func testEnum89() {
+    AssertParse(
+      """
+      enum E_53662_Newline {
+        case identifier1
+        case identifier2
+        case #^DIAG^#
+        case identifier 
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected identifier in enum case"),
+        // TODO: Old parser expected error on line 5: keyword 'case' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 5: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 3 - 7 = '`case`'
+      ]
+    )
+  }
+
+  func testEnum90() {
+    AssertParse(
+      """
+      enum E_53662_Newline2 {
+        case #^DIAG^#
+        func foo() {} 
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected identifier in enum case"),
+        // TODO: Old parser expected error on line 3: keyword 'func' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 3: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 3 - 7 = '`func`'
+      ]
+    )
+  }
+
+  func testEnum91() {
+    AssertParse(
+      """
+      enum E_53662_PatternMatching {
+        case #^DIAG_1^#let #^DIAG_2^#.foo(x, y): 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected pattern in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected declaration in enum"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '.foo(x, y):' in enum"),
+      ]
+    )
+  }
+
+  func testEnum92() {
+    AssertParse(
+      #"""
+      enum CasesWithMissingElement: Int {
+        case a = "hello", #^DIAG_1^#
+        case b = "hello", #^DIAG_2^#
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'CasesWithMissingElement' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized
+        // TODO: Old parser expected error on line 2: expected identifier after comma in enum 'case' declaration
+        // TODO: Old parser expected error on line 2: cannot convert value of type 'String' to raw type 'Int'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in enum case"),
+        // TODO: Old parser expected error on line 3: expected identifier after comma in enum 'case' declaration
+        // TODO: Old parser expected error on line 3: cannot convert value of type 'String' to raw type 'Int'
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in enum case"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/EnumTests.swift
+++ b/Tests/SwiftParserTest/translated/EnumTests.swift
@@ -166,10 +166,7 @@ final class EnumTests: XCTestCase {
       enum EnumCaseAttributes {
         @xyz case EmptyAttributes  
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: unknown attribute 'xyz'
-      ]
+      """
     )
   }
 
@@ -343,11 +340,7 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum RawTypeEmpty : Int {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: an enum with no cases cannot declare a raw type
-        // TODO: Old parser expected error on line 1: 'RawTypeEmpty' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized
-      ]
+      """
     )
   }
 
@@ -381,10 +374,7 @@ final class EnumTests: XCTestCase {
       enum RawTypeNotFirst : RawTypeNotFirstProtocol, Int { 
         case E
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: raw type 'Int' must appear first in the enum inheritance clause, Fix-It replacements: 24 - 24 = 'Int, ', 47 - 52 = ''
-      ]
+      """
     )
   }
 
@@ -394,11 +384,7 @@ final class EnumTests: XCTestCase {
       enum ExpressibleByRawTypeNotLiteral : Array<Int> { 
         case Ladd, Elliott, Sixteenth, Harrison
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: raw type 'Array<Int>' is not expressible by a string, integer, or floating-point literal
-        // TODO: Old parser expected error on line 1: 'ExpressibleByRawTypeNotLiteral' declares raw type 'Array<Int>', but does not conform to RawRepresentable and conformance could not be synthesized
-      ]
+      """
     )
   }
 
@@ -411,10 +397,7 @@ final class EnumTests: XCTestCase {
           self = .Morrison
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'RawTypeCircularityA' has a raw type that depends on itself
-      ]
+      """
     )
   }
 
@@ -427,10 +410,7 @@ final class EnumTests: XCTestCase {
           self = .Willamette
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 1: enum 'RawTypeCircularityB' declared here
-      ]
+      """
     )
   }
 
@@ -444,12 +424,7 @@ final class EnumTests: XCTestCase {
         case Everett 
         case Flanders
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: 'ExpressibleByRawTypeNotIntegerLiteral' declares raw type 'ExpressibleByFloatLiteralOnly', but does not conform to RawRepresentable and conformance could not be synthesized
-        // TODO: Old parser expected error on line 4: RawRepresentable conformance cannot be synthesized because raw type 'ExpressibleByFloatLiteralOnly' is not Equatable
-        // TODO: Old parser expected error on line 5: enum cases require explicit raw values when the raw type is not expressible by integer or string literal
-      ]
+      """
     )
   }
 
@@ -482,11 +457,7 @@ final class EnumTests: XCTestCase {
         case Lovejoy 
         case Marshall = "M"
       }
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'RawTypeWithUnicodeScalarValues' declares raw type 'UnicodeScalar' (aka 'Unicode.Scalar'), but does not conform to RawRepresentable and conformance could not be synthesized
-        // TODO: Old parser expected error on line 3: enum cases require explicit raw values when the raw type is not expressible by integer or string literal
-      ]
+      """#
     )
   }
 
@@ -498,11 +469,7 @@ final class EnumTests: XCTestCase {
         case Second 
         case Third = "は"
       }
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'RawTypeWithCharacterValues' declares raw type 'Character', but does not conform to RawRepresentable and conformance could not be synthesized
-        // TODO: Old parser expected error on line 3: enum cases require explicit raw values when the raw type is not expressible by integer or string literal
-      ]
+      """#
     )
   }
 
@@ -525,11 +492,7 @@ final class EnumTests: XCTestCase {
       enum RawTypeWithCharacterValues_Error1 : Character { 
         case First = "abc" 
       }
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'RawTypeWithCharacterValues_Error1' declares raw type 'Character', but does not conform to RawRepresentable and conformance could not be synthesized
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'String' to raw type 'Character'
-      ]
+      """#
     )
   }
 
@@ -541,11 +504,7 @@ final class EnumTests: XCTestCase {
         case Overton 
         case Pettygrove = 2.25
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'RawTypeWithFloatValues' declares raw type 'Float', but does not conform to RawRepresentable and conformance could not be synthesized
-        // TODO: Old parser expected error on line 3: enum case must declare a raw value when the preceding raw value is not an integer
-      ]
+      """
     )
   }
 
@@ -568,10 +527,7 @@ final class EnumTests: XCTestCase {
       enum RawValuesWithoutRawType {
         case Upshur = 22 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: enum case cannot have a raw value if the enum does not have a raw type
-      ]
+      """
     )
   }
 
@@ -582,11 +538,7 @@ final class EnumTests: XCTestCase {
         case Vaughn = 22 
         case Wilson = 22 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: raw value previously used here
-        // TODO: Old parser expected error on line 3: raw value for enum case is not unique
-      ]
+      """
     )
   }
 
@@ -597,11 +549,7 @@ final class EnumTests: XCTestCase {
         case Vaughn = 22   
         case Wilson = 22.0 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: raw value previously used here
-        // TODO: Old parser expected error on line 3: raw value for enum case is not unique
-      ]
+      """
     )
   }
 
@@ -613,11 +561,7 @@ final class EnumTests: XCTestCase {
         case Vaughn = 9223372036854775807   
         case Wilson = 9223372036854775807.0 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 3: raw value previously used here
-        // TODO: Old parser expected error on line 4: raw value for enum case is not unique
-      ]
+      """
     )
   }
 
@@ -629,11 +573,7 @@ final class EnumTests: XCTestCase {
         case Vaughn = 18446744073709551615   
         case Wilson = 18446744073709551615.0 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 3: raw value previously used here
-        // TODO: Old parser expected error on line 4: raw value for enum case is not unique
-      ]
+      """
     )
   }
 
@@ -683,11 +623,7 @@ final class EnumTests: XCTestCase {
         case Vaughn = "XYZ" 
         case Wilson = "XYZ" 
       }
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: raw value previously used here
-        // TODO: Old parser expected error on line 3: raw value for enum case is not unique
-      ]
+      """#
     )
   }
 
@@ -712,12 +648,7 @@ final class EnumTests: XCTestCase {
         case Wilson    
         case Yeon = 23 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: raw value auto-incremented from here
-        // TODO: Old parser expected note on line 3: raw value previously used here
-        // TODO: Old parser expected error on line 4: raw value for enum case is not unique
-      ]
+      """
     )
   }
 
@@ -729,12 +660,7 @@ final class EnumTests: XCTestCase {
         case Wilson = 22 
         case Yeon 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: raw value previously used here
-        // TODO: Old parser expected note on line 3: raw value auto-incremented from here
-        // TODO: Old parser expected error on line 4: raw value for enum case is not unique
-      ]
+      """
     )
   }
 
@@ -746,12 +672,7 @@ final class EnumTests: XCTestCase {
         case Wilson 
         case Yeon = 1 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: raw value implicitly auto-incremented from zero
-        // TODO: Old parser expected note on line 3: raw value previously used here
-        // TODO: Old parser expected error on line 4: raw value for enum case is not unique
-      ]
+      """
     )
   }
 
@@ -762,11 +683,7 @@ final class EnumTests: XCTestCase {
         case A = "B" 
         case B 
       }
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: raw value previously used here
-        // TODO: Old parser expected error on line 3: raw value for enum case is not unique
-      ]
+      """#
     )
   }
 
@@ -777,11 +694,7 @@ final class EnumTests: XCTestCase {
         case A 
         case B = "A" 
       }
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: raw value previously used here
-        // TODO: Old parser expected error on line 3: raw value for enum case is not unique
-      ]
+      """#
     )
   }
 
@@ -793,11 +706,7 @@ final class EnumTests: XCTestCase {
         case B 
         case C = "B" 
       }
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected note on line 3: raw value previously used here
-        // TODO: Old parser expected error on line 4: raw value for enum case is not unique
-      ]
+      """#
     )
   }
 
@@ -821,14 +730,7 @@ final class EnumTests: XCTestCase {
         case Powell(Int) 
         case Terwilliger(Int) = 17 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'RawTypeWithPayload' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized
-        // TODO: Old parser expected note on line 1: declared raw type 'Int' here
-        // TODO: Old parser expected note on line 1: declared raw type 'Int' here
-        // TODO: Old parser expected error on line 2: enum with raw type cannot have cases with arguments
-        // TODO: Old parser expected error on line 3: enum with raw type cannot have cases with arguments
-      ]
+      """
     )
   }
 
@@ -838,11 +740,7 @@ final class EnumTests: XCTestCase {
       enum RawTypeMismatch : Int { 
         case Barbur = "foo" 
       }
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'RawTypeMismatch' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized
-        // TODO: Old parser expected error on line 2: 
-      ]
+      """#
     )
   }
 
@@ -853,11 +751,7 @@ final class EnumTests: XCTestCase {
         case Foo 
         case Foo 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: 'Foo' previously declared here
-        // TODO: Old parser expected error on line 3: invalid redeclaration of 'Foo'
-      ]
+      """
     )
   }
 
@@ -869,13 +763,7 @@ final class EnumTests: XCTestCase {
         case Foo 
         case Bar 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: 'Foo' previously declared here
-        // TODO: Old parser expected note on line 2: 'Bar' previously declared here
-        // TODO: Old parser expected error on line 3: invalid redeclaration of 'Foo'
-        // TODO: Old parser expected error on line 4: invalid redeclaration of 'Bar'
-      ]
+      """
     )
   }
 
@@ -886,11 +774,7 @@ final class EnumTests: XCTestCase {
         case Foo 
         case Foo(Int) 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: 'Foo' previously declared here
-        // TODO: Old parser expected error on line 3: invalid redeclaration of 'Foo'
-      ]
+      """
     )
   }
 
@@ -901,12 +785,7 @@ final class EnumTests: XCTestCase {
         case Foo = 1 
         case Foo = 2 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'DuplicateMembers4' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized
-        // TODO: Old parser expected note on line 2: 'Foo' previously declared here
-        // TODO: Old parser expected error on line 3: invalid redeclaration of 'Foo'
-      ]
+      """
     )
   }
 
@@ -919,9 +798,6 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: 'DuplicateMembers5' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized
-        // TODO: Old parser expected note on line 2: 'Foo' previously declared here
-        // TODO: Old parser expected error on line 3: invalid redeclaration of 'Foo'
         // TODO: Old parser expected error on line 3: raw value for enum case must be a literal
       ]
     )
@@ -935,11 +811,7 @@ final class EnumTests: XCTestCase {
         case Foo 
         case Foo 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: invalid redeclaration of 'Foo'
-        // TODO: Old parser expected error on line 4: invalid redeclaration of 'Foo'
-      ]
+      """
     )
   }
 
@@ -950,12 +822,7 @@ final class EnumTests: XCTestCase {
         case Foo 
         case Foo = "Bar" 
       }
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'DuplicateMembers7' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized
-        // TODO: Old parser expected note on line 2: 'Foo' previously declared here
-        // TODO: Old parser expected error on line 3: invalid redeclaration of 'Foo'
-      ]
+      """#
     )
   }
 
@@ -1024,12 +891,7 @@ final class EnumTests: XCTestCase {
         case A 
         case B = 0 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: raw value previously used here
-        // TODO: Old parser expected note on line 2: raw value implicitly auto-incremented from zero
-        // TODO: Old parser expected error on line 3: raw value for enum case is not unique
-      ]
+      """
     )
   }
 
@@ -1040,11 +902,7 @@ final class EnumTests: XCTestCase {
         case A = "abc"
         case B 
       }
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'ManyLiteralB' declares raw type 'ManyLiteralable', but does not conform to RawRepresentable and conformance could not be synthesized
-        // TODO: Old parser expected error on line 3: enum case must declare a raw value when the preceding raw value is not an integer
-      ]
+      """#
     )
   }
 
@@ -1108,11 +966,7 @@ final class EnumTests: XCTestCase {
       enum foo : String { 
         case bar = nil 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: 'foo' declares raw type 'String', but does not conform to RawRepresentable and conformance could not be synthesized
-        // TODO: Old parser expected error on line 2: cannot convert 'nil' to raw type 'String'
-      ]
+      """
     )
   }
 
@@ -1141,10 +995,7 @@ final class EnumTests: XCTestCase {
           let _ = staticVar 
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: static member 'staticVar' cannot be used on instance of type 'EnumWithStaticMember'
-      ]
+      """
     )
   }
 
@@ -1227,13 +1078,7 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 11: enum case 'A' cannot be used as an instance member, Fix-It replacements: 9 - 9 = 'SE0036.'
-        // TODO: Old parser expected error on line 12: enum case 'A' cannot be used as an instance member, Fix-It replacements: 9 - 13 = 'SE0036'
-        // TODO: Old parser expected error on line 24: enum case 'A' cannot be used as an instance member, Fix-It replacements: 10 - 10 = '.'
         // TODO: Old parser expected error on line 25: '_' can only appear in a pattern or on the left side of an assignment
-        // TODO: Old parser expected error on line 26: enum case 'C' cannot be used as an instance member, Fix-It replacements: 10 - 10 = '.'
-        // TODO: Old parser expected error on line 52: enum case 'A' cannot be used as an instance member, Fix-It replacements: 12 - 12 = 'SE0036.'
-        // TODO: Old parser expected error on line 55: enum case 'B' cannot be used as an instance member, Fix-It replacements: 12 - 12 = 'SE0036.'
       ]
     )
   }
@@ -1434,12 +1279,9 @@ final class EnumTests: XCTestCase {
       }
       """#,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: 'CasesWithMissingElement' declares raw type 'Int', but does not conform to RawRepresentable and conformance could not be synthesized
         // TODO: Old parser expected error on line 2: expected identifier after comma in enum 'case' declaration
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'String' to raw type 'Int'
         DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in enum case"),
         // TODO: Old parser expected error on line 3: expected identifier after comma in enum 'case' declaration
-        // TODO: Old parser expected error on line 3: cannot convert value of type 'String' to raw type 'Int'
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in enum case"),
       ]
     )

--- a/Tests/SwiftParserTest/translated/ErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/ErrorsTests.swift
@@ -1,0 +1,369 @@
+// This test file has been translated from swift/test/Parse/errors.swift
+
+import XCTest
+
+final class ErrorsTests: XCTestCase {
+  func testErrors1() {
+    AssertParse(
+      #"""
+      enum MSV : Error {
+        case Foo, Bar, Baz
+        case CarriesInt(Int)
+        var _domain: String { return "" }
+        var _code: Int { return 0 }
+      }
+      """#
+    )
+  }
+
+  func testErrors2() {
+    AssertParse(
+      """
+      func opaque_error() -> Error { return MSV.Foo }
+      """
+    )
+  }
+
+  func testErrors3() {
+    AssertParse(
+      """
+      func one() {
+        do {
+          true ? () : #^DIAG_1^#throw opaque_error() 
+        } catch _ {
+        }
+        do {
+        } catch { 
+          let error2 = error
+        }
+        do {
+        } catch #^DIAG_2^#where true { 
+          let error2 = error
+        } catch {
+        }
+        // <rdar://problem/20985280> QoI: improve diagnostic on improper pattern match on type
+        do {
+          throw opaque_error()
+        } catch MSV { 
+        } catch {
+        }
+        do {
+          throw opaque_error()
+        } catch is Error {  
+        }
+        func foo() throws {}
+        do {
+      #if false
+          try foo()
+      #endif
+        } catch {    // don't warn, #if code should be scanned.
+        }
+        do {
+      #if false
+          throw opaque_error()
+      #endif
+        } catch {    // don't warn, #if code should be scanned.
+        }
+        do {
+          throw opaque_error()
+        } catch MSV.Foo, MSV.CarriesInt(let num) { 
+        } catch {
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: expected expression after '? ... :' in ternary expression
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in 'do' statement"),
+        // TODO: Old parser expected warning on line 7: 'catch' block is unreachable because no errors are thrown in 'do' block
+        // TODO: Old parser expected warning on line 11: 'catch' block is unreachable because no errors are thrown in 'do' block
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in pattern"),
+        // TODO: Old parser expected error on line 18: 'is' keyword required to pattern match against type name, Fix-It replacements: 11 - 11 = 'is '
+        // TODO: Old parser expected warning on line 23: 'is' test is always true
+        // TODO: Old parser expected error on line 40: 'num' must be bound in every pattern
+      ]
+    )
+  }
+
+  func testErrors4() {
+    AssertParse(
+      """
+      func takesAutoclosure(_ fn : @autoclosure () -> Int) {}
+      func takesThrowingAutoclosure(_ fn : @autoclosure () throws -> Int) {}
+      """
+    )
+  }
+
+  func testErrors5() {
+    AssertParse(
+      """
+      func genError() throws -> Int { throw MSV.Foo }
+      func genNoError() -> Int { return 0 }
+      """
+    )
+  }
+
+  func testErrors6() {
+    AssertParse(
+      """
+      func testAutoclosures() throws {
+        takesAutoclosure(genError()) 
+        takesAutoclosure(genNoError())
+        try takesAutoclosure(genError()) 
+        try takesAutoclosure(genNoError()) 
+        takesAutoclosure(try genError()) 
+        takesAutoclosure(try genNoError()) 
+        takesThrowingAutoclosure(try genError())
+        takesThrowingAutoclosure(try genNoError()) 
+        try takesThrowingAutoclosure(genError())
+        try takesThrowingAutoclosure(genNoError()) 
+        takesThrowingAutoclosure(genError()) 
+        takesThrowingAutoclosure(genNoError())
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: call can throw, but it is not marked with 'try' and it is executed in a non-throwing autoclosure
+        // TODO: Old parser expected error on line 4: call can throw, but it is executed in a non-throwing autoclosure
+        // TODO: Old parser expected warning on line 5: no calls to throwing functions occur within 'try' expression
+        // TODO: Old parser expected error on line 6: call can throw, but it is executed in a non-throwing autoclosure
+        // TODO: Old parser expected warning on line 7: no calls to throwing functions occur within 'try' expression
+        // TODO: Old parser expected warning on line 9: no calls to throwing functions occur within 'try' expression
+        // TODO: Old parser expected warning on line 11: no calls to throwing functions occur within 'try' expression
+        // TODO: Old parser expected error on line 12: call can throw but is not marked with 'try'
+        // TODO: Old parser expected note on line 12: did you mean to use 'try'?, Fix-It replacements: 28 - 28 = 'try '
+        // TODO: Old parser expected note on line 12: did you mean to handle error as optional value?, Fix-It replacements: 28 - 28 = 'try? '
+        // TODO: Old parser expected note on line 12: did you mean to disable error propagation?, Fix-It replacements: 28 - 28 = 'try! '
+      ]
+    )
+  }
+
+  func testErrors7() {
+    AssertParse(
+      """
+      func illformed() throws {
+          do {
+            _ = try genError()
+          } catch MSV.CarriesInt(let i) where i == genError()#^DIAG^#) { 
+          }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: call can throw, but errors cannot be thrown out of a catch guard expression
+        // TODO: Old parser expected error on line 4: expected '{'
+        DiagnosticSpec(message: "unexpected text ')' in 'catch' clause"),
+      ]
+    )
+  }
+
+  func testErrors8() {
+    AssertParse(
+      """
+      func postThrows() -> Int #^DIAG^#throws { 
+        return 5
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'throws' may only occur before '->', Fix-It replacements: 19 - 19 = 'throws ', 26 - 33 = ''
+        DiagnosticSpec(message: "extraneous code at top level"),
+      ]
+    )
+  }
+
+  func testErrors9() {
+    AssertParse(
+      """
+      func postThrows2() -> #^DIAG^#throws Int { 
+        return try postThrows()
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'throws' may only occur before '->', Fix-It replacements: 20 - 20 = 'throws ', 23 - 30 = ''
+        DiagnosticSpec(message: "'throws' may only occur before '->'"),
+      ]
+    )
+  }
+
+  func testErrors10() {
+    AssertParse(
+      """
+      func postRethrows(_ f: () throws -> Int) -> Int #^DIAG^#rethrows { 
+        return try f()
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'rethrows' may only occur before '->', Fix-It replacements: 42 - 42 = 'rethrows ', 49 - 58 = ''
+        DiagnosticSpec(message: "extraneous code at top level"),
+      ]
+    )
+  }
+
+  func testErrors11() {
+    AssertParse(
+      """
+      func postRethrows2(_ f: () throws -> Int) #^DIAG_1^#-> #^DIAG_2^#rethrows Int { 
+        return try f()
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'rethrows' may only occur before '->', Fix-It replacements: 43 - 43 = 'rethrows ', 46 - 55 = ''
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected 'rethrows' in function signature"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text 'rethrows' in function signature"),
+      ]
+    )
+  }
+
+  func testErrors12() {
+    AssertParse(
+      """
+      func postThrows3() {
+        _ = { () -> Int #^DIAG^#throws in } 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'throws' may only occur before '->', Fix-It replacements: 19 - 26 = '', 12 - 12 = 'throws '
+        DiagnosticSpec(message: "expected 'in' in closure signature"),
+        DiagnosticSpec(message: "unexpected text 'throws in' in closure"),
+      ]
+    )
+  }
+
+  func testErrors13() {
+    AssertParse(
+      """
+      func dupThrows1() throws #^DIAG^#rethrows -> throws Int throw {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'rethrows' has already been specified, Fix-It replacements: 26 - 35 = ''
+        // TODO: Old parser expected error on line 1: 'throws' has already been specified, Fix-It replacements: 38 - 45 = ''
+        // TODO: Old parser expected error on line 1: 'throw' has already been specified, Fix-It replacements: 49 - 55 = ''
+        DiagnosticSpec(message: "extraneous 'rethrows -> throws Int throw {}' at top level"),
+      ]
+    )
+  }
+
+  func testErrors14() {
+    AssertParse(
+      """
+      func dupThrows2(_ f: () throws -> #^DIAG^#rethrows Int) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'rethrows' has already been specified, Fix-It replacements: 35 - 44 = ''
+        DiagnosticSpec(message: "expected type in function type"),
+        DiagnosticSpec(message: "unexpected text 'rethrows Int' in parameter clause"),
+      ]
+    )
+  }
+
+  func testErrors15() {
+    AssertParse(
+      """
+      func dupThrows3() {
+        _ = { () try throws in }
+        _ = { () throws -> Int #^DIAG^#throws in }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected throwing specifier; did you mean 'throws'?, Fix-It replacements: 12 - 15 = 'throws'
+        // TODO: Old parser expected error on line 2: 'throws' has already been specified, Fix-It replacements: 16 - 23 = ''
+        // TODO: Old parser expected error on line 3: 'throws' has already been specified, Fix-It replacements: 26 - 33 = ''
+        DiagnosticSpec(message: "expected 'in' in closure signature"),
+        DiagnosticSpec(message: "unexpected text 'throws in' in closure"),
+      ]
+    )
+  }
+
+  func testErrors16() {
+    AssertParse(
+      """
+      func incompleteThrowType() {
+        // FIXME: Bad recovery for incomplete function type.
+        let _: () #^DIAG^#throws
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: consecutive statements on a line must be separated by ';'
+        // TODO: Old parser expected error on line 3: expected expression
+        DiagnosticSpec(message: "unexpected text 'throws' in function"),
+      ]
+    )
+  }
+
+  func testErrors17() {
+    AssertParse(
+      """
+      // rdar://21328447
+      func fixitThrow0() throw {} 
+      func fixitThrow1() throw #^DIAG^#-> Int {} 
+      func fixitThrow2() throws {
+        var _: (Int)
+        throw MSV.Foo
+        var _: (Int) throw -> Int 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected throwing specifier; did you mean 'throws'?, Fix-It replacements: 20 - 25 = 'throws'
+        // TODO: Old parser expected error on line 3: expected throwing specifier; did you mean 'throws'?, Fix-It replacements: 20 - 25 = 'throws'
+        DiagnosticSpec(message: "expected expression in 'throw' statement"),
+        DiagnosticSpec(message: "unexpected text '-> Int {}' before function"),
+        // TODO: Old parser expected error on line 7: expected throwing specifier; did you mean 'throws'?, Fix-It replacements: 16 - 21 = 'throws'
+      ]
+    )
+  }
+
+  func testErrors18() {
+    AssertParse(
+      """
+      let fn: () -> #^DIAG^#throws Void
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'throws' may only occur before '->', Fix-It replacements: 12 - 12 = 'throws ', 15 - 22 = ''
+        DiagnosticSpec(message: "expected type in function type"),
+        DiagnosticSpec(message: "extraneous 'throws Void' at top level"),
+      ]
+    )
+  }
+
+  func testErrors19() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/53979
+      """
+    )
+  }
+
+  func testErrors20() {
+    AssertParse(
+      """
+      func fixitTry0<T>(a: T) try #^DIAG^#where T:ExpressibleByStringLiteral {} 
+      func fixitTry1<T>(a: T) try {} 
+      func fixitTry2() try {} 
+      let fixitTry3 : () try -> Int
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected throwing specifier; did you mean 'throws'?, Fix-It replacements: 25 - 28 = 'throws'
+        DiagnosticSpec(message: "expected expression in 'try' expression"),
+        DiagnosticSpec(message: "unexpected text 'where T:ExpressibleByStringLiteral {}' before function"),
+        // TODO: Old parser expected error on line 2: expected throwing specifier; did you mean 'throws'?, Fix-It replacements: 25 - 28 = 'throws'
+        // TODO: Old parser expected error on line 3: expected throwing specifier; did you mean 'throws'?, Fix-It replacements: 18 - 21 = 'throws'
+        // TODO: Old parser expected error on line 4: expected throwing specifier; did you mean 'throws'?, Fix-It replacements: 20 - 23 = 'throws'
+      ]
+    )
+  }
+
+  func testErrors21() {
+    AssertParse(
+      """
+      func fixitAwait0() await { } 
+      func fixitAwait1() await #^DIAG_1^#-> Int { } 
+      func fixitAwait2() throws await #^DIAG_2^#-> Int { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected async specifier; did you mean 'async'?, Fix-It replacements: 20 - 25 = 'async'
+        // TODO: Old parser expected error on line 2: expected async specifier; did you mean 'async'?, Fix-It replacements: 20 - 25 = 'async'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in 'await' expression"),
+        // TODO: Old parser expected error on line 3: expected async specifier; did you mean 'async'?, Fix-It replacements: 27 - 32 = 'async'
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'await' expression"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/ErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/ErrorsTests.swift
@@ -74,12 +74,7 @@ final class ErrorsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 3: expected expression after '? ... :' in ternary expression
         DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in 'do' statement"),
-        // TODO: Old parser expected warning on line 7: 'catch' block is unreachable because no errors are thrown in 'do' block
-        // TODO: Old parser expected warning on line 11: 'catch' block is unreachable because no errors are thrown in 'do' block
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in pattern"),
-        // TODO: Old parser expected error on line 18: 'is' keyword required to pattern match against type name, Fix-It replacements: 11 - 11 = 'is '
-        // TODO: Old parser expected warning on line 23: 'is' test is always true
-        // TODO: Old parser expected error on line 40: 'num' must be bound in every pattern
       ]
     )
   }
@@ -119,20 +114,7 @@ final class ErrorsTests: XCTestCase {
         takesThrowingAutoclosure(genError()) 
         takesThrowingAutoclosure(genNoError())
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: call can throw, but it is not marked with 'try' and it is executed in a non-throwing autoclosure
-        // TODO: Old parser expected error on line 4: call can throw, but it is executed in a non-throwing autoclosure
-        // TODO: Old parser expected warning on line 5: no calls to throwing functions occur within 'try' expression
-        // TODO: Old parser expected error on line 6: call can throw, but it is executed in a non-throwing autoclosure
-        // TODO: Old parser expected warning on line 7: no calls to throwing functions occur within 'try' expression
-        // TODO: Old parser expected warning on line 9: no calls to throwing functions occur within 'try' expression
-        // TODO: Old parser expected warning on line 11: no calls to throwing functions occur within 'try' expression
-        // TODO: Old parser expected error on line 12: call can throw but is not marked with 'try'
-        // TODO: Old parser expected note on line 12: did you mean to use 'try'?, Fix-It replacements: 28 - 28 = 'try '
-        // TODO: Old parser expected note on line 12: did you mean to handle error as optional value?, Fix-It replacements: 28 - 28 = 'try? '
-        // TODO: Old parser expected note on line 12: did you mean to disable error propagation?, Fix-It replacements: 28 - 28 = 'try! '
-      ]
+      """
     )
   }
 
@@ -147,7 +129,6 @@ final class ErrorsTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 4: call can throw, but errors cannot be thrown out of a catch guard expression
         // TODO: Old parser expected error on line 4: expected '{'
         DiagnosticSpec(message: "unexpected text ')' in 'catch' clause"),
       ]

--- a/Tests/SwiftParserTest/translated/EscapedIdentifiersTests.swift
+++ b/Tests/SwiftParserTest/translated/EscapedIdentifiersTests.swift
@@ -1,0 +1,90 @@
+// This test file has been translated from swift/test/Parse/escaped_identifiers.swift
+
+import XCTest
+
+final class EscapedIdentifiersTests: XCTestCase {
+  func testEscapedIdentifiers1() {
+    AssertParse(
+      """
+      func `protocol`() {}
+      """
+    )
+  }
+
+  func testEscapedIdentifiers2() {
+    AssertParse(
+      """
+      `protocol`()
+      """
+    )
+  }
+
+  func testEscapedIdentifiers3() {
+    AssertParse(
+      """
+      class `Type` {}
+      """
+    )
+  }
+
+  func testEscapedIdentifiers4() {
+    AssertParse(
+      """
+      var `class` = `Type`.self
+      """
+    )
+  }
+
+  func testEscapedIdentifiers5() {
+    AssertParse(
+      """
+      func foo() {}
+      """
+    )
+  }
+
+  func testEscapedIdentifiers6() {
+    AssertParse(
+      """
+      `foo`()
+      """
+    )
+  }
+
+  func testEscapedIdentifiers7() {
+    AssertParse(
+      """
+      // Escaping suppresses identifier contextualization.
+      var get: (() -> ()) -> () = { $0() }
+      """
+    )
+  }
+
+  func testEscapedIdentifiers8() {
+    AssertParse(
+      """
+      var applyGet: Int {
+        `get` { }
+        return 0
+      }
+      """
+    )
+  }
+
+  func testEscapedIdentifiers9() {
+    AssertParse(
+      """
+      enum `switch` {}
+      """
+    )
+  }
+
+  func testEscapedIdentifiers10() {
+    AssertParse(
+      """
+      typealias `Self` = Int
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/ForeachAsyncTests.swift
+++ b/Tests/SwiftParserTest/translated/ForeachAsyncTests.swift
@@ -68,8 +68,6 @@ final class ForeachAsyncTests: XCTestCase {
       }#^DIAG_3^#
       """,
       diagnostics: [
-        // TODO: Old parser expected note on line 1: 'r' declared here
-        // TODO: Old parser expected error on line 8: cannot find 'i' in scope; did you mean 'r'?
         // TODO: Old parser expected error on line 21: found an unexpected second identifier in constant declaration
         // TODO: Old parser expected note on line 21: join the identifiers together
         // TODO: Old parser expected note on line 21: join the identifiers together with camel-case

--- a/Tests/SwiftParserTest/translated/ForeachAsyncTests.swift
+++ b/Tests/SwiftParserTest/translated/ForeachAsyncTests.swift
@@ -1,0 +1,86 @@
+// This test file has been translated from swift/test/Parse/foreach_async.swift
+
+import XCTest
+
+final class ForeachAsyncTests: XCTestCase {
+  func testForeachAsync1() {
+    AssertParse(
+      """
+      import _Concurrency
+      """
+    )
+  }
+
+  func testForeachAsync2() {
+    AssertParse(
+      """
+      struct AsyncRange<Bound: Comparable & Strideable>: AsyncSequence, AsyncIteratorProtocol where Bound.Stride : SignedInteger {
+        var range: Range<Bound>.Iterator
+        typealias Element = Bound
+        mutating func next() async -> Element? { return range.next() }
+        func cancel() { }
+        func makeAsyncIterator() -> Self { return self }
+      }
+      """
+    )
+  }
+
+  func testForeachAsync3() {
+    AssertParse(
+      """
+      struct AsyncIntRange<Int> : AsyncSequence, AsyncIteratorProtocol {
+        typealias Element = (Int, Int)
+        func next() async -> (Int, Int)? {}
+        func cancel() { }
+        typealias AsyncIterator = AsyncIntRange<Int>
+        func makeAsyncIterator() -> AsyncIntRange<Int> { return self }
+      }
+      """
+    )
+  }
+
+  func testForeachAsync4() {
+    AssertParse(
+      """
+      func for_each(r: AsyncRange<Int>, iir: AsyncIntRange<Int>) async { 
+        var sum = 0
+        // Simple foreach loop, using the variable in the body
+        for await i in r {
+          sum = sum + i
+        }
+        // Check scoping of variable introduced with foreach loop
+        i = 0 
+        // For-each loops with two variables and varying degrees of typedness
+        for await (i, j) in iir {
+          sum = sum + i + j
+        }
+        for await (i, j) in iir {
+          sum = sum + i + j
+        }
+        for await (i, j) : (Int, Int) in iir {
+          sum = sum + i + j
+        }
+        // Parse errors
+        // FIXME: Bad diagnostics; should be just 'expected 'in' after for-each patter'.
+        for await i #^DIAG_1^#r { 
+        }         
+        for await i in r #^DIAG_2^#sum = sum + i; 
+      }#^DIAG_3^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 1: 'r' declared here
+        // TODO: Old parser expected error on line 8: cannot find 'i' in scope; did you mean 'r'?
+        // TODO: Old parser expected error on line 21: found an unexpected second identifier in constant declaration
+        // TODO: Old parser expected note on line 21: join the identifiers together
+        // TODO: Old parser expected note on line 21: join the identifiers together with camel-case
+        // TODO: Old parser expected error on line 21: expected 'in' after for-each pattern
+        // TODO: Old parser expected error on line 21: expected Sequence expression for for-each loop
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected 'in' in 'for' statement"),
+        // TODO: Old parser expected error on line 23: expected '{' to start the body of for-each loop
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '{' in 'for' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected '}' to end function"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/ForeachTests.swift
+++ b/Tests/SwiftParserTest/translated/ForeachTests.swift
@@ -45,8 +45,6 @@ final class ForeachTests: XCTestCase {
       }#^DIAG_3^#
       """,
       diagnostics: [
-        // TODO: Old parser expected note on line 1: 'r' declared here
-        // TODO: Old parser expected error on line 8: cannot find 'i' in scope; did you mean 'r'?
         // TODO: Old parser expected error on line 21: found an unexpected second identifier in constant declaration
         // TODO: Old parser expected note on line 21: join the identifiers together
         // TODO: Old parser expected note on line 21: join the identifiers together with camel-case

--- a/Tests/SwiftParserTest/translated/ForeachTests.swift
+++ b/Tests/SwiftParserTest/translated/ForeachTests.swift
@@ -1,0 +1,63 @@
+// This test file has been translated from swift/test/Parse/foreach.swift
+
+import XCTest
+
+final class ForeachTests: XCTestCase {
+  func testForeach1() {
+    AssertParse(
+      """
+      struct IntRange<Int> : Sequence, IteratorProtocol {
+        typealias Element = (Int, Int)
+        func next() -> (Int, Int)? {}
+        typealias Iterator = IntRange<Int>
+        func makeIterator() -> IntRange<Int> { return self }
+      }
+      """
+    )
+  }
+
+  func testForeach2() {
+    AssertParse(
+      """
+      func for_each(r: Range<Int>, iir: IntRange<Int>) { 
+        var sum = 0
+        // Simple foreach loop, using the variable in the body
+        for i in r {
+          sum = sum + i
+        }
+        // Check scoping of variable introduced with foreach loop
+        i = 0 
+        // For-each loops with two variables and varying degrees of typedness
+        for (i, j) in iir {
+          sum = sum + i + j
+        }
+        for (i, j) in iir {
+          sum = sum + i + j
+        }
+        for (i, j) : (Int, Int) in iir {
+          sum = sum + i + j
+        }
+        // Parse errors
+        // FIXME: Bad diagnostics; should be just 'expected 'in' after for-each patter'.
+        for i #^DIAG_1^#r { 
+        }         
+        for i in r #^DIAG_2^#sum = sum + i; 
+      }#^DIAG_3^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 1: 'r' declared here
+        // TODO: Old parser expected error on line 8: cannot find 'i' in scope; did you mean 'r'?
+        // TODO: Old parser expected error on line 21: found an unexpected second identifier in constant declaration
+        // TODO: Old parser expected note on line 21: join the identifiers together
+        // TODO: Old parser expected note on line 21: join the identifiers together with camel-case
+        // TODO: Old parser expected error on line 21: expected 'in' after for-each pattern
+        // TODO: Old parser expected error on line 21: expected Sequence expression for for-each loop
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected 'in' in 'for' statement"),
+        // TODO: Old parser expected error on line 23: expected '{' to start the body of for-each loop
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '{' in 'for' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected '}' to end function"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
+++ b/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
@@ -16,10 +16,7 @@ final class GenericDisambiguationTests: XCTestCase {
       }
       struct B {}
       struct D {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 1: generic type 'A' declared here
-      ]
+      """
     )
   }
 
@@ -114,10 +111,7 @@ final class GenericDisambiguationTests: XCTestCase {
     AssertParse(
       """
       A<B>(x: 0)
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unused
-      ]
+      """
     )
   }
 
@@ -182,10 +176,7 @@ final class GenericDisambiguationTests: XCTestCase {
     AssertParse(
       """
       A<B, D>.c()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: generic type 'A' specialized with too many type parameters (got 2, but expected 1)
-      ]
+      """
     )
   }
 
@@ -194,10 +185,7 @@ final class GenericDisambiguationTests: XCTestCase {
       """
       A<B?>(x: 0) // parses as type 
       _ = a < b ? c : d
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unused
-      ]
+      """
     )
   }
 
@@ -205,10 +193,7 @@ final class GenericDisambiguationTests: XCTestCase {
     AssertParse(
       """
       A<(B) throws -> D>(x: 0)
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: unused
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
+++ b/Tests/SwiftParserTest/translated/GenericDisambiguationTests.swift
@@ -1,0 +1,215 @@
+// This test file has been translated from swift/test/Parse/generic_disambiguation.swift
+
+import XCTest
+
+final class GenericDisambiguationTests: XCTestCase {
+  func testGenericDisambiguation1() {
+    AssertParse(
+      """
+      struct A<B> { 
+        init(x:Int) {}
+        static func c() {}
+        struct C<D> {
+          static func e() {}
+        }
+        struct F {}
+      }
+      struct B {}
+      struct D {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 1: generic type 'A' declared here
+      ]
+    )
+  }
+
+  func testGenericDisambiguation2() {
+    AssertParse(
+      """
+      protocol Runcible {}
+      protocol Fungible {}
+      """
+    )
+  }
+
+  func testGenericDisambiguation3() {
+    AssertParse(
+      """
+      func meta<T>(_ m: T.Type) {}
+      func meta2<T>(_ m: T.Type, _ x: Int) {}
+      """
+    )
+  }
+
+  func testGenericDisambiguation4() {
+    AssertParse(
+      """
+      func generic<T>(_ x: T) {}
+      """
+    )
+  }
+
+  func testGenericDisambiguation5() {
+    AssertParse(
+      """
+      var a, b, c, d : Int
+      """
+    )
+  }
+
+  func testGenericDisambiguation6() {
+    AssertParse(
+      """
+      _ = a < b
+      _ = (a < b, c > d)
+      // Parses as generic because of lparen after '>'
+      (a < b, c > (d)) 
+      // Parses as generic because of lparen after '>'
+      (a<b, c>(d)) 
+      _ = a>(b)
+      _ = a > (b)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: cannot specialize a non-generic definition
+        // TODO: Old parser expected note on line 4: while parsing this '<' as a type parameter bracket
+        // TODO: Old parser expected error on line 6: cannot specialize a non-generic definition
+        // TODO: Old parser expected note on line 6: while parsing this '<' as a type parameter bracket
+      ]
+    )
+  }
+
+  func testGenericDisambiguation7() {
+    AssertParse(
+      """
+      generic<Int>(0)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot explicitly specialize a generic function
+        // TODO: Old parser expected note on line 1: while parsing this '<' as a type parameter bracket
+      ]
+    )
+  }
+
+  func testGenericDisambiguation8() {
+    AssertParse(
+      """
+      A<B>.c()
+      A<A<B>>.c()
+      A<A<B>.F>.c()
+      A<(A<B>) -> B>.c()
+      A<[[Int]]>.c()
+      A<[[A<B>]]>.c()
+      A<(Int, UnicodeScalar)>.c()
+      A<(a:Int, b:UnicodeScalar)>.c()
+      A<Runcible & Fungible>.c()
+      A<@convention(c) () -> Int32>.c()
+      A<(@autoclosure @escaping () -> Int, Int) -> Void>.c()
+      _ = [@convention(block) ()  -> Int]().count
+      _ = [String: (@escaping (A<B>) -> Int) -> Void]().keys
+      """
+    )
+  }
+
+  func testGenericDisambiguation9() {
+    AssertParse(
+      """
+      A<B>(x: 0)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unused
+      ]
+    )
+  }
+
+  func testGenericDisambiguation10() {
+    AssertParse(
+      """
+      meta(A<B>.self)
+      """
+    )
+  }
+
+  func testGenericDisambiguation11() {
+    AssertParse(
+      """
+      meta2(A<B>.self, 0)
+      """
+    )
+  }
+
+  func testGenericDisambiguation12() {
+    AssertParse(
+      """
+      // FIXME: Nested generic types. Need to be able to express $T0<A, B, C> in the
+      // typechecker.
+      /*
+      A<B>.C<D>.e()
+      """
+    )
+  }
+
+  func testGenericDisambiguation13() {
+    AssertParse(
+      """
+      A<B>.C<D>(0)
+      """
+    )
+  }
+
+  func testGenericDisambiguation14() {
+    AssertParse(
+      """
+      meta(A<B>.C<D>.self)
+      meta2(A<B>.C<D>.self, 0)
+       #^DIAG^#*/
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "extraneous '*/' at top level"),
+      ]
+    )
+  }
+
+  func testGenericDisambiguation15() {
+    AssertParse(
+      """
+      // TODO: parse empty <> list
+      //A<>.c() // e/xpected-error{{xxx}}
+      """
+    )
+  }
+
+  func testGenericDisambiguation16() {
+    AssertParse(
+      """
+      A<B, D>.c()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: generic type 'A' specialized with too many type parameters (got 2, but expected 1)
+      ]
+    )
+  }
+
+  func testGenericDisambiguation17() {
+    AssertParse(
+      """
+      A<B?>(x: 0) // parses as type 
+      _ = a < b ? c : d
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unused
+      ]
+    )
+  }
+
+  func testGenericDisambiguation18() {
+    AssertParse(
+      """
+      A<(B) throws -> D>(x: 0)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: unused
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/GuardTests.swift
+++ b/Tests/SwiftParserTest/translated/GuardTests.swift
@@ -1,0 +1,28 @@
+// This test file has been translated from swift/test/Parse/guard.swift
+
+import XCTest
+
+final class GuardTests: XCTestCase {
+  func testGuard1() {
+    AssertParse(
+      """
+      func noConditionNoElse() {
+        guard {} #^DIAG_1^#
+      }
+      func noCondition() {
+        guard #^DIAG_2^#else {} 
+      }#^DIAG_3^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: missing condition in 'guard' statement
+        // TODO: Old parser expected error on line 2: expected 'else' after 'guard' condition
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected 'else' in 'guard' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '{' in 'guard' statement"),
+        // TODO: Old parser expected error on line 5: missing condition in 'guard' statement
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'guard' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected '}' to end function"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/GuardTopLevelTests.swift
+++ b/Tests/SwiftParserTest/translated/GuardTopLevelTests.swift
@@ -1,0 +1,32 @@
+// This test file has been translated from swift/test/Parse/guard-top-level.swift
+
+import XCTest
+
+final class GuardTopLevelTests: XCTestCase {
+  func testGuardTopLevel1() {
+    AssertParse(
+      """
+      let a: Int? = 1
+      guard let b = a else {
+      }
+      """
+    )
+  }
+
+  func testGuardTopLevel2() {
+    AssertParse(
+      """
+      func foo() {} // to interrupt the TopLevelCodeDecl
+      """
+    )
+  }
+
+  func testGuardTopLevel3() {
+    AssertParse(
+      """
+      let c = b
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
+++ b/Tests/SwiftParserTest/translated/HashbangLibraryTests.swift
@@ -1,0 +1,20 @@
+// This test file has been translated from swift/test/Parse/hashbang_library.swift
+
+import XCTest
+
+final class HashbangLibraryTests: XCTestCase {
+  func testHashbangLibrary1() {
+    AssertParse(
+      """
+      #!/usr/bin/swift 
+      class Foo {}
+      // Check that we diagnose and skip the hashbang at the beginning of the file
+      // when compiling in library mode.
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: hashbang line is allowed only in the main file
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/HashbangMainTests.swift
+++ b/Tests/SwiftParserTest/translated/HashbangMainTests.swift
@@ -10,10 +10,7 @@ final class HashbangMainTests: XCTestCase {
       let x = 42
       x + x 
       // Check that we skip the hashbang at the beginning of the file.
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 3: result of operator '+' is unused
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/HashbangMainTests.swift
+++ b/Tests/SwiftParserTest/translated/HashbangMainTests.swift
@@ -1,0 +1,20 @@
+// This test file has been translated from swift/test/Parse/hashbang_main.swift
+
+import XCTest
+
+final class HashbangMainTests: XCTestCase {
+  func testHashbangMain1() {
+    AssertParse(
+      """
+      #!/usr/bin/swift
+      let x = 42
+      x + x 
+      // Check that we skip the hashbang at the beginning of the file.
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 3: result of operator '+' is unused
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/IdentifiersTests.swift
+++ b/Tests/SwiftParserTest/translated/IdentifiersTests.swift
@@ -1,0 +1,184 @@
+// This test file has been translated from swift/test/Parse/identifiers.swift
+
+import XCTest
+
+final class IdentifiersTests: XCTestCase {
+  func testIdentifiers1() {
+    AssertParse(
+      """
+      func my_print<T>(_ t: T) {}
+      """
+    )
+  }
+
+  func testIdentifiers2() {
+    AssertParse(
+      #"""
+      class 你好 {
+        class שלום {
+          class வணக்கம் {
+            class Γειά {
+              class func привет() {
+                my_print("hello")
+              }
+            }
+          }
+        }
+      }
+      """#
+    )
+  }
+
+  func testIdentifiers3() {
+    AssertParse(
+      """
+      你好.שלום.வணக்கம்.Γειά.привет()
+      """
+    )
+  }
+
+  func testIdentifiers4() {
+    AssertParse(
+      """
+      // Identifiers cannot start with combining chars.
+      _ = .́duh()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot find 'duh' in scope
+        // TODO: Old parser expected error on line 2: cannot find operator '.́' in scope
+      ]
+    )
+  }
+
+  func testIdentifiers5() {
+    AssertParse(
+      """
+      // Combining characters can be used within identifiers.
+      func s̈pin̈al_tap̈() {}
+      """
+    )
+  }
+
+  func testIdentifiers6() {
+    AssertParse(
+      """
+      // Private-use characters aren't valid in Swift source.
+      ()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: invalid character in source file, Fix-It replacements: 1 - 4 = ' '
+      ]
+    )
+  }
+
+  func testIdentifiers7() {
+    AssertParse(
+      """
+      // Placeholders are recognized as identifiers but with error.
+      func <#some name#>() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: editor placeholder in source file
+      ]
+    )
+  }
+
+  func testIdentifiers8() {
+    AssertParse(
+      """
+      // Keywords as identifiers
+      class #^DIAG_1^#switch {} #^DIAG_2^#
+      struct Self {} 
+      protocol #^DIAG_3^#enum #^DIAG_4^#{} 
+      protocol test {
+        associatedtype #^DIAG_5^#public 
+      #^DIAG_6^#}
+      func #^DIAG_7^#_(_ x: Int) {}#^DIAG_8^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: keyword 'switch' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 2: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 7 - 13 = '`switch`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in class"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected member block in class"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '{}' in 'switch' statement"),
+        // TODO: Old parser expected error on line 3: keyword 'Self' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 3: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 12 = '`Self`'
+        // TODO: Old parser expected error on line 4: keyword 'enum' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 4: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 10 - 14 = '`enum`'
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected identifier in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected member block in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected identifier in enum"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected member block in enum"),
+        // TODO: Old parser expected error on line 6: keyword 'public' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 6: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 18 - 24 = '`public`'
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected identifier in associatedtype declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_6", message: "unexpected text '}' in function"),
+        // TODO: Old parser expected note on line 8: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 6 - 7 = '`_`'
+        // TODO: Old parser expected error on line 8: keyword '_' cannot be used as an identifier here
+        DiagnosticSpec(locationMarker: "DIAG_7", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "DIAG_7", message: "unexpected text '_' before parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_8", message: "expected '}' to end protocol"),
+      ]
+    )
+  }
+
+  func testIdentifiers9() {
+    AssertParse(
+      """
+      // SIL keywords are tokenized as normal identifiers in non-SIL mode.
+      _ = undef 
+      _ = sil 
+      _ = sil_stage 
+      _ = sil_vtable 
+      _ = sil_global 
+      _ = sil_witness_table 
+      _ = sil_default_witness_table 
+      _ = sil_coverage_map 
+      _ = sil_scope
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot find 'undef' in scope
+        // TODO: Old parser expected error on line 3: cannot find 'sil' in scope
+        // TODO: Old parser expected error on line 4: cannot find 'sil_stage' in scope
+        // TODO: Old parser expected error on line 5: cannot find 'sil_vtable' in scope
+        // TODO: Old parser expected error on line 6: cannot find 'sil_global' in scope
+        // TODO: Old parser expected error on line 7: cannot find 'sil_witness_table' in scope
+        // TODO: Old parser expected error on line 8: cannot find 'sil_default_witness_table' in scope
+        // TODO: Old parser expected error on line 9: cannot find 'sil_coverage_map' in scope
+        // TODO: Old parser expected error on line 10: cannot find 'sil_scope' in scope
+      ]
+    )
+  }
+
+  func testIdentifiers10() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/57542
+      // Make sure we do not parse the '_' on the newline as being part of the 'variable' identifier on the line before.
+      """
+    )
+  }
+
+  func testIdentifiers11() {
+    AssertParse(
+      """
+      @propertyWrapper 
+      struct Wrapper {
+        var wrappedValue = 0
+      }
+      """
+    )
+  }
+
+  func testIdentifiers12() {
+    AssertParse(
+      """
+      func localScope() {
+        @Wrapper var variable
+        _ = 0
+      }
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/IdentifiersTests.swift
+++ b/Tests/SwiftParserTest/translated/IdentifiersTests.swift
@@ -42,11 +42,7 @@ final class IdentifiersTests: XCTestCase {
       """
       // Identifiers cannot start with combining chars.
       _ = .́duh()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot find 'duh' in scope
-        // TODO: Old parser expected error on line 2: cannot find operator '.́' in scope
-      ]
+      """
     )
   }
 
@@ -135,18 +131,7 @@ final class IdentifiersTests: XCTestCase {
       _ = sil_default_witness_table 
       _ = sil_coverage_map 
       _ = sil_scope
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot find 'undef' in scope
-        // TODO: Old parser expected error on line 3: cannot find 'sil' in scope
-        // TODO: Old parser expected error on line 4: cannot find 'sil_stage' in scope
-        // TODO: Old parser expected error on line 5: cannot find 'sil_vtable' in scope
-        // TODO: Old parser expected error on line 6: cannot find 'sil_global' in scope
-        // TODO: Old parser expected error on line 7: cannot find 'sil_witness_table' in scope
-        // TODO: Old parser expected error on line 8: cannot find 'sil_default_witness_table' in scope
-        // TODO: Old parser expected error on line 9: cannot find 'sil_coverage_map' in scope
-        // TODO: Old parser expected error on line 10: cannot find 'sil_scope' in scope
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
+++ b/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
@@ -1,0 +1,315 @@
+// This test file has been translated from swift/test/Parse/ifconfig_expr.swift
+
+import XCTest
+
+final class IfconfigExprTests: XCTestCase {
+  func testIfconfigExpr1() {
+    AssertParse(
+      """
+      postfix operator ++
+      postfix func ++ (_: Int) -> Int { 0 }
+      """
+    )
+  }
+
+  func testIfconfigExpr2() {
+    AssertParse(
+      """
+      struct OneResult {}
+      struct TwoResult {}
+      """
+    )
+  }
+
+  func testIfconfigExpr3() {
+    AssertParse(
+      """
+      protocol MyProto {
+          func optionalMethod() -> [Int]?
+      }
+      struct MyStruct {
+          var optionalMember: MyProto? { nil }
+          func methodOne() -> OneResult { OneResult() }
+          func methodTwo() -> TwoResult { TwoResult() }
+      }
+      """
+    )
+  }
+
+  func testIfconfigExpr4() {
+    AssertParse(
+      """
+      func globalFunc<T>(_ arg: T) -> T { arg }
+      """
+    )
+  }
+
+  func testIfconfigExpr5() {
+    AssertParse(
+      """
+      func testBasic(baseExpr: MyStruct) {
+          baseExpr
+      #if CONDITION_1
+            .methodOne() 
+      #else
+            .methodTwo()
+      #endif
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 4: result of call to 'methodOne()' is unused
+      ]
+    )
+  }
+
+  func testIfconfigExpr6() {
+    AssertParse(
+      """
+      MyStruct()
+      #if CONDITION_1
+        .methodOne() 
+      #else
+        .methodTwo()
+      #endif
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 3: result of call to 'methodOne()' is unused
+      ]
+    )
+  }
+
+  func testIfconfigExpr7() {
+    AssertParse(
+      #"""
+      func testInvalidContent(baseExpr: MyStruct, otherExpr: Int) {
+        baseExpr      
+      #if CONDITION_1
+          { $0 + 1  } 
+      #endif
+        baseExpr      
+      #if CONDITION_1
+          #^DIAG_1^#+ otherExpr 
+      #endif
+        baseExpr
+      #if CONDITION_1
+          .methodOne() 
+        #^DIAG_2^#print("debug") 
+      #endif
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 2: expression of type 'MyStruct' is unused
+        // TODO: Old parser expected error on line 4: closure expression is unused
+        // TODO: Old parser expected warning on line 6: expression of type 'MyStruct' is unused
+        // TODO: Old parser expected error on line 8: unary operator cannot be separated from its operand
+        // TODO: Old parser expected warning on line 8: result of operator '+' is unused
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '+ otherExpr' in conditional compilation block"),
+        // TODO: Old parser expected warning on line 12: result of call to 'methodOne()' is unused
+        // TODO: Old parser expected error on line 13: unexpected tokens in '#if' expression body
+        DiagnosticSpec(locationMarker: "DIAG_2", message: #"unexpected text 'print("debug")' in conditional compilation block"#),
+      ]
+    )
+  }
+
+  func testIfconfigExpr8() {
+    AssertParse(
+      """
+      func testExprKind(baseExpr: MyStruct, idx: Int) {
+        baseExpr
+      #if CONDITION_1
+        .optionalMember?.optionalMethod()![idx]++ 
+      #else
+        .otherMethod(arg) {
+          //...
+        }
+      #endif
+        baseExpr
+      #if CONDITION_1
+        .methodOne() #^DIAG^#+ 12 
+      #endif
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 4: result of operator '++' is unused
+        // TODO: Old parser expected error on line 12: unexpected tokens in '#if' expression body
+        // TODO: Old parser expected warning on line 12: result of call to 'methodOne()' is unused
+        DiagnosticSpec(message: "unexpected text '+ 12' in conditional compilation block"),
+      ]
+    )
+  }
+
+  func testIfconfigExpr9() {
+    AssertParse(
+      """
+      func emptyElse(baseExpr: MyStruct) {
+        baseExpr
+      #if CONDITION_1
+          .methodOne() 
+      #elseif CONDITION_2#^DIAG_1^#
+          // OK. Do nothing.
+      #endif
+        baseExpr
+      #if CONDITION_1
+          .methodOne() 
+      #elseif CONDITION_2#^DIAG_2^#
+        #^DIAG_3^#return         
+      #endif
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 4: result of call to 'methodOne()' is unused
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in conditional compilation clause"),
+        // TODO: Old parser expected warning on line 10: result of call to 'methodOne()' is unused
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in conditional compilation clause"),
+        // TODO: Old parser expected error on line 12: unexpected tokens in '#if' expression body
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text 'return' in conditional compilation block"),
+      ]
+    )
+  }
+
+  func testIfconfigExpr10() {
+    AssertParse(
+      """
+      func consecutiveIfConfig(baseExpr: MyStruct) {
+          baseExpr
+      #if CONDITION_1
+        .methodOne()
+      #endif
+      #if CONDITION_2
+        .methodTwo()
+      #endif
+        .unknownMethod() 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 9: value of type 'OneResult' has no member 'unknownMethod'
+      ]
+    )
+  }
+
+  func testIfconfigExpr11() {
+    AssertParse(
+      """
+      func nestedIfConfig(baseExpr: MyStruct) {
+        baseExpr
+      #if CONDITION_1
+        #if CONDITION_2
+          .methodOne()
+        #endif
+        #if CONDITION_1
+          .methodTwo() 
+        #endif
+      #else
+        .unknownMethod1()
+        #if CONDITION_2
+          .unknownMethod2()
+        #endif
+      #endif
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 8: result of call to 'methodTwo()' is unused
+      ]
+    )
+  }
+
+  func testIfconfigExpr12() {
+    AssertParse(
+      """
+      func ifconfigExprInExpr(baseExpr: MyStruct) {
+        globalFunc( 
+          baseExpr
+      #if CONDITION_1
+            .methodOne()
+      #else
+            .methodTwo()
+      #endif
+        )
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 2: result of call to 'globalFunc' is unused
+      ]
+    )
+  }
+
+  func testIfconfigExpr13() {
+    AssertParse(
+      #"""
+      func canImportVersioned() {
+      #if canImport(A, _version: 2)
+        let a = 1
+      #endif
+      #if canImport(A, _version: 2.2)
+        let a = 1
+      #endif
+      #if canImport(A, _version: 2.2.2)
+        let a = 1
+      #endif
+      #if canImport(A, _version: 2.2.2.2)
+        let a = 1
+      #endif
+      #if canImport(A, _version: 2.2.2.2.2) 
+        let a = 1
+      #endif
+      #if canImport(A, _underlyingVersion: 4)
+        let a = 1
+      #endif
+      #if canImport(A, _underlyingVersion: 2.200)
+        let a = 1
+      #endif
+      #if canImport(A, _underlyingVersion: 2.200.1)
+        let a = 1
+      #endif
+      #if canImport(A, _underlyingVersion: 2.200.1.3)
+        let a = 1
+      #endif
+      #if canImport(A, unknown: 2.2) 
+        let a = 1
+      #endif
+      #if canImport(A,#^DIAG_1^#) 
+        let a = 1
+      #endif
+      #if canImport(A, 2.2) 
+        let a = 1
+      #endif
+      #if canImport(A, 2.2, 1.1) 
+        let a = 1
+      #endif
+      #if canImport(A, _version:#^DIAG_2^#) 
+        let a = 1
+      #endif
+      #if canImport(A, _version: "") 
+        let a = 1
+      #endif
+      #if canImport(A, _version: >=2.2) 
+        let a = 1
+      #endif
+      #if canImport(A, _version: #^DIAG_3^#20A301) 
+        let a = 1
+      #endif
+      #if canImport(A, _version: "20A301") 
+        let a = 1
+      #endif
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 14: trailing components of version '2.2.2.2' are ignored
+        // TODO: Old parser expected error on line 29: 2nd parameter of canImport should be labeled as _version or _underlyingVersion
+        // TODO: Old parser expected error on line 32: unexpected ',' separator
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected value in function call"),
+        // TODO: Old parser expected error on line 35: 2nd parameter of canImport should be labeled as _version or _underlyingVersion
+        // TODO: Old parser expected error on line 38: canImport can take only two parameters
+        // TODO: Old parser expected error on line 41: expected expression in list of expressions
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected value in function call"),
+        // TODO: Old parser expected error on line 44: _version argument cannot be empty
+        // TODO: Old parser expected error on line 47: cannot parse module version '>=2.2'
+        // TODO: Old parser expected error on line 50: 'A' is not a valid digit in integer literal
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected value in function call"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text '20A301' in function call"),
+        // TODO: Old parser expected error on line 53: cannot parse module version '20A301'
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
+++ b/Tests/SwiftParserTest/translated/IfconfigExprTests.swift
@@ -55,10 +55,7 @@ final class IfconfigExprTests: XCTestCase {
             .methodTwo()
       #endif
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 4: result of call to 'methodOne()' is unused
-      ]
+      """
     )
   }
 
@@ -71,10 +68,7 @@ final class IfconfigExprTests: XCTestCase {
       #else
         .methodTwo()
       #endif
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 3: result of call to 'methodOne()' is unused
-      ]
+      """
     )
   }
 
@@ -98,13 +92,8 @@ final class IfconfigExprTests: XCTestCase {
       }
       """#,
       diagnostics: [
-        // TODO: Old parser expected warning on line 2: expression of type 'MyStruct' is unused
-        // TODO: Old parser expected error on line 4: closure expression is unused
-        // TODO: Old parser expected warning on line 6: expression of type 'MyStruct' is unused
         // TODO: Old parser expected error on line 8: unary operator cannot be separated from its operand
-        // TODO: Old parser expected warning on line 8: result of operator '+' is unused
         DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '+ otherExpr' in conditional compilation block"),
-        // TODO: Old parser expected warning on line 12: result of call to 'methodOne()' is unused
         // TODO: Old parser expected error on line 13: unexpected tokens in '#if' expression body
         DiagnosticSpec(locationMarker: "DIAG_2", message: #"unexpected text 'print("debug")' in conditional compilation block"#),
       ]
@@ -130,9 +119,7 @@ final class IfconfigExprTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected warning on line 4: result of operator '++' is unused
         // TODO: Old parser expected error on line 12: unexpected tokens in '#if' expression body
-        // TODO: Old parser expected warning on line 12: result of call to 'methodOne()' is unused
         DiagnosticSpec(message: "unexpected text '+ 12' in conditional compilation block"),
       ]
     )
@@ -157,9 +144,7 @@ final class IfconfigExprTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected warning on line 4: result of call to 'methodOne()' is unused
         DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in conditional compilation clause"),
-        // TODO: Old parser expected warning on line 10: result of call to 'methodOne()' is unused
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in conditional compilation clause"),
         // TODO: Old parser expected error on line 12: unexpected tokens in '#if' expression body
         DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text 'return' in conditional compilation block"),
@@ -180,10 +165,7 @@ final class IfconfigExprTests: XCTestCase {
       #endif
         .unknownMethod() 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 9: value of type 'OneResult' has no member 'unknownMethod'
-      ]
+      """
     )
   }
 
@@ -206,10 +188,7 @@ final class IfconfigExprTests: XCTestCase {
         #endif
       #endif
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 8: result of call to 'methodTwo()' is unused
-      ]
+      """
     )
   }
 
@@ -226,10 +205,7 @@ final class IfconfigExprTests: XCTestCase {
       #endif
         )
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 2: result of call to 'globalFunc' is unused
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/ImplicitGetterIncompleteTests.swift
+++ b/Tests/SwiftParserTest/translated/ImplicitGetterIncompleteTests.swift
@@ -1,0 +1,44 @@
+// This test file has been translated from swift/test/Parse/implicit_getter_incomplete.swift
+
+import XCTest
+
+final class ImplicitGetterIncompleteTests: XCTestCase {
+  func testImplicitGetterIncomplete1() {
+    AssertParse(
+      """
+      func test1() {
+        var a : Int {
+      #if arch(x86_64)
+          return 0
+      #else
+          return 1
+      #endif
+        }
+      }
+      """
+    )
+  }
+
+  func testImplicitGetterIncomplete2() {
+    AssertParse(
+      #"""
+      // Would trigger assertion when AST verifier checks source ranges ("child source range not contained within its parent")
+      func test2() { 
+        var a : Int { 
+          switch i { 
+      }#^DIAG^#
+      // expected-error@+1 2 {{expected '}'}}
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: match
+        // TODO: Old parser expected note on line 3: match
+        // TODO: Old parser expected note on line 3: 'a' declared here
+        // TODO: Old parser expected error on line 4: cannot find 'i' in scope; did you mean 'a'
+        // TODO: Old parser expected error on line 4: 'switch' statement body must have at least one 'case'
+        DiagnosticSpec(message: "expected '}' to end variable"),
+        DiagnosticSpec(message: "expected '}' to end function"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/ImplicitGetterIncompleteTests.swift
+++ b/Tests/SwiftParserTest/translated/ImplicitGetterIncompleteTests.swift
@@ -30,10 +30,6 @@ final class ImplicitGetterIncompleteTests: XCTestCase {
       // expected-error@+1 2 {{expected '}'}}
       """#,
       diagnostics: [
-        // TODO: Old parser expected note on line 2: match
-        // TODO: Old parser expected note on line 3: match
-        // TODO: Old parser expected note on line 3: 'a' declared here
-        // TODO: Old parser expected error on line 4: cannot find 'i' in scope; did you mean 'a'
         // TODO: Old parser expected error on line 4: 'switch' statement body must have at least one 'case'
         DiagnosticSpec(message: "expected '}' to end variable"),
         DiagnosticSpec(message: "expected '}' to end function"),

--- a/Tests/SwiftParserTest/translated/InitDeinitTests.swift
+++ b/Tests/SwiftParserTest/translated/InitDeinitTests.swift
@@ -1,0 +1,413 @@
+// This test file has been translated from swift/test/Parse/init_deinit.swift
+
+import XCTest
+
+final class InitDeinitTests: XCTestCase {
+  func testInitDeinit1() {
+    AssertParse(
+      """
+      struct FooStructConstructorA {
+        init #^DIAG^#
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '('
+        // TODO: Old parser expected error on line 2: initializer requires a body
+        DiagnosticSpec(message: "expected argument list in function declaration"),
+      ]
+    )
+  }
+
+  func testInitDeinit2() {
+    AssertParse(
+      """
+      struct FooStructConstructorB {
+        init() 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: initializer requires a body
+      ]
+    )
+  }
+
+  func testInitDeinit3() {
+    AssertParse(
+      """
+      struct FooStructConstructorC {
+        init #^DIAG_1^#{} 
+        init<T> #^DIAG_2^#{} 
+        init? #^DIAG_3^#{ self.init() } 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '(', Fix-It replacements: 7 - 7 = '()'
+        // TODO: Old parser expected note on line 2: 'init()' previously declared here
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected argument list in function declaration"),
+        // TODO: Old parser expected error on line 3: expected '(', Fix-It replacements: 10 - 10 = '()'
+        // TODO: Old parser expected error on line 3: generic parameter 'T' is not used in function signature
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected argument list in function declaration"),
+        // TODO: Old parser expected error on line 4: expected '(', Fix-It replacements: 8 - 8 = '()'
+        // TODO: Old parser expected error on line 4: invalid redeclaration of 'init()'
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected argument list in function declaration"),
+      ]
+    )
+  }
+
+  func testInitDeinit4() {
+    AssertParse(
+      """
+      struct FooStructConstructorD {
+        init() -> FooStructConstructorD { }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: initializers cannot have a result type
+      ]
+    )
+  }
+
+  func testInitDeinit5() {
+    AssertParse(
+      """
+      struct FooStructDeinitializerA {
+        deinit 
+        deinit #^DIAG_1^#x 
+        deinit #^DIAG_2^#x() 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '{' for deinitializer
+        // TODO: Old parser expected error on line 3: deinitializers cannot have a name, Fix-It replacements: 10 - 12 = ''
+        // TODO: Old parser expected error on line 3: expected '{' for deinitializer
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text 'x' before deinitializer"),
+        // TODO: Old parser expected error on line 4: deinitializers cannot have a name, Fix-It replacements: 10 - 11 = ''
+        // TODO: Old parser expected error on line 4: no parameter clause allowed on deinitializer, Fix-It replacements: 11 - 13 = ''
+        // TODO: Old parser expected error on line 4: expected '{' for deinitializer
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected declaration in struct"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text 'x()' in struct"),
+      ]
+    )
+  }
+
+  func testInitDeinit6() {
+    AssertParse(
+      """
+      struct FooStructDeinitializerB {
+        deinit 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '{' for deinitializer
+      ]
+    )
+  }
+
+  func testInitDeinit7() {
+    AssertParse(
+      """
+      struct FooStructDeinitializerC {
+        deinit {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: deinitializers may only be declared within a class or actor
+      ]
+    )
+  }
+
+  func testInitDeinit8() {
+    AssertParse(
+      """
+      class FooClassDeinitializerA {
+        deinit#^DIAG^#(a : Int) {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: no parameter clause allowed on deinitializer, Fix-It replacements: 9 - 18 = ''
+        DiagnosticSpec(message: "expected declaration in class"),
+        DiagnosticSpec(message: "unexpected text '(a : Int) {}' in class"),
+      ]
+    )
+  }
+
+  func testInitDeinit9() {
+    AssertParse(
+      """
+      class FooClassDeinitializerB {
+        deinit { }
+      }
+      """
+    )
+  }
+
+  func testInitDeinit10() {
+    AssertParse(
+      """
+      class FooClassDeinitializerC {
+        deinit #^DIAG^#x (a : Int) {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: deinitializers cannot have a name, Fix-It replacements: 10 - 12 = ''
+        // TODO: Old parser expected error on line 2: no parameter clause allowed on deinitializer, Fix-It replacements: 12 - 22 = ''
+        DiagnosticSpec(message: "expected declaration in class"),
+        DiagnosticSpec(message: "unexpected text 'x (a : Int) {}' in class"),
+      ]
+    )
+  }
+
+  func testInitDeinit11() {
+    AssertParse(
+      """
+      init #^DIAG^#{} 
+      init() 
+      init() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: initializers may only be declared within a type
+        // TODO: Old parser expected error on line 1: expected '(', Fix-It replacements: 5 - 5 = '()'
+        DiagnosticSpec(message: "expected argument list in function declaration"),
+        // TODO: Old parser expected error on line 2: initializers may only be declared within a type
+        // TODO: Old parser expected error on line 3: initializers may only be declared within a type
+      ]
+    )
+  }
+
+  func testInitDeinit12() {
+    AssertParse(
+      """
+      deinit {} 
+      deinit 
+      deinit {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: deinitializers may only be declared within a class or actor
+        // TODO: Old parser expected error on line 2: expected '{' for deinitializer
+        // TODO: Old parser expected error on line 3: deinitializers may only be declared within a class or actor
+      ]
+    )
+  }
+
+  func testInitDeinit13() {
+    AssertParse(
+      """
+      struct BarStruct {
+        init() {}
+        deinit {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: deinitializers may only be declared within a class or actor
+      ]
+    )
+  }
+
+  func testInitDeinit14() {
+    AssertParse(
+      """
+      extension BarStruct {
+        init(x : Int) {}
+        // When/if we allow 'var' in extensions, then we should also allow dtors
+        deinit {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: deinitializers may only be declared within a class or actor
+      ]
+    )
+  }
+
+  func testInitDeinit15() {
+    AssertParse(
+      """
+      enum BarUnion {
+        init() {}
+        deinit {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: deinitializers may only be declared within a class or actor
+      ]
+    )
+  }
+
+  func testInitDeinit16() {
+    AssertParse(
+      """
+      extension BarUnion {
+        init(x : Int) {}
+        deinit {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: deinitializers may only be declared within a class or actor
+      ]
+    )
+  }
+
+  func testInitDeinit17() {
+    AssertParse(
+      """
+      class BarClass {
+        init() {}
+        deinit {}
+      }
+      """
+    )
+  }
+
+  func testInitDeinit18() {
+    AssertParse(
+      """
+      extension BarClass {
+        convenience init(x : Int) { self.init() }
+        deinit {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: deinitializers may only be declared within a class or actor
+      ]
+    )
+  }
+
+  func testInitDeinit19() {
+    AssertParse(
+      """
+      protocol BarProtocol {
+        init() {} 
+        deinit {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: protocol initializers must not have bodies
+        // TODO: Old parser expected error on line 3: deinitializers may only be declared within a class or actor
+      ]
+    )
+  }
+
+  func testInitDeinit20() {
+    AssertParse(
+      """
+      extension BarProtocol {
+        init(x : Int) {}
+        deinit {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: deinitializers may only be declared within a class or actor
+      ]
+    )
+  }
+
+  func testInitDeinit21() {
+    AssertParse(
+      """
+      func fooFunc() {
+        init() {} 
+        deinit {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: initializers may only be declared within a type
+        // TODO: Old parser expected error on line 3: deinitializers may only be declared within a class or actor
+      ]
+    )
+  }
+
+  func testInitDeinit22() {
+    AssertParse(
+      """
+      func barFunc() {
+        var x : () = { () -> () in
+          init() {} 
+          return
+        } ()
+        var y : () = { () -> () in
+          deinit {} 
+          return
+        } ()
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 2: variable 'x' was never used; consider replacing with '_' or removing it
+        // TODO: Old parser expected error on line 3: initializers may only be declared within a type
+        // TODO: Old parser expected warning on line 6: variable 'y' was never used; consider replacing with '_' or removing it
+        // TODO: Old parser expected error on line 7: deinitializers may only be declared within a class or actor
+      ]
+    )
+  }
+
+  func testInitDeinit23() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/43464
+      """
+    )
+  }
+
+  func testInitDeinit24() {
+    AssertParse(
+      """
+      class Aaron {
+        init(x: Int) {}
+        convenience init() { init(x: #^DIAG^#1) } 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: missing 'self.' at initializer invocation, Fix-It replacements: 24 - 24 = 'self.'
+        DiagnosticSpec(message: "expected type in function parameter"),
+        DiagnosticSpec(message: "unexpected text '1' in parameter clause"),
+      ]
+    )
+  }
+
+  func testInitDeinit25() {
+    AssertParse(
+      """
+      class Theodosia: Aaron {
+        init() {
+          init(x: #^DIAG^#2) 
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: missing 'super.' at initializer invocation, Fix-It replacements: 5 - 5 = 'super.'
+        DiagnosticSpec(message: "expected type in function parameter"),
+        DiagnosticSpec(message: "unexpected text '2' in parameter clause"),
+      ]
+    )
+  }
+
+  func testInitDeinit26() {
+    AssertParse(
+      """
+      struct AaronStruct {
+        init(x: Int) {}
+        init() { init(x: #^DIAG^#1) } 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: missing 'self.' at initializer invocation, Fix-It replacements: 12 - 12 = 'self.'
+        DiagnosticSpec(message: "expected type in function parameter"),
+        DiagnosticSpec(message: "unexpected text '1' in parameter clause"),
+      ]
+    )
+  }
+
+  func testInitDeinit27() {
+    AssertParse(
+      """
+      enum AaronEnum: Int {
+        case A = 1
+        init(x: Int) { init(rawValue: x)#^DIAG^#! } 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: missing 'self.' at initializer invocation, Fix-It replacements: 18 - 18 = 'self.'
+        DiagnosticSpec(message: "unexpected text '!' in initializer"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/InitDeinitTests.swift
+++ b/Tests/SwiftParserTest/translated/InitDeinitTests.swift
@@ -42,13 +42,10 @@ final class InitDeinitTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: expected '(', Fix-It replacements: 7 - 7 = '()'
-        // TODO: Old parser expected note on line 2: 'init()' previously declared here
         DiagnosticSpec(locationMarker: "DIAG_1", message: "expected argument list in function declaration"),
         // TODO: Old parser expected error on line 3: expected '(', Fix-It replacements: 10 - 10 = '()'
-        // TODO: Old parser expected error on line 3: generic parameter 'T' is not used in function signature
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected argument list in function declaration"),
         // TODO: Old parser expected error on line 4: expected '(', Fix-It replacements: 8 - 8 = '()'
-        // TODO: Old parser expected error on line 4: invalid redeclaration of 'init()'
         DiagnosticSpec(locationMarker: "DIAG_3", message: "expected argument list in function declaration"),
       ]
     )
@@ -330,9 +327,7 @@ final class InitDeinitTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected warning on line 2: variable 'x' was never used; consider replacing with '_' or removing it
         // TODO: Old parser expected error on line 3: initializers may only be declared within a type
-        // TODO: Old parser expected warning on line 6: variable 'y' was never used; consider replacing with '_' or removing it
         // TODO: Old parser expected error on line 7: deinitializers may only be declared within a class or actor
       ]
     )

--- a/Tests/SwiftParserTest/translated/InvalidIfExprTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidIfExprTests.swift
@@ -1,0 +1,36 @@
+// This test file has been translated from swift/test/Parse/invalid_if_expr.swift
+
+import XCTest
+
+final class InvalidIfExprTests: XCTestCase {
+  func testInvalidIfExpr1() {
+    AssertParse(
+      """
+      func unbalanced_question(a: Bool, b: Bool, c: Bool, d: Bool) {
+        (a ? b#^DIAG_1^#) 
+        (a ? b : c ? d#^DIAG_2^#) 
+        (a ? b ? c : d#^DIAG_3^#) 
+        (a ? b ? c#^DIAG_4^#) 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected ':' after '? ...' in ternary
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected ':' after '? ...' in ternary expression"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in tuple"),
+        // TODO: Old parser expected error on line 3: expected ':' after '? ...' in ternary
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ':' after '? ...' in ternary expression"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in tuple"),
+        // TODO: Old parser expected error on line 4: expected ':' after '? ...' in ternary
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected ':' after '? ...' in ternary expression"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in tuple"),
+        // TODO: Old parser expected error on line 5: expected ':' after '? ...' in ternary
+        // TODO: Old parser expected error on line 5: expected ':' after '? ...' in ternary
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected ':' after '? ...' in ternary expression"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected expression in tuple"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected ':' after '? ...' in ternary expression"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected expression in tuple"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/InvalidStringInterpolationProtocolTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidStringInterpolationProtocolTests.swift
@@ -1,0 +1,127 @@
+// This test file has been translated from swift/test/Parse/invalid_string_interpolation_protocol.swift
+
+import XCTest
+
+final class InvalidStringInterpolationProtocolTests: XCTestCase {
+  func testInvalidStringInterpolationProtocol1() {
+    AssertParse(
+      """
+      // Has a lot of invalid 'appendInterpolation' methods
+      public struct BadStringInterpolation: StringInterpolationProtocol {
+        //  {{educational-notes=string-interpolation-conformance}}
+        public init(literalCapacity: Int, interpolationCount: Int) {}
+        public mutating func appendLiteral(_: String) {}
+        public static func appendInterpolation(static: ()) {
+          //  {{educational-notes=string-interpolation-conformance}}
+        }
+        private func appendInterpolation(private: ()) {
+        }
+        func appendInterpolation(default: ()) {
+        }
+        public func appendInterpolation(intResult: ()) -> Int {
+          //  {{educational-notes=string-interpolation-conformance}}
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: type conforming to 'StringInterpolationProtocol' does not implement a valid 'appendInterpolation' method
+        // TODO: Old parser expected warning on line 6: 'appendInterpolation' method will never be used because it is static, Fix-It replacements: 10 - 17 = ''
+        // TODO: Old parser expected warning on line 9: 'appendInterpolation' method is private, but 'BadStringInterpolation' is public
+        // TODO: Old parser expected warning on line 11: 'appendInterpolation' method is internal, but 'BadStringInterpolation' is public
+        // TODO: Old parser expected warning on line 13: 'appendInterpolation' method does not return 'Void' or have a discardable result, Fix-It replacements: 10 - 10 = '@discardableResult '
+      ]
+    )
+  }
+
+  func testInvalidStringInterpolationProtocol2() {
+    AssertParse(
+      """
+      // Has no 'appendInterpolation' methods at all
+      public struct IncompleteStringInterpolation: StringInterpolationProtocol {
+        public init(literalCapacity: Int, interpolationCount: Int) {}
+        public mutating func appendLiteral(_: String) {}
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: type conforming to 'StringInterpolationProtocol' does not implement a valid 'appendInterpolation' method
+      ]
+    )
+  }
+
+  func testInvalidStringInterpolationProtocol3() {
+    AssertParse(
+      """
+      // Has only good 'appendInterpolation' methods.
+      public struct GoodStringInterpolation: StringInterpolationProtocol {
+        public init(literalCapacity: Int, interpolationCount: Int) {}
+        public mutating func appendLiteral(_: String) {}
+        public func appendInterpolation(noResult: ()) {}
+        public func appendInterpolation(voidResult: ()) -> Void {}
+        @discardableResult
+        public func appendInterpolation(discardableResult: ()) -> Int {}
+      }
+      """
+    )
+  }
+
+  func testInvalidStringInterpolationProtocol4() {
+    AssertParse(
+      """
+      // Has only good 'appendInterpolation' methods, but they're in an extension.
+      public struct GoodSplitStringInterpolation: StringInterpolationProtocol {
+        public init(literalCapacity: Int, interpolationCount: Int) {}
+        public mutating func appendLiteral(_: String) {}
+      }
+      """
+    )
+  }
+
+  func testInvalidStringInterpolationProtocol5() {
+    AssertParse(
+      """
+      extension GoodSplitStringInterpolation {
+        public func appendInterpolation(noResult: ()) {}
+        public func appendInterpolation(voidResult: ()) -> Void {}
+        @discardableResult
+        public func appendInterpolation(discardableResult: ()) -> Int {}
+      }
+      """
+    )
+  }
+
+  func testInvalidStringInterpolationProtocol6() {
+    AssertParse(
+      """
+      // Has only good 'appendInterpolation' methods, and is not public.
+      struct GoodNonPublicStringInterpolation: StringInterpolationProtocol {
+        init(literalCapacity: Int, interpolationCount: Int) {}
+        mutating func appendLiteral(_: String) {}
+        func appendInterpolation(noResult: ()) {}
+        public func appendInterpolation(voidResult: ()) -> Void {}
+        @discardableResult
+        func appendInterpolation(discardableResult: ()) -> Int {}
+      }
+      """
+    )
+  }
+
+  func testInvalidStringInterpolationProtocol7() {
+    AssertParse(
+      """
+      // Has a mixture of good and bad 'appendInterpolation' methods.
+      // We don't emit any errors in this case--we assume the others
+      // are implementation details or something.
+      public struct GoodStringInterpolationWithBadOnesToo: StringInterpolationProtocol {
+        public init(literalCapacity: Int, interpolationCount: Int) {}
+        public mutating func appendLiteral(_: String) {}
+        public func appendInterpolation(noResult: ()) {}
+        public static func appendInterpolation(static: ()) {}
+        private func appendInterpolation(private: ()) {}
+        func appendInterpolation(default: ()) {}
+        public func appendInterpolation(intResult: ()) -> Int {}
+      }
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/InvalidStringInterpolationProtocolTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidStringInterpolationProtocolTests.swift
@@ -22,14 +22,7 @@ final class InvalidStringInterpolationProtocolTests: XCTestCase {
           //  {{educational-notes=string-interpolation-conformance}}
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: type conforming to 'StringInterpolationProtocol' does not implement a valid 'appendInterpolation' method
-        // TODO: Old parser expected warning on line 6: 'appendInterpolation' method will never be used because it is static, Fix-It replacements: 10 - 17 = ''
-        // TODO: Old parser expected warning on line 9: 'appendInterpolation' method is private, but 'BadStringInterpolation' is public
-        // TODO: Old parser expected warning on line 11: 'appendInterpolation' method is internal, but 'BadStringInterpolation' is public
-        // TODO: Old parser expected warning on line 13: 'appendInterpolation' method does not return 'Void' or have a discardable result, Fix-It replacements: 10 - 10 = '@discardableResult '
-      ]
+      """
     )
   }
 
@@ -41,10 +34,7 @@ final class InvalidStringInterpolationProtocolTests: XCTestCase {
         public init(literalCapacity: Int, interpolationCount: Int) {}
         public mutating func appendLiteral(_: String) {}
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: type conforming to 'StringInterpolationProtocol' does not implement a valid 'appendInterpolation' method
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/InvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidTests.swift
@@ -78,7 +78,6 @@ final class InvalidTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot find 'undeclared_func' in scope
         DiagnosticSpec(message: "expected value in function call"),
         DiagnosticSpec(message: "expected ')' to end function call"),
         // TODO: Old parser expected error on line 3: expected expression in list of expressions
@@ -90,10 +89,7 @@ final class InvalidTests: XCTestCase {
     AssertParse(
       """
       func runAction() {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 1: 'runAction' declared here
-      ]
+      """
     )
   }
 
@@ -107,11 +103,8 @@ final class InvalidTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: argument passed to call that takes no arguments
-        // TODO: Old parser expected error on line 3: cannot find 'SKAction' in scope; did you mean 'runAction'?, Fix-It replacements: 13 - 21 = 'runAction'
         // TODO: Old parser expected error on line 3: expected ',' separator, Fix-It replacements: 32 - 32 = ','
         DiagnosticSpec(message: "expected ')' to end function call"),
-        // TODO: Old parser expected error on line 4: cannot find 'skview' in scope
       ]
     )
   }
@@ -137,9 +130,7 @@ final class InvalidTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot find 'state' in scope
         DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '}' to end 'switch' statement"),
-        // TODO: Old parser expected error on line 2: all statements inside a switch must be covered by a 'case' or 'default'
         DiagnosticSpec(locationMarker: "DIAG_2", message: "extraneous code at top level"),
       ]
     )
@@ -166,8 +157,6 @@ final class InvalidTests: XCTestCase {
       """#,
       diagnostics: [
         DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '}' to end 'switch' statement"),
-        // TODO: Old parser expected error on line 3: all statements inside a switch must be covered by a 'case' or 'default'
-        // TODO: Old parser expected error on line 8: expression pattern of type 'String' cannot match values of type 'Int'
         DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text in function"),
         DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous '}' at top level"),
       ]
@@ -262,8 +251,6 @@ final class InvalidTests: XCTestCase {
         DiagnosticSpec(locationMarker: "DIAG_4", message: "expected type in function type"),
         DiagnosticSpec(locationMarker: "DIAG_4", message: "expected ')' to end parameter clause"),
         DiagnosticSpec(locationMarker: "DIAG_5", message: "unexpected text ') {}' before protocol"),
-        // TODO: Old parser expected error on line 5: an associated type named 'Food' must be declared in the protocol 'Animal' or a protocol it inherits
-        // TODO: Old parser expected error on line 6: cannot find type 'Food' in scope
         // TODO: Old parser expected error on line 13: expected ':' following argument label and parameter name
         DiagnosticSpec(locationMarker: "DIAG_6", message: "expected ':' and type in function parameter"),
         // TODO: Old parser expected error on line 20: unexpected ',' separator
@@ -325,12 +312,6 @@ final class InvalidTests: XCTestCase {
         DiagnosticSpec(locationMarker: "DIAG_25", message: "expected '}' to end 'for' statement"),
         DiagnosticSpec(locationMarker: "DIAG_25", message: "extraneous code at top level"),
         // TODO: Old parser expected error on line 41: 'weak' must be a mutable variable, because it may change at runtime
-        // TODO: Old parser expected error on line 41: 'weak' variable should have optional type 'T?'
-        // TODO: Old parser expected error on line 41: 'weak' must not be applied to non-class-bound 'T'; consider adding a protocol conformance that has a class bound
-        // TODO: Old parser expected error on line 44: cannot convert value of type '()' to expected argument type 'Bool'
-        // TODO: Old parser expected error on line 45: cannot convert value of type '()' to expected argument type 'Bool'
-        // TODO: Old parser expected error on line 46: cannot convert value of type '()' to expected argument type 'Bool'
-        // TODO: Old parser expected error on line 47: cannot convert value of type '()' to expected argument type 'Bool'
         // TODO: Old parser expected error on line 49: @NSApplicationMain may only be used on 'class' declarations
         // TODO: Old parser expected error on line 50: '@available' attribute cannot be applied to this declaration
         // TODO: Old parser expected error on line 51: '@discardableResult' attribute cannot be applied to this declaration

--- a/Tests/SwiftParserTest/translated/InvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidTests.swift
@@ -1,0 +1,349 @@
+// This test file has been translated from swift/test/Parse/invalid.swift
+
+import XCTest
+
+final class InvalidTests: XCTestCase {
+  func testInvalid1() {
+    AssertParse(
+      """
+      // rdar://15946844
+      func test1(inout #^DIAG_1^#var x : Int#^DIAG_2^#) {}  
+      func test2(inout #^DIAG_3^#let x : Int#^DIAG_4^#) {}  
+      func test3(f : (inout _ #^DIAG_5^#x : Int) -> Void) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 2: 'var' in this position is interpreted as an argument label, Fix-It replacements: 18 - 21 = '`var`'
+        // TODO: Old parser expected error on line 2: 'inout' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 12 - 17 = '', 26 - 26 = 'inout '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text ') {}' before function"),
+        // TODO: Old parser expected warning on line 3: 'let' in this position is interpreted as an argument label, Fix-It replacements: 18 - 21 = '`let`'
+        // TODO: Old parser expected error on line 3: 'inout' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 12 - 17 = '', 26 - 26 = 'inout '
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "unexpected text ') {}' before function"),
+        // TODO: Old parser expected error on line 4: 'inout' before a parameter name is not allowed, place it before the parameter type instead
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "unexpected text 'x : Int' in function type"),
+      ]
+    )
+  }
+
+  func testInvalid2() {
+    AssertParse(
+      """
+      func test1s(__shared #^DIAG_1^#var x : Int#^DIAG_2^#) {}  
+      func test2s(__shared #^DIAG_3^#let x : Int#^DIAG_4^#) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: 'var' in this position is interpreted as an argument label, Fix-It replacements: 22 - 25 = '`var`'
+        // TODO: Old parser expected error on line 1: '__shared' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 21 = '', 30 - 30 = '__shared '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text ') {}' before function"),
+        // TODO: Old parser expected warning on line 2: 'let' in this position is interpreted as an argument label, Fix-It replacements: 22 - 25 = '`let`'
+        // TODO: Old parser expected error on line 2: '__shared' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 21 = '', 30 - 30 = '__shared '
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "extraneous ') {}' at top level"),
+      ]
+    )
+  }
+
+  func testInvalid3() {
+    AssertParse(
+      """
+      func test1o(__owned #^DIAG_1^#var x : Int#^DIAG_2^#) {}  
+      func test2o(__owned #^DIAG_3^#let x : Int#^DIAG_4^#) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: 'var' in this position is interpreted as an argument label, Fix-It replacements: 21 - 24 = '`var`'
+        // TODO: Old parser expected error on line 1: '__owned' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 20 = ''
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text ') {}' before function"),
+        // TODO: Old parser expected warning on line 2: 'let' in this position is interpreted as an argument label, Fix-It replacements: 21 - 24 = '`let`'
+        // TODO: Old parser expected error on line 2: '__owned' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 20 = ''
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "extraneous ') {}' at top level"),
+      ]
+    )
+  }
+
+  func testInvalid4() {
+    AssertParse(
+      """
+      func test3() {
+        undeclared_func( #^DIAG^#
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot find 'undeclared_func' in scope
+        DiagnosticSpec(message: "expected value in function call"),
+        DiagnosticSpec(message: "expected ')' to end function call"),
+        // TODO: Old parser expected error on line 3: expected expression in list of expressions
+      ]
+    )
+  }
+
+  func testInvalid5() {
+    AssertParse(
+      """
+      func runAction() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 1: 'runAction' declared here
+      ]
+    )
+  }
+
+  func testInvalid6() {
+    AssertParse(
+      """
+      // rdar://16601779
+      func foo() {
+        runAction(SKAction.sequence()#^DIAG^#
+          skview!
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: argument passed to call that takes no arguments
+        // TODO: Old parser expected error on line 3: cannot find 'SKAction' in scope; did you mean 'runAction'?, Fix-It replacements: 13 - 21 = 'runAction'
+        // TODO: Old parser expected error on line 3: expected ',' separator, Fix-It replacements: 32 - 32 = ','
+        DiagnosticSpec(message: "expected ')' to end function call"),
+        // TODO: Old parser expected error on line 4: cannot find 'skview' in scope
+      ]
+    )
+  }
+
+  func testInvalid7() {
+    AssertParse(
+      """
+      super.init()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'super' cannot be used outside of class members
+      ]
+    )
+  }
+
+  func testInvalid8() {
+    AssertParse(
+      """
+      switch state { #^DIAG_1^#
+        let duration : Int = 0 
+        #^DIAG_2^#case 1:
+          break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot find 'state' in scope
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '}' to end 'switch' statement"),
+        // TODO: Old parser expected error on line 2: all statements inside a switch must be covered by a 'case' or 'default'
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "extraneous code at top level"),
+      ]
+    )
+  }
+
+  func testInvalid9() {
+    AssertParse(
+      #"""
+      func testNotCoveredCase(x: Int) {
+        switch x {#^DIAG_1^#
+          let y = "foo" 
+          switch y {
+            case "bar":
+              blah blah // ignored
+          }
+        #^DIAG_2^#case "baz": 
+          break
+        case 1:
+          break
+        default:
+          break
+        }
+      #^DIAG_3^#}
+      """#,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '}' to end 'switch' statement"),
+        // TODO: Old parser expected error on line 3: all statements inside a switch must be covered by a 'case' or 'default'
+        // TODO: Old parser expected error on line 8: expression pattern of type 'String' cannot match values of type 'Int'
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text in function"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous '}' at top level"),
+      ]
+    )
+  }
+
+  func testInvalid10() {
+    AssertParse(
+      ##"""
+      // rdar://18926814
+      func test4() {
+        let abc = 123
+        _ = " >> \( abc #^DIAG_1^#} ) << "#^DIAG_2^#
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: expected ',' separator, Fix-It replacements: 18 - 18 = ','
+        // TODO: Old parser expected error on line 4: expected expression in list of expressions
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '}' in string literal"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '}' to end function"),
+      ]
+    )
+  }
+
+  func testInvalid11() {
+    AssertParse(
+      """
+      #^DIAG_1^#}
+      // rdar://problem/18507467
+      func d(_ b: #^DIAG_2^#String #^DIAG_3^#-> #^DIAG_4^#<T>() -> T#^DIAG_5^#) {} 
+      // <rdar://problem/22143680> QoI: terrible diagnostic when trying to form a generic protocol
+      protocol Animal<Food> {  
+        func feed(_ food: Food) 
+      }
+      // https://github.com/apple/swift/issues/43190
+      // Crash with invalid parameter declaration
+      do {
+        class Starfish {}
+        struct Salmon {}
+        func f(s Starfish#^DIAG_6^#,  
+                  _ ss: Salmon) -> [Int] {}
+        func g() { f(Starfish(), Salmon()) }
+      }
+      // https://github.com/apple/swift/issues/43313
+      do {
+        func f(_ a: Int, b: Int) {}
+        f(1, b: 2,#^DIAG_7^#) 
+      }
+      // https://github.com/apple/swift/issues/43591
+      // Two inout crash compiler
+      func f1_43591(a : inout inout Int) {}  
+      func f2_43591(inout inout b#^DIAG_8^#: Int) {} 
+      func f3_43591(let let #^DIAG_9^#a: Int) {} 
+      func f4_43591(inout x#^DIAG_10^#: inout String) {} 
+      func f5_43591(inout i#^DIAG_11^#: inout Int) {} 
+      func #^DIAG_12^#repeat#^DIAG_13^#() {}#^DIAG_14^#
+      let #^DIAG_15^#for #^DIAG_16^#= 2
+      func dog #^DIAG_17^#cow() {} 
+      func cat #^DIAG_18^#Mouse() {} 
+      func friend #^DIAG_19^#ship<T>(x: T) {} 
+      func were#^DIAG_20^#
+      wolf#^DIAG_21^#() {} 
+      func hammer#^DIAG_22^#
+      leavings<T>#^DIAG_23^#(x: T) {} 
+      prefix operator %
+      prefix func %<T>(x: T) -> T { return x } // No error expected - the < is considered an identifier but is peeled off by the parser.
+      struct Weak<T: #^DIAG_24^#class#^DIAG_25^#> { 
+        weak let value: T 
+      }
+      let x: () = ()
+      !() 
+      !(()) 
+      !(x) 
+      !x 
+      // https://github.com/apple/swift/issues/50734
+      func f1_50734(@NSApplicationMain x: Int) {} 
+      func f2_50734(@available(iOS, deprecated: 0) x: Int) {} 
+      func f3_50734(@discardableResult x: Int) {} 
+      func f4_50734(@objcMembers x: String) {} 
+      func f5_50734(@weak x: String) {} 
+      class C_50734<@NSApplicationMain T: AnyObject> {} 
+      func f6_50734<@discardableResult T>(x: T) {} 
+      enum E_50734<@indirect T> {} 
+      protocol P {
+        @available(swift, introduced: 4.2) associatedtype Assoc 
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '}' before function"),
+        // TODO: Old parser expected error on line 3: expected type for function result
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '(' to start function type"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected ')' in function type"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected type in function type"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "unexpected text ') {}' before protocol"),
+        // TODO: Old parser expected error on line 5: an associated type named 'Food' must be declared in the protocol 'Animal' or a protocol it inherits
+        // TODO: Old parser expected error on line 6: cannot find type 'Food' in scope
+        // TODO: Old parser expected error on line 13: expected ':' following argument label and parameter name
+        DiagnosticSpec(locationMarker: "DIAG_6", message: "expected ':' and type in function parameter"),
+        // TODO: Old parser expected error on line 20: unexpected ',' separator
+        DiagnosticSpec(locationMarker: "DIAG_7", message: "expected value in function call"),
+        // TODO: Old parser expected error on line 24: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 19 - 25 = ''
+        // TODO: Old parser expected error on line 25: inout' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 15 - 20 = '', 30 - 30 = 'inout '
+        // TODO: Old parser expected error on line 25: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 21 - 27 = ''
+        DiagnosticSpec(locationMarker: "DIAG_8", message: "unexpected text ': Int' in parameter clause"),
+        // TODO: Old parser expected warning on line 26: 'let' in this position is interpreted as an argument label, Fix-It replacements: 15 - 18 = '`let`'
+        // TODO: Old parser expected error on line 26: expected ',' separator, Fix-It replacements: 22 - 22 = ','
+        // TODO: Old parser expected error on line 26: expected ':' following argument label and parameter name
+        // TODO: Old parser expected warning on line 26: extraneous duplicate parameter name; 'let' already has an argument label, Fix-It replacements: 15 - 19 = ''
+        DiagnosticSpec(locationMarker: "DIAG_9", message: "unexpected text 'a' in function parameter"),
+        // TODO: Old parser expected error on line 27: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 15 - 20 = ''
+        DiagnosticSpec(locationMarker: "DIAG_10", message: "unexpected text ': inout String' in parameter clause"),
+        // TODO: Old parser expected error on line 28: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 15 - 20 = ''
+        DiagnosticSpec(locationMarker: "DIAG_11", message: "unexpected text ': inout Int' in parameter clause"),
+        // TODO: Old parser expected error on line 29: keyword 'repeat' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 29: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 6 - 12 = '`repeat`'
+        DiagnosticSpec(locationMarker: "DIAG_12", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "DIAG_12", message: "expected argument list in function declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_13", message: "unexpected text '()' in 'repeat' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_14", message: "expected 'while' in 'repeat' statement"),
+        // TODO: Old parser expected error on line 30: keyword 'for' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 30: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 5 - 8 = '`for`'
+        DiagnosticSpec(locationMarker: "DIAG_15", message: "expected expression in pattern"),
+        DiagnosticSpec(locationMarker: "DIAG_16", message: "expected pattern, 'in' and expression in 'for' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_16", message: "expected '{' in 'for' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_16", message: "unexpected text '= 2' before function"),
+        // TODO: Old parser expected error on line 31: found an unexpected second identifier in function declaration; is there an accidental break?
+        // TODO: Old parser expected note on line 31: join the identifiers together, Fix-It replacements: 6 - 13 = 'dogcow'
+        // TODO: Old parser expected note on line 31: join the identifiers together with camel-case, Fix-It replacements: 6 - 13 = 'dogCow'
+        DiagnosticSpec(locationMarker: "DIAG_17", message: "unexpected text 'cow' before parameter clause"),
+        // TODO: Old parser expected error on line 32: found an unexpected second identifier in function declaration; is there an accidental break?
+        // TODO: Old parser expected note on line 32: join the identifiers together, Fix-It replacements: 6 - 15 = 'catMouse'
+        DiagnosticSpec(locationMarker: "DIAG_18", message: "unexpected text 'Mouse' before parameter clause"),
+        // TODO: Old parser expected error on line 33: found an unexpected second identifier in function declaration; is there an accidental break?
+        // TODO: Old parser expected note on line 33: join the identifiers together, Fix-It replacements: 6 - 17 = 'friendship'
+        // TODO: Old parser expected note on line 33: join the identifiers together with camel-case, Fix-It replacements: 6 - 17 = 'friendShip'
+        DiagnosticSpec(locationMarker: "DIAG_19", message: "unexpected text 'ship<T>' before parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_20", message: "expected '(' to start parameter clause"),
+        // TODO: Old parser expected error on line 35: found an unexpected second identifier in function declaration; is there an accidental break?
+        // TODO: Old parser expected note on line 35: join the identifiers together, Fix-It replacements: 6 - 5 = 'werewolf'
+        // TODO: Old parser expected note on line 35: join the identifiers together with camel-case, Fix-It replacements: 6 - 5 = 'wereWolf'
+        DiagnosticSpec(locationMarker: "DIAG_21", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_22", message: "expected '(' to start parameter clause"),
+        // TODO: Old parser expected error on line 37: found an unexpected second identifier in function declaration; is there an accidental break?
+        // TODO: Old parser expected note on line 37: join the identifiers together, Fix-It replacements: 6 - 9 = 'hammerleavings'
+        // TODO: Old parser expected note on line 37: join the identifiers together with camel-case, Fix-It replacements: 6 - 9 = 'hammerLeavings'
+        DiagnosticSpec(locationMarker: "DIAG_23", message: "expected ')' to end parameter clause"),
+        // TODO: Old parser expected error on line 40: 'class' constraint can only appear on protocol declarations
+        // TODO: Old parser expected note on line 40: did you mean to write an 'AnyObject' constraint?, Fix-It replacements: 16 - 21 = 'AnyObject'
+        DiagnosticSpec(locationMarker: "DIAG_24", message: "expected '>' to end generic parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_24", message: "expected '{' in struct"),
+        DiagnosticSpec(locationMarker: "DIAG_25", message: "expected identifier in class"),
+        DiagnosticSpec(locationMarker: "DIAG_25", message: "expected member block in class"),
+        DiagnosticSpec(locationMarker: "DIAG_25", message: "expected declaration in struct"),
+        DiagnosticSpec(locationMarker: "DIAG_25", message: "expected '}' to end struct"),
+        DiagnosticSpec(locationMarker: "DIAG_25", message: "expected '}' to end 'for' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_25", message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 41: 'weak' must be a mutable variable, because it may change at runtime
+        // TODO: Old parser expected error on line 41: 'weak' variable should have optional type 'T?'
+        // TODO: Old parser expected error on line 41: 'weak' must not be applied to non-class-bound 'T'; consider adding a protocol conformance that has a class bound
+        // TODO: Old parser expected error on line 44: cannot convert value of type '()' to expected argument type 'Bool'
+        // TODO: Old parser expected error on line 45: cannot convert value of type '()' to expected argument type 'Bool'
+        // TODO: Old parser expected error on line 46: cannot convert value of type '()' to expected argument type 'Bool'
+        // TODO: Old parser expected error on line 47: cannot convert value of type '()' to expected argument type 'Bool'
+        // TODO: Old parser expected error on line 49: @NSApplicationMain may only be used on 'class' declarations
+        // TODO: Old parser expected error on line 50: '@available' attribute cannot be applied to this declaration
+        // TODO: Old parser expected error on line 51: '@discardableResult' attribute cannot be applied to this declaration
+        // TODO: Old parser expected error on line 52: @objcMembers may only be used on 'class' declarations
+        // TODO: Old parser expected error on line 53: 'weak' is a declaration modifier, not an attribute
+        // TODO: Old parser expected error on line 53: 'weak' may only be used on 'var' declarations
+        // TODO: Old parser expected error on line 54: @NSApplicationMain may only be used on 'class' declarations
+        // TODO: Old parser expected error on line 55: '@discardableResult' attribute cannot be applied to this declaration
+        // TODO: Old parser expected error on line 56: 'indirect' is a declaration modifier, not an attribute
+        // TODO: Old parser expected error on line 56: 'indirect' modifier cannot be applied to this declaration
+        // TODO: Old parser expected error on line 58: '@available' attribute cannot be applied to this declaration
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
+++ b/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
@@ -98,14 +98,7 @@ final class MatchingPatternsTests: XCTestCase {
       case _: 
         ()
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: invalid redeclaration of 'a'
-        // TODO: Old parser expected note on line 2: 'a' previously declared here
-        // TODO: Old parser expected warning on line 2: variable 'a' was never used; consider replacing with '_' or removing it
-        // TODO: Old parser expected warning on line 2: variable 'a' was never used; consider replacing with '_' or removing it
-        // TODO: Old parser expected warning on line 4: case is already handled by previous patterns; consider removing it
-      ]
+      """
     )
   }
 
@@ -129,11 +122,7 @@ final class MatchingPatternsTests: XCTestCase {
            is (a: Int, b: Int):
         ()
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: switch must be exhaustive
-        // TODO: Old parser expected note on line 1: do you want to add a default clause?
-      ]
+      """
     )
   }
 
@@ -189,22 +178,7 @@ final class MatchingPatternsTests: XCTestCase {
           }
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 4: 'Twain' declared here
-        // TODO: Old parser expected error on line 10: pattern with associated values does not match enum case 'Naught'
-        // TODO: Old parser expected note on line 10: remove associated values to make the pattern match, Fix-It replacements: 17 - 19 = ''
-        // TODO: Old parser expected error on line 11: pattern with associated values does not match enum case 'Naught'
-        // TODO: Old parser expected note on line 11: remove associated values to make the pattern match, Fix-It replacements: 17 - 20 = ''
-        // TODO: Old parser expected error on line 12: pattern with associated values does not match enum case 'Naught'
-        // TODO: Old parser expected note on line 12: remove associated values to make the pattern match, Fix-It replacements: 17 - 23 = ''
-        // TODO: Old parser expected error on line 15: tuple pattern cannot match values of the non-tuple type 'T'
-        // TODO: Old parser expected error on line 17: tuple pattern cannot match values of the non-tuple type 'T'
-        // TODO: Old parser expected error on line 19: tuple pattern has the wrong length for tuple type '(T, T)'
-        // TODO: Old parser expected warning on line 20: enum case 'Twain' has 2 associated values; matching them as a tuple is deprecated
-        // TODO: Old parser expected error on line 22: tuple pattern has the wrong length for tuple type '(T, T)'
-        // TODO: Old parser expected error on line 26: type 'Foo' has no member 'Naught'
-      ]
+      """
     )
   }
 
@@ -214,13 +188,7 @@ final class MatchingPatternsTests: XCTestCase {
       var n : Voluntary<Int> = .Naught
       if case let .Naught(value) = n {} 
       if case let .Naught(value1, value2, value3) = n {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: pattern with associated values does not match enum case 'Naught'
-        // TODO: Old parser expected note on line 2: remove associated values to make the pattern match, Fix-It replacements: 20 - 27 = ''
-        // TODO: Old parser expected error on line 3: pattern with associated values does not match enum case 'Naught'
-        // TODO: Old parser expected note on line 3: remove associated values to make the pattern match, Fix-It replacements: 20 - 44 = ''
-      ]
+      """
     )
   }
 
@@ -250,18 +218,7 @@ final class MatchingPatternsTests: XCTestCase {
            .Twain(_, _, _): 
         ()
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line -47: 'Twain' declared here
-        // TODO: Old parser expected error on line 2: enum case 'A' is not a member of type 'Voluntary<Int>'
-        // TODO: Old parser expected error on line 5: pattern with associated values does not match enum case 'Naught'
-        // TODO: Old parser expected note on line 5: remove associated values to make the pattern match, Fix-It replacements: 27 - 29 = ''
-        // TODO: Old parser expected error on line 6: pattern with associated values does not match enum case 'Naught'
-        // TODO: Old parser expected note on line 6: remove associated values to make the pattern match, Fix-It replacements: 27 - 33 = ''
-        // TODO: Old parser expected error on line 12: tuple pattern cannot match values of the non-tuple type 'Int'
-        // TODO: Old parser expected warning on line 19: enum case 'Twain' has 2 associated values; matching them as a tuple is deprecated
-        // TODO: Old parser expected error on line 21: tuple pattern has the wrong length for tuple type '(Int, Int)'
-      ]
+      """
     )
   }
 
@@ -280,10 +237,7 @@ final class MatchingPatternsTests: XCTestCase {
       case .Foo: 
         ()
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: type 'Int' has no member 'Foo'
-      ]
+      """
     )
   }
 
@@ -307,16 +261,7 @@ final class MatchingPatternsTests: XCTestCase {
           }
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 8: switch must be exhaustive
-        // TODO: Old parser expected note on line 8: missing case: '.Mere(_)'
-        // TODO: Old parser expected note on line 8: missing case: '.Twain(_, _)'
-        // TODO: Old parser expected warning on line 10: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 11: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 12: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 13: case is already handled by previous patterns; consider removing it
-      ]
+      """
     )
   }
 
@@ -330,13 +275,7 @@ final class MatchingPatternsTests: XCTestCase {
           ()
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: switch must be exhaustive
-        // TODO: Old parser expected note on line 2: missing case: '.Mere(_)'
-        // TODO: Old parser expected note on line 2: missing case: '.Twain(_, _)'
-        // TODO: Old parser expected warning on line 4: case is already handled by previous patterns; consider removing it
-      ]
+      """
     )
   }
 
@@ -364,16 +303,7 @@ final class MatchingPatternsTests: XCTestCase {
            .Compound(_): 
         ()
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 3: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 4: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 7: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 8: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 9: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 10: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 11: case is already handled by previous patterns; consider removing it
-      ]
+      """
     )
   }
 
@@ -435,15 +365,7 @@ final class MatchingPatternsTests: XCTestCase {
         acceptInt(x)
         acceptString("\(x)")
       }
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 9: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 12: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 15: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 18: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 21: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 24: case is already handled by previous patterns; consider removing it
-      ]
+      """#
     )
   }
 
@@ -551,11 +473,7 @@ final class MatchingPatternsTests: XCTestCase {
       default:
         ()
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: collection downcast in cast pattern is not implemented; use an explicit downcast to '[Derived]' instead
-        // TODO: Old parser expected error on line 4: collection downcast in cast pattern is not implemented; use an explicit downcast to '[Derived]' instead
-      ]
+      """
     )
   }
 
@@ -590,10 +508,7 @@ final class MatchingPatternsTests: XCTestCase {
       case (1?)?: break
       case (_?)?: break 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 5: case is already handled by previous patterns; consider removing it
-      ]
+      """
     )
   }
 
@@ -606,7 +521,6 @@ final class MatchingPatternsTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 2: expected ',' separator, Fix-It replacements: 25 - 25 = ','
         // TODO: Old parser expected error on line 2: expected pattern
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int?' to specified type '(responseObject: _)'
         DiagnosticSpec(message: "unexpected text '?' in tuple pattern"),
       ]
     )

--- a/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
+++ b/Tests/SwiftParserTest/translated/MatchingPatternsTests.swift
@@ -1,0 +1,615 @@
+// This test file has been translated from swift/test/Parse/matching_patterns.swift
+
+import XCTest
+
+final class MatchingPatternsTests: XCTestCase {
+  func testMatchingPatterns1() {
+    AssertParse(
+      """
+      import imported_enums
+      """
+    )
+  }
+
+  func testMatchingPatterns2() {
+    AssertParse(
+      """
+      // TODO: Implement tuple equality in the library.
+      // BLOCKED: <rdar://problem/13822406>
+      func ~= (x: (Int,Int,Int), y: (Int,Int,Int)) -> Bool {
+        return true
+      }
+      """
+    )
+  }
+
+  func testMatchingPatterns3() {
+    AssertParse(
+      """
+      var x:Int
+      """
+    )
+  }
+
+  func testMatchingPatterns4() {
+    AssertParse(
+      """
+      func square(_ x: Int) -> Int { return x*x }
+      """
+    )
+  }
+
+  func testMatchingPatterns5() {
+    AssertParse(
+      """
+      struct A<B> {
+        struct C<D> { }
+      }
+      """
+    )
+  }
+
+  func testMatchingPatterns6() {
+    AssertParse(
+      #"""
+      switch x {
+      // Expressions as patterns.
+      case 0:
+        ()
+      case 1 + 2:
+        ()
+      case square(9):
+        ()
+      // 'var' and 'let' patterns.
+      case var a:
+        a = 1
+      case let a:
+        a = 1         
+      case var var a: 
+        a += 1
+      case var let a: 
+        print(a, terminator: "")
+      case var (var b): 
+        b += 1
+      // 'Any' pattern.
+      case _:
+        ()
+      // patterns are resolved in expression-only positions are errors.
+      case 1 + (_): 
+        ()
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 13: cannot assign
+        // TODO: Old parser expected error on line 14: 'var' cannot appear nested inside another 'var' or 'let' pattern
+        // TODO: Old parser expected error on line 16: 'let' cannot appear nested inside another 'var' or 'let' pattern
+        // TODO: Old parser expected error on line 18: 'var' cannot appear nested inside another 'var'
+        // TODO: Old parser expected error on line 24: '_' can only appear in a pattern or on the left side of an assignment
+      ]
+    )
+  }
+
+  func testMatchingPatterns7() {
+    AssertParse(
+      """
+      switch (x,x) {
+      case (var a, var a): 
+        fallthrough
+      case _: 
+        ()
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: invalid redeclaration of 'a'
+        // TODO: Old parser expected note on line 2: 'a' previously declared here
+        // TODO: Old parser expected warning on line 2: variable 'a' was never used; consider replacing with '_' or removing it
+        // TODO: Old parser expected warning on line 2: variable 'a' was never used; consider replacing with '_' or removing it
+        // TODO: Old parser expected warning on line 4: case is already handled by previous patterns; consider removing it
+      ]
+    )
+  }
+
+  func testMatchingPatterns8() {
+    AssertParse(
+      """
+      var e : Any = 0
+      """
+    )
+  }
+
+  func testMatchingPatterns9() {
+    AssertParse(
+      """
+      switch e { 
+      // 'is' pattern.
+      case is Int,
+           is A<Int>,
+           is A<Int>.C<Int>,
+           is (Int, Int),
+           is (a: Int, b: Int):
+        ()
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: do you want to add a default clause?
+      ]
+    )
+  }
+
+  func testMatchingPatterns10() {
+    AssertParse(
+      """
+      // Enum patterns.
+      enum Foo { case A, B, C }
+      """
+    )
+  }
+
+  func testMatchingPatterns11() {
+    AssertParse(
+      """
+      func == <T>(_: Voluntary<T>, _: Voluntary<T>) -> Bool { return true }
+      """
+    )
+  }
+
+  func testMatchingPatterns12() {
+    AssertParse(
+      """
+      enum Voluntary<T> : Equatable {
+        case Naught
+        case Mere(T)
+        case Twain(T, T)
+        func enumMethod(_ other: Voluntary<T>, foo: Foo) {
+          switch self {
+          case other:
+            ()
+          case .Naught,
+               .Naught(), 
+               .Naught(_), 
+               .Naught(_, _): 
+            ()
+          case .Mere,
+               .Mere(), 
+               .Mere(_),
+               .Mere(_, _): 
+            ()
+          case .Twain(), 
+               .Twain(_), 
+               .Twain(_, _),
+               .Twain(_, _, _): 
+            ()
+          }
+          switch foo {
+          case .Naught: 
+            ()
+          case .A, .B, .C:
+            ()
+          }
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 4: 'Twain' declared here
+        // TODO: Old parser expected error on line 10: pattern with associated values does not match enum case 'Naught'
+        // TODO: Old parser expected note on line 10: remove associated values to make the pattern match, Fix-It replacements: 17 - 19 = ''
+        // TODO: Old parser expected error on line 11: pattern with associated values does not match enum case 'Naught'
+        // TODO: Old parser expected note on line 11: remove associated values to make the pattern match, Fix-It replacements: 17 - 20 = ''
+        // TODO: Old parser expected error on line 12: pattern with associated values does not match enum case 'Naught'
+        // TODO: Old parser expected note on line 12: remove associated values to make the pattern match, Fix-It replacements: 17 - 23 = ''
+        // TODO: Old parser expected error on line 15: tuple pattern cannot match values of the non-tuple type 'T'
+        // TODO: Old parser expected error on line 17: tuple pattern cannot match values of the non-tuple type 'T'
+        // TODO: Old parser expected error on line 19: tuple pattern has the wrong length for tuple type '(T, T)'
+        // TODO: Old parser expected warning on line 20: enum case 'Twain' has 2 associated values; matching them as a tuple is deprecated
+        // TODO: Old parser expected error on line 22: tuple pattern has the wrong length for tuple type '(T, T)'
+        // TODO: Old parser expected error on line 26: type 'Foo' has no member 'Naught'
+      ]
+    )
+  }
+
+  func testMatchingPatterns13() {
+    AssertParse(
+      """
+      var n : Voluntary<Int> = .Naught
+      if case let .Naught(value) = n {} 
+      if case let .Naught(value1, value2, value3) = n {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: pattern with associated values does not match enum case 'Naught'
+        // TODO: Old parser expected note on line 2: remove associated values to make the pattern match, Fix-It replacements: 20 - 27 = ''
+        // TODO: Old parser expected error on line 3: pattern with associated values does not match enum case 'Naught'
+        // TODO: Old parser expected note on line 3: remove associated values to make the pattern match, Fix-It replacements: 20 - 44 = ''
+      ]
+    )
+  }
+
+  func testMatchingPatterns14() {
+    AssertParse(
+      """
+      switch n {
+      case Foo.A: 
+        ()
+      case Voluntary<Int>.Naught,
+           Voluntary<Int>.Naught(), 
+           Voluntary<Int>.Naught(_, _), 
+           Voluntary.Naught,
+           .Naught:
+        ()
+      case Voluntary<Int>.Mere,
+           Voluntary<Int>.Mere(_),
+           Voluntary<Int>.Mere(_, _), 
+           Voluntary.Mere,
+           Voluntary.Mere(_),
+           .Mere,
+           .Mere(_):
+        ()
+      case .Twain,
+           .Twain(_), 
+           .Twain(_, _),
+           .Twain(_, _, _): 
+        ()
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line -47: 'Twain' declared here
+        // TODO: Old parser expected error on line 2: enum case 'A' is not a member of type 'Voluntary<Int>'
+        // TODO: Old parser expected error on line 5: pattern with associated values does not match enum case 'Naught'
+        // TODO: Old parser expected note on line 5: remove associated values to make the pattern match, Fix-It replacements: 27 - 29 = ''
+        // TODO: Old parser expected error on line 6: pattern with associated values does not match enum case 'Naught'
+        // TODO: Old parser expected note on line 6: remove associated values to make the pattern match, Fix-It replacements: 27 - 33 = ''
+        // TODO: Old parser expected error on line 12: tuple pattern cannot match values of the non-tuple type 'Int'
+        // TODO: Old parser expected warning on line 19: enum case 'Twain' has 2 associated values; matching them as a tuple is deprecated
+        // TODO: Old parser expected error on line 21: tuple pattern has the wrong length for tuple type '(Int, Int)'
+      ]
+    )
+  }
+
+  func testMatchingPatterns15() {
+    AssertParse(
+      """
+      var notAnEnum = 0
+      """
+    )
+  }
+
+  func testMatchingPatterns16() {
+    AssertParse(
+      """
+      switch notAnEnum {
+      case .Foo: 
+        ()
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: type 'Int' has no member 'Foo'
+      ]
+    )
+  }
+
+  func testMatchingPatterns17() {
+    AssertParse(
+      """
+      struct ContainsEnum {
+        enum Possible<T> {
+          case Naught
+          case Mere(T)
+          case Twain(T, T)
+        }
+        func member(_ n: Possible<Int>) {
+          switch n { 
+          case ContainsEnum.Possible<Int>.Naught,
+               ContainsEnum.Possible.Naught, 
+               Possible<Int>.Naught, 
+               Possible.Naught, 
+               .Naught: 
+            ()
+          }
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 8: switch must be exhaustive
+        // TODO: Old parser expected note on line 8: missing case: '.Mere(_)'
+        // TODO: Old parser expected note on line 8: missing case: '.Twain(_, _)'
+        // TODO: Old parser expected warning on line 10: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 11: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 12: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 13: case is already handled by previous patterns; consider removing it
+      ]
+    )
+  }
+
+  func testMatchingPatterns18() {
+    AssertParse(
+      """
+      func nonmemberAccessesMemberType(_ n: ContainsEnum.Possible<Int>) {
+        switch n { 
+        case ContainsEnum.Possible<Int>.Naught,
+             .Naught: 
+          ()
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: switch must be exhaustive
+        // TODO: Old parser expected note on line 2: missing case: '.Mere(_)'
+        // TODO: Old parser expected note on line 2: missing case: '.Twain(_, _)'
+        // TODO: Old parser expected warning on line 4: case is already handled by previous patterns; consider removing it
+      ]
+    )
+  }
+
+  func testMatchingPatterns19() {
+    AssertParse(
+      """
+      var m : ImportedEnum = .Simple
+      """
+    )
+  }
+
+  func testMatchingPatterns20() {
+    AssertParse(
+      """
+      switch m {
+      case imported_enums.ImportedEnum.Simple,
+           ImportedEnum.Simple, 
+           .Simple: 
+        ()
+      case imported_enums.ImportedEnum.Compound,
+           imported_enums.ImportedEnum.Compound(_), 
+           ImportedEnum.Compound, 
+           ImportedEnum.Compound(_), 
+           .Compound, 
+           .Compound(_): 
+        ()
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 3: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 4: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 7: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 8: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 9: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 10: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 11: case is already handled by previous patterns; consider removing it
+      ]
+    )
+  }
+
+  func testMatchingPatterns21() {
+    AssertParse(
+      """
+      // Check that single-element tuple payloads work sensibly in patterns.
+      """
+    )
+  }
+
+  func testMatchingPatterns22() {
+    AssertParse(
+      """
+      enum LabeledScalarPayload {
+        case Payload(name: Int)
+      }
+      """
+    )
+  }
+
+  func testMatchingPatterns23() {
+    AssertParse(
+      """
+      var lsp: LabeledScalarPayload = .Payload(name: 0)
+      func acceptInt(_: Int) {}
+      func acceptString(_: String) {}
+      """
+    )
+  }
+
+  func testMatchingPatterns24() {
+    AssertParse(
+      #"""
+      switch lsp {
+      case .Payload(0):
+        ()
+      case .Payload(name: 0):
+        ()
+      case let .Payload(x):
+        acceptInt(x)
+        acceptString("\(x)")
+      case let .Payload(name: x): 
+        acceptInt(x)
+        acceptString("\(x)")
+      case let .Payload((name: x)): 
+        acceptInt(x)
+        acceptString("\(x)")
+      case .Payload(let (name: x)): 
+        acceptInt(x)
+        acceptString("\(x)")
+      case .Payload(let (name: x)): 
+        acceptInt(x)
+        acceptString("\(x)")
+      case .Payload(let x): 
+        acceptInt(x)
+        acceptString("\(x)")
+      case .Payload((let x)): 
+        acceptInt(x)
+        acceptString("\(x)")
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 9: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 12: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 15: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 18: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 21: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 24: case is already handled by previous patterns; consider removing it
+      ]
+    )
+  }
+
+  func testMatchingPatterns25() {
+    AssertParse(
+      """
+      // Property patterns.
+      """
+    )
+  }
+
+  func testMatchingPatterns26() {
+    AssertParse(
+      """
+      struct S {
+        static var stat: Int = 0
+        var x, y : Int
+        var comp : Int {
+          return x + y
+        }
+        func nonProperty() {}
+      }
+      """
+    )
+  }
+
+  func testMatchingPatterns27() {
+    AssertParse(
+      """
+      // Tuple patterns.
+      """
+    )
+  }
+
+  func testMatchingPatterns28() {
+    AssertParse(
+      """
+      var t = (1, 2, 3)
+      """
+    )
+  }
+
+  func testMatchingPatterns29() {
+    AssertParse(
+      """
+      prefix operator +++
+      infix operator +++
+      prefix func +++(x: (Int,Int,Int)) -> (Int,Int,Int) { return x }
+      func +++(x: (Int,Int,Int), y: (Int,Int,Int)) -> (Int,Int,Int) {
+        return (x.0+y.0, x.1+y.1, x.2+y.2)
+      }
+      """
+    )
+  }
+
+  func testMatchingPatterns30() {
+    AssertParse(
+      """
+      switch t {
+      case (_, var a, 3):
+        a += 1
+      case var (_, b, 3):
+        b += 1
+      case var (_, var c, 3): 
+        c += 1
+      case (1, 2, 3):
+        ()
+      // patterns in expression-only positions are errors.
+      case +++(_, var d, 3):
+        ()
+      case (_, var e, 3) +++ (1, 2, 3):
+        ()
+      case (let (_, _, _)) + 1:
+        ()
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 6: 'var' cannot appear nested inside another 'var'
+        // TODO: Old parser expected error on line 11: '_' can only appear in a pattern or on the left side of an assignment
+        // TODO: Old parser expected error on line 13: '_' can only appear in a pattern or on the left side of an assignment
+        // TODO: Old parser expected error on line 15: '_' can only appear in a pattern or on the left side of an assignment
+      ]
+    )
+  }
+
+  func testMatchingPatterns31() {
+    AssertParse(
+      #"""
+      // FIXME: We don't currently allow subpatterns for "isa" patterns that
+      // require interesting conditional downcasts.
+      class Base { }
+      class Derived : Base { }
+      """#
+    )
+  }
+
+  func testMatchingPatterns32() {
+    AssertParse(
+      """
+      switch [Derived(), Derived(), Base()] {
+      case let ds as [Derived]: 
+        ()
+      case is [Derived]: 
+        ()
+      default:
+        ()
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: collection downcast in cast pattern is not implemented; use an explicit downcast to '[Derived]' instead
+        // TODO: Old parser expected error on line 4: collection downcast in cast pattern is not implemented; use an explicit downcast to '[Derived]' instead
+      ]
+    )
+  }
+
+  func testMatchingPatterns33() {
+    AssertParse(
+      """
+      // Optional patterns.
+      let op1 : Int?
+      let op2 : Int??
+      """
+    )
+  }
+
+  func testMatchingPatterns34() {
+    AssertParse(
+      """
+      switch op1 {
+      case nil: break
+      case 1?: break
+      case _?: break
+      }
+      """
+    )
+  }
+
+  func testMatchingPatterns35() {
+    AssertParse(
+      """
+      switch op2 {
+      case nil: break
+      case _?: break
+      case (1?)?: break
+      case (_?)?: break 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 5: case is already handled by previous patterns; consider removing it
+      ]
+    )
+  }
+
+  func testMatchingPatterns36() {
+    AssertParse(
+      #"""
+      // <rdar://problem/20365753> Bogus diagnostic "refutable pattern match can fail"
+      let (responseObject: Int#^DIAG^#?) = op1
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected ',' separator, Fix-It replacements: 25 - 25 = ','
+        // TODO: Old parser expected error on line 2: expected pattern
+        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int?' to specified type '(responseObject: _)'
+        DiagnosticSpec(message: "unexpected text '?' in tuple pattern"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/MetatypeObjectConversionTests.swift
+++ b/Tests/SwiftParserTest/translated/MetatypeObjectConversionTests.swift
@@ -37,11 +37,7 @@ final class MetatypeObjectConversionTests: XCTestCase {
         takesAnyObject(S.self) 
         takesAnyObject(ClassConstrainedProto.self) 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: argument type 'S.Type' expected to be an instance of a class or class-constrained type
-        // TODO: Old parser expected error on line 4: argument type '(any ClassConstrainedProto).Type' expected to be an instance of a class or class-constrained type
-      ]
+      """
     )
   }
 
@@ -55,10 +51,7 @@ final class MetatypeObjectConversionTests: XCTestCase {
         takesAnyObject(classConstrained)
         takesAnyObject(compo)
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: argument type 'any NonClassProto.Type' expected to be an instance of a class or class-constrained type
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/MetatypeObjectConversionTests.swift
+++ b/Tests/SwiftParserTest/translated/MetatypeObjectConversionTests.swift
@@ -1,0 +1,65 @@
+// This test file has been translated from swift/test/Parse/metatype_object_conversion.swift
+
+import XCTest
+
+final class MetatypeObjectConversionTests: XCTestCase {
+  func testMetatypeObjectConversion1() {
+    AssertParse(
+      """
+      class C {}
+      struct S {}
+      """
+    )
+  }
+
+  func testMetatypeObjectConversion2() {
+    AssertParse(
+      """
+      protocol NonClassProto {}
+      protocol ClassConstrainedProto : class {}
+      """
+    )
+  }
+
+  func testMetatypeObjectConversion3() {
+    AssertParse(
+      """
+      func takesAnyObject(_ x: AnyObject) {}
+      """
+    )
+  }
+
+  func testMetatypeObjectConversion4() {
+    AssertParse(
+      """
+      func concreteTypes() {
+        takesAnyObject(C.self) 
+        takesAnyObject(S.self) 
+        takesAnyObject(ClassConstrainedProto.self) 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: argument type 'S.Type' expected to be an instance of a class or class-constrained type
+        // TODO: Old parser expected error on line 4: argument type '(any ClassConstrainedProto).Type' expected to be an instance of a class or class-constrained type
+      ]
+    )
+  }
+
+  func testMetatypeObjectConversion5() {
+    AssertParse(
+      """
+      func existentialMetatypes(nonClass: NonClassProto.Type,
+                                classConstrained: ClassConstrainedProto.Type,
+                                compo: (NonClassProto & ClassConstrainedProto).Type) {
+        takesAnyObject(nonClass) 
+        takesAnyObject(classConstrained)
+        takesAnyObject(compo)
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: argument type 'any NonClassProto.Type' expected to be an instance of a class or class-constrained type
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/MoveExprTests.swift
+++ b/Tests/SwiftParserTest/translated/MoveExprTests.swift
@@ -1,0 +1,40 @@
+// This test file has been translated from swift/test/Parse/move_expr.swift
+
+import XCTest
+
+final class MoveExprTests: XCTestCase {
+  func testMoveExpr1() {
+    AssertParse(
+      """
+      var global: Int = 5
+      func testGlobal() {
+          let _ = _move global
+      }
+      """
+    )
+  }
+
+  func testMoveExpr2() {
+    AssertParse(
+      """
+      func testLet() {
+          let t = String()
+          let _ = _move t
+      }
+      """
+    )
+  }
+
+  func testMoveExpr3() {
+    AssertParse(
+      """
+      func testVar() {
+          var t = String()
+          t = String()
+          let _ = _move t
+      }
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/MultilineErrorsTests.swift
@@ -1,0 +1,465 @@
+// This test file has been translated from swift/test/Parse/multiline_errors.swift
+
+import XCTest
+
+final class MultilineErrorsTests: XCTestCase {
+  func testMultilineErrors1() {
+    AssertParse(
+      """
+      import Swift
+      """
+    )
+  }
+
+  func testMultilineErrors2() {
+    AssertParse(
+      """
+      // ===---------- Multiline --------===
+      """
+    )
+  }
+
+  func testMultilineErrors3() {
+    AssertParse(
+      #"""
+      // expecting at least 4 columns of leading indentation
+      _ = """
+          Eleven
+        Mu
+          """
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: insufficient indentation of line in multi-line string literal
+        // TODO: Old parser expected note on line 4: change indentation of this line to match closing delimiter, Fix-It replacements: 3 - 3 = '  '
+        // TODO: Old parser expected note on line 5: should match space here
+      ]
+    )
+  }
+
+  func testMultilineErrors4() {
+    AssertParse(
+      #"""
+      // expecting at least 4 columns of leading indentation
+      _ = """
+          Eleven
+         Mu
+          """
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: insufficient indentation of line in multi-line string literal
+        // TODO: Old parser expected note on line 4: change indentation of this line to match closing delimiter, Fix-It replacements: 4 - 4 = ' '
+        // TODO: Old parser expected note on line 5: should match space here
+      ]
+    )
+  }
+
+  func testMultilineErrors5() {
+    AssertParse(
+      #"""
+      // \t is not the same as an actual tab for de-indentation
+      _ = """
+      	Twelve
+      \tNu
+      	"""
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: insufficient indentation of line in multi-line string literal
+        // TODO: Old parser expected note on line 4: change indentation of this line to match closing delimiter, Fix-It replacements: 1 - 1 = '	'
+        // TODO: Old parser expected note on line 5: should match tab here
+      ]
+    )
+  }
+
+  func testMultilineErrors6() {
+    AssertParse(
+      #"""
+      _ = """
+          \(42
+      )
+          """
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: insufficient indentation of line in multi-line string literal
+        // TODO: Old parser expected note on line 3: change indentation of this line to match closing delimiter, Fix-It replacements: 1 - 1 = '    '
+        // TODO: Old parser expected note on line 4: should match space here
+      ]
+    )
+  }
+
+  func testMultilineErrors7() {
+    AssertParse(
+      #"""
+      _ = """
+          Foo
+      \
+          Bar 
+          """
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: insufficient indentation of line in multi-line string literal
+        // TODO: Old parser expected note on line 3: change indentation of this line to match closing delimiter, Fix-It replacements: 1 - 1 = '    '
+        // TODO: Old parser expected note on line 5: should match space here
+      ]
+    )
+  }
+
+  func testMultilineErrors8() {
+    AssertParse(
+      #"""
+      // a tab is not the same as multiple spaces for de-indentation
+      _ = """
+        Thirteen
+      	Xi
+        """
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: unexpected tab in indentation of line in multi-line string literal
+        // TODO: Old parser expected note on line 4: change indentation of this line to match closing delimiter, Fix-It replacements: 1 - 2 = '  '
+        // TODO: Old parser expected note on line 5: should match space here
+      ]
+    )
+  }
+
+  func testMultilineErrors9() {
+    AssertParse(
+      #"""
+      // a tab is not the same as multiple spaces for de-indentation
+      _ = """
+          Fourteen
+        	Pi
+          """
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: unexpected tab in indentation of line in multi-line string literal
+        // TODO: Old parser expected note on line 4: change indentation of this line to match closing delimiter, Fix-It replacements: 3 - 4 = '  '
+        // TODO: Old parser expected note on line 5: should match space here
+      ]
+    )
+  }
+
+  func testMultilineErrors10() {
+    AssertParse(
+      #"""
+      // multiple spaces are not the same as a tab for de-indentation
+      _ = """
+      	Thirteen 2
+        Xi 2
+      	"""
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: unexpected space in indentation of line in multi-line string literal
+        // TODO: Old parser expected note on line 4: change indentation of this line to match closing delimiter, Fix-It replacements: 1 - 3 = '	'
+        // TODO: Old parser expected note on line 5: should match tab here
+      ]
+    )
+  }
+
+  func testMultilineErrors11() {
+    AssertParse(
+      #"""
+      // multiple spaces are not the same as a tab for de-indentation
+      _ = """
+      		Fourteen 2
+      	  Pi 2
+      		"""
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: unexpected space in indentation of line in multi-line string literal
+        // TODO: Old parser expected note on line 4: change indentation of this line to match closing delimiter, Fix-It replacements: 2 - 4 = '	'
+        // TODO: Old parser expected note on line 5: should match tab here
+      ]
+    )
+  }
+
+  func testMultilineErrors12() {
+    AssertParse(
+      #"""
+      // newline currently required after opening """
+      _ = """Fourteen
+          Pi
+          """
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: multi-line string literal content must begin on a new line, Fix-It replacements: 8 - 8 = '\n'
+      ]
+    )
+  }
+
+  func testMultilineErrors13() {
+    AssertParse(
+      #"""
+      // newline currently required before closing """
+      _ = """
+          Fourteen
+          Pi"""
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: multi-line string literal closing delimiter must begin on a new line, Fix-It replacements: 7 - 7 = '\n'
+      ]
+    )
+  }
+
+  func testMultilineErrors14() {
+    AssertParse(
+      #"""
+      // newline currently required after opening """
+      _ = """"""
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: multi-line string literal content must begin on a new line, Fix-It replacements: 8 - 8 = '\n'
+      ]
+    )
+  }
+
+  func testMultilineErrors15() {
+    AssertParse(
+      #"""
+      // newline currently required after opening """
+      _ = """ """
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: multi-line string literal content must begin on a new line, Fix-It replacements: 8 - 8 = '\n'
+      ]
+    )
+  }
+
+  func testMultilineErrors16() {
+    AssertParse(
+      #"""
+      // two lines should get only one error
+      _ = """
+          Hello,
+              World!
+      	"""
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: unexpected space in indentation of next 2 lines in multi-line string literal
+        // TODO: Old parser expected note on line 3: change indentation of these lines to match closing delimiter, Fix-It replacements: 1 - 5 = '	', 1 - 5 = '	'
+        // TODO: Old parser expected note on line 5: should match tab here
+      ]
+    )
+  }
+
+  func testMultilineErrors17() {
+    AssertParse(
+      #"""
+      _ = """
+      Zero A
+      Zero B
+      	One A
+      	One B
+        Two A
+        Two B
+      Three A
+      Three B
+      		Four A
+      		Four B
+      			Five A
+      			Five B
+      		"""
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: insufficient indentation of next 2 lines in multi-line string literal
+        // TODO: Old parser expected note on line 2: change indentation of these lines to match closing delimiter, Fix-It replacements: 1 - 1 = '		', 1 - 1 = '		'
+        // TODO: Old parser expected error on line 4: insufficient indentation of next 2 lines in multi-line string literal
+        // TODO: Old parser expected note on line 4: change indentation of these lines to match closing delimiter, Fix-It replacements: 2 - 2 = '	', 2 - 2 = '	'
+        // TODO: Old parser expected error on line 6: unexpected space in indentation of next 4 lines in multi-line string literal
+        // TODO: Old parser expected note on line 6: change indentation of these lines to match closing delimiter, Fix-It replacements: 1 - 1 = '		', 1 - 1 = '		', 1 - 1 = '		', 1 - 1 = '		'
+        // TODO: Old parser expected note on line 14: should match tab here
+        // TODO: Old parser expected note on line 14: should match tab here
+        // TODO: Old parser expected note on line 14: should match tab here
+      ]
+    )
+  }
+
+  func testMultilineErrors18() {
+    AssertParse(
+      ##"""
+      _ = #^DIAG^#"hello\("""
+                  world
+                  """
+                  )!"
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
+        // TODO: Old parser expected error on line 1: unterminated string literal
+        DiagnosticSpec(message: "expected expression"),
+        DiagnosticSpec(message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 4: unterminated string literal
+      ]
+    )
+  }
+
+  func testMultilineErrors19() {
+    AssertParse(
+      ##"""
+      _ = #^DIAG^#"hello\(
+                  """
+                  world
+                  """)!"
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
+        // TODO: Old parser expected error on line 1: unterminated string literal
+        DiagnosticSpec(message: "expected expression"),
+        DiagnosticSpec(message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 4: unterminated string literal
+      ]
+    )
+  }
+
+  func testMultilineErrors20() {
+    AssertParse(
+      ##"""
+      _ = #^DIAG^#"""
+        line one \ non-whitespace
+        line two
+        """
+      """##,
+      diagnostics: [
+        DiagnosticSpec(message: "expected expression"),
+        DiagnosticSpec(message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 2: invalid escape sequence in literal
+      ]
+    )
+  }
+
+  func testMultilineErrors21() {
+    AssertParse(
+      #"""
+      _ = """
+        line one
+        line two\
+        """
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: escaped newline at the last line is not allowed, Fix-It replacements: 11 - 12 = ''
+      ]
+    )
+  }
+
+  func testMultilineErrors22() {
+    AssertParse(
+      #"""
+      _ = """
+        \\\	   
+        """
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: escaped newline at the last line is not allowed, Fix-It replacements: 5 - 10 = ''
+      ]
+    )
+  }
+
+  func testMultilineErrors23() {
+    AssertParse(
+      #"""
+      _ = """
+        \(42)\		
+        """
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: escaped newline at the last line is not allowed, Fix-It replacements: 8 - 11 = ''
+      ]
+    )
+  }
+
+  func testMultilineErrors24() {
+    AssertParse(
+      #"""
+      _ = """
+        foo\
+        """
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: escaped newline at the last line is not allowed, Fix-It replacements: 6 - 7 = ''
+      ]
+    )
+  }
+
+  func testMultilineErrors25() {
+    AssertParse(
+      #"""
+      _ = """
+        foo\
+        """
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: escaped newline at the last line is not allowed, Fix-It replacements: 6 - 7 = ''
+      ]
+    )
+  }
+
+  func testMultilineErrors26() {
+    AssertParse(
+      ##"""
+      _ = #^DIAG^#"""
+        foo\
+      """##,
+      diagnostics: [
+        DiagnosticSpec(message: "expected expression"),
+        DiagnosticSpec(message: "extraneous code at top level"),
+      ]
+    )
+  }
+
+  func testMultilineErrors27() {
+    AssertParse(
+      #"""
+      """ // OK because LF + CR is two new lines.#^DIAG^#
+      """#,
+      diagnostics: [
+        DiagnosticSpec(message: #"expected '"""' to end string literal"#),
+      ]
+    )
+  }
+
+  func testMultilineErrors28() {
+    AssertParse(
+      #"""
+      _ = """
+      \
+        """
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: escaped newline at the last line is not allowed, Fix-It replacements: 1 - 2 = ''
+        // TODO: Old parser expected error on line 2: insufficient indentation of line in multi-line string literal
+        // TODO: Old parser expected note on line 2: change indentation of this line to match closing delimiter, Fix-It replacements: 1 - 1 = '  '
+        // TODO: Old parser expected note on line 3: should match space here
+      ]
+    )
+  }
+
+  func testMultilineErrors29() {
+    AssertParse(
+      #"""
+      _ = """\
+        """
+        // FIXME: Bad diagnostics
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: multi-line string literal content must begin on a new line
+        // TODO: Old parser expected error on line 1: escaped newline at the last line is not allowed, Fix-It replacements: 8 - 9 = ''
+      ]
+    )
+  }
+
+  func testMultilineErrors30() {
+    AssertParse(
+      ##"""
+      let _ = #^DIAG^#"""
+        foo
+        \("bar
+        baz
+        """
+      """##,
+      diagnostics: [
+        DiagnosticSpec(message: "expected expression in variable"),
+        DiagnosticSpec(message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 3: cannot find ')' to match opening '(' in string interpolation
+        // TODO: Old parser expected error on line 3: unterminated string literal
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/MultilinePoundDiagnosticArgRdar41154797Tests.swift
+++ b/Tests/SwiftParserTest/translated/MultilinePoundDiagnosticArgRdar41154797Tests.swift
@@ -1,0 +1,18 @@
+// This test file has been translated from swift/test/Parse/multiline_pound_diagnostic_arg_rdar_41154797.swift
+
+import XCTest
+
+final class MultilinePoundDiagnosticArgRdar41154797Tests: XCTestCase {
+  func testMultilinePoundDiagnosticArgRdar411547971() {
+    AssertParse(
+      ##"""
+      #error("""#^DIAG^#
+      """##,
+      diagnostics: [
+        DiagnosticSpec(message: #"expected '"""' to end string literal"#),
+        DiagnosticSpec(message: "expected ')' to end '#error' directive"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/NoimplicitcopyAttrTests.swift
+++ b/Tests/SwiftParserTest/translated/NoimplicitcopyAttrTests.swift
@@ -1,0 +1,84 @@
+// This test file has been translated from swift/test/Parse/noimplicitcopy_attr.swift
+
+import XCTest
+
+final class NoimplicitcopyAttrTests: XCTestCase {
+  func testNoimplicitcopyAttr1() {
+    AssertParse(
+      """
+      f// RUN: %target-typecheck-verify-swift -parse -parse-stdlib -disable-availability-checking -verify-syntax-tree
+      """
+    )
+  }
+
+  func testNoimplicitcopyAttr2() {
+    AssertParse(
+      """
+      import Swift
+      """
+    )
+  }
+
+  func testNoimplicitcopyAttr3() {
+    AssertParse(
+      """
+      class Klass {}
+      """
+    )
+  }
+
+  func testNoimplicitcopyAttr4() {
+    AssertParse(
+      """
+      func argumentsAndReturns(@_noImplicitCopy _ x: Klass) -> Klass {
+          return x
+      }
+      """
+    )
+  }
+
+  func testNoimplicitcopyAttr5() {
+    AssertParse(
+      """
+      func letDecls(@_noImplicitCopy  _ x: Klass) -> () {
+          @_noImplicitCopy let y: Klass = x
+          print(y)
+      }
+      """
+    )
+  }
+
+  func testNoimplicitcopyAttr6() {
+    AssertParse(
+      """
+      func varDecls(@_noImplicitCopy _ x: Klass, @_noImplicitCopy _ x2: Klass) -> () {
+          @_noImplicitCopy var y: Klass = x
+          y = x2
+          print(y)
+      }
+      """
+    )
+  }
+
+  func testNoimplicitcopyAttr7() {
+    AssertParse(
+      """
+      func getKlass() -> Builtin.NativeObject {
+          let k = Klass()
+          let b = Builtin.unsafeCastToNativeObject(k)
+          return Builtin.move(b)
+      }
+      """
+    )
+  }
+
+  func testNoimplicitcopyAttr8() {
+    AssertParse(
+      """
+      @_noImplicitCopy var g: Builtin.NativeObject = getKlass()
+      @_noImplicitCopy let g2: Builtin.NativeObject = getKlass()
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/NumberIdentifierErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/NumberIdentifierErrorsTests.swift
@@ -1,0 +1,179 @@
+// This test file has been translated from swift/test/Parse/number_identifier_errors.swift
+
+import XCTest
+
+final class NumberIdentifierErrorsTests: XCTestCase {
+  func testNumberIdentifierErrors1() {
+    AssertParse(
+      """
+      // Per rdar://problem/32316666 , it is a common mistake for beginners
+      // to start a function name with a number, so it's worth
+      // special-casing the diagnostic to make it clearer.
+      """
+    )
+  }
+
+  func testNumberIdentifierErrors2() {
+    AssertParse(
+      """
+      func #^DIAG_1^#1() {}
+      func #^DIAG_2^#2.0() {}
+      func #^DIAG_3^#3func() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: function name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '1' before parameter clause"),
+        // TODO: Old parser expected error on line 2: function name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '2.0' before parameter clause"),
+        // TODO: Old parser expected error on line 3: function name can only start with a letter or underscore, not a number
+        // TODO: Old parser expected error on line 3: 'f' is not a valid digit in integer literal
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "identifier can only start with a letter or underscore, not a number"),
+      ]
+    )
+  }
+
+  func testNumberIdentifierErrors3() {
+    AssertParse(
+      """
+      protocol #^DIAG_1^#4 {
+        associatedtype #^DIAG_2^#5
+      }
+      protocol #^DIAG_3^#6.0 {
+        associatedtype #^DIAG_4^#7.0
+      }
+      protocol #^DIAG_5^#8protocol {
+        associatedtype #^DIAG_6^#9associatedtype
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: protocol name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected member block in protocol"),
+        // TODO: Old parser expected error on line 2: associatedtype name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in associatedtype declaration"),
+        // TODO: Old parser expected error on line 4: protocol name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected identifier in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected member block in protocol"),
+        // TODO: Old parser expected error on line 5: associatedtype name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected identifier in associatedtype declaration"),
+        // TODO: Old parser expected error on line 7: protocol name can only start with a letter or underscore, not a number
+        // TODO: Old parser expected error on line 7: 'p' is not a valid digit in integer literal
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "identifier can only start with a letter or underscore, not a number"),
+        // TODO: Old parser expected error on line 8: associatedtype name can only start with a letter or underscore, not a number
+        // TODO: Old parser expected error on line 8: 'a' is not a valid digit in integer literal
+        DiagnosticSpec(locationMarker: "DIAG_6", message: "identifier can only start with a letter or underscore, not a number"),
+      ]
+    )
+  }
+
+  func testNumberIdentifierErrors4() {
+    AssertParse(
+      """
+      typealias #^DIAG_1^#10 = Int
+      typealias #^DIAG_2^#11.0 = Int
+      typealias #^DIAG_3^#12typealias = Int
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: typealias name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in typealias declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '10' in typealias declaration"),
+        // TODO: Old parser expected error on line 2: typealias name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in typealias declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '11.0' in typealias declaration"),
+        // TODO: Old parser expected error on line 3: typealias name can only start with a letter or underscore, not a number
+        // TODO: Old parser expected error on line 3: 't' is not a valid digit in integer literal
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "identifier can only start with a letter or underscore, not a number"),
+      ]
+    )
+  }
+
+  func testNumberIdentifierErrors5() {
+    AssertParse(
+      """
+      struct #^DIAG_1^#13 {}
+      struct #^DIAG_2^#14.0 {}
+      struct #^DIAG_3^#15struct {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: struct name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in struct"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected member block in struct"),
+        // TODO: Old parser expected error on line 2: struct name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in struct"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in struct"),
+        // TODO: Old parser expected error on line 3: struct name can only start with a letter or underscore, not a number
+        // TODO: Old parser expected error on line 3: 's' is not a valid digit in integer literal
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "identifier can only start with a letter or underscore, not a number"),
+      ]
+    )
+  }
+
+  func testNumberIdentifierErrors6() {
+    AssertParse(
+      """
+      enum #^DIAG_1^#16 {}
+      enum #^DIAG_2^#17.0 {}
+      enum #^DIAG_3^#18enum {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: enum name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in enum"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected member block in enum"),
+        // TODO: Old parser expected error on line 2: enum name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in enum"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in enum"),
+        // TODO: Old parser expected error on line 3: enum name can only start with a letter or underscore, not a number
+        // TODO: Old parser expected error on line 3: 'n' is not a valid digit in floating point exponent
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "identifier can only start with a letter or underscore, not a number"),
+      ]
+    )
+  }
+
+  func testNumberIdentifierErrors7() {
+    AssertParse(
+      """
+      class #^DIAG_1^#19 {
+        func #^DIAG_2^#20() {}
+      }
+      class #^DIAG_3^#21.0 {
+        func #^DIAG_4^#22.0() {}
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: class name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in class"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected member block in class"),
+        // TODO: Old parser expected error on line 2: function name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '20' before parameter clause"),
+        // TODO: Old parser expected error on line 4: class name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected identifier in class"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected member block in class"),
+        // TODO: Old parser expected error on line 5: function name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "unexpected text '22.0' before parameter clause"),
+      ]
+    )
+  }
+
+  func testNumberIdentifierErrors8() {
+    AssertParse(
+      """
+      class #^DIAG_1^#23class {
+        func #^DIAG_2^#24method() {}
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: class name can only start with a letter or underscore, not a number
+        // TODO: Old parser expected error on line 1: 'c' is not a valid digit in integer literal
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "identifier can only start with a letter or underscore, not a number"),
+        // TODO: Old parser expected error on line 2: function name can only start with a letter or underscore, not a number
+        // TODO: Old parser expected error on line 2: 'm' is not a valid digit in integer literal
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "identifier can only start with a letter or underscore, not a number"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/ObjcEnumTests.swift
+++ b/Tests/SwiftParserTest/translated/ObjcEnumTests.swift
@@ -19,10 +19,7 @@ final class ObjcEnumTests: XCTestCase {
       @objc enum Generic<T>: Int32 { 
         case Zim, Zang, Zung
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: '@objc' enum cannot be generic, Fix-It replacements: 1 - 7 = ''
-      ]
+      """
     )
   }
 
@@ -42,10 +39,7 @@ final class ObjcEnumTests: XCTestCase {
       @objc enum NoRawType { 
         case Zim, Zang, Zung
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: '@objc' enum must declare an integer raw type
-      ]
+      """
     )
   }
 
@@ -55,10 +49,7 @@ final class ObjcEnumTests: XCTestCase {
       @objc enum NonIntegerRawType: Float { 
         case Zim = 1.0, Zang = 1.5, Zung = 2.0
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: '@objc' enum raw type 'Float' is not an integer type
-      ]
+      """
     )
   }
 
@@ -79,11 +70,7 @@ final class ObjcEnumTests: XCTestCase {
         @objc func foo(x: Foo) {}
         @objc func nonObjC(x: NonObjCEnum) {} 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 3: non-'@objc' enums cannot be represented in Objective-C
-        // TODO: Old parser expected error on line 3: type of the parameter cannot be represented in Objective-C
-      ]
+      """
     )
   }
 
@@ -94,12 +81,7 @@ final class ObjcEnumTests: XCTestCase {
       @objc enum r23681566 : Int32 {  
         case Foo(progress: Int)     
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: 'r23681566' declares raw type 'Int32', but does not conform to RawRepresentable and conformance could not be synthesized
-        // TODO: Old parser expected note on line 2: declared raw type 'Int32' here
-        // TODO: Old parser expected error on line 3: enum with raw type cannot have cases with arguments
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/ObjcEnumTests.swift
+++ b/Tests/SwiftParserTest/translated/ObjcEnumTests.swift
@@ -1,0 +1,106 @@
+// This test file has been translated from swift/test/Parse/objc_enum.swift
+
+import XCTest
+
+final class ObjcEnumTests: XCTestCase {
+  func testObjcEnum1() {
+    AssertParse(
+      """
+      @objc enum Foo: Int32 {
+        case Zim, Zang, Zung
+      }
+      """
+    )
+  }
+
+  func testObjcEnum2() {
+    AssertParse(
+      """
+      @objc enum Generic<T>: Int32 { 
+        case Zim, Zang, Zung
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '@objc' enum cannot be generic, Fix-It replacements: 1 - 7 = ''
+      ]
+    )
+  }
+
+  func testObjcEnum3() {
+    AssertParse(
+      """
+      @objc(EnumRuntimeName) enum RuntimeNamed: Int32 {
+        case Zim, Zang, Zung
+      }
+      """
+    )
+  }
+
+  func testObjcEnum4() {
+    AssertParse(
+      """
+      @objc enum NoRawType { 
+        case Zim, Zang, Zung
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '@objc' enum must declare an integer raw type
+      ]
+    )
+  }
+
+  func testObjcEnum5() {
+    AssertParse(
+      """
+      @objc enum NonIntegerRawType: Float { 
+        case Zim = 1.0, Zang = 1.5, Zung = 2.0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '@objc' enum raw type 'Float' is not an integer type
+      ]
+    )
+  }
+
+  func testObjcEnum6() {
+    AssertParse(
+      """
+      enum NonObjCEnum: Int {
+        case Zim, Zang, Zung
+      }
+      """
+    )
+  }
+
+  func testObjcEnum7() {
+    AssertParse(
+      """
+      class Bar {
+        @objc func foo(x: Foo) {}
+        @objc func nonObjC(x: NonObjCEnum) {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 3: non-'@objc' enums cannot be represented in Objective-C
+        // TODO: Old parser expected error on line 3: type of the parameter cannot be represented in Objective-C
+      ]
+    )
+  }
+
+  func testObjcEnum8() {
+    AssertParse(
+      """
+      // <rdar://problem/23681566> @objc enums with payloads rejected with no source location info
+      @objc enum r23681566 : Int32 {  
+        case Foo(progress: Int)     
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'r23681566' declares raw type 'Int32', but does not conform to RawRepresentable and conformance could not be synthesized
+        // TODO: Old parser expected note on line 2: declared raw type 'Int32' here
+        // TODO: Old parser expected error on line 3: enum with raw type cannot have cases with arguments
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/ObjectLiteralsTests.swift
+++ b/Tests/SwiftParserTest/translated/ObjectLiteralsTests.swift
@@ -1,0 +1,93 @@
+// This test file has been translated from swift/test/Parse/object_literals.swift
+
+import XCTest
+
+final class ObjectLiteralsTests: XCTestCase {
+  func testObjectLiterals1() {
+    AssertParse(
+      """
+      let _ = [#^DIAG_1^##Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha)#] 
+      let _ = [#^DIAG_2^##Image(imageLiteral: localResourceNameAsString)#] 
+      let _ = [#^DIAG_3^##FileReference(fileReferenceLiteral: localResourceNameAsString)#]
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '[#Color(...)#]' has been renamed to '#colorLiteral(...), Fix-It replacements: 9 - 10 = '', 11 - 16 = 'colorLiteral', 17 - 32 = 'red', 78 - 80 = ''
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '#Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha)#' in array"),
+        // TODO: Old parser expected error on line 2: '[#Image(...)#]' has been renamed to '#imageLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 16 = 'imageLiteral', 17 - 29 = 'resourceName', 57 - 59 = ''
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '#Image(imageLiteral: localResourceNameAsString)#' in array"),
+        // TODO: Old parser expected error on line 3: '[#FileReference(...)#]' has been renamed to '#fileLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 24 = 'fileLiteral', 25 - 45 = 'resourceName', 73 - 75 = ''
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text '#FileReference(fileReferenceLiteral: localResourceNameAsString)#' in array"),
+      ]
+    )
+  }
+
+  func testObjectLiterals2() {
+    AssertParse(
+      """
+      let _ = #^DIAG_1^##Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha) 
+      let _ = #^DIAG_2^##Image(imageLiteral: localResourceNameAsString) 
+      let _ = #^DIAG_3^##FileReference(fileReferenceLiteral: localResourceNameAsString)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '#Color(...)' has been renamed to '#colorLiteral(...), Fix-It replacements: 10 - 15 = 'colorLiteral', 16 - 31 = 'red'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '#Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha)' before variable"),
+        // TODO: Old parser expected error on line 2: '#Image(...)' has been renamed to '#imageLiteral(...)', Fix-It replacements: 10 - 15 = 'imageLiteral', 16 - 28 = 'resourceName'
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '#Image(imageLiteral: localResourceNameAsString)' before variable"),
+        // TODO: Old parser expected error on line 3: '#FileReference(...)' has been renamed to '#fileLiteral(...)', Fix-It replacements: 10 - 23 = 'fileLiteral', 24 - 44 = 'resourceName'
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous '#FileReference(fileReferenceLiteral: localResourceNameAsString)' at top level"),
+      ]
+    )
+  }
+
+  func testObjectLiterals3() {
+    AssertParse(
+      """
+      let _ = #^DIAG_1^##notAPound 
+      let _ = #^DIAG_2^##notAPound(1, 2) 
+      let _ = #^DIAG_3^##Color //  {{none}}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: use of unknown directive '#notAPound'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '#notAPound' before variable"),
+        // TODO: Old parser expected error on line 2: use of unknown directive '#notAPound'
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '#notAPound(1, 2)' before variable"),
+        // TODO: Old parser expected error on line 3: expected argument list in object literal
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous '#Color' at top level"),
+      ]
+    )
+  }
+
+  func testObjectLiterals4() {
+    AssertParse(
+      """
+      let _ = [#^DIAG_1^###] //  {{none}}
+      let _ = [#^DIAG_2^##Color(_: 1, green: 1, 2) 
+      let _ = [#^DIAG_3^##Color(red: 1, green: 1, blue: 1)# 
+      let _ = [#^DIAG_4^##Color(withRed: 1, green: 1, whatever: 2)#] 
+      let _ = #^DIAG_5^##Color(_: 1, green: 1)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected expression in container literal
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '##' in array"),
+        // TODO: Old parser expected error on line 2: '[#Color(...)#]' has been renamed to '#colorLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 16 = 'colorLiteral', 17 - 18 = 'red'
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ']' to end array"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '#Color(_: 1, green: 1, 2)' before variable"),
+        // TODO: Old parser expected error on line 3: '[#Color(...)#]' has been renamed to '#colorLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 16 = 'colorLiteral', 17 - 20 = 'red', 43 - 44 = ''
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected ']' to end array"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text '#Color(red: 1, green: 1, blue: 1)#' before variable"),
+        // TODO: Old parser expected error on line 4: '[#Color(...)#]' has been renamed to '#colorLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 16 = 'colorLiteral', 17 - 24 = 'red', 51 - 53 = ''
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "unexpected text '#Color(withRed: 1, green: 1, whatever: 2)#' in array"),
+        // TODO: Old parser expected error on line 5: '#Color(...)' has been renamed to '#colorLiteral(...)', Fix-It replacements: 10 - 15 = 'colorLiteral', 16 - 17 = 'red'
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected expression in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "extraneous '#Color(_: 1, green: 1)' at top level"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/OperatorDeclDesignatedTypesTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorDeclDesignatedTypesTests.swift
@@ -1,0 +1,235 @@
+// This test file has been translated from swift/test/Parse/operator_decl_designated_types.swift
+
+import XCTest
+
+final class OperatorDeclDesignatedTypesTests: XCTestCase {
+  func testOperatorDeclDesignatedTypes1() {
+    AssertParse(
+      """
+      precedencegroup LowPrecedence {
+        associativity: right
+      }
+      """
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes2() {
+    AssertParse(
+      """
+      precedencegroup MediumPrecedence {
+        associativity: left
+        higherThan: LowPrecedence
+      }
+      """
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes3() {
+    AssertParse(
+      """
+      protocol PrefixMagicOperatorProtocol {
+      }
+      """
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes4() {
+    AssertParse(
+      """
+      protocol PostfixMagicOperatorProtocol {
+      }
+      """
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes5() {
+    AssertParse(
+      """
+      protocol InfixMagicOperatorProtocol {
+      }
+      """
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes6() {
+    AssertParse(
+      """
+      prefix operator ^^ : PrefixMagicOperatorProtocol
+      infix operator  <*< : MediumPrecedence, InfixMagicOperatorProtocol
+      postfix operator ^^ : PostfixMagicOperatorProtocol
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler; please remove the designated type list from this operator declaration, Fix-It replacements: 20 - 49 = ''
+        // TODO: Old parser expected warning on line 2: designated types are no longer used by the compiler, Fix-It replacements: 39 - 67 = ''
+        // TODO: Old parser expected warning on line 3: designated types are no longer used by the compiler, Fix-It replacements: 21 - 51 = ''
+      ]
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes7() {
+    AssertParse(
+      """
+      infix operator ^*^
+      prefix operator *^^
+      postfix operator ^^*
+      """
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes8() {
+    AssertParse(
+      """
+      infix operator **>> : UndeclaredPrecedence
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 21 - 43 = ''
+      ]
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes9() {
+    AssertParse(
+      """
+      infix operator **+> : MediumPrecedence, UndeclaredProtocol
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 39 - 59 = ''
+      ]
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes10() {
+    AssertParse(
+      """
+      prefix operator *+*> : MediumPrecedence
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 22 - 40 = ''
+      ]
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes11() {
+    AssertParse(
+      """
+      postfix operator ++*> : MediumPrecedence
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 23 - 41 = ''
+      ]
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes12() {
+    AssertParse(
+      """
+      prefix operator *++> : UndeclaredProtocol
+      postfix operator +*+> : UndeclaredProtocol
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 22 - 42 = ''
+        // TODO: Old parser expected warning on line 2: designated types are no longer used by the compiler, Fix-It replacements: 23 - 43 = ''
+      ]
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes13() {
+    AssertParse(
+      """
+      struct Struct {}
+      class Class {}
+      infix operator *>*> : Struct
+      infix operator >**> : Class
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 3: designated types are no longer used by the compiler, Fix-It replacements: 21 - 29 = ''
+        // TODO: Old parser expected warning on line 4: designated types are no longer used by the compiler, Fix-It replacements: 21 - 28 = ''
+      ]
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes14() {
+    AssertParse(
+      """
+      prefix operator **>> : Struct
+      prefix operator *>*> : Class
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 22 - 30 = ''
+        // TODO: Old parser expected warning on line 2: designated types are no longer used by the compiler, Fix-It replacements: 22 - 29 = ''
+      ]
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes15() {
+    AssertParse(
+      """
+      postfix operator >*>* : Struct
+      postfix operator >>** : Class
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 23 - 31 = ''
+        // TODO: Old parser expected warning on line 2: designated types are no longer used by the compiler, Fix-It replacements: 23 - 30 = ''
+      ]
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes16() {
+    AssertParse(
+      """
+      infix operator  <*<<< : MediumPrecedence, &
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 41 - 44 = ''
+      ]
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes17() {
+    AssertParse(
+      """
+      infix operator **^^ : MediumPrecedence 
+      infix operator **^^ : InfixMagicOperatorProtocol
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 1: previous operator declaration here
+        // TODO: Old parser expected error on line 2: operator redeclared
+        // TODO: Old parser expected warning on line 2: designated types are no longer used by the compiler, Fix-It replacements: 21 - 50 = ''
+      ]
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes18() {
+    AssertParse(
+      """
+      infix operator ^%*%^ : MediumPrecedence, Struct, Class
+      infix operator ^%*%% : Struct, Class
+      prefix operator %^*^^ : Struct, Class
+      postfix operator ^^*^% : Struct, Class
+      prefix operator %%*^^ : LowPrecedence, Class
+      postfix operator ^^*%% : MediumPrecedence, Class
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 40 - 55 = ''
+        // TODO: Old parser expected warning on line 2: designated types are no longer used by the compiler, Fix-It replacements: 30 - 37 = ''
+        // TODO: Old parser expected warning on line 2: designated types are no longer used by the compiler, Fix-It replacements: 22 - 30 = ''
+        // TODO: Old parser expected warning on line 3: designated types are no longer used by the compiler, Fix-It replacements: 23 - 38 = ''
+        // TODO: Old parser expected warning on line 4: designated types are no longer used by the compiler, Fix-It replacements: 24 - 39 = ''
+        // TODO: Old parser expected warning on line 5: designated types are no longer used by the compiler, Fix-It replacements: 23 - 45 = ''
+        // TODO: Old parser expected warning on line 6: designated types are no longer used by the compiler, Fix-It replacements: 24 - 49 = ''
+      ]
+    )
+  }
+
+  func testOperatorDeclDesignatedTypes19() {
+    AssertParse(
+      """
+      infix operator <*<>*> : AdditionPrecedence,
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: designated types are no longer used by the compiler, Fix-It replacements: 43 - 44 = ''
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/OperatorDeclDesignatedTypesTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorDeclDesignatedTypesTests.swift
@@ -192,8 +192,6 @@ final class OperatorDeclDesignatedTypesTests: XCTestCase {
       infix operator **^^ : InfixMagicOperatorProtocol
       """,
       diagnostics: [
-        // TODO: Old parser expected note on line 1: previous operator declaration here
-        // TODO: Old parser expected error on line 2: operator redeclared
         // TODO: Old parser expected warning on line 2: designated types are no longer used by the compiler, Fix-It replacements: 21 - 50 = ''
       ]
     )

--- a/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
@@ -1,0 +1,342 @@
+// This test file has been translated from swift/test/Parse/operator_decl.swift
+
+import XCTest
+
+final class OperatorDeclTests: XCTestCase {
+  func testOperatorDecl1() {
+    AssertParse(
+      """
+      prefix operator +++ {} 
+      postfix operator +++ {} 
+      infix operator +++ {} 
+      infix operator +++* { //  {{none}}
+        associativity right
+      }
+      infix operator +++*+ : A { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: operator should no longer be declared with body, Fix-It replacements: 20 - 23 = ''
+        // TODO: Old parser expected error on line 2: operator should no longer be declared with body, Fix-It replacements: 21 - 24 = ''
+        // TODO: Old parser expected error on line 3: operator should no longer be declared with body, Fix-It replacements: 19 - 22 = ''
+        // TODO: Old parser expected error on line 4: operator should no longer be declared with body; use a precedence group instead
+        // TODO: Old parser expected error on line 7: operator should no longer be declared with body, Fix-It replacements: 25 - 29 = ''
+      ]
+    )
+  }
+
+  func testOperatorDecl2() {
+    AssertParse(
+      """
+      prefix operator +++** : A { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: only infix operators may declare a precedence, Fix-It replacements: 23 - 27 = ''
+        // TODO: Old parser expected error on line 1: operator should no longer be declared with body, Fix-It replacements: 26 - 30 = ''
+      ]
+    )
+  }
+
+  func testOperatorDecl3() {
+    AssertParse(
+      """
+      prefix operator ++*++ : A
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: only infix operators may declare a precedence, Fix-It replacements: 23 - 26 = ''
+      ]
+    )
+  }
+
+  func testOperatorDecl4() {
+    AssertParse(
+      """
+      postfix operator ++*+* : A { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: only infix operators may declare a precedence, Fix-It replacements: 24 - 28 = ''
+        // TODO: Old parser expected error on line 1: operator should no longer be declared with body, Fix-It replacements: 27 - 31 = ''
+      ]
+    )
+  }
+
+  func testOperatorDecl5() {
+    AssertParse(
+      """
+      postfix operator ++**+ : A
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: only infix operators may declare a precedence, Fix-It replacements: 24 - 27 = ''
+      ]
+    )
+  }
+
+  func testOperatorDecl6() {
+    AssertParse(
+      """
+      operator ++*** : A
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: operator must be declared as 'prefix', 'postfix', or 'infix'
+      ]
+    )
+  }
+
+  func testOperatorDecl7() {
+    AssertParse(
+      """
+      operator +*+++ { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: operator must be declared as 'prefix', 'postfix', or 'infix'
+        // TODO: Old parser expected error on line 1: operator should no longer be declared with body, Fix-It replacements: 15 - 19 = ''
+      ]
+    )
+  }
+
+  func testOperatorDecl8() {
+    AssertParse(
+      """
+      operator +*++* : A { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: operator must be declared as 'prefix', 'postfix', or 'infix'
+        // TODO: Old parser expected error on line 1: operator should no longer be declared with body, Fix-It replacements: 19 - 23 = ''
+      ]
+    )
+  }
+
+  func testOperatorDecl9() {
+    AssertParse(
+      """
+      prefix operator
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected operator name in operator declaration
+      ]
+    )
+  }
+
+  func testOperatorDecl10() {
+    AssertParse(
+      """
+      #^DIAG^#;
+      prefix operator %%+
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "unexpected text before operator"),
+      ]
+    )
+  }
+
+  func testOperatorDecl11() {
+    AssertParse(
+      """
+      prefix operator ??
+      postfix operator ?? 
+      prefix operator !!
+      postfix operator !! 
+      postfix operator ?$$
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: postfix operator names starting with '?' or '!' are disallowed to avoid collisions with built-in unwrapping operators
+        // TODO: Old parser expected error on line 4: postfix operator names starting with '?' or '!' are disallowed to avoid collisions with built-in unwrapping operators
+        // TODO: Old parser expected error on line 5: postfix operator names starting with '?' or '!' are disallowed
+        // TODO: Old parser expected error on line 5: '$$' is considered an identifier
+      ]
+    )
+  }
+
+  func testOperatorDecl12() {
+    AssertParse(
+      """
+      infix operator --aa 
+      infix operator aa#^DIAG_1^#--: A 
+      infix operator <<$$@#^DIAG_2^#< 
+      infix operator !!@aa 
+      infix operator ##^DIAG_3^#++= 
+      infix operator ++=#^DIAG_4^## 
+      infix operator ->#^DIAG_5^##
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'aa' is considered an identifier and must not appear within an operator name
+        // TODO: Old parser expected error on line 2: 'aa' is considered an identifier and must not appear within an operator name
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text before operator"),
+        // TODO: Old parser expected error on line 3: '$$' is considered an identifier and must not appear within an operator name
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected name in attribute"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text in operator"),
+        // TODO: Old parser expected error on line 4: '@' is not allowed in operator names
+        // TODO: Old parser expected error on line 5: '#' is not allowed in operator names
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text before operator"),
+        // TODO: Old parser expected error on line 6: '#' is not allowed in operator names
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "unexpected text before operator"),
+        // TODO: Old parser expected error on line 7: '#' is not allowed in operator names
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "extraneous '#' at top level"),
+      ]
+    )
+  }
+
+  func testOperatorDecl13() {
+    AssertParse(
+      """
+      // FIXME: Ideally, we shouldn't emit the «consistent whitespace» diagnostic
+      // where = cannot possibly mean an assignment.
+      infix operator =#^DIAG^##=
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: '#' is not allowed in operator names
+        // TODO: Old parser expected error on line 3: '=' must have consistent whitespace on both sides
+        DiagnosticSpec(message: "extraneous '#=' at top level"),
+      ]
+    )
+  }
+
+  func testOperatorDecl14() {
+    AssertParse(
+      """
+      infix operator +++=
+      infix operator *** : A
+      infix operator --- : #^DIAG^#;
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: expected precedence group name after ':' in operator declaration
+        DiagnosticSpec(message: "expected identifier in operator"),
+      ]
+    )
+  }
+
+  func testOperatorDecl15() {
+    AssertParse(
+      """
+      precedencegroup #^DIAG_1^#{ 
+        associativity: right
+      }
+      precedencegroup A {
+        associativity #^DIAG_2^#right 
+      }
+      precedencegroup B {
+        #^DIAG_3^#precedence 123 
+      }
+      precedencegroup C {
+        associativity: sinister 
+      }
+      precedencegroup D {
+        assignment: #^DIAG_4^#no 
+      }
+      precedencegroup E {
+        higherThan:#^DIAG_5^#
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected identifier after 'precedencegroup'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in precedencegroup"),
+        // TODO: Old parser expected error on line 5: expected colon after attribute name in precedence group
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ':' in 'associativity' property of precedencegroup"),
+        // TODO: Old parser expected error on line 8: 'precedence' is not a valid precedence group attribute
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text 'precedence 123' in precedencegroup"),
+        // TODO: Old parser expected error on line 11: expected 'none', 'left', or 'right' after 'associativity'
+        // TODO: Old parser expected error on line 14: expected 'true' or 'false' after 'assignment'
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected 'true' in 'assignment' property of precedencegroup"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "unexpected text 'no' in precedencegroup"),
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected identifier in 'relation' property of precedencegroup"),
+        // TODO: Old parser expected error on line 18: expected name of related precedence group after 'higherThan'
+      ]
+    )
+  }
+
+  func testOperatorDecl16() {
+    AssertParse(
+      """
+      precedencegroup F {
+        higherThan: A, B, C
+      }
+      """
+    )
+  }
+
+  func testOperatorDecl17() {
+    AssertParse(
+      """
+      precedencegroup BangBangBang {
+        associativity: none
+        associativity: left 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: 'associativity' attribute for precedence group declared multiple times
+      ]
+    )
+  }
+
+  func testOperatorDecl18() {
+    AssertParse(
+      """
+      precedencegroup CaretCaretCaret {
+        assignment: true 
+        assignment: false 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: 'assignment' attribute for precedence group declared multiple times
+      ]
+    )
+  }
+
+  func testOperatorDecl19() {
+    AssertParse(
+      """
+      class Foo {
+        infix operator ||| 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'operator' may only be declared at file scope
+      ]
+    )
+  }
+
+  func testOperatorDecl20() {
+    AssertParse(
+      """
+      infix operator **<< : UndeclaredPrecedenceGroup
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: unknown precedence group 'UndeclaredPrecedenceGroup'
+      ]
+    )
+  }
+
+  func testOperatorDecl21() {
+    AssertParse(
+      """
+      protocol Proto {}
+      infix operator *<*< : F, Proto
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: consecutive statements on a line must be separated by ';'
+        // TODO: Old parser expected error on line 2: expected expression
+      ]
+    )
+  }
+
+  func testOperatorDecl22() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/60932
+      """
+    )
+  }
+
+  func testOperatorDecl23() {
+    AssertParse(
+      """
+      postfix operator ++:#^DIAG^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: only infix operators may declare a precedence, Fix-It replacements: 20 - 21 = ''
+        DiagnosticSpec(message: "expected identifier in operator"),
+        // TODO: Old parser expected error on line 2: expected precedence group name after ':' in operator declaration
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/OperatorsTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorsTests.swift
@@ -1,0 +1,336 @@
+// This test file has been translated from swift/test/Parse/operators.swift
+
+import XCTest
+
+final class OperatorsTests: XCTestCase {
+  func testOperators1() {
+    AssertParse(
+      """
+      // This disables importing the stdlib intentionally.
+      """
+    )
+  }
+
+  func testOperators2() {
+    AssertParse(
+      """
+      infix operator == : Equal
+      precedencegroup Equal {
+        associativity: left
+        higherThan: FatArrow
+      }
+      """
+    )
+  }
+
+  func testOperators3() {
+    AssertParse(
+      """
+      infix operator & : BitAnd
+      precedencegroup BitAnd {
+        associativity: left
+        higherThan: Equal
+      }
+      """
+    )
+  }
+
+  func testOperators4() {
+    AssertParse(
+      """
+      infix operator => : FatArrow
+      precedencegroup FatArrow {
+        associativity: right
+        higherThan: AssignmentPrecedence
+      }
+      precedencegroup AssignmentPrecedence {
+        assignment: true
+      }
+      """
+    )
+  }
+
+  func testOperators5() {
+    AssertParse(
+      """
+      precedencegroup DefaultPrecedence {}
+      """
+    )
+  }
+
+  func testOperators6() {
+    AssertParse(
+      """
+      struct Man {}
+      struct TheDevil {}
+      struct God {}
+      """
+    )
+  }
+
+  func testOperators7() {
+    AssertParse(
+      """
+      struct Five {}
+      struct Six {}
+      struct Seven {}
+      """
+    )
+  }
+
+  func testOperators8() {
+    AssertParse(
+      """
+      struct ManIsFive {}
+      struct TheDevilIsSix {}
+      struct GodIsSeven {}
+      """
+    )
+  }
+
+  func testOperators9() {
+    AssertParse(
+      """
+      struct TheDevilIsSixThenGodIsSeven {}
+      """
+    )
+  }
+
+  func testOperators10() {
+    AssertParse(
+      """
+      func == (x: Man, y: Five) -> ManIsFive {}
+      func == (x: TheDevil, y: Six) -> TheDevilIsSix {}
+      func == (x: God, y: Seven) -> GodIsSeven {}
+      """
+    )
+  }
+
+  func testOperators11() {
+    AssertParse(
+      """
+      func => (x: TheDevilIsSix, y: GodIsSeven) -> TheDevilIsSixThenGodIsSeven {}
+      func => (x: ManIsFive, y: TheDevilIsSixThenGodIsSeven) {}
+      """
+    )
+  }
+
+  func testOperators12() {
+    AssertParse(
+      """
+      func test1() {
+        Man() == Five() => TheDevil() == Six() => God() == Seven()
+      }
+      """
+    )
+  }
+
+  func testOperators13() {
+    AssertParse(
+      """
+      postfix operator *!*
+      prefix operator *!*
+      """
+    )
+  }
+
+  func testOperators14() {
+    AssertParse(
+      """
+      struct LOOK {}
+      struct LOOKBang {
+        func exclaim() {}
+      }
+      """
+    )
+  }
+
+  func testOperators15() {
+    AssertParse(
+      """
+      postfix func *!* (x: LOOK) -> LOOKBang {}
+      prefix func *!* (x: LOOKBang) {}
+      """
+    )
+  }
+
+  func testOperators16() {
+    AssertParse(
+      """
+      func test2() {
+        *!*LOOK()*!*
+      }
+      """
+    )
+  }
+
+  func testOperators17() {
+    AssertParse(
+      """
+      // This should be parsed as (x*!*).exclaim()
+      LOOK()*!*.exclaim()
+      """
+    )
+  }
+
+  func testOperators18() {
+    AssertParse(
+      """
+      prefix operator ^
+      infix operator ^
+      postfix operator ^
+      """
+    )
+  }
+
+  func testOperators19() {
+    AssertParse(
+      """
+      postfix func ^ (x: God) -> TheDevil {}
+      prefix func ^ (x: TheDevil) -> God {}
+      """
+    )
+  }
+
+  func testOperators20() {
+    AssertParse(
+      """
+      func ^ (x: TheDevil, y: God) -> Man {}
+      """
+    )
+  }
+
+  func testOperators21() {
+    AssertParse(
+      """
+      var _ : TheDevil = God()^
+      var _ : God = ^TheDevil()
+      var _ : Man = TheDevil() ^ God()
+      var _ : Man = God()^ ^ ^TheDevil()
+      let _ = God()^TheDevil()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: operator argument #2 must precede operator argument #1, Fix-It replacements: 9 - 9 = 'TheDevil()', 14 - 25 = ''
+      ]
+    )
+  }
+
+  func testOperators22() {
+    AssertParse(
+      """
+      postfix func ^ (x: Man) -> () -> God {
+        return { return God() }
+      }
+      """
+    )
+  }
+
+  func testOperators23() {
+    AssertParse(
+      """
+      var _ : God = Man()^()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot convert value of type 'Man' to expected argument type 'TheDevil'
+        // TODO: Old parser expected error on line 1: cannot convert value of type '()' to expected argument type 'God'
+        // TODO: Old parser expected error on line 1: cannot convert value of type 'Man' to specified type 'God'
+      ]
+    )
+  }
+
+  func testOperators24() {
+    AssertParse(
+      """
+      func &(x : Man, y : Man) -> Man { return x } // forgive amp_prefix token
+      """
+    )
+  }
+
+  func testOperators25() {
+    AssertParse(
+      """
+      prefix operator ⚽️
+      """
+    )
+  }
+
+  func testOperators26() {
+    AssertParse(
+      """
+      prefix func ⚽️(x: Man) { }
+      """
+    )
+  }
+
+  func testOperators27() {
+    AssertParse(
+      """
+      infix operator ?? : OptTest
+      precedencegroup OptTest {
+        associativity: right
+      }
+      """
+    )
+  }
+
+  func testOperators28() {
+    AssertParse(
+      """
+      func ??(x: Man, y: TheDevil) -> TheDevil {
+        return y
+      }
+      """
+    )
+  }
+
+  func testOperators29() {
+    AssertParse(
+      """
+      func test3(a: Man, b: Man, c: TheDevil) -> TheDevil {
+        return a ?? b ?? c
+      }
+      """
+    )
+  }
+
+  func testOperators30() {
+    AssertParse(
+      """
+      // <rdar://problem/17821399> We don't parse infix operators bound on both
+      // sides that begin with ! or ? correctly yet.
+      infix operator !!
+      """
+    )
+  }
+
+  func testOperators31() {
+    AssertParse(
+      """
+      func !!(x: Man, y: Man) {}
+      let foo = Man()
+      let bar = TheDevil()
+      foo!!foo
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: cannot force unwrap value of non-optional type 'Man', Fix-It replacements: 4 - 5 = ''
+        // TODO: Old parser expected error on line 4: cannot force unwrap value of non-optional type 'Man', Fix-It replacements: 5 - 6 = ''
+        // TODO: Old parser expected error on line 4: consecutive statements, Fix-It replacements: 6 - 6 = ';'
+        // TODO: Old parser expected warning on line 4: expression of type 'Man' is unused
+      ]
+    )
+  }
+
+  func testOperators32() {
+    AssertParse(
+      """
+      foo??bar
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: broken standard library
+        // TODO: Old parser expected error on line 1: consecutive statements, Fix-It replacements: 6 - 6 = ';'
+        // TODO: Old parser expected warning on line 1: expression of type 'TheDevil' is unused
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/OperatorsTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorsTests.swift
@@ -229,12 +229,7 @@ final class OperatorsTests: XCTestCase {
     AssertParse(
       """
       var _ : God = Man()^()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot convert value of type 'Man' to expected argument type 'TheDevil'
-        // TODO: Old parser expected error on line 1: cannot convert value of type '()' to expected argument type 'God'
-        // TODO: Old parser expected error on line 1: cannot convert value of type 'Man' to specified type 'God'
-      ]
+      """
     )
   }
 
@@ -312,10 +307,7 @@ final class OperatorsTests: XCTestCase {
       foo!!foo
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 4: cannot force unwrap value of non-optional type 'Man', Fix-It replacements: 4 - 5 = ''
-        // TODO: Old parser expected error on line 4: cannot force unwrap value of non-optional type 'Man', Fix-It replacements: 5 - 6 = ''
         // TODO: Old parser expected error on line 4: consecutive statements, Fix-It replacements: 6 - 6 = ';'
-        // TODO: Old parser expected warning on line 4: expression of type 'Man' is unused
       ]
     )
   }
@@ -326,9 +318,7 @@ final class OperatorsTests: XCTestCase {
       foo??bar
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: broken standard library
         // TODO: Old parser expected error on line 1: consecutive statements, Fix-It replacements: 6 - 6 = ';'
-        // TODO: Old parser expected warning on line 1: expression of type 'TheDevil' is unused
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/OptionalChainLvaluesTests.swift
+++ b/Tests/SwiftParserTest/translated/OptionalChainLvaluesTests.swift
@@ -34,10 +34,7 @@ final class OptionalChainLvaluesTests: XCTestCase {
       """
       var mutT: T?
       let immT: T? = nil
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: change 'let' to 'var' to make it mutable, Fix-It replacements: 1 - 4 = 'var'
-      ]
+      """
     )
   }
 
@@ -68,12 +65,7 @@ final class OptionalChainLvaluesTests: XCTestCase {
       mutT?.immS?.mutateS() 
       mutT?.mutS?.x += 1
       mutT?.mutS?.y++
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot use mutating member on immutable value: 'immT' is a 'let' constant
-        // TODO: Old parser expected error on line 4: cannot use mutating member on immutable value: 'immS' is a 'let' constant
-        // TODO: Old parser expected error on line 6: cannot pass immutable value to mutating operator: 'y' is a 'let' constant
-      ]
+      """
     )
   }
 
@@ -83,11 +75,7 @@ final class OptionalChainLvaluesTests: XCTestCase {
       // Prefix operators don't chain
       ++mutT?.mutS?.x 
       ++mutT?.mutS?.y
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot pass immutable value of type 'Int?' to mutating operator
-        // TODO: Old parser expected error on line 3: cannot pass immutable value of type 'Int?' to mutating operator
-      ]
+      """
     )
   }
 
@@ -104,17 +92,7 @@ final class OptionalChainLvaluesTests: XCTestCase {
       mutT?.immS? = S() 
       mutT?.immS?.x += 0 
       mutT?.immS?.y -= 0
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 5: value of optional type 'Int?' must be unwrapped
-        // TODO: Old parser expected note on line 5: coalesce
-        // TODO: Old parser expected note on line 5: force-unwrap
-        // TODO: Old parser expected error on line 6: left side of mutating operator isn't mutable: 'y' is a 'let' constant
-        // TODO: Old parser expected error on line 7: cannot assign to property: 'immS' is a 'let' constant
-        // TODO: Old parser expected error on line 8: cannot assign to value: 'immS' is a 'let' constant
-        // TODO: Old parser expected error on line 9: left side of mutating operator isn't mutable: 'immS' is a 'let' constant
-        // TODO: Old parser expected error on line 10: left side of mutating operator isn't mutable: 'y' is a 'let' constant
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/OptionalChainLvaluesTests.swift
+++ b/Tests/SwiftParserTest/translated/OptionalChainLvaluesTests.swift
@@ -1,0 +1,121 @@
+// This test file has been translated from swift/test/Parse/optional_chain_lvalues.swift
+
+import XCTest
+
+final class OptionalChainLvaluesTests: XCTestCase {
+  func testOptionalChainLvalues1() {
+    AssertParse(
+      """
+      struct S {
+        var x: Int = 0
+        let y: Int = 0  // expected-note 3 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}} {{3-6=var}}
+        mutating func mutateS() {}
+        init() {}
+      }
+      """
+    )
+  }
+
+  func testOptionalChainLvalues2() {
+    AssertParse(
+      """
+      struct T {
+        var mutS: S? = nil
+        let immS: S? = nil  // expected-note 4 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}}
+        mutating func mutateT() {}
+        init() {}
+      }
+      """
+    )
+  }
+
+  func testOptionalChainLvalues3() {
+    AssertParse(
+      """
+      var mutT: T?
+      let immT: T? = nil
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: change 'let' to 'var' to make it mutable, Fix-It replacements: 1 - 4 = 'var'
+      ]
+    )
+  }
+
+  func testOptionalChainLvalues4() {
+    AssertParse(
+      """
+      postfix operator ++
+      prefix operator ++
+      """
+    )
+  }
+
+  func testOptionalChainLvalues5() {
+    AssertParse(
+      """
+      public postfix func ++ <T>(rhs: inout T) -> T { fatalError() }
+      public prefix func ++ <T>(rhs: inout T) -> T { fatalError() }
+      """
+    )
+  }
+
+  func testOptionalChainLvalues6() {
+    AssertParse(
+      """
+      mutT?.mutateT()
+      immT?.mutateT() 
+      mutT?.mutS?.mutateS()
+      mutT?.immS?.mutateS() 
+      mutT?.mutS?.x += 1
+      mutT?.mutS?.y++
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot use mutating member on immutable value: 'immT' is a 'let' constant
+        // TODO: Old parser expected error on line 4: cannot use mutating member on immutable value: 'immS' is a 'let' constant
+        // TODO: Old parser expected error on line 6: cannot pass immutable value to mutating operator: 'y' is a 'let' constant
+      ]
+    )
+  }
+
+  func testOptionalChainLvalues7() {
+    AssertParse(
+      """
+      // Prefix operators don't chain
+      ++mutT?.mutS?.x 
+      ++mutT?.mutS?.y
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot pass immutable value of type 'Int?' to mutating operator
+        // TODO: Old parser expected error on line 3: cannot pass immutable value of type 'Int?' to mutating operator
+      ]
+    )
+  }
+
+  func testOptionalChainLvalues8() {
+    AssertParse(
+      """
+      mutT? = T()
+      mutT?.mutS = S()
+      mutT?.mutS? = S()
+      mutT?.mutS?.x += 0
+      _ = mutT?.mutS?.x + 0 
+      mutT?.mutS?.y -= 0 
+      mutT?.immS = S() 
+      mutT?.immS? = S() 
+      mutT?.immS?.x += 0 
+      mutT?.immS?.y -= 0
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: value of optional type 'Int?' must be unwrapped
+        // TODO: Old parser expected note on line 5: coalesce
+        // TODO: Old parser expected note on line 5: force-unwrap
+        // TODO: Old parser expected error on line 6: left side of mutating operator isn't mutable: 'y' is a 'let' constant
+        // TODO: Old parser expected error on line 7: cannot assign to property: 'immS' is a 'let' constant
+        // TODO: Old parser expected error on line 8: cannot assign to value: 'immS' is a 'let' constant
+        // TODO: Old parser expected error on line 9: left side of mutating operator isn't mutable: 'immS' is a 'let' constant
+        // TODO: Old parser expected error on line 10: left side of mutating operator isn't mutable: 'y' is a 'let' constant
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/OptionalLvaluesTests.swift
+++ b/Tests/SwiftParserTest/translated/OptionalLvaluesTests.swift
@@ -1,0 +1,181 @@
+// This test file has been translated from swift/test/Parse/optional_lvalues.swift
+
+import XCTest
+
+final class OptionalLvaluesTests: XCTestCase {
+  func testOptionalLvalues1() {
+    AssertParse(
+      """
+      struct S {
+        var x: Int = 0
+        let y: Int = 0 // expected-note 4 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}}
+        init() {}
+      }
+      """
+    )
+  }
+
+  func testOptionalLvalues2() {
+    AssertParse(
+      """
+      struct T {
+        var mutS: S? = nil
+        let immS: S? = nil // expected-note 10 {{change 'let' to 'var' to make it mutable}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}} {{3-6=var}}
+        init() {}
+      }
+      """
+    )
+  }
+
+  func testOptionalLvalues3() {
+    AssertParse(
+      """
+      var mutT: T?
+      let immT: T? = nil  // expected-note 4 {{change 'let' to 'var' to make it mutable}} {{1-4=var}} {{1-4=var}} {{1-4=var}} {{1-4=var}}
+      """
+    )
+  }
+
+  func testOptionalLvalues4() {
+    AssertParse(
+      """
+      let mutTPayload = mutT!
+      """
+    )
+  }
+
+  func testOptionalLvalues5() {
+    AssertParse(
+      """
+      mutT! = T()
+      mutT!.mutS = S()
+      mutT!.mutS! = S()
+      mutT!.mutS!.x = 0
+      mutT!.mutS!.y = 0 
+      mutT!.immS = S() 
+      mutT!.immS! = S() 
+      mutT!.immS!.x = 0 
+      mutT!.immS!.y = 0
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: cannot assign to property: 'y' is a 'let' constant
+        // TODO: Old parser expected error on line 6: cannot assign to property: 'immS' is a 'let' constant
+        // TODO: Old parser expected error on line 7: cannot assign through '!': 'immS' is a 'let' constant
+        // TODO: Old parser expected error on line 8: cannot assign to property: 'immS' is a 'let' constant
+        // TODO: Old parser expected error on line 9: cannot assign to property: 'y' is a 'let' constant
+      ]
+    )
+  }
+
+  func testOptionalLvalues6() {
+    AssertParse(
+      """
+      immT! = T() 
+      immT!.mutS = S() 
+      immT!.mutS! = S() 
+      immT!.mutS!.x = 0 
+      immT!.mutS!.y = 0 
+      immT!.immS = S() 
+      immT!.immS! = S() 
+      immT!.immS!.x = 0 
+      immT!.immS!.y = 0
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot assign through '!': 'immT' is a 'let' constant
+        // TODO: Old parser expected error on line 2: cannot assign to property: 'immT' is a 'let' constant
+        // TODO: Old parser expected error on line 3: cannot assign through '!': 'immT' is a 'let' constant
+        // TODO: Old parser expected error on line 4: cannot assign to property: 'immT' is a 'let' constant
+        // TODO: Old parser expected error on line 5: cannot assign to property: 'y' is a 'let' constant
+        // TODO: Old parser expected error on line 6: cannot assign to property: 'immS' is a 'let' constant
+        // TODO: Old parser expected error on line 7: cannot assign through '!': 'immS' is a 'let' constant
+        // TODO: Old parser expected error on line 8: cannot assign to property: 'immS' is a 'let' constant
+        // TODO: Old parser expected error on line 9: cannot assign to property: 'y' is a 'let' constant
+      ]
+    )
+  }
+
+  func testOptionalLvalues7() {
+    AssertParse(
+      """
+      var mutIUO: T! = nil
+      let immIUO: T! = nil // expected-note 2 {{change 'let' to 'var' to make it mutable}} {{1-4=var}} {{1-4=var}}
+      """
+    )
+  }
+
+  func testOptionalLvalues8() {
+    AssertParse(
+      """
+      mutIUO!.mutS = S()
+      mutIUO!.immS = S() 
+      immIUO!.mutS = S() 
+      immIUO!.immS = S()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot assign to property: 'immS' is a 'let' constant
+        // TODO: Old parser expected error on line 3: cannot assign to property: 'immIUO' is a 'let' constant
+        // TODO: Old parser expected error on line 4: cannot assign to property: 'immS' is a 'let' constant
+      ]
+    )
+  }
+
+  func testOptionalLvalues9() {
+    AssertParse(
+      """
+      mutIUO.mutS = S()
+      mutIUO.immS = S() 
+      immIUO.mutS = S() 
+      immIUO.immS = S()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot assign to property: 'immS' is a 'let' constant
+        // TODO: Old parser expected error on line 3: cannot assign to property: 'immIUO' is a 'let' constant
+        // TODO: Old parser expected error on line 4: cannot assign to property: 'immS' is a 'let' constant
+      ]
+    )
+  }
+
+  func testOptionalLvalues10() {
+    AssertParse(
+      """
+      func foo(x: Int) {}
+      """
+    )
+  }
+
+  func testOptionalLvalues11() {
+    AssertParse(
+      """
+      var nonOptional: S = S()
+      _ = nonOptional! 
+      _ = nonOptional!.x
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot force unwrap value of non-optional type 'S', Fix-It replacements: 16 - 17 = ''
+        // TODO: Old parser expected error on line 3: cannot force unwrap value of non-optional type 'S', Fix-It replacements: 16 - 17 = ''
+      ]
+    )
+  }
+
+  func testOptionalLvalues12() {
+    AssertParse(
+      """
+      class C {}
+      class D: C {}
+      """
+    )
+  }
+
+  func testOptionalLvalues13() {
+    AssertParse(
+      """
+      let c = C()
+      let d = (c as! D)!
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot force unwrap value of non-optional type 'D', Fix-It replacements: 18 - 19 = ''
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/OptionalLvaluesTests.swift
+++ b/Tests/SwiftParserTest/translated/OptionalLvaluesTests.swift
@@ -56,14 +56,7 @@ final class OptionalLvaluesTests: XCTestCase {
       mutT!.immS! = S() 
       mutT!.immS!.x = 0 
       mutT!.immS!.y = 0
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 5: cannot assign to property: 'y' is a 'let' constant
-        // TODO: Old parser expected error on line 6: cannot assign to property: 'immS' is a 'let' constant
-        // TODO: Old parser expected error on line 7: cannot assign through '!': 'immS' is a 'let' constant
-        // TODO: Old parser expected error on line 8: cannot assign to property: 'immS' is a 'let' constant
-        // TODO: Old parser expected error on line 9: cannot assign to property: 'y' is a 'let' constant
-      ]
+      """
     )
   }
 
@@ -79,18 +72,7 @@ final class OptionalLvaluesTests: XCTestCase {
       immT!.immS! = S() 
       immT!.immS!.x = 0 
       immT!.immS!.y = 0
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot assign through '!': 'immT' is a 'let' constant
-        // TODO: Old parser expected error on line 2: cannot assign to property: 'immT' is a 'let' constant
-        // TODO: Old parser expected error on line 3: cannot assign through '!': 'immT' is a 'let' constant
-        // TODO: Old parser expected error on line 4: cannot assign to property: 'immT' is a 'let' constant
-        // TODO: Old parser expected error on line 5: cannot assign to property: 'y' is a 'let' constant
-        // TODO: Old parser expected error on line 6: cannot assign to property: 'immS' is a 'let' constant
-        // TODO: Old parser expected error on line 7: cannot assign through '!': 'immS' is a 'let' constant
-        // TODO: Old parser expected error on line 8: cannot assign to property: 'immS' is a 'let' constant
-        // TODO: Old parser expected error on line 9: cannot assign to property: 'y' is a 'let' constant
-      ]
+      """
     )
   }
 
@@ -110,12 +92,7 @@ final class OptionalLvaluesTests: XCTestCase {
       mutIUO!.immS = S() 
       immIUO!.mutS = S() 
       immIUO!.immS = S()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot assign to property: 'immS' is a 'let' constant
-        // TODO: Old parser expected error on line 3: cannot assign to property: 'immIUO' is a 'let' constant
-        // TODO: Old parser expected error on line 4: cannot assign to property: 'immS' is a 'let' constant
-      ]
+      """
     )
   }
 
@@ -126,12 +103,7 @@ final class OptionalLvaluesTests: XCTestCase {
       mutIUO.immS = S() 
       immIUO.mutS = S() 
       immIUO.immS = S()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot assign to property: 'immS' is a 'let' constant
-        // TODO: Old parser expected error on line 3: cannot assign to property: 'immIUO' is a 'let' constant
-        // TODO: Old parser expected error on line 4: cannot assign to property: 'immS' is a 'let' constant
-      ]
+      """
     )
   }
 
@@ -149,11 +121,7 @@ final class OptionalLvaluesTests: XCTestCase {
       var nonOptional: S = S()
       _ = nonOptional! 
       _ = nonOptional!.x
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot force unwrap value of non-optional type 'S', Fix-It replacements: 16 - 17 = ''
-        // TODO: Old parser expected error on line 3: cannot force unwrap value of non-optional type 'S', Fix-It replacements: 16 - 17 = ''
-      ]
+      """
     )
   }
 
@@ -171,10 +139,7 @@ final class OptionalLvaluesTests: XCTestCase {
       """
       let c = C()
       let d = (c as! D)!
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot force unwrap value of non-optional type 'D', Fix-It replacements: 18 - 19 = ''
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/OptionalTests.swift
+++ b/Tests/SwiftParserTest/translated/OptionalTests.swift
@@ -1,0 +1,60 @@
+// This test file has been translated from swift/test/Parse/optional.swift
+
+import XCTest
+
+final class OptionalTests: XCTestCase {
+  func testOptional1() {
+    AssertParse(
+      """
+      struct A {
+        func foo() {}
+      }
+      """
+    )
+  }
+
+  func testOptional2() {
+    AssertParse(
+      """
+      var a : A?
+      var b : A #^DIAG^#?
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: consecutive statements on a line, Fix-It replacements: 10 - 10 = ';'
+        // TODO: Old parser expected error on line 2: expected expression
+        DiagnosticSpec(message: "extraneous '?' at top level"),
+      ]
+    )
+  }
+
+  func testOptional3() {
+    AssertParse(
+      """
+      var c = a?  
+      var d : ()? = a?.foo()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '?' must be followed by a call, member lookup, or subscript
+      ]
+    )
+  }
+
+  func testOptional4() {
+    AssertParse(
+      """
+      var e : (() -> A)?
+      var f = e?()
+      """
+    )
+  }
+
+  func testOptional5() {
+    AssertParse(
+      """
+      struct B<T> {}
+      var g = B<A?>()
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/OriginalDefinedInAttrTests.swift
+++ b/Tests/SwiftParserTest/translated/OriginalDefinedInAttrTests.swift
@@ -1,0 +1,161 @@
+// This test file has been translated from swift/test/Parse/original_defined_in_attr.swift
+
+import XCTest
+
+final class OriginalDefinedInAttrTests: XCTestCase {
+  func testOriginalDefinedInAttr1() {
+    AssertParse(
+      #"""
+      @_originallyDefinedIn(module: "foo", OSX 13.13) 
+      public func foo() {}
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '@_originallyDefinedIn' requires that 'foo()' have explicit availability for macOS
+      ]
+    )
+  }
+
+  func testOriginalDefinedInAttr2() {
+    AssertParse(
+      #"""
+      @_originallyDefinedIn(modulename: "foo", OSX 13.13) 
+      public func foo1() {}
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected 'module: "original"' in the first argument to @_originallyDefinedIn
+      ]
+    )
+  }
+
+  func testOriginalDefinedInAttr3() {
+    AssertParse(
+      #"""
+      @_originallyDefinedIn(module: "foo", OSX 13.13.3) 
+      public class ToplevelClass {}
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: '@_originallyDefinedIn' only uses major and minor version number
+        // TODO: Old parser expected error on line 1: '@_originallyDefinedIn' requires that 'ToplevelClass' have explicit availability for macOS
+      ]
+    )
+  }
+
+  func testOriginalDefinedInAttr4() {
+    AssertParse(
+      #"""
+      @_originallyDefinedIn(module: "foo") 
+      public class ToplevelClass1 {}
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected at least one platform version in '@_originallyDefinedIn' attribute
+      ]
+    )
+  }
+
+  func testOriginalDefinedInAttr5() {
+    AssertParse(
+      """
+      @_originallyDefinedIn(OSX 13.13.3) 
+      public class ToplevelClass2 {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected 'module: "original"' in the first argument to @_originallyDefinedIn
+      ]
+    )
+  }
+
+  func testOriginalDefinedInAttr6() {
+    AssertParse(
+      #"""
+      @_originallyDefinedIn(module: "foo",
+      public class ToplevelClass3 {}#^DIAG^#
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected platform in '@_originallyDefinedIn' attribute
+        DiagnosticSpec(message: "expected ')' to end attribute"),
+        DiagnosticSpec(message: "expected declaration after attribute"),
+      ]
+    )
+  }
+
+  func testOriginalDefinedInAttr7() {
+    AssertParse(
+      #"""
+      @available(OSX 13.10, *)
+      @_originallyDefinedIn(module: "foo", * 13.13) 
+      @_originallyDefinedIn(module: "foo", OSX 13.13, iOS 7.0)
+      @_originallyDefinedIn(module: "foo", OSX 13.14, * 7.0) 
+      public class ToplevelClass4 {
+      	@_originallyDefinedIn(module: "foo", OSX 13.13) 
+      	subscript(index: Int) -> Int {
+              get { return 1 }
+              set(newValue) {}
+      	}
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 2: * as platform name has no effect
+        // TODO: Old parser expected error on line 2: expected at least one platform version in '@_originallyDefinedIn' attribute
+        // TODO: Old parser expected warning on line 4: * as platform name has no effect
+        // TODO: Old parser expected error on line 4: '@_originallyDefinedIn' contains multiple versions for macOS
+        // TODO: Old parser expected error on line 6: '@_originallyDefinedIn' attribute cannot be applied to this declaration
+      ]
+    )
+  }
+
+  func testOriginalDefinedInAttr8() {
+    AssertParse(
+      #"""
+      @available(OSX 13.10, *)
+      @_originallyDefinedIn(module: "foo", OSX 13.13) 
+      @_originallyDefinedIn(module: "foo", iOS 7.0)
+      internal class ToplevelClass5 {}
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 2: '@_originallyDefinedIn' does not have any effect on internal declarations
+      ]
+    )
+  }
+
+  func testOriginalDefinedInAttr9() {
+    AssertParse(
+      #"""
+      @available(OSX 13.10, *)
+      @_originallyDefinedIn(module: "foo", OSX 13.13) 
+      @_originallyDefinedIn(module: "foo", iOS 7.0)
+      private class ToplevelClass6 {}
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 2: '@_originallyDefinedIn' does not have any effect on private declarations
+      ]
+    )
+  }
+
+  func testOriginalDefinedInAttr10() {
+    AssertParse(
+      #"""
+      @available(OSX 13.10, *)
+      @_originallyDefinedIn(module: "foo", OSX 13.13) 
+      @_originallyDefinedIn(module: "foo", iOS 7.0)
+      fileprivate class ToplevelClass7 {}
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 2: '@_originallyDefinedIn' does not have any effect on fileprivate declarations
+      ]
+    )
+  }
+
+  func testOriginalDefinedInAttr11() {
+    AssertParse(
+      #"""
+      @available(OSX 13.10, *)
+      @_originallyDefinedIn(module: "foo", OSX 13.13, iOS 7.0) 
+      internal class ToplevelClass8 {}
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 2: '@_originallyDefinedIn' does not have any effect on internal declarations
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/PatternWithoutVariablesScriptTests.swift
+++ b/Tests/SwiftParserTest/translated/PatternWithoutVariablesScriptTests.swift
@@ -1,0 +1,14 @@
+// This test file has been translated from swift/test/Parse/pattern_without_variables_script.swift
+
+import XCTest
+
+final class PatternWithoutVariablesScriptTests: XCTestCase {
+  func testPatternWithoutVariablesScript1() {
+    AssertParse(
+      """
+      _ = 1
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
+++ b/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
@@ -73,7 +73,6 @@ final class PatternWithoutVariablesTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected warning on line 3: 'let' pattern has no effect; sub-pattern didn't bind any variables, Fix-It replacements: 8 - 12 = ''
         // TODO: Old parser expected warning on line 9: 'let' pattern has no effect; sub-pattern didn't bind any variables, Fix-It replacements: 8 - 12 = ''
-        // TODO: Old parser expected warning on line 14: 'if' condition is always true
         // TODO: Old parser expected warning on line 14: 'let' pattern has no effect; sub-pattern didn't bind any variables, Fix-It replacements: 11 - 15 = ''
       ]
     )

--- a/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
+++ b/Tests/SwiftParserTest/translated/PatternWithoutVariablesTests.swift
@@ -1,0 +1,96 @@
+// This test file has been translated from swift/test/Parse/pattern_without_variables.swift
+
+import XCTest
+
+final class PatternWithoutVariablesTests: XCTestCase {
+  func testPatternWithoutVariables1() {
+    AssertParse(
+      """
+      let _ = 1
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: global variable declaration does not bind any variables
+      ]
+    )
+  }
+
+  func testPatternWithoutVariables2() {
+    AssertParse(
+      """
+      func foo() {
+        let _ = 1 // OK
+      }
+      """
+    )
+  }
+
+  func testPatternWithoutVariables3() {
+    AssertParse(
+      """
+      struct Foo {
+        let _ = 1 
+        var (_, _) = (1, 2) 
+        func foo() {
+          let _ = 1 // OK
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: property declaration does not bind any variables
+        // TODO: Old parser expected error on line 3: property declaration does not bind any variables
+      ]
+    )
+  }
+
+  func testPatternWithoutVariables4() {
+    AssertParse(
+      #"""
+      // <rdar://problem/19786845> Warn on "let" and "var" when no data is bound in a pattern
+      enum SimpleEnum { case Bar }
+      """#
+    )
+  }
+
+  func testPatternWithoutVariables5() {
+    AssertParse(
+      #"""
+      func testVarLetPattern(a : SimpleEnum) {
+        switch a {
+        case let .Bar: break      
+        }
+        switch a {
+        case let x: _ = x; break         // Ok.
+        }
+        switch a {
+        case let _: break         
+        }
+        switch (a, 42) {
+        case let (_, x): _ = x; break    // ok
+        }
+        if case let _ = "str" {}  
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 3: 'let' pattern has no effect; sub-pattern didn't bind any variables, Fix-It replacements: 8 - 12 = ''
+        // TODO: Old parser expected warning on line 9: 'let' pattern has no effect; sub-pattern didn't bind any variables, Fix-It replacements: 8 - 12 = ''
+        // TODO: Old parser expected warning on line 14: 'if' condition is always true
+        // TODO: Old parser expected warning on line 14: 'let' pattern has no effect; sub-pattern didn't bind any variables, Fix-It replacements: 11 - 15 = ''
+      ]
+    )
+  }
+
+  func testPatternWithoutVariables6() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/53293
+      class C_53293 {
+        static var _: Int { 0 } 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: getter/setter can only be defined for a single variable
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/PlaygroundLvaluesTests.swift
+++ b/Tests/SwiftParserTest/translated/PlaygroundLvaluesTests.swift
@@ -1,0 +1,25 @@
+// This test file has been translated from swift/test/Parse/playground_lvalues.swift
+
+import XCTest
+
+final class PlaygroundLvaluesTests: XCTestCase {
+  func testPlaygroundLvalues1() {
+    AssertParse(
+      """
+      var a = 1, b = 2
+      let z = 3
+      """
+    )
+  }
+
+  func testPlaygroundLvalues2() {
+    AssertParse(
+      """
+      a
+      (a, b)
+      (a, z)
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/PoundAssertTests.swift
+++ b/Tests/SwiftParserTest/translated/PoundAssertTests.swift
@@ -1,0 +1,82 @@
+// This test file has been translated from swift/test/Parse/pound_assert.swift
+
+import XCTest
+
+final class PoundAssertTests: XCTestCase {
+  func testPoundAssert1() {
+    AssertParse(
+      """
+      #assert(true, 123)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected a string literal
+      ]
+    )
+  }
+
+  func testPoundAssert2() {
+    AssertParse(
+      #"""
+      #assert(true, "error \(1) message")
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '#assert' message cannot be an interpolated string literal
+      ]
+    )
+  }
+
+  func testPoundAssert3() {
+    AssertParse(
+      #"""
+      #assert #^DIAG^#true, "error message")
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected '(' in #assert directive
+        DiagnosticSpec(message: "expected '(' in '#assert' statement"),
+      ]
+    )
+  }
+
+  func testPoundAssert4() {
+    AssertParse(
+      #"""
+      #assert(#^DIAG^#, "error message")
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected a condition expression
+        DiagnosticSpec(message: "expected condition in '#assert' statement"),
+      ]
+    )
+  }
+
+  func testPoundAssert5() {
+    AssertParse(
+      """
+      func unbalanced1() {
+        #assert(true #^DIAG^#
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected ')' in #assert directive
+        // TODO: Old parser expected note on line 2: to match this opening '('
+        DiagnosticSpec(message: "expected ')' to end '#assert' statement"),
+      ]
+    )
+  }
+
+  func testPoundAssert6() {
+    AssertParse(
+      #"""
+      func unbalanced2() {
+        #assert(true, "hello world" #^DIAG^#
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected ')' in #assert directive
+        // TODO: Old parser expected note on line 2: to match this opening '('
+        DiagnosticSpec(message: "expected ')' to end '#assert' statement"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/RawStringErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/RawStringErrorsTests.swift
@@ -1,0 +1,112 @@
+// This test file has been translated from swift/test/Parse/raw_string_errors.swift
+
+import XCTest
+
+final class RawStringErrorsTests: XCTestCase {
+  func testRawStringErrors1() {
+    AssertParse(
+      ###"""
+      let _ = "foo\(#"bar"##^DIAG^##)baz"
+      """###,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: too many '#' characters in closing delimiter
+        // TODO: Old parser expected error on line 1: expected ',' separator
+        // TODO: Old parser expected error on line 1: expected expression in list of expressions
+        DiagnosticSpec(message: "unexpected text '#' in string literal"),
+      ]
+    )
+  }
+
+  func testRawStringErrors2() {
+    AssertParse(
+      ###"""
+      let _ = #^DIAG^##"\##("invalid")"#
+      """###,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: too many '#' characters in delimited escape
+        // TODO: Old parser expected error on line 1: invalid escape sequence in literal
+        DiagnosticSpec(message: "expected expression in variable"),
+        DiagnosticSpec(message: ###"extraneous '#"\##("invalid")"#' at top level"###),
+      ]
+    )
+  }
+
+  func testRawStringErrors3() {
+    AssertParse(
+      #####"""
+      let _ = ###"""invalid"####^DIAG^####
+      """#####,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: too many '#' characters in closing delimiter, Fix-It replacements: 26 - 29 = ''
+        // TODO: Old parser expected error on line 1: consecutive statements on a line must be separated by ';'
+        // TODO: Old parser expected error on line 1: expected expression
+        DiagnosticSpec(message: "extraneous '###' at top level"),
+      ]
+    )
+  }
+
+  func testRawStringErrors4() {
+    AssertParse(
+      #####"""
+      let _ = ####"invalid"####^DIAG^#
+      """#####,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: unterminated string literal
+        DiagnosticSpec(message: #####"expected '"####' to end string literal"#####),
+      ]
+    )
+  }
+
+  func testRawStringErrors5() {
+    AssertParse(
+      #####"""
+      let _ = ###"invalid"####^DIAG^####
+      """#####,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: too many '#' characters in closing delimiter, Fix-It replacements: 24 - 27 = ''
+        // TODO: Old parser expected error on line 1: consecutive statements on a line must be separated by ';'
+        // TODO: Old parser expected error on line 1: expected expression
+        DiagnosticSpec(message: "extraneous '###' at top level"),
+      ]
+    )
+  }
+
+  func testRawStringErrors6() {
+    AssertParse(
+      ###"""
+      let _ = ##"""aa
+        foobar
+        aa"""##
+      """###,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: multi-line string literal content must begin on a new line, Fix-It replacements: 14 - 14 = '\n'
+        // TODO: Old parser expected error on line 3: multi-line string literal closing delimiter must begin on a new line, Fix-It replacements: 5 - 5 = '\n'
+      ]
+    )
+  }
+
+  func testRawStringErrors7() {
+    AssertParse(
+      ##"""
+      let _ = #""" foo "bar" #baz
+        """#
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: multi-line string literal content must begin on a new line, Fix-It replacements: 13 - 13 = '\n'
+      ]
+    )
+  }
+
+  func testRawStringErrors8() {
+    AssertParse(
+      ####"""
+      let _ = ###""" "# "##
+        """###
+      """####,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: multi-line string literal content must begin on a new line, Fix-It replacements: 15 - 15 = '\n'
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/RecoveryLibraryTests.swift
+++ b/Tests/SwiftParserTest/translated/RecoveryLibraryTests.swift
@@ -1,0 +1,46 @@
+// This test file has been translated from swift/test/Parse/recovery_library.swift
+
+import XCTest
+
+final class RecoveryLibraryTests: XCTestCase {
+  func testRecoveryLibrary1() {
+    AssertParse(
+      """
+      //===--- Recovery for extra braces at top level.
+      //===--- Keep this test the first one in the file.
+      """
+    )
+  }
+
+  func testRecoveryLibrary2() {
+    AssertParse(
+      """
+      // Check that we handle multiple consecutive right braces.
+      #^DIAG_1^#} 
+      } 
+      func foo() {}
+      // Check that we handle multiple consecutive right braces.
+      #^DIAG_2^#} 
+      } 
+      func bar() {}
+      //===--- Recovery for extra braces at top level.
+      //===--- Keep this test the last one in the file.
+      // Check that we handle multiple consecutive right braces.
+      #^DIAG_3^#} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: extraneous '}' at top level, Fix-It replacements: 1 - 3 = ''
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text before function"),
+        // TODO: Old parser expected error on line 3: extraneous '}' at top level, Fix-It replacements: 1 - 3 = ''
+        // TODO: Old parser expected error on line 6: extraneous '}' at top level, Fix-It replacements: 1 - 3 = ''
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text before function"),
+        // TODO: Old parser expected error on line 7: extraneous '}' at top level, Fix-It replacements: 1 - 3 = ''
+        // TODO: Old parser expected error on line 12: extraneous '}' at top level, Fix-It replacements: 1 - 3 = ''
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 13: extraneous '}' at top level, Fix-It replacements: 1 - 3 = ''
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/ResultBuilderTests.swift
+++ b/Tests/SwiftParserTest/translated/ResultBuilderTests.swift
@@ -1,0 +1,86 @@
+// This test file has been translated from swift/test/Parse/result-builder.swift
+
+import XCTest
+
+final class ResultBuilderTests: XCTestCase {
+  func testResultBuilder1() {
+    AssertParse(
+      """
+      // rdar://70158735
+      """
+    )
+  }
+
+  func testResultBuilder2() {
+    AssertParse(
+      """
+      @resultBuilder
+      struct A<T> {
+        static func buildBlock(_ values: Int...) -> Int { return 0 }
+      }
+      """
+    )
+  }
+
+  func testResultBuilder3() {
+    AssertParse(
+      """
+      struct B<T> {}
+      """
+    )
+  }
+
+  func testResultBuilder4() {
+    AssertParse(
+      """
+      extension B {
+        @resultBuilder
+        struct Generic<U> {
+          static func buildBlock(_ values: Int...) -> Int { return 0 }
+        }
+        @resultBuilder
+        struct NonGeneric {
+          static func buildBlock(_ values: Int...) -> Int { return 0 }
+        }
+      }
+      """
+    )
+  }
+
+  func testResultBuilder5() {
+    AssertParse(
+      """
+      @A<Float> var test0: Int {
+        1
+        2
+        3
+      }
+      """
+    )
+  }
+
+  func testResultBuilder6() {
+    AssertParse(
+      """
+      @B<Float>.NonGeneric var test1: Int {
+        1
+        2
+        3
+      }
+      """
+    )
+  }
+
+  func testResultBuilder7() {
+    AssertParse(
+      """
+      @B<Float>.Generic<Float> var test2: Int {
+        1
+        2
+        3
+      }
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/SelfRebindingTests.swift
+++ b/Tests/SwiftParserTest/translated/SelfRebindingTests.swift
@@ -68,10 +68,7 @@ final class SelfRebindingTests: XCTestCase {
               something() // this should still refer `MyCls.something`.
           }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 4: initialization of immutable value 'self' was never used
-      ]
+      """
     )
   }
 
@@ -109,16 +106,7 @@ final class SelfRebindingTests: XCTestCase {
           func `self`() {
           }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 2: 'self' refers to the method 'TypeWithSelfMethod.self', which may be unexpected
-        // TODO: Old parser expected note on line 2: use 'TypeWithSelfMethod.self' to silence this warning, Fix-It replacements: 20 - 20 = 'TypeWithSelfMethod.'
-        // TODO: Old parser expected error on line 4: cannot use instance member 'self' within property initializer; property initializers run before 'self' is available
-        // TODO: Old parser expected warning on line 6: 'self' refers to the method 'TypeWithSelfMethod.self', which may be unexpected
-        // TODO: Old parser expected note on line 6: use 'TypeWithSelfMethod.self' to silence this warning, Fix-It replacements: 15 - 15 = 'TypeWithSelfMethod.'
-        // TODO: Old parser expected warning on line 8: 'self' refers to the method 'TypeWithSelfMethod.self', which may be unexpected
-        // TODO: Old parser expected note on line 8: use 'TypeWithSelfMethod.self' to silence this warning, Fix-It replacements: 53 - 53 = 'TypeWithSelfMethod.'
-      ]
+      """
     )
   }
 
@@ -137,12 +125,7 @@ final class SelfRebindingTests: XCTestCase {
               ()
           }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: cannot use instance member 'self' within property initializer; property initializers run before 'self' is available
-        // TODO: Old parser expected error on line 6: cannot use instance member 'self' within property initializer; property initializers run before 'self' is available
-        // TODO: Old parser expected error on line 8: cannot use instance member 'self' within property initializer; property initializers run before 'self' is available
-      ]
+      """
     )
   }
 
@@ -159,12 +142,7 @@ final class SelfRebindingTests: XCTestCase {
           let propertyFromFunc = funcThatReturnsSomething(self) 
           let `self`: () = ()
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: cannot use instance member 'self' within property initializer; property initializers run before 'self' is available
-        // TODO: Old parser expected error on line 6: cannot use instance member 'self' within property initializer; property initializers run before 'self' is available
-        // TODO: Old parser expected error on line 8: cannot use instance member 'self' within property initializer; property initializers run before 'self' is available
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/SelfRebindingTests.swift
+++ b/Tests/SwiftParserTest/translated/SelfRebindingTests.swift
@@ -1,0 +1,197 @@
+// This test file has been translated from swift/test/Parse/self_rebinding.swift
+
+import XCTest
+
+final class SelfRebindingTests: XCTestCase {
+  func testSelfRebinding1() {
+    AssertParse(
+      #"""
+      class Writer {
+          private var articleWritten = 47
+          func stop() {
+              let rest: () -> Void = { [weak self] in
+                  let articleWritten = self?.articleWritten ?? 0
+                  guard let `self` = self else {
+                      return
+                  }
+                  self.articleWritten = articleWritten
+              }
+              fatalError("I'm running out of time")
+              rest()
+          }
+          func nonStop() {
+              let write: () -> Void = { [weak self] in
+                  self?.articleWritten += 1
+                  if let self = self {
+                      self.articleWritten += 1
+                  }
+                  if let `self` = self {
+                      self.articleWritten += 1
+                  }
+                  guard let self = self else {
+                      return
+                  }
+                  self.articleWritten += 1
+              }
+              write()
+          }
+      }
+      """#
+    )
+  }
+
+  func testSelfRebinding2() {
+    AssertParse(
+      """
+      struct T {
+          var mutable: Int = 0
+          func f() {
+              let #^DIAG^#self = self
+          }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: keyword 'self' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 4: if this name is unavoidable, use backticks to escape it
+        DiagnosticSpec(message: "expected pattern in variable"),
+      ]
+    )
+  }
+
+  func testSelfRebinding3() {
+    AssertParse(
+      """
+      class MyCls {
+          func something() {}
+          func test() {
+              let `self` = Writer() // Even if `self` is shadowed,
+              something() // this should still refer `MyCls.something`.
+          }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 4: initialization of immutable value 'self' was never used
+      ]
+    )
+  }
+
+  func testSelfRebinding4() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/47136
+      // Method called 'self' can be confused with regular 'self'
+      """
+    )
+  }
+
+  func testSelfRebinding5() {
+    AssertParse(
+      """
+      func funcThatReturnsSomething(_ any: Any) -> Any {
+          any
+      }
+      """
+    )
+  }
+
+  func testSelfRebinding6() {
+    AssertParse(
+      """
+      struct TypeWithSelfMethod {
+          let property = self 
+          // Existing warning expected, not confusable
+          let property2 = self() 
+          let propertyFromClosure: () = {
+              print(self) 
+          }()
+          let propertyFromFunc = funcThatReturnsSomething(self) 
+          let propertyFromFunc2 = funcThatReturnsSomething(TypeWithSelfMethod.self) // OK
+          func `self`() {
+          }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 2: 'self' refers to the method 'TypeWithSelfMethod.self', which may be unexpected
+        // TODO: Old parser expected note on line 2: use 'TypeWithSelfMethod.self' to silence this warning, Fix-It replacements: 20 - 20 = 'TypeWithSelfMethod.'
+        // TODO: Old parser expected error on line 4: cannot use instance member 'self' within property initializer; property initializers run before 'self' is available
+        // TODO: Old parser expected warning on line 6: 'self' refers to the method 'TypeWithSelfMethod.self', which may be unexpected
+        // TODO: Old parser expected note on line 6: use 'TypeWithSelfMethod.self' to silence this warning, Fix-It replacements: 15 - 15 = 'TypeWithSelfMethod.'
+        // TODO: Old parser expected warning on line 8: 'self' refers to the method 'TypeWithSelfMethod.self', which may be unexpected
+        // TODO: Old parser expected note on line 8: use 'TypeWithSelfMethod.self' to silence this warning, Fix-It replacements: 53 - 53 = 'TypeWithSelfMethod.'
+      ]
+    )
+  }
+
+  func testSelfRebinding7() {
+    AssertParse(
+      """
+      /// Test fix_unqualified_access_member_named_self doesn't appear for computed var called `self`
+      /// it can't currently be referenced as a static member -- unlike a method with the same name
+      struct TypeWithSelfComputedVar {
+          let property = self 
+          let propertyFromClosure: () = {
+              print(self) 
+          }()
+          let propertyFromFunc = funcThatReturnsSomething(self) 
+          var `self`: () {
+              ()
+          }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: cannot use instance member 'self' within property initializer; property initializers run before 'self' is available
+        // TODO: Old parser expected error on line 6: cannot use instance member 'self' within property initializer; property initializers run before 'self' is available
+        // TODO: Old parser expected error on line 8: cannot use instance member 'self' within property initializer; property initializers run before 'self' is available
+      ]
+    )
+  }
+
+  func testSelfRebinding8() {
+    AssertParse(
+      """
+      /// Test fix_unqualified_access_member_named_self doesn't appear for property called `self`
+      /// it can't currently be referenced as a static member -- unlike a method with the same name
+      struct TypeWithSelfProperty {
+          let property = self 
+          let propertyFromClosure: () = {
+              print(self) 
+          }()
+          let propertyFromFunc = funcThatReturnsSomething(self) 
+          let `self`: () = ()
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: cannot use instance member 'self' within property initializer; property initializers run before 'self' is available
+        // TODO: Old parser expected error on line 6: cannot use instance member 'self' within property initializer; property initializers run before 'self' is available
+        // TODO: Old parser expected error on line 8: cannot use instance member 'self' within property initializer; property initializers run before 'self' is available
+      ]
+    )
+  }
+
+  func testSelfRebinding9() {
+    AssertParse(
+      """
+      enum EnumCaseNamedSelf {
+          case `self`
+          init() {
+              self = .self // OK
+              self = .`self` // OK
+              self = EnumCaseNamedSelf.`self` // OK
+          }
+      }
+      """
+    )
+  }
+
+  func testSelfRebinding10() {
+    AssertParse(
+      """
+      // rdar://90624344 - warning about `self` which cannot be fixed because it's located in implicitly generated code.
+      struct TestImplicitSelfUse : Codable {
+        let `self`: Int // Ok
+      }
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/SemicolonTests.swift
+++ b/Tests/SwiftParserTest/translated/SemicolonTests.swift
@@ -1,0 +1,139 @@
+// This test file has been translated from swift/test/Parse/semicolon.swift
+
+import XCTest
+
+final class SemicolonTests: XCTestCase {
+  func testSemicolon1() {
+    AssertParse(
+      #"""
+      let a = 42;
+      var b = "b";
+      """#
+    )
+  }
+
+  func testSemicolon2() {
+    AssertParse(
+      """
+      struct A {
+          var a1: Int;
+          let a2: Int ;
+          var a3: Int;let a4: Int
+          var a5: Int; let a6: Int;
+      };
+      """
+    )
+  }
+
+  func testSemicolon3() {
+    AssertParse(
+      """
+      enum B {
+          case B1;
+          case B2(value: Int);
+          case B3
+          case B4; case B5 ; case B6;
+      };
+      """
+    )
+  }
+
+  func testSemicolon4() {
+    AssertParse(
+      """
+      class C {
+          var x: Int;
+          let y = 3.14159;
+          init(x: Int) { self.x = x; }
+      };
+      """
+    )
+  }
+
+  func testSemicolon5() {
+    AssertParse(
+      """
+      typealias C1 = C;
+      """
+    )
+  }
+
+  func testSemicolon6() {
+    AssertParse(
+      """
+      protocol D {
+          var foo: () -> Int { get };
+      }
+      """
+    )
+  }
+
+  func testSemicolon7() {
+    AssertParse(
+      """
+      struct D1: D {
+          let foo = { return 42; };
+      }
+      func e() -> Bool {
+          return false;
+      }
+      """
+    )
+  }
+
+  func testSemicolon8() {
+    AssertParse(
+      """
+      import Swift;
+      """
+    )
+  }
+
+  func testSemicolon9() {
+    AssertParse(
+      """
+      for i in 1..<1000 {
+          if i % 2 == 1 {
+              break;
+          };
+      }
+      """
+    )
+  }
+
+  func testSemicolon10() {
+    AssertParse(
+      """
+      let six = (1..<3).reduce(0, +);
+      """
+    )
+  }
+
+  func testSemicolon11() {
+    AssertParse(
+      """
+      func lessThanTwo(input: UInt) -> Bool {
+          switch input {
+          case 0:     return true;
+          case 1, 2:  return true;
+          default:
+              return false;
+          }
+      }
+      """
+    )
+  }
+
+  func testSemicolon12() {
+    AssertParse(
+      """
+      enum StarWars {
+          enum Quality { case 😀; case 🙂; case 😐; case 😏; case 😞 };
+          case Ep4; case Ep5; case Ep6
+          case Ep1, Ep2; case Ep3;
+      };
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/StringLiteralEof1Tests.swift
+++ b/Tests/SwiftParserTest/translated/StringLiteralEof1Tests.swift
@@ -1,0 +1,21 @@
+// This test file has been translated from swift/test/Parse/string_literal_eof1.swift
+
+import XCTest
+
+final class StringLiteralEof1Tests: XCTestCase {
+  func testStringLiteralEof11() {
+    AssertParse(
+      ##"""
+      // NOTE: DO NOT add a newline at EOF.
+      _ = #^DIAG^#"foo\(
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: unterminated string literal
+        // TODO: Old parser expected error on line 2: cannot find ')' to match opening '(' in string interpolation
+        DiagnosticSpec(message: "expected expression"),
+        DiagnosticSpec(message: #"extraneous '"foo\(' at top level"#),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/StringLiteralEof2Tests.swift
+++ b/Tests/SwiftParserTest/translated/StringLiteralEof2Tests.swift
@@ -1,0 +1,21 @@
+// This test file has been translated from swift/test/Parse/string_literal_eof2.swift
+
+import XCTest
+
+final class StringLiteralEof2Tests: XCTestCase {
+  func testStringLiteralEof21() {
+    AssertParse(
+      ##"""
+      // NOTE: DO NOT add a newline at EOF.
+      _ = #^DIAG^#"foo\("bar
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot find ')' to match opening '(' in string interpolation
+        // TODO: Old parser expected error on line 2: unterminated string literal
+        DiagnosticSpec(message: "expected expression"),
+        DiagnosticSpec(message: #"extraneous '"foo\("bar' at top level"#),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/StringLiteralEof3Tests.swift
+++ b/Tests/SwiftParserTest/translated/StringLiteralEof3Tests.swift
@@ -1,0 +1,35 @@
+// This test file has been translated from swift/test/Parse/string_literal_eof3.swift
+
+import XCTest
+
+final class StringLiteralEof3Tests: XCTestCase {
+  func testStringLiteralEof31() {
+    AssertParse(
+      ##"""
+      _ = #^DIAG^#"foo \
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: unterminated string literal
+        // TODO: Old parser expected error on line 1: invalid escape sequence in literal
+        DiagnosticSpec(message: "expected expression"),
+        DiagnosticSpec(message: #"extraneous '"foo \' at top level"#),
+      ]
+    )
+  }
+
+  func testStringLiteralEof32() {
+    AssertParse(
+      ##"""
+      // NOTE: DO NOT add a newline at EOF.
+      _ = #^DIAG^#"foo \
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: unterminated string literal
+        // TODO: Old parser expected error on line 2: invalid escape sequence in literal
+        DiagnosticSpec(message: "expected expression"),
+        DiagnosticSpec(message: #"extraneous '"foo \' at top level"#),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/StringLiteralEof4Tests.swift
+++ b/Tests/SwiftParserTest/translated/StringLiteralEof4Tests.swift
@@ -1,0 +1,20 @@
+// This test file has been translated from swift/test/Parse/string_literal_eof4.swift
+
+import XCTest
+
+final class StringLiteralEof4Tests: XCTestCase {
+  func testStringLiteralEof41() {
+    AssertParse(
+      #"""
+      // NOTE: DO NOT add a newline at EOF.
+      _ = """
+          foo#^DIAG^#
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: unterminated string literal
+        DiagnosticSpec(message: #"expected '"""' to end string literal"#),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/StringLiteralEof5Tests.swift
+++ b/Tests/SwiftParserTest/translated/StringLiteralEof5Tests.swift
@@ -1,0 +1,23 @@
+// This test file has been translated from swift/test/Parse/string_literal_eof5.swift
+
+import XCTest
+
+final class StringLiteralEof5Tests: XCTestCase {
+  func testStringLiteralEof51() {
+    AssertParse(
+      ##"""
+      // NOTE: DO NOT add a newline at EOF.
+      _ = #^DIAG^#"""
+          foo
+          \(
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: unterminated string literal
+        DiagnosticSpec(message: "expected expression"),
+        DiagnosticSpec(message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 4: cannot find ')' to match opening '(' in string interpolation
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/StringLiteralEof6Tests.swift
+++ b/Tests/SwiftParserTest/translated/StringLiteralEof6Tests.swift
@@ -1,0 +1,23 @@
+// This test file has been translated from swift/test/Parse/string_literal_eof6.swift
+
+import XCTest
+
+final class StringLiteralEof6Tests: XCTestCase {
+  func testStringLiteralEof61() {
+    AssertParse(
+      ##"""
+      // NOTE: DO NOT add a newline at EOF.
+      _ = #^DIAG^#"""
+          foo
+          \("bar
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: unterminated string literal
+        DiagnosticSpec(message: "expected expression"),
+        DiagnosticSpec(message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 4: cannot find ')' to match opening '(' in string interpolation
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/StringLiteralEof7Tests.swift
+++ b/Tests/SwiftParserTest/translated/StringLiteralEof7Tests.swift
@@ -1,0 +1,24 @@
+// This test file has been translated from swift/test/Parse/string_literal_eof7.swift
+
+import XCTest
+
+final class StringLiteralEof7Tests: XCTestCase {
+  func testStringLiteralEof71() {
+    AssertParse(
+      ##"""
+      _ = #^DIAG^#"""
+          foo
+          \("bar
+          baz
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: unterminated string literal
+        DiagnosticSpec(message: "expected expression"),
+        DiagnosticSpec(message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 3: cannot find ')' to match opening '(' in string interpolation
+        // TODO: Old parser expected error on line 3: unterminated string literal
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/SubscriptingTests.swift
+++ b/Tests/SwiftParserTest/translated/SubscriptingTests.swift
@@ -1,0 +1,466 @@
+// This test file has been translated from swift/test/Parse/subscripting.swift
+
+import XCTest
+
+final class SubscriptingTests: XCTestCase {
+  func testSubscripting1() {
+    AssertParse(
+      """
+      struct X { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 1: did you mean
+      ]
+    )
+  }
+
+  func testSubscripting2() {
+    AssertParse(
+      """
+      // Simple examples
+      struct X1 {
+        var stored: Int
+        subscript(i: Int) -> Int {
+          get {
+            return stored
+          }
+          mutating
+          set {
+            stored = newValue
+          }
+        }
+      }
+      """
+    )
+  }
+
+  func testSubscripting3() {
+    AssertParse(
+      """
+      struct X2 {
+        var stored: Int
+        subscript(i: Int) -> Int {
+          get {
+            return stored + i
+          }
+          set(v) {
+            stored = v - i
+          }
+        }
+      }
+      """
+    )
+  }
+
+  func testSubscripting4() {
+    AssertParse(
+      """
+      struct X3 {
+        var stored: Int
+        subscript(_: Int) -> Int {
+          get {
+            return stored
+          }
+          set(v) {
+            stored = v
+          }
+        }
+      }
+      """
+    )
+  }
+
+  func testSubscripting5() {
+    AssertParse(
+      """
+      struct X4 {
+        var stored: Int
+        subscript(i: Int, j: Int) -> Int {
+          get {
+            return stored + i + j
+          }
+          mutating
+          set(v) {
+            stored = v + i - j
+          }
+        }
+      }
+      """
+    )
+  }
+
+  func testSubscripting6() {
+    AssertParse(
+      """
+      struct X5 {
+        static var stored: Int = 1
+        static subscript(i: Int) -> Int {
+          get {
+            return stored + i
+          }
+          set {
+            stored = newValue - i
+          }
+        }
+      }
+      """
+    )
+  }
+
+  func testSubscripting7() {
+    AssertParse(
+      """
+      class X6 {
+        static var stored: Int = 1
+        class subscript(i: Int) -> Int {
+          get {
+            return stored + i
+          }
+          set {
+            stored = newValue - i
+          }
+        }
+      }
+      """
+    )
+  }
+
+  func testSubscripting8() {
+    AssertParse(
+      """
+      struct Y1 {
+        var stored: Int
+        subscript(_: i, j: Int) -> Int { 
+          get {
+            return stored + j
+          }
+          set {
+            stored = j
+          }
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: cannot find type 'i' in scope
+      ]
+    )
+  }
+
+  func testSubscripting9() {
+    AssertParse(
+      """
+      // Mutating getters on constants
+      // https://github.com/apple/swift/issues/43457
+      """
+    )
+  }
+
+  func testSubscripting10() {
+    AssertParse(
+      """
+      struct Y2 {
+        subscript(_: Int) -> Int {
+          mutating get { return 0 }
+        }
+      }
+      """
+    )
+  }
+
+  func testSubscripting11() {
+    AssertParse(
+      """
+      // FIXME: This test case does not belong in Parse/
+      let y2 = Y2() 
+      _ = y2[0]
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 2: change 'let' to 'var' to make it mutable, Fix-It replacements: 1 - 4 = 'var'
+        // TODO: Old parser expected error on line 3: cannot use mutating getter on immutable value: 'y2' is a 'let' constant
+      ]
+    )
+  }
+
+  func testSubscripting12() {
+    AssertParse(
+      """
+      // Parsing errors
+      struct A0 {
+        subscript #^DIAG_1^#
+          i : #^DIAG_2^#Int#^DIAG_3^#
+           -> Int #^DIAG_4^#{
+          get {
+            return stored
+          }
+          set {
+            stored = value
+          }
+        }
+        subscript #^DIAG_5^#-> Int { 
+          return 1
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: expected '(' for subscript parameters
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '(' to start parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '(' to start function type"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected ')' in function type"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected '->' and return type in subscript"),
+        // TODO: Old parser expected error on line 13: expected '(' for subscript parameters, Fix-It replacements: 12 - 12 = '()'
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected argument list in function declaration"),
+      ]
+    )
+  }
+
+  func testSubscripting13() {
+    AssertParse(
+      """
+      struct A1 {
+        subscript (i : Int) #^DIAG_1^#
+           #^DIAG_2^#Int {
+          get {
+            return stored 
+          }
+          set {
+            stored = newValue
+          }
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '->' for subscript element type
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '->' and return type in subscript"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected declaration in struct"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text in struct"),
+        // TODO: Old parser expected error on line 5: cannot find 'stored' in scope
+        // TODO: Old parser expected error on line 8: cannot find 'stored' in scope
+      ]
+    )
+  }
+
+  func testSubscripting14() {
+    AssertParse(
+      """
+      struct A2 {
+        subscript (i : Int) -> #^DIAG^#
+           {
+          get {
+            return stored
+          }
+          set {
+            stored = newValue 
+          }
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected subscripting element type
+        DiagnosticSpec(message: "expected return type in subscript"),
+        // TODO: Old parser expected error on line 8: cannot find 'stored' in scope
+      ]
+    )
+  }
+
+  func testSubscripting15() {
+    AssertParse(
+      """
+      struct A3 {
+        subscript(i : Int) #^DIAG^#
+        {
+          get {
+            return i
+          }
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '->' for subscript element type
+        // TODO: Old parser expected error on line 2: expected subscripting element type
+        DiagnosticSpec(message: "expected '->' and return type in subscript"),
+      ]
+    )
+  }
+
+  func testSubscripting16() {
+    AssertParse(
+      """
+      struct A4 {
+        subscript(i : Int) #^DIAG^#{ 
+          get {
+            return i
+          }
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '->' for subscript element type
+        // TODO: Old parser expected error on line 2: expected subscripting element type
+        DiagnosticSpec(message: "expected '->' and return type in subscript"),
+      ]
+    )
+  }
+
+  func testSubscripting17() {
+    AssertParse(
+      """
+      struct A5 {
+        subscript(i : Int) -> Int 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '{' in subscript to specify getter and setter implementation
+      ]
+    )
+  }
+
+  func testSubscripting18() {
+    AssertParse(
+      """
+      struct A6 {
+        subscript(i: Int)#^DIAG^#(j: Int) -> Int { 
+          get {
+            return i + j 
+          }
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '->' for subscript element type
+        // TODO: Old parser expected error on line 2: function types cannot have argument labels
+        // TODO: Old parser expected note on line 2: did you mean
+        DiagnosticSpec(message: "expected '->' and return type in subscript"),
+        DiagnosticSpec(message: "expected declaration in struct"),
+        DiagnosticSpec(message: "unexpected text in struct"),
+        // TODO: Old parser expected error on line 4: cannot find 'j' in scope
+        // TODO: Old parser expected error on line 4: cannot convert return expression of type 'Int' to return type '(Int) -> Int'
+      ]
+    )
+  }
+
+  func testSubscripting19() {
+    AssertParse(
+      """
+      struct A7 {
+        class subscript(a: Float) -> Int { 
+          get {
+            return 42
+          }
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: class subscripts are only allowed within classes; use 'static' to declare a static subscript, Fix-It replacements: 3 - 8 = 'static'
+      ]
+    )
+  }
+
+  func testSubscripting20() {
+    AssertParse(
+      """
+      class A7b {
+        class static subscript(a: Float) -> Int { 
+          get {
+            return 42
+          }
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'static' cannot appear after another 'static' or 'class' keyword, Fix-It replacements: 9 - 16 = ''
+      ]
+    )
+  }
+
+  func testSubscripting21() {
+    AssertParse(
+      """
+      struct A8 {
+        subscript(i : Int) -> Int #^DIAG_1^#
+          #^DIAG_2^#get {
+            return stored
+          }
+          set {
+            stored = value
+          }
+        }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '{' in subscript to specify getter and setter implementation
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected declaration in struct"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text in struct"),
+      ]
+    )
+  }
+
+  func testSubscripting22() {
+    AssertParse(
+      """
+      struct A9 {
+        subscript #^DIAG^#x() -> Int { 
+          return 0
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: subscripts cannot have a name, Fix-It replacements: 13 - 14 = ''
+        DiagnosticSpec(message: "unexpected text 'x' before parameter clause"),
+      ]
+    )
+  }
+
+  func testSubscripting23() {
+    AssertParse(
+      """
+      struct A10 {
+        subscript #^DIAG_1^#x(i: Int) -> Int { 
+          return 0
+        }
+        subscript #^DIAG_2^#x<T>(i: T) -> Int { 
+          return 0
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: subscripts cannot have a name, Fix-It replacements: 13 - 14 = ''
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text 'x' before parameter clause"),
+        // TODO: Old parser expected error on line 5: subscripts cannot have a name, Fix-It replacements: 13 - 14 = ''
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text 'x<T>' before parameter clause"),
+      ]
+    )
+  }
+
+  func testSubscripting24() {
+    AssertParse(
+      """
+      struct A11 {
+        subscript #^DIAG_1^#x y : #^DIAG_2^#Int #^DIAG_3^#-> Int #^DIAG_4^#{ 
+          return 0
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '(' for subscript parameters
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '(' to start parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '(' to start function type"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected ')' in function type"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected '->' and return type in subscript"),
+      ]
+    )
+  }
+
+  func testSubscripting25() {
+    AssertParse(
+      """
+      #^DIAG^#}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: extraneous '}' at top level, Fix-It replacements: 1 - 3 = ''
+        DiagnosticSpec(message: "extraneous '}' at top level"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/SubscriptingTests.swift
+++ b/Tests/SwiftParserTest/translated/SubscriptingTests.swift
@@ -7,10 +7,7 @@ final class SubscriptingTests: XCTestCase {
     AssertParse(
       """
       struct X { }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 1: did you mean
-      ]
+      """
     )
   }
 
@@ -139,10 +136,7 @@ final class SubscriptingTests: XCTestCase {
           }
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: cannot find type 'i' in scope
-      ]
+      """
     )
   }
 
@@ -173,11 +167,7 @@ final class SubscriptingTests: XCTestCase {
       // FIXME: This test case does not belong in Parse/
       let y2 = Y2() 
       _ = y2[0]
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 2: change 'let' to 'var' to make it mutable, Fix-It replacements: 1 - 4 = 'var'
-        // TODO: Old parser expected error on line 3: cannot use mutating getter on immutable value: 'y2' is a 'let' constant
-      ]
+      """
     )
   }
 
@@ -329,12 +319,9 @@ final class SubscriptingTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 2: expected '->' for subscript element type
         // TODO: Old parser expected error on line 2: function types cannot have argument labels
-        // TODO: Old parser expected note on line 2: did you mean
         DiagnosticSpec(message: "expected '->' and return type in subscript"),
         DiagnosticSpec(message: "expected declaration in struct"),
         DiagnosticSpec(message: "unexpected text in struct"),
-        // TODO: Old parser expected error on line 4: cannot find 'j' in scope
-        // TODO: Old parser expected error on line 4: cannot convert return expression of type 'Int' to return type '(Int) -> Int'
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/SuperTests.swift
+++ b/Tests/SwiftParserTest/translated/SuperTests.swift
@@ -1,0 +1,139 @@
+// This test file has been translated from swift/test/Parse/super.swift
+
+import XCTest
+
+final class SuperTests: XCTestCase {
+  func testSuper1() {
+    AssertParse(
+      """
+      class B {
+        var foo: Int
+        func bar() {}
+        init() {} 
+        init(x: Int) {} 
+        subscript(x: Int) -> Int {
+          get {}
+          set {}
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 4: found this candidate
+        // TODO: Old parser expected note on line 5: found this candidate
+      ]
+    )
+  }
+
+  func testSuper2() {
+    AssertParse(
+      #"""
+      class D : B {
+        override init() {
+          super.init()
+          super.init(42)
+        }
+        override init(x:Int) {
+          let _: () -> B = super.init 
+        }
+        convenience init(y:Int) {
+          let _: () -> D = self.init 
+        }
+        init(z: Int) {
+          super
+            .init(x: z)
+        }
+        func super_calls() {
+          super.foo        
+          super.foo.bar    
+          super.bar        
+          super.bar()
+          // FIXME: should also say "'super.init' cannot be referenced outside of an initializer"
+          super.init 
+          super.init() 
+          super.init(0) 
+          super[0]        
+          super
+            .bar()
+        }
+        func bad_super_1() {
+          super.#^DIAG^#$0 
+        }
+        func bad_super_2() {
+          super(0) 
+        }
+        func bad_super_3() {
+          super 
+            [1]
+        }
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: missing argument label 'x:' in call
+        // TODO: Old parser expected error on line 7: cannot reference 'super.init' initializer chain as function value
+        // TODO: Old parser expected error on line 10: cannot reference 'self.init' initializer delegation as function value
+        // TODO: Old parser expected warning on line 17: property is accessed but result is unused
+        // TODO: Old parser expected error on line 18: value of type 'Int' has no member 'bar'
+        // TODO: Old parser expected error on line 19: function is unused
+        // TODO: Old parser expected error on line 22: no exact matches in reference to initializer
+        // TODO: Old parser expected error on line 23: 'super.init' cannot be called outside of an initializer
+        // TODO: Old parser expected error on line 24: missing argument label 'x:' in call
+        // TODO: Old parser expected error on line 24: 'super.init' cannot be called outside of an initializer
+        // TODO: Old parser expected warning on line 25: subscript is accessed but result is unused
+        // TODO: Old parser expected error on line 30: expected identifier or 'init'
+        DiagnosticSpec(message: "expected identifier in member access"),
+        // TODO: Old parser expected error on line 33: expected '.' or '[' after 'super'
+        // TODO: Old parser expected error on line 36: expected '.' or '[' after 'super'
+      ]
+    )
+  }
+
+  func testSuper3() {
+    AssertParse(
+      """
+      class Closures : B {
+        func captureWeak() {
+          let g = { [weak self] () -> Void in // expected-note * {{'self' explicitly captured here}}
+            super.foo() 
+          }
+          g()
+        }
+        func captureUnowned() {
+          let g = { [unowned self] () -> Void in // expected-note * {{'self' explicitly captured here}}
+            super.foo() 
+          }
+          g()
+        }
+        func nestedInner() {
+          let g = { () -> Void in
+            let h = { [weak self] () -> Void in // expected-note * {{'self' explicitly captured here}}
+              super.foo() 
+              nil ?? super.foo() 
+            }
+            h()
+          }
+          g()
+        }
+        func nestedOuter() {
+          let g = { [weak self] () -> Void in // expected-note * {{'self' explicitly captured here}}
+            let h = { () -> Void in
+              super.foo() 
+              nil ?? super.foo() 
+            }
+            h()
+          }
+          g()
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: using 'super' in a closure where 'self' is explicitly captured is not yet supported
+        // TODO: Old parser expected error on line 10: using 'super' in a closure where 'self' is explicitly captured is not yet supported
+        // TODO: Old parser expected error on line 17: using 'super' in a closure where 'self' is explicitly captured is not yet supported
+        // TODO: Old parser expected error on line 18: using 'super' in a closure where 'self' is explicitly captured is not yet supported
+        // TODO: Old parser expected error on line 27: using 'super' in a closure where 'self' is explicitly captured is not yet supported
+        // TODO: Old parser expected error on line 28: using 'super' in a closure where 'self' is explicitly captured is not yet supported
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/SuperTests.swift
+++ b/Tests/SwiftParserTest/translated/SuperTests.swift
@@ -16,11 +16,7 @@ final class SuperTests: XCTestCase {
           set {}
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 4: found this candidate
-        // TODO: Old parser expected note on line 5: found this candidate
-      ]
+      """
     )
   }
 
@@ -68,18 +64,6 @@ final class SuperTests: XCTestCase {
       }
       """#,
       diagnostics: [
-        // TODO: Old parser expected error on line 4: missing argument label 'x:' in call
-        // TODO: Old parser expected error on line 7: cannot reference 'super.init' initializer chain as function value
-        // TODO: Old parser expected error on line 10: cannot reference 'self.init' initializer delegation as function value
-        // TODO: Old parser expected warning on line 17: property is accessed but result is unused
-        // TODO: Old parser expected error on line 18: value of type 'Int' has no member 'bar'
-        // TODO: Old parser expected error on line 19: function is unused
-        // TODO: Old parser expected error on line 22: no exact matches in reference to initializer
-        // TODO: Old parser expected error on line 23: 'super.init' cannot be called outside of an initializer
-        // TODO: Old parser expected error on line 24: missing argument label 'x:' in call
-        // TODO: Old parser expected error on line 24: 'super.init' cannot be called outside of an initializer
-        // TODO: Old parser expected warning on line 25: subscript is accessed but result is unused
-        // TODO: Old parser expected error on line 30: expected identifier or 'init'
         DiagnosticSpec(message: "expected identifier in member access"),
         // TODO: Old parser expected error on line 33: expected '.' or '[' after 'super'
         // TODO: Old parser expected error on line 36: expected '.' or '[' after 'super'
@@ -124,15 +108,7 @@ final class SuperTests: XCTestCase {
           g()
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: using 'super' in a closure where 'self' is explicitly captured is not yet supported
-        // TODO: Old parser expected error on line 10: using 'super' in a closure where 'self' is explicitly captured is not yet supported
-        // TODO: Old parser expected error on line 17: using 'super' in a closure where 'self' is explicitly captured is not yet supported
-        // TODO: Old parser expected error on line 18: using 'super' in a closure where 'self' is explicitly captured is not yet supported
-        // TODO: Old parser expected error on line 27: using 'super' in a closure where 'self' is explicitly captured is not yet supported
-        // TODO: Old parser expected error on line 28: using 'super' in a closure where 'self' is explicitly captured is not yet supported
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/SwitchIncompleteTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchIncompleteTests.swift
@@ -12,8 +12,6 @@ final class SwitchIncompleteTests: XCTestCase {
       case 1:#^DIAG^#
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: switch must be exhaustive
-        // TODO: Old parser expected note on line 3: do you want to add a default clause?
         // TODO: Old parser expected note on line 3: to match this opening '{'
         DiagnosticSpec(message: "expected '}' to end 'switch' statement"),
         // TODO: Old parser expected error on line 5: expected '}' at end of 'switch' statement

--- a/Tests/SwiftParserTest/translated/SwitchIncompleteTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchIncompleteTests.swift
@@ -1,0 +1,24 @@
+// This test file has been translated from swift/test/Parse/switch_incomplete.swift
+
+import XCTest
+
+final class SwitchIncompleteTests: XCTestCase {
+  func testSwitchIncomplete1() {
+    AssertParse(
+      """
+      // <rdar://problem/15971438> Incomplete switch was parsing to an AST that
+      // triggered an assertion failure.
+      switch 1 { 
+      case 1:#^DIAG^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: switch must be exhaustive
+        // TODO: Old parser expected note on line 3: do you want to add a default clause?
+        // TODO: Old parser expected note on line 3: to match this opening '{'
+        DiagnosticSpec(message: "expected '}' to end 'switch' statement"),
+        // TODO: Old parser expected error on line 5: expected '}' at end of 'switch' statement
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/SwitchTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchTests.swift
@@ -1,0 +1,1483 @@
+// This test file has been translated from swift/test/Parse/switch.swift
+
+import XCTest
+
+final class SwitchTests: XCTestCase {
+  func testSwitch1() {
+    AssertParse(
+      """
+      // TODO: Implement tuple equality in the library.
+      // BLOCKED: <rdar://problem/13822406>
+      func ~= (x: (Int,Int), y: (Int,Int)) -> Bool {
+        return true
+      }
+      """
+    )
+  }
+
+  func testSwitch2() {
+    AssertParse(
+      """
+      func parseError1(x: Int) {
+        switch #^DIAG_1^#func #^DIAG_2^#{} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected expression in 'switch' statement
+        // TODO: Old parser expected error on line 2: expected identifier in function declaration
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression and '{}' to end 'switch' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected argument list in function declaration"),
+      ]
+    )
+  }
+
+  func testSwitch3() {
+    AssertParse(
+      """
+      func parseError2(x: Int) {
+        switch x #^DIAG_1^#
+      }#^DIAG_2^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '{' after 'switch' subject expression
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '{' in 'switch' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '}' to end function"),
+      ]
+    )
+  }
+
+  func testSwitch4() {
+    AssertParse(
+      """
+      func parseError3(x: Int) {
+        switch x {
+          case #^DIAG^#
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: expected pattern
+        // TODO: Old parser expected error on line 3: expected ':' after 'case'
+        DiagnosticSpec(message: "expected expression in pattern"),
+        DiagnosticSpec(message: "expected ':' in switch case"),
+      ]
+    )
+  }
+
+  func testSwitch5() {
+    AssertParse(
+      """
+      func parseError4(x: Int) {
+        switch x {
+        case var z where #^DIAG^#
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: expected expression for 'where' guard of 'case'
+        // TODO: Old parser expected error on line 3: expected ':' after 'case'
+        DiagnosticSpec(message: "expected expression in 'where' clause"),
+        DiagnosticSpec(message: "expected ':' in switch case"),
+      ]
+    )
+  }
+
+  func testSwitch6() {
+    AssertParse(
+      """
+      func parseError5(x: Int) {
+        switch x {
+        case let z #^DIAG^#
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: expected ':' after 'case'
+        // TODO: Old parser expected warning on line 3: immutable value 'z' was never used, Fix-It replacements: 8 - 13 = '_'
+        DiagnosticSpec(message: "expected ':' in switch case"),
+      ]
+    )
+  }
+
+  func testSwitch7() {
+    AssertParse(
+      """
+      func parseError6(x: Int) {
+        switch x {
+        default #^DIAG^#
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: expected ':' after 'default'
+        DiagnosticSpec(message: "expected ':' in switch case"),
+      ]
+    )
+  }
+
+  func testSwitch8() {
+    AssertParse(
+      """
+      var x: Int
+      """
+    )
+  }
+
+  func testSwitch9() {
+    AssertParse(
+      """
+      switch x {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'switch' statement body must have at least one 'case' or 'default' block
+      ]
+    )
+  }
+
+  func testSwitch10() {
+    AssertParse(
+      """
+      switch x {
+      case 0:
+        x = 0
+      // Multiple patterns per case
+      case 1, 2, 3:
+        x = 0
+      // 'where' guard
+      case _ where x % 2 == 0:
+        x = 1
+        x = 2
+        x = 3
+      case _ where x % 2 == 0,
+           _ where x % 3 == 0:
+        x = 1
+      case 10,
+           _ where x % 3 == 0:
+        x = 1
+      case _ where x % 2 == 0,
+           20:
+        x = 1
+      case var y where y % 2 == 0:
+        x = y + 1
+      case _ where 0: 
+        x = 0
+      default:
+        x = 1
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 23: type 'Int' cannot be used as a boolean; test for '!= 0' instead
+      ]
+    )
+  }
+
+  func testSwitch11() {
+    AssertParse(
+      """
+      // Multiple cases per case block
+      switch x { 
+      case 0: 
+      case 1:
+        x = 0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: switch must be exhaustive
+        // TODO: Old parser expected note on line 2: do you want to add a default clause?
+        // TODO: Old parser expected error on line 3: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 8 - 8 = ' break'
+      ]
+    )
+  }
+
+  func testSwitch12() {
+    AssertParse(
+      """
+      switch x {
+      case 0: 
+      default:
+        x = 0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 8 - 8 = ' break'
+      ]
+    )
+  }
+
+  func testSwitch13() {
+    AssertParse(
+      """
+      switch x { 
+      case 0:
+        x = 0
+      case 1: 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: do you want to add a default clause?
+        // TODO: Old parser expected error on line 4: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 8 - 8 = ' break'
+      ]
+    )
+  }
+
+  func testSwitch14() {
+    AssertParse(
+      """
+      switch x {
+      case 0:
+        x = 0
+      default: 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: 'default' label in a 'switch' must have at least one executable statement, Fix-It replacements: 9 - 9 = ' break'
+      ]
+    )
+  }
+
+  func testSwitch15() {
+    AssertParse(
+      """
+      switch x { 
+      case 0:#^DIAG^#
+        ; 
+      case 1:
+        x = 0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: do you want to add a default clause?
+        DiagnosticSpec(message: "expected expression in switch case"),
+        // TODO: Old parser expected error on line 3: ';' statements are not allowed, Fix-It replacements: 3 - 5 = ''
+      ]
+    )
+  }
+
+  func testSwitch16() {
+    AssertParse(
+      """
+      switch x {
+        #^DIAG^#x = 1 
+      default:
+        x = 0
+      case 0: 
+        x = 0
+      case 1:
+        x = 0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: all statements inside a switch must be covered by a 'case' or 'default'
+        DiagnosticSpec(message: "unexpected text 'x = 1' in switch case"),
+        // TODO: Old parser expected error on line 5: additional 'case' blocks cannot appear after the 'default' block of a 'switch'
+      ]
+    )
+  }
+
+  func testSwitch17() {
+    AssertParse(
+      """
+      switch x {
+      default:
+        x = 0
+      default: 
+        x = 0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: additional 'case' blocks cannot appear after the 'default' block of a 'switch'
+      ]
+    )
+  }
+
+  func testSwitch18() {
+    AssertParse(
+      """
+      switch x { 
+        #^DIAG^#x = 1 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'switch' statement body must have at least one 'case' or 'default' block
+        // TODO: Old parser expected error on line 2: all statements inside a switch must be covered by a 'case' or 'default'
+        DiagnosticSpec(message: "unexpected text 'x = 1' in 'switch' statement"),
+      ]
+    )
+  }
+
+  func testSwitch19() {
+    AssertParse(
+      """
+      switch x { 
+        #^DIAG^#x = 1 
+        x = 2
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'switch' statement body must have at least one 'case' or 'default' block
+        // TODO: Old parser expected error on line 2: all statements inside a switch must be covered by a 'case' or 'default'
+        DiagnosticSpec(message: "unexpected text in 'switch' statement"),
+      ]
+    )
+  }
+
+  func testSwitch20() {
+    AssertParse(
+      """
+      switch x {
+      default: 
+      case 0: 
+        x = 0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'default' label in a 'switch' must have at least one executable statement, Fix-It replacements: 9 - 9 = ' break'
+        // TODO: Old parser expected error on line 3: additional 'case' blocks cannot appear after the 'default' block of a 'switch'
+      ]
+    )
+  }
+
+  func testSwitch21() {
+    AssertParse(
+      """
+      switch x {
+      default: 
+      default: 
+        x = 0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'default' label in a 'switch' must have at least one executable statement, Fix-It replacements: 9 - 9 = ' break'
+        // TODO: Old parser expected error on line 3: additional 'case' blocks cannot appear after the 'default' block of a 'switch'
+      ]
+    )
+  }
+
+  func testSwitch22() {
+    AssertParse(
+      """
+      switch x { 
+      default #^DIAG^#where x == 0: 
+        x = 0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: do you want to add a default clause?
+        // TODO: Old parser expected error on line 2: 'default' cannot be used with a 'where' guard expression
+        DiagnosticSpec(message: "unexpected text 'where x == 0' in switch case"),
+      ]
+    )
+  }
+
+  func testSwitch23() {
+    AssertParse(
+      """
+      switch x { 
+      case 0: 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: do you want to add a default clause?
+        // TODO: Old parser expected error on line 2: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 8 - 8 = ' break'
+      ]
+    )
+  }
+
+  func testSwitch24() {
+    AssertParse(
+      """
+      switch x { 
+      case 0: 
+      case 1:
+        x = 0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: do you want to add a default clause?
+        // TODO: Old parser expected error on line 2: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 8 - 8 = ' break'
+      ]
+    )
+  }
+
+  func testSwitch25() {
+    AssertParse(
+      """
+      switch x { 
+      case 0:
+        x = 0
+      case 1: 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: do you want to add a default clause?
+        // TODO: Old parser expected error on line 4: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 8 - 8 = ' break'
+      ]
+    )
+  }
+
+  func testSwitch26() {
+    AssertParse(
+      """
+      #^DIAG^#case 0: 
+      var y = 0
+      default: 
+      var z = 1
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'case' label can only appear inside a 'switch' statement
+        DiagnosticSpec(message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 3: 'default' label can only appear inside a 'switch' statement
+      ]
+    )
+  }
+
+  func testSwitch27() {
+    AssertParse(
+      """
+      fallthrough
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'fallthrough' is only allowed inside a switch
+      ]
+    )
+  }
+
+  func testSwitch28() {
+    AssertParse(
+      """
+      switch x {
+      case 0:
+        fallthrough
+      case 1:
+        fallthrough
+      default:
+        fallthrough 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 7: 'fallthrough' without a following 'case' or 'default' block
+      ]
+    )
+  }
+
+  func testSwitch29() {
+    AssertParse(
+      """
+      // Fallthrough can transfer control anywhere within a case and can appear
+      // multiple times in the same case.
+      switch x {
+      case 0:
+        if true { fallthrough }
+        if false { fallthrough }
+        x += 1
+      default:
+        x += 1
+      }
+      """
+    )
+  }
+
+  func testSwitch30() {
+    AssertParse(
+      """
+      // Cases cannot contain 'var' bindings if there are multiple matching patterns
+      // attached to a block. They may however contain other non-binding patterns.
+      """
+    )
+  }
+
+  func testSwitch31() {
+    AssertParse(
+      """
+      var t = (1, 2)
+      """
+    )
+  }
+
+  func testSwitch32() {
+    AssertParse(
+      """
+      switch t {
+      case (var a, 2), (1, _): 
+        ()
+      case (_, 2), (var a, _): 
+        ()
+      case (var a, 2), (1, var b): 
+        ()
+      case (var a, 2): 
+      case (1, _):
+        ()
+      case (_, 2): 
+      case (1, var a): 
+        ()
+      case (var a, 2): 
+      case (1, var b): 
+        ()
+      case (1, let b): // let bindings expected-warning {{immutable value 'b' was never used; consider replacing with '_' or removing it}}
+        ()
+      case (_, 2), (let a, _): 
+        ()
+      // OK
+      case (_, 2), (1, _):
+        ()
+      case (_, var a), (_, var a): 
+        ()
+      case (var a, var b), (var b, var a): 
+        ()
+      case (_, 2): 
+      case (1, _):
+        ()
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'a' must be bound in every pattern
+        // TODO: Old parser expected warning on line 2: variable 'a' was never used; consider replacing with '_' or removing it
+        // TODO: Old parser expected error on line 4: 'a' must be bound in every pattern
+        // TODO: Old parser expected error on line 6: 'a' must be bound in every pattern
+        // TODO: Old parser expected error on line 6: 'b' must be bound in every pattern
+        // TODO: Old parser expected warning on line 6: variable 'a' was never used; consider replacing with '_' or removing it
+        // TODO: Old parser expected error on line 8: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 17 - 17 = ' break'
+        // TODO: Old parser expected warning on line 8: variable 'a' was never used; consider replacing with '_' or removing it
+        // TODO: Old parser expected error on line 11: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 13 - 13 = ' break'
+        // TODO: Old parser expected warning on line 12: variable 'a' was never used; consider replacing with '_' or removing it
+        // TODO: Old parser expected error on line 14: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 17 - 17 = ' break'
+        // TODO: Old parser expected warning on line 14: variable 'a' was never used; consider replacing with '_' or removing it
+        // TODO: Old parser expected warning on line 15: variable 'b' was never used; consider replacing with '_' or removing it
+        // TODO: Old parser expected error on line 19: 'a' must be bound in every pattern
+        // TODO: Old parser expected warning on line 19: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 24: variable 'a' was never used; consider replacing with '_' or removing it
+        // TODO: Old parser expected warning on line 24: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 24: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 26: variable 'a' was never used; consider replacing with '_' or removing it
+        // TODO: Old parser expected warning on line 26: variable 'b' was never used; consider replacing with '_' or removing it
+        // TODO: Old parser expected warning on line 26: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected warning on line 26: case is already handled by previous patterns; consider removing it
+        // TODO: Old parser expected error on line 28: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 13 - 13 = ' break'
+      ]
+    )
+  }
+
+  func testSwitch33() {
+    AssertParse(
+      """
+      func patternVarUsedInAnotherPattern(x: Int) {
+        switch x {
+        case let a, 
+             value: 
+          break
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: 'a' must be bound in every pattern
+        // TODO: Old parser expected error on line 4: cannot find 'value' in scope
+      ]
+    )
+  }
+
+  func testSwitch34() {
+    AssertParse(
+      """
+      // Fallthroughs can only transfer control into a case label with bindings if the previous case binds a superset of those vars.
+      switch t {
+      case (1, 2):
+        fallthrough 
+      case (var a, var b): 
+        t = (b, a)
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: 'fallthrough' from a case which doesn't bind variable 'a'
+        // TODO: Old parser expected error on line 4: 'fallthrough' from a case which doesn't bind variable 'b'
+        // TODO: Old parser expected warning on line 5: variable 'a' was never mutated; consider changing to 'let' constant
+        // TODO: Old parser expected warning on line 5: variable 'b' was never mutated; consider changing to 'let' constant
+      ]
+    )
+  }
+
+  func testSwitch35() {
+    AssertParse(
+      """
+      switch t { // specifically notice on next line that we shouldn't complain that a is unused - just never mutated
+      case (var a, let b): 
+        t = (b, b)
+        fallthrough // ok - notice that subset of bound variables falling through is fine
+      case (2, let a):
+        t = (a, a)
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 2: variable 'a' was never mutated; consider changing to 'let' constant
+      ]
+    )
+  }
+
+  func testSwitch36() {
+    AssertParse(
+      """
+      func patternVarDiffType(x: Int, y: Double) {
+        switch (x, y) {
+        case (1, let a): 
+          fallthrough
+        case (let a, _):
+          break
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: pattern variable bound to type 'Double', fallthrough case bound to type 'Int'
+      ]
+    )
+  }
+
+  func testSwitch37() {
+    AssertParse(
+      """
+      func patternVarDiffMutability(x: Int, y: Double) {
+        switch x {
+        case let a where a < 5, var a where a > 10: 
+          break
+        default:
+          break
+        }
+        switch (x, y) {
+        // Would be nice to have a fixit in the following line if we detect that all bindings in the same pattern have the same problem.
+        case let (a, b) where a < 5, var (a, b) where a > 10: // expected-error 2{{'var' pattern binding must match previous 'let' pattern binding}}{{none}}
+          break
+        case (let a, var b) where a < 5, (let a, let b) where a > 10: 
+          break
+        case (let a, let b) where a < 5, (var a, let b) where a > 10, (let a, var b) where a == 8:
+          break
+        default:
+          break
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: 'var' pattern binding must match previous 'let' pattern binding, Fix-It replacements: 27 - 30 = 'let'
+        // TODO: Old parser expected error on line 12: 'let' pattern binding must match previous 'var' pattern binding, Fix-It replacements: 44 - 47 = 'var'
+        // TODO: Old parser expected error on line 14: 'var' pattern binding must match previous 'let' pattern binding, Fix-It replacements: 37 - 40 = 'let'
+        // TODO: Old parser expected error on line 14: 'var' pattern binding must match previous 'let' pattern binding, Fix-It replacements: 73 - 76 = 'let'
+      ]
+    )
+  }
+
+  func testSwitch38() {
+    AssertParse(
+      """
+      func test_label(x : Int) {
+      Gronk: 
+        switch x {
+        case 42: return
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: switch must be exhaustive
+        // TODO: Old parser expected note on line 2: do you want to add a default clause?
+      ]
+    )
+  }
+
+  func testSwitch39() {
+    AssertParse(
+      """
+      func enumElementSyntaxOnTuple() {
+        switch (1, 1) {
+        case .Bar: 
+          break
+        default:
+          break
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: value of tuple type '(Int, Int)' has no member 'Bar'
+      ]
+    )
+  }
+
+  func testSwitch40() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/42798
+      enum Whatever { case Thing }
+      func f0(values: [Whatever]) { 
+          switch value { 
+          case .Thing: // Ok. Don't emit diagnostics about enum case not found in type <<error type>>.
+              break
+          }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 3: 'values' declared here
+        // TODO: Old parser expected error on line 4: cannot find 'value' in scope; did you mean 'values'?
+      ]
+    )
+  }
+
+  func testSwitch41() {
+    AssertParse(
+      #"""
+      // https://github.com/apple/swift/issues/43334
+      // https://github.com/apple/swift/issues/43335
+      enum Whichever {
+        case Thing
+        static let title = "title"
+        static let alias: Whichever = .Thing
+      }
+      func f1(x: String, y: Whichever) {
+        switch x {
+          case Whichever.title: // Ok. Don't emit diagnostics for static member of enum.
+              break
+          case Whichever.buzz: 
+              break
+          case Whichever.alias: 
+          default:
+            break
+        }
+        switch y {
+          case Whichever.Thing: // Ok.
+              break
+          case Whichever.alias: // Ok. Don't emit diagnostics for static member of enum.
+              break
+          case Whichever.title: 
+              break
+        }
+        switch y {
+          case .alias:
+            break
+          default:
+            break
+        }
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 12: type 'Whichever' has no member 'buzz'
+        // TODO: Old parser expected error on line 14: expression pattern of type 'Whichever' cannot match values of type 'String'
+        // TODO: Old parser expected note on line 14: overloads for '~=' exist
+        // TODO: Old parser expected error on line 14: 'case' label in a 'switch' must have at least one executable statement
+        // TODO: Old parser expected error on line 23: expression pattern of type 'String' cannot match values of type 'Whichever'
+      ]
+    )
+  }
+
+  func testSwitch42() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      case .Thing: 
+      @unknown case _:
+        x = 0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 13 - 13 = ' break'
+      ]
+    )
+  }
+
+  func testSwitch43() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      case .Thing: 
+      @unknown default:
+        x = 0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 13 - 13 = ' break'
+      ]
+    )
+  }
+
+  func testSwitch44() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      case .Thing:
+        x = 0
+      @unknown case _: 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 17 - 17 = ' break'
+      ]
+    )
+  }
+
+  func testSwitch45() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      case .Thing:
+        x = 0
+      @unknown default: 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: 'default' label in a 'switch' must have at least one executable statement, Fix-It replacements: 18 - 18 = ' break'
+      ]
+    )
+  }
+
+  func testSwitch46() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      @unknown default:
+        x = 0
+      default: 
+        x = 0
+      case .Thing:
+        x = 0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: additional 'case' blocks cannot appear after the 'default' block of a 'switch'
+      ]
+    )
+  }
+
+  func testSwitch47() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      default:
+        x = 0
+      @unknown case _: 
+        x = 0
+      case .Thing:
+        x = 0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: additional 'case' blocks cannot appear after the 'default' block of a 'switch'
+        // TODO: Old parser expected error on line 4: '@unknown' can only be applied to the last case in a switch
+      ]
+    )
+  }
+
+  func testSwitch48() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      default:
+        x = 0
+      @unknown default: 
+        x = 0
+      case .Thing:
+        x = 0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: additional 'case' blocks cannot appear after the 'default' block of a 'switch'
+      ]
+    )
+  }
+
+  func testSwitch49() {
+    AssertParse(
+      """
+      switch Whatever.Thing { 
+      @unknown default #^DIAG^#where x == 0: 
+        x = 0
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: add missing case: '.Thing'
+        // TODO: Old parser expected error on line 2: 'default' cannot be used with a 'where' guard expression
+        DiagnosticSpec(message: "unexpected text 'where x == 0' in switch case"),
+      ]
+    )
+  }
+
+  func testSwitch50() {
+    AssertParse(
+      """
+      switch Whatever.Thing { 
+      @unknown case _:
+        fallthrough 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: add missing case: '.Thing'
+        // TODO: Old parser expected error on line 3: 'fallthrough' without a following 'case' or 'default' block
+      ]
+    )
+  }
+
+  func testSwitch51() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      @unknown case _: 
+        fallthrough
+      case .Thing:
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '@unknown' can only be applied to the last case in a switch
+      ]
+    )
+  }
+
+  func testSwitch52() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      @unknown default:
+        fallthrough
+      case .Thing: 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: additional 'case' blocks cannot appear after the 'default' block of a 'switch'
+      ]
+    )
+  }
+
+  func testSwitch53() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      @unknown case _, _: 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '@unknown' cannot be applied to multiple patterns
+      ]
+    )
+  }
+
+  func testSwitch54() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      @unknown case _, _, _: 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '@unknown' cannot be applied to multiple patterns
+      ]
+    )
+  }
+
+  func testSwitch55() {
+    AssertParse(
+      """
+      switch Whatever.Thing { 
+      @unknown case let value: 
+        _ = value
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: add missing case: '.Thing'
+        // TODO: Old parser expected error on line 2: '@unknown' is only supported for catch-all cases ("case _")
+      ]
+    )
+  }
+
+  func testSwitch56() {
+    AssertParse(
+      """
+      switch (Whatever.Thing, Whatever.Thing) { 
+      @unknown case (_, _): 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: add missing case: '(_, _)'
+        // TODO: Old parser expected error on line 2: '@unknown' is only supported for catch-all cases ("case _")
+      ]
+    )
+  }
+
+  func testSwitch57() {
+    AssertParse(
+      """
+      switch Whatever.Thing { 
+      @unknown case is Whatever: 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: add missing case: '.Thing'
+        // TODO: Old parser expected error on line 2: '@unknown' is only supported for catch-all cases ("case _")
+        // TODO: Old parser expected warning on line 2: 'is' test is always true
+      ]
+    )
+  }
+
+  func testSwitch58() {
+    AssertParse(
+      """
+      switch Whatever.Thing { 
+      @unknown case .Thing: 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: add missing case: '.Thing'
+        // TODO: Old parser expected error on line 2: '@unknown' is only supported for catch-all cases ("case _")
+      ]
+    )
+  }
+
+  func testSwitch59() {
+    AssertParse(
+      """
+      switch Whatever.Thing { 
+      @unknown case (_): // okay
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: add missing case: '.Thing'
+      ]
+    )
+  }
+
+  func testSwitch60() {
+    AssertParse(
+      """
+      switch Whatever.Thing { 
+      @unknown case _ where x == 0: 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: add missing case: '.Thing'
+        // TODO: Old parser expected error on line 2: 'where' cannot be used with '@unknown'
+      ]
+    )
+  }
+
+  func testSwitch61() {
+    AssertParse(
+      """
+      switch Whatever.Thing { 
+      @unknown default #^DIAG^#where x == 0: 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 1: add missing case: '.Thing'
+        // TODO: Old parser expected error on line 2: 'default' cannot be used with a 'where' guard expression
+        DiagnosticSpec(message: "unexpected text 'where x == 0' in switch case"),
+      ]
+    )
+  }
+
+  func testSwitch62() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      case .Thing:
+        x = 0
+      #if true
+      @unknown case _:
+        x = 0
+      #endif
+      }
+      """
+    )
+  }
+
+  func testSwitch63() {
+    AssertParse(
+      """
+      switch x {
+      case 0:
+        break
+      @garbage case _: 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: unknown attribute 'garbage'
+      ]
+    )
+  }
+
+  func testSwitch64() {
+    AssertParse(
+      """
+      switch x {
+      case 0:
+        break
+      @garbage @moreGarbage default: 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: unknown attribute 'garbage'
+        // TODO: Old parser expected error on line 4: unknown attribute 'moreGarbage'
+      ]
+    )
+  }
+
+  func testSwitch65() {
+    AssertParse(
+      """
+      @unknown let _ = 1
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: unknown attribute 'unknown'
+      ]
+    )
+  }
+
+  func testSwitch66() {
+    AssertParse(
+      """
+      switch x {
+      case _:
+        @unknown let _ = 1 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: unknown attribute 'unknown'
+      ]
+    )
+  }
+
+  func testSwitch67() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      case .Thing:
+        break
+      @unknown#^DIAG_1^#(garbage) case _: 
+        break
+      }
+      switch Whatever.Thing {
+      case .Thing:
+        break
+      @unknown 
+      @unknown 
+      case _:
+        break
+      }
+      switch Whatever.Thing { 
+      @unknown @garbage#^DIAG_2^#(foobar) 
+      case _:
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: unexpected '(' in attribute 'unknown'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '(garbage)' in switch case"),
+        // TODO: Old parser expected note on line 10: attribute already specified here
+        // TODO: Old parser expected error on line 11: duplicate attribute
+        // TODO: Old parser expected warning on line 15: switch must be exhaustive
+        // TODO: Old parser expected note on line 15: add missing case: '.Thing'
+        // TODO: Old parser expected error on line 16: unknown attribute 'garbage'
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '(foobar)' in switch case"),
+      ]
+    )
+  }
+
+  func testSwitch68() {
+    AssertParse(
+      """
+      switch x { 
+      case 1:
+        break
+      @unknown case _: 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 4: remove '@unknown' to handle remaining values, Fix-It replacements: 1 - 10 = ''
+      ]
+    )
+  }
+
+  func testSwitch69() {
+    AssertParse(
+      """
+      switch x { 
+      @unknown case _: 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 2: remove '@unknown' to handle remaining values, Fix-It replacements: 1 - 10 = ''
+      ]
+    )
+  }
+
+  func testSwitch70() {
+    AssertParse(
+      """
+      switch x { 
+      @unknown default: 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: switch must be exhaustive
+        // TODO: Old parser expected note on line 2: remove '@unknown' to handle remaining values, Fix-It replacements: 1 - 10 = ''
+      ]
+    )
+  }
+
+  func testSwitch71() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      case .Thing:
+        break
+      @unknown case _: 
+        break
+      @unknown case _:
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: '@unknown' can only be applied to the last case in a switch
+      ]
+    )
+  }
+
+  func testSwitch72() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      case .Thing:
+        break
+      @unknown case _: 
+        break
+      @unknown default:
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: '@unknown' can only be applied to the last case in a switch
+      ]
+    )
+  }
+
+  func testSwitch73() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      case .Thing:
+        break
+      @unknown default:
+        break
+      @unknown default: 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 6: additional 'case' blocks cannot appear after the 'default' block of a 'switch'
+      ]
+    )
+  }
+
+  func testSwitch74() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      @unknown case _: 
+        break
+      @unknown case _:
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '@unknown' can only be applied to the last case in a switch
+      ]
+    )
+  }
+
+  func testSwitch75() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      @unknown case _: 
+        break
+      @unknown default:
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '@unknown' can only be applied to the last case in a switch
+      ]
+    )
+  }
+
+  func testSwitch76() {
+    AssertParse(
+      """
+      switch Whatever.Thing {
+      @unknown default:
+        break
+      @unknown default: 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: additional 'case' blocks cannot appear after the 'default' block of a 'switch'
+      ]
+    )
+  }
+
+  func testSwitch77() {
+    AssertParse(
+      """
+      switch x {
+      @unknown case _: 
+        break
+      @unknown case _:
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '@unknown' can only be applied to the last case in a switch
+      ]
+    )
+  }
+
+  func testSwitch78() {
+    AssertParse(
+      """
+      switch x {
+      @unknown case _: 
+        break
+      @unknown default:
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '@unknown' can only be applied to the last case in a switch
+      ]
+    )
+  }
+
+  func testSwitch79() {
+    AssertParse(
+      """
+      switch x {
+      @unknown default:
+        break
+      @unknown default: 
+        break
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: additional 'case' blocks cannot appear after the 'default' block of a 'switch'
+      ]
+    )
+  }
+
+  func testSwitch80() {
+    AssertParse(
+      """
+      func testReturnBeforeUnknownDefault() {
+        switch x { 
+        case 1:
+          return#^DIAG^#
+        @unknown default: 
+          break
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: switch must be exhaustive
+        DiagnosticSpec(message: "expected expression in 'return' statement"),
+        // TODO: Old parser expected note on line 5: remove '@unknown' to handle remaining values
+      ]
+    )
+  }
+
+  func testSwitch81() {
+    AssertParse(
+      """
+      func testReturnBeforeIncompleteUnknownDefault() {
+        switch x { 
+        case 1:
+          return#^DIAG_1^#
+        @unknown default #^DIAG_2^#
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: switch must be exhaustive
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in 'return' statement"),
+        // TODO: Old parser expected error on line 5: expected ':' after 'default'
+        // TODO: Old parser expected note on line 5: remove '@unknown' to handle remaining values
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ':' in switch case"),
+      ]
+    )
+  }
+
+  func testSwitch82() {
+    AssertParse(
+      """
+      func testReturnBeforeIncompleteUnknownDefault2() {
+        switch x { 
+        case 1:
+          return
+        @unknown #^DIAG^#
+        } 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: switch must be exhaustive
+        // TODO: Old parser expected note on line 2: do you want to add a default clause?
+        // TODO: Old parser expected error on line 5: unknown attribute 'unknown'
+        DiagnosticSpec(message: "expected declaration after attribute in switch case"),
+        // TODO: Old parser expected error on line 6: expected declaration
+      ]
+    )
+  }
+
+  func testSwitch83() {
+    AssertParse(
+      """
+      func testIncompleteArrayLiteral() {
+        switch x { 
+        case 1:
+          _ = [1 #^DIAG^#
+        @unknown default: 
+          ()
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: switch must be exhaustive
+        // TODO: Old parser expected error on line 4: expected ']' in container literal expression
+        // TODO: Old parser expected note on line 4: to match this opening '['
+        DiagnosticSpec(message: "expected ']' to end array"),
+        // TODO: Old parser expected note on line 5: remove '@unknown' to handle remaining values
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/SwitchTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchTests.swift
@@ -94,7 +94,6 @@ final class SwitchTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 3: expected ':' after 'case'
-        // TODO: Old parser expected warning on line 3: immutable value 'z' was never used, Fix-It replacements: 8 - 13 = '_'
         DiagnosticSpec(message: "expected ':' in switch case"),
       ]
     )
@@ -165,10 +164,7 @@ final class SwitchTests: XCTestCase {
       default:
         x = 1
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 23: type 'Int' cannot be used as a boolean; test for '!= 0' instead
-      ]
+      """
     )
   }
 
@@ -183,8 +179,6 @@ final class SwitchTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: switch must be exhaustive
-        // TODO: Old parser expected note on line 2: do you want to add a default clause?
         // TODO: Old parser expected error on line 3: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 8 - 8 = ' break'
       ]
     )
@@ -215,8 +209,6 @@ final class SwitchTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: switch must be exhaustive
-        // TODO: Old parser expected note on line 1: do you want to add a default clause?
         // TODO: Old parser expected error on line 4: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 8 - 8 = ' break'
       ]
     )
@@ -248,8 +240,6 @@ final class SwitchTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: switch must be exhaustive
-        // TODO: Old parser expected note on line 1: do you want to add a default clause?
         DiagnosticSpec(message: "expected expression in switch case"),
         // TODO: Old parser expected error on line 3: ';' statements are not allowed, Fix-It replacements: 3 - 5 = ''
       ]
@@ -365,8 +355,6 @@ final class SwitchTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: switch must be exhaustive
-        // TODO: Old parser expected note on line 1: do you want to add a default clause?
         // TODO: Old parser expected error on line 2: 'default' cannot be used with a 'where' guard expression
         DiagnosticSpec(message: "unexpected text 'where x == 0' in switch case"),
       ]
@@ -381,8 +369,6 @@ final class SwitchTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: switch must be exhaustive
-        // TODO: Old parser expected note on line 1: do you want to add a default clause?
         // TODO: Old parser expected error on line 2: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 8 - 8 = ' break'
       ]
     )
@@ -398,8 +384,6 @@ final class SwitchTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: switch must be exhaustive
-        // TODO: Old parser expected note on line 1: do you want to add a default clause?
         // TODO: Old parser expected error on line 2: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 8 - 8 = ' break'
       ]
     )
@@ -415,8 +399,6 @@ final class SwitchTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: switch must be exhaustive
-        // TODO: Old parser expected note on line 1: do you want to add a default clause?
         // TODO: Old parser expected error on line 4: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 8 - 8 = ' break'
       ]
     )
@@ -537,28 +519,9 @@ final class SwitchTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: 'a' must be bound in every pattern
-        // TODO: Old parser expected warning on line 2: variable 'a' was never used; consider replacing with '_' or removing it
-        // TODO: Old parser expected error on line 4: 'a' must be bound in every pattern
-        // TODO: Old parser expected error on line 6: 'a' must be bound in every pattern
-        // TODO: Old parser expected error on line 6: 'b' must be bound in every pattern
-        // TODO: Old parser expected warning on line 6: variable 'a' was never used; consider replacing with '_' or removing it
         // TODO: Old parser expected error on line 8: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 17 - 17 = ' break'
-        // TODO: Old parser expected warning on line 8: variable 'a' was never used; consider replacing with '_' or removing it
         // TODO: Old parser expected error on line 11: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 13 - 13 = ' break'
-        // TODO: Old parser expected warning on line 12: variable 'a' was never used; consider replacing with '_' or removing it
         // TODO: Old parser expected error on line 14: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 17 - 17 = ' break'
-        // TODO: Old parser expected warning on line 14: variable 'a' was never used; consider replacing with '_' or removing it
-        // TODO: Old parser expected warning on line 15: variable 'b' was never used; consider replacing with '_' or removing it
-        // TODO: Old parser expected error on line 19: 'a' must be bound in every pattern
-        // TODO: Old parser expected warning on line 19: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 24: variable 'a' was never used; consider replacing with '_' or removing it
-        // TODO: Old parser expected warning on line 24: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 24: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 26: variable 'a' was never used; consider replacing with '_' or removing it
-        // TODO: Old parser expected warning on line 26: variable 'b' was never used; consider replacing with '_' or removing it
-        // TODO: Old parser expected warning on line 26: case is already handled by previous patterns; consider removing it
-        // TODO: Old parser expected warning on line 26: case is already handled by previous patterns; consider removing it
         // TODO: Old parser expected error on line 28: 'case' label in a 'switch' must have at least one executable statement, Fix-It replacements: 13 - 13 = ' break'
       ]
     )
@@ -574,11 +537,7 @@ final class SwitchTests: XCTestCase {
           break
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: 'a' must be bound in every pattern
-        // TODO: Old parser expected error on line 4: cannot find 'value' in scope
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/ToplevelLibraryInvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/ToplevelLibraryInvalidTests.swift
@@ -15,13 +15,9 @@ final class ToplevelLibraryInvalidTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: expressions are not allowed at the top level
-        // TODO: Old parser expected warning on line 2: result of operator '+' is unused
         // TODO: Old parser expected error on line 3: expressions are not allowed at the top level
-        // TODO: Old parser expected warning on line 3: result of operator '+' is unused
         // TODO: Old parser expected error on line 5: expressions are not allowed at the top level
-        // TODO: Old parser expected error on line 5: function is unused
         // TODO: Old parser expected error on line 6: expressions are not allowed at the top level
-        // TODO: Old parser expected warning on line 6: result of call to closure returning 'Int' is unused
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/ToplevelLibraryInvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/ToplevelLibraryInvalidTests.swift
@@ -1,0 +1,44 @@
+// This test file has been translated from swift/test/Parse/toplevel_library_invalid.swift
+
+import XCTest
+
+final class ToplevelLibraryInvalidTests: XCTestCase {
+  func testToplevelLibraryInvalid1() {
+    AssertParse(
+      """
+      let x = 42
+      x + x; 
+      x + x; 
+      // Make sure we don't crash on closures at the top level
+      ({ }) 
+      ({ 5 }())
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expressions are not allowed at the top level
+        // TODO: Old parser expected warning on line 2: result of operator '+' is unused
+        // TODO: Old parser expected error on line 3: expressions are not allowed at the top level
+        // TODO: Old parser expected warning on line 3: result of operator '+' is unused
+        // TODO: Old parser expected error on line 5: expressions are not allowed at the top level
+        // TODO: Old parser expected error on line 5: function is unused
+        // TODO: Old parser expected error on line 6: expressions are not allowed at the top level
+        // TODO: Old parser expected warning on line 6: result of call to closure returning 'Int' is unused
+      ]
+    )
+  }
+
+  func testToplevelLibraryInvalid2() {
+    AssertParse(
+      """
+      for i#^DIAG^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected 'in' after for-each pattern
+        // TODO: Old parser expected error on line 1: expected Sequence expression for for-each loop
+        // TODO: Old parser expected error on line 1: expected '{' to start the body of for-each loop
+        DiagnosticSpec(message: "expected 'in' and expression in 'for' statement"),
+        DiagnosticSpec(message: "expected code block in 'for' statement"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/ToplevelLibraryTests.swift
+++ b/Tests/SwiftParserTest/translated/ToplevelLibraryTests.swift
@@ -1,0 +1,15 @@
+// This test file has been translated from swift/test/Parse/toplevel_library.swift
+
+import XCTest
+
+final class ToplevelLibraryTests: XCTestCase {
+  func testToplevelLibrary1() {
+    AssertParse(
+      """
+      // make sure trailing semicolons are valid syntax in toplevel library code.
+      var x = 4;
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
+++ b/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
@@ -125,10 +125,7 @@ final class TrailingClosuresTests: XCTestCase {
         duration: Int,
         animations: (() -> Void)? = nil,
         completion: (() -> Void)? = nil) {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 1: declared here
-      ]
+      """
     )
   }
 
@@ -136,10 +133,7 @@ final class TrailingClosuresTests: XCTestCase {
     AssertParse(
       """
       multiple_trailing_with_defaults(duration: 42) {}
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: backward matching of the unlabeled trailing closure is deprecated; label the argument with 'completion' to suppress this warning
-      ]
+      """
     )
   }
 
@@ -171,13 +165,8 @@ final class TrailingClosuresTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 4: missing argument label 'g:' in call, Fix-It replacements: 9 - 10 = 'g'
         // TODO: Old parser expected error on line 5: editor placeholder in source file
         DiagnosticSpec(message: "unexpected text ': <#T##() -> Void#>' before function"),
-        // TODO: Old parser expected note on line 9: 'mixed_args_2(_:a:_:)' declared here
-        // TODO: Old parser expected error on line 11: extraneous argument label 'a:' in call, Fix-It replacements: 19 - 20 = '_'
-        // TODO: Old parser expected error on line 13: missing argument for parameter 'a' in call, Fix-It replacements: 18 - 18 = ' a: <#() -> Void#>'
-        // TODO: Old parser expected error on line 14: missing argument label 'a:' in call, Fix-It replacements: 19 - 20 = 'a'
       ]
     )
   }
@@ -193,13 +182,10 @@ final class TrailingClosuresTests: XCTestCase {
       _ = produce { 2 } `default`: { 3 }
       """,
       diagnostics: [
-        // TODO: Old parser expected note on line 1: declared here
-        // TODO: Old parser expected error on line 5: missing argument for parameter 'default' in call
         // TODO: Old parser expected error on line 5: consecutive statements
         // TODO: Old parser expected error on line 5: 'default' label can only appear inside a 'switch' statement
         DiagnosticSpec(message: "extraneous code at top level"),
         // TODO: Old parser expected error on line 6: labeled block needs 'do'
-        // TODO: Old parser expected warning on line 6: integer literal is unused
       ]
     )
   }
@@ -222,10 +208,7 @@ final class TrailingClosuresTests: XCTestCase {
               3
           }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: extra trailing closure passed in call
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
+++ b/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
@@ -1,0 +1,232 @@
+// This test file has been translated from swift/test/Parse/trailing_closures.swift
+
+import XCTest
+
+final class TrailingClosuresTests: XCTestCase {
+  func testTrailingClosures1() {
+    AssertParse(
+      """
+      func foo<T, U>(a: () -> T, b: () -> U) {}
+      """
+    )
+  }
+
+  func testTrailingClosures2() {
+    AssertParse(
+      #"""
+      foo { 42 }
+      b: { "" }
+      """#
+    )
+  }
+
+  func testTrailingClosures3() {
+    AssertParse(
+      #"""
+      foo { 42 } b: { "" }
+      """#
+    )
+  }
+
+  func testTrailingClosures4() {
+    AssertParse(
+      """
+      func when<T>(_ condition: @autoclosure () -> Bool,
+                   `then` trueBranch: () -> T,
+                   `else` falseBranch: () -> T) -> T {
+        return condition() ? trueBranch() : falseBranch()
+      }
+      """
+    )
+  }
+
+  func testTrailingClosures5() {
+    AssertParse(
+      """
+      let _ = when (2 < 3) { 3 } else: { 4 }
+      """
+    )
+  }
+
+  func testTrailingClosures6() {
+    AssertParse(
+      """
+      struct S {
+        static func foo(a: Int = 42, b: (inout Int) -> Void) -> S {
+          return S()
+        }
+        static func foo(a: Int = 42, ab: () -> Void, b: (inout Int) -> Void) -> S {
+          return S()
+        }
+        subscript(v v: () -> Int) -> Int {
+          get { return v() }
+        }
+        subscript(u u: () -> Int, v v: () -> Int) -> Int {
+          get { return u() + v() }
+        }
+        subscript(cond: Bool, v v: () -> Int) -> Int {
+          get { return cond ? 0 : v() }
+        }
+        subscript(cond: Bool, u u: () -> Int, v v: () -> Int) -> Int {
+          get { return cond ? u() : v() }
+        }
+      }
+      """
+    )
+  }
+
+  func testTrailingClosures7() {
+    AssertParse(
+      """
+      let _: S = .foo {
+        $0 = $0 + 1
+      }
+      """
+    )
+  }
+
+  func testTrailingClosures8() {
+    AssertParse(
+      """
+      let _: S = .foo {} b: { $0 = $0 + 1 }
+      """
+    )
+  }
+
+  func testTrailingClosures9() {
+    AssertParse(
+      """
+      func bar(_ s: S) {
+        _ = s[] {
+          42
+        }
+        _ = s[] {
+          21
+        } v: {
+          42
+        }
+        _ = s[true] {
+          42
+        }
+        _ = s[true] {
+          21
+        } v: {
+          42
+        }
+      }
+      """
+    )
+  }
+
+  func testTrailingClosures10() {
+    AssertParse(
+      """
+      func multiple_trailing_with_defaults( 
+        duration: Int,
+        animations: (() -> Void)? = nil,
+        completion: (() -> Void)? = nil) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 1: declared here
+      ]
+    )
+  }
+
+  func testTrailingClosures11() {
+    AssertParse(
+      """
+      multiple_trailing_with_defaults(duration: 42) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: backward matching of the unlabeled trailing closure is deprecated; label the argument with 'completion' to suppress this warning
+      ]
+    )
+  }
+
+  func testTrailingClosures12() {
+    AssertParse(
+      """
+      multiple_trailing_with_defaults(duration: 42) {} completion: {}
+      """
+    )
+  }
+
+  func testTrailingClosures13() {
+    AssertParse(
+      """
+      func test_multiple_trailing_syntax_without_labels() {
+        func fn(f: () -> Void, g: () -> Void) {}
+        fn {} g: {} // Ok
+        fn {} _: {} //  {{none}}
+        fn {} g#^DIAG^#: <#T##() -> Void#> 
+        func multiple(_: () -> Void, _: () -> Void) {}
+        multiple {} _: { }
+        func mixed_args_1(a: () -> Void, _: () -> Void) {}
+        func mixed_args_2(_: () -> Void, a: () -> Void, _: () -> Void) {} 
+        mixed_args_1 {} _: {}
+        mixed_args_1 {} a: {}  //  {{none}}
+        mixed_args_2 {} a: {} _: {}
+        mixed_args_2 {} _: {} //  {{none}}
+        mixed_args_2 {} _: {} _: {} //  {{none}}
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: missing argument label 'g:' in call, Fix-It replacements: 9 - 10 = 'g'
+        // TODO: Old parser expected error on line 5: editor placeholder in source file
+        DiagnosticSpec(message: "unexpected text ': <#T##() -> Void#>' before function"),
+        // TODO: Old parser expected note on line 9: 'mixed_args_2(_:a:_:)' declared here
+        // TODO: Old parser expected error on line 11: extraneous argument label 'a:' in call, Fix-It replacements: 19 - 20 = '_'
+        // TODO: Old parser expected error on line 13: missing argument for parameter 'a' in call, Fix-It replacements: 18 - 18 = ' a: <#() -> Void#>'
+        // TODO: Old parser expected error on line 14: missing argument label 'a:' in call, Fix-It replacements: 19 - 20 = 'a'
+      ]
+    )
+  }
+
+  func testTrailingClosures14() {
+    AssertParse(
+      """
+      func produce(fn: () -> Int?, default d: () -> Int) -> Int { 
+        return fn() ?? d()
+      }
+      // TODO: The diagnostics here are perhaps a little overboard.
+      _ = produce { 0 } #^DIAG^#default: { 1 } 
+      _ = produce { 2 } `default`: { 3 }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 1: declared here
+        // TODO: Old parser expected error on line 5: missing argument for parameter 'default' in call
+        // TODO: Old parser expected error on line 5: consecutive statements
+        // TODO: Old parser expected error on line 5: 'default' label can only appear inside a 'switch' statement
+        DiagnosticSpec(message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 6: labeled block needs 'do'
+        // TODO: Old parser expected warning on line 6: integer literal is unused
+      ]
+    )
+  }
+
+  func testTrailingClosures15() {
+    AssertParse(
+      """
+      func f() -> Int { 42 }
+      """
+    )
+  }
+
+  func testTrailingClosures16() {
+    AssertParse(
+      """
+      // This should be interpreted as a trailing closure, instead of being 
+      // interpreted as a computed property with undesired initial value.
+      struct TrickyTest {
+          var x : Int = f () { 
+              3
+          }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: extra trailing closure passed in call
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/TrailingSemiTests.swift
+++ b/Tests/SwiftParserTest/translated/TrailingSemiTests.swift
@@ -1,0 +1,99 @@
+// This test file has been translated from swift/test/Parse/trailing-semi.swift
+
+import XCTest
+
+final class TrailingSemiTests: XCTestCase {
+  func testTrailingSemi1() {
+    AssertParse(
+      """
+      struct S {
+        var a : Int ;
+        func b () {};
+        static func c () {};
+      }
+      """
+    )
+  }
+
+  func testTrailingSemi2() {
+    AssertParse(
+      """
+      struct SpuriousSemi {
+        #^DIAG_1^#; 
+        var a : Int ; #^DIAG_2^#; 
+        func b () {};#^DIAG_3^#
+        ; #^DIAG_4^#static func c () {};  #^DIAG_5^#
+        ;#^DIAG_6^#;
+      #^DIAG_7^#}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: unexpected ';' separator, Fix-It replacements: 3 - 5 = ''
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text ';' before variable"),
+        // TODO: Old parser expected error on line 3: unexpected ';' separator, Fix-It replacements: 17 - 19 = ''
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text ';' before function"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected declaration in struct"),
+        // TODO: Old parser expected error on line 5: unexpected ';' separator, Fix-It replacements: 3 - 5 = ''
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected '}' to end struct"),
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected expression"),
+        // TODO: Old parser expected error on line 6: unexpected ';' separator, Fix-It replacements: 3 - 4 = ''
+        // TODO: Old parser expected error on line 6: unexpected ';' separator, Fix-It replacements: 4 - 5 = ''
+        DiagnosticSpec(locationMarker: "DIAG_6", message: "expected expression"),
+        DiagnosticSpec(locationMarker: "DIAG_7", message: "extraneous '}' at top level"),
+      ]
+    )
+  }
+
+  func testTrailingSemi3() {
+    AssertParse(
+      """
+      class C {
+        var a : Int = 10 func aa() {}; 
+      #if FLAG1
+        var aaa: Int = 42 func aaaa() {}; 
+      #elseif FLAG2
+        var aaa: Int = 42 func aaaa() {} 
+      #else
+        var aaa: Int = 42 func aaaa() {} 
+      #endif
+        func b () {};
+        class func c () {};
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: consecutive declarations on a line must be separated by ';', Fix-It replacements: 19 - 19 = ';'
+        // TODO: Old parser expected error on line 4: consecutive declarations on a line must be separated by ';', Fix-It replacements: 20 - 20 = ';'
+        // TODO: Old parser expected error on line 6: consecutive declarations on a line must be separated by ';', Fix-It replacements: 20 - 20 = ';'
+        // TODO: Old parser expected error on line 8: consecutive declarations on a line must be separated by ';', Fix-It replacements: 20 - 20 = ';'
+      ]
+    )
+  }
+
+  func testTrailingSemi4() {
+    AssertParse(
+      """
+      extension S {
+        //var a : Int ;
+        func bb () {};
+        static func cc () {};
+        func dd() {} subscript(i: Int) -> Int { return 1 } 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: consecutive declarations on a line must be separated by ';', Fix-It replacements: 15 - 15 = ';'
+      ]
+    )
+  }
+
+  func testTrailingSemi5() {
+    AssertParse(
+      """
+      protocol P {
+        var a : Int { get };
+        func b ();
+        static func c ();
+      }
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/TrySwift5Tests.swift
+++ b/Tests/SwiftParserTest/translated/TrySwift5Tests.swift
@@ -50,20 +50,7 @@ final class TrySwift5Tests: XCTestCase {
       x += try foo() %%%% bar() 
       x += try foo() %%% bar()
       x = foo() + try bar()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 4: result of operator '%%%%' is unused
-        // TODO: Old parser expected error on line 4: call can throw but is not marked with 'try'
-        // TODO: Old parser expected error on line 4: 'try' following assignment operator does not cover everything to its right
-        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 21 - 21 = 'try '
-        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 21 - 21 = 'try? '
-        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 21 - 21 = 'try! '
-        // TODO: Old parser expected error on line 6: call can throw but is not marked with 'try'
-        // TODO: Old parser expected error on line 6: 'try' cannot appear to the right of a non-assignment operator
-        // TODO: Old parser expected note on line 6: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
-        // TODO: Old parser expected note on line 6: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
-        // TODO: Old parser expected note on line 6: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
-      ]
+      """
     )
   }
 
@@ -72,10 +59,7 @@ final class TrySwift5Tests: XCTestCase {
       """
       var y = true ? try foo() : try bar() + 0
       var z = true ? try foo() : try bar() %%% 0
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: 'try' following conditional operator does not cover everything to its right
-      ]
+      """
     )
   }
 
@@ -88,20 +72,7 @@ final class TrySwift5Tests: XCTestCase {
       a += try! foo() %%%% bar() 
       a += try! foo() %%% bar()
       a = foo() + try! bar()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 4: result of operator '%%%%' is unused
-        // TODO: Old parser expected error on line 4: call can throw but is not marked with 'try'
-        // TODO: Old parser expected error on line 4: 'try!' following assignment operator does not cover everything to its right
-        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 22 - 22 = 'try '
-        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 22 - 22 = 'try? '
-        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 22 - 22 = 'try! '
-        // TODO: Old parser expected error on line 6: call can throw but is not marked with 'try'
-        // TODO: Old parser expected error on line 6: 'try!' cannot appear to the right of a non-assignment operator
-        // TODO: Old parser expected note on line 6: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
-        // TODO: Old parser expected note on line 6: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
-        // TODO: Old parser expected note on line 6: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
-      ]
+      """
     )
   }
 
@@ -110,10 +81,7 @@ final class TrySwift5Tests: XCTestCase {
       """
       var b = true ? try! foo() : try! bar() + 0
       var c = true ? try! foo() : try! bar() %%% 0
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: 'try!' following conditional operator does not cover everything to its right
-      ]
+      """
     )
   }
 
@@ -141,29 +109,7 @@ final class TrySwift5Tests: XCTestCase {
       _ = (try? foo()) == bar() 
       _ = foo() == (try? bar()) 
       _ = (try? foo()) == (try? bar())
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int?' to specified type 'Double'
-        // TODO: Old parser expected warning on line 5: result of operator '%%%%' is unused
-        // TODO: Old parser expected error on line 5: call can throw but is not marked with 'try'
-        // TODO: Old parser expected error on line 5: 'try?' following assignment operator does not cover everything to its right
-        // TODO: Old parser expected note on line 5: did you mean to use 'try'?, Fix-It replacements: 23 - 23 = 'try '
-        // TODO: Old parser expected note on line 5: did you mean to handle error as optional value?, Fix-It replacements: 23 - 23 = 'try? '
-        // TODO: Old parser expected note on line 5: did you mean to disable error propagation?, Fix-It replacements: 23 - 23 = 'try! '
-        // TODO: Old parser expected error on line 7: call can throw but is not marked with 'try'
-        // TODO: Old parser expected error on line 7: 'try?' cannot appear to the right of a non-assignment operator
-        // TODO: Old parser expected note on line 7: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
-        // TODO: Old parser expected note on line 7: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
-        // TODO: Old parser expected note on line 7: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
-        // TODO: Old parser expected error on line 8: call can throw but is not marked with 'try'
-        // TODO: Old parser expected note on line 8: did you mean to use 'try'?, Fix-It replacements: 21 - 21 = 'try '
-        // TODO: Old parser expected note on line 8: did you mean to handle error as optional value?, Fix-It replacements: 21 - 21 = 'try? '
-        // TODO: Old parser expected note on line 8: did you mean to disable error propagation?, Fix-It replacements: 21 - 21 = 'try! '
-        // TODO: Old parser expected error on line 9: call can throw but is not marked with 'try'
-        // TODO: Old parser expected note on line 9: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
-        // TODO: Old parser expected note on line 9: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
-        // TODO: Old parser expected note on line 9: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
-      ]
+      """
     )
   }
 
@@ -172,10 +118,7 @@ final class TrySwift5Tests: XCTestCase {
       """
       let j = true ? try? foo() : try? bar() + 0
       let k = true ? try? foo() : try? bar() %%% 0
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: 'try?' following conditional operator does not cover everything to its right
-      ]
+      """
     )
   }
 
@@ -204,19 +147,10 @@ final class TrySwift5Tests: XCTestCase {
         // TODO: Old parser expected error on line 4: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 40 - 40 = 'try '
         DiagnosticSpec(locationMarker: "DIAG_4", message: "expected expression in 'try' expression"),
         // TODO: Old parser expected error on line 5: 'try' must be placed on the initial value expression
-        // TODO: Old parser expected note on line 5: did you mean to use 'try'?, Fix-It replacements: 18 - 18 = 'try '
-        // TODO: Old parser expected note on line 5: did you mean to use 'try'?, Fix-It replacements: 34 - 34 = 'try '
-        // TODO: Old parser expected note on line 5: did you mean to handle error as optional value?, Fix-It replacements: 18 - 18 = 'try? '
-        // TODO: Old parser expected note on line 5: did you mean to handle error as optional value?, Fix-It replacements: 34 - 34 = 'try? '
-        // TODO: Old parser expected note on line 5: did you mean to disable error propagation?, Fix-It replacements: 18 - 18 = 'try! '
-        // TODO: Old parser expected note on line 5: did you mean to disable error propagation?, Fix-It replacements: 34 - 34 = 'try! '
         DiagnosticSpec(locationMarker: "DIAG_5", message: "expected expression in 'try' expression"),
-        // TODO: Old parser expected note on line 6: in declaration of 'TryDecl'
         // TODO: Old parser expected error on line 7: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
-        // TODO: Old parser expected error on line 7: call can throw, but errors cannot be thrown out of a property initializer
         DiagnosticSpec(locationMarker: "DIAG_6", message: "unexpected text 'try' before variable"),
         // TODO: Old parser expected error on line 8: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
-        // TODO: Old parser expected error on line 8: call can throw, but errors cannot be thrown out of a property initializer
         DiagnosticSpec(locationMarker: "DIAG_7", message: "unexpected text 'try' before variable"),
         // TODO: Old parser expected error on line 9: expected declaration
         DiagnosticSpec(locationMarker: "DIAG_8", message: "unexpected text 'try' before function"),
@@ -249,10 +183,8 @@ final class TrySwift5Tests: XCTestCase {
         DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in 'try' expression"),
         DiagnosticSpec(locationMarker: "DIAG_4", message: "expected expression in 'throw' statement"),
         // TODO: Old parser expected error on line 7: 'try' cannot be used with 'return'
-        // TODO: Old parser expected error on line 7: non-void function should return a value
         DiagnosticSpec(locationMarker: "DIAG_5", message: "expected expression in 'try' expression"),
         // TODO: Old parser expected error on line 9: 'try' must be placed on the thrown expression, Fix-It replacements: 3 - 7 = '', 13 - 13 = 'try '
-        // TODO: Old parser expected error on line 9: thrown expression type 'Int' does not conform to 'Error'
         DiagnosticSpec(locationMarker: "DIAG_6", message: "expected expression in 'try' expression"),
         // TODO: Old parser expected error on line 10: 'try' must be placed on the returned expression, Fix-It replacements: 3 - 7 = '', 14 - 14 = 'try '
         DiagnosticSpec(locationMarker: "DIAG_7", message: "expected expression in 'try' expression"),
@@ -271,13 +203,7 @@ final class TrySwift5Tests: XCTestCase {
       let _ = try! "foo"*"bar"
       let _ = try? "foo"*"bar"
       let _ = (try? "foo"*"bar") ?? 0
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: operator can throw but expression is not marked with 'try'
-        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 9 - 9 = 'try '
-        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 9 - 9 = 'try? '
-        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 9 - 9 = 'try! '
-      ]
+      """#
     )
   }
 
@@ -291,13 +217,7 @@ final class TrySwift5Tests: XCTestCase {
         } catch {
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: call can throw but is not marked with 'try'
-        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
-        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
-        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
-      ]
+      """
     )
   }
 
@@ -311,11 +231,7 @@ final class TrySwift5Tests: XCTestCase {
           x(f)  
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 5: call can throw but is not marked with 'try'
-        // TODO: Old parser expected note on line 5: call is to 'rethrows' function, but argument function can throw
-      ]
+      """
     )
   }
 
@@ -326,14 +242,7 @@ final class TrySwift5Tests: XCTestCase {
       func callThrowingClosureWithoutTry(closure: (Int) throws -> Int) rethrows {
         closure(0)  
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: call can throw but is not marked with 'try'
-        // TODO: Old parser expected warning on line 3: result of call to function returning 'Int' is unused
-        // TODO: Old parser expected note on line 3: did you mean to use 'try'?, Fix-It replacements: 3 - 3 = 'try '
-        // TODO: Old parser expected note on line 3: did you mean to handle error as optional value?, Fix-It replacements: 3 - 3 = 'try? '
-        // TODO: Old parser expected note on line 3: did you mean to disable error propagation?, Fix-It replacements: 3 - 3 = 'try! '
-      ]
+      """
     )
   }
 
@@ -343,10 +252,7 @@ final class TrySwift5Tests: XCTestCase {
       func producesOptional() throws -> Int? { return nil }
       let singleOptional = try? producesOptional()
       let _: String = singleOptional
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: cannot convert value of type 'Int?' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -354,10 +260,7 @@ final class TrySwift5Tests: XCTestCase {
     AssertParse(
       """
       let _ = (try? foo())!!
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot force unwrap value of non-optional type 'Int'
-      ]
+      """
     )
   }
 
@@ -366,10 +269,7 @@ final class TrySwift5Tests: XCTestCase {
       """
       func producesDoubleOptional() throws -> Int?? { return 3 }
       let _: String = try? producesDoubleOptional()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int??' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -400,11 +300,7 @@ final class TrySwift5Tests: XCTestCase {
       if try? maybeThrow() { 
       }
       let _: Int = try? foo()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot be used as a boolean, Fix-It replacements: 4 - 4 = '((', 21 - 21 = ') != nil)'
-        // TODO: Old parser expected error on line 3: value of optional type 'Int?' not unwrapped; did you mean to use 'try!' or chain with '?'?, Fix-It replacements: 14 - 18 = 'try!'
-      ]
+      """
     )
   }
 
@@ -415,11 +311,7 @@ final class TrySwift5Tests: XCTestCase {
       func test(_: X) {}
       func producesObject() throws -> AnyObject { return X() }
       test(try producesObject())
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: 'AnyObject' is not convertible to 'X'
-        // TODO: Old parser expected note on line 4: did you mean to use 'as!' to force downcast?, Fix-It replacements: 26 - 26 = ' as! X'
-      ]
+      """
     )
   }
 
@@ -429,13 +321,7 @@ final class TrySwift5Tests: XCTestCase {
       _ = "a\(try maybeThrow())b"
       _ = try "a\(maybeThrow())b"
       _ = "a\(maybeThrow())"
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: call can throw but is not marked with 'try'
-        // TODO: Old parser expected note on line 3: did you mean to use 'try'?, Fix-It replacements: 9 - 9 = 'try '
-        // TODO: Old parser expected note on line 3: did you mean to handle error as optional value?, Fix-It replacements: 9 - 9 = 'try? '
-        // TODO: Old parser expected note on line 3: did you mean to disable error propagation?, Fix-It replacements: 9 - 9 = 'try! '
-      ]
+      """#
     )
   }
 
@@ -455,13 +341,7 @@ final class TrySwift5Tests: XCTestCase {
       _ = try "a\()b"
       _ = "a\()b" 
       _ = try "\() \(1)"
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: interpolation can throw but is not marked with 'try'
-        // TODO: Old parser expected note on line 2: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
-        // TODO: Old parser expected note on line 2: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
-        // TODO: Old parser expected note on line 2: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
-      ]
+      """#
     )
   }
 
@@ -471,10 +351,7 @@ final class TrySwift5Tests: XCTestCase {
       func testGenericOptionalTry<T>(_ call: () throws -> T ) {
         let _: String = try? call() 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'T?' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -494,10 +371,7 @@ final class TrySwift5Tests: XCTestCase {
       """
       // Test with a non-optional type
       let _: String = genericOptionalTry({ () throws -> Int in return 3 })
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int?' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -506,10 +380,7 @@ final class TrySwift5Tests: XCTestCase {
       """
       // Test with an optional type
       let _: String = genericOptionalTry({ () throws -> Int? in return nil })
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int??' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -530,11 +401,7 @@ final class TrySwift5Tests: XCTestCase {
       let _: Int? = (try? produceAny()) as? Int // good
       let _: String = try? produceAny() as? Int 
       let _: String = (try? produceAny()) as? Int
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: cannot convert value of type 'Int?' to specified type 'String'
-        // TODO: Old parser expected error on line 4: cannot convert value of type 'Int?' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -560,11 +427,7 @@ final class TrySwift5Tests: XCTestCase {
       let _: Int = try? optProducer?.produceInt() 
       let _: String = try? optProducer?.produceInt() 
       let _: Int?? = try? optProducer?.produceInt() // This was the expected type before Swift 5, but this still works; just adds more optional-ness
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: cannot convert value of type 'Int?' to specified type 'Int'
-        // TODO: Old parser expected error on line 4: cannot convert value of type 'Int?' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -572,10 +435,7 @@ final class TrySwift5Tests: XCTestCase {
     AssertParse(
       """
       let _: Int? = try? optProducer?.produceIntNoThrowing()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 1: no calls to throwing functions occur within 'try' expression
-      ]
+      """
     )
   }
 
@@ -586,10 +446,7 @@ final class TrySwift5Tests: XCTestCase {
       let _: Int? = try? optProducer?.produceAny() as? Int // good
       let _: Int?? = try? optProducer?.produceAny() as? Int // good
       let _: String = try? optProducer?.produceAny() as? Int
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: cannot convert value of type 'Int?' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -597,10 +454,7 @@ final class TrySwift5Tests: XCTestCase {
     AssertParse(
       """
       let _: String = try? optProducer?.produceDoubleOptionalInt()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot convert value of type 'Int??' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -616,10 +470,7 @@ final class TrySwift5Tests: XCTestCase {
     AssertParse(
       """
       let _: Int = try? producer.produceDoubleOptionalInt()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot convert value of type 'Int??' to specified type 'Int'
-      ]
+      """
     )
   }
 
@@ -628,10 +479,7 @@ final class TrySwift5Tests: XCTestCase {
       """
       // We don't offer 'try!' here because it would not change the type of the expression in Swift 5+
       let _: Int? = try? producer.produceDoubleOptionalInt()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int??' to specified type 'Int?'
-      ]
+      """
     )
   }
 
@@ -641,10 +489,7 @@ final class TrySwift5Tests: XCTestCase {
       let _: Int?? = try? producer.produceDoubleOptionalInt() // good
       let _: Int??? = try? producer.produceDoubleOptionalInt() // good
       let _: String = try? producer.produceDoubleOptionalInt()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: cannot convert value of type 'Int??' to specified type 'String'
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/TrySwift5Tests.swift
+++ b/Tests/SwiftParserTest/translated/TrySwift5Tests.swift
@@ -1,0 +1,680 @@
+// This test file has been translated from swift/test/Parse/try_swift5.swift
+
+import XCTest
+
+final class TrySwift5Tests: XCTestCase {
+  func testTrySwift51() {
+    AssertParse(
+      """
+      // Intentionally has lower precedence than assignments and ?:
+      infix operator %%%% : LowPrecedence
+      precedencegroup LowPrecedence {
+        associativity: none
+        lowerThan: AssignmentPrecedence
+      }
+      func %%%%<T, U>(x: T, y: U) -> Int { return 0 }
+      """
+    )
+  }
+
+  func testTrySwift52() {
+    AssertParse(
+      """
+      // Intentionally has lower precedence between assignments and ?:
+      infix operator %%% : MiddlingPrecedence
+      precedencegroup MiddlingPrecedence {
+        associativity: none
+        higherThan: AssignmentPrecedence
+        lowerThan: TernaryPrecedence
+      }
+      func %%%<T, U>(x: T, y: U) -> Int { return 1 }
+      """
+    )
+  }
+
+  func testTrySwift53() {
+    AssertParse(
+      """
+      func foo() throws -> Int { return 0 }
+      func bar() throws -> Int { return 0 }
+      """
+    )
+  }
+
+  func testTrySwift54() {
+    AssertParse(
+      """
+      var x = try foo() + bar()
+      x = try foo() + bar()
+      x += try foo() + bar()
+      x += try foo() %%%% bar() 
+      x += try foo() %%% bar()
+      x = foo() + try bar()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 4: result of operator '%%%%' is unused
+        // TODO: Old parser expected error on line 4: call can throw but is not marked with 'try'
+        // TODO: Old parser expected error on line 4: 'try' following assignment operator does not cover everything to its right
+        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 21 - 21 = 'try '
+        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 21 - 21 = 'try? '
+        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 21 - 21 = 'try! '
+        // TODO: Old parser expected error on line 6: call can throw but is not marked with 'try'
+        // TODO: Old parser expected error on line 6: 'try' cannot appear to the right of a non-assignment operator
+        // TODO: Old parser expected note on line 6: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
+        // TODO: Old parser expected note on line 6: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
+        // TODO: Old parser expected note on line 6: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
+      ]
+    )
+  }
+
+  func testTrySwift55() {
+    AssertParse(
+      """
+      var y = true ? try foo() : try bar() + 0
+      var z = true ? try foo() : try bar() %%% 0
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'try' following conditional operator does not cover everything to its right
+      ]
+    )
+  }
+
+  func testTrySwift56() {
+    AssertParse(
+      """
+      var a = try! foo() + bar()
+      a = try! foo() + bar()
+      a += try! foo() + bar()
+      a += try! foo() %%%% bar() 
+      a += try! foo() %%% bar()
+      a = foo() + try! bar()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 4: result of operator '%%%%' is unused
+        // TODO: Old parser expected error on line 4: call can throw but is not marked with 'try'
+        // TODO: Old parser expected error on line 4: 'try!' following assignment operator does not cover everything to its right
+        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 22 - 22 = 'try '
+        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 22 - 22 = 'try? '
+        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 22 - 22 = 'try! '
+        // TODO: Old parser expected error on line 6: call can throw but is not marked with 'try'
+        // TODO: Old parser expected error on line 6: 'try!' cannot appear to the right of a non-assignment operator
+        // TODO: Old parser expected note on line 6: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
+        // TODO: Old parser expected note on line 6: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
+        // TODO: Old parser expected note on line 6: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
+      ]
+    )
+  }
+
+  func testTrySwift57() {
+    AssertParse(
+      """
+      var b = true ? try! foo() : try! bar() + 0
+      var c = true ? try! foo() : try! bar() %%% 0
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'try!' following conditional operator does not cover everything to its right
+      ]
+    )
+  }
+
+  func testTrySwift58() {
+    AssertParse(
+      """
+      infix operator ?+= : AssignmentPrecedence
+      func ?+=(lhs: inout Int?, rhs: Int?) {
+        lhs = lhs! + rhs!
+      }
+      """
+    )
+  }
+
+  func testTrySwift59() {
+    AssertParse(
+      """
+      var i = try? foo() + bar()
+      let _: Double = i 
+      i = try? foo() + bar()
+      i ?+= try? foo() + bar()
+      i ?+= try? foo() %%%% bar() 
+      i ?+= try? foo() %%% bar()
+      _ = foo() == try? bar() 
+      _ = (try? foo()) == bar() 
+      _ = foo() == (try? bar()) 
+      _ = (try? foo()) == (try? bar())
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int?' to specified type 'Double'
+        // TODO: Old parser expected warning on line 5: result of operator '%%%%' is unused
+        // TODO: Old parser expected error on line 5: call can throw but is not marked with 'try'
+        // TODO: Old parser expected error on line 5: 'try?' following assignment operator does not cover everything to its right
+        // TODO: Old parser expected note on line 5: did you mean to use 'try'?, Fix-It replacements: 23 - 23 = 'try '
+        // TODO: Old parser expected note on line 5: did you mean to handle error as optional value?, Fix-It replacements: 23 - 23 = 'try? '
+        // TODO: Old parser expected note on line 5: did you mean to disable error propagation?, Fix-It replacements: 23 - 23 = 'try! '
+        // TODO: Old parser expected error on line 7: call can throw but is not marked with 'try'
+        // TODO: Old parser expected error on line 7: 'try?' cannot appear to the right of a non-assignment operator
+        // TODO: Old parser expected note on line 7: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
+        // TODO: Old parser expected note on line 7: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
+        // TODO: Old parser expected note on line 7: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
+        // TODO: Old parser expected error on line 8: call can throw but is not marked with 'try'
+        // TODO: Old parser expected note on line 8: did you mean to use 'try'?, Fix-It replacements: 21 - 21 = 'try '
+        // TODO: Old parser expected note on line 8: did you mean to handle error as optional value?, Fix-It replacements: 21 - 21 = 'try? '
+        // TODO: Old parser expected note on line 8: did you mean to disable error propagation?, Fix-It replacements: 21 - 21 = 'try! '
+        // TODO: Old parser expected error on line 9: call can throw but is not marked with 'try'
+        // TODO: Old parser expected note on line 9: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
+        // TODO: Old parser expected note on line 9: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
+        // TODO: Old parser expected note on line 9: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
+      ]
+    )
+  }
+
+  func testTrySwift510() {
+    AssertParse(
+      """
+      let j = true ? try? foo() : try? bar() + 0
+      let k = true ? try? foo() : try? bar() %%% 0
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'try?' following conditional operator does not cover everything to its right
+      ]
+    )
+  }
+
+  func testTrySwift511() {
+    AssertParse(
+      """
+      try #^DIAG_1^#let singleLet = foo() 
+      try #^DIAG_2^#var singleVar = foo() 
+      try #^DIAG_3^#let uninit: Int 
+      try #^DIAG_4^#let (destructure1, destructure2) = (foo(), bar()) 
+      try #^DIAG_5^#let multi1 = foo(), multi2 = bar() //  expected-error 2 {{call can throw but is not marked with 'try'}}
+      class TryDecl { 
+        #^DIAG_6^#try let singleLet = foo() 
+        #^DIAG_7^#try var singleVar = foo() 
+        #^DIAG_8^#try 
+        func method() {}
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 21 - 21 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 2: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 21 - 21 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 3: 'try' must be placed on the initial value expression
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 4: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 40 - 40 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 5: 'try' must be placed on the initial value expression
+        // TODO: Old parser expected note on line 5: did you mean to use 'try'?, Fix-It replacements: 18 - 18 = 'try '
+        // TODO: Old parser expected note on line 5: did you mean to use 'try'?, Fix-It replacements: 34 - 34 = 'try '
+        // TODO: Old parser expected note on line 5: did you mean to handle error as optional value?, Fix-It replacements: 18 - 18 = 'try? '
+        // TODO: Old parser expected note on line 5: did you mean to handle error as optional value?, Fix-It replacements: 34 - 34 = 'try? '
+        // TODO: Old parser expected note on line 5: did you mean to disable error propagation?, Fix-It replacements: 18 - 18 = 'try! '
+        // TODO: Old parser expected note on line 5: did you mean to disable error propagation?, Fix-It replacements: 34 - 34 = 'try! '
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected note on line 6: in declaration of 'TryDecl'
+        // TODO: Old parser expected error on line 7: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
+        // TODO: Old parser expected error on line 7: call can throw, but errors cannot be thrown out of a property initializer
+        DiagnosticSpec(locationMarker: "DIAG_6", message: "unexpected text 'try' before variable"),
+        // TODO: Old parser expected error on line 8: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
+        // TODO: Old parser expected error on line 8: call can throw, but errors cannot be thrown out of a property initializer
+        DiagnosticSpec(locationMarker: "DIAG_7", message: "unexpected text 'try' before variable"),
+        // TODO: Old parser expected error on line 9: expected declaration
+        DiagnosticSpec(locationMarker: "DIAG_8", message: "unexpected text 'try' before function"),
+      ]
+    )
+  }
+
+  func testTrySwift512() {
+    AssertParse(
+      """
+      func test() throws -> Int {
+        try #^DIAG_1^#while true { 
+          try #^DIAG_2^#break 
+        }
+        try #^DIAG_3^#throw #^DIAG_4^#
+        ; // Reset parser.
+        try #^DIAG_5^#return 
+        ; // Reset parser.
+        try #^DIAG_6^#throw foo() 
+        try #^DIAG_7^#return foo() 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'try' cannot be used with 'while'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 3: 'try' cannot be used with 'break'
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 5: 'try' must be placed on the thrown expression, Fix-It replacements: 3 - 7 = '', 3 - 3 = 'try '
+        // TODO: Old parser expected error on line 5: expected expression in 'throw' statement
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in 'try' expression"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected expression in 'throw' statement"),
+        // TODO: Old parser expected error on line 7: 'try' cannot be used with 'return'
+        // TODO: Old parser expected error on line 7: non-void function should return a value
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 9: 'try' must be placed on the thrown expression, Fix-It replacements: 3 - 7 = '', 13 - 13 = 'try '
+        // TODO: Old parser expected error on line 9: thrown expression type 'Int' does not conform to 'Error'
+        DiagnosticSpec(locationMarker: "DIAG_6", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 10: 'try' must be placed on the returned expression, Fix-It replacements: 3 - 7 = '', 14 - 14 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_7", message: "expected expression in 'try' expression"),
+      ]
+    )
+  }
+
+  func testTrySwift513() {
+    AssertParse(
+      #"""
+      // Test operators.
+      func *(a : String, b : String) throws -> Int { return 42 }
+      let _ = "foo"
+              *  
+              "bar"
+      let _ = try! "foo"*"bar"
+      let _ = try? "foo"*"bar"
+      let _ = (try? "foo"*"bar") ?? 0
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: operator can throw but expression is not marked with 'try'
+        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 9 - 9 = 'try '
+        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 9 - 9 = 'try? '
+        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 9 - 9 = 'try! '
+      ]
+    )
+  }
+
+  func testTrySwift514() {
+    AssertParse(
+      """
+      // <rdar://problem/21414023> Assertion failure when compiling function that takes throwing functions and rethrows
+      func rethrowsDispatchError(handleError: ((Error) throws -> ()), body: () throws -> ()) rethrows {
+        do {
+          body()   
+        } catch {
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: call can throw but is not marked with 'try'
+        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
+        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
+        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
+      ]
+    )
+  }
+
+  func testTrySwift515() {
+    AssertParse(
+      """
+      // <rdar://problem/21432429> Calling rethrows from rethrows crashes Swift compiler
+      struct r21432429 {
+        func x(_ f: () throws -> ()) rethrows {}
+        func y(_ f: () throws -> ()) rethrows {
+          x(f)  
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: call can throw but is not marked with 'try'
+        // TODO: Old parser expected note on line 5: call is to 'rethrows' function, but argument function can throw
+      ]
+    )
+  }
+
+  func testTrySwift516() {
+    AssertParse(
+      """
+      // <rdar://problem/21427855> Swift 2: Omitting try from call to throwing closure in rethrowing function crashes compiler
+      func callThrowingClosureWithoutTry(closure: (Int) throws -> Int) rethrows {
+        closure(0)  
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: call can throw but is not marked with 'try'
+        // TODO: Old parser expected warning on line 3: result of call to function returning 'Int' is unused
+        // TODO: Old parser expected note on line 3: did you mean to use 'try'?, Fix-It replacements: 3 - 3 = 'try '
+        // TODO: Old parser expected note on line 3: did you mean to handle error as optional value?, Fix-It replacements: 3 - 3 = 'try? '
+        // TODO: Old parser expected note on line 3: did you mean to disable error propagation?, Fix-It replacements: 3 - 3 = 'try! '
+      ]
+    )
+  }
+
+  func testTrySwift517() {
+    AssertParse(
+      """
+      func producesOptional() throws -> Int? { return nil }
+      let singleOptional = try? producesOptional()
+      let _: String = singleOptional
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: cannot convert value of type 'Int?' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTrySwift518() {
+    AssertParse(
+      """
+      let _ = (try? foo())!!
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot force unwrap value of non-optional type 'Int'
+      ]
+    )
+  }
+
+  func testTrySwift519() {
+    AssertParse(
+      """
+      func producesDoubleOptional() throws -> Int?? { return 3 }
+      let _: String = try? producesDoubleOptional()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int??' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTrySwift520() {
+    AssertParse(
+      """
+      func maybeThrow() throws {}
+      try maybeThrow() // okay
+      try! maybeThrow() // okay
+      try? maybeThrow() // okay since return type of maybeThrow is Void
+      _ = try? maybeThrow() // okay
+      """
+    )
+  }
+
+  func testTrySwift521() {
+    AssertParse(
+      """
+      let _: () -> Void = { try! maybeThrow() } // okay
+      let _: () -> Void = { try? maybeThrow() } // okay since return type of maybeThrow is Void
+      """
+    )
+  }
+
+  func testTrySwift522() {
+    AssertParse(
+      """
+      if try? maybeThrow() { 
+      }
+      let _: Int = try? foo()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot be used as a boolean, Fix-It replacements: 4 - 4 = '((', 21 - 21 = ') != nil)'
+        // TODO: Old parser expected error on line 3: value of optional type 'Int?' not unwrapped; did you mean to use 'try!' or chain with '?'?, Fix-It replacements: 14 - 18 = 'try!'
+      ]
+    )
+  }
+
+  func testTrySwift523() {
+    AssertParse(
+      """
+      class X {}
+      func test(_: X) {}
+      func producesObject() throws -> AnyObject { return X() }
+      test(try producesObject())
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: 'AnyObject' is not convertible to 'X'
+        // TODO: Old parser expected note on line 4: did you mean to use 'as!' to force downcast?, Fix-It replacements: 26 - 26 = ' as! X'
+      ]
+    )
+  }
+
+  func testTrySwift524() {
+    AssertParse(
+      #"""
+      _ = "a\(try maybeThrow())b"
+      _ = try "a\(maybeThrow())b"
+      _ = "a\(maybeThrow())"
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: call can throw but is not marked with 'try'
+        // TODO: Old parser expected note on line 3: did you mean to use 'try'?, Fix-It replacements: 9 - 9 = 'try '
+        // TODO: Old parser expected note on line 3: did you mean to handle error as optional value?, Fix-It replacements: 9 - 9 = 'try? '
+        // TODO: Old parser expected note on line 3: did you mean to disable error propagation?, Fix-It replacements: 9 - 9 = 'try! '
+      ]
+    )
+  }
+
+  func testTrySwift525() {
+    AssertParse(
+      """
+      extension DefaultStringInterpolation {
+        mutating func appendInterpolation() throws {}
+      }
+      """
+    )
+  }
+
+  func testTrySwift526() {
+    AssertParse(
+      #"""
+      _ = try "a\()b"
+      _ = "a\()b" 
+      _ = try "\() \(1)"
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: interpolation can throw but is not marked with 'try'
+        // TODO: Old parser expected note on line 2: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
+        // TODO: Old parser expected note on line 2: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
+        // TODO: Old parser expected note on line 2: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
+      ]
+    )
+  }
+
+  func testTrySwift527() {
+    AssertParse(
+      """
+      func testGenericOptionalTry<T>(_ call: () throws -> T ) {
+        let _: String = try? call() 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot convert value of type 'T?' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTrySwift528() {
+    AssertParse(
+      """
+      func genericOptionalTry<T>(_ call: () throws -> T ) -> T? {
+        let x = try? call() // no error expected
+        return x
+      }
+      """
+    )
+  }
+
+  func testTrySwift529() {
+    AssertParse(
+      """
+      // Test with a non-optional type
+      let _: String = genericOptionalTry({ () throws -> Int in return 3 })
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int?' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTrySwift530() {
+    AssertParse(
+      """
+      // Test with an optional type
+      let _: String = genericOptionalTry({ () throws -> Int? in return nil })
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int??' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTrySwift531() {
+    AssertParse(
+      """
+      func produceAny() throws -> Any {
+        return 3
+      }
+      """
+    )
+  }
+
+  func testTrySwift532() {
+    AssertParse(
+      """
+      let _: Int? = try? produceAny() as? Int // good
+      let _: Int? = (try? produceAny()) as? Int // good
+      let _: String = try? produceAny() as? Int 
+      let _: String = (try? produceAny()) as? Int
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: cannot convert value of type 'Int?' to specified type 'String'
+        // TODO: Old parser expected error on line 4: cannot convert value of type 'Int?' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTrySwift533() {
+    AssertParse(
+      """
+      struct ThingProducer {
+        func produceInt() throws -> Int { return 3 }
+        func produceIntNoThrowing() -> Int { return 3 }
+        func produceAny() throws -> Any { return 3 }
+        func produceOptionalAny() throws -> Any? { return 3 }
+        func produceDoubleOptionalInt() throws -> Int?? { return 3 }
+      }
+      """
+    )
+  }
+
+  func testTrySwift534() {
+    AssertParse(
+      """
+      let optProducer: ThingProducer? = ThingProducer()
+      let _: Int? = try? optProducer?.produceInt()
+      let _: Int = try? optProducer?.produceInt() 
+      let _: String = try? optProducer?.produceInt() 
+      let _: Int?? = try? optProducer?.produceInt() // This was the expected type before Swift 5, but this still works; just adds more optional-ness
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: cannot convert value of type 'Int?' to specified type 'Int'
+        // TODO: Old parser expected error on line 4: cannot convert value of type 'Int?' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTrySwift535() {
+    AssertParse(
+      """
+      let _: Int? = try? optProducer?.produceIntNoThrowing()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: no calls to throwing functions occur within 'try' expression
+      ]
+    )
+  }
+
+  func testTrySwift536() {
+    AssertParse(
+      """
+      let _: Int? = (try? optProducer?.produceAny()) as? Int // good
+      let _: Int? = try? optProducer?.produceAny() as? Int // good
+      let _: Int?? = try? optProducer?.produceAny() as? Int // good
+      let _: String = try? optProducer?.produceAny() as? Int
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: cannot convert value of type 'Int?' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTrySwift537() {
+    AssertParse(
+      """
+      let _: String = try? optProducer?.produceDoubleOptionalInt()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot convert value of type 'Int??' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTrySwift538() {
+    AssertParse(
+      """
+      let producer = ThingProducer()
+      """
+    )
+  }
+
+  func testTrySwift539() {
+    AssertParse(
+      """
+      let _: Int = try? producer.produceDoubleOptionalInt()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot convert value of type 'Int??' to specified type 'Int'
+      ]
+    )
+  }
+
+  func testTrySwift540() {
+    AssertParse(
+      """
+      // We don't offer 'try!' here because it would not change the type of the expression in Swift 5+
+      let _: Int? = try? producer.produceDoubleOptionalInt()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int??' to specified type 'Int?'
+      ]
+    )
+  }
+
+  func testTrySwift541() {
+    AssertParse(
+      """
+      let _: Int?? = try? producer.produceDoubleOptionalInt() // good
+      let _: Int??? = try? producer.produceDoubleOptionalInt() // good
+      let _: String = try? producer.produceDoubleOptionalInt()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: cannot convert value of type 'Int??' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTrySwift542() {
+    AssertParse(
+      """
+      // rdar://problem/46742002
+      protocol Dummy : AnyObject {}
+      """
+    )
+  }
+
+  func testTrySwift543() {
+    AssertParse(
+      """
+      class F<T> {
+        func wait() throws -> T { fatalError() }
+      }
+      """
+    )
+  }
+
+  func testTrySwift544() {
+    AssertParse(
+      """
+      func bar(_ a: F<Dummy>, _ b: F<Dummy>) {
+        _ = (try? a.wait()) === (try? b.wait())
+      }
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/TryTests.swift
+++ b/Tests/SwiftParserTest/translated/TryTests.swift
@@ -50,20 +50,7 @@ final class TryTests: XCTestCase {
       x += try foo() %%%% bar() 
       x += try foo() %%% bar()
       x = foo() + try bar()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 4: result of operator '%%%%' is unused
-        // TODO: Old parser expected error on line 4: call can throw but is not marked with 'try'
-        // TODO: Old parser expected error on line 4: 'try' following assignment operator does not cover everything to its right
-        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 21 - 21 = 'try '
-        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 21 - 21 = 'try? '
-        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 21 - 21 = 'try! '
-        // TODO: Old parser expected error on line 6: call can throw but is not marked with 'try'
-        // TODO: Old parser expected error on line 6: 'try' cannot appear to the right of a non-assignment operator
-        // TODO: Old parser expected note on line 6: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
-        // TODO: Old parser expected note on line 6: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
-        // TODO: Old parser expected note on line 6: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
-      ]
+      """
     )
   }
 
@@ -72,10 +59,7 @@ final class TryTests: XCTestCase {
       """
       var y = true ? try foo() : try bar() + 0
       var z = true ? try foo() : try bar() %%% 0
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: 'try' following conditional operator does not cover everything to its right
-      ]
+      """
     )
   }
 
@@ -88,20 +72,7 @@ final class TryTests: XCTestCase {
       a += try! foo() %%%% bar() 
       a += try! foo() %%% bar()
       a = foo() + try! bar()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected warning on line 4: result of operator '%%%%' is unused
-        // TODO: Old parser expected error on line 4: call can throw but is not marked with 'try'
-        // TODO: Old parser expected error on line 4: 'try!' following assignment operator does not cover everything to its right
-        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 22 - 22 = 'try '
-        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 22 - 22 = 'try? '
-        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 22 - 22 = 'try! '
-        // TODO: Old parser expected error on line 6: call can throw but is not marked with 'try'
-        // TODO: Old parser expected error on line 6: 'try!' cannot appear to the right of a non-assignment operator
-        // TODO: Old parser expected note on line 6: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
-        // TODO: Old parser expected note on line 6: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
-        // TODO: Old parser expected note on line 6: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
-      ]
+      """
     )
   }
 
@@ -110,10 +81,7 @@ final class TryTests: XCTestCase {
       """
       var b = true ? try! foo() : try! bar() + 0
       var c = true ? try! foo() : try! bar() %%% 0
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: 'try!' following conditional operator does not cover everything to its right
-      ]
+      """
     )
   }
 
@@ -141,29 +109,7 @@ final class TryTests: XCTestCase {
       _ = (try? foo()) == bar() 
       _ = foo() == (try? bar()) 
       _ = (try? foo()) == (try? bar())
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int?' to specified type 'Double'
-        // TODO: Old parser expected warning on line 5: result of operator '%%%%' is unused
-        // TODO: Old parser expected error on line 5: call can throw but is not marked with 'try'
-        // TODO: Old parser expected error on line 5: 'try?' following assignment operator does not cover everything to its right
-        // TODO: Old parser expected note on line 5: did you mean to use 'try'?, Fix-It replacements: 23 - 23 = 'try '
-        // TODO: Old parser expected note on line 5: did you mean to handle error as optional value?, Fix-It replacements: 23 - 23 = 'try? '
-        // TODO: Old parser expected note on line 5: did you mean to disable error propagation?, Fix-It replacements: 23 - 23 = 'try! '
-        // TODO: Old parser expected error on line 7: call can throw but is not marked with 'try'
-        // TODO: Old parser expected error on line 7: 'try?' cannot appear to the right of a non-assignment operator
-        // TODO: Old parser expected note on line 7: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
-        // TODO: Old parser expected note on line 7: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
-        // TODO: Old parser expected note on line 7: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
-        // TODO: Old parser expected error on line 8: call can throw but is not marked with 'try'
-        // TODO: Old parser expected note on line 8: did you mean to use 'try'?, Fix-It replacements: 21 - 21 = 'try '
-        // TODO: Old parser expected note on line 8: did you mean to handle error as optional value?, Fix-It replacements: 21 - 21 = 'try? '
-        // TODO: Old parser expected note on line 8: did you mean to disable error propagation?, Fix-It replacements: 21 - 21 = 'try! '
-        // TODO: Old parser expected error on line 9: call can throw but is not marked with 'try'
-        // TODO: Old parser expected note on line 9: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
-        // TODO: Old parser expected note on line 9: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
-        // TODO: Old parser expected note on line 9: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
-      ]
+      """
     )
   }
 
@@ -172,10 +118,7 @@ final class TryTests: XCTestCase {
       """
       let j = true ? try? foo() : try? bar() + 0
       let k = true ? try? foo() : try? bar() %%% 0
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: 'try?' following conditional operator does not cover everything to its right
-      ]
+      """
     )
   }
 
@@ -271,13 +214,7 @@ final class TryTests: XCTestCase {
       let _ = try! "foo"*"bar"
       let _ = try? "foo"*"bar"
       let _ = (try? "foo"*"bar") ?? 0
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: operator can throw but expression is not marked with 'try'
-        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 9 - 9 = 'try '
-        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 9 - 9 = 'try? '
-        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 9 - 9 = 'try! '
-      ]
+      """#
     )
   }
 
@@ -291,13 +228,7 @@ final class TryTests: XCTestCase {
         } catch {
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: call can throw but is not marked with 'try'
-        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
-        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
-        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
-      ]
+      """
     )
   }
 
@@ -311,11 +242,7 @@ final class TryTests: XCTestCase {
           x(f)  
         }
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 5: call can throw but is not marked with 'try'
-        // TODO: Old parser expected note on line 5: call is to 'rethrows' function, but argument function can throw
-      ]
+      """
     )
   }
 
@@ -326,14 +253,7 @@ final class TryTests: XCTestCase {
       func callThrowingClosureWithoutTry(closure: (Int) throws -> Int) rethrows {
         closure(0)  
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: call can throw but is not marked with 'try'
-        // TODO: Old parser expected warning on line 3: result of call to function returning 'Int' is unused
-        // TODO: Old parser expected note on line 3: did you mean to use 'try'?, Fix-It replacements: 3 - 3 = 'try '
-        // TODO: Old parser expected note on line 3: did you mean to handle error as optional value?, Fix-It replacements: 3 - 3 = 'try? '
-        // TODO: Old parser expected note on line 3: did you mean to disable error propagation?, Fix-It replacements: 3 - 3 = 'try! '
-      ]
+      """
     )
   }
 
@@ -342,10 +262,7 @@ final class TryTests: XCTestCase {
       """
       func producesOptional() throws -> Int? { return nil }
       let _: String = try? producesOptional()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int??' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -353,10 +270,7 @@ final class TryTests: XCTestCase {
     AssertParse(
       """
       let _ = (try? foo())!!
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot force unwrap value of non-optional type 'Int'
-      ]
+      """
     )
   }
 
@@ -365,10 +279,7 @@ final class TryTests: XCTestCase {
       """
       func producesDoubleOptional() throws -> Int?? { return 3 }
       let _: String = try? producesDoubleOptional()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int???' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -399,11 +310,7 @@ final class TryTests: XCTestCase {
       if try? maybeThrow() { 
       }
       let _: Int = try? foo()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot be used as a boolean, Fix-It replacements: 4 - 4 = '((', 21 - 21 = ') != nil)'
-        // TODO: Old parser expected error on line 3: value of optional type 'Int?' not unwrapped; did you mean to use 'try!' or chain with '?'?, Fix-It replacements: 14 - 18 = 'try!'
-      ]
+      """
     )
   }
 
@@ -414,11 +321,7 @@ final class TryTests: XCTestCase {
       func test(_: X) {}
       func producesObject() throws -> AnyObject { return X() }
       test(try producesObject())
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: 'AnyObject' is not convertible to 'X'
-        // TODO: Old parser expected note on line 4: did you mean to use 'as!' to force downcast?, Fix-It replacements: 26 - 26 = ' as! X'
-      ]
+      """
     )
   }
 
@@ -428,13 +331,7 @@ final class TryTests: XCTestCase {
       _ = "a\(try maybeThrow())b"
       _ = try "a\(maybeThrow())b"
       _ = "a\(maybeThrow())"
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected error on line 3: call can throw but is not marked with 'try'
-        // TODO: Old parser expected note on line 3: did you mean to use 'try'?, Fix-It replacements: 9 - 9 = 'try '
-        // TODO: Old parser expected note on line 3: did you mean to handle error as optional value?, Fix-It replacements: 9 - 9 = 'try? '
-        // TODO: Old parser expected note on line 3: did you mean to disable error propagation?, Fix-It replacements: 9 - 9 = 'try! '
-      ]
+      """#
     )
   }
 
@@ -454,13 +351,7 @@ final class TryTests: XCTestCase {
       _ = try "a\()b"
       _ = "a\()b" 
       _ = try "\() \(1)"
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: interpolation can throw but is not marked with 'try'
-        // TODO: Old parser expected note on line 2: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
-        // TODO: Old parser expected note on line 2: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
-        // TODO: Old parser expected note on line 2: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
-      ]
+      """#
     )
   }
 
@@ -470,10 +361,7 @@ final class TryTests: XCTestCase {
       func testGenericOptionalTry<T>(_ call: () throws -> T ) {
         let _: String = try? call() 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'T?' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -493,10 +381,7 @@ final class TryTests: XCTestCase {
       """
       // Test with a non-optional type
       let _: String = genericOptionalTry({ () throws -> Int in return 3 })
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int?' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -505,10 +390,7 @@ final class TryTests: XCTestCase {
       """
       // Test with an optional type
       let _: String = genericOptionalTry({ () throws -> Int? in return nil })
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int??' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -529,12 +411,7 @@ final class TryTests: XCTestCase {
       let _: Int?? = (try? produceAny()) as? Int // good
       let _: String = try? produceAny() as? Int 
       let _: String = (try? produceAny()) as? Int
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: value of optional type 'Int??' not unwrapped; did you mean to use 'try!' or chain with '?'?
-        // TODO: Old parser expected error on line 3: cannot convert value of type 'Int??' to specified type 'String'
-        // TODO: Old parser expected error on line 4: cannot convert value of type 'Int?' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -560,12 +437,7 @@ final class TryTests: XCTestCase {
       let _: Int = try? optProducer?.produceInt() 
       let _: String = try? optProducer?.produceInt() 
       let _: Int?? = try? optProducer?.produceInt() // good
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: value of optional type 'Int??' not unwrapped; did you mean to use 'try!' or chain with '?'?
-        // TODO: Old parser expected error on line 3: cannot convert value of type 'Int??' to specified type 'Int'
-        // TODO: Old parser expected error on line 4: cannot convert value of type 'Int??' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -574,11 +446,7 @@ final class TryTests: XCTestCase {
       """
       let _: Int? = try? optProducer?.produceIntNoThrowing() 
       let _: Int?? = try? optProducer?.produceIntNoThrowing()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: value of optional type 'Int??' not unwrapped; did you mean to use 'try!' or chain with '?'?
-        // TODO: Old parser expected warning on line 2: no calls to throwing functions occur within 'try' expression
-      ]
+      """
     )
   }
 
@@ -589,11 +457,7 @@ final class TryTests: XCTestCase {
       let _: Int? = try? optProducer?.produceAny() as? Int 
       let _: Int?? = try? optProducer?.produceAny() as? Int // good
       let _: String = try? optProducer?.produceAny() as? Int
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: value of optional type 'Int??' not unwrapped; did you mean to use 'try!' or chain with '?'?
-        // TODO: Old parser expected error on line 4: cannot convert value of type 'Int??' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -601,10 +465,7 @@ final class TryTests: XCTestCase {
     AssertParse(
       """
       let _: String = try? optProducer?.produceDoubleOptionalInt()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: cannot convert value of type 'Int???' to specified type 'String'
-      ]
+      """
     )
   }
 
@@ -624,13 +485,7 @@ final class TryTests: XCTestCase {
       let _: Int?? = try? producer.produceDoubleOptionalInt() 
       let _: Int??? = try? producer.produceDoubleOptionalInt() // good
       let _: String = try? producer.produceDoubleOptionalInt()
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 1: value of optional type 'Int???' not unwrapped; did you mean to use 'try!' or chain with '?'?
-        // TODO: Old parser expected error on line 2: value of optional type 'Int???' not unwrapped; did you mean to use 'try!' or chain with '?'?
-        // TODO: Old parser expected error on line 3: value of optional type 'Int???' not unwrapped; did you mean to use 'try!' or chain with '?'?
-        // TODO: Old parser expected error on line 5: cannot convert value of type 'Int???' to specified type 'String'
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/TryTests.swift
+++ b/Tests/SwiftParserTest/translated/TryTests.swift
@@ -1,0 +1,666 @@
+// This test file has been translated from swift/test/Parse/try.swift
+
+import XCTest
+
+final class TryTests: XCTestCase {
+  func testTry1() {
+    AssertParse(
+      """
+      // Intentionally has lower precedence than assignments and ?:
+      infix operator %%%% : LowPrecedence
+      precedencegroup LowPrecedence {
+        associativity: none
+        lowerThan: AssignmentPrecedence
+      }
+      func %%%%<T, U>(x: T, y: U) -> Int { return 0 }
+      """
+    )
+  }
+
+  func testTry2() {
+    AssertParse(
+      """
+      // Intentionally has lower precedence between assignments and ?:
+      infix operator %%% : MiddlingPrecedence
+      precedencegroup MiddlingPrecedence {
+        associativity: none
+        higherThan: AssignmentPrecedence
+        lowerThan: TernaryPrecedence
+      }
+      func %%%<T, U>(x: T, y: U) -> Int { return 1 }
+      """
+    )
+  }
+
+  func testTry3() {
+    AssertParse(
+      """
+      func foo() throws -> Int { return 0 }
+      func bar() throws -> Int { return 0 }
+      """
+    )
+  }
+
+  func testTry4() {
+    AssertParse(
+      """
+      var x = try foo() + bar()
+      x = try foo() + bar()
+      x += try foo() + bar()
+      x += try foo() %%%% bar() 
+      x += try foo() %%% bar()
+      x = foo() + try bar()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 4: result of operator '%%%%' is unused
+        // TODO: Old parser expected error on line 4: call can throw but is not marked with 'try'
+        // TODO: Old parser expected error on line 4: 'try' following assignment operator does not cover everything to its right
+        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 21 - 21 = 'try '
+        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 21 - 21 = 'try? '
+        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 21 - 21 = 'try! '
+        // TODO: Old parser expected error on line 6: call can throw but is not marked with 'try'
+        // TODO: Old parser expected error on line 6: 'try' cannot appear to the right of a non-assignment operator
+        // TODO: Old parser expected note on line 6: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
+        // TODO: Old parser expected note on line 6: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
+        // TODO: Old parser expected note on line 6: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
+      ]
+    )
+  }
+
+  func testTry5() {
+    AssertParse(
+      """
+      var y = true ? try foo() : try bar() + 0
+      var z = true ? try foo() : try bar() %%% 0
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'try' following conditional operator does not cover everything to its right
+      ]
+    )
+  }
+
+  func testTry6() {
+    AssertParse(
+      """
+      var a = try! foo() + bar()
+      a = try! foo() + bar()
+      a += try! foo() + bar()
+      a += try! foo() %%%% bar() 
+      a += try! foo() %%% bar()
+      a = foo() + try! bar()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 4: result of operator '%%%%' is unused
+        // TODO: Old parser expected error on line 4: call can throw but is not marked with 'try'
+        // TODO: Old parser expected error on line 4: 'try!' following assignment operator does not cover everything to its right
+        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 22 - 22 = 'try '
+        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 22 - 22 = 'try? '
+        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 22 - 22 = 'try! '
+        // TODO: Old parser expected error on line 6: call can throw but is not marked with 'try'
+        // TODO: Old parser expected error on line 6: 'try!' cannot appear to the right of a non-assignment operator
+        // TODO: Old parser expected note on line 6: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
+        // TODO: Old parser expected note on line 6: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
+        // TODO: Old parser expected note on line 6: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
+      ]
+    )
+  }
+
+  func testTry7() {
+    AssertParse(
+      """
+      var b = true ? try! foo() : try! bar() + 0
+      var c = true ? try! foo() : try! bar() %%% 0
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'try!' following conditional operator does not cover everything to its right
+      ]
+    )
+  }
+
+  func testTry8() {
+    AssertParse(
+      """
+      infix operator ?+= : AssignmentPrecedence
+      func ?+=(lhs: inout Int?, rhs: Int?) {
+        lhs = lhs! + rhs!
+      }
+      """
+    )
+  }
+
+  func testTry9() {
+    AssertParse(
+      """
+      var i = try? foo() + bar()
+      let _: Double = i 
+      i = try? foo() + bar()
+      i ?+= try? foo() + bar()
+      i ?+= try? foo() %%%% bar() 
+      i ?+= try? foo() %%% bar()
+      _ = foo() == try? bar() 
+      _ = (try? foo()) == bar() 
+      _ = foo() == (try? bar()) 
+      _ = (try? foo()) == (try? bar())
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int?' to specified type 'Double'
+        // TODO: Old parser expected warning on line 5: result of operator '%%%%' is unused
+        // TODO: Old parser expected error on line 5: call can throw but is not marked with 'try'
+        // TODO: Old parser expected error on line 5: 'try?' following assignment operator does not cover everything to its right
+        // TODO: Old parser expected note on line 5: did you mean to use 'try'?, Fix-It replacements: 23 - 23 = 'try '
+        // TODO: Old parser expected note on line 5: did you mean to handle error as optional value?, Fix-It replacements: 23 - 23 = 'try? '
+        // TODO: Old parser expected note on line 5: did you mean to disable error propagation?, Fix-It replacements: 23 - 23 = 'try! '
+        // TODO: Old parser expected error on line 7: call can throw but is not marked with 'try'
+        // TODO: Old parser expected error on line 7: 'try?' cannot appear to the right of a non-assignment operator
+        // TODO: Old parser expected note on line 7: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
+        // TODO: Old parser expected note on line 7: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
+        // TODO: Old parser expected note on line 7: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
+        // TODO: Old parser expected error on line 8: call can throw but is not marked with 'try'
+        // TODO: Old parser expected note on line 8: did you mean to use 'try'?, Fix-It replacements: 21 - 21 = 'try '
+        // TODO: Old parser expected note on line 8: did you mean to handle error as optional value?, Fix-It replacements: 21 - 21 = 'try? '
+        // TODO: Old parser expected note on line 8: did you mean to disable error propagation?, Fix-It replacements: 21 - 21 = 'try! '
+        // TODO: Old parser expected error on line 9: call can throw but is not marked with 'try'
+        // TODO: Old parser expected note on line 9: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
+        // TODO: Old parser expected note on line 9: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
+        // TODO: Old parser expected note on line 9: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
+      ]
+    )
+  }
+
+  func testTry10() {
+    AssertParse(
+      """
+      let j = true ? try? foo() : try? bar() + 0
+      let k = true ? try? foo() : try? bar() %%% 0
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'try?' following conditional operator does not cover everything to its right
+      ]
+    )
+  }
+
+  func testTry11() {
+    AssertParse(
+      """
+      try #^DIAG_1^#let singleLet = foo() 
+      try #^DIAG_2^#var singleVar = foo() 
+      try #^DIAG_3^#let uninit: Int 
+      try #^DIAG_4^#let (destructure1, destructure2) = (foo(), bar()) 
+      try #^DIAG_5^#let multi1 = foo(), multi2 = bar() //  expected-error 2 {{call can throw but is not marked with 'try'}}
+      class TryDecl { 
+        #^DIAG_6^#try let singleLet = foo() 
+        #^DIAG_7^#try var singleVar = foo() 
+        #^DIAG_8^#try 
+        func method() {}
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 21 - 21 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 2: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 21 - 21 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 3: 'try' must be placed on the initial value expression
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 4: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 40 - 40 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 5: 'try' must be placed on the initial value expression
+        // TODO: Old parser expected note on line 5: did you mean to use 'try'?, Fix-It replacements: 18 - 18 = 'try '
+        // TODO: Old parser expected note on line 5: did you mean to use 'try'?, Fix-It replacements: 34 - 34 = 'try '
+        // TODO: Old parser expected note on line 5: did you mean to handle error as optional value?, Fix-It replacements: 18 - 18 = 'try? '
+        // TODO: Old parser expected note on line 5: did you mean to handle error as optional value?, Fix-It replacements: 34 - 34 = 'try? '
+        // TODO: Old parser expected note on line 5: did you mean to disable error propagation?, Fix-It replacements: 18 - 18 = 'try! '
+        // TODO: Old parser expected note on line 5: did you mean to disable error propagation?, Fix-It replacements: 34 - 34 = 'try! '
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected note on line 6: in declaration of 'TryDecl'
+        // TODO: Old parser expected error on line 7: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
+        // TODO: Old parser expected error on line 7: call can throw, but errors cannot be thrown out of a property initializer
+        DiagnosticSpec(locationMarker: "DIAG_6", message: "unexpected text 'try' before variable"),
+        // TODO: Old parser expected error on line 8: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
+        // TODO: Old parser expected error on line 8: call can throw, but errors cannot be thrown out of a property initializer
+        DiagnosticSpec(locationMarker: "DIAG_7", message: "unexpected text 'try' before variable"),
+        // TODO: Old parser expected error on line 9: expected declaration
+        DiagnosticSpec(locationMarker: "DIAG_8", message: "unexpected text 'try' before function"),
+      ]
+    )
+  }
+
+  func testTry12() {
+    AssertParse(
+      """
+      func test() throws -> Int {
+        try #^DIAG_1^#while true { 
+          try #^DIAG_2^#break 
+        }
+        try #^DIAG_3^#throw #^DIAG_4^#
+        ; // Reset parser.
+        try #^DIAG_5^#return 
+        ; // Reset parser.
+        try #^DIAG_6^#throw foo() 
+        try #^DIAG_7^#return foo() 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: 'try' cannot be used with 'while'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 3: 'try' cannot be used with 'break'
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 5: 'try' must be placed on the thrown expression, Fix-It replacements: 3 - 7 = '', 3 - 3 = 'try '
+        // TODO: Old parser expected error on line 5: expected expression in 'throw' statement
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in 'try' expression"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected expression in 'throw' statement"),
+        // TODO: Old parser expected error on line 7: 'try' cannot be used with 'return'
+        // TODO: Old parser expected error on line 7: non-void function should return a value
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 9: 'try' must be placed on the thrown expression, Fix-It replacements: 3 - 7 = '', 13 - 13 = 'try '
+        // TODO: Old parser expected error on line 9: thrown expression type 'Int' does not conform to 'Error'
+        DiagnosticSpec(locationMarker: "DIAG_6", message: "expected expression in 'try' expression"),
+        // TODO: Old parser expected error on line 10: 'try' must be placed on the returned expression, Fix-It replacements: 3 - 7 = '', 14 - 14 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_7", message: "expected expression in 'try' expression"),
+      ]
+    )
+  }
+
+  func testTry13() {
+    AssertParse(
+      #"""
+      // Test operators.
+      func *(a : String, b : String) throws -> Int { return 42 }
+      let _ = "foo"
+              *  
+              "bar"
+      let _ = try! "foo"*"bar"
+      let _ = try? "foo"*"bar"
+      let _ = (try? "foo"*"bar") ?? 0
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: operator can throw but expression is not marked with 'try'
+        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 9 - 9 = 'try '
+        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 9 - 9 = 'try? '
+        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 9 - 9 = 'try! '
+      ]
+    )
+  }
+
+  func testTry14() {
+    AssertParse(
+      """
+      // <rdar://problem/21414023> Assertion failure when compiling function that takes throwing functions and rethrows
+      func rethrowsDispatchError(handleError: ((Error) throws -> ()), body: () throws -> ()) rethrows {
+        do {
+          body()   
+        } catch {
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: call can throw but is not marked with 'try'
+        // TODO: Old parser expected note on line 4: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
+        // TODO: Old parser expected note on line 4: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
+        // TODO: Old parser expected note on line 4: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
+      ]
+    )
+  }
+
+  func testTry15() {
+    AssertParse(
+      """
+      // <rdar://problem/21432429> Calling rethrows from rethrows crashes Swift compiler
+      struct r21432429 {
+        func x(_ f: () throws -> ()) rethrows {}
+        func y(_ f: () throws -> ()) rethrows {
+          x(f)  
+        }
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: call can throw but is not marked with 'try'
+        // TODO: Old parser expected note on line 5: call is to 'rethrows' function, but argument function can throw
+      ]
+    )
+  }
+
+  func testTry16() {
+    AssertParse(
+      """
+      // <rdar://problem/21427855> Swift 2: Omitting try from call to throwing closure in rethrowing function crashes compiler
+      func callThrowingClosureWithoutTry(closure: (Int) throws -> Int) rethrows {
+        closure(0)  
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: call can throw but is not marked with 'try'
+        // TODO: Old parser expected warning on line 3: result of call to function returning 'Int' is unused
+        // TODO: Old parser expected note on line 3: did you mean to use 'try'?, Fix-It replacements: 3 - 3 = 'try '
+        // TODO: Old parser expected note on line 3: did you mean to handle error as optional value?, Fix-It replacements: 3 - 3 = 'try? '
+        // TODO: Old parser expected note on line 3: did you mean to disable error propagation?, Fix-It replacements: 3 - 3 = 'try! '
+      ]
+    )
+  }
+
+  func testTry17() {
+    AssertParse(
+      """
+      func producesOptional() throws -> Int? { return nil }
+      let _: String = try? producesOptional()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int??' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTry18() {
+    AssertParse(
+      """
+      let _ = (try? foo())!!
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot force unwrap value of non-optional type 'Int'
+      ]
+    )
+  }
+
+  func testTry19() {
+    AssertParse(
+      """
+      func producesDoubleOptional() throws -> Int?? { return 3 }
+      let _: String = try? producesDoubleOptional()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int???' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTry20() {
+    AssertParse(
+      """
+      func maybeThrow() throws {}
+      try maybeThrow() // okay
+      try! maybeThrow() // okay
+      try? maybeThrow() // okay since return type of maybeThrow is Void
+      _ = try? maybeThrow() // okay
+      """
+    )
+  }
+
+  func testTry21() {
+    AssertParse(
+      """
+      let _: () -> Void = { try! maybeThrow() } // okay
+      let _: () -> Void = { try? maybeThrow() } // okay since return type of maybeThrow is Void
+      """
+    )
+  }
+
+  func testTry22() {
+    AssertParse(
+      """
+      if try? maybeThrow() { 
+      }
+      let _: Int = try? foo()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot be used as a boolean, Fix-It replacements: 4 - 4 = '((', 21 - 21 = ') != nil)'
+        // TODO: Old parser expected error on line 3: value of optional type 'Int?' not unwrapped; did you mean to use 'try!' or chain with '?'?, Fix-It replacements: 14 - 18 = 'try!'
+      ]
+    )
+  }
+
+  func testTry23() {
+    AssertParse(
+      """
+      class X {}
+      func test(_: X) {}
+      func producesObject() throws -> AnyObject { return X() }
+      test(try producesObject())
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: 'AnyObject' is not convertible to 'X'
+        // TODO: Old parser expected note on line 4: did you mean to use 'as!' to force downcast?, Fix-It replacements: 26 - 26 = ' as! X'
+      ]
+    )
+  }
+
+  func testTry24() {
+    AssertParse(
+      #"""
+      _ = "a\(try maybeThrow())b"
+      _ = try "a\(maybeThrow())b"
+      _ = "a\(maybeThrow())"
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 3: call can throw but is not marked with 'try'
+        // TODO: Old parser expected note on line 3: did you mean to use 'try'?, Fix-It replacements: 9 - 9 = 'try '
+        // TODO: Old parser expected note on line 3: did you mean to handle error as optional value?, Fix-It replacements: 9 - 9 = 'try? '
+        // TODO: Old parser expected note on line 3: did you mean to disable error propagation?, Fix-It replacements: 9 - 9 = 'try! '
+      ]
+    )
+  }
+
+  func testTry25() {
+    AssertParse(
+      """
+      extension DefaultStringInterpolation {
+        mutating func appendInterpolation() throws {}
+      }
+      """
+    )
+  }
+
+  func testTry26() {
+    AssertParse(
+      #"""
+      _ = try "a\()b"
+      _ = "a\()b" 
+      _ = try "\() \(1)"
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: interpolation can throw but is not marked with 'try'
+        // TODO: Old parser expected note on line 2: did you mean to use 'try'?, Fix-It replacements: 5 - 5 = 'try '
+        // TODO: Old parser expected note on line 2: did you mean to handle error as optional value?, Fix-It replacements: 5 - 5 = 'try? '
+        // TODO: Old parser expected note on line 2: did you mean to disable error propagation?, Fix-It replacements: 5 - 5 = 'try! '
+      ]
+    )
+  }
+
+  func testTry27() {
+    AssertParse(
+      """
+      func testGenericOptionalTry<T>(_ call: () throws -> T ) {
+        let _: String = try? call() 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot convert value of type 'T?' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTry28() {
+    AssertParse(
+      """
+      func genericOptionalTry<T>(_ call: () throws -> T ) -> T? {
+        let x = try? call() // no error expected
+        return x
+      }
+      """
+    )
+  }
+
+  func testTry29() {
+    AssertParse(
+      """
+      // Test with a non-optional type
+      let _: String = genericOptionalTry({ () throws -> Int in return 3 })
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int?' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTry30() {
+    AssertParse(
+      """
+      // Test with an optional type
+      let _: String = genericOptionalTry({ () throws -> Int? in return nil })
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot convert value of type 'Int??' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTry31() {
+    AssertParse(
+      """
+      func produceAny() throws -> Any {
+        return 3
+      }
+      """
+    )
+  }
+
+  func testTry32() {
+    AssertParse(
+      """
+      let _: Int? = try? produceAny() as? Int 
+      let _: Int?? = (try? produceAny()) as? Int // good
+      let _: String = try? produceAny() as? Int 
+      let _: String = (try? produceAny()) as? Int
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: value of optional type 'Int??' not unwrapped; did you mean to use 'try!' or chain with '?'?
+        // TODO: Old parser expected error on line 3: cannot convert value of type 'Int??' to specified type 'String'
+        // TODO: Old parser expected error on line 4: cannot convert value of type 'Int?' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTry33() {
+    AssertParse(
+      """
+      struct ThingProducer {
+        func produceInt() throws -> Int { return 3 }
+        func produceIntNoThrowing() -> Int { return 3 }
+        func produceAny() throws -> Any { return 3 }
+        func produceOptionalAny() throws -> Any? { return 3 }
+        func produceDoubleOptionalInt() throws -> Int?? { return 3 }
+      }
+      """
+    )
+  }
+
+  func testTry34() {
+    AssertParse(
+      """
+      let optProducer: ThingProducer? = ThingProducer()
+      let _: Int? = try? optProducer?.produceInt() 
+      let _: Int = try? optProducer?.produceInt() 
+      let _: String = try? optProducer?.produceInt() 
+      let _: Int?? = try? optProducer?.produceInt() // good
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: value of optional type 'Int??' not unwrapped; did you mean to use 'try!' or chain with '?'?
+        // TODO: Old parser expected error on line 3: cannot convert value of type 'Int??' to specified type 'Int'
+        // TODO: Old parser expected error on line 4: cannot convert value of type 'Int??' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTry35() {
+    AssertParse(
+      """
+      let _: Int? = try? optProducer?.produceIntNoThrowing() 
+      let _: Int?? = try? optProducer?.produceIntNoThrowing()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: value of optional type 'Int??' not unwrapped; did you mean to use 'try!' or chain with '?'?
+        // TODO: Old parser expected warning on line 2: no calls to throwing functions occur within 'try' expression
+      ]
+    )
+  }
+
+  func testTry36() {
+    AssertParse(
+      """
+      let _: Int? = (try? optProducer?.produceAny()) as? Int // good
+      let _: Int? = try? optProducer?.produceAny() as? Int 
+      let _: Int?? = try? optProducer?.produceAny() as? Int // good
+      let _: String = try? optProducer?.produceAny() as? Int
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: value of optional type 'Int??' not unwrapped; did you mean to use 'try!' or chain with '?'?
+        // TODO: Old parser expected error on line 4: cannot convert value of type 'Int??' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTry37() {
+    AssertParse(
+      """
+      let _: String = try? optProducer?.produceDoubleOptionalInt()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot convert value of type 'Int???' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTry38() {
+    AssertParse(
+      """
+      let producer = ThingProducer()
+      """
+    )
+  }
+
+  func testTry39() {
+    AssertParse(
+      """
+      let _: Int = try? producer.produceDoubleOptionalInt() 
+      let _: Int? = try? producer.produceDoubleOptionalInt() 
+      let _: Int?? = try? producer.produceDoubleOptionalInt() 
+      let _: Int??? = try? producer.produceDoubleOptionalInt() // good
+      let _: String = try? producer.produceDoubleOptionalInt()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: value of optional type 'Int???' not unwrapped; did you mean to use 'try!' or chain with '?'?
+        // TODO: Old parser expected error on line 2: value of optional type 'Int???' not unwrapped; did you mean to use 'try!' or chain with '?'?
+        // TODO: Old parser expected error on line 3: value of optional type 'Int???' not unwrapped; did you mean to use 'try!' or chain with '?'?
+        // TODO: Old parser expected error on line 5: cannot convert value of type 'Int???' to specified type 'String'
+      ]
+    )
+  }
+
+  func testTry40() {
+    AssertParse(
+      """
+      // rdar://problem/46742002
+      protocol Dummy : class {}
+      """
+    )
+  }
+
+  func testTry41() {
+    AssertParse(
+      """
+      class F<T> {
+        func wait() throws -> T { fatalError() }
+      }
+      """
+    )
+  }
+
+  func testTry42() {
+    AssertParse(
+      """
+      func bar(_ a: F<Dummy>, _ b: F<Dummy>) {
+        _ = (try? a.wait()) === (try? b.wait())
+      }
+      """
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/TypeExprTests.swift
+++ b/Tests/SwiftParserTest/translated/TypeExprTests.swift
@@ -104,15 +104,7 @@ final class TypeExprTests: XCTestCase {
         _ = Foo.dynamicType 
         _ = Bad 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 9: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 9: add arguments, Fix-It replacements: 10 - 10 = '()'
-        // TODO: Old parser expected note on line 9: use '.self', Fix-It replacements: 10 - 10 = '.self'
-        // TODO: Old parser expected error on line 10: type 'Foo' has no member 'dynamicType'
-        // TODO: Old parser expected error on line 11: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 11: use '.self' to reference the type object, Fix-It replacements: 10 - 10 = '.self'
-      ]
+      """
     )
   }
 
@@ -131,14 +123,7 @@ final class TypeExprTests: XCTestCase {
         _ = Foo.Bar 
         _ = Foo.Bar.dynamicType 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: cannot use 'Protocol' with non-protocol type 'Foo'
-        // TODO: Old parser expected error on line 10: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 10: add arguments, Fix-It replacements: 14 - 14 = '()'
-        // TODO: Old parser expected note on line 10: use '.self', Fix-It replacements: 14 - 14 = '.self'
-        // TODO: Old parser expected error on line 11: type 'Foo.Bar' has no member 'dynamicType'
-      ]
+      """
     )
   }
 
@@ -152,13 +137,7 @@ final class TypeExprTests: XCTestCase {
         let _ = Foo.Type 
         let _ = type(of: Foo.Type) 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 5: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 5: use '.self' to reference the type object
-        // TODO: Old parser expected error on line 6: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 6: use '.self' to reference the type object
-      ]
+      """
     )
   }
 
@@ -174,12 +153,7 @@ final class TypeExprTests: XCTestCase {
         _ = Gen<Foo>.instMeth
         _ = Gen<Foo> 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 8: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 8: use '.self' to reference the type object
-        // TODO: Old parser expected note on line 8: add arguments after the type to construct a value of the type
-      ]
+      """
     )
   }
 
@@ -196,13 +170,7 @@ final class TypeExprTests: XCTestCase {
         _ = Gen<Foo>.Bar 
         _ = Gen<Foo>.Bar.dynamicType 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 8: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 8: add arguments after the type to construct a value of the type
-        // TODO: Old parser expected note on line 8: use '.self' to reference the type object
-        // TODO: Old parser expected error on line 9: type 'Gen<Foo>.Bar' has no member 'dynamicType'
-      ]
+      """
     )
   }
 
@@ -229,14 +197,7 @@ final class TypeExprTests: XCTestCase {
         _ = type(fo: Foo.Bar.self) // No error here.
         _ = type(of: Foo.Bar.self, [1, 2, 3]) // No error here.
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected note on line 3: 'type(of:flag:)' declared here
-        // TODO: Old parser expected error on line 15: missing argument for parameter 'flag' in call, Fix-It replacements: 28 - 28 = ', flag: <#Bool#>'
-        // TODO: Old parser expected error on line 16: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 16: add arguments after the type to construct a value of the type
-        // TODO: Old parser expected note on line 16: use '.self' to reference the type object
-      ]
+      """
     )
   }
 
@@ -251,12 +212,7 @@ final class TypeExprTests: XCTestCase {
         let _ : () = T.meth()
         _ = T 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 7: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 7: add arguments, Fix-It replacements: 8 - 8 = '()'
-        // TODO: Old parser expected note on line 7: use '.self', Fix-It replacements: 8 - 8 = '.self'
-      ]
+      """
     )
   }
 
@@ -271,12 +227,7 @@ final class TypeExprTests: XCTestCase {
         let _ : () = T.Zang.meth()
         _ = T.Zang 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 7: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 7: add arguments, Fix-It replacements: 13 - 13 = '()'
-        // TODO: Old parser expected note on line 7: use '.self', Fix-It replacements: 13 - 13 = '.self'
-      ]
+      """
     )
   }
 
@@ -306,15 +257,7 @@ final class TypeExprTests: XCTestCase {
         let _: B.Type = D 
         let _: D.Type = D 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 8: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 8: add arguments, Fix-It replacements: 20 - 20 = '()'
-        // TODO: Old parser expected note on line 8: use '.self', Fix-It replacements: 20 - 20 = '.self'
-        // TODO: Old parser expected error on line 9: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 9: add arguments, Fix-It replacements: 20 - 20 = '()'
-        // TODO: Old parser expected note on line 9: use '.self', Fix-It replacements: 20 - 20 = '.self'
-      ]
+      """
     )
   }
 
@@ -328,12 +271,7 @@ final class TypeExprTests: XCTestCase {
         let prop = Foo.nonexistent 
         let meth = Foo.nonexistent() 
       }
-      """#,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: argument passed to call that takes no arguments
-        // TODO: Old parser expected error on line 5: type 'Foo' has no member 'nonexistent'
-        // TODO: Old parser expected error on line 6: type 'Foo' has no member 'nonexistent'
-      ]
+      """#
     )
   }
 
@@ -356,10 +294,7 @@ final class TypeExprTests: XCTestCase {
         _ = P.Protocol.Type.self
         _ = B.Type.self
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 5: cannot use 'Protocol' with non-protocol type '(any P).Type'
-      ]
+      """
     )
   }
 
@@ -379,11 +314,7 @@ final class TypeExprTests: XCTestCase {
       func inAccessibleInit() {
         _ = E 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 2: use '.self', Fix-It replacements: 8 - 8 = '.self'
-      ]
+      """
     )
   }
 
@@ -414,15 +345,7 @@ final class TypeExprTests: XCTestCase {
         _ = F 
         _ = G 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 2: add arguments, Fix-It replacements: 8 - 8 = '()'
-        // TODO: Old parser expected note on line 2: use '.self', Fix-It replacements: 8 - 8 = '.self'
-        // TODO: Old parser expected error on line 3: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 3: add arguments, Fix-It replacements: 8 - 8 = '()'
-        // TODO: Old parser expected note on line 3: use '.self', Fix-It replacements: 8 - 8 = '.self'
-      ]
+      """
     )
   }
 
@@ -466,13 +389,7 @@ final class TypeExprTests: XCTestCase {
         // TODO: Old parser expected error on line 12: single argument function types require parentheses
         // TODO: Old parser expected error on line 16: expected type before '->'
         // TODO: Old parser expected error on line 17: expected type after '->'
-        // TODO: Old parser expected error on line 18: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 18: use '.self' to reference the type object
-        // TODO: Old parser expected error on line 19: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 19: use '.self' to reference the type object
-        // TODO: Old parser expected error on line 20: cannot convert value of type '(@convention(c) () -> Int).Type' to expected argument type 'Int'
         // TODO: Old parser expected error on line 21: expected type after '->'
-        // TODO: Old parser expected error on line 22: type '(@autoclosure () -> Int) -> (Int, Int)' has no member '1'
         // TODO: Old parser expected error on line 27: argument type of @autoclosure parameter must be '()'
         // TODO: Old parser expected error on line 28: 'throws' may only occur before '->'
         DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in array element"),
@@ -507,20 +424,9 @@ final class TypeExprTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 5: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 5: use '.self', Fix-It replacements: 7 - 7 = '(', 14 - 14 = ').self'
-        // TODO: Old parser expected error on line 6: binary operator '&' cannot be applied to operands of type '(any P1).Type' and '(any P2).Type'
-        // TODO: Old parser expected error on line 9: non-protocol, non-class type '(any P2, any P3)' cannot be used within a protocol-constrained type
-        // TODO: Old parser expected error on line 10: non-protocol, non-class type 'Int' cannot be used within a protocol-constrained type
-        // TODO: Old parser expected error on line 11: non-protocol, non-class type '(any P1)?' cannot be used within a protocol-constrained type
-        // TODO: Old parser expected error on line 12: non-protocol, non-class type 'any P2.Type' cannot be used within a protocol-constrained type
         // TODO: Old parser expected error on line 13: single argument function types require parentheses, Fix-It replacements: 7 - 7 = '(', 14 - 14 = ')'
-        // TODO: Old parser expected error on line 13: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 13: use '.self', Fix-It replacements: 7 - 7 = '(', 20 - 20 = ').self'
         // TODO: Old parser expected error on line 14: single argument function types require parentheses, Fix-It replacements: 18 - 18 = '(', 25 - 25 = ')'
         // TODO: Old parser expected error on line 14: single argument function types require parentheses, Fix-It replacements: 7 - 7 = '(', 14 - 14 = ')'
-        // TODO: Old parser expected error on line 14: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 14: use '.self', Fix-It replacements: 7 - 7 = '(', 32 - 32 = ').self'
         // TODO: Old parser expected error on line 16: single argument function types require parentheses, Fix-It replacements: 8 - 8 = '(', 15 - 15 = ')'
       ]
     )
@@ -538,10 +444,7 @@ final class TypeExprTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected warning on line 6: no calls to throwing functions occur within 'try' expression
         // TODO: Old parser expected error on line 6: single argument function types require parentheses, Fix-It replacements: 11 - 11 = '(', 18 - 18 = ')'
-        // TODO: Old parser expected error on line 6: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 6: use '.self' to reference the type object, Fix-It replacements: 11 - 11 = '(', 36 - 36 = ').self'
       ]
     )
   }
@@ -581,28 +484,7 @@ final class TypeExprTests: XCTestCase {
         Swift.Int 
         _ = Swift.Int
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 4: add arguments after the type to construct a value of the type
-        // TODO: Old parser expected note on line 4: use '.self' to reference the type object
-        // TODO: Old parser expected error on line 5: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 5: add arguments after the type to construct a value of the type
-        // TODO: Old parser expected note on line 5: use '.self' to reference the type object
-        // TODO: Old parser expected error on line 6: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 6: add arguments after the type to construct a value of the type
-        // TODO: Old parser expected note on line 6: use '.self' to reference the type object
-        // TODO: Old parser expected error on line 7: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 7: add arguments after the type to construct a value of the type
-        // TODO: Old parser expected note on line 7: use '.self' to reference the type object
-        // TODO: Old parser expected warning on line 8: expression of type 'Int.Type' is unused
-        // TODO: Old parser expected error on line 8: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 8: add arguments after the type to construct a value of the type
-        // TODO: Old parser expected note on line 8: use '.self' to reference the type object
-        // TODO: Old parser expected error on line 9: expected member name or constructor call after type name
-        // TODO: Old parser expected note on line 9: add arguments after the type to construct a value of the type
-        // TODO: Old parser expected note on line 9: use '.self' to reference the type object
-      ]
+      """
     )
   }
 

--- a/Tests/SwiftParserTest/translated/TypeExprTests.swift
+++ b/Tests/SwiftParserTest/translated/TypeExprTests.swift
@@ -1,0 +1,609 @@
+// This test file has been translated from swift/test/Parse/type_expr.swift
+
+import XCTest
+
+final class TypeExprTests: XCTestCase {
+  func testTypeExpr1() {
+    AssertParse(
+      """
+      // not ready: dont_run: %target-typecheck-verify-swift -enable-astscope-lookup -swift-version 4
+      """
+    )
+  }
+
+  func testTypeExpr2() {
+    AssertParse(
+      """
+      // Types in expression contexts must be followed by a member access or
+      // constructor call.
+      """
+    )
+  }
+
+  func testTypeExpr3() {
+    AssertParse(
+      """
+      struct Foo {
+        struct Bar {
+          init() {}
+          static var prop: Int = 0
+          static func meth() {}
+          func instMeth() {}
+        }
+        init() {}
+        static var prop: Int = 0
+        static func meth() {}
+        func instMeth() {}
+      }
+      """
+    )
+  }
+
+  func testTypeExpr4() {
+    AssertParse(
+      """
+      protocol Zim {
+        associatedtype Zang
+        init()
+        // TODO class var prop: Int { get }
+        static func meth() {} 
+        func instMeth() {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: protocol methods must not have bodies
+        // TODO: Old parser expected error on line 6: protocol methods must not have bodies
+      ]
+    )
+  }
+
+  func testTypeExpr5() {
+    AssertParse(
+      """
+      protocol Bad {
+        init() {} 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: protocol initializers must not have bodies
+      ]
+    )
+  }
+
+  func testTypeExpr6() {
+    AssertParse(
+      """
+      struct Gen<T> {
+        struct Bar {
+          init() {}
+          static var prop: Int { return 0 }
+          static func meth() {}
+          func instMeth() {}
+        }
+        init() {}
+        static var prop: Int { return 0 }
+        static func meth() {}
+        func instMeth() {}
+      }
+      """
+    )
+  }
+
+  func testTypeExpr7() {
+    AssertParse(
+      """
+      func unqualifiedType() {
+        _ = Foo.self
+        _ = Foo.self
+        _ = Foo()
+        _ = Foo.prop
+        _ = Foo.meth
+        let _ : () = Foo.meth()
+        _ = Foo.instMeth
+        _ = Foo 
+        _ = Foo.dynamicType 
+        _ = Bad 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 9: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 9: add arguments, Fix-It replacements: 10 - 10 = '()'
+        // TODO: Old parser expected note on line 9: use '.self', Fix-It replacements: 10 - 10 = '.self'
+        // TODO: Old parser expected error on line 10: type 'Foo' has no member 'dynamicType'
+        // TODO: Old parser expected error on line 11: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 11: use '.self' to reference the type object, Fix-It replacements: 10 - 10 = '.self'
+      ]
+    )
+  }
+
+  func testTypeExpr8() {
+    AssertParse(
+      """
+      func qualifiedType() {
+        _ = Foo.Bar.self
+        let _ : Foo.Bar.Type = Foo.Bar.self
+        let _ : Foo.Protocol = Foo.self 
+        _ = Foo.Bar()
+        _ = Foo.Bar.prop
+        _ = Foo.Bar.meth
+        let _ : () = Foo.Bar.meth()
+        _ = Foo.Bar.instMeth
+        _ = Foo.Bar 
+        _ = Foo.Bar.dynamicType 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: cannot use 'Protocol' with non-protocol type 'Foo'
+        // TODO: Old parser expected error on line 10: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 10: add arguments, Fix-It replacements: 14 - 14 = '()'
+        // TODO: Old parser expected note on line 10: use '.self', Fix-It replacements: 14 - 14 = '.self'
+        // TODO: Old parser expected error on line 11: type 'Foo.Bar' has no member 'dynamicType'
+      ]
+    )
+  }
+
+  func testTypeExpr9() {
+    AssertParse(
+      """
+      // We allow '.Type' in expr context
+      func metaType() {
+        let _ = Foo.Type.self
+        let _ = Foo.Type.self
+        let _ = Foo.Type 
+        let _ = type(of: Foo.Type) 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 5: use '.self' to reference the type object
+        // TODO: Old parser expected error on line 6: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 6: use '.self' to reference the type object
+      ]
+    )
+  }
+
+  func testTypeExpr10() {
+    AssertParse(
+      """
+      func genType() {
+        _ = Gen<Foo>.self
+        _ = Gen<Foo>()
+        _ = Gen<Foo>.prop
+        _ = Gen<Foo>.meth
+        let _ : () = Gen<Foo>.meth()
+        _ = Gen<Foo>.instMeth
+        _ = Gen<Foo> 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 8: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 8: use '.self' to reference the type object
+        // TODO: Old parser expected note on line 8: add arguments after the type to construct a value of the type
+      ]
+    )
+  }
+
+  func testTypeExpr11() {
+    AssertParse(
+      """
+      func genQualifiedType() {
+        _ = Gen<Foo>.Bar.self
+        _ = Gen<Foo>.Bar()
+        _ = Gen<Foo>.Bar.prop
+        _ = Gen<Foo>.Bar.meth
+        let _ : () = Gen<Foo>.Bar.meth()
+        _ = Gen<Foo>.Bar.instMeth
+        _ = Gen<Foo>.Bar 
+        _ = Gen<Foo>.Bar.dynamicType 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 8: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 8: add arguments after the type to construct a value of the type
+        // TODO: Old parser expected note on line 8: use '.self' to reference the type object
+        // TODO: Old parser expected error on line 9: type 'Gen<Foo>.Bar' has no member 'dynamicType'
+      ]
+    )
+  }
+
+  func testTypeExpr12() {
+    AssertParse(
+      """
+      func typeOfShadowing() {
+        // Try to shadow type(of:)
+        func type<T>(of t: T.Type, flag: Bool) -> T.Type { 
+          return t
+        }
+        func type<T, U>(of t: T.Type, _ : U) -> T.Type {
+          return t
+        }
+        func type<T>(_ t: T.Type) -> T.Type {
+          return t
+        }
+        func type<T>(fo t: T.Type) -> T.Type {
+          return t
+        }
+        _ = type(of: Gen<Foo>.Bar) 
+        _ = type(Gen<Foo>.Bar) 
+        _ = type(of: Gen<Foo>.Bar.self, flag: false) // No error here.
+        _ = type(fo: Foo.Bar.self) // No error here.
+        _ = type(of: Foo.Bar.self, [1, 2, 3]) // No error here.
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected note on line 3: 'type(of:flag:)' declared here
+        // TODO: Old parser expected error on line 15: missing argument for parameter 'flag' in call, Fix-It replacements: 28 - 28 = ', flag: <#Bool#>'
+        // TODO: Old parser expected error on line 16: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 16: add arguments after the type to construct a value of the type
+        // TODO: Old parser expected note on line 16: use '.self' to reference the type object
+      ]
+    )
+  }
+
+  func testTypeExpr13() {
+    AssertParse(
+      """
+      func archetype<T: Zim>(_: T) {
+        _ = T.self
+        _ = T()
+        // TODO let prop = T.prop
+        _ = T.meth
+        let _ : () = T.meth()
+        _ = T 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 7: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 7: add arguments, Fix-It replacements: 8 - 8 = '()'
+        // TODO: Old parser expected note on line 7: use '.self', Fix-It replacements: 8 - 8 = '.self'
+      ]
+    )
+  }
+
+  func testTypeExpr14() {
+    AssertParse(
+      """
+      func assocType<T: Zim>(_: T) where T.Zang: Zim {
+        _ = T.Zang.self
+        _ = T.Zang()
+        // TODO _ = T.Zang.prop
+        _ = T.Zang.meth
+        let _ : () = T.Zang.meth()
+        _ = T.Zang 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 7: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 7: add arguments, Fix-It replacements: 13 - 13 = '()'
+        // TODO: Old parser expected note on line 7: use '.self', Fix-It replacements: 13 - 13 = '.self'
+      ]
+    )
+  }
+
+  func testTypeExpr15() {
+    AssertParse(
+      """
+      class B {
+        class func baseMethod() {}
+      }
+      class D: B {
+        class func derivedMethod() {}
+      }
+      """
+    )
+  }
+
+  func testTypeExpr16() {
+    AssertParse(
+      """
+      func derivedType() {
+        let _: B.Type = D.self
+        _ = D.baseMethod
+        let _ : () = D.baseMethod()
+        let _: D.Type = D.self
+        _ = D.derivedMethod
+        let _ : () = D.derivedMethod()
+        let _: B.Type = D 
+        let _: D.Type = D 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 8: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 8: add arguments, Fix-It replacements: 20 - 20 = '()'
+        // TODO: Old parser expected note on line 8: use '.self', Fix-It replacements: 20 - 20 = '.self'
+        // TODO: Old parser expected error on line 9: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 9: add arguments, Fix-It replacements: 20 - 20 = '()'
+        // TODO: Old parser expected note on line 9: use '.self', Fix-It replacements: 20 - 20 = '.self'
+      ]
+    )
+  }
+
+  func testTypeExpr17() {
+    AssertParse(
+      #"""
+      // Referencing a nonexistent member or constructor should not trigger errors
+      // about the type expression.
+      func nonexistentMember() {
+        let cons = Foo("this constructor does not exist") 
+        let prop = Foo.nonexistent 
+        let meth = Foo.nonexistent() 
+      }
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: argument passed to call that takes no arguments
+        // TODO: Old parser expected error on line 5: type 'Foo' has no member 'nonexistent'
+        // TODO: Old parser expected error on line 6: type 'Foo' has no member 'nonexistent'
+      ]
+    )
+  }
+
+  func testTypeExpr18() {
+    AssertParse(
+      """
+      protocol P {}
+      """
+    )
+  }
+
+  func testTypeExpr19() {
+    AssertParse(
+      """
+      func meta_metatypes() {
+        let _: P.Protocol = P.self
+        _ = P.Type.self
+        _ = P.Protocol.self
+        _ = P.Protocol.Protocol.self 
+        _ = P.Protocol.Type.self
+        _ = B.Type.self
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: cannot use 'Protocol' with non-protocol type '(any P).Type'
+      ]
+    )
+  }
+
+  func testTypeExpr20() {
+    AssertParse(
+      """
+      class E {
+        private init() {}
+      }
+      """
+    )
+  }
+
+  func testTypeExpr21() {
+    AssertParse(
+      """
+      func inAccessibleInit() {
+        _ = E 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 2: use '.self', Fix-It replacements: 8 - 8 = '.self'
+      ]
+    )
+  }
+
+  func testTypeExpr22() {
+    AssertParse(
+      """
+      enum F: Int {
+        case A, B
+      }
+      """
+    )
+  }
+
+  func testTypeExpr23() {
+    AssertParse(
+      """
+      struct G {
+        var x: Int
+      }
+      """
+    )
+  }
+
+  func testTypeExpr24() {
+    AssertParse(
+      """
+      func implicitInit() {
+        _ = F 
+        _ = G 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 2: add arguments, Fix-It replacements: 8 - 8 = '()'
+        // TODO: Old parser expected note on line 2: use '.self', Fix-It replacements: 8 - 8 = '.self'
+        // TODO: Old parser expected error on line 3: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 3: add arguments, Fix-It replacements: 8 - 8 = '()'
+        // TODO: Old parser expected note on line 3: use '.self', Fix-It replacements: 8 - 8 = '.self'
+      ]
+    )
+  }
+
+  func testTypeExpr25() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/43119
+      func testFunctionCollectionTypes() {
+        _ = [(Int) -> Int]()
+        _ = [(Int, Int) -> Int]()
+        _ = [(x: Int, y: Int) -> Int]()
+        // Make sure associativity is correct
+        let a = [(Int) -> (Int) -> Int]()
+        let b: Int = a[0](5)(4)
+        _ = [String: (Int) -> Int]()
+        _ = [String: (Int, Int) -> Int]()
+        _ = [1 -> Int]() 
+        _ = [Int -> 1]() 
+        // Should parse () as void type when before or after arrow
+        _ = [() -> Int]()
+        _ = [(Int) -> ()]()
+        _ = 2 + () -> Int 
+        _ = () -> (Int, Int).2 
+        _ = (Int) -> Int 
+        _ = @convention(c) () -> Int 
+        _ = 1 + (@convention(c) () -> Int).self 
+        _ = (@autoclosure () -> Int) -> (Int, Int).2 
+        _ = ((@autoclosure () -> Int) -> (Int, Int)).1 
+        _ = ((inout Int) -> Void).self
+        _ = [(Int) throws -> Int]()
+        _ = [@convention(swift) (Int) throws -> Int]().count
+        _ = [(inout Int) throws -> (inout () -> Void) -> Void]().count
+        _ = [String: (@autoclosure (Int) -> Int32) -> Void]().keys 
+        let _ = [(Int) -> #^DIAG_1^#throws Int]() 
+        let _ = [Int throws #^DIAG_2^#Int](); 
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 11: expected type before '->'
+        // TODO: Old parser expected error on line 12: expected type after '->'
+        // TODO: Old parser expected error on line 12: single argument function types require parentheses
+        // TODO: Old parser expected error on line 16: expected type before '->'
+        // TODO: Old parser expected error on line 17: expected type after '->'
+        // TODO: Old parser expected error on line 18: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 18: use '.self' to reference the type object
+        // TODO: Old parser expected error on line 19: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 19: use '.self' to reference the type object
+        // TODO: Old parser expected error on line 20: cannot convert value of type '(@convention(c) () -> Int).Type' to expected argument type 'Int'
+        // TODO: Old parser expected error on line 21: expected type after '->'
+        // TODO: Old parser expected error on line 22: type '(@autoclosure () -> Int) -> (Int, Int)' has no member '1'
+        // TODO: Old parser expected error on line 27: argument type of @autoclosure parameter must be '()'
+        // TODO: Old parser expected error on line 28: 'throws' may only occur before '->'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in array element"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text 'throws Int' in array"),
+        // TODO: Old parser expected error on line 29: 'throws' may only occur before '->'
+        // TODO: Old parser expected error on line 29: consecutive statements on a line must be separated by ';'
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '->' in array element"),
+      ]
+    )
+  }
+
+  func testTypeExpr26() {
+    AssertParse(
+      """
+      protocol P1 {}
+      protocol P2 {}
+      protocol P3 {}
+      func compositionType() {
+        _ = P1 & P2 
+        _ = P1 & P2.self 
+        _ = (P1 & P2).self // Ok.
+        _ = (P1 & (P2)).self // FIXME: OK? while `typealias P = P1 & (P2)` is rejected.
+        _ = (P1 & (P2, P3)).self 
+        _ = (P1 & Int).self 
+        _ = (P1? & P2).self 
+        _ = (P1 & P2.Type).self 
+        _ = P1 & P2 -> P3
+        _ = P1 & P2 -> P3 & P1 -> Int
+        _ = (() -> P1 & P2).self // Ok
+        _ = (P1 & P2 -> P3 & P2).self 
+        _ = ((P1 & P2) -> (P3 & P2) -> P1 & Any).self // Ok
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 5: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 5: use '.self', Fix-It replacements: 7 - 7 = '(', 14 - 14 = ').self'
+        // TODO: Old parser expected error on line 6: binary operator '&' cannot be applied to operands of type '(any P1).Type' and '(any P2).Type'
+        // TODO: Old parser expected error on line 9: non-protocol, non-class type '(any P2, any P3)' cannot be used within a protocol-constrained type
+        // TODO: Old parser expected error on line 10: non-protocol, non-class type 'Int' cannot be used within a protocol-constrained type
+        // TODO: Old parser expected error on line 11: non-protocol, non-class type '(any P1)?' cannot be used within a protocol-constrained type
+        // TODO: Old parser expected error on line 12: non-protocol, non-class type 'any P2.Type' cannot be used within a protocol-constrained type
+        // TODO: Old parser expected error on line 13: single argument function types require parentheses, Fix-It replacements: 7 - 7 = '(', 14 - 14 = ')'
+        // TODO: Old parser expected error on line 13: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 13: use '.self', Fix-It replacements: 7 - 7 = '(', 20 - 20 = ').self'
+        // TODO: Old parser expected error on line 14: single argument function types require parentheses, Fix-It replacements: 18 - 18 = '(', 25 - 25 = ')'
+        // TODO: Old parser expected error on line 14: single argument function types require parentheses, Fix-It replacements: 7 - 7 = '(', 14 - 14 = ')'
+        // TODO: Old parser expected error on line 14: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 14: use '.self', Fix-It replacements: 7 - 7 = '(', 32 - 32 = ').self'
+        // TODO: Old parser expected error on line 16: single argument function types require parentheses, Fix-It replacements: 8 - 8 = '(', 15 - 15 = ')'
+      ]
+    )
+  }
+
+  func testTypeExpr27() {
+    AssertParse(
+      """
+      func complexSequence() {
+        // (assign_expr
+        //   (discard_assignment_expr)
+        //   (try_expr
+        //     (type_expr typerepr='P1 & P2 throws -> P3 & P1')))
+        _ = try P1 & P2 throws -> P3 & P1
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 6: no calls to throwing functions occur within 'try' expression
+        // TODO: Old parser expected error on line 6: single argument function types require parentheses, Fix-It replacements: 11 - 11 = '(', 18 - 18 = ')'
+        // TODO: Old parser expected error on line 6: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 6: use '.self' to reference the type object, Fix-It replacements: 11 - 11 = '(', 36 - 36 = ').self'
+      ]
+    )
+  }
+
+  func testTypeExpr28() {
+    AssertParse(
+      """
+      func takesVoid(f: #^DIAG_1^#Void #^DIAG_2^#-> ()) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: single argument function types require parentheses, Fix-It replacements: 19 - 23 = '()'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '(' to start function type"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ')' in function type"),
+      ]
+    )
+  }
+
+  func testTypeExpr29() {
+    AssertParse(
+      """
+      func takesOneArg<T>(_: T.Type) {}
+      func takesTwoArgs<T>(_: T.Type, _: Int) {}
+      """
+    )
+  }
+
+  func testTypeExpr30() {
+    AssertParse(
+      """
+      func testMissingSelf() {
+        // None of these were not caught in Swift 3.
+        // See test/Compatibility/type_expr.swift.
+        takesOneArg(Int)
+        takesOneArg(Swift.Int)
+        takesTwoArgs(Int, 0)
+        takesTwoArgs(Swift.Int, 0)
+        Swift.Int 
+        _ = Swift.Int
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 4: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 4: add arguments after the type to construct a value of the type
+        // TODO: Old parser expected note on line 4: use '.self' to reference the type object
+        // TODO: Old parser expected error on line 5: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 5: add arguments after the type to construct a value of the type
+        // TODO: Old parser expected note on line 5: use '.self' to reference the type object
+        // TODO: Old parser expected error on line 6: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 6: add arguments after the type to construct a value of the type
+        // TODO: Old parser expected note on line 6: use '.self' to reference the type object
+        // TODO: Old parser expected error on line 7: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 7: add arguments after the type to construct a value of the type
+        // TODO: Old parser expected note on line 7: use '.self' to reference the type object
+        // TODO: Old parser expected warning on line 8: expression of type 'Int.Type' is unused
+        // TODO: Old parser expected error on line 8: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 8: add arguments after the type to construct a value of the type
+        // TODO: Old parser expected note on line 8: use '.self' to reference the type object
+        // TODO: Old parser expected error on line 9: expected member name or constructor call after type name
+        // TODO: Old parser expected note on line 9: add arguments after the type to construct a value of the type
+        // TODO: Old parser expected note on line 9: use '.self' to reference the type object
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/TypealiasTests.swift
+++ b/Tests/SwiftParserTest/translated/TypealiasTests.swift
@@ -1,0 +1,154 @@
+// This test file has been translated from swift/test/Parse/typealias.swift
+
+import XCTest
+
+final class TypealiasTests: XCTestCase {
+  func testTypealias1() {
+    AssertParse(
+      """
+      //===--- Simple positive tests.
+      """
+    )
+  }
+
+  func testTypealias2() {
+    AssertParse(
+      """
+      typealias IntPair = (Int, Int)
+      typealias IntTriple = (Int, Int, Int)
+      typealias FiveInts = (IntPair, IntTriple)
+      var fiveInts : FiveInts = ((4,2), (1,2,3))
+      """
+    )
+  }
+
+  func testTypealias3() {
+    AssertParse(
+      """
+      // <rdar://problem/13339798> QoI: poor diagnostic in malformed typealias
+      typealias Foo1 #^DIAG_1^#: Int  
+      typealias Foo2#^DIAG_2^#: Int  
+      typealias Foo3 #^DIAG_3^#:Int  
+      typealias Foo4#^DIAG_4^#:/*comment*/Int
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected '=' in type alias declaration, Fix-It replacements: 16 - 17 = '='
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '=' and value in typealias declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text ': Int' before typealias declaration"),
+        // TODO: Old parser expected error on line 3: expected '=' in type alias declaration, Fix-It replacements: 15 - 16 = ' ='
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '=' and value in typealias declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text ': Int' before typealias declaration"),
+        // TODO: Old parser expected error on line 4: expected '=' in type alias declaration, Fix-It replacements: 16 - 17 = '= '
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected '=' and value in typealias declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text ':Int' before typealias declaration"),
+        // TODO: Old parser expected error on line 5: expected '=' in type alias declaration, Fix-It replacements: 15 - 16 = ' = '
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected '=' and value in typealias declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "extraneous ':/*comment*/Int' at top level"),
+      ]
+    )
+  }
+
+  func testTypealias4() {
+    AssertParse(
+      """
+      //===--- Tests for error recovery.
+      """
+    )
+  }
+
+  func testTypealias5() {
+    AssertParse(
+      """
+      typealias Recovery1#^DIAG^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected '=' in type alias declaration
+        DiagnosticSpec(message: "expected '=' and value in typealias declaration"),
+      ]
+    )
+  }
+
+  func testTypealias6() {
+    AssertParse(
+      """
+      typealias Recovery2 #^DIAG^#:
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected '=' in type alias declaration
+        // TODO: Old parser expected error on line 1: expected type in type alias declaration
+        DiagnosticSpec(message: "expected '=' and value in typealias declaration"),
+        DiagnosticSpec(message: "extraneous ':' at top level"),
+      ]
+    )
+  }
+
+  func testTypealias7() {
+    AssertParse(
+      """
+      typealias Recovery3 =#^DIAG^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected type in type alias declaration
+        DiagnosticSpec(message: "expected value in typealias declaration"),
+      ]
+    )
+  }
+
+  func testTypealias8() {
+    AssertParse(
+      """
+      typealias Recovery4 #^DIAG^#: Int
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected '=' in type alias declaration
+        DiagnosticSpec(message: "expected '=' and value in typealias declaration"),
+        DiagnosticSpec(message: "extraneous ': Int' at top level"),
+      ]
+    )
+  }
+
+  func testTypealias9() {
+    AssertParse(
+      """
+      typealias Recovery5 #^DIAG^#: Int, Float
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected '=' in type alias declaration
+        // TODO: Old parser expected error on line 1: consecutive statements on a line must be separated by ';'
+        // TODO: Old parser expected error on line 1: expected expression
+        DiagnosticSpec(message: "expected '=' and value in typealias declaration"),
+        DiagnosticSpec(message: "extraneous ': Int, Float' at top level"),
+      ]
+    )
+  }
+
+  func testTypealias10() {
+    AssertParse(
+      """
+      typealias Recovery6 = #^DIAG^#=
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected type in type alias declaration
+        DiagnosticSpec(message: "expected value in typealias declaration"),
+        DiagnosticSpec(message: "extraneous '=' at top level"),
+      ]
+    )
+  }
+
+  func testTypealias11() {
+    AssertParse(
+      """
+      typealias #^DIAG_1^#switch #^DIAG_2^#= Int
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: keyword 'switch' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 11 - 17 = '`switch`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in typealias declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '=' and value in typealias declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression and '{}' to end 'switch' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "extraneous '= Int' at top level"),
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/UnclosedStringInterpolationTests.swift
+++ b/Tests/SwiftParserTest/translated/UnclosedStringInterpolationTests.swift
@@ -1,0 +1,114 @@
+// This test file has been translated from swift/test/Parse/unclosed-string-interpolation.swift
+
+import XCTest
+
+final class UnclosedStringInterpolationTests: XCTestCase {
+  func testUnclosedStringInterpolation1() {
+    AssertParse(
+      #"""
+      let mid = "pete"
+      """#
+    )
+  }
+
+  func testUnclosedStringInterpolation2() {
+    AssertParse(
+      ##"""
+      _ = #^DIAG^#"mid == \(pete"
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
+        // TODO: Old parser expected error on line 1: unterminated string literal
+        DiagnosticSpec(message: "expected expression"),
+        DiagnosticSpec(message: #"extraneous '"mid == \(pete"' at top level"#),
+      ]
+    )
+  }
+
+  func testUnclosedStringInterpolation3() {
+    AssertParse(
+      ##"""
+      let theGoat = #^DIAG^#"kanye \("
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
+        // TODO: Old parser expected error on line 1: unterminated string literal
+        DiagnosticSpec(message: "expected expression in variable"),
+        DiagnosticSpec(message: #"extraneous '"kanye \("' at top level"#),
+      ]
+    )
+  }
+
+  func testUnclosedStringInterpolation4() {
+    AssertParse(
+      ##"""
+      let equation1 = #^DIAG^#"2 + 2 = \(2 + 2"
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
+        // TODO: Old parser expected error on line 1: unterminated string literal
+        DiagnosticSpec(message: "expected expression in variable"),
+        DiagnosticSpec(message: #"extraneous '"2 + 2 = \(2 + 2"' at top level"#),
+      ]
+    )
+  }
+
+  func testUnclosedStringInterpolation5() {
+    AssertParse(
+      ##"""
+      let s = #^DIAG^#"\(x"; print(x)
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
+        // TODO: Old parser expected error on line 1: unterminated string literal
+        DiagnosticSpec(message: "expected expression in variable"),
+        DiagnosticSpec(message: #"extraneous '"\(x"; print(x)' at top level"#),
+      ]
+    )
+  }
+
+  func testUnclosedStringInterpolation6() {
+    AssertParse(
+      ##"""
+      let zzz = #^DIAG^#"\(x; print(x)
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
+        // TODO: Old parser expected error on line 1: unterminated string literal
+        DiagnosticSpec(message: "expected expression in variable"),
+        DiagnosticSpec(message: #"extraneous '"\(x; print(x)' at top level"#),
+      ]
+    )
+  }
+
+  func testUnclosedStringInterpolation7() {
+    AssertParse(
+      ##"""
+      let goatedAlbum = #^DIAG^#"The Life Of \("Pablo"
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: cannot find ')' to match opening '(' in string interpolation
+        // TODO: Old parser expected error on line 1: unterminated string literal
+        DiagnosticSpec(message: "expected expression in variable"),
+        DiagnosticSpec(message: #"extraneous '"The Life Of \("Pablo"' at top level"#),
+      ]
+    )
+  }
+
+  func testUnclosedStringInterpolation8() {
+    AssertParse(
+      ##"""
+      _ = #^DIAG^#"""
+      \(
+      """
+      """##,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: unterminated string literal
+        DiagnosticSpec(message: "expected expression"),
+        DiagnosticSpec(message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 2: cannot find ')' to match opening '(' in string interpolation
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/UnknownPlatformTests.swift
+++ b/Tests/SwiftParserTest/translated/UnknownPlatformTests.swift
@@ -1,0 +1,77 @@
+// This test file has been translated from swift/test/Parse/unknown_platform.swift
+
+import XCTest
+
+final class UnknownPlatformTests: XCTestCase {
+  func testUnknownPlatform1() {
+    AssertParse(
+      """
+      #if hasGreeble(blah)
+      #endif
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: unexpected platform condition
+      ]
+    )
+  }
+
+  func testUnknownPlatform2() {
+    AssertParse(
+      """
+      // Future compiler, short-circuit right-hand side
+      #if compiler(>=10.0) && hasGreeble(blah)
+      #endif
+      """
+    )
+  }
+
+  func testUnknownPlatform3() {
+    AssertParse(
+      """
+      // Current compiler, short-circuit right-hand side
+      #if compiler(<10.0) || hasGreeble(blah)
+      #endif
+      """
+    )
+  }
+
+  func testUnknownPlatform4() {
+    AssertParse(
+      """
+      // This compiler, don't short-circuit.
+      #if compiler(>=5.7) && hasGreeble(blah)
+      #endif
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: unexpected platform condition
+      ]
+    )
+  }
+
+  func testUnknownPlatform5() {
+    AssertParse(
+      """
+      // This compiler, don't short-circuit.
+      #if compiler(<5.8) || hasGreeble(blah)
+      #endif
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: unexpected platform condition
+      ]
+    )
+  }
+
+  func testUnknownPlatform6() {
+    AssertParse(
+      #"""
+      // Not a "version" check, so don't short-circuit.
+      #if os(macOS) && hasGreeble(blah)
+      #endif
+      """#,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: unexpected platform condition
+      ]
+    )
+  }
+
+}

--- a/Tests/SwiftParserTest/translated/UpcomingFeatureTests.swift
+++ b/Tests/SwiftParserTest/translated/UpcomingFeatureTests.swift
@@ -1,0 +1,18 @@
+// This test file has been translated from swift/test/Parse/upcoming_feature.swift
+
+import XCTest
+
+final class UpcomingFeatureTests: XCTestCase {
+  func testUpcomingFeature1() {
+    AssertParse(
+      """
+      #if hasFeature(17)
+      #endif
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: unexpected platform condition argument: expected feature name
+      ]
+    )
+  }
+
+}


### PR DESCRIPTION
This translates the test cases from swift/test/Parse into XCTests that can be run in the swift-syntax repository.

All previously expected errors, warnings and notes are imported as TODOs, while the expected diagnostics are filled with those the parser currently produces.

In a first step, this performs a mechanical 1:1 translation. A second commit in this PR removes TODOs that area obviously semantic. Upcoming commits will need to address the TODOs by
- removing them (e.g. because the diagnostics are semantic and should be reported by ASTGen in the new scheme)
- matching them up with diagnostics that are already produced by the new parser
- Adjusting the new parser to produce the previously expected diagnostics.

Powering through these TODOs will be quite a bit of effort but it’s something that I think we need to do…