### PR TITLE
Lowercase diagnostic and Fix-It messages and remove "after <previous token>" clause from missing node diagnostics

### DIFF
--- a/Sources/SwiftParser/Diagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParser/Diagnostics/MissingNodesError.swift
@@ -169,7 +169,7 @@ public struct MissingNodesError: ParserError {
   }
 
   public var message: String {
-    var message = "Expected \(missingNodesDescription(missingNodes: missingNodes, commonParent: commonParent))"
+    var message = "expected \(missingNodesDescription(missingNodes: missingNodes, commonParent: commonParent))"
     if let afterClause = afterClause {
       message += " \(afterClause)"
     }

--- a/Sources/SwiftParser/Diagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParser/Diagnostics/MissingNodesError.swift
@@ -128,13 +128,6 @@ public struct MissingNodesError: ParserError {
       }
     }
 
-    // The after clause only provides value if the first missing node is not a token.
-    // TODO: Revisit whether we want to have this clause at all.
-    if !firstMissingNode.is(TokenSyntax.self) {
-      if let previousToken = firstMissingNode.previousToken(viewMode: .fixedUp), previousToken.presence == .present {
-        return "after '\(previousToken.text)'"
-      }
-    }
     return nil
   }
 

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -53,8 +53,8 @@ public extension ParserFixIt {
 /// Please order the cases in this enum alphabetically by case name.
 public enum StaticParserError: String, DiagnosticMessage {
   case cStyleForLoop = "C-style for statement has been removed in Swift 3"
-  case missingColonInTernaryExprDiagnostic = "Expected ':' after '? ...' in ternary expression"
-  case missingFunctionParameterClause = "Expected argument list in function declaration"
+  case missingColonInTernaryExprDiagnostic = "expected ':' after '? ...' in ternary expression"
+  case missingFunctionParameterClause = "expected argument list in function declaration"
   case throwsInReturnPosition = "'throws' may only occur before '->'"
 
   public var message: String { self.rawValue }
@@ -73,9 +73,9 @@ public struct ExtaneousCodeAtTopLevel: ParserError {
 
   public var message: String {
     if let shortContent = extraneousCode.contentForDiagnosticsIfShortSingleLine {
-      return "Extraneous '\(shortContent)' at top level"
+      return "extraneous '\(shortContent)' at top level"
     } else {
-      return "Extraneous code at top level"
+      return "extraneous code at top level"
     }
   }
 }
@@ -98,7 +98,7 @@ public struct MissingAttributeArgument: ParserError {
   public let attributeName: TokenSyntax
 
   public var message: String {
-    return "Expected argument for '@\(attributeName)' attribute"
+    return "expected argument for '@\(attributeName)' attribute"
   }
 }
 
@@ -106,7 +106,7 @@ public struct UnexpectedNodesError: ParserError {
   public let unexpectedNodes: UnexpectedNodesSyntax
 
   public var message: String {
-    var message = "Unexpected text"
+    var message = "unexpected text"
     if let shortContent = unexpectedNodes.contentForDiagnosticsIfShortSingleLine {
       message += " '\(shortContent)'"
     }
@@ -124,8 +124,8 @@ public struct UnexpectedNodesError: ParserError {
 // MARK: - Fix-Its (please sort alphabetically)
 
 public enum StaticParserFixIt: String, FixItMessage {
-  case insertAttributeArguments = "Insert attribute argument"
-  case moveThrowBeforeArrow = "Move 'throws' before '->'"
+  case insertAttributeArguments = "insert attribute argument"
+  case moveThrowBeforeArrow = "move 'throws' before '->'"
 
   public var message: String { self.rawValue }
 

--- a/Tests/SwiftParserTest/Attributes.swift
+++ b/Tests/SwiftParserTest/Attributes.swift
@@ -11,8 +11,8 @@ final class AttributeTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected argument for '@_dynamicReplacement' attribute", fixIts: ["Insert attribute argument"]),
-        DiagnosticSpec(message: "Expected ')' to end attribute", fixIts: ["Insert ')'"]),
+        DiagnosticSpec(message: "expected argument for '@_dynamicReplacement' attribute", fixIts: ["insert attribute argument"]),
+        DiagnosticSpec(message: "expected ')' to end attribute", fixIts: ["Insert ')'"]),
       ],
       fixedSource: """
         @_dynamicReplacement(for: <#identifier#>)
@@ -30,9 +30,9 @@ final class AttributeTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ':' and parameters in '@differentiable' argument", fixIts: ["Insert ':' and parameters"]),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '=' and right-hand type in same type requirement", fixIts: ["Insert '=' and right-hand type"]),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected ')' to end attribute", fixIts: ["Insert ')'"]),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected ':' and parameters in '@differentiable' argument", fixIts: ["Insert ':' and parameters"]),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '=' and right-hand type in same type requirement", fixIts: ["Insert '=' and right-hand type"]),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ')' to end attribute", fixIts: ["Insert ')'"]),
       ],
       fixedSource: """
         @differentiable(reverse wrt: <#syntax#>,where T = <#type#>)
@@ -48,9 +48,9 @@ final class AttributeTests: XCTestCase {
       @_specialize(e#^DIAG^#
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected ':' in attribute argument"),
-        DiagnosticSpec(message: "Expected ')' to end attribute"),
-        DiagnosticSpec(message: "Expected declaration after attribute"),
+        DiagnosticSpec(message: "expected ':' in attribute argument"),
+        DiagnosticSpec(message: "expected ')' to end attribute"),
+        DiagnosticSpec(message: "expected declaration after attribute"),
       ]
     )
   }
@@ -61,9 +61,9 @@ final class AttributeTests: XCTestCase {
       @_specialize(e#^DIAG_1^#, exported#^DIAG_2^#)#^DIAG_3^#
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected ':' in attribute argument"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected ': false' in attribute argument"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "Expected declaration after attribute"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected ':' in attribute argument"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ': false' in attribute argument"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected declaration after attribute"),
       ]
     )
   }
@@ -231,7 +231,7 @@ final class AttributeTests: XCTestCase {
   func testMissingDeclarationAfterAttributes() {
     AssertParse(
       "@resultBuilder#^DIAG^#",
-      diagnostics: [DiagnosticSpec(message: "Expected declaration after attribute")],
+      diagnostics: [DiagnosticSpec(message: "expected declaration after attribute")],
       fixedSource: """
         @resultBuilder
         <#declaration#>

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -38,9 +38,9 @@ final class DeclarationTests: XCTestCase {
                 r#^DIAG2^#
                 """,
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "DIAG1", message: "Expected identifier in function"),
-                  DiagnosticSpec(locationMarker: "DIAG1", message: "Expected argument list in function declaration"),
-                  DiagnosticSpec(locationMarker: "DIAG2", message: "Expected '=' and right-hand type in same type requirement"),
+                  DiagnosticSpec(locationMarker: "DIAG1", message: "expected identifier in function"),
+                  DiagnosticSpec(locationMarker: "DIAG1", message: "expected argument list in function declaration"),
+                  DiagnosticSpec(locationMarker: "DIAG2", message: "expected '=' and right-hand type in same type requirement"),
                 ])
   }
 
@@ -51,7 +51,7 @@ final class DeclarationTests: XCTestCase {
       func foo() {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text '}' before function")
+        DiagnosticSpec(message: "unexpected text '}' before function")
       ]
     )
   }
@@ -76,14 +76,14 @@ final class DeclarationTests: XCTestCase {
 
     AssertParse("class T where t#^DIAG^#",
                 diagnostics: [
-                  DiagnosticSpec(message: "Expected '=' and right-hand type in same type requirement"),
-                  DiagnosticSpec(message: "Expected member block in class"),
+                  DiagnosticSpec(message: "expected '=' and right-hand type in same type requirement"),
+                  DiagnosticSpec(message: "expected member block in class"),
                 ])
     AssertParse("class B<where g#^DIAG^#",
                 diagnostics: [
-                  DiagnosticSpec(message: "Expected '=' and right-hand type in same type requirement"),
-                  DiagnosticSpec(message: "Expected '>' to end generic parameter clause"),
-                  DiagnosticSpec(message: "Expected member block in class"),
+                  DiagnosticSpec(message: "expected '=' and right-hand type in same type requirement"),
+                  DiagnosticSpec(message: "expected '>' to end generic parameter clause"),
+                  DiagnosticSpec(message: "expected member block in class"),
                 ])
   }
 
@@ -113,7 +113,7 @@ final class DeclarationTests: XCTestCase {
       actor Foo {}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text '}' before actor")
+        DiagnosticSpec(message: "unexpected text '}' before actor")
       ]
     )
   }
@@ -139,9 +139,9 @@ final class DeclarationTests: XCTestCase {
     AssertParse(
       "protocol P{#^DIAG_1^#{}case#^DIAG_2^#",
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '{}' before enum case"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected identifier in enum case"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '}' to end protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '{}' before enum case"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '}' to end protocol"),
       ])
   }
 
@@ -169,8 +169,8 @@ final class DeclarationTests: XCTestCase {
     AssertParse(
       "_ = foo/* */?.description#^DIAG^#",
       diagnostics: [
-        DiagnosticSpec(message: "Expected ':' after '? ...' in ternary expression"),
-        DiagnosticSpec(message: "Expected expression"),
+        DiagnosticSpec(message: "expected ':' after '? ...' in ternary expression"),
+        DiagnosticSpec(message: "expected expression"),
       ]
     )
     
@@ -243,8 +243,8 @@ final class DeclarationTests: XCTestCase {
       private(#^DIAG^#get) var a = 0
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected 'set' in modifier"),
-        DiagnosticSpec(message: "Unexpected text 'get' in modifier")
+        DiagnosticSpec(message: "expected 'set' in modifier"),
+        DiagnosticSpec(message: "unexpected text 'get' in modifier")
       ]
     )
 
@@ -255,9 +255,9 @@ final class DeclarationTests: XCTestCase {
       ) var a = 0
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected 'set)' to end modifier"),
+        DiagnosticSpec(message: "expected 'set)' to end modifier"),
         // FIXME: It should print `+` as detail of text.
-        DiagnosticSpec(message: "Unexpected text in variable")
+        DiagnosticSpec(message: "unexpected text in variable")
       ]
     )
 
@@ -266,7 +266,7 @@ final class DeclarationTests: XCTestCase {
       private(#^DIAG^#get, set) var a = 0
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'get,' in modifier")
+        DiagnosticSpec(message: "unexpected text 'get,' in modifier")
       ]
     )
 
@@ -275,7 +275,7 @@ final class DeclarationTests: XCTestCase {
       private(#^DIAG^#get: set) var a = 0
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'get:' in modifier")
+        DiagnosticSpec(message: "unexpected text 'get:' in modifier")
       ]
     )
 
@@ -284,7 +284,7 @@ final class DeclarationTests: XCTestCase {
       #^DIAG^#private(
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Extraneous 'private(' at top level")
+        DiagnosticSpec(message: "extraneous 'private(' at top level")
       ]
     )
 
@@ -293,7 +293,7 @@ final class DeclarationTests: XCTestCase {
       private(#^DIAG^#var a = 0
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected 'set)' to end modifier"),
+        DiagnosticSpec(message: "expected 'set)' to end modifier"),
       ]
     )
 
@@ -302,8 +302,8 @@ final class DeclarationTests: XCTestCase {
       private(#^LEFT^#get, set#^RIGHT^#, didSet) var a = 0
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "LEFT", message: "Unexpected text 'get,' in modifier"),
-        DiagnosticSpec(locationMarker: "RIGHT", message: "Unexpected text ', didSet' in modifier")
+        DiagnosticSpec(locationMarker: "LEFT", message: "unexpected text 'get,' in modifier"),
+        DiagnosticSpec(locationMarker: "RIGHT", message: "unexpected text ', didSet' in modifier")
       ]
     )
 
@@ -312,8 +312,8 @@ final class DeclarationTests: XCTestCase {
       private(#^DIAG^#get, didSet var a = 0
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected 'set)' to end modifier"),
-        DiagnosticSpec(message: "Unexpected text 'get, didSet' in variable")
+        DiagnosticSpec(message: "expected 'set)' to end modifier"),
+        DiagnosticSpec(message: "unexpected text 'get, didSet' in variable")
       ]
     )
   }
