### PR TITLE
Relax Upper Bound for swift-argument-parser

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -185,7 +185,7 @@ let package = Package(
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
   // Building standalone.
   package.dependencies += [
-    .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.0.1")),
+    .package(url: "https://github.com/apple/swift-argument-parser.git", Version("1.0.1")..<Version("1.2.0")),
   ]
 } else {
   package.dependencies += [


### PR DESCRIPTION
Since we only rely on a narrow slice of this for a testing tool, we don't really have the same version bounds issues that other packages have. To enable broader adoption of swift-syntax, keep the lower bound compatible with Apple's swift ecosystem, and the upper bound loose enough for 3rd parties. Over time, we can continue to relax this upper bound as we discover more clients.

Ultimately, it would be great if we could restrict the argument parser to being a "private" dependency of this package since we don't actually depend on it in a meaningful sense for the library targets here.