### PR TITLE
Improve error messages when using SyntaxStringInterpolation with invalid syntax code

### DIFF
--- a/Sources/SwiftDiagnostics/Diagnostic.swift
+++ b/Sources/SwiftDiagnostics/Diagnostic.swift
@@ -55,13 +55,9 @@ public struct Diagnostic: CustomDebugStringConvertible {
   }
 
   public var debugDescription: String {
-    if let root = node.root.as(SourceFileSyntax.self) {
-      let locationConverter = SourceLocationConverter(file: "", tree: root)
-      let location = location(converter: locationConverter)
-      return "\(location): \(message)"
-    } else {
-      return "<unknown>: \(message)"
-    }
+    let locationConverter = SourceLocationConverter(file: "", tree: node.root)
+    let location = location(converter: locationConverter)
+    return "\(location): \(message)"
   }
 }
 

--- a/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntaxNodeProtocol.swift
@@ -65,7 +65,9 @@ extension RawSyntax: RawSyntaxNodeProtocol {
 }
 
 @_spi(RawSyntax)
-public struct RawTokenSyntax: RawSyntaxNodeProtocol {
+public struct RawTokenSyntax: RawSyntaxToSyntax, RawSyntaxNodeProtocol {
+  public typealias SyntaxType = TokenSyntax
+
   var tokenView: RawSyntaxTokenView {
     return raw.tokenView!
   }

--- a/Sources/SwiftSyntax/SourceLocation.swift
+++ b/Sources/SwiftSyntax/SourceLocation.swift
@@ -121,10 +121,11 @@ public final class SourceLocationConverter {
 
   /// - Parameters:
   ///   - file: The file path associated with the syntax tree.
-  ///   - tree: The syntax tree to convert positions to line/columns for.
-  public init(file: String, tree: SourceFileSyntax) {
+  ///   - tree: The root of the syntax tree to convert positions to line/columns for.
+  public init<SyntaxType: SyntaxProtocol>(file: String, tree: SyntaxType) {
+    assert(tree.parent == nil, "SourceLocationConverter must be passed the root of the syntax tree")
     self.file = file
-    (self.lines, endOfFile) = computeLines(tree: tree)
+    (self.lines, endOfFile) = computeLines(tree: Syntax(tree))
     assert(tree.byteSize == endOfFile.utf8Offset)
   }
 
@@ -335,7 +336,7 @@ public extension SyntaxProtocol {
 /// Returns array of lines with the position at the start of the line and
 /// the end-of-file position.
 fileprivate func computeLines(
-  tree: SourceFileSyntax
+  tree: Syntax
 ) -> ([AbsolutePosition], AbsolutePosition) {
   var lines: [AbsolutePosition] = []
   // First line starts from the beginning.

--- a/Sources/SwiftSyntaxBuilder/SyntaxExpressibleByStringInterpolationConformances.swift.gyb
+++ b/Sources/SwiftSyntaxBuilder/SyntaxExpressibleByStringInterpolationConformances.swift.gyb
@@ -25,10 +25,10 @@
 % for base_kind in STRING_INTERPOLATION_BASE_KINDS:
 %   node = NODE_MAP[base_kind]
 extension ${base_kind}SyntaxProtocol {
-  public static func parse(from parser: inout Parser) -> Self {
+  public static func parse(from parser: inout Parser) throws -> Self {
     let node = parser.${node.parser_function}().syntax
     guard let result = node.as(Self.self) else {
-      fatalError("Parsing was expected to produce a \(Self.self) but produced \(type(of: node.asProtocol(${base_kind}SyntaxProtocol.self)))")
+      throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: type(of: node.asProtocol(${base_kind}SyntaxProtocol.self)))
     }
     return result
   }

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/SyntaxExpressibleByStringInterpolationConformances.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/SyntaxExpressibleByStringInterpolationConformances.swift
@@ -16,50 +16,50 @@
 @_spi(RawSyntax) import SwiftParser
 
 extension DeclSyntaxProtocol {
-  public static func parse(from parser: inout Parser) -> Self {
+  public static func parse(from parser: inout Parser) throws -> Self {
     let node = parser.parseDeclaration().syntax
     guard let result = node.as(Self.self) else {
-      fatalError("Parsing was expected to produce a \(Self.self) but produced \(type(of: node.asProtocol(DeclSyntaxProtocol.self)))")
+      throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: type(of: node.asProtocol(DeclSyntaxProtocol.self)))
     }
     return result
   }
 }
 
 extension ExprSyntaxProtocol {
-  public static func parse(from parser: inout Parser) -> Self {
+  public static func parse(from parser: inout Parser) throws -> Self {
     let node = parser.parseExpression().syntax
     guard let result = node.as(Self.self) else {
-      fatalError("Parsing was expected to produce a \(Self.self) but produced \(type(of: node.asProtocol(ExprSyntaxProtocol.self)))")
+      throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: type(of: node.asProtocol(ExprSyntaxProtocol.self)))
     }
     return result
   }
 }
 
 extension PatternSyntaxProtocol {
-  public static func parse(from parser: inout Parser) -> Self {
+  public static func parse(from parser: inout Parser) throws -> Self {
     let node = parser.parsePattern().syntax
     guard let result = node.as(Self.self) else {
-      fatalError("Parsing was expected to produce a \(Self.self) but produced \(type(of: node.asProtocol(PatternSyntaxProtocol.self)))")
+      throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: type(of: node.asProtocol(PatternSyntaxProtocol.self)))
     }
     return result
   }
 }
 
 extension StmtSyntaxProtocol {
-  public static func parse(from parser: inout Parser) -> Self {
+  public static func parse(from parser: inout Parser) throws -> Self {
     let node = parser.parseStatement().syntax
     guard let result = node.as(Self.self) else {
-      fatalError("Parsing was expected to produce a \(Self.self) but produced \(type(of: node.asProtocol(StmtSyntaxProtocol.self)))")
+      throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: type(of: node.asProtocol(StmtSyntaxProtocol.self)))
     }
     return result
   }
 }
 
 extension TypeSyntaxProtocol {
-  public static func parse(from parser: inout Parser) -> Self {
+  public static func parse(from parser: inout Parser) throws -> Self {
     let node = parser.parseType().syntax
     guard let result = node.as(Self.self) else {
-      fatalError("Parsing was expected to produce a \(Self.self) but produced \(type(of: node.asProtocol(TypeSyntaxProtocol.self)))")
+      throw SyntaxStringInterpolationError.producedInvalidNodeType(expectedType: Self.self, actualType: type(of: node.asProtocol(TypeSyntaxProtocol.self)))
     }
     return result
   }

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolation.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolation.swift
@@ -49,7 +49,7 @@ final class StringInterpolationTests: XCTestCase {
   }
 
   func testPatternInterpolation() throws {
-    let letPattern: PatternSyntax = "let x: Int"
+    let letPattern: PatternSyntax = "let x"
     XCTAssertTrue(letPattern.is(ValueBindingPatternSyntax.self))
   }
 


### PR DESCRIPTION
If parsing source text of a `SyntaxStringInterpolation` produced a tree with errors or did not consume all characters in the string literal (and would thus drop text), raise a fatal error.

To make sure parsing errors are displayed at the string literal itself and don’t navigate Xcode to the `SyntaxExpressibleByStringInterpolation` initializer that `fatalError`ed, split the initializer into a throwing variant and a `@_transparent` one that `fatalError`s when the throwing initializer encounters an error. Because `@_transparent` is also transparent in terms of source locations, this will make the crash appear at the start of the string literal.

## Example error messages

<img width="912" alt="Screenshot 2022-09-29 at 14 18 42" src="https://user-images.githubusercontent.com/4062178/193029422-24fbcbc1-ea47-4975-a1d9-1c59510775f2.png">
<img width="912" alt="Screenshot 2022-09-29 at 14 20 22" src="https://user-images.githubusercontent.com/4062178/193029707-f7e2a37b-bcce-4041-968f-488ec7b93ac7.png">