@@ -545,7 +545,7 @@ final class DeclarationTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected declaration after 'public' modifier in struct")
+        DiagnosticSpec(message: "expected declaration after 'public' modifier in struct")
       ]
     )
   }
@@ -555,7 +555,7 @@ final class DeclarationTests: XCTestCase {
       "(first second #^DIAG^#Int)",
       { $0.parseFunctionSignature() },
       diagnostics: [
-        DiagnosticSpec(message: "Expected ':' in function parameter")
+        DiagnosticSpec(message: "expected ':' in function parameter")
       ]
     )
   }
@@ -565,7 +565,7 @@ final class DeclarationTests: XCTestCase {
       "(first second #^DIAG^#third fourth: Int)",
       { $0.parseFunctionSignature() },
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'third fourth' in function parameter")
+        DiagnosticSpec(message: "unexpected text 'third fourth' in function parameter")
       ]
     )
   }
@@ -575,7 +575,7 @@ final class DeclarationTests: XCTestCase {
       "(first second: Int#^DIAG^#",
       { $0.parseFunctionSignature() },
       diagnostics: [
-        DiagnosticSpec(message: "Expected ')' to end parameter clause")
+        DiagnosticSpec(message: "expected ')' to end parameter clause")
       ]
     )
   }
@@ -585,7 +585,7 @@ final class DeclarationTests: XCTestCase {
       "#^DIAG^#first second: Int)",
       { $0.parseFunctionSignature() },
       diagnostics: [
-        DiagnosticSpec(message: "Expected '(' to start parameter clause")
+        DiagnosticSpec(message: "expected '(' to start parameter clause")
       ]
     )
   }
@@ -619,7 +619,7 @@ final class DeclarationTests: XCTestCase {
         body: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "Expected argument list in function declaration")
+        DiagnosticSpec(message: "expected argument list in function declaration")
       ]
     )
   }
@@ -629,7 +629,7 @@ final class DeclarationTests: XCTestCase {
       "() -> #^DIAG^#throws Int",
       { $0.parseFunctionSignature() },
       diagnostics: [
-        DiagnosticSpec(message: "'throws' may only occur before '->'", fixIts: ["Move 'throws' before '->'"])
+        DiagnosticSpec(message: "'throws' may only occur before '->'", fixIts: ["move 'throws' before '->'"])
       ],
       fixedSource: "() throws -> Int"
     )
@@ -644,7 +644,7 @@ final class DeclarationTests: XCTestCase {
       #^DIAG^#}
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Extraneous '}' at top level")
+        DiagnosticSpec(message: "extraneous '}' at top level")
       ]
     )
   }
@@ -657,7 +657,7 @@ final class DeclarationTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected '->' and return type in subscript"),
+        DiagnosticSpec(message: "expected '->' and return type in subscript"),
       ]
     )
   }
@@ -702,8 +702,8 @@ final class DeclarationTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "EXPECTED_DECL", message: "Expected declaration in struct"),
-        DiagnosticSpec(locationMarker: "UNEXPECTED_TEXT", message: #"Unexpected text '/ ###line 25 "line-directive.swift"' in struct"#)
+        DiagnosticSpec(locationMarker: "EXPECTED_DECL", message: "expected declaration in struct"),
+        DiagnosticSpec(locationMarker: "UNEXPECTED_TEXT", message: #"unexpected text '/ ###line 25 "line-directive.swift"' in struct"#)
       ]
     )
   }
@@ -716,7 +716,7 @@ final class DeclarationTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'bogus rethrows set' in variable")
+        DiagnosticSpec(message: "unexpected text 'bogus rethrows set' in variable")
       ]
     )
   }
@@ -727,7 +727,7 @@ final class DeclarationTests: XCTestCase {
       Lorem ipsum dolor sit amet#^DIAG^#, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Extraneous code at top level"),
+        DiagnosticSpec(message: "extraneous code at top level"),
       ]
     )
   }
@@ -750,7 +750,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'third' in function parameter")
+        DiagnosticSpec(message: "unexpected text 'third' in function parameter")
       ]
     )
   }
@@ -773,7 +773,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'third fourth' in function parameter")
+        DiagnosticSpec(message: "unexpected text 'third fourth' in function parameter")
       ]
     )
   }
@@ -794,11 +794,11 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(locationMarker: "MISSING_COLON", message: "Expected ':' in function parameter"),
-        DiagnosticSpec(locationMarker: "MISSING_RPAREN", message: "Expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "MISSING_IDENTIFIER", message: "Expected identifier in struct"),
-        DiagnosticSpec(locationMarker: "BRACES", message: "Expected member block in struct"),
-        DiagnosticSpec(locationMarker: "BRACES", message: "Extraneous ': Int) {}' at top level"),
+        DiagnosticSpec(locationMarker: "MISSING_COLON", message: "expected ':' in function parameter"),
+        DiagnosticSpec(locationMarker: "MISSING_RPAREN", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "MISSING_IDENTIFIER", message: "expected identifier in struct"),
+        DiagnosticSpec(locationMarker: "BRACES", message: "expected member block in struct"),
+        DiagnosticSpec(locationMarker: "BRACES", message: "extraneous ': Int) {}' at top level"),
       ]
     )
   }
@@ -826,7 +826,7 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text '[third fourth]' in function parameter")
+        DiagnosticSpec(message: "unexpected text '[third fourth]' in function parameter")
       ]
     )
   }
@@ -851,9 +851,9 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(locationMarker: "COLON", message: "Expected ':' in function parameter"),
-        DiagnosticSpec(locationMarker: "END_ARRAY" , message: "Expected ']' to end array type"),
-        DiagnosticSpec(locationMarker: "END_ARRAY", message: "Unexpected text 'fourth: Int' in parameter clause")
+        DiagnosticSpec(locationMarker: "COLON", message: "expected ':' in function parameter"),
+        DiagnosticSpec(locationMarker: "END_ARRAY" , message: "expected ']' to end array type"),
+        DiagnosticSpec(locationMarker: "END_ARRAY", message: "unexpected text 'fourth: Int' in parameter clause")
       ]
     )
   }
@@ -877,9 +877,9 @@ final class DeclarationTests: XCTestCase {
         trailingComma: nil
       )),
       diagnostics: [
-        DiagnosticSpec(locationMarker: "COLON", message: "Expected ':' in function parameter"),
-        DiagnosticSpec(locationMarker: "RPAREN", message: "Expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "EXTRANEOUS", message: "Extraneous ': Int) {}' at top level")
+        DiagnosticSpec(locationMarker: "COLON", message: "expected ':' in function parameter"),
+        DiagnosticSpec(locationMarker: "RPAREN", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "EXTRANEOUS", message: "extraneous ': Int) {}' at top level")
       ]
     )
   }
@@ -892,12 +892,12 @@ final class DeclarationTests: XCTestCase {
       @#^END^#
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "OPENING_BRACE", message: "Expected '{' in struct"),
-        DiagnosticSpec(locationMarker: "AFTER_POUND_IF", message: "Expected condition in conditional compilation clause"),
-        DiagnosticSpec(locationMarker: "END", message: "Expected name in attribute"),
-        DiagnosticSpec(locationMarker: "END", message: "Expected declaration after attribute in conditional compilation clause"),
-        DiagnosticSpec(locationMarker: "END", message: "Expected '#endif' in conditional compilation block"),
-        DiagnosticSpec(locationMarker: "END", message: "Expected '}' to end struct")
+        DiagnosticSpec(locationMarker: "OPENING_BRACE", message: "expected '{' in struct"),
+        DiagnosticSpec(locationMarker: "AFTER_POUND_IF", message: "expected condition in conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "END", message: "expected name in attribute"),
+        DiagnosticSpec(locationMarker: "END", message: "expected declaration after attribute in conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "END", message: "expected '#endif' in conditional compilation block"),
+        DiagnosticSpec(locationMarker: "END", message: "expected '}' to end struct")
       ]
     )
   }
@@ -958,8 +958,8 @@ final class DeclarationTests: XCTestCase {
     AssertParse(
       "#^DIAG_1^#}class C#^DIAG_2^#",
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before class"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected member block in class"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '}' before class"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in class"),
       ],
       fixedSource: """
         }class C {}
@@ -967,39 +967,39 @@ final class DeclarationTests: XCTestCase {
     )
     AssertParse("#^DIAG_1^#}enum C#^DIAG_2^#",
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before enum"),
-                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected member block in enum"),
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '}' before enum"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in enum"),
                 ])
     AssertParse("#^DIAG_1^#}protocol C#^DIAG_2^#",
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before protocol"),
-                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected member block in protocol"),
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '}' before protocol"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in protocol"),
                 ])
     AssertParse("#^DIAG_1^#}actor C#^DIAG_2^#",
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before actor"),
-                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected member block in actor"),
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '}' before actor"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in actor"),
                 ])
     AssertParse("#^DIAG_1^#}struct C#^DIAG_2^#",
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before struct"),
-                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected member block in struct"),
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '}' before struct"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in struct"),
                 ])
     AssertParse("#^DIAG_1^#}func C#^DIAG_2^#",
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before function"),
-                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected argument list in function declaration"),
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '}' before function"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "expected argument list in function declaration"),
                 ])
     AssertParse("#^DIAG_1^#}init#^DIAG_2^#",
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before initializer"),
-                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected argument list in function declaration"),
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '}' before initializer"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "expected argument list in function declaration"),
                 ])
     AssertParse("#^DIAG_1^#}subscript#^DIAG_2^#",
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before subscript"),
-                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected argument list in function declaration"),
-                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '->' and return type in subscript"),
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '}' before subscript"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "expected argument list in function declaration"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '->' and return type in subscript"),
                 ])
   }
 
@@ -1055,10 +1055,10 @@ final class DeclarationTests: XCTestCase {
       struct U<@#^DIAG^#
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected name in attribute"),
-        DiagnosticSpec(message: "Expected identifier in generic parameter"),
-        DiagnosticSpec(message: "Expected '>' to end generic parameter clause"),
-        DiagnosticSpec(message: "Expected member block in struct"),
+        DiagnosticSpec(message: "expected name in attribute"),
+        DiagnosticSpec(message: "expected identifier in generic parameter"),
+        DiagnosticSpec(message: "expected '>' to end generic parameter clause"),
+        DiagnosticSpec(message: "expected member block in struct"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -702,7 +702,7 @@ final class DeclarationTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "EXPECTED_DECL", message: "Expected declaration after '{' in struct"),
+        DiagnosticSpec(locationMarker: "EXPECTED_DECL", message: "Expected declaration in struct"),
         DiagnosticSpec(locationMarker: "UNEXPECTED_TEXT", message: #"Unexpected text '/ ###line 25 "line-directive.swift"' in struct"#)
       ]
     )
@@ -893,8 +893,8 @@ final class DeclarationTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "OPENING_BRACE", message: "Expected '{' in struct"),
-        DiagnosticSpec(locationMarker: "AFTER_POUND_IF", message: "Expected condition after '#if' in conditional compilation clause"),
-        DiagnosticSpec(locationMarker: "END", message: "Expected name after '@' in attribute"),
+        DiagnosticSpec(locationMarker: "AFTER_POUND_IF", message: "Expected condition in conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "END", message: "Expected name in attribute"),
         DiagnosticSpec(locationMarker: "END", message: "Expected declaration after attribute in conditional compilation clause"),
         DiagnosticSpec(locationMarker: "END", message: "Expected '#endif' in conditional compilation block"),
         DiagnosticSpec(locationMarker: "END", message: "Expected '}' to end struct")
@@ -1055,7 +1055,7 @@ final class DeclarationTests: XCTestCase {
       struct U<@#^DIAG^#
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected name after '@' in attribute"),
+        DiagnosticSpec(message: "Expected name in attribute"),
         DiagnosticSpec(message: "Expected identifier in generic parameter"),
         DiagnosticSpec(message: "Expected '>' to end generic parameter clause"),
         DiagnosticSpec(message: "Expected member block in struct"),

--- a/Tests/SwiftParserTest/Directives.swift
+++ b/Tests/SwiftParserTest/Directives.swift
@@ -88,7 +88,7 @@ final class DirectiveTests: XCTestCase {
     AssertParse(
       "#if test#^DIAG^#",
       diagnostics: [
-        DiagnosticSpec(message: "Expected '#endif' in conditional compilation block")
+        DiagnosticSpec(message: "expected '#endif' in conditional compilation block")
       ]
     )
   }
@@ -105,8 +105,8 @@ final class DirectiveTests: XCTestCase {
       #endif
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '}' before conditional compilation clause"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Unexpected text '}' in conditional compilation block"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '}' before conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '}' in conditional compilation block"),
       ]
     )
   }
@@ -148,9 +148,9 @@ final class DirectiveTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected declaration after attribute in conditional compilation clause"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected declaration after attribute in conditional compilation clause"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "Expected declaration after attribute in conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected declaration after attribute in conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected declaration after attribute in conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected declaration after attribute in conditional compilation clause"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -7,7 +7,7 @@ final class ExpressionTests: XCTestCase {
     AssertParse(
       "let a =#^DIAG^#",
       diagnostics: [
-        DiagnosticSpec(message: "Expected expression after '=' in variable")
+        DiagnosticSpec(message: "Expected expression in variable")
       ]
     )
 
@@ -15,7 +15,7 @@ final class ExpressionTests: XCTestCase {
     AssertParse(
       "a ? b :#^DIAG^#",
       diagnostics: [
-        DiagnosticSpec(message: "Expected expression after ':'")
+        DiagnosticSpec(message: "Expected expression")
       ]
     )
   }
@@ -102,7 +102,7 @@ final class ExpressionTests: XCTestCase {
       c[#^DIAG^#
       """#,
       diagnostics: [
-        DiagnosticSpec(message: "Expected value after '[' in subscript"),
+        DiagnosticSpec(message: "Expected value in subscript"),
         DiagnosticSpec(message: "Expected ']' to end subscript"),
       ]
     )
@@ -173,7 +173,7 @@ final class ExpressionTests: XCTestCase {
         ,#^END_ARRAY^#
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "EXPECTED_EXPR", message: "Expected value after '[' in array element"),
+        DiagnosticSpec(locationMarker: "EXPECTED_EXPR", message: "Expected value in array element"),
         DiagnosticSpec(locationMarker: "END_ARRAY", message: "Expected ']' to end array"),
       ]
     )
@@ -183,7 +183,7 @@ final class ExpressionTests: XCTestCase {
       ([1:#^DIAG^#)
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected value after ':' in dictionary element"),
+        DiagnosticSpec(message: "Expected value in dictionary element"),
         DiagnosticSpec(message: "Expected ']' to end dictionary"),
       ]
     )
@@ -401,8 +401,8 @@ final class ExpressionTests: XCTestCase {
       \#^AFTER_SLASH^#\(#^AFTER_PAREN^#
       """##,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "AFTER_SLASH", message: #"Expected root and expression after '\' in key path"#),
-        DiagnosticSpec(locationMarker: "AFTER_PAREN", message: "Expected value after '(' in tuple"),
+        DiagnosticSpec(locationMarker: "AFTER_SLASH", message: #"Expected root and expression in key path"#),
+        DiagnosticSpec(locationMarker: "AFTER_PAREN", message: "Expected value in tuple"),
         DiagnosticSpec(locationMarker: "AFTER_PAREN", message: "Expected ')' to end tuple"),
         DiagnosticSpec(locationMarker: "AFTER_PAREN", message: "Expected expression in key path"),
       ]
@@ -467,8 +467,8 @@ final class ExpressionTests: XCTestCase {
           print "\(i)\"\n#^END^#
       """#,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "KEY_PATH_1", message: "Expected expression after 'n' in key path"),
-        DiagnosticSpec(locationMarker: "KEY_PATH_2", message: "Expected expression after 'n' in key path"),
+        DiagnosticSpec(locationMarker: "KEY_PATH_1", message: "Expected expression in key path"),
+        DiagnosticSpec(locationMarker: "KEY_PATH_2", message: "Expected expression in key path"),
         DiagnosticSpec(locationMarker: "END", message: #"Expected '"' to end string literal"#),
         DiagnosticSpec(locationMarker: "END", message: "Expected '}' to end 'if' statement"),
         DiagnosticSpec(locationMarker: "END", message: "Expected '}' to end function"),
@@ -479,7 +479,7 @@ final class ExpressionTests: XCTestCase {
                 diagnostics: [
                   DiagnosticSpec(message: "Expected identifier in '#keyPath' expression"),
                   DiagnosticSpec(message: "Expected ')' to end '#keyPath' expression"),
-                  DiagnosticSpec(locationMarker: "MISSING_VALUE", message: "Expected value after ':' in function call"),
+                  DiagnosticSpec(locationMarker: "MISSING_VALUE", message: "Expected value in function call"),
                 ])
   }
 
@@ -488,7 +488,7 @@ final class ExpressionTests: XCTestCase {
       "[(Int) -> #^DIAG^#throws Int]()",
       diagnostics: [
         // FIXME: We should suggest to move 'throws' in front of '->'
-        DiagnosticSpec(message: "Expected expression after '->' in array element"),
+        DiagnosticSpec(message: "Expected expression in array element"),
         DiagnosticSpec(message: "Unexpected text 'throws Int' in array"),
       ]
     )
@@ -510,7 +510,7 @@ final class ExpressionTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected expression after ':' in 'do' statement")
+        DiagnosticSpec(message: "Expected expression in 'do' statement")
       ]
     )
   }
@@ -521,10 +521,10 @@ final class ExpressionTests: XCTestCase {
       let #^VAR_NAME^#:(#^DIAG_1^#..)->#^END^#
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "VAR_NAME", message: "Expected pattern after 'let' in variable"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected type after '(' in function type"),
+        DiagnosticSpec(locationMarker: "VAR_NAME", message: "Expected pattern in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected type in function type"),
         DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '..' in function type"),
-        DiagnosticSpec(locationMarker: "END", message: "Expected type after '->' in function type"),
+        DiagnosticSpec(locationMarker: "END", message: "Expected type in function type"),
       ]
     )
   }
@@ -536,7 +536,7 @@ final class ExpressionTests: XCTestCase {
       substructure: Syntax(TokenSyntax.contextualKeyword("async")),
       substructureAfterMarker: "ASYNC",
       diagnostics: [
-        DiagnosticSpec(locationMarker: "END", message: "Expected expression after '->'")
+        DiagnosticSpec(locationMarker: "END", message: "Expected expression")
       ]
     )
   }

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -7,7 +7,7 @@ final class ExpressionTests: XCTestCase {
     AssertParse(
       "let a =#^DIAG^#",
       diagnostics: [
-        DiagnosticSpec(message: "Expected expression in variable")
+        DiagnosticSpec(message: "expected expression in variable")
       ]
     )
 
@@ -15,7 +15,7 @@ final class ExpressionTests: XCTestCase {
     AssertParse(
       "a ? b :#^DIAG^#",
       diagnostics: [
-        DiagnosticSpec(message: "Expected expression")
+        DiagnosticSpec(message: "expected expression")
       ]
     )
   }
@@ -102,8 +102,8 @@ final class ExpressionTests: XCTestCase {
       c[#^DIAG^#
       """#,
       diagnostics: [
-        DiagnosticSpec(message: "Expected value in subscript"),
-        DiagnosticSpec(message: "Expected ']' to end subscript"),
+        DiagnosticSpec(message: "expected value in subscript"),
+        DiagnosticSpec(message: "expected ']' to end subscript"),
       ]
     )
 
@@ -173,8 +173,8 @@ final class ExpressionTests: XCTestCase {
         ,#^END_ARRAY^#
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "EXPECTED_EXPR", message: "Expected value in array element"),
-        DiagnosticSpec(locationMarker: "END_ARRAY", message: "Expected ']' to end array"),
+        DiagnosticSpec(locationMarker: "EXPECTED_EXPR", message: "expected value in array element"),
+        DiagnosticSpec(locationMarker: "END_ARRAY", message: "expected ']' to end array"),
       ]
     )
 
@@ -183,8 +183,8 @@ final class ExpressionTests: XCTestCase {
       ([1:#^DIAG^#)
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected value in dictionary element"),
-        DiagnosticSpec(message: "Expected ']' to end dictionary"),
+        DiagnosticSpec(message: "expected value in dictionary element"),
+        DiagnosticSpec(message: "expected ']' to end dictionary"),
       ]
     )
   }
@@ -219,7 +219,7 @@ final class ExpressionTests: XCTestCase {
       #^DIAG^#"\(()
       """#,
       diagnostics: [
-        DiagnosticSpec(message: #"Extraneous '"\(()' at top level"#)
+        DiagnosticSpec(message: #"extraneous '"\(()' at top level"#)
       ]
     )
   }
@@ -243,7 +243,7 @@ final class ExpressionTests: XCTestCase {
       " >> \( abc #^DIAG^#} ) << "
       """#,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text '}' in string literal")
+        DiagnosticSpec(message: "unexpected text '}' in string literal")
       ]
     )
 
@@ -264,7 +264,7 @@ final class ExpressionTests: XCTestCase {
       "\",#^DIAG^#
       """#,
       diagnostics: [
-        DiagnosticSpec(message: #"Expected '"' to end string literal"#)
+        DiagnosticSpec(message: #"expected '"' to end string literal"#)
       ]
     )
 
@@ -331,7 +331,7 @@ final class ExpressionTests: XCTestCase {
        """"#^DIAG^#
        """##,
        diagnostics: [
-         DiagnosticSpec(message: #"Expected '"""' to end string literal"#)
+         DiagnosticSpec(message: #"expected '"""' to end string literal"#)
        ]
      )
 
@@ -340,7 +340,7 @@ final class ExpressionTests: XCTestCase {
        """""#^DIAG^#
        """##,
        diagnostics: [
-         DiagnosticSpec(message: #"Expected '"""' to end string literal"#)
+         DiagnosticSpec(message: #"expected '"""' to end string literal"#)
        ]
      )
 
@@ -357,7 +357,7 @@ final class ExpressionTests: XCTestCase {
       #"#^DIAG^#
       """##,
       diagnostics: [
-        DiagnosticSpec(message: ##"Expected '"#' to end string literal"##),
+        DiagnosticSpec(message: ##"expected '"#' to end string literal"##),
       ]
     )
 
@@ -366,7 +366,7 @@ final class ExpressionTests: XCTestCase {
       #"""#^DIAG^#
       """##,
       diagnostics: [
-        DiagnosticSpec(message: ##"Expected '"""#' to end string literal"##),
+        DiagnosticSpec(message: ##"expected '"""#' to end string literal"##),
       ]
     )
 
@@ -375,14 +375,14 @@ final class ExpressionTests: XCTestCase {
       #"""a#^DIAG^#
       """##,
       diagnostics: [
-        DiagnosticSpec(message: ##"Expected '"""#' to end string literal"##),
+        DiagnosticSpec(message: ##"expected '"""#' to end string literal"##),
       ]
     )
 
     AssertParse(
       ###"#^DIAG^#"\"###,
       diagnostics: [
-        DiagnosticSpec(message: "Extraneous '\"\\' at top level")
+        DiagnosticSpec(message: "extraneous '\"\\' at top level")
       ]
     )
   }
@@ -401,10 +401,10 @@ final class ExpressionTests: XCTestCase {
       \#^AFTER_SLASH^#\(#^AFTER_PAREN^#
       """##,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "AFTER_SLASH", message: #"Expected root and expression in key path"#),
-        DiagnosticSpec(locationMarker: "AFTER_PAREN", message: "Expected value in tuple"),
-        DiagnosticSpec(locationMarker: "AFTER_PAREN", message: "Expected ')' to end tuple"),
-        DiagnosticSpec(locationMarker: "AFTER_PAREN", message: "Expected expression in key path"),
+        DiagnosticSpec(locationMarker: "AFTER_SLASH", message: "expected root and expression in key path"),
+        DiagnosticSpec(locationMarker: "AFTER_PAREN", message: "expected value in tuple"),
+        DiagnosticSpec(locationMarker: "AFTER_PAREN", message: "expected ')' to end tuple"),
+        DiagnosticSpec(locationMarker: "AFTER_PAREN", message: "expected expression in key path"),
       ]
     )
 
@@ -419,7 +419,7 @@ final class ExpressionTests: XCTestCase {
       "#^DIAG^#
       """#,
       diagnostics: [
-        DiagnosticSpec(message: #"Expected '"' to end string literal"#)
+        DiagnosticSpec(message: #"expected '"' to end string literal"#)
       ]
     )
 
@@ -428,7 +428,7 @@ final class ExpressionTests: XCTestCase {
       "'#^DIAG^#
       """#,
       diagnostics: [
-        DiagnosticSpec(message: #"Expected '"' to end string literal"#)
+        DiagnosticSpec(message: #"expected '"' to end string literal"#)
       ]
     )
   }
@@ -451,8 +451,8 @@ final class ExpressionTests: XCTestCase {
     AssertParse(
       "foo ? 1#^DIAG^#",
       diagnostics: [
-        DiagnosticSpec(message: "Expected ':' after '? ...' in ternary expression"),
-        DiagnosticSpec(message: "Expected expression"),
+        DiagnosticSpec(message: "expected ':' after '? ...' in ternary expression"),
+        DiagnosticSpec(message: "expected expression"),
       ]
     )
   }
@@ -467,19 +467,19 @@ final class ExpressionTests: XCTestCase {
           print "\(i)\"\n#^END^#
       """#,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "KEY_PATH_1", message: "Expected expression in key path"),
-        DiagnosticSpec(locationMarker: "KEY_PATH_2", message: "Expected expression in key path"),
-        DiagnosticSpec(locationMarker: "END", message: #"Expected '"' to end string literal"#),
-        DiagnosticSpec(locationMarker: "END", message: "Expected '}' to end 'if' statement"),
-        DiagnosticSpec(locationMarker: "END", message: "Expected '}' to end function"),
+        DiagnosticSpec(locationMarker: "KEY_PATH_1", message: "expected expression in key path"),
+        DiagnosticSpec(locationMarker: "KEY_PATH_2", message: "expected expression in key path"),
+        DiagnosticSpec(locationMarker: "END", message: #"expected '"' to end string literal"#),
+        DiagnosticSpec(locationMarker: "END", message: "expected '}' to end 'if' statement"),
+        DiagnosticSpec(locationMarker: "END", message: "expected '}' to end function"),
       ]
     )
 
     AssertParse("#keyPath(#^DIAG^#(b:#^MISSING_VALUE^#)",
                 diagnostics: [
-                  DiagnosticSpec(message: "Expected identifier in '#keyPath' expression"),
-                  DiagnosticSpec(message: "Expected ')' to end '#keyPath' expression"),
-                  DiagnosticSpec(locationMarker: "MISSING_VALUE", message: "Expected value in function call"),
+                  DiagnosticSpec(message: "expected identifier in '#keyPath' expression"),
+                  DiagnosticSpec(message: "expected ')' to end '#keyPath' expression"),
+                  DiagnosticSpec(locationMarker: "MISSING_VALUE", message: "expected value in function call"),
                 ])
   }
 
@@ -488,15 +488,15 @@ final class ExpressionTests: XCTestCase {
       "[(Int) -> #^DIAG^#throws Int]()",
       diagnostics: [
         // FIXME: We should suggest to move 'throws' in front of '->'
-        DiagnosticSpec(message: "Expected expression in array element"),
-        DiagnosticSpec(message: "Unexpected text 'throws Int' in array"),
+        DiagnosticSpec(message: "expected expression in array element"),
+        DiagnosticSpec(message: "unexpected text 'throws Int' in array"),
       ]
     )
 
     AssertParse(
       "let _ = [Int throws #^DIAG^#Int]()",
       diagnostics: [
-        DiagnosticSpec(message: "Expected '->' in array element")
+        DiagnosticSpec(message: "expected '->' in array element")
       ]
     )
   }
@@ -510,7 +510,7 @@ final class ExpressionTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected expression in 'do' statement")
+        DiagnosticSpec(message: "expected expression in 'do' statement")
       ]
     )
   }
@@ -521,10 +521,10 @@ final class ExpressionTests: XCTestCase {
       let #^VAR_NAME^#:(#^DIAG_1^#..)->#^END^#
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "VAR_NAME", message: "Expected pattern in variable"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected type in function type"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text '..' in function type"),
-        DiagnosticSpec(locationMarker: "END", message: "Expected type in function type"),
+        DiagnosticSpec(locationMarker: "VAR_NAME", message: "expected pattern in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected type in function type"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '..' in function type"),
+        DiagnosticSpec(locationMarker: "END", message: "expected type in function type"),
       ]
     )
   }
@@ -536,7 +536,7 @@ final class ExpressionTests: XCTestCase {
       substructure: Syntax(TokenSyntax.contextualKeyword("async")),
       substructureAfterMarker: "ASYNC",
       diagnostics: [
-        DiagnosticSpec(locationMarker: "END", message: "Expected expression")
+        DiagnosticSpec(locationMarker: "END", message: "expected expression")
       ]
     )
   }

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -45,7 +45,7 @@ final class StatementTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected expression after 'case' in pattern"),
+        DiagnosticSpec(message: "Expected expression in pattern"),
         DiagnosticSpec(message: "Expected '=' and expression in pattern matching"),
         DiagnosticSpec(message: "Unexpected text '* ! = x' in 'if' statement"),
       ]

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -45,9 +45,9 @@ final class StatementTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Expected expression in pattern"),
-        DiagnosticSpec(message: "Expected '=' and expression in pattern matching"),
-        DiagnosticSpec(message: "Unexpected text '* ! = x' in 'if' statement"),
+        DiagnosticSpec(message: "expected expression in pattern"),
+        DiagnosticSpec(message: "expected '=' and expression in pattern matching"),
+        DiagnosticSpec(message: "unexpected text '* ! = x' in 'if' statement"),
       ]
     )
   }
@@ -178,14 +178,14 @@ final class StatementTests: XCTestCase {
     AssertParse(
       "/*#-editable-code Swift Platground editable area*/#^DIAG^#default/*#-end-editable-code*/",
       diagnostics: [
-        DiagnosticSpec(message: "Extraneous 'default' at top level")
+        DiagnosticSpec(message: "extraneous 'default' at top level")
       ]
     )
 
     AssertParse(
       "#^DIAG^#case:",
       diagnostics: [
-        DiagnosticSpec(message: "Extraneous 'case:' at top level")
+        DiagnosticSpec(message: "extraneous 'case:' at top level")
       ])
 
     AssertParse(
@@ -193,7 +193,7 @@ final class StatementTests: XCTestCase {
       #^DIAG^#case: { ("Hello World") }
       """#,
       diagnostics: [
-        DiagnosticSpec(message: #"Extraneous 'case: { ("Hello World") }' at top level"#)
+        DiagnosticSpec(message: #"extraneous 'case: { ("Hello World") }' at top level"#)
       ]
     )
   }
@@ -213,8 +213,8 @@ final class StatementTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "TEST_1", message: "Unexpected text '@s return' in function"),
-        DiagnosticSpec(locationMarker: "TEST_2", message: "Unexpected text '@unknown return' in function")
+        DiagnosticSpec(locationMarker: "TEST_1", message: "unexpected text '@s return' in function"),
+        DiagnosticSpec(locationMarker: "TEST_2", message: "unexpected text '@unknown return' in function")
       ]
     )
   }
@@ -232,8 +232,8 @@ final class StatementTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "FOO", message: "Unexpected text 'foo()' before conditional compilation clause"),
-        DiagnosticSpec(locationMarker: "BAR", message: "Unexpected text 'bar()' in conditional compilation block"),
+        DiagnosticSpec(locationMarker: "FOO", message: "unexpected text 'foo()' before conditional compilation clause"),
+        DiagnosticSpec(locationMarker: "BAR", message: "unexpected text 'bar()' in conditional compilation block"),
       ]
     )
 
@@ -252,7 +252,7 @@ final class StatementTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "Unexpected text 'print()' before conditional compilation clause")
+        DiagnosticSpec(message: "unexpected text 'print()' before conditional compilation clause")
       ]
     )
   }
@@ -261,7 +261,7 @@ final class StatementTests: XCTestCase {
     AssertParse(
       "LABEL#^DIAG^#:",
       diagnostics: [
-        DiagnosticSpec(message: "Extraneous ':' at top level")
+        DiagnosticSpec(message: "extraneous ':' at top level")
       ]
     )
   }

--- a/Tests/SwiftParserTest/Types.swift
+++ b/Tests/SwiftParserTest/Types.swift
@@ -31,9 +31,9 @@ final class TypeTests: XCTestCase {
 
   func testFunctionTypes() throws {
     AssertParse("t as(#^DIAG^#..)->#^END^#", diagnostics: [
-      DiagnosticSpec(message: "Expected type in function type"),
-      DiagnosticSpec(message: "Unexpected text '..' in function type"),
-      DiagnosticSpec(locationMarker: "END", message: "Expected type in function type"),
+      DiagnosticSpec(message: "expected type in function type"),
+      DiagnosticSpec(message: "unexpected text '..' in function type"),
+      DiagnosticSpec(locationMarker: "END", message: "expected type in function type"),
     ])
   }
 
@@ -60,22 +60,22 @@ final class TypeTests: XCTestCase {
     AssertParse("{[#^DIAG_1^#class]in#^DIAG_2^#",
                 { $0.parseClosureExpression() },
                 diagnostics: [
-                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected identifier in closure capture item"),
-                  DiagnosticSpec(locationMarker: "DIAG_1", message: "Unexpected text 'class' in closure capture signature"),
-                  DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected '}' to end closure"),
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in closure capture item"),
+                  DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text 'class' in closure capture signature"),
+                  DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '}' to end closure"),
                 ])
 
     AssertParse("{[n#^DIAG^#`]in}",
                 { $0.parseClosureExpression() },
                 diagnostics: [
-                  DiagnosticSpec(message: "Unexpected text '`' in closure capture signature")
+                  DiagnosticSpec(message: "unexpected text '`' in closure capture signature")
                 ])
 
     AssertParse("{[weak#^DIAG^#^]in}",
                 { $0.parseClosureExpression() },
                 diagnostics: [
-                  DiagnosticSpec(message: "Expected identifier in closure capture item"),
-                  DiagnosticSpec(message: "Unexpected text '^' in closure capture signature"),
+                  DiagnosticSpec(message: "expected identifier in closure capture item"),
+                  DiagnosticSpec(message: "unexpected text '^' in closure capture signature"),
                 ])
   }
 
@@ -95,8 +95,8 @@ final class TypeTests: XCTestCase {
       """#,
       diagnostics: [
         // FIXME: This should be a valid parse
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected expression in key path"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected expression in key path"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in key path"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in key path"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/Types.swift
+++ b/Tests/SwiftParserTest/Types.swift
@@ -31,9 +31,9 @@ final class TypeTests: XCTestCase {
 
   func testFunctionTypes() throws {
     AssertParse("t as(#^DIAG^#..)->#^END^#", diagnostics: [
-      DiagnosticSpec(message: "Expected type after '(' in function type"),
+      DiagnosticSpec(message: "Expected type in function type"),
       DiagnosticSpec(message: "Unexpected text '..' in function type"),
-      DiagnosticSpec(locationMarker: "END", message: "Expected type after '->' in function type"),
+      DiagnosticSpec(locationMarker: "END", message: "Expected type in function type"),
     ])
   }
 
@@ -95,8 +95,8 @@ final class TypeTests: XCTestCase {
       """#,
       diagnostics: [
         // FIXME: This should be a valid parse
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected expression after 'i' in key path"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected expression after 'i' in key path"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "Expected expression in key path"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "Expected expression in key path"),
       ]
     )
   }


### PR DESCRIPTION
- Remove "after <previous token>" clause from missing node diagnostics
  - The “after” clause doesn’t seem to be generally useful. We can always add it back in special cases where it’s useful
- Lowercase diagnostic and Fix-It messages
  - This matches the capitalization of messages in the compiler