### PR TITLE
Use parser integration of SwiftSyntaxBuilder in Code Generation

### DIFF
--- a/CodeGeneration/Package.swift
+++ b/CodeGeneration/Package.swift
@@ -12,7 +12,7 @@ let package = Package(
     .executable(name: "generate-swiftsyntaxbuilder", targets: ["generate-swiftsyntaxbuilder"]),
   ],
   dependencies: [
-    .package(url: "https://github.com/apple/swift-syntax.git", revision: "dcd692d759e09730098e45ba7276d0d96d004bac"),
+    .package(url: "https://github.com/apple/swift-syntax.git", revision: "108a09851eb34b855bd0f9ff3e52ea396b531b58"),
     .package(url: "https://github.com/apple/swift-argument-parser.git", .upToNextMinor(from: "1.1.4")),
   ],
   targets: [

--- a/CodeGeneration/Sources/Utils/GenerateTemplates.swift
+++ b/CodeGeneration/Sources/Utils/GenerateTemplates.swift
@@ -12,6 +12,7 @@
 
 import Foundation
 import SwiftSyntaxBuilder
+import SwiftBasicFormat
 
 public func generateTemplates(templates: [(SourceFile, String)], destination: URL, verbose: Bool) throws {
   let format = Format(indentWidth: 2)

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableChild.swift
@@ -37,7 +37,7 @@ public extension Child {
   /// represents this child node.
   func generateExprBuildSyntaxNode(varName: ExpressibleAsExprBuildable, formatName: String) -> ExpressibleAsExprBuildable {
     if type.isToken {
-      return FunctionCallExpr(MemberAccessExpr(base: type.optionalChained(expr: varName), name: "buildToken")) {
+      return FunctionCallExpr(calledExpression: MemberAccessExpr(base: type.optionalChained(expr: varName), name: "buildToken")) {
         TupleExprElement(label: "format", expression: "format")
       }
     } else {
@@ -46,7 +46,7 @@ public extension Child {
         format = MemberAccessExpr(base: format, name: "_indented")
       }
       let expr = type.optionalChained(expr: varName)
-      return FunctionCallExpr(MemberAccessExpr(base: expr, name: "build\(type.baseName)")) {
+      return FunctionCallExpr(calledExpression: MemberAccessExpr(base: expr, name: "build\(type.baseName)")) {
         TupleExprElement(label: "format", expression: format)
       }
     }
@@ -88,7 +88,7 @@ public extension Child {
       })
     }
     let disjunction = ExprList(assertChoices.flatMap { [$0, BinaryOperatorExpr("||")] }.dropLast())
-    return FunctionCallExpr("assert") {
+    return FunctionCallExpr(calledExpression: "assert") {
       SequenceExpr(elements: disjunction)
     }
   }

--- a/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
+++ b/CodeGeneration/Sources/Utils/SyntaxBuildableType.swift
@@ -75,8 +75,8 @@ public struct SyntaxBuildableType: Hashable {
   ///  - For base kinds: `<BaseKind>Buildable`, e.g. `ExprBuildable` (these are implemented as protocols)
   ///  - For token: `TokenSyntax` (tokens don't have a dedicated type in SwiftSyntaxBuilder)
   /// If the type is optional, the type is wrapped in an `OptionalType`.
-  public var buildable: ExpressibleAsTypeBuildable {
-    optionalWrapped(type: buildableBaseName)
+  public var buildable: TypeBuildable {
+    optionalWrapped(type: buildableBaseName).createTypeBuildable()
   }
 
   /// Whether parameters of this type should be initializable by a result builder.
@@ -119,7 +119,7 @@ public struct SyntaxBuildableType: Hashable {
   /// The `ExpressibleAs*` Swift type for this syntax kind. Tokens don't
   /// have an `ExpressibleAs*` type, so for those this method just returns
   /// `TokenSyntax`. If the type is optional, this terminates with a `?`.
-  public var expressibleAs: ExpressibleAsTypeBuildable {
+  public var expressibleAs: TypeBuildable {
     optionalWrapped(type: expressibleAsBaseName)
   }
 
@@ -136,7 +136,7 @@ public struct SyntaxBuildableType: Hashable {
   /// The corresponding `*Syntax` type defined in the `SwiftSyntax` module,
   /// which will eventually get built from `SwiftSyntaxBuilder`. If the type
   /// is optional, this terminates with a `?`.
-  public var syntax: ExpressibleAsTypeBuildable {
+  public var syntax: TypeBuildable {
     optionalWrapped(type: syntaxBaseName)
   }
 
@@ -148,7 +148,7 @@ public struct SyntaxBuildableType: Hashable {
   }
 
   /// Assuming that this is a base kind, return the corresponding `*ListBuildable` type.
-  public var listBuildable: ExpressibleAsTypeBuildable {
+  public var listBuildable: TypeBuildable {
     optionalWrapped(type: listBuildableBaseName)
   }
 
@@ -237,11 +237,11 @@ public struct SyntaxBuildableType: Hashable {
   }
 
   /// Wraps a type in an optional depending on whether `isOptional` is true.
-  public func optionalWrapped(type: ExpressibleAsTypeBuildable) -> ExpressibleAsTypeBuildable {
+  public func optionalWrapped(type: ExpressibleAsTypeBuildable) -> TypeBuildable {
     if isOptional {
       return OptionalType(wrappedType: type)
     } else {
-      return type
+      return type.createTypeBuildable()
     }
   }
 
@@ -269,7 +269,7 @@ public struct SyntaxBuildableType: Hashable {
     if isToken {
       return varName
     } else {
-      return FunctionCallExpr(MemberAccessExpr(base: optionalChained(expr: varName), name: "create\(buildableBaseName)"))
+      return FunctionCallExpr(calledExpression: MemberAccessExpr(base: optionalChained(expr: varName), name: "create\(buildableBaseName)"))
     }
   }
 }

--- a/Sources/SwiftBasicFormat/generated/Format.swift
+++ b/Sources/SwiftBasicFormat/generated/Format.swift
@@ -17,7 +17,7 @@ import SwiftSyntax
 public struct Format {
   public let indentWidth: Int
   private var indents: Int = 0
-  public init (indentWidth: Int = 4) {
+  public init(indentWidth: Int = 4) {
     self.indentWidth = indentWidth
   }
 }

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableCollectionNodes.swift
@@ -26,24 +26,19 @@ public struct CodeBlockItemList: ExpressibleByArrayLiteral, SyntaxBuildable, Exp
   /// Creates a `CodeBlockItemList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsCodeBlockItem`
-  public init (_ elements: [ExpressibleAsCodeBlockItem]) {
-    self.elements = elements.map {
-      $0.createCodeBlockItem()
-    }
+  public init(_ elements: [ExpressibleAsCodeBlockItem]) {
+    self.elements = elements.map { $0.createCodeBlockItem() }
   }
   /// Creates a new `CodeBlockItemList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsCodeBlockItemList]) {
-    elements = lists.flatMap {
-      $0.createCodeBlockItemList().elements
-    }
+  public init(combining lists: [ExpressibleAsCodeBlockItemList]) {
+    elements = lists.flatMap { $0.createCodeBlockItemList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsCodeBlockItem...) {
+  public init(arrayLiteral elements: ExpressibleAsCodeBlockItem...) {
     self.init(elements)
   }
   public func buildCodeBlockItemList(format: Format) -> CodeBlockItemListSyntax {
-    var result = CodeBlockItemListSyntax(elements.map {
-      $0.buildCodeBlockItem(format: format)
-    })
+    
+    var result = CodeBlockItemListSyntax(elements.map { $0.buildCodeBlockItem(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -89,24 +84,19 @@ public struct UnexpectedNodes: ExpressibleByArrayLiteral, SyntaxBuildable, Expre
   /// Creates a `UnexpectedNodes` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsSyntaxBuildable`
-  public init (_ elements: [ExpressibleAsSyntaxBuildable]) {
-    self.elements = elements.map {
-      $0.createSyntaxBuildable()
-    }
+  public init(_ elements: [ExpressibleAsSyntaxBuildable]) {
+    self.elements = elements.map { $0.createSyntaxBuildable() }
   }
   /// Creates a new `UnexpectedNodes` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsUnexpectedNodes]) {
-    elements = lists.flatMap {
-      $0.createUnexpectedNodes().elements
-    }
+  public init(combining lists: [ExpressibleAsUnexpectedNodes]) {
+    elements = lists.flatMap { $0.createUnexpectedNodes().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsSyntaxBuildable...) {
+  public init(arrayLiteral elements: ExpressibleAsSyntaxBuildable...) {
     self.init(elements)
   }
   public func buildUnexpectedNodes(format: Format) -> UnexpectedNodesSyntax {
-    var result = UnexpectedNodesSyntax(elements.map {
-      $0.buildSyntax(format: format)
-    })
+    
+    var result = UnexpectedNodesSyntax(elements.map { $0.buildSyntax(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -157,24 +147,19 @@ public struct TupleExprElementList: ExpressibleByArrayLiteral, SyntaxBuildable, 
   /// Creates a `TupleExprElementList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsTupleExprElement`
-  public init (_ elements: [ExpressibleAsTupleExprElement]) {
-    self.elements = elements.map {
-      $0.createTupleExprElement()
-    }
+  public init(_ elements: [ExpressibleAsTupleExprElement]) {
+    self.elements = elements.map { $0.createTupleExprElement() }
   }
   /// Creates a new `TupleExprElementList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsTupleExprElementList]) {
-    elements = lists.flatMap {
-      $0.createTupleExprElementList().elements
-    }
+  public init(combining lists: [ExpressibleAsTupleExprElementList]) {
+    elements = lists.flatMap { $0.createTupleExprElementList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsTupleExprElement...) {
+  public init(arrayLiteral elements: ExpressibleAsTupleExprElement...) {
     self.init(elements)
   }
   public func buildTupleExprElementList(format: Format) -> TupleExprElementListSyntax {
-    var result = TupleExprElementListSyntax(elements.map {
-      $0.buildTupleExprElement(format: format)
-    })
+    
+    var result = TupleExprElementListSyntax(elements.map { $0.buildTupleExprElement(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -225,24 +210,19 @@ public struct ArrayElementList: ExpressibleByArrayLiteral, SyntaxBuildable, Expr
   /// Creates a `ArrayElementList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsArrayElement`
-  public init (_ elements: [ExpressibleAsArrayElement]) {
-    self.elements = elements.map {
-      $0.createArrayElement()
-    }
+  public init(_ elements: [ExpressibleAsArrayElement]) {
+    self.elements = elements.map { $0.createArrayElement() }
   }
   /// Creates a new `ArrayElementList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsArrayElementList]) {
-    elements = lists.flatMap {
-      $0.createArrayElementList().elements
-    }
+  public init(combining lists: [ExpressibleAsArrayElementList]) {
+    elements = lists.flatMap { $0.createArrayElementList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsArrayElement...) {
+  public init(arrayLiteral elements: ExpressibleAsArrayElement...) {
     self.init(elements)
   }
   public func buildArrayElementList(format: Format) -> ArrayElementListSyntax {
-    var result = ArrayElementListSyntax(elements.map {
-      $0.buildArrayElement(format: format)
-    })
+    
+    var result = ArrayElementListSyntax(elements.map { $0.buildArrayElement(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -288,24 +268,19 @@ public struct DictionaryElementList: ExpressibleByArrayLiteral, SyntaxBuildable,
   /// Creates a `DictionaryElementList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsDictionaryElement`
-  public init (_ elements: [ExpressibleAsDictionaryElement]) {
-    self.elements = elements.map {
-      $0.createDictionaryElement()
-    }
+  public init(_ elements: [ExpressibleAsDictionaryElement]) {
+    self.elements = elements.map { $0.createDictionaryElement() }
   }
   /// Creates a new `DictionaryElementList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsDictionaryElementList]) {
-    elements = lists.flatMap {
-      $0.createDictionaryElementList().elements
-    }
+  public init(combining lists: [ExpressibleAsDictionaryElementList]) {
+    elements = lists.flatMap { $0.createDictionaryElementList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsDictionaryElement...) {
+  public init(arrayLiteral elements: ExpressibleAsDictionaryElement...) {
     self.init(elements)
   }
   public func buildDictionaryElementList(format: Format) -> DictionaryElementListSyntax {
-    var result = DictionaryElementListSyntax(elements.map {
-      $0.buildDictionaryElement(format: format)
-    })
+    
+    var result = DictionaryElementListSyntax(elements.map { $0.buildDictionaryElement(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -356,24 +331,19 @@ public struct StringLiteralSegments: ExpressibleByArrayLiteral, SyntaxBuildable,
   /// Creates a `StringLiteralSegments` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsSyntaxBuildable`
-  public init (_ elements: [ExpressibleAsSyntaxBuildable]) {
-    self.elements = elements.map {
-      $0.createSyntaxBuildable()
-    }
+  public init(_ elements: [ExpressibleAsSyntaxBuildable]) {
+    self.elements = elements.map { $0.createSyntaxBuildable() }
   }
   /// Creates a new `StringLiteralSegments` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsStringLiteralSegments]) {
-    elements = lists.flatMap {
-      $0.createStringLiteralSegments().elements
-    }
+  public init(combining lists: [ExpressibleAsStringLiteralSegments]) {
+    elements = lists.flatMap { $0.createStringLiteralSegments().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsSyntaxBuildable...) {
+  public init(arrayLiteral elements: ExpressibleAsSyntaxBuildable...) {
     self.init(elements)
   }
   public func buildStringLiteralSegments(format: Format) -> StringLiteralSegmentsSyntax {
-    var result = StringLiteralSegmentsSyntax(elements.map {
-      $0.buildSyntax(format: format)
-    })
+    
+    var result = StringLiteralSegmentsSyntax(elements.map { $0.buildSyntax(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -424,24 +394,19 @@ public struct DeclNameArgumentList: ExpressibleByArrayLiteral, SyntaxBuildable, 
   /// Creates a `DeclNameArgumentList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsDeclNameArgument`
-  public init (_ elements: [ExpressibleAsDeclNameArgument]) {
-    self.elements = elements.map {
-      $0.createDeclNameArgument()
-    }
+  public init(_ elements: [ExpressibleAsDeclNameArgument]) {
+    self.elements = elements.map { $0.createDeclNameArgument() }
   }
   /// Creates a new `DeclNameArgumentList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsDeclNameArgumentList]) {
-    elements = lists.flatMap {
-      $0.createDeclNameArgumentList().elements
-    }
+  public init(combining lists: [ExpressibleAsDeclNameArgumentList]) {
+    elements = lists.flatMap { $0.createDeclNameArgumentList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsDeclNameArgument...) {
+  public init(arrayLiteral elements: ExpressibleAsDeclNameArgument...) {
     self.init(elements)
   }
   public func buildDeclNameArgumentList(format: Format) -> DeclNameArgumentListSyntax {
-    var result = DeclNameArgumentListSyntax(elements.map {
-      $0.buildDeclNameArgument(format: format)
-    })
+    
+    var result = DeclNameArgumentListSyntax(elements.map { $0.buildDeclNameArgument(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -492,24 +457,19 @@ public struct ExprList: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleA
   /// Creates a `ExprList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsExprBuildable`
-  public init (_ elements: [ExpressibleAsExprBuildable]) {
-    self.elements = elements.map {
-      $0.createExprBuildable()
-    }
+  public init(_ elements: [ExpressibleAsExprBuildable]) {
+    self.elements = elements.map { $0.createExprBuildable() }
   }
   /// Creates a new `ExprList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsExprList]) {
-    elements = lists.flatMap {
-      $0.createExprList().elements
-    }
+  public init(combining lists: [ExpressibleAsExprList]) {
+    elements = lists.flatMap { $0.createExprList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsExprBuildable...) {
+  public init(arrayLiteral elements: ExpressibleAsExprBuildable...) {
     self.init(elements)
   }
   public func buildExprList(format: Format) -> ExprListSyntax {
-    var result = ExprListSyntax(elements.map {
-      $0.buildExpr(format: format)
-    })
+    
+    var result = ExprListSyntax(elements.map { $0.buildExpr(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -555,24 +515,19 @@ public struct ClosureCaptureItemList: ExpressibleByArrayLiteral, SyntaxBuildable
   /// Creates a `ClosureCaptureItemList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsClosureCaptureItem`
-  public init (_ elements: [ExpressibleAsClosureCaptureItem]) {
-    self.elements = elements.map {
-      $0.createClosureCaptureItem()
-    }
+  public init(_ elements: [ExpressibleAsClosureCaptureItem]) {
+    self.elements = elements.map { $0.createClosureCaptureItem() }
   }
   /// Creates a new `ClosureCaptureItemList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsClosureCaptureItemList]) {
-    elements = lists.flatMap {
-      $0.createClosureCaptureItemList().elements
-    }
+  public init(combining lists: [ExpressibleAsClosureCaptureItemList]) {
+    elements = lists.flatMap { $0.createClosureCaptureItemList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsClosureCaptureItem...) {
+  public init(arrayLiteral elements: ExpressibleAsClosureCaptureItem...) {
     self.init(elements)
   }
   public func buildClosureCaptureItemList(format: Format) -> ClosureCaptureItemListSyntax {
-    var result = ClosureCaptureItemListSyntax(elements.map {
-      $0.buildClosureCaptureItem(format: format)
-    })
+    
+    var result = ClosureCaptureItemListSyntax(elements.map { $0.buildClosureCaptureItem(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -623,24 +578,19 @@ public struct ClosureParamList: ExpressibleByArrayLiteral, SyntaxBuildable, Expr
   /// Creates a `ClosureParamList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsClosureParam`
-  public init (_ elements: [ExpressibleAsClosureParam]) {
-    self.elements = elements.map {
-      $0.createClosureParam()
-    }
+  public init(_ elements: [ExpressibleAsClosureParam]) {
+    self.elements = elements.map { $0.createClosureParam() }
   }
   /// Creates a new `ClosureParamList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsClosureParamList]) {
-    elements = lists.flatMap {
-      $0.createClosureParamList().elements
-    }
+  public init(combining lists: [ExpressibleAsClosureParamList]) {
+    elements = lists.flatMap { $0.createClosureParamList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsClosureParam...) {
+  public init(arrayLiteral elements: ExpressibleAsClosureParam...) {
     self.init(elements)
   }
   public func buildClosureParamList(format: Format) -> ClosureParamListSyntax {
-    var result = ClosureParamListSyntax(elements.map {
-      $0.buildClosureParam(format: format)
-    })
+    
+    var result = ClosureParamListSyntax(elements.map { $0.buildClosureParam(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -691,24 +641,19 @@ public struct MultipleTrailingClosureElementList: ExpressibleByArrayLiteral, Syn
   /// Creates a `MultipleTrailingClosureElementList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsMultipleTrailingClosureElement`
-  public init (_ elements: [ExpressibleAsMultipleTrailingClosureElement]) {
-    self.elements = elements.map {
-      $0.createMultipleTrailingClosureElement()
-    }
+  public init(_ elements: [ExpressibleAsMultipleTrailingClosureElement]) {
+    self.elements = elements.map { $0.createMultipleTrailingClosureElement() }
   }
   /// Creates a new `MultipleTrailingClosureElementList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsMultipleTrailingClosureElementList]) {
-    elements = lists.flatMap {
-      $0.createMultipleTrailingClosureElementList().elements
-    }
+  public init(combining lists: [ExpressibleAsMultipleTrailingClosureElementList]) {
+    elements = lists.flatMap { $0.createMultipleTrailingClosureElementList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsMultipleTrailingClosureElement...) {
+  public init(arrayLiteral elements: ExpressibleAsMultipleTrailingClosureElement...) {
     self.init(elements)
   }
   public func buildMultipleTrailingClosureElementList(format: Format) -> MultipleTrailingClosureElementListSyntax {
-    var result = MultipleTrailingClosureElementListSyntax(elements.map {
-      $0.buildMultipleTrailingClosureElement(format: format)
-    })
+    
+    var result = MultipleTrailingClosureElementListSyntax(elements.map { $0.buildMultipleTrailingClosureElement(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -759,24 +704,19 @@ public struct ObjcName: ExpressibleByArrayLiteral, SyntaxBuildable, ExpressibleA
   /// Creates a `ObjcName` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsObjcNamePiece`
-  public init (_ elements: [ExpressibleAsObjcNamePiece]) {
-    self.elements = elements.map {
-      $0.createObjcNamePiece()
-    }
+  public init(_ elements: [ExpressibleAsObjcNamePiece]) {
+    self.elements = elements.map { $0.createObjcNamePiece() }
   }
   /// Creates a new `ObjcName` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsObjcName]) {
-    elements = lists.flatMap {
-      $0.createObjcName().elements
-    }
+  public init(combining lists: [ExpressibleAsObjcName]) {
+    elements = lists.flatMap { $0.createObjcName().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsObjcNamePiece...) {
+  public init(arrayLiteral elements: ExpressibleAsObjcNamePiece...) {
     self.init(elements)
   }
   public func buildObjcName(format: Format) -> ObjcNameSyntax {
-    var result = ObjcNameSyntax(elements.map {
-      $0.buildObjcNamePiece(format: format)
-    })
+    
+    var result = ObjcNameSyntax(elements.map { $0.buildObjcNamePiece(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -827,24 +767,19 @@ public struct FunctionParameterList: ExpressibleByArrayLiteral, SyntaxBuildable,
   /// Creates a `FunctionParameterList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsFunctionParameter`
-  public init (_ elements: [ExpressibleAsFunctionParameter]) {
-    self.elements = elements.map {
-      $0.createFunctionParameter()
-    }
+  public init(_ elements: [ExpressibleAsFunctionParameter]) {
+    self.elements = elements.map { $0.createFunctionParameter() }
   }
   /// Creates a new `FunctionParameterList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsFunctionParameterList]) {
-    elements = lists.flatMap {
-      $0.createFunctionParameterList().elements
-    }
+  public init(combining lists: [ExpressibleAsFunctionParameterList]) {
+    elements = lists.flatMap { $0.createFunctionParameterList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsFunctionParameter...) {
+  public init(arrayLiteral elements: ExpressibleAsFunctionParameter...) {
     self.init(elements)
   }
   public func buildFunctionParameterList(format: Format) -> FunctionParameterListSyntax {
-    var result = FunctionParameterListSyntax(elements.map {
-      $0.buildFunctionParameter(format: format)
-    })
+    
+    var result = FunctionParameterListSyntax(elements.map { $0.buildFunctionParameter(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -895,24 +830,19 @@ public struct IfConfigClauseList: ExpressibleByArrayLiteral, SyntaxBuildable, Ex
   /// Creates a `IfConfigClauseList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsIfConfigClause`
-  public init (_ elements: [ExpressibleAsIfConfigClause]) {
-    self.elements = elements.map {
-      $0.createIfConfigClause()
-    }
+  public init(_ elements: [ExpressibleAsIfConfigClause]) {
+    self.elements = elements.map { $0.createIfConfigClause() }
   }
   /// Creates a new `IfConfigClauseList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsIfConfigClauseList]) {
-    elements = lists.flatMap {
-      $0.createIfConfigClauseList().elements
-    }
+  public init(combining lists: [ExpressibleAsIfConfigClauseList]) {
+    elements = lists.flatMap { $0.createIfConfigClauseList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsIfConfigClause...) {
+  public init(arrayLiteral elements: ExpressibleAsIfConfigClause...) {
     self.init(elements)
   }
   public func buildIfConfigClauseList(format: Format) -> IfConfigClauseListSyntax {
-    var result = IfConfigClauseListSyntax(elements.map {
-      $0.buildIfConfigClause(format: format)
-    })
+    
+    var result = IfConfigClauseListSyntax(elements.map { $0.buildIfConfigClause(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -963,24 +893,19 @@ public struct InheritedTypeList: ExpressibleByArrayLiteral, SyntaxBuildable, Exp
   /// Creates a `InheritedTypeList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsInheritedType`
-  public init (_ elements: [ExpressibleAsInheritedType]) {
-    self.elements = elements.map {
-      $0.createInheritedType()
-    }
+  public init(_ elements: [ExpressibleAsInheritedType]) {
+    self.elements = elements.map { $0.createInheritedType() }
   }
   /// Creates a new `InheritedTypeList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsInheritedTypeList]) {
-    elements = lists.flatMap {
-      $0.createInheritedTypeList().elements
-    }
+  public init(combining lists: [ExpressibleAsInheritedTypeList]) {
+    elements = lists.flatMap { $0.createInheritedTypeList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsInheritedType...) {
+  public init(arrayLiteral elements: ExpressibleAsInheritedType...) {
     self.init(elements)
   }
   public func buildInheritedTypeList(format: Format) -> InheritedTypeListSyntax {
-    var result = InheritedTypeListSyntax(elements.map {
-      $0.buildInheritedType(format: format)
-    })
+    
+    var result = InheritedTypeListSyntax(elements.map { $0.buildInheritedType(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -1031,24 +956,19 @@ public struct MemberDeclList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
   /// Creates a `MemberDeclList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsMemberDeclListItem`
-  public init (_ elements: [ExpressibleAsMemberDeclListItem]) {
-    self.elements = elements.map {
-      $0.createMemberDeclListItem()
-    }
+  public init(_ elements: [ExpressibleAsMemberDeclListItem]) {
+    self.elements = elements.map { $0.createMemberDeclListItem() }
   }
   /// Creates a new `MemberDeclList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsMemberDeclList]) {
-    elements = lists.flatMap {
-      $0.createMemberDeclList().elements
-    }
+  public init(combining lists: [ExpressibleAsMemberDeclList]) {
+    elements = lists.flatMap { $0.createMemberDeclList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsMemberDeclListItem...) {
+  public init(arrayLiteral elements: ExpressibleAsMemberDeclListItem...) {
     self.init(elements)
   }
   public func buildMemberDeclList(format: Format) -> MemberDeclListSyntax {
-    var result = MemberDeclListSyntax(elements.map {
-      $0.buildMemberDeclListItem(format: format)
-    })
+    
+    var result = MemberDeclListSyntax(elements.map { $0.buildMemberDeclListItem(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -1094,24 +1014,19 @@ public struct ModifierList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
   /// Creates a `ModifierList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsDeclModifier`
-  public init (_ elements: [ExpressibleAsDeclModifier]) {
-    self.elements = elements.map {
-      $0.createDeclModifier()
-    }
+  public init(_ elements: [ExpressibleAsDeclModifier]) {
+    self.elements = elements.map { $0.createDeclModifier() }
   }
   /// Creates a new `ModifierList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsModifierList]) {
-    elements = lists.flatMap {
-      $0.createModifierList().elements
-    }
+  public init(combining lists: [ExpressibleAsModifierList]) {
+    elements = lists.flatMap { $0.createModifierList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsDeclModifier...) {
+  public init(arrayLiteral elements: ExpressibleAsDeclModifier...) {
     self.init(elements)
   }
   public func buildModifierList(format: Format) -> ModifierListSyntax {
-    var result = ModifierListSyntax(elements.map {
-      $0.buildDeclModifier(format: format)
-    })
+    
+    var result = ModifierListSyntax(elements.map { $0.buildDeclModifier(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -1162,24 +1077,19 @@ public struct AccessPath: ExpressibleByArrayLiteral, SyntaxBuildable, Expressibl
   /// Creates a `AccessPath` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsAccessPathComponent`
-  public init (_ elements: [ExpressibleAsAccessPathComponent]) {
-    self.elements = elements.map {
-      $0.createAccessPathComponent()
-    }
+  public init(_ elements: [ExpressibleAsAccessPathComponent]) {
+    self.elements = elements.map { $0.createAccessPathComponent() }
   }
   /// Creates a new `AccessPath` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsAccessPath]) {
-    elements = lists.flatMap {
-      $0.createAccessPath().elements
-    }
+  public init(combining lists: [ExpressibleAsAccessPath]) {
+    elements = lists.flatMap { $0.createAccessPath().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsAccessPathComponent...) {
+  public init(arrayLiteral elements: ExpressibleAsAccessPathComponent...) {
     self.init(elements)
   }
   public func buildAccessPath(format: Format) -> AccessPathSyntax {
-    var result = AccessPathSyntax(elements.map {
-      $0.buildAccessPathComponent(format: format)
-    })
+    
+    var result = AccessPathSyntax(elements.map { $0.buildAccessPathComponent(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -1230,24 +1140,19 @@ public struct AccessorList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
   /// Creates a `AccessorList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsAccessorDecl`
-  public init (_ elements: [ExpressibleAsAccessorDecl]) {
-    self.elements = elements.map {
-      $0.createAccessorDecl()
-    }
+  public init(_ elements: [ExpressibleAsAccessorDecl]) {
+    self.elements = elements.map { $0.createAccessorDecl() }
   }
   /// Creates a new `AccessorList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsAccessorList]) {
-    elements = lists.flatMap {
-      $0.createAccessorList().elements
-    }
+  public init(combining lists: [ExpressibleAsAccessorList]) {
+    elements = lists.flatMap { $0.createAccessorList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsAccessorDecl...) {
+  public init(arrayLiteral elements: ExpressibleAsAccessorDecl...) {
     self.init(elements)
   }
   public func buildAccessorList(format: Format) -> AccessorListSyntax {
-    var result = AccessorListSyntax(elements.map {
-      $0.buildAccessorDecl(format: format)
-    })
+    
+    var result = AccessorListSyntax(elements.map { $0.buildAccessorDecl(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -1293,24 +1198,19 @@ public struct PatternBindingList: ExpressibleByArrayLiteral, SyntaxBuildable, Ex
   /// Creates a `PatternBindingList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsPatternBinding`
-  public init (_ elements: [ExpressibleAsPatternBinding]) {
-    self.elements = elements.map {
-      $0.createPatternBinding()
-    }
+  public init(_ elements: [ExpressibleAsPatternBinding]) {
+    self.elements = elements.map { $0.createPatternBinding() }
   }
   /// Creates a new `PatternBindingList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsPatternBindingList]) {
-    elements = lists.flatMap {
-      $0.createPatternBindingList().elements
-    }
+  public init(combining lists: [ExpressibleAsPatternBindingList]) {
+    elements = lists.flatMap { $0.createPatternBindingList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsPatternBinding...) {
+  public init(arrayLiteral elements: ExpressibleAsPatternBinding...) {
     self.init(elements)
   }
   public func buildPatternBindingList(format: Format) -> PatternBindingListSyntax {
-    var result = PatternBindingListSyntax(elements.map {
-      $0.buildPatternBinding(format: format)
-    })
+    
+    var result = PatternBindingListSyntax(elements.map { $0.buildPatternBinding(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -1361,24 +1261,19 @@ public struct EnumCaseElementList: ExpressibleByArrayLiteral, SyntaxBuildable, E
   /// Creates a `EnumCaseElementList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsEnumCaseElement`
-  public init (_ elements: [ExpressibleAsEnumCaseElement]) {
-    self.elements = elements.map {
-      $0.createEnumCaseElement()
-    }
+  public init(_ elements: [ExpressibleAsEnumCaseElement]) {
+    self.elements = elements.map { $0.createEnumCaseElement() }
   }
   /// Creates a new `EnumCaseElementList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsEnumCaseElementList]) {
-    elements = lists.flatMap {
-      $0.createEnumCaseElementList().elements
-    }
+  public init(combining lists: [ExpressibleAsEnumCaseElementList]) {
+    elements = lists.flatMap { $0.createEnumCaseElementList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsEnumCaseElement...) {
+  public init(arrayLiteral elements: ExpressibleAsEnumCaseElement...) {
     self.init(elements)
   }
   public func buildEnumCaseElementList(format: Format) -> EnumCaseElementListSyntax {
-    var result = EnumCaseElementListSyntax(elements.map {
-      $0.buildEnumCaseElement(format: format)
-    })
+    
+    var result = EnumCaseElementListSyntax(elements.map { $0.buildEnumCaseElement(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -1429,24 +1324,19 @@ public struct DesignatedTypeList: ExpressibleByArrayLiteral, SyntaxBuildable, Ex
   /// Creates a `DesignatedTypeList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsDesignatedTypeElement`
-  public init (_ elements: [ExpressibleAsDesignatedTypeElement]) {
-    self.elements = elements.map {
-      $0.createDesignatedTypeElement()
-    }
+  public init(_ elements: [ExpressibleAsDesignatedTypeElement]) {
+    self.elements = elements.map { $0.createDesignatedTypeElement() }
   }
   /// Creates a new `DesignatedTypeList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsDesignatedTypeList]) {
-    elements = lists.flatMap {
-      $0.createDesignatedTypeList().elements
-    }
+  public init(combining lists: [ExpressibleAsDesignatedTypeList]) {
+    elements = lists.flatMap { $0.createDesignatedTypeList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsDesignatedTypeElement...) {
+  public init(arrayLiteral elements: ExpressibleAsDesignatedTypeElement...) {
     self.init(elements)
   }
   public func buildDesignatedTypeList(format: Format) -> DesignatedTypeListSyntax {
-    var result = DesignatedTypeListSyntax(elements.map {
-      $0.buildDesignatedTypeElement(format: format)
-    })
+    
+    var result = DesignatedTypeListSyntax(elements.map { $0.buildDesignatedTypeElement(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -1497,24 +1387,19 @@ public struct PrecedenceGroupAttributeList: ExpressibleByArrayLiteral, SyntaxBui
   /// Creates a `PrecedenceGroupAttributeList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsSyntaxBuildable`
-  public init (_ elements: [ExpressibleAsSyntaxBuildable]) {
-    self.elements = elements.map {
-      $0.createSyntaxBuildable()
-    }
+  public init(_ elements: [ExpressibleAsSyntaxBuildable]) {
+    self.elements = elements.map { $0.createSyntaxBuildable() }
   }
   /// Creates a new `PrecedenceGroupAttributeList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsPrecedenceGroupAttributeList]) {
-    elements = lists.flatMap {
-      $0.createPrecedenceGroupAttributeList().elements
-    }
+  public init(combining lists: [ExpressibleAsPrecedenceGroupAttributeList]) {
+    elements = lists.flatMap { $0.createPrecedenceGroupAttributeList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsSyntaxBuildable...) {
+  public init(arrayLiteral elements: ExpressibleAsSyntaxBuildable...) {
     self.init(elements)
   }
   public func buildPrecedenceGroupAttributeList(format: Format) -> PrecedenceGroupAttributeListSyntax {
-    var result = PrecedenceGroupAttributeListSyntax(elements.map {
-      $0.buildSyntax(format: format)
-    })
+    
+    var result = PrecedenceGroupAttributeListSyntax(elements.map { $0.buildSyntax(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -1565,24 +1450,19 @@ public struct PrecedenceGroupNameList: ExpressibleByArrayLiteral, SyntaxBuildabl
   /// Creates a `PrecedenceGroupNameList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsPrecedenceGroupNameElement`
-  public init (_ elements: [ExpressibleAsPrecedenceGroupNameElement]) {
-    self.elements = elements.map {
-      $0.createPrecedenceGroupNameElement()
-    }
+  public init(_ elements: [ExpressibleAsPrecedenceGroupNameElement]) {
+    self.elements = elements.map { $0.createPrecedenceGroupNameElement() }
   }
   /// Creates a new `PrecedenceGroupNameList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsPrecedenceGroupNameList]) {
-    elements = lists.flatMap {
-      $0.createPrecedenceGroupNameList().elements
-    }
+  public init(combining lists: [ExpressibleAsPrecedenceGroupNameList]) {
+    elements = lists.flatMap { $0.createPrecedenceGroupNameList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsPrecedenceGroupNameElement...) {
+  public init(arrayLiteral elements: ExpressibleAsPrecedenceGroupNameElement...) {
     self.init(elements)
   }
   public func buildPrecedenceGroupNameList(format: Format) -> PrecedenceGroupNameListSyntax {
-    var result = PrecedenceGroupNameListSyntax(elements.map {
-      $0.buildPrecedenceGroupNameElement(format: format)
-    })
+    
+    var result = PrecedenceGroupNameListSyntax(elements.map { $0.buildPrecedenceGroupNameElement(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -1633,22 +1513,19 @@ public struct TokenList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressible
   /// Creates a `TokenList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `Token`
-  public init (_ elements: [Token]) {
+  public init(_ elements: [Token]) {
     self.elements = elements
   }
   /// Creates a new `TokenList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsTokenList]) {
-    elements = lists.flatMap {
-      $0.createTokenList().elements
-    }
+  public init(combining lists: [ExpressibleAsTokenList]) {
+    elements = lists.flatMap { $0.createTokenList().elements }
   }
-  public init (arrayLiteral elements: Token...) {
+  public init(arrayLiteral elements: Token...) {
     self.init(elements)
   }
   public func buildTokenList(format: Format) -> TokenListSyntax {
-    var result = TokenListSyntax(elements.map {
-      $0.buildToken(format: format)
-    })
+    
+    var result = TokenListSyntax(elements.map { $0.buildToken(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -1699,22 +1576,19 @@ public struct NonEmptyTokenList: ExpressibleByArrayLiteral, SyntaxBuildable, Exp
   /// Creates a `NonEmptyTokenList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `Token`
-  public init (_ elements: [Token]) {
+  public init(_ elements: [Token]) {
     self.elements = elements
   }
   /// Creates a new `NonEmptyTokenList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsNonEmptyTokenList]) {
-    elements = lists.flatMap {
-      $0.createNonEmptyTokenList().elements
-    }
+  public init(combining lists: [ExpressibleAsNonEmptyTokenList]) {
+    elements = lists.flatMap { $0.createNonEmptyTokenList().elements }
   }
-  public init (arrayLiteral elements: Token...) {
+  public init(arrayLiteral elements: Token...) {
     self.init(elements)
   }
   public func buildNonEmptyTokenList(format: Format) -> NonEmptyTokenListSyntax {
-    var result = NonEmptyTokenListSyntax(elements.map {
-      $0.buildToken(format: format)
-    })
+    
+    var result = NonEmptyTokenListSyntax(elements.map { $0.buildToken(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -1765,24 +1639,19 @@ public struct AttributeList: ExpressibleByArrayLiteral, SyntaxBuildable, Express
   /// Creates a `AttributeList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsSyntaxBuildable`
-  public init (_ elements: [ExpressibleAsSyntaxBuildable]) {
-    self.elements = elements.map {
-      $0.createSyntaxBuildable()
-    }
+  public init(_ elements: [ExpressibleAsSyntaxBuildable]) {
+    self.elements = elements.map { $0.createSyntaxBuildable() }
   }
   /// Creates a new `AttributeList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsAttributeList]) {
-    elements = lists.flatMap {
-      $0.createAttributeList().elements
-    }
+  public init(combining lists: [ExpressibleAsAttributeList]) {
+    elements = lists.flatMap { $0.createAttributeList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsSyntaxBuildable...) {
+  public init(arrayLiteral elements: ExpressibleAsSyntaxBuildable...) {
     self.init(elements)
   }
   public func buildAttributeList(format: Format) -> AttributeListSyntax {
-    var result = AttributeListSyntax(elements.map {
-      $0.buildSyntax(format: format)
-    })
+    
+    var result = AttributeListSyntax(elements.map { $0.buildSyntax(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -1833,24 +1702,19 @@ public struct SpecializeAttributeSpecList: ExpressibleByArrayLiteral, SyntaxBuil
   /// Creates a `SpecializeAttributeSpecList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsSyntaxBuildable`
-  public init (_ elements: [ExpressibleAsSyntaxBuildable]) {
-    self.elements = elements.map {
-      $0.createSyntaxBuildable()
-    }
+  public init(_ elements: [ExpressibleAsSyntaxBuildable]) {
+    self.elements = elements.map { $0.createSyntaxBuildable() }
   }
   /// Creates a new `SpecializeAttributeSpecList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsSpecializeAttributeSpecList]) {
-    elements = lists.flatMap {
-      $0.createSpecializeAttributeSpecList().elements
-    }
+  public init(combining lists: [ExpressibleAsSpecializeAttributeSpecList]) {
+    elements = lists.flatMap { $0.createSpecializeAttributeSpecList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsSyntaxBuildable...) {
+  public init(arrayLiteral elements: ExpressibleAsSyntaxBuildable...) {
     self.init(elements)
   }
   public func buildSpecializeAttributeSpecList(format: Format) -> SpecializeAttributeSpecListSyntax {
-    var result = SpecializeAttributeSpecListSyntax(elements.map {
-      $0.buildSyntax(format: format)
-    })
+    
+    var result = SpecializeAttributeSpecListSyntax(elements.map { $0.buildSyntax(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -1901,24 +1765,19 @@ public struct ObjCSelector: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
   /// Creates a `ObjCSelector` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsObjCSelectorPiece`
-  public init (_ elements: [ExpressibleAsObjCSelectorPiece]) {
-    self.elements = elements.map {
-      $0.createObjCSelectorPiece()
-    }
+  public init(_ elements: [ExpressibleAsObjCSelectorPiece]) {
+    self.elements = elements.map { $0.createObjCSelectorPiece() }
   }
   /// Creates a new `ObjCSelector` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsObjCSelector]) {
-    elements = lists.flatMap {
-      $0.createObjCSelector().elements
-    }
+  public init(combining lists: [ExpressibleAsObjCSelector]) {
+    elements = lists.flatMap { $0.createObjCSelector().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsObjCSelectorPiece...) {
+  public init(arrayLiteral elements: ExpressibleAsObjCSelectorPiece...) {
     self.init(elements)
   }
   public func buildObjCSelector(format: Format) -> ObjCSelectorSyntax {
-    var result = ObjCSelectorSyntax(elements.map {
-      $0.buildObjCSelectorPiece(format: format)
-    })
+    
+    var result = ObjCSelectorSyntax(elements.map { $0.buildObjCSelectorPiece(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -1969,24 +1828,19 @@ public struct DifferentiabilityParamList: ExpressibleByArrayLiteral, SyntaxBuild
   /// Creates a `DifferentiabilityParamList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsDifferentiabilityParam`
-  public init (_ elements: [ExpressibleAsDifferentiabilityParam]) {
-    self.elements = elements.map {
-      $0.createDifferentiabilityParam()
-    }
+  public init(_ elements: [ExpressibleAsDifferentiabilityParam]) {
+    self.elements = elements.map { $0.createDifferentiabilityParam() }
   }
   /// Creates a new `DifferentiabilityParamList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsDifferentiabilityParamList]) {
-    elements = lists.flatMap {
-      $0.createDifferentiabilityParamList().elements
-    }
+  public init(combining lists: [ExpressibleAsDifferentiabilityParamList]) {
+    elements = lists.flatMap { $0.createDifferentiabilityParamList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsDifferentiabilityParam...) {
+  public init(arrayLiteral elements: ExpressibleAsDifferentiabilityParam...) {
     self.init(elements)
   }
   public func buildDifferentiabilityParamList(format: Format) -> DifferentiabilityParamListSyntax {
-    var result = DifferentiabilityParamListSyntax(elements.map {
-      $0.buildDifferentiabilityParam(format: format)
-    })
+    
+    var result = DifferentiabilityParamListSyntax(elements.map { $0.buildDifferentiabilityParam(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -2037,24 +1891,19 @@ public struct BackDeployVersionList: ExpressibleByArrayLiteral, SyntaxBuildable,
   /// Creates a `BackDeployVersionList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsBackDeployVersionArgument`
-  public init (_ elements: [ExpressibleAsBackDeployVersionArgument]) {
-    self.elements = elements.map {
-      $0.createBackDeployVersionArgument()
-    }
+  public init(_ elements: [ExpressibleAsBackDeployVersionArgument]) {
+    self.elements = elements.map { $0.createBackDeployVersionArgument() }
   }
   /// Creates a new `BackDeployVersionList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsBackDeployVersionList]) {
-    elements = lists.flatMap {
-      $0.createBackDeployVersionList().elements
-    }
+  public init(combining lists: [ExpressibleAsBackDeployVersionList]) {
+    elements = lists.flatMap { $0.createBackDeployVersionList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsBackDeployVersionArgument...) {
+  public init(arrayLiteral elements: ExpressibleAsBackDeployVersionArgument...) {
     self.init(elements)
   }
   public func buildBackDeployVersionList(format: Format) -> BackDeployVersionListSyntax {
-    var result = BackDeployVersionListSyntax(elements.map {
-      $0.buildBackDeployVersionArgument(format: format)
-    })
+    
+    var result = BackDeployVersionListSyntax(elements.map { $0.buildBackDeployVersionArgument(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -2105,24 +1954,19 @@ public struct SwitchCaseList: ExpressibleByArrayLiteral, SyntaxBuildable, Expres
   /// Creates a `SwitchCaseList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsSyntaxBuildable`
-  public init (_ elements: [ExpressibleAsSyntaxBuildable]) {
-    self.elements = elements.map {
-      $0.createSyntaxBuildable()
-    }
+  public init(_ elements: [ExpressibleAsSyntaxBuildable]) {
+    self.elements = elements.map { $0.createSyntaxBuildable() }
   }
   /// Creates a new `SwitchCaseList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsSwitchCaseList]) {
-    elements = lists.flatMap {
-      $0.createSwitchCaseList().elements
-    }
+  public init(combining lists: [ExpressibleAsSwitchCaseList]) {
+    elements = lists.flatMap { $0.createSwitchCaseList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsSyntaxBuildable...) {
+  public init(arrayLiteral elements: ExpressibleAsSyntaxBuildable...) {
     self.init(elements)
   }
   public func buildSwitchCaseList(format: Format) -> SwitchCaseListSyntax {
-    var result = SwitchCaseListSyntax(elements.map {
-      $0.buildSyntax(format: format)
-    })
+    
+    var result = SwitchCaseListSyntax(elements.map { $0.buildSyntax(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -2173,24 +2017,19 @@ public struct CatchClauseList: ExpressibleByArrayLiteral, SyntaxBuildable, Expre
   /// Creates a `CatchClauseList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsCatchClause`
-  public init (_ elements: [ExpressibleAsCatchClause]) {
-    self.elements = elements.map {
-      $0.createCatchClause()
-    }
+  public init(_ elements: [ExpressibleAsCatchClause]) {
+    self.elements = elements.map { $0.createCatchClause() }
   }
   /// Creates a new `CatchClauseList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsCatchClauseList]) {
-    elements = lists.flatMap {
-      $0.createCatchClauseList().elements
-    }
+  public init(combining lists: [ExpressibleAsCatchClauseList]) {
+    elements = lists.flatMap { $0.createCatchClauseList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsCatchClause...) {
+  public init(arrayLiteral elements: ExpressibleAsCatchClause...) {
     self.init(elements)
   }
   public func buildCatchClauseList(format: Format) -> CatchClauseListSyntax {
-    var result = CatchClauseListSyntax(elements.map {
-      $0.buildCatchClause(format: format)
-    })
+    
+    var result = CatchClauseListSyntax(elements.map { $0.buildCatchClause(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -2241,24 +2080,19 @@ public struct CaseItemList: ExpressibleByArrayLiteral, SyntaxBuildable, Expressi
   /// Creates a `CaseItemList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsCaseItem`
-  public init (_ elements: [ExpressibleAsCaseItem]) {
-    self.elements = elements.map {
-      $0.createCaseItem()
-    }
+  public init(_ elements: [ExpressibleAsCaseItem]) {
+    self.elements = elements.map { $0.createCaseItem() }
   }
   /// Creates a new `CaseItemList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsCaseItemList]) {
-    elements = lists.flatMap {
-      $0.createCaseItemList().elements
-    }
+  public init(combining lists: [ExpressibleAsCaseItemList]) {
+    elements = lists.flatMap { $0.createCaseItemList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsCaseItem...) {
+  public init(arrayLiteral elements: ExpressibleAsCaseItem...) {
     self.init(elements)
   }
   public func buildCaseItemList(format: Format) -> CaseItemListSyntax {
-    var result = CaseItemListSyntax(elements.map {
-      $0.buildCaseItem(format: format)
-    })
+    
+    var result = CaseItemListSyntax(elements.map { $0.buildCaseItem(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -2309,24 +2143,19 @@ public struct CatchItemList: ExpressibleByArrayLiteral, SyntaxBuildable, Express
   /// Creates a `CatchItemList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsCatchItem`
-  public init (_ elements: [ExpressibleAsCatchItem]) {
-    self.elements = elements.map {
-      $0.createCatchItem()
-    }
+  public init(_ elements: [ExpressibleAsCatchItem]) {
+    self.elements = elements.map { $0.createCatchItem() }
   }
   /// Creates a new `CatchItemList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsCatchItemList]) {
-    elements = lists.flatMap {
-      $0.createCatchItemList().elements
-    }
+  public init(combining lists: [ExpressibleAsCatchItemList]) {
+    elements = lists.flatMap { $0.createCatchItemList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsCatchItem...) {
+  public init(arrayLiteral elements: ExpressibleAsCatchItem...) {
     self.init(elements)
   }
   public func buildCatchItemList(format: Format) -> CatchItemListSyntax {
-    var result = CatchItemListSyntax(elements.map {
-      $0.buildCatchItem(format: format)
-    })
+    
+    var result = CatchItemListSyntax(elements.map { $0.buildCatchItem(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -2377,24 +2206,19 @@ public struct ConditionElementList: ExpressibleByArrayLiteral, SyntaxBuildable, 
   /// Creates a `ConditionElementList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsConditionElement`
-  public init (_ elements: [ExpressibleAsConditionElement]) {
-    self.elements = elements.map {
-      $0.createConditionElement()
-    }
+  public init(_ elements: [ExpressibleAsConditionElement]) {
+    self.elements = elements.map { $0.createConditionElement() }
   }
   /// Creates a new `ConditionElementList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsConditionElementList]) {
-    elements = lists.flatMap {
-      $0.createConditionElementList().elements
-    }
+  public init(combining lists: [ExpressibleAsConditionElementList]) {
+    elements = lists.flatMap { $0.createConditionElementList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsConditionElement...) {
+  public init(arrayLiteral elements: ExpressibleAsConditionElement...) {
     self.init(elements)
   }
   public func buildConditionElementList(format: Format) -> ConditionElementListSyntax {
-    var result = ConditionElementListSyntax(elements.map {
-      $0.buildConditionElement(format: format)
-    })
+    
+    var result = ConditionElementListSyntax(elements.map { $0.buildConditionElement(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -2445,24 +2269,19 @@ public struct GenericRequirementList: ExpressibleByArrayLiteral, SyntaxBuildable
   /// Creates a `GenericRequirementList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsGenericRequirement`
-  public init (_ elements: [ExpressibleAsGenericRequirement]) {
-    self.elements = elements.map {
-      $0.createGenericRequirement()
-    }
+  public init(_ elements: [ExpressibleAsGenericRequirement]) {
+    self.elements = elements.map { $0.createGenericRequirement() }
   }
   /// Creates a new `GenericRequirementList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsGenericRequirementList]) {
-    elements = lists.flatMap {
-      $0.createGenericRequirementList().elements
-    }
+  public init(combining lists: [ExpressibleAsGenericRequirementList]) {
+    elements = lists.flatMap { $0.createGenericRequirementList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsGenericRequirement...) {
+  public init(arrayLiteral elements: ExpressibleAsGenericRequirement...) {
     self.init(elements)
   }
   public func buildGenericRequirementList(format: Format) -> GenericRequirementListSyntax {
-    var result = GenericRequirementListSyntax(elements.map {
-      $0.buildGenericRequirement(format: format)
-    })
+    
+    var result = GenericRequirementListSyntax(elements.map { $0.buildGenericRequirement(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -2513,24 +2332,19 @@ public struct GenericParameterList: ExpressibleByArrayLiteral, SyntaxBuildable, 
   /// Creates a `GenericParameterList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsGenericParameter`
-  public init (_ elements: [ExpressibleAsGenericParameter]) {
-    self.elements = elements.map {
-      $0.createGenericParameter()
-    }
+  public init(_ elements: [ExpressibleAsGenericParameter]) {
+    self.elements = elements.map { $0.createGenericParameter() }
   }
   /// Creates a new `GenericParameterList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsGenericParameterList]) {
-    elements = lists.flatMap {
-      $0.createGenericParameterList().elements
-    }
+  public init(combining lists: [ExpressibleAsGenericParameterList]) {
+    elements = lists.flatMap { $0.createGenericParameterList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsGenericParameter...) {
+  public init(arrayLiteral elements: ExpressibleAsGenericParameter...) {
     self.init(elements)
   }
   public func buildGenericParameterList(format: Format) -> GenericParameterListSyntax {
-    var result = GenericParameterListSyntax(elements.map {
-      $0.buildGenericParameter(format: format)
-    })
+    
+    var result = GenericParameterListSyntax(elements.map { $0.buildGenericParameter(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -2581,24 +2395,19 @@ public struct PrimaryAssociatedTypeList: ExpressibleByArrayLiteral, SyntaxBuilda
   /// Creates a `PrimaryAssociatedTypeList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsPrimaryAssociatedType`
-  public init (_ elements: [ExpressibleAsPrimaryAssociatedType]) {
-    self.elements = elements.map {
-      $0.createPrimaryAssociatedType()
-    }
+  public init(_ elements: [ExpressibleAsPrimaryAssociatedType]) {
+    self.elements = elements.map { $0.createPrimaryAssociatedType() }
   }
   /// Creates a new `PrimaryAssociatedTypeList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsPrimaryAssociatedTypeList]) {
-    elements = lists.flatMap {
-      $0.createPrimaryAssociatedTypeList().elements
-    }
+  public init(combining lists: [ExpressibleAsPrimaryAssociatedTypeList]) {
+    elements = lists.flatMap { $0.createPrimaryAssociatedTypeList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsPrimaryAssociatedType...) {
+  public init(arrayLiteral elements: ExpressibleAsPrimaryAssociatedType...) {
     self.init(elements)
   }
   public func buildPrimaryAssociatedTypeList(format: Format) -> PrimaryAssociatedTypeListSyntax {
-    var result = PrimaryAssociatedTypeListSyntax(elements.map {
-      $0.buildPrimaryAssociatedType(format: format)
-    })
+    
+    var result = PrimaryAssociatedTypeListSyntax(elements.map { $0.buildPrimaryAssociatedType(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -2649,24 +2458,19 @@ public struct CompositionTypeElementList: ExpressibleByArrayLiteral, SyntaxBuild
   /// Creates a `CompositionTypeElementList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsCompositionTypeElement`
-  public init (_ elements: [ExpressibleAsCompositionTypeElement]) {
-    self.elements = elements.map {
-      $0.createCompositionTypeElement()
-    }
+  public init(_ elements: [ExpressibleAsCompositionTypeElement]) {
+    self.elements = elements.map { $0.createCompositionTypeElement() }
   }
   /// Creates a new `CompositionTypeElementList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsCompositionTypeElementList]) {
-    elements = lists.flatMap {
-      $0.createCompositionTypeElementList().elements
-    }
+  public init(combining lists: [ExpressibleAsCompositionTypeElementList]) {
+    elements = lists.flatMap { $0.createCompositionTypeElementList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsCompositionTypeElement...) {
+  public init(arrayLiteral elements: ExpressibleAsCompositionTypeElement...) {
     self.init(elements)
   }
   public func buildCompositionTypeElementList(format: Format) -> CompositionTypeElementListSyntax {
-    var result = CompositionTypeElementListSyntax(elements.map {
-      $0.buildCompositionTypeElement(format: format)
-    })
+    
+    var result = CompositionTypeElementListSyntax(elements.map { $0.buildCompositionTypeElement(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -2717,24 +2521,19 @@ public struct TupleTypeElementList: ExpressibleByArrayLiteral, SyntaxBuildable, 
   /// Creates a `TupleTypeElementList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsTupleTypeElement`
-  public init (_ elements: [ExpressibleAsTupleTypeElement]) {
-    self.elements = elements.map {
-      $0.createTupleTypeElement()
-    }
+  public init(_ elements: [ExpressibleAsTupleTypeElement]) {
+    self.elements = elements.map { $0.createTupleTypeElement() }
   }
   /// Creates a new `TupleTypeElementList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsTupleTypeElementList]) {
-    elements = lists.flatMap {
-      $0.createTupleTypeElementList().elements
-    }
+  public init(combining lists: [ExpressibleAsTupleTypeElementList]) {
+    elements = lists.flatMap { $0.createTupleTypeElementList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsTupleTypeElement...) {
+  public init(arrayLiteral elements: ExpressibleAsTupleTypeElement...) {
     self.init(elements)
   }
   public func buildTupleTypeElementList(format: Format) -> TupleTypeElementListSyntax {
-    var result = TupleTypeElementListSyntax(elements.map {
-      $0.buildTupleTypeElement(format: format)
-    })
+    
+    var result = TupleTypeElementListSyntax(elements.map { $0.buildTupleTypeElement(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -2785,24 +2584,19 @@ public struct GenericArgumentList: ExpressibleByArrayLiteral, SyntaxBuildable, E
   /// Creates a `GenericArgumentList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsGenericArgument`
-  public init (_ elements: [ExpressibleAsGenericArgument]) {
-    self.elements = elements.map {
-      $0.createGenericArgument()
-    }
+  public init(_ elements: [ExpressibleAsGenericArgument]) {
+    self.elements = elements.map { $0.createGenericArgument() }
   }
   /// Creates a new `GenericArgumentList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsGenericArgumentList]) {
-    elements = lists.flatMap {
-      $0.createGenericArgumentList().elements
-    }
+  public init(combining lists: [ExpressibleAsGenericArgumentList]) {
+    elements = lists.flatMap { $0.createGenericArgumentList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsGenericArgument...) {
+  public init(arrayLiteral elements: ExpressibleAsGenericArgument...) {
     self.init(elements)
   }
   public func buildGenericArgumentList(format: Format) -> GenericArgumentListSyntax {
-    var result = GenericArgumentListSyntax(elements.map {
-      $0.buildGenericArgument(format: format)
-    })
+    
+    var result = GenericArgumentListSyntax(elements.map { $0.buildGenericArgument(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -2853,24 +2647,19 @@ public struct TuplePatternElementList: ExpressibleByArrayLiteral, SyntaxBuildabl
   /// Creates a `TuplePatternElementList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsTuplePatternElement`
-  public init (_ elements: [ExpressibleAsTuplePatternElement]) {
-    self.elements = elements.map {
-      $0.createTuplePatternElement()
-    }
+  public init(_ elements: [ExpressibleAsTuplePatternElement]) {
+    self.elements = elements.map { $0.createTuplePatternElement() }
   }
   /// Creates a new `TuplePatternElementList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsTuplePatternElementList]) {
-    elements = lists.flatMap {
-      $0.createTuplePatternElementList().elements
-    }
+  public init(combining lists: [ExpressibleAsTuplePatternElementList]) {
+    elements = lists.flatMap { $0.createTuplePatternElementList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsTuplePatternElement...) {
+  public init(arrayLiteral elements: ExpressibleAsTuplePatternElement...) {
     self.init(elements)
   }
   public func buildTuplePatternElementList(format: Format) -> TuplePatternElementListSyntax {
-    var result = TuplePatternElementListSyntax(elements.map {
-      $0.buildTuplePatternElement(format: format)
-    })
+    
+    var result = TuplePatternElementListSyntax(elements.map { $0.buildTuplePatternElement(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)
@@ -2921,24 +2710,19 @@ public struct AvailabilitySpecList: ExpressibleByArrayLiteral, SyntaxBuildable, 
   /// Creates a `AvailabilitySpecList` with the provided list of elements.
   /// - Parameters:
   ///   - elements: A list of `ExpressibleAsAvailabilityArgument`
-  public init (_ elements: [ExpressibleAsAvailabilityArgument]) {
-    self.elements = elements.map {
-      $0.createAvailabilityArgument()
-    }
+  public init(_ elements: [ExpressibleAsAvailabilityArgument]) {
+    self.elements = elements.map { $0.createAvailabilityArgument() }
   }
   /// Creates a new `AvailabilitySpecList` by flattening the elements in `lists`
-  public init (combining lists: [ExpressibleAsAvailabilitySpecList]) {
-    elements = lists.flatMap {
-      $0.createAvailabilitySpecList().elements
-    }
+  public init(combining lists: [ExpressibleAsAvailabilitySpecList]) {
+    elements = lists.flatMap { $0.createAvailabilitySpecList().elements }
   }
-  public init (arrayLiteral elements: ExpressibleAsAvailabilityArgument...) {
+  public init(arrayLiteral elements: ExpressibleAsAvailabilityArgument...) {
     self.init(elements)
   }
   public func buildAvailabilitySpecList(format: Format) -> AvailabilitySpecListSyntax {
-    var result = AvailabilitySpecListSyntax(elements.map {
-      $0.buildAvailabilityArgument(format: format)
-    })
+    
+    var result = AvailabilitySpecListSyntax(elements.map { $0.buildAvailabilityArgument(format: format) })
     if !leadingTrivia.isEmpty {
       let trivia = (leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
       result = result.withLeadingTrivia(trivia)

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -47,7 +47,7 @@ public struct CodeBlockItem: SyntaxBuildable, ExpressibleAsCodeBlockItem {
     assert(semicolon == nil || semicolon!.text == #";"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeItem: unexpectedBeforeItem?.createUnexpectedNodes(), item: item.createSyntaxBuildable(), unexpectedBetweenItemAndSemicolon: unexpectedBetweenItemAndSemicolon?.createUnexpectedNodes(), semicolon: semicolon, unexpectedBetweenSemicolonAndErrorTokens: unexpectedBetweenSemicolonAndErrorTokens?.createUnexpectedNodes(), errorTokens: errorTokens?.createSyntaxBuildable()))
   }
-  public init (_ constructedNode: CodeBlockItemSyntax) {
+  public init(_ constructedNode: CodeBlockItemSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `CodeBlockItemSyntax`.
@@ -89,13 +89,13 @@ public struct CodeBlockItem: SyntaxBuildable, ExpressibleAsCodeBlockItem {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -103,12 +103,12 @@ public struct CodeBlockItem: SyntaxBuildable, ExpressibleAsCodeBlockItem {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -155,7 +155,7 @@ public struct CodeBlock: SyntaxBuildable, ExpressibleAsCodeBlock {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLeftBrace: unexpectedBeforeLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndStatements: unexpectedBetweenLeftBraceAndStatements, statements: statementsBuilder(), unexpectedBetweenStatementsAndRightBrace: unexpectedBetweenStatementsAndRightBrace, rightBrace: rightBrace)
   }
-  public init (_ constructedNode: CodeBlockSyntax) {
+  public init(_ constructedNode: CodeBlockSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `CodeBlockSyntax`.
@@ -197,13 +197,13 @@ public struct CodeBlock: SyntaxBuildable, ExpressibleAsCodeBlock {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -211,12 +211,12 @@ public struct CodeBlock: SyntaxBuildable, ExpressibleAsCodeBlock {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -250,7 +250,7 @@ public struct InOutExpr: ExprBuildable, ExpressibleAsInOutExpr {
     assert(ampersand.text == #"&"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeAmpersand: unexpectedBeforeAmpersand?.createUnexpectedNodes(), ampersand: ampersand, unexpectedBetweenAmpersandAndExpression: unexpectedBetweenAmpersandAndExpression?.createUnexpectedNodes(), expression: expression.createExprBuildable()))
   }
-  public init (_ constructedNode: InOutExprSyntax) {
+  public init(_ constructedNode: InOutExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `InOutExprSyntax`.
@@ -299,13 +299,13 @@ public struct InOutExpr: ExprBuildable, ExpressibleAsInOutExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -313,12 +313,12 @@ public struct InOutExpr: ExprBuildable, ExpressibleAsInOutExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -348,7 +348,7 @@ public struct PoundColumnExpr: ExprBuildable, ExpressibleAsPoundColumnExpr {
     assert(poundColumn.text == #"#column"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePoundColumn: unexpectedBeforePoundColumn?.createUnexpectedNodes(), poundColumn: poundColumn))
   }
-  public init (_ constructedNode: PoundColumnExprSyntax) {
+  public init(_ constructedNode: PoundColumnExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PoundColumnExprSyntax`.
@@ -397,13 +397,13 @@ public struct PoundColumnExpr: ExprBuildable, ExpressibleAsPoundColumnExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -411,12 +411,12 @@ public struct PoundColumnExpr: ExprBuildable, ExpressibleAsPoundColumnExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -455,7 +455,7 @@ public struct TryExpr: ExprBuildable, ExpressibleAsTryExpr {
     assert(questionOrExclamationMark == nil || questionOrExclamationMark!.text == #"?"# || questionOrExclamationMark!.text == #"!"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeTryKeyword: unexpectedBeforeTryKeyword?.createUnexpectedNodes(), tryKeyword: tryKeyword, unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: unexpectedBetweenTryKeywordAndQuestionOrExclamationMark?.createUnexpectedNodes(), questionOrExclamationMark: questionOrExclamationMark, unexpectedBetweenQuestionOrExclamationMarkAndExpression: unexpectedBetweenQuestionOrExclamationMarkAndExpression?.createUnexpectedNodes(), expression: expression.createExprBuildable()))
   }
-  public init (_ constructedNode: TryExprSyntax) {
+  public init(_ constructedNode: TryExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `TryExprSyntax`.
@@ -504,13 +504,13 @@ public struct TryExpr: ExprBuildable, ExpressibleAsTryExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -518,12 +518,12 @@ public struct TryExpr: ExprBuildable, ExpressibleAsTryExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -563,7 +563,7 @@ public struct AwaitExpr: ExprBuildable, ExpressibleAsAwaitExpr {
   public init (leadingTrivia: Trivia = [], unexpectedBeforeAwaitKeyword: ExpressibleAsUnexpectedNodes? = nil, awaitKeyword: String, unexpectedBetweenAwaitKeywordAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAwaitKeyword: unexpectedBeforeAwaitKeyword, awaitKeyword: Token.`contextualKeyword`(awaitKeyword), unexpectedBetweenAwaitKeywordAndExpression: unexpectedBetweenAwaitKeywordAndExpression, expression: expression)
   }
-  public init (_ constructedNode: AwaitExprSyntax) {
+  public init(_ constructedNode: AwaitExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AwaitExprSyntax`.
@@ -612,13 +612,13 @@ public struct AwaitExpr: ExprBuildable, ExpressibleAsAwaitExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -626,12 +626,12 @@ public struct AwaitExpr: ExprBuildable, ExpressibleAsAwaitExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -671,7 +671,7 @@ public struct MoveExpr: ExprBuildable, ExpressibleAsMoveExpr {
   public init (leadingTrivia: Trivia = [], unexpectedBeforeMoveKeyword: ExpressibleAsUnexpectedNodes? = nil, moveKeyword: String, unexpectedBetweenMoveKeywordAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeMoveKeyword: unexpectedBeforeMoveKeyword, moveKeyword: Token.`contextualKeyword`(moveKeyword), unexpectedBetweenMoveKeywordAndExpression: unexpectedBetweenMoveKeywordAndExpression, expression: expression)
   }
-  public init (_ constructedNode: MoveExprSyntax) {
+  public init(_ constructedNode: MoveExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `MoveExprSyntax`.
@@ -720,13 +720,13 @@ public struct MoveExpr: ExprBuildable, ExpressibleAsMoveExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -734,12 +734,12 @@ public struct MoveExpr: ExprBuildable, ExpressibleAsMoveExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -773,7 +773,7 @@ public struct DeclNameArgument: SyntaxBuildable, ExpressibleAsDeclNameArgument {
     assert(colon.text == #":"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeName: unexpectedBeforeName?.createUnexpectedNodes(), name: name, unexpectedBetweenNameAndColon: unexpectedBetweenNameAndColon?.createUnexpectedNodes(), colon: colon))
   }
-  public init (_ constructedNode: DeclNameArgumentSyntax) {
+  public init(_ constructedNode: DeclNameArgumentSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DeclNameArgumentSyntax`.
@@ -815,13 +815,13 @@ public struct DeclNameArgument: SyntaxBuildable, ExpressibleAsDeclNameArgument {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -829,12 +829,12 @@ public struct DeclNameArgument: SyntaxBuildable, ExpressibleAsDeclNameArgument {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -873,7 +873,7 @@ public struct DeclNameArguments: SyntaxBuildable, ExpressibleAsDeclNameArguments
     assert(rightParen.text == #")"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLeftParen: unexpectedBeforeLeftParen?.createUnexpectedNodes(), leftParen: leftParen, unexpectedBetweenLeftParenAndArguments: unexpectedBetweenLeftParenAndArguments?.createUnexpectedNodes(), arguments: arguments.createDeclNameArgumentList(), unexpectedBetweenArgumentsAndRightParen: unexpectedBetweenArgumentsAndRightParen?.createUnexpectedNodes(), rightParen: rightParen))
   }
-  public init (_ constructedNode: DeclNameArgumentsSyntax) {
+  public init(_ constructedNode: DeclNameArgumentsSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DeclNameArgumentsSyntax`.
@@ -915,13 +915,13 @@ public struct DeclNameArguments: SyntaxBuildable, ExpressibleAsDeclNameArguments
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -929,12 +929,12 @@ public struct DeclNameArguments: SyntaxBuildable, ExpressibleAsDeclNameArguments
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -967,7 +967,7 @@ public struct IdentifierExpr: ExprBuildable, ExpressibleAsIdentifierExpr {
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token, unexpectedBetweenIdentifierAndDeclNameArguments: ExpressibleAsUnexpectedNodes? = nil, declNameArguments: ExpressibleAsDeclNameArguments? = nil) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeIdentifier: unexpectedBeforeIdentifier?.createUnexpectedNodes(), identifier: identifier, unexpectedBetweenIdentifierAndDeclNameArguments: unexpectedBetweenIdentifierAndDeclNameArguments?.createUnexpectedNodes(), declNameArguments: declNameArguments?.createDeclNameArguments()))
   }
-  public init (_ constructedNode: IdentifierExprSyntax) {
+  public init(_ constructedNode: IdentifierExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `IdentifierExprSyntax`.
@@ -1016,13 +1016,13 @@ public struct IdentifierExpr: ExprBuildable, ExpressibleAsIdentifierExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -1030,12 +1030,12 @@ public struct IdentifierExpr: ExprBuildable, ExpressibleAsIdentifierExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -1065,7 +1065,7 @@ public struct SuperRefExpr: ExprBuildable, ExpressibleAsSuperRefExpr {
     assert(superKeyword.text == #"super"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeSuperKeyword: unexpectedBeforeSuperKeyword?.createUnexpectedNodes(), superKeyword: superKeyword))
   }
-  public init (_ constructedNode: SuperRefExprSyntax) {
+  public init(_ constructedNode: SuperRefExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `SuperRefExprSyntax`.
@@ -1114,13 +1114,13 @@ public struct SuperRefExpr: ExprBuildable, ExpressibleAsSuperRefExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -1128,12 +1128,12 @@ public struct SuperRefExpr: ExprBuildable, ExpressibleAsSuperRefExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -1163,7 +1163,7 @@ public struct NilLiteralExpr: ExprBuildable, ExpressibleAsNilLiteralExpr {
     assert(nilKeyword.text == #"nil"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeNilKeyword: unexpectedBeforeNilKeyword?.createUnexpectedNodes(), nilKeyword: nilKeyword))
   }
-  public init (_ constructedNode: NilLiteralExprSyntax) {
+  public init(_ constructedNode: NilLiteralExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `NilLiteralExprSyntax`.
@@ -1212,13 +1212,13 @@ public struct NilLiteralExpr: ExprBuildable, ExpressibleAsNilLiteralExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -1226,12 +1226,12 @@ public struct NilLiteralExpr: ExprBuildable, ExpressibleAsNilLiteralExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -1261,7 +1261,7 @@ public struct DiscardAssignmentExpr: ExprBuildable, ExpressibleAsDiscardAssignme
     assert(wildcard.text == #"_"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeWildcard: unexpectedBeforeWildcard?.createUnexpectedNodes(), wildcard: wildcard))
   }
-  public init (_ constructedNode: DiscardAssignmentExprSyntax) {
+  public init(_ constructedNode: DiscardAssignmentExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DiscardAssignmentExprSyntax`.
@@ -1310,13 +1310,13 @@ public struct DiscardAssignmentExpr: ExprBuildable, ExpressibleAsDiscardAssignme
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -1324,12 +1324,12 @@ public struct DiscardAssignmentExpr: ExprBuildable, ExpressibleAsDiscardAssignme
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -1359,7 +1359,7 @@ public struct AssignmentExpr: ExprBuildable, ExpressibleAsAssignmentExpr {
     assert(assignToken.text == #"="#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeAssignToken: unexpectedBeforeAssignToken?.createUnexpectedNodes(), assignToken: assignToken))
   }
-  public init (_ constructedNode: AssignmentExprSyntax) {
+  public init(_ constructedNode: AssignmentExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AssignmentExprSyntax`.
@@ -1408,13 +1408,13 @@ public struct AssignmentExpr: ExprBuildable, ExpressibleAsAssignmentExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -1422,12 +1422,12 @@ public struct AssignmentExpr: ExprBuildable, ExpressibleAsAssignmentExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -1464,7 +1464,7 @@ public struct SequenceExpr: ExprBuildable, ExpressibleAsSequenceExpr {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeElements: unexpectedBeforeElements, elements: elementsBuilder())
   }
-  public init (_ constructedNode: SequenceExprSyntax) {
+  public init(_ constructedNode: SequenceExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `SequenceExprSyntax`.
@@ -1513,13 +1513,13 @@ public struct SequenceExpr: ExprBuildable, ExpressibleAsSequenceExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -1527,12 +1527,12 @@ public struct SequenceExpr: ExprBuildable, ExpressibleAsSequenceExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -1562,7 +1562,7 @@ public struct PoundLineExpr: ExprBuildable, ExpressibleAsPoundLineExpr {
     assert(poundLine.text == #"#line"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePoundLine: unexpectedBeforePoundLine?.createUnexpectedNodes(), poundLine: poundLine))
   }
-  public init (_ constructedNode: PoundLineExprSyntax) {
+  public init(_ constructedNode: PoundLineExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PoundLineExprSyntax`.
@@ -1611,13 +1611,13 @@ public struct PoundLineExpr: ExprBuildable, ExpressibleAsPoundLineExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -1625,12 +1625,12 @@ public struct PoundLineExpr: ExprBuildable, ExpressibleAsPoundLineExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -1660,7 +1660,7 @@ public struct PoundFileExpr: ExprBuildable, ExpressibleAsPoundFileExpr {
     assert(poundFile.text == #"#file"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePoundFile: unexpectedBeforePoundFile?.createUnexpectedNodes(), poundFile: poundFile))
   }
-  public init (_ constructedNode: PoundFileExprSyntax) {
+  public init(_ constructedNode: PoundFileExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PoundFileExprSyntax`.
@@ -1709,13 +1709,13 @@ public struct PoundFileExpr: ExprBuildable, ExpressibleAsPoundFileExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -1723,12 +1723,12 @@ public struct PoundFileExpr: ExprBuildable, ExpressibleAsPoundFileExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -1758,7 +1758,7 @@ public struct PoundFileIDExpr: ExprBuildable, ExpressibleAsPoundFileIDExpr {
     assert(poundFileID.text == #"#fileID"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePoundFileID: unexpectedBeforePoundFileID?.createUnexpectedNodes(), poundFileID: poundFileID))
   }
-  public init (_ constructedNode: PoundFileIDExprSyntax) {
+  public init(_ constructedNode: PoundFileIDExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PoundFileIDExprSyntax`.
@@ -1807,13 +1807,13 @@ public struct PoundFileIDExpr: ExprBuildable, ExpressibleAsPoundFileIDExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -1821,12 +1821,12 @@ public struct PoundFileIDExpr: ExprBuildable, ExpressibleAsPoundFileIDExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -1856,7 +1856,7 @@ public struct PoundFilePathExpr: ExprBuildable, ExpressibleAsPoundFilePathExpr {
     assert(poundFilePath.text == #"#filePath"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePoundFilePath: unexpectedBeforePoundFilePath?.createUnexpectedNodes(), poundFilePath: poundFilePath))
   }
-  public init (_ constructedNode: PoundFilePathExprSyntax) {
+  public init(_ constructedNode: PoundFilePathExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PoundFilePathExprSyntax`.
@@ -1905,13 +1905,13 @@ public struct PoundFilePathExpr: ExprBuildable, ExpressibleAsPoundFilePathExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -1919,12 +1919,12 @@ public struct PoundFilePathExpr: ExprBuildable, ExpressibleAsPoundFilePathExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -1954,7 +1954,7 @@ public struct PoundFunctionExpr: ExprBuildable, ExpressibleAsPoundFunctionExpr {
     assert(poundFunction.text == #"#function"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePoundFunction: unexpectedBeforePoundFunction?.createUnexpectedNodes(), poundFunction: poundFunction))
   }
-  public init (_ constructedNode: PoundFunctionExprSyntax) {
+  public init(_ constructedNode: PoundFunctionExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PoundFunctionExprSyntax`.
@@ -2003,13 +2003,13 @@ public struct PoundFunctionExpr: ExprBuildable, ExpressibleAsPoundFunctionExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -2017,12 +2017,12 @@ public struct PoundFunctionExpr: ExprBuildable, ExpressibleAsPoundFunctionExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -2052,7 +2052,7 @@ public struct PoundDsohandleExpr: ExprBuildable, ExpressibleAsPoundDsohandleExpr
     assert(poundDsohandle.text == #"#dsohandle"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePoundDsohandle: unexpectedBeforePoundDsohandle?.createUnexpectedNodes(), poundDsohandle: poundDsohandle))
   }
-  public init (_ constructedNode: PoundDsohandleExprSyntax) {
+  public init(_ constructedNode: PoundDsohandleExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PoundDsohandleExprSyntax`.
@@ -2101,13 +2101,13 @@ public struct PoundDsohandleExpr: ExprBuildable, ExpressibleAsPoundDsohandleExpr
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -2115,12 +2115,12 @@ public struct PoundDsohandleExpr: ExprBuildable, ExpressibleAsPoundDsohandleExpr
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -2159,7 +2159,7 @@ public struct SymbolicReferenceExpr: ExprBuildable, ExpressibleAsSymbolicReferen
   public init (leadingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericArgumentClause: ExpressibleAsUnexpectedNodes? = nil, genericArgumentClause: ExpressibleAsGenericArgumentClause? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeIdentifier: unexpectedBeforeIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericArgumentClause: unexpectedBetweenIdentifierAndGenericArgumentClause, genericArgumentClause: genericArgumentClause)
   }
-  public init (_ constructedNode: SymbolicReferenceExprSyntax) {
+  public init(_ constructedNode: SymbolicReferenceExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `SymbolicReferenceExprSyntax`.
@@ -2208,13 +2208,13 @@ public struct SymbolicReferenceExpr: ExprBuildable, ExpressibleAsSymbolicReferen
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -2222,12 +2222,12 @@ public struct SymbolicReferenceExpr: ExprBuildable, ExpressibleAsSymbolicReferen
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -2264,11 +2264,9 @@ public struct PrefixOperatorExpr: ExprBuildable, ExpressibleAsPrefixOperatorExpr
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforeOperatorToken: ExpressibleAsUnexpectedNodes? = nil, operatorToken: String?, unexpectedBetweenOperatorTokenAndPostfixExpression: ExpressibleAsUnexpectedNodes? = nil, postfixExpression: ExpressibleAsExprBuildable) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeOperatorToken: unexpectedBeforeOperatorToken, operatorToken: operatorToken.map {
-      Token.`prefixOperator`($0)
-    }, unexpectedBetweenOperatorTokenAndPostfixExpression: unexpectedBetweenOperatorTokenAndPostfixExpression, postfixExpression: postfixExpression)
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeOperatorToken: unexpectedBeforeOperatorToken, operatorToken: operatorToken.map { Token.`prefixOperator`($0) }, unexpectedBetweenOperatorTokenAndPostfixExpression: unexpectedBetweenOperatorTokenAndPostfixExpression, postfixExpression: postfixExpression)
   }
-  public init (_ constructedNode: PrefixOperatorExprSyntax) {
+  public init(_ constructedNode: PrefixOperatorExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PrefixOperatorExprSyntax`.
@@ -2317,13 +2315,13 @@ public struct PrefixOperatorExpr: ExprBuildable, ExpressibleAsPrefixOperatorExpr
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -2331,12 +2329,12 @@ public struct PrefixOperatorExpr: ExprBuildable, ExpressibleAsPrefixOperatorExpr
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -2365,7 +2363,7 @@ public struct BinaryOperatorExpr: ExprBuildable, ExpressibleAsBinaryOperatorExpr
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeOperatorToken: ExpressibleAsUnexpectedNodes? = nil, operatorToken: Token) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeOperatorToken: unexpectedBeforeOperatorToken?.createUnexpectedNodes(), operatorToken: operatorToken))
   }
-  public init (_ constructedNode: BinaryOperatorExprSyntax) {
+  public init(_ constructedNode: BinaryOperatorExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `BinaryOperatorExprSyntax`.
@@ -2414,13 +2412,13 @@ public struct BinaryOperatorExpr: ExprBuildable, ExpressibleAsBinaryOperatorExpr
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -2428,12 +2426,12 @@ public struct BinaryOperatorExpr: ExprBuildable, ExpressibleAsBinaryOperatorExpr
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -2477,11 +2475,9 @@ public struct ArrowExpr: ExprBuildable, ExpressibleAsArrowExpr {
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforeAsyncKeyword: ExpressibleAsUnexpectedNodes? = nil, asyncKeyword: String?, unexpectedBetweenAsyncKeywordAndThrowsToken: ExpressibleAsUnexpectedNodes? = nil, throwsToken: Token? = nil, unexpectedBetweenThrowsTokenAndArrowToken: ExpressibleAsUnexpectedNodes? = nil, arrowToken: Token = Token.`arrow`) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAsyncKeyword: unexpectedBeforeAsyncKeyword, asyncKeyword: asyncKeyword.map {
-      Token.`contextualKeyword`($0)
-    }, unexpectedBetweenAsyncKeywordAndThrowsToken: unexpectedBetweenAsyncKeywordAndThrowsToken, throwsToken: throwsToken, unexpectedBetweenThrowsTokenAndArrowToken: unexpectedBetweenThrowsTokenAndArrowToken, arrowToken: arrowToken)
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAsyncKeyword: unexpectedBeforeAsyncKeyword, asyncKeyword: asyncKeyword.map { Token.`contextualKeyword`($0) }, unexpectedBetweenAsyncKeywordAndThrowsToken: unexpectedBetweenAsyncKeywordAndThrowsToken, throwsToken: throwsToken, unexpectedBetweenThrowsTokenAndArrowToken: unexpectedBetweenThrowsTokenAndArrowToken, arrowToken: arrowToken)
   }
-  public init (_ constructedNode: ArrowExprSyntax) {
+  public init(_ constructedNode: ArrowExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ArrowExprSyntax`.
@@ -2530,13 +2526,13 @@ public struct ArrowExpr: ExprBuildable, ExpressibleAsArrowExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -2544,12 +2540,12 @@ public struct ArrowExpr: ExprBuildable, ExpressibleAsArrowExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -2586,7 +2582,7 @@ public struct InfixOperatorExpr: ExprBuildable, ExpressibleAsInfixOperatorExpr {
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftOperand: ExpressibleAsUnexpectedNodes? = nil, leftOperand: ExpressibleAsExprBuildable, unexpectedBetweenLeftOperandAndOperatorOperand: ExpressibleAsUnexpectedNodes? = nil, operatorOperand: ExpressibleAsExprBuildable, unexpectedBetweenOperatorOperandAndRightOperand: ExpressibleAsUnexpectedNodes? = nil, rightOperand: ExpressibleAsExprBuildable) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLeftOperand: unexpectedBeforeLeftOperand?.createUnexpectedNodes(), leftOperand: leftOperand.createExprBuildable(), unexpectedBetweenLeftOperandAndOperatorOperand: unexpectedBetweenLeftOperandAndOperatorOperand?.createUnexpectedNodes(), operatorOperand: operatorOperand.createExprBuildable(), unexpectedBetweenOperatorOperandAndRightOperand: unexpectedBetweenOperatorOperandAndRightOperand?.createUnexpectedNodes(), rightOperand: rightOperand.createExprBuildable()))
   }
-  public init (_ constructedNode: InfixOperatorExprSyntax) {
+  public init(_ constructedNode: InfixOperatorExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `InfixOperatorExprSyntax`.
@@ -2635,13 +2631,13 @@ public struct InfixOperatorExpr: ExprBuildable, ExpressibleAsInfixOperatorExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -2649,12 +2645,12 @@ public struct InfixOperatorExpr: ExprBuildable, ExpressibleAsInfixOperatorExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -2689,7 +2685,7 @@ public struct FloatLiteralExpr: ExprBuildable, ExpressibleAsFloatLiteralExpr {
   public init (leadingTrivia: Trivia = [], unexpectedBeforeFloatingDigits: ExpressibleAsUnexpectedNodes? = nil, floatingDigits: String) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeFloatingDigits: unexpectedBeforeFloatingDigits, floatingDigits: Token.`floatingLiteral`(floatingDigits))
   }
-  public init (_ constructedNode: FloatLiteralExprSyntax) {
+  public init(_ constructedNode: FloatLiteralExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `FloatLiteralExprSyntax`.
@@ -2738,13 +2734,13 @@ public struct FloatLiteralExpr: ExprBuildable, ExpressibleAsFloatLiteralExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -2752,12 +2748,12 @@ public struct FloatLiteralExpr: ExprBuildable, ExpressibleAsFloatLiteralExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -2804,7 +2800,7 @@ public struct TupleExpr: ExprBuildable, ExpressibleAsTupleExpr {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLeftParen: unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndElementList: unexpectedBetweenLeftParenAndElementList, elementList: elementListBuilder(), unexpectedBetweenElementListAndRightParen: unexpectedBetweenElementListAndRightParen, rightParen: rightParen)
   }
-  public init (_ constructedNode: TupleExprSyntax) {
+  public init(_ constructedNode: TupleExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `TupleExprSyntax`.
@@ -2853,13 +2849,13 @@ public struct TupleExpr: ExprBuildable, ExpressibleAsTupleExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -2867,12 +2863,12 @@ public struct TupleExpr: ExprBuildable, ExpressibleAsTupleExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -2919,7 +2915,7 @@ public struct ArrayExpr: ExprBuildable, ExpressibleAsArrayExpr {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLeftSquare: unexpectedBeforeLeftSquare, leftSquare: leftSquare, unexpectedBetweenLeftSquareAndElements: unexpectedBetweenLeftSquareAndElements, elements: elementsBuilder(), unexpectedBetweenElementsAndRightSquare: unexpectedBetweenElementsAndRightSquare, rightSquare: rightSquare)
   }
-  public init (_ constructedNode: ArrayExprSyntax) {
+  public init(_ constructedNode: ArrayExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ArrayExprSyntax`.
@@ -2968,13 +2964,13 @@ public struct ArrayExpr: ExprBuildable, ExpressibleAsArrayExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -2982,12 +2978,12 @@ public struct ArrayExpr: ExprBuildable, ExpressibleAsArrayExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -3026,7 +3022,7 @@ public struct DictionaryExpr: ExprBuildable, ExpressibleAsDictionaryExpr {
     assert(rightSquare.text == #"]"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLeftSquare: unexpectedBeforeLeftSquare?.createUnexpectedNodes(), leftSquare: leftSquare, unexpectedBetweenLeftSquareAndContent: unexpectedBetweenLeftSquareAndContent?.createUnexpectedNodes(), content: content.createSyntaxBuildable(), unexpectedBetweenContentAndRightSquare: unexpectedBetweenContentAndRightSquare?.createUnexpectedNodes(), rightSquare: rightSquare))
   }
-  public init (_ constructedNode: DictionaryExprSyntax) {
+  public init(_ constructedNode: DictionaryExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DictionaryExprSyntax`.
@@ -3075,13 +3071,13 @@ public struct DictionaryExpr: ExprBuildable, ExpressibleAsDictionaryExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -3089,12 +3085,12 @@ public struct DictionaryExpr: ExprBuildable, ExpressibleAsDictionaryExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -3124,9 +3120,9 @@ public struct TupleExprElement: SyntaxBuildable, ExpressibleAsTupleExprElement, 
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -3145,7 +3141,7 @@ public struct TupleExprElement: SyntaxBuildable, ExpressibleAsTupleExprElement, 
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLabel: unexpectedBeforeLabel?.createUnexpectedNodes(), label: label, unexpectedBetweenLabelAndColon: unexpectedBetweenLabelAndColon?.createUnexpectedNodes(), colon: colon, unexpectedBetweenColonAndExpression: unexpectedBetweenColonAndExpression?.createUnexpectedNodes(), expression: expression.createExprBuildable(), unexpectedBetweenExpressionAndTrailingComma: unexpectedBetweenExpressionAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: TupleExprElementSyntax) {
+  public init(_ constructedNode: TupleExprElementSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `TupleExprElementSyntax`.
@@ -3188,12 +3184,12 @@ public struct TupleExprElement: SyntaxBuildable, ExpressibleAsTupleExprElement, 
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -3202,13 +3198,13 @@ public struct TupleExprElement: SyntaxBuildable, ExpressibleAsTupleExprElement, 
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -3216,12 +3212,12 @@ public struct TupleExprElement: SyntaxBuildable, ExpressibleAsTupleExprElement, 
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -3247,9 +3243,9 @@ public struct ArrayElement: SyntaxBuildable, ExpressibleAsArrayElement, HasTrail
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -3263,7 +3259,7 @@ public struct ArrayElement: SyntaxBuildable, ExpressibleAsArrayElement, HasTrail
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeExpression: unexpectedBeforeExpression?.createUnexpectedNodes(), expression: expression.createExprBuildable(), unexpectedBetweenExpressionAndTrailingComma: unexpectedBetweenExpressionAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: ArrayElementSyntax) {
+  public init(_ constructedNode: ArrayElementSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ArrayElementSyntax`.
@@ -3306,12 +3302,12 @@ public struct ArrayElement: SyntaxBuildable, ExpressibleAsArrayElement, HasTrail
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -3320,13 +3316,13 @@ public struct ArrayElement: SyntaxBuildable, ExpressibleAsArrayElement, HasTrail
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -3334,12 +3330,12 @@ public struct ArrayElement: SyntaxBuildable, ExpressibleAsArrayElement, HasTrail
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -3369,9 +3365,9 @@ public struct DictionaryElement: SyntaxBuildable, ExpressibleAsDictionaryElement
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -3390,7 +3386,7 @@ public struct DictionaryElement: SyntaxBuildable, ExpressibleAsDictionaryElement
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeKeyExpression: unexpectedBeforeKeyExpression?.createUnexpectedNodes(), keyExpression: keyExpression.createExprBuildable(), unexpectedBetweenKeyExpressionAndColon: unexpectedBetweenKeyExpressionAndColon?.createUnexpectedNodes(), colon: colon, unexpectedBetweenColonAndValueExpression: unexpectedBetweenColonAndValueExpression?.createUnexpectedNodes(), valueExpression: valueExpression.createExprBuildable(), unexpectedBetweenValueExpressionAndTrailingComma: unexpectedBetweenValueExpressionAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: DictionaryElementSyntax) {
+  public init(_ constructedNode: DictionaryElementSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DictionaryElementSyntax`.
@@ -3433,12 +3429,12 @@ public struct DictionaryElement: SyntaxBuildable, ExpressibleAsDictionaryElement
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -3447,13 +3443,13 @@ public struct DictionaryElement: SyntaxBuildable, ExpressibleAsDictionaryElement
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -3461,12 +3457,12 @@ public struct DictionaryElement: SyntaxBuildable, ExpressibleAsDictionaryElement
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -3501,7 +3497,7 @@ public struct IntegerLiteralExpr: ExprBuildable, ExpressibleAsIntegerLiteralExpr
   public init (leadingTrivia: Trivia = [], unexpectedBeforeDigits: ExpressibleAsUnexpectedNodes? = nil, digits: String) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeDigits: unexpectedBeforeDigits, digits: Token.`integerLiteral`(digits))
   }
-  public init (_ constructedNode: IntegerLiteralExprSyntax) {
+  public init(_ constructedNode: IntegerLiteralExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `IntegerLiteralExprSyntax`.
@@ -3550,13 +3546,13 @@ public struct IntegerLiteralExpr: ExprBuildable, ExpressibleAsIntegerLiteralExpr
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -3564,12 +3560,12 @@ public struct IntegerLiteralExpr: ExprBuildable, ExpressibleAsIntegerLiteralExpr
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -3599,7 +3595,7 @@ public struct BooleanLiteralExpr: ExprBuildable, ExpressibleAsBooleanLiteralExpr
     assert(booleanLiteral.text == #"true"# || booleanLiteral.text == #"false"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeBooleanLiteral: unexpectedBeforeBooleanLiteral?.createUnexpectedNodes(), booleanLiteral: booleanLiteral))
   }
-  public init (_ constructedNode: BooleanLiteralExprSyntax) {
+  public init(_ constructedNode: BooleanLiteralExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `BooleanLiteralExprSyntax`.
@@ -3648,13 +3644,13 @@ public struct BooleanLiteralExpr: ExprBuildable, ExpressibleAsBooleanLiteralExpr
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -3662,12 +3658,12 @@ public struct BooleanLiteralExpr: ExprBuildable, ExpressibleAsBooleanLiteralExpr
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -3706,7 +3702,7 @@ public struct UnresolvedTernaryExpr: ExprBuildable, ExpressibleAsUnresolvedTerna
     assert(colonMark.text == #":"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeQuestionMark: unexpectedBeforeQuestionMark?.createUnexpectedNodes(), questionMark: questionMark, unexpectedBetweenQuestionMarkAndFirstChoice: unexpectedBetweenQuestionMarkAndFirstChoice?.createUnexpectedNodes(), firstChoice: firstChoice.createExprBuildable(), unexpectedBetweenFirstChoiceAndColonMark: unexpectedBetweenFirstChoiceAndColonMark?.createUnexpectedNodes(), colonMark: colonMark))
   }
-  public init (_ constructedNode: UnresolvedTernaryExprSyntax) {
+  public init(_ constructedNode: UnresolvedTernaryExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `UnresolvedTernaryExprSyntax`.
@@ -3755,13 +3751,13 @@ public struct UnresolvedTernaryExpr: ExprBuildable, ExpressibleAsUnresolvedTerna
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -3769,12 +3765,12 @@ public struct UnresolvedTernaryExpr: ExprBuildable, ExpressibleAsUnresolvedTerna
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -3821,7 +3817,7 @@ public struct TernaryExpr: ExprBuildable, ExpressibleAsTernaryExpr {
     assert(colonMark.text == #":"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeConditionExpression: unexpectedBeforeConditionExpression?.createUnexpectedNodes(), conditionExpression: conditionExpression.createExprBuildable(), unexpectedBetweenConditionExpressionAndQuestionMark: unexpectedBetweenConditionExpressionAndQuestionMark?.createUnexpectedNodes(), questionMark: questionMark, unexpectedBetweenQuestionMarkAndFirstChoice: unexpectedBetweenQuestionMarkAndFirstChoice?.createUnexpectedNodes(), firstChoice: firstChoice.createExprBuildable(), unexpectedBetweenFirstChoiceAndColonMark: unexpectedBetweenFirstChoiceAndColonMark?.createUnexpectedNodes(), colonMark: colonMark, unexpectedBetweenColonMarkAndSecondChoice: unexpectedBetweenColonMarkAndSecondChoice?.createUnexpectedNodes(), secondChoice: secondChoice.createExprBuildable()))
   }
-  public init (_ constructedNode: TernaryExprSyntax) {
+  public init(_ constructedNode: TernaryExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `TernaryExprSyntax`.
@@ -3870,13 +3866,13 @@ public struct TernaryExpr: ExprBuildable, ExpressibleAsTernaryExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -3884,12 +3880,12 @@ public struct TernaryExpr: ExprBuildable, ExpressibleAsTernaryExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -3931,7 +3927,7 @@ public struct MemberAccessExpr: ExprBuildable, ExpressibleAsMemberAccessExpr {
     assert(dot.text == #"."# || dot.text == #"."#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeBase: unexpectedBeforeBase?.createUnexpectedNodes(), base: base?.createExprBuildable(), unexpectedBetweenBaseAndDot: unexpectedBetweenBaseAndDot?.createUnexpectedNodes(), dot: dot, unexpectedBetweenDotAndName: unexpectedBetweenDotAndName?.createUnexpectedNodes(), name: name, unexpectedBetweenNameAndDeclNameArguments: unexpectedBetweenNameAndDeclNameArguments?.createUnexpectedNodes(), declNameArguments: declNameArguments?.createDeclNameArguments()))
   }
-  public init (_ constructedNode: MemberAccessExprSyntax) {
+  public init(_ constructedNode: MemberAccessExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `MemberAccessExprSyntax`.
@@ -3980,13 +3976,13 @@ public struct MemberAccessExpr: ExprBuildable, ExpressibleAsMemberAccessExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -3994,12 +3990,12 @@ public struct MemberAccessExpr: ExprBuildable, ExpressibleAsMemberAccessExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -4029,7 +4025,7 @@ public struct UnresolvedIsExpr: ExprBuildable, ExpressibleAsUnresolvedIsExpr {
     assert(isTok.text == #"is"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeIsTok: unexpectedBeforeIsTok?.createUnexpectedNodes(), isTok: isTok))
   }
-  public init (_ constructedNode: UnresolvedIsExprSyntax) {
+  public init(_ constructedNode: UnresolvedIsExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `UnresolvedIsExprSyntax`.
@@ -4078,13 +4074,13 @@ public struct UnresolvedIsExpr: ExprBuildable, ExpressibleAsUnresolvedIsExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -4092,12 +4088,12 @@ public struct UnresolvedIsExpr: ExprBuildable, ExpressibleAsUnresolvedIsExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -4135,7 +4131,7 @@ public struct IsExpr: ExprBuildable, ExpressibleAsIsExpr {
     assert(isTok.text == #"is"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeExpression: unexpectedBeforeExpression?.createUnexpectedNodes(), expression: expression.createExprBuildable(), unexpectedBetweenExpressionAndIsTok: unexpectedBetweenExpressionAndIsTok?.createUnexpectedNodes(), isTok: isTok, unexpectedBetweenIsTokAndTypeName: unexpectedBetweenIsTokAndTypeName?.createUnexpectedNodes(), typeName: typeName.createTypeBuildable()))
   }
-  public init (_ constructedNode: IsExprSyntax) {
+  public init(_ constructedNode: IsExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `IsExprSyntax`.
@@ -4184,13 +4180,13 @@ public struct IsExpr: ExprBuildable, ExpressibleAsIsExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -4198,12 +4194,12 @@ public struct IsExpr: ExprBuildable, ExpressibleAsIsExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -4238,7 +4234,7 @@ public struct UnresolvedAsExpr: ExprBuildable, ExpressibleAsUnresolvedAsExpr {
     assert(questionOrExclamationMark == nil || questionOrExclamationMark!.text == #"?"# || questionOrExclamationMark!.text == #"!"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeAsTok: unexpectedBeforeAsTok?.createUnexpectedNodes(), asTok: asTok, unexpectedBetweenAsTokAndQuestionOrExclamationMark: unexpectedBetweenAsTokAndQuestionOrExclamationMark?.createUnexpectedNodes(), questionOrExclamationMark: questionOrExclamationMark))
   }
-  public init (_ constructedNode: UnresolvedAsExprSyntax) {
+  public init(_ constructedNode: UnresolvedAsExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `UnresolvedAsExprSyntax`.
@@ -4287,13 +4283,13 @@ public struct UnresolvedAsExpr: ExprBuildable, ExpressibleAsUnresolvedAsExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -4301,12 +4297,12 @@ public struct UnresolvedAsExpr: ExprBuildable, ExpressibleAsUnresolvedAsExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -4349,7 +4345,7 @@ public struct AsExpr: ExprBuildable, ExpressibleAsAsExpr {
     assert(questionOrExclamationMark == nil || questionOrExclamationMark!.text == #"?"# || questionOrExclamationMark!.text == #"!"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeExpression: unexpectedBeforeExpression?.createUnexpectedNodes(), expression: expression.createExprBuildable(), unexpectedBetweenExpressionAndAsTok: unexpectedBetweenExpressionAndAsTok?.createUnexpectedNodes(), asTok: asTok, unexpectedBetweenAsTokAndQuestionOrExclamationMark: unexpectedBetweenAsTokAndQuestionOrExclamationMark?.createUnexpectedNodes(), questionOrExclamationMark: questionOrExclamationMark, unexpectedBetweenQuestionOrExclamationMarkAndTypeName: unexpectedBetweenQuestionOrExclamationMarkAndTypeName?.createUnexpectedNodes(), typeName: typeName.createTypeBuildable()))
   }
-  public init (_ constructedNode: AsExprSyntax) {
+  public init(_ constructedNode: AsExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AsExprSyntax`.
@@ -4398,13 +4394,13 @@ public struct AsExpr: ExprBuildable, ExpressibleAsAsExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -4412,12 +4408,12 @@ public struct AsExpr: ExprBuildable, ExpressibleAsAsExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -4446,7 +4442,7 @@ public struct TypeExpr: ExprBuildable, ExpressibleAsTypeExpr {
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeType: unexpectedBeforeType?.createUnexpectedNodes(), type: type.createTypeBuildable()))
   }
-  public init (_ constructedNode: TypeExprSyntax) {
+  public init(_ constructedNode: TypeExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `TypeExprSyntax`.
@@ -4495,13 +4491,13 @@ public struct TypeExpr: ExprBuildable, ExpressibleAsTypeExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -4509,12 +4505,12 @@ public struct TypeExpr: ExprBuildable, ExpressibleAsTypeExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -4546,9 +4542,9 @@ public struct ClosureCaptureItem: SyntaxBuildable, ExpressibleAsClosureCaptureIt
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -4573,11 +4569,9 @@ public struct ClosureCaptureItem: SyntaxBuildable, ExpressibleAsClosureCaptureIt
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforeSpecifier: ExpressibleAsUnexpectedNodes? = nil, specifier: ExpressibleAsTokenList? = nil, unexpectedBetweenSpecifierAndName: ExpressibleAsUnexpectedNodes? = nil, name: String?, unexpectedBetweenNameAndAssignToken: ExpressibleAsUnexpectedNodes? = nil, assignToken: Token? = nil, unexpectedBetweenAssignTokenAndExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeSpecifier: unexpectedBeforeSpecifier, specifier: specifier, unexpectedBetweenSpecifierAndName: unexpectedBetweenSpecifierAndName, name: name.map {
-      Token.`identifier`($0)
-    }, unexpectedBetweenNameAndAssignToken: unexpectedBetweenNameAndAssignToken, assignToken: assignToken, unexpectedBetweenAssignTokenAndExpression: unexpectedBetweenAssignTokenAndExpression, expression: expression, unexpectedBetweenExpressionAndTrailingComma: unexpectedBetweenExpressionAndTrailingComma, trailingComma: trailingComma)
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeSpecifier: unexpectedBeforeSpecifier, specifier: specifier, unexpectedBetweenSpecifierAndName: unexpectedBetweenSpecifierAndName, name: name.map { Token.`identifier`($0) }, unexpectedBetweenNameAndAssignToken: unexpectedBetweenNameAndAssignToken, assignToken: assignToken, unexpectedBetweenAssignTokenAndExpression: unexpectedBetweenAssignTokenAndExpression, expression: expression, unexpectedBetweenExpressionAndTrailingComma: unexpectedBetweenExpressionAndTrailingComma, trailingComma: trailingComma)
   }
-  public init (_ constructedNode: ClosureCaptureItemSyntax) {
+  public init(_ constructedNode: ClosureCaptureItemSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ClosureCaptureItemSyntax`.
@@ -4620,12 +4614,12 @@ public struct ClosureCaptureItem: SyntaxBuildable, ExpressibleAsClosureCaptureIt
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -4634,13 +4628,13 @@ public struct ClosureCaptureItem: SyntaxBuildable, ExpressibleAsClosureCaptureIt
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -4648,12 +4642,12 @@ public struct ClosureCaptureItem: SyntaxBuildable, ExpressibleAsClosureCaptureIt
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -4700,7 +4694,7 @@ public struct ClosureCaptureSignature: SyntaxBuildable, ExpressibleAsClosureCapt
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLeftSquare: unexpectedBeforeLeftSquare, leftSquare: leftSquare, unexpectedBetweenLeftSquareAndItems: unexpectedBetweenLeftSquareAndItems, items: itemsBuilder(), unexpectedBetweenItemsAndRightSquare: unexpectedBetweenItemsAndRightSquare, rightSquare: rightSquare)
   }
-  public init (_ constructedNode: ClosureCaptureSignatureSyntax) {
+  public init(_ constructedNode: ClosureCaptureSignatureSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ClosureCaptureSignatureSyntax`.
@@ -4742,13 +4736,13 @@ public struct ClosureCaptureSignature: SyntaxBuildable, ExpressibleAsClosureCapt
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -4756,12 +4750,12 @@ public struct ClosureCaptureSignature: SyntaxBuildable, ExpressibleAsClosureCapt
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -4787,9 +4781,9 @@ public struct ClosureParam: SyntaxBuildable, ExpressibleAsClosureParam, HasTrail
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -4803,7 +4797,7 @@ public struct ClosureParam: SyntaxBuildable, ExpressibleAsClosureParam, HasTrail
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeName: unexpectedBeforeName?.createUnexpectedNodes(), name: name, unexpectedBetweenNameAndTrailingComma: unexpectedBetweenNameAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: ClosureParamSyntax) {
+  public init(_ constructedNode: ClosureParamSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ClosureParamSyntax`.
@@ -4846,12 +4840,12 @@ public struct ClosureParam: SyntaxBuildable, ExpressibleAsClosureParam, HasTrail
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -4860,13 +4854,13 @@ public struct ClosureParam: SyntaxBuildable, ExpressibleAsClosureParam, HasTrail
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -4874,12 +4868,12 @@ public struct ClosureParam: SyntaxBuildable, ExpressibleAsClosureParam, HasTrail
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -4939,11 +4933,9 @@ public struct ClosureSignature: SyntaxBuildable, ExpressibleAsClosureSignature {
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndCapture: ExpressibleAsUnexpectedNodes? = nil, capture: ExpressibleAsClosureCaptureSignature? = nil, unexpectedBetweenCaptureAndInput: ExpressibleAsUnexpectedNodes? = nil, input: ExpressibleAsSyntaxBuildable? = nil, unexpectedBetweenInputAndAsyncKeyword: ExpressibleAsUnexpectedNodes? = nil, asyncKeyword: String?, unexpectedBetweenAsyncKeywordAndThrowsTok: ExpressibleAsUnexpectedNodes? = nil, throwsTok: Token? = nil, unexpectedBetweenThrowsTokAndOutput: ExpressibleAsUnexpectedNodes? = nil, output: ExpressibleAsReturnClause? = nil, unexpectedBetweenOutputAndInTok: ExpressibleAsUnexpectedNodes? = nil, inTok: Token = Token.`in`) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndCapture: unexpectedBetweenAttributesAndCapture, capture: capture, unexpectedBetweenCaptureAndInput: unexpectedBetweenCaptureAndInput, input: input, unexpectedBetweenInputAndAsyncKeyword: unexpectedBetweenInputAndAsyncKeyword, asyncKeyword: asyncKeyword.map {
-      Token.`contextualKeyword`($0)
-    }, unexpectedBetweenAsyncKeywordAndThrowsTok: unexpectedBetweenAsyncKeywordAndThrowsTok, throwsTok: throwsTok, unexpectedBetweenThrowsTokAndOutput: unexpectedBetweenThrowsTokAndOutput, output: output, unexpectedBetweenOutputAndInTok: unexpectedBetweenOutputAndInTok, inTok: inTok)
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndCapture: unexpectedBetweenAttributesAndCapture, capture: capture, unexpectedBetweenCaptureAndInput: unexpectedBetweenCaptureAndInput, input: input, unexpectedBetweenInputAndAsyncKeyword: unexpectedBetweenInputAndAsyncKeyword, asyncKeyword: asyncKeyword.map { Token.`contextualKeyword`($0) }, unexpectedBetweenAsyncKeywordAndThrowsTok: unexpectedBetweenAsyncKeywordAndThrowsTok, throwsTok: throwsTok, unexpectedBetweenThrowsTokAndOutput: unexpectedBetweenThrowsTokAndOutput, output: output, unexpectedBetweenOutputAndInTok: unexpectedBetweenOutputAndInTok, inTok: inTok)
   }
-  public init (_ constructedNode: ClosureSignatureSyntax) {
+  public init(_ constructedNode: ClosureSignatureSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ClosureSignatureSyntax`.
@@ -4985,13 +4977,13 @@ public struct ClosureSignature: SyntaxBuildable, ExpressibleAsClosureSignature {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -4999,12 +4991,12 @@ public struct ClosureSignature: SyntaxBuildable, ExpressibleAsClosureSignature {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -5055,7 +5047,7 @@ public struct ClosureExpr: ExprBuildable, ExpressibleAsClosureExpr {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLeftBrace: unexpectedBeforeLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndSignature: unexpectedBetweenLeftBraceAndSignature, signature: signature, unexpectedBetweenSignatureAndStatements: unexpectedBetweenSignatureAndStatements, statements: statementsBuilder(), unexpectedBetweenStatementsAndRightBrace: unexpectedBetweenStatementsAndRightBrace, rightBrace: rightBrace)
   }
-  public init (_ constructedNode: ClosureExprSyntax) {
+  public init(_ constructedNode: ClosureExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ClosureExprSyntax`.
@@ -5104,13 +5096,13 @@ public struct ClosureExpr: ExprBuildable, ExpressibleAsClosureExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -5118,12 +5110,12 @@ public struct ClosureExpr: ExprBuildable, ExpressibleAsClosureExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -5152,7 +5144,7 @@ public struct UnresolvedPatternExpr: ExprBuildable, ExpressibleAsUnresolvedPatte
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforePattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePattern: unexpectedBeforePattern?.createUnexpectedNodes(), pattern: pattern.createPatternBuildable()))
   }
-  public init (_ constructedNode: UnresolvedPatternExprSyntax) {
+  public init(_ constructedNode: UnresolvedPatternExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `UnresolvedPatternExprSyntax`.
@@ -5201,13 +5193,13 @@ public struct UnresolvedPatternExpr: ExprBuildable, ExpressibleAsUnresolvedPatte
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -5215,12 +5207,12 @@ public struct UnresolvedPatternExpr: ExprBuildable, ExpressibleAsUnresolvedPatte
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -5258,7 +5250,7 @@ public struct MultipleTrailingClosureElement: SyntaxBuildable, ExpressibleAsMult
     assert(colon.text == #":"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLabel: unexpectedBeforeLabel?.createUnexpectedNodes(), label: label, unexpectedBetweenLabelAndColon: unexpectedBetweenLabelAndColon?.createUnexpectedNodes(), colon: colon, unexpectedBetweenColonAndClosure: unexpectedBetweenColonAndClosure?.createUnexpectedNodes(), closure: closure.createClosureExpr()))
   }
-  public init (_ constructedNode: MultipleTrailingClosureElementSyntax) {
+  public init(_ constructedNode: MultipleTrailingClosureElementSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `MultipleTrailingClosureElementSyntax`.
@@ -5300,13 +5292,13 @@ public struct MultipleTrailingClosureElement: SyntaxBuildable, ExpressibleAsMult
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -5314,12 +5306,12 @@ public struct MultipleTrailingClosureElement: SyntaxBuildable, ExpressibleAsMult
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -5378,7 +5370,7 @@ public struct FunctionCallExpr: ExprBuildable, ExpressibleAsFunctionCallExpr {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeCalledExpression: unexpectedBeforeCalledExpression, calledExpression: calledExpression, unexpectedBetweenCalledExpressionAndLeftParen: unexpectedBetweenCalledExpressionAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList: unexpectedBetweenLeftParenAndArgumentList, argumentList: argumentListBuilder(), unexpectedBetweenArgumentListAndRightParen: unexpectedBetweenArgumentListAndRightParen, rightParen: rightParen, unexpectedBetweenRightParenAndTrailingClosure: unexpectedBetweenRightParenAndTrailingClosure, trailingClosure: trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures: additionalTrailingClosures)
   }
-  public init (_ constructedNode: FunctionCallExprSyntax) {
+  public init(_ constructedNode: FunctionCallExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `FunctionCallExprSyntax`.
@@ -5427,13 +5419,13 @@ public struct FunctionCallExpr: ExprBuildable, ExpressibleAsFunctionCallExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -5441,12 +5433,12 @@ public struct FunctionCallExpr: ExprBuildable, ExpressibleAsFunctionCallExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -5505,7 +5497,7 @@ public struct SubscriptExpr: ExprBuildable, ExpressibleAsSubscriptExpr {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeCalledExpression: unexpectedBeforeCalledExpression, calledExpression: calledExpression, unexpectedBetweenCalledExpressionAndLeftBracket: unexpectedBetweenCalledExpressionAndLeftBracket, leftBracket: leftBracket, unexpectedBetweenLeftBracketAndArgumentList: unexpectedBetweenLeftBracketAndArgumentList, argumentList: argumentListBuilder(), unexpectedBetweenArgumentListAndRightBracket: unexpectedBetweenArgumentListAndRightBracket, rightBracket: rightBracket, unexpectedBetweenRightBracketAndTrailingClosure: unexpectedBetweenRightBracketAndTrailingClosure, trailingClosure: trailingClosure, unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures, additionalTrailingClosures: additionalTrailingClosures)
   }
-  public init (_ constructedNode: SubscriptExprSyntax) {
+  public init(_ constructedNode: SubscriptExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `SubscriptExprSyntax`.
@@ -5554,13 +5546,13 @@ public struct SubscriptExpr: ExprBuildable, ExpressibleAsSubscriptExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -5568,12 +5560,12 @@ public struct SubscriptExpr: ExprBuildable, ExpressibleAsSubscriptExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -5607,7 +5599,7 @@ public struct OptionalChainingExpr: ExprBuildable, ExpressibleAsOptionalChaining
     assert(questionMark.text == #"?"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeExpression: unexpectedBeforeExpression?.createUnexpectedNodes(), expression: expression.createExprBuildable(), unexpectedBetweenExpressionAndQuestionMark: unexpectedBetweenExpressionAndQuestionMark?.createUnexpectedNodes(), questionMark: questionMark))
   }
-  public init (_ constructedNode: OptionalChainingExprSyntax) {
+  public init(_ constructedNode: OptionalChainingExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `OptionalChainingExprSyntax`.
@@ -5656,13 +5648,13 @@ public struct OptionalChainingExpr: ExprBuildable, ExpressibleAsOptionalChaining
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -5670,12 +5662,12 @@ public struct OptionalChainingExpr: ExprBuildable, ExpressibleAsOptionalChaining
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -5709,7 +5701,7 @@ public struct ForcedValueExpr: ExprBuildable, ExpressibleAsForcedValueExpr {
     assert(exclamationMark.text == #"!"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeExpression: unexpectedBeforeExpression?.createUnexpectedNodes(), expression: expression.createExprBuildable(), unexpectedBetweenExpressionAndExclamationMark: unexpectedBetweenExpressionAndExclamationMark?.createUnexpectedNodes(), exclamationMark: exclamationMark))
   }
-  public init (_ constructedNode: ForcedValueExprSyntax) {
+  public init(_ constructedNode: ForcedValueExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ForcedValueExprSyntax`.
@@ -5758,13 +5750,13 @@ public struct ForcedValueExpr: ExprBuildable, ExpressibleAsForcedValueExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -5772,12 +5764,12 @@ public struct ForcedValueExpr: ExprBuildable, ExpressibleAsForcedValueExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -5816,7 +5808,7 @@ public struct PostfixUnaryExpr: ExprBuildable, ExpressibleAsPostfixUnaryExpr {
   public init (leadingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndOperatorToken: ExpressibleAsUnexpectedNodes? = nil, operatorToken: String) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeExpression: unexpectedBeforeExpression, expression: expression, unexpectedBetweenExpressionAndOperatorToken: unexpectedBetweenExpressionAndOperatorToken, operatorToken: Token.`postfixOperator`(operatorToken))
   }
-  public init (_ constructedNode: PostfixUnaryExprSyntax) {
+  public init(_ constructedNode: PostfixUnaryExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PostfixUnaryExprSyntax`.
@@ -5865,13 +5857,13 @@ public struct PostfixUnaryExpr: ExprBuildable, ExpressibleAsPostfixUnaryExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -5879,12 +5871,12 @@ public struct PostfixUnaryExpr: ExprBuildable, ExpressibleAsPostfixUnaryExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -5917,7 +5909,7 @@ public struct SpecializeExpr: ExprBuildable, ExpressibleAsSpecializeExpr {
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndGenericArgumentClause: ExpressibleAsUnexpectedNodes? = nil, genericArgumentClause: ExpressibleAsGenericArgumentClause) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeExpression: unexpectedBeforeExpression?.createUnexpectedNodes(), expression: expression.createExprBuildable(), unexpectedBetweenExpressionAndGenericArgumentClause: unexpectedBetweenExpressionAndGenericArgumentClause?.createUnexpectedNodes(), genericArgumentClause: genericArgumentClause.createGenericArgumentClause()))
   }
-  public init (_ constructedNode: SpecializeExprSyntax) {
+  public init(_ constructedNode: SpecializeExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `SpecializeExprSyntax`.
@@ -5966,13 +5958,13 @@ public struct SpecializeExpr: ExprBuildable, ExpressibleAsSpecializeExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -5980,12 +5972,12 @@ public struct SpecializeExpr: ExprBuildable, ExpressibleAsSpecializeExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -6020,7 +6012,7 @@ public struct StringSegment: SyntaxBuildable, ExpressibleAsStringSegment {
   public init (leadingTrivia: Trivia = [], unexpectedBeforeContent: ExpressibleAsUnexpectedNodes? = nil, content: String) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeContent: unexpectedBeforeContent, content: Token.`stringSegment`(content))
   }
-  public init (_ constructedNode: StringSegmentSyntax) {
+  public init(_ constructedNode: StringSegmentSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `StringSegmentSyntax`.
@@ -6062,13 +6054,13 @@ public struct StringSegment: SyntaxBuildable, ExpressibleAsStringSegment {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -6076,12 +6068,12 @@ public struct StringSegment: SyntaxBuildable, ExpressibleAsStringSegment {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -6135,11 +6127,9 @@ public struct ExpressionSegment: SyntaxBuildable, ExpressibleAsExpressionSegment
   public init (leadingTrivia: Trivia = [], unexpectedBeforeBackslash: ExpressibleAsUnexpectedNodes? = nil, backslash: Token = Token.`backslash`, unexpectedBetweenBackslashAndDelimiter: ExpressibleAsUnexpectedNodes? = nil, delimiter: String?, unexpectedBetweenDelimiterAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndExpressions: ExpressibleAsUnexpectedNodes? = nil, unexpectedBetweenExpressionsAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`stringInterpolationAnchor`, @TupleExprElementListBuilder expressionsBuilder: () -> ExpressibleAsTupleExprElementList =  {
     TupleExprElementList([])
   }) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeBackslash: unexpectedBeforeBackslash, backslash: backslash, unexpectedBetweenBackslashAndDelimiter: unexpectedBetweenBackslashAndDelimiter, delimiter: delimiter.map {
-      Token.`rawStringDelimiter`($0)
-    }, unexpectedBetweenDelimiterAndLeftParen: unexpectedBetweenDelimiterAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndExpressions: unexpectedBetweenLeftParenAndExpressions, expressions: expressionsBuilder(), unexpectedBetweenExpressionsAndRightParen: unexpectedBetweenExpressionsAndRightParen, rightParen: rightParen)
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeBackslash: unexpectedBeforeBackslash, backslash: backslash, unexpectedBetweenBackslashAndDelimiter: unexpectedBetweenBackslashAndDelimiter, delimiter: delimiter.map { Token.`rawStringDelimiter`($0) }, unexpectedBetweenDelimiterAndLeftParen: unexpectedBetweenDelimiterAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndExpressions: unexpectedBetweenLeftParenAndExpressions, expressions: expressionsBuilder(), unexpectedBetweenExpressionsAndRightParen: unexpectedBetweenExpressionsAndRightParen, rightParen: rightParen)
   }
-  public init (_ constructedNode: ExpressionSegmentSyntax) {
+  public init(_ constructedNode: ExpressionSegmentSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ExpressionSegmentSyntax`.
@@ -6181,13 +6171,13 @@ public struct ExpressionSegment: SyntaxBuildable, ExpressibleAsExpressionSegment
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -6195,12 +6185,12 @@ public struct ExpressionSegment: SyntaxBuildable, ExpressibleAsExpressionSegment
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -6251,13 +6241,9 @@ public struct StringLiteralExpr: ExprBuildable, ExpressibleAsStringLiteralExpr {
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforeOpenDelimiter: ExpressibleAsUnexpectedNodes? = nil, openDelimiter: String?, unexpectedBetweenOpenDelimiterAndOpenQuote: ExpressibleAsUnexpectedNodes? = nil, openQuote: Token, unexpectedBetweenOpenQuoteAndSegments: ExpressibleAsUnexpectedNodes? = nil, segments: ExpressibleAsStringLiteralSegments, unexpectedBetweenSegmentsAndCloseQuote: ExpressibleAsUnexpectedNodes? = nil, closeQuote: Token, unexpectedBetweenCloseQuoteAndCloseDelimiter: ExpressibleAsUnexpectedNodes? = nil, closeDelimiter: String?) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeOpenDelimiter: unexpectedBeforeOpenDelimiter, openDelimiter: openDelimiter.map {
-      Token.`rawStringDelimiter`($0)
-    }, unexpectedBetweenOpenDelimiterAndOpenQuote: unexpectedBetweenOpenDelimiterAndOpenQuote, openQuote: openQuote, unexpectedBetweenOpenQuoteAndSegments: unexpectedBetweenOpenQuoteAndSegments, segments: segments, unexpectedBetweenSegmentsAndCloseQuote: unexpectedBetweenSegmentsAndCloseQuote, closeQuote: closeQuote, unexpectedBetweenCloseQuoteAndCloseDelimiter: unexpectedBetweenCloseQuoteAndCloseDelimiter, closeDelimiter: closeDelimiter.map {
-      Token.`rawStringDelimiter`($0)
-    })
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeOpenDelimiter: unexpectedBeforeOpenDelimiter, openDelimiter: openDelimiter.map { Token.`rawStringDelimiter`($0) }, unexpectedBetweenOpenDelimiterAndOpenQuote: unexpectedBetweenOpenDelimiterAndOpenQuote, openQuote: openQuote, unexpectedBetweenOpenQuoteAndSegments: unexpectedBetweenOpenQuoteAndSegments, segments: segments, unexpectedBetweenSegmentsAndCloseQuote: unexpectedBetweenSegmentsAndCloseQuote, closeQuote: closeQuote, unexpectedBetweenCloseQuoteAndCloseDelimiter: unexpectedBetweenCloseQuoteAndCloseDelimiter, closeDelimiter: closeDelimiter.map { Token.`rawStringDelimiter`($0) })
   }
-  public init (_ constructedNode: StringLiteralExprSyntax) {
+  public init(_ constructedNode: StringLiteralExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `StringLiteralExprSyntax`.
@@ -6306,13 +6292,13 @@ public struct StringLiteralExpr: ExprBuildable, ExpressibleAsStringLiteralExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -6320,12 +6306,12 @@ public struct StringLiteralExpr: ExprBuildable, ExpressibleAsStringLiteralExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -6360,7 +6346,7 @@ public struct RegexLiteralExpr: ExprBuildable, ExpressibleAsRegexLiteralExpr {
   public init (leadingTrivia: Trivia = [], unexpectedBeforeRegex: ExpressibleAsUnexpectedNodes? = nil, regex: String) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeRegex: unexpectedBeforeRegex, regex: Token.`regexLiteral`(regex))
   }
-  public init (_ constructedNode: RegexLiteralExprSyntax) {
+  public init(_ constructedNode: RegexLiteralExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `RegexLiteralExprSyntax`.
@@ -6409,13 +6395,13 @@ public struct RegexLiteralExpr: ExprBuildable, ExpressibleAsRegexLiteralExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -6423,12 +6409,12 @@ public struct RegexLiteralExpr: ExprBuildable, ExpressibleAsRegexLiteralExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -6466,7 +6452,7 @@ public struct KeyPathExpr: ExprBuildable, ExpressibleAsKeyPathExpr {
     assert(backslash.text == #"\"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeBackslash: unexpectedBeforeBackslash?.createUnexpectedNodes(), backslash: backslash, unexpectedBetweenBackslashAndRootExpr: unexpectedBetweenBackslashAndRootExpr?.createUnexpectedNodes(), rootExpr: rootExpr?.createExprBuildable(), unexpectedBetweenRootExprAndExpression: unexpectedBetweenRootExprAndExpression?.createUnexpectedNodes(), expression: expression.createExprBuildable()))
   }
-  public init (_ constructedNode: KeyPathExprSyntax) {
+  public init(_ constructedNode: KeyPathExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `KeyPathExprSyntax`.
@@ -6515,13 +6501,13 @@ public struct KeyPathExpr: ExprBuildable, ExpressibleAsKeyPathExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -6529,12 +6515,12 @@ public struct KeyPathExpr: ExprBuildable, ExpressibleAsKeyPathExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -6564,7 +6550,7 @@ public struct KeyPathBaseExpr: ExprBuildable, ExpressibleAsKeyPathBaseExpr {
     assert(period.text == #"."#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePeriod: unexpectedBeforePeriod?.createUnexpectedNodes(), period: period))
   }
-  public init (_ constructedNode: KeyPathBaseExprSyntax) {
+  public init(_ constructedNode: KeyPathBaseExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `KeyPathBaseExprSyntax`.
@@ -6613,13 +6599,13 @@ public struct KeyPathBaseExpr: ExprBuildable, ExpressibleAsKeyPathBaseExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -6627,12 +6613,12 @@ public struct KeyPathBaseExpr: ExprBuildable, ExpressibleAsKeyPathBaseExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -6672,7 +6658,7 @@ public struct ObjcNamePiece: SyntaxBuildable, ExpressibleAsObjcNamePiece {
   public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndDot: ExpressibleAsUnexpectedNodes? = nil, dot: Token? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeName: unexpectedBeforeName, name: Token.`identifier`(name), unexpectedBetweenNameAndDot: unexpectedBetweenNameAndDot, dot: dot)
   }
-  public init (_ constructedNode: ObjcNamePieceSyntax) {
+  public init(_ constructedNode: ObjcNamePieceSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ObjcNamePieceSyntax`.
@@ -6714,13 +6700,13 @@ public struct ObjcNamePiece: SyntaxBuildable, ExpressibleAsObjcNamePiece {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -6728,12 +6714,12 @@ public struct ObjcNamePiece: SyntaxBuildable, ExpressibleAsObjcNamePiece {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -6777,7 +6763,7 @@ public struct ObjcKeyPathExpr: ExprBuildable, ExpressibleAsObjcKeyPathExpr {
     assert(rightParen.text == #")"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeKeyPath: unexpectedBeforeKeyPath?.createUnexpectedNodes(), keyPath: keyPath, unexpectedBetweenKeyPathAndLeftParen: unexpectedBetweenKeyPathAndLeftParen?.createUnexpectedNodes(), leftParen: leftParen, unexpectedBetweenLeftParenAndName: unexpectedBetweenLeftParenAndName?.createUnexpectedNodes(), name: name.createObjcName(), unexpectedBetweenNameAndRightParen: unexpectedBetweenNameAndRightParen?.createUnexpectedNodes(), rightParen: rightParen))
   }
-  public init (_ constructedNode: ObjcKeyPathExprSyntax) {
+  public init(_ constructedNode: ObjcKeyPathExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ObjcKeyPathExprSyntax`.
@@ -6826,13 +6812,13 @@ public struct ObjcKeyPathExpr: ExprBuildable, ExpressibleAsObjcKeyPathExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -6840,12 +6826,12 @@ public struct ObjcKeyPathExpr: ExprBuildable, ExpressibleAsObjcKeyPathExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -6903,11 +6889,9 @@ public struct ObjcSelectorExpr: ExprBuildable, ExpressibleAsObjcSelectorExpr {
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforePoundSelector: ExpressibleAsUnexpectedNodes? = nil, poundSelector: Token = Token.`poundSelector`, unexpectedBetweenPoundSelectorAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndKind: ExpressibleAsUnexpectedNodes? = nil, kind: String?, unexpectedBetweenKindAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndName: ExpressibleAsUnexpectedNodes? = nil, name: ExpressibleAsExprBuildable, unexpectedBetweenNameAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforePoundSelector: unexpectedBeforePoundSelector, poundSelector: poundSelector, unexpectedBetweenPoundSelectorAndLeftParen: unexpectedBetweenPoundSelectorAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndKind: unexpectedBetweenLeftParenAndKind, kind: kind.map {
-      Token.`contextualKeyword`($0)
-    }, unexpectedBetweenKindAndColon: unexpectedBetweenKindAndColon, colon: colon, unexpectedBetweenColonAndName: unexpectedBetweenColonAndName, name: name, unexpectedBetweenNameAndRightParen: unexpectedBetweenNameAndRightParen, rightParen: rightParen)
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforePoundSelector: unexpectedBeforePoundSelector, poundSelector: poundSelector, unexpectedBetweenPoundSelectorAndLeftParen: unexpectedBetweenPoundSelectorAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndKind: unexpectedBetweenLeftParenAndKind, kind: kind.map { Token.`contextualKeyword`($0) }, unexpectedBetweenKindAndColon: unexpectedBetweenKindAndColon, colon: colon, unexpectedBetweenColonAndName: unexpectedBetweenColonAndName, name: name, unexpectedBetweenNameAndRightParen: unexpectedBetweenNameAndRightParen, rightParen: rightParen)
   }
-  public init (_ constructedNode: ObjcSelectorExprSyntax) {
+  public init(_ constructedNode: ObjcSelectorExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ObjcSelectorExprSyntax`.
@@ -6956,13 +6940,13 @@ public struct ObjcSelectorExpr: ExprBuildable, ExpressibleAsObjcSelectorExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -6970,12 +6954,12 @@ public struct ObjcSelectorExpr: ExprBuildable, ExpressibleAsObjcSelectorExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -7008,7 +6992,7 @@ public struct PostfixIfConfigExpr: ExprBuildable, ExpressibleAsPostfixIfConfigEx
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeBase: ExpressibleAsUnexpectedNodes? = nil, base: ExpressibleAsExprBuildable? = nil, unexpectedBetweenBaseAndConfig: ExpressibleAsUnexpectedNodes? = nil, config: ExpressibleAsIfConfigDecl) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeBase: unexpectedBeforeBase?.createUnexpectedNodes(), base: base?.createExprBuildable(), unexpectedBetweenBaseAndConfig: unexpectedBetweenBaseAndConfig?.createUnexpectedNodes(), config: config.createIfConfigDecl()))
   }
-  public init (_ constructedNode: PostfixIfConfigExprSyntax) {
+  public init(_ constructedNode: PostfixIfConfigExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PostfixIfConfigExprSyntax`.
@@ -7057,13 +7041,13 @@ public struct PostfixIfConfigExpr: ExprBuildable, ExpressibleAsPostfixIfConfigEx
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -7071,12 +7055,12 @@ public struct PostfixIfConfigExpr: ExprBuildable, ExpressibleAsPostfixIfConfigEx
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -7111,7 +7095,7 @@ public struct EditorPlaceholderExpr: ExprBuildable, ExpressibleAsEditorPlacehold
   public init (leadingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: String) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeIdentifier: unexpectedBeforeIdentifier, identifier: Token.`identifier`(identifier))
   }
-  public init (_ constructedNode: EditorPlaceholderExprSyntax) {
+  public init(_ constructedNode: EditorPlaceholderExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `EditorPlaceholderExprSyntax`.
@@ -7160,13 +7144,13 @@ public struct EditorPlaceholderExpr: ExprBuildable, ExpressibleAsEditorPlacehold
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -7174,12 +7158,12 @@ public struct EditorPlaceholderExpr: ExprBuildable, ExpressibleAsEditorPlacehold
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -7231,7 +7215,7 @@ public struct ObjectLiteralExpr: ExprBuildable, ExpressibleAsObjectLiteralExpr {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeIdentifier: unexpectedBeforeIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndLeftParen: unexpectedBetweenIdentifierAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArguments: unexpectedBetweenLeftParenAndArguments, arguments: argumentsBuilder(), unexpectedBetweenArgumentsAndRightParen: unexpectedBetweenArgumentsAndRightParen, rightParen: rightParen)
   }
-  public init (_ constructedNode: ObjectLiteralExprSyntax) {
+  public init(_ constructedNode: ObjectLiteralExprSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ObjectLiteralExprSyntax`.
@@ -7280,13 +7264,13 @@ public struct ObjectLiteralExpr: ExprBuildable, ExpressibleAsObjectLiteralExpr {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -7294,12 +7278,12 @@ public struct ObjectLiteralExpr: ExprBuildable, ExpressibleAsObjectLiteralExpr {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -7333,7 +7317,7 @@ public struct TypeInitializerClause: SyntaxBuildable, ExpressibleAsTypeInitializ
     assert(equal.text == #"="#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeEqual: unexpectedBeforeEqual?.createUnexpectedNodes(), equal: equal, unexpectedBetweenEqualAndValue: unexpectedBetweenEqualAndValue?.createUnexpectedNodes(), value: value.createTypeBuildable()))
   }
-  public init (_ constructedNode: TypeInitializerClauseSyntax) {
+  public init(_ constructedNode: TypeInitializerClauseSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `TypeInitializerClauseSyntax`.
@@ -7375,13 +7359,13 @@ public struct TypeInitializerClause: SyntaxBuildable, ExpressibleAsTypeInitializ
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -7389,12 +7373,12 @@ public struct TypeInitializerClause: SyntaxBuildable, ExpressibleAsTypeInitializ
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -7454,7 +7438,7 @@ public struct TypealiasDecl: DeclBuildable, ExpressibleAsTypealiasDecl {
   public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndTypealiasKeyword: ExpressibleAsUnexpectedNodes? = nil, typealiasKeyword: Token = Token.`typealias`, unexpectedBetweenTypealiasKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndGenericParameterClause: ExpressibleAsUnexpectedNodes? = nil, genericParameterClause: ExpressibleAsGenericParameterClause? = nil, unexpectedBetweenGenericParameterClauseAndInitializer: ExpressibleAsUnexpectedNodes? = nil, initializer: ExpressibleAsTypeInitializerClause, unexpectedBetweenInitializerAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndTypealiasKeyword: unexpectedBetweenModifiersAndTypealiasKeyword, typealiasKeyword: typealiasKeyword, unexpectedBetweenTypealiasKeywordAndIdentifier: unexpectedBetweenTypealiasKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause: unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInitializer: unexpectedBetweenGenericParameterClauseAndInitializer, initializer: initializer, unexpectedBetweenInitializerAndGenericWhereClause: unexpectedBetweenInitializerAndGenericWhereClause, genericWhereClause: genericWhereClause)
   }
-  public init (_ constructedNode: TypealiasDeclSyntax) {
+  public init(_ constructedNode: TypealiasDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `TypealiasDeclSyntax`.
@@ -7503,13 +7487,13 @@ public struct TypealiasDecl: DeclBuildable, ExpressibleAsTypealiasDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -7517,12 +7501,12 @@ public struct TypealiasDecl: DeclBuildable, ExpressibleAsTypealiasDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -7582,7 +7566,7 @@ public struct AssociatedtypeDecl: DeclBuildable, ExpressibleAsAssociatedtypeDecl
   public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndAssociatedtypeKeyword: ExpressibleAsUnexpectedNodes? = nil, associatedtypeKeyword: Token = Token.`associatedtype`, unexpectedBetweenAssociatedtypeKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndInheritanceClause: ExpressibleAsUnexpectedNodes? = nil, inheritanceClause: ExpressibleAsTypeInheritanceClause? = nil, unexpectedBetweenInheritanceClauseAndInitializer: ExpressibleAsUnexpectedNodes? = nil, initializer: ExpressibleAsTypeInitializerClause? = nil, unexpectedBetweenInitializerAndGenericWhereClause: ExpressibleAsUnexpectedNodes? = nil, genericWhereClause: ExpressibleAsGenericWhereClause? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndAssociatedtypeKeyword: unexpectedBetweenModifiersAndAssociatedtypeKeyword, associatedtypeKeyword: associatedtypeKeyword, unexpectedBetweenAssociatedtypeKeywordAndIdentifier: unexpectedBetweenAssociatedtypeKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndInheritanceClause: unexpectedBetweenIdentifierAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndInitializer: unexpectedBetweenInheritanceClauseAndInitializer, initializer: initializer, unexpectedBetweenInitializerAndGenericWhereClause: unexpectedBetweenInitializerAndGenericWhereClause, genericWhereClause: genericWhereClause)
   }
-  public init (_ constructedNode: AssociatedtypeDeclSyntax) {
+  public init(_ constructedNode: AssociatedtypeDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AssociatedtypeDeclSyntax`.
@@ -7631,13 +7615,13 @@ public struct AssociatedtypeDecl: DeclBuildable, ExpressibleAsAssociatedtypeDecl
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -7645,12 +7629,12 @@ public struct AssociatedtypeDecl: DeclBuildable, ExpressibleAsAssociatedtypeDecl
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -7697,7 +7681,7 @@ public struct ParameterClause: SyntaxBuildable, ExpressibleAsParameterClause {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLeftParen: unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndParameterList: unexpectedBetweenLeftParenAndParameterList, parameterList: parameterListBuilder(), unexpectedBetweenParameterListAndRightParen: unexpectedBetweenParameterListAndRightParen, rightParen: rightParen)
   }
-  public init (_ constructedNode: ParameterClauseSyntax) {
+  public init(_ constructedNode: ParameterClauseSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ParameterClauseSyntax`.
@@ -7739,13 +7723,13 @@ public struct ParameterClause: SyntaxBuildable, ExpressibleAsParameterClause {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -7753,12 +7737,12 @@ public struct ParameterClause: SyntaxBuildable, ExpressibleAsParameterClause {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -7792,7 +7776,7 @@ public struct ReturnClause: SyntaxBuildable, ExpressibleAsReturnClause {
     assert(arrow.text == #"->"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeArrow: unexpectedBeforeArrow?.createUnexpectedNodes(), arrow: arrow, unexpectedBetweenArrowAndReturnType: unexpectedBetweenArrowAndReturnType?.createUnexpectedNodes(), returnType: returnType.createTypeBuildable()))
   }
-  public init (_ constructedNode: ReturnClauseSyntax) {
+  public init(_ constructedNode: ReturnClauseSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ReturnClauseSyntax`.
@@ -7834,13 +7818,13 @@ public struct ReturnClause: SyntaxBuildable, ExpressibleAsReturnClause {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -7848,12 +7832,12 @@ public struct ReturnClause: SyntaxBuildable, ExpressibleAsReturnClause {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -7900,11 +7884,9 @@ public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforeInput: ExpressibleAsUnexpectedNodes? = nil, input: ExpressibleAsParameterClause, unexpectedBetweenInputAndAsyncOrReasyncKeyword: ExpressibleAsUnexpectedNodes? = nil, asyncOrReasyncKeyword: String?, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: ExpressibleAsUnexpectedNodes? = nil, throwsOrRethrowsKeyword: Token? = nil, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: ExpressibleAsUnexpectedNodes? = nil, output: ExpressibleAsReturnClause? = nil) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeInput: unexpectedBeforeInput, input: input, unexpectedBetweenInputAndAsyncOrReasyncKeyword: unexpectedBetweenInputAndAsyncOrReasyncKeyword, asyncOrReasyncKeyword: asyncOrReasyncKeyword.map {
-      Token.`contextualKeyword`($0)
-    }, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword, throwsOrRethrowsKeyword: throwsOrRethrowsKeyword, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: unexpectedBetweenThrowsOrRethrowsKeywordAndOutput, output: output)
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeInput: unexpectedBeforeInput, input: input, unexpectedBetweenInputAndAsyncOrReasyncKeyword: unexpectedBetweenInputAndAsyncOrReasyncKeyword, asyncOrReasyncKeyword: asyncOrReasyncKeyword.map { Token.`contextualKeyword`($0) }, unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword, throwsOrRethrowsKeyword: throwsOrRethrowsKeyword, unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: unexpectedBetweenThrowsOrRethrowsKeywordAndOutput, output: output)
   }
-  public init (_ constructedNode: FunctionSignatureSyntax) {
+  public init(_ constructedNode: FunctionSignatureSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `FunctionSignatureSyntax`.
@@ -7946,13 +7928,13 @@ public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -7960,12 +7942,12 @@ public struct FunctionSignature: SyntaxBuildable, ExpressibleAsFunctionSignature
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -8003,7 +7985,7 @@ public struct IfConfigClause: SyntaxBuildable, ExpressibleAsIfConfigClause {
     assert(poundKeyword.text == #"#if"# || poundKeyword.text == #"#elseif"# || poundKeyword.text == #"#else"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePoundKeyword: unexpectedBeforePoundKeyword?.createUnexpectedNodes(), poundKeyword: poundKeyword, unexpectedBetweenPoundKeywordAndCondition: unexpectedBetweenPoundKeywordAndCondition?.createUnexpectedNodes(), condition: condition?.createExprBuildable(), unexpectedBetweenConditionAndElements: unexpectedBetweenConditionAndElements?.createUnexpectedNodes(), elements: elements.createSyntaxBuildable()))
   }
-  public init (_ constructedNode: IfConfigClauseSyntax) {
+  public init(_ constructedNode: IfConfigClauseSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `IfConfigClauseSyntax`.
@@ -8045,13 +8027,13 @@ public struct IfConfigClause: SyntaxBuildable, ExpressibleAsIfConfigClause {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -8059,12 +8041,12 @@ public struct IfConfigClause: SyntaxBuildable, ExpressibleAsIfConfigClause {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -8098,7 +8080,7 @@ public struct IfConfigDecl: DeclBuildable, ExpressibleAsIfConfigDecl {
     assert(poundEndif.text == #"#endif"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeClauses: unexpectedBeforeClauses?.createUnexpectedNodes(), clauses: clauses.createIfConfigClauseList(), unexpectedBetweenClausesAndPoundEndif: unexpectedBetweenClausesAndPoundEndif?.createUnexpectedNodes(), poundEndif: poundEndif))
   }
-  public init (_ constructedNode: IfConfigDeclSyntax) {
+  public init(_ constructedNode: IfConfigDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `IfConfigDeclSyntax`.
@@ -8147,13 +8129,13 @@ public struct IfConfigDecl: DeclBuildable, ExpressibleAsIfConfigDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -8161,12 +8143,12 @@ public struct IfConfigDecl: DeclBuildable, ExpressibleAsIfConfigDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -8210,7 +8192,7 @@ public struct PoundErrorDecl: DeclBuildable, ExpressibleAsPoundErrorDecl {
     assert(rightParen.text == #")"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePoundError: unexpectedBeforePoundError?.createUnexpectedNodes(), poundError: poundError, unexpectedBetweenPoundErrorAndLeftParen: unexpectedBetweenPoundErrorAndLeftParen?.createUnexpectedNodes(), leftParen: leftParen, unexpectedBetweenLeftParenAndMessage: unexpectedBetweenLeftParenAndMessage?.createUnexpectedNodes(), message: message.createStringLiteralExpr(), unexpectedBetweenMessageAndRightParen: unexpectedBetweenMessageAndRightParen?.createUnexpectedNodes(), rightParen: rightParen))
   }
-  public init (_ constructedNode: PoundErrorDeclSyntax) {
+  public init(_ constructedNode: PoundErrorDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PoundErrorDeclSyntax`.
@@ -8259,13 +8241,13 @@ public struct PoundErrorDecl: DeclBuildable, ExpressibleAsPoundErrorDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -8273,12 +8255,12 @@ public struct PoundErrorDecl: DeclBuildable, ExpressibleAsPoundErrorDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -8322,7 +8304,7 @@ public struct PoundWarningDecl: DeclBuildable, ExpressibleAsPoundWarningDecl {
     assert(rightParen.text == #")"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePoundWarning: unexpectedBeforePoundWarning?.createUnexpectedNodes(), poundWarning: poundWarning, unexpectedBetweenPoundWarningAndLeftParen: unexpectedBetweenPoundWarningAndLeftParen?.createUnexpectedNodes(), leftParen: leftParen, unexpectedBetweenLeftParenAndMessage: unexpectedBetweenLeftParenAndMessage?.createUnexpectedNodes(), message: message.createStringLiteralExpr(), unexpectedBetweenMessageAndRightParen: unexpectedBetweenMessageAndRightParen?.createUnexpectedNodes(), rightParen: rightParen))
   }
-  public init (_ constructedNode: PoundWarningDeclSyntax) {
+  public init(_ constructedNode: PoundWarningDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PoundWarningDeclSyntax`.
@@ -8371,13 +8353,13 @@ public struct PoundWarningDecl: DeclBuildable, ExpressibleAsPoundWarningDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -8385,12 +8367,12 @@ public struct PoundWarningDecl: DeclBuildable, ExpressibleAsPoundWarningDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -8434,7 +8416,7 @@ public struct PoundSourceLocation: DeclBuildable, ExpressibleAsPoundSourceLocati
     assert(rightParen.text == #")"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePoundSourceLocation: unexpectedBeforePoundSourceLocation?.createUnexpectedNodes(), poundSourceLocation: poundSourceLocation, unexpectedBetweenPoundSourceLocationAndLeftParen: unexpectedBetweenPoundSourceLocationAndLeftParen?.createUnexpectedNodes(), leftParen: leftParen, unexpectedBetweenLeftParenAndArgs: unexpectedBetweenLeftParenAndArgs?.createUnexpectedNodes(), args: args?.createPoundSourceLocationArgs(), unexpectedBetweenArgsAndRightParen: unexpectedBetweenArgsAndRightParen?.createUnexpectedNodes(), rightParen: rightParen))
   }
-  public init (_ constructedNode: PoundSourceLocationSyntax) {
+  public init(_ constructedNode: PoundSourceLocationSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PoundSourceLocationSyntax`.
@@ -8483,13 +8465,13 @@ public struct PoundSourceLocation: DeclBuildable, ExpressibleAsPoundSourceLocati
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -8497,12 +8479,12 @@ public struct PoundSourceLocation: DeclBuildable, ExpressibleAsPoundSourceLocati
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -8566,7 +8548,7 @@ public struct PoundSourceLocationArgs: SyntaxBuildable, ExpressibleAsPoundSource
   public init (leadingTrivia: Trivia = [], unexpectedBeforeFileArgLabel: ExpressibleAsUnexpectedNodes? = nil, fileArgLabel: String, unexpectedBetweenFileArgLabelAndFileArgColon: ExpressibleAsUnexpectedNodes? = nil, fileArgColon: Token = Token.`colon`, unexpectedBetweenFileArgColonAndFileName: ExpressibleAsUnexpectedNodes? = nil, fileName: String, unexpectedBetweenFileNameAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token = Token.`comma`, unexpectedBetweenCommaAndLineArgLabel: ExpressibleAsUnexpectedNodes? = nil, lineArgLabel: String, unexpectedBetweenLineArgLabelAndLineArgColon: ExpressibleAsUnexpectedNodes? = nil, lineArgColon: Token = Token.`colon`, unexpectedBetweenLineArgColonAndLineNumber: ExpressibleAsUnexpectedNodes? = nil, lineNumber: String) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeFileArgLabel: unexpectedBeforeFileArgLabel, fileArgLabel: Token.`identifier`(fileArgLabel), unexpectedBetweenFileArgLabelAndFileArgColon: unexpectedBetweenFileArgLabelAndFileArgColon, fileArgColon: fileArgColon, unexpectedBetweenFileArgColonAndFileName: unexpectedBetweenFileArgColonAndFileName, fileName: Token.`stringLiteral`(fileName), unexpectedBetweenFileNameAndComma: unexpectedBetweenFileNameAndComma, comma: comma, unexpectedBetweenCommaAndLineArgLabel: unexpectedBetweenCommaAndLineArgLabel, lineArgLabel: Token.`identifier`(lineArgLabel), unexpectedBetweenLineArgLabelAndLineArgColon: unexpectedBetweenLineArgLabelAndLineArgColon, lineArgColon: lineArgColon, unexpectedBetweenLineArgColonAndLineNumber: unexpectedBetweenLineArgColonAndLineNumber, lineNumber: Token.`integerLiteral`(lineNumber))
   }
-  public init (_ constructedNode: PoundSourceLocationArgsSyntax) {
+  public init(_ constructedNode: PoundSourceLocationArgsSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PoundSourceLocationArgsSyntax`.
@@ -8608,13 +8590,13 @@ public struct PoundSourceLocationArgs: SyntaxBuildable, ExpressibleAsPoundSource
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -8622,12 +8604,12 @@ public struct PoundSourceLocationArgs: SyntaxBuildable, ExpressibleAsPoundSource
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -8672,7 +8654,7 @@ public struct DeclModifierDetail: SyntaxBuildable, ExpressibleAsDeclModifierDeta
   public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndDetail: ExpressibleAsUnexpectedNodes? = nil, detail: String, unexpectedBetweenDetailAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLeftParen: unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndDetail: unexpectedBetweenLeftParenAndDetail, detail: Token.`identifier`(detail), unexpectedBetweenDetailAndRightParen: unexpectedBetweenDetailAndRightParen, rightParen: rightParen)
   }
-  public init (_ constructedNode: DeclModifierDetailSyntax) {
+  public init(_ constructedNode: DeclModifierDetailSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DeclModifierDetailSyntax`.
@@ -8714,13 +8696,13 @@ public struct DeclModifierDetail: SyntaxBuildable, ExpressibleAsDeclModifierDeta
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -8728,12 +8710,12 @@ public struct DeclModifierDetail: SyntaxBuildable, ExpressibleAsDeclModifierDeta
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -8767,7 +8749,7 @@ public struct DeclModifier: SyntaxBuildable, ExpressibleAsDeclModifier {
     assert(name.text == #"class"# || name.text == #"convenience"# || name.text == #"dynamic"# || name.text == #"final"# || name.text == #"infix"# || name.text == #"lazy"# || name.text == #"optional"# || name.text == #"override"# || name.text == #"postfix"# || name.text == #"prefix"# || name.text == #"required"# || name.text == #"static"# || name.text == #"unowned"# || name.text == #"weak"# || name.text == #"private"# || name.text == #"fileprivate"# || name.text == #"internal"# || name.text == #"public"# || name.text == #"open"# || name.text == #"mutating"# || name.text == #"nonmutating"# || name.text == #"indirect"# || name.text == #"__consuming"# || name.text == #"actor"# || name.text == #"async"# || name.text == #"distributed"# || name.text == #"isolated"# || name.text == #"nonisolated"# || name.text == #"_const"# || name.text == #"_local"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeName: unexpectedBeforeName?.createUnexpectedNodes(), name: name, unexpectedBetweenNameAndDetail: unexpectedBetweenNameAndDetail?.createUnexpectedNodes(), detail: detail?.createDeclModifierDetail()))
   }
-  public init (_ constructedNode: DeclModifierSyntax) {
+  public init(_ constructedNode: DeclModifierSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DeclModifierSyntax`.
@@ -8809,13 +8791,13 @@ public struct DeclModifier: SyntaxBuildable, ExpressibleAsDeclModifier {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -8823,12 +8805,12 @@ public struct DeclModifier: SyntaxBuildable, ExpressibleAsDeclModifier {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -8854,9 +8836,9 @@ public struct InheritedType: SyntaxBuildable, ExpressibleAsInheritedType, HasTra
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -8870,7 +8852,7 @@ public struct InheritedType: SyntaxBuildable, ExpressibleAsInheritedType, HasTra
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeTypeName: unexpectedBeforeTypeName?.createUnexpectedNodes(), typeName: typeName.createTypeBuildable(), unexpectedBetweenTypeNameAndTrailingComma: unexpectedBetweenTypeNameAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: InheritedTypeSyntax) {
+  public init(_ constructedNode: InheritedTypeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `InheritedTypeSyntax`.
@@ -8913,12 +8895,12 @@ public struct InheritedType: SyntaxBuildable, ExpressibleAsInheritedType, HasTra
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -8927,13 +8909,13 @@ public struct InheritedType: SyntaxBuildable, ExpressibleAsInheritedType, HasTra
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -8941,12 +8923,12 @@ public struct InheritedType: SyntaxBuildable, ExpressibleAsInheritedType, HasTra
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -8988,7 +8970,7 @@ public struct TypeInheritanceClause: SyntaxBuildable, ExpressibleAsTypeInheritan
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeColon: unexpectedBeforeColon, colon: colon, unexpectedBetweenColonAndInheritedTypeCollection: unexpectedBetweenColonAndInheritedTypeCollection, inheritedTypeCollection: inheritedTypeCollectionBuilder())
   }
-  public init (_ constructedNode: TypeInheritanceClauseSyntax) {
+  public init(_ constructedNode: TypeInheritanceClauseSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `TypeInheritanceClauseSyntax`.
@@ -9030,13 +9012,13 @@ public struct TypeInheritanceClause: SyntaxBuildable, ExpressibleAsTypeInheritan
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -9044,12 +9026,12 @@ public struct TypeInheritanceClause: SyntaxBuildable, ExpressibleAsTypeInheritan
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -9115,7 +9097,7 @@ public struct ClassDecl: DeclBuildable, ExpressibleAsClassDecl {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndClassKeyword: unexpectedBetweenModifiersAndClassKeyword, classKeyword: classKeyword, unexpectedBetweenClassKeywordAndIdentifier: unexpectedBetweenClassKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause: unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause: unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause: unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers: unexpectedBetweenGenericWhereClauseAndMembers, members: membersBuilder())
   }
-  public init (_ constructedNode: ClassDeclSyntax) {
+  public init(_ constructedNode: ClassDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ClassDeclSyntax`.
@@ -9164,13 +9146,13 @@ public struct ClassDecl: DeclBuildable, ExpressibleAsClassDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -9178,12 +9160,12 @@ public struct ClassDecl: DeclBuildable, ExpressibleAsClassDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -9249,7 +9231,7 @@ public struct ActorDecl: DeclBuildable, ExpressibleAsActorDecl {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndActorKeyword: unexpectedBetweenModifiersAndActorKeyword, actorKeyword: Token.`contextualKeyword`(actorKeyword), unexpectedBetweenActorKeywordAndIdentifier: unexpectedBetweenActorKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause: unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause: unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause: unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers: unexpectedBetweenGenericWhereClauseAndMembers, members: membersBuilder())
   }
-  public init (_ constructedNode: ActorDeclSyntax) {
+  public init(_ constructedNode: ActorDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ActorDeclSyntax`.
@@ -9298,13 +9280,13 @@ public struct ActorDecl: DeclBuildable, ExpressibleAsActorDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -9312,12 +9294,12 @@ public struct ActorDecl: DeclBuildable, ExpressibleAsActorDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -9383,7 +9365,7 @@ public struct StructDecl: DeclBuildable, ExpressibleAsStructDecl {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndStructKeyword: unexpectedBetweenModifiersAndStructKeyword, structKeyword: structKeyword, unexpectedBetweenStructKeywordAndIdentifier: unexpectedBetweenStructKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameterClause: unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndInheritanceClause: unexpectedBetweenGenericParameterClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause: unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers: unexpectedBetweenGenericWhereClauseAndMembers, members: membersBuilder())
   }
-  public init (_ constructedNode: StructDeclSyntax) {
+  public init(_ constructedNode: StructDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `StructDeclSyntax`.
@@ -9432,13 +9414,13 @@ public struct StructDecl: DeclBuildable, ExpressibleAsStructDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -9446,12 +9428,12 @@ public struct StructDecl: DeclBuildable, ExpressibleAsStructDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -9517,7 +9499,7 @@ public struct ProtocolDecl: DeclBuildable, ExpressibleAsProtocolDecl {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndProtocolKeyword: unexpectedBetweenModifiersAndProtocolKeyword, protocolKeyword: protocolKeyword, unexpectedBetweenProtocolKeywordAndIdentifier: unexpectedBetweenProtocolKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause: unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause, primaryAssociatedTypeClause: primaryAssociatedTypeClause, unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause: unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause: unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers: unexpectedBetweenGenericWhereClauseAndMembers, members: membersBuilder())
   }
-  public init (_ constructedNode: ProtocolDeclSyntax) {
+  public init(_ constructedNode: ProtocolDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ProtocolDeclSyntax`.
@@ -9566,13 +9548,13 @@ public struct ProtocolDecl: DeclBuildable, ExpressibleAsProtocolDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -9580,12 +9562,12 @@ public struct ProtocolDecl: DeclBuildable, ExpressibleAsProtocolDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -9647,7 +9629,7 @@ public struct ExtensionDecl: DeclBuildable, ExpressibleAsExtensionDecl {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndExtensionKeyword: unexpectedBetweenModifiersAndExtensionKeyword, extensionKeyword: extensionKeyword, unexpectedBetweenExtensionKeywordAndExtendedType: unexpectedBetweenExtensionKeywordAndExtendedType, extendedType: extendedType, unexpectedBetweenExtendedTypeAndInheritanceClause: unexpectedBetweenExtendedTypeAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause: unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers: unexpectedBetweenGenericWhereClauseAndMembers, members: membersBuilder())
   }
-  public init (_ constructedNode: ExtensionDeclSyntax) {
+  public init(_ constructedNode: ExtensionDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ExtensionDeclSyntax`.
@@ -9696,13 +9678,13 @@ public struct ExtensionDecl: DeclBuildable, ExpressibleAsExtensionDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -9710,12 +9692,12 @@ public struct ExtensionDecl: DeclBuildable, ExpressibleAsExtensionDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -9762,7 +9744,7 @@ public struct MemberDeclBlock: SyntaxBuildable, ExpressibleAsMemberDeclBlock {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLeftBrace: unexpectedBeforeLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndMembers: unexpectedBetweenLeftBraceAndMembers, members: membersBuilder(), unexpectedBetweenMembersAndRightBrace: unexpectedBetweenMembersAndRightBrace, rightBrace: rightBrace)
   }
-  public init (_ constructedNode: MemberDeclBlockSyntax) {
+  public init(_ constructedNode: MemberDeclBlockSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `MemberDeclBlockSyntax`.
@@ -9804,13 +9786,13 @@ public struct MemberDeclBlock: SyntaxBuildable, ExpressibleAsMemberDeclBlock {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -9818,12 +9800,12 @@ public struct MemberDeclBlock: SyntaxBuildable, ExpressibleAsMemberDeclBlock {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -9858,7 +9840,7 @@ public struct MemberDeclListItem: SyntaxBuildable, ExpressibleAsMemberDeclListIt
     assert(semicolon == nil || semicolon!.text == #";"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeDecl: unexpectedBeforeDecl?.createUnexpectedNodes(), decl: decl.createDeclBuildable(), unexpectedBetweenDeclAndSemicolon: unexpectedBetweenDeclAndSemicolon?.createUnexpectedNodes(), semicolon: semicolon))
   }
-  public init (_ constructedNode: MemberDeclListItemSyntax) {
+  public init(_ constructedNode: MemberDeclListItemSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `MemberDeclListItemSyntax`.
@@ -9900,13 +9882,13 @@ public struct MemberDeclListItem: SyntaxBuildable, ExpressibleAsMemberDeclListIt
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -9914,12 +9896,12 @@ public struct MemberDeclListItem: SyntaxBuildable, ExpressibleAsMemberDeclListIt
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -9960,7 +9942,7 @@ public struct SourceFile: SyntaxBuildable, ExpressibleAsSourceFile {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeStatements: unexpectedBeforeStatements, statements: statementsBuilder(), unexpectedBetweenStatementsAndEOFToken: unexpectedBetweenStatementsAndEOFToken, eofToken: eofToken)
   }
-  public init (_ constructedNode: SourceFileSyntax) {
+  public init(_ constructedNode: SourceFileSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `SourceFileSyntax`.
@@ -10002,13 +9984,13 @@ public struct SourceFile: SyntaxBuildable, ExpressibleAsSourceFile {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -10016,12 +9998,12 @@ public struct SourceFile: SyntaxBuildable, ExpressibleAsSourceFile {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -10055,7 +10037,7 @@ public struct InitializerClause: SyntaxBuildable, ExpressibleAsInitializerClause
     assert(equal.text == #"="#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeEqual: unexpectedBeforeEqual?.createUnexpectedNodes(), equal: equal, unexpectedBetweenEqualAndValue: unexpectedBetweenEqualAndValue?.createUnexpectedNodes(), value: value.createExprBuildable()))
   }
-  public init (_ constructedNode: InitializerClauseSyntax) {
+  public init(_ constructedNode: InitializerClauseSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `InitializerClauseSyntax`.
@@ -10097,13 +10079,13 @@ public struct InitializerClause: SyntaxBuildable, ExpressibleAsInitializerClause
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -10111,12 +10093,12 @@ public struct InitializerClause: SyntaxBuildable, ExpressibleAsInitializerClause
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -10158,9 +10140,9 @@ public struct FunctionParameter: SyntaxBuildable, ExpressibleAsFunctionParameter
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -10192,7 +10174,7 @@ public struct FunctionParameter: SyntaxBuildable, ExpressibleAsFunctionParameter
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes?.createUnexpectedNodes(), attributes: attributes?.createAttributeList(), unexpectedBetweenAttributesAndIsolatedToken: unexpectedBetweenAttributesAndIsolatedToken?.createUnexpectedNodes(), isolatedToken: isolatedToken, unexpectedBetweenIsolatedTokenAndConstToken: unexpectedBetweenIsolatedTokenAndConstToken?.createUnexpectedNodes(), constToken: constToken, unexpectedBetweenConstTokenAndFirstName: unexpectedBetweenConstTokenAndFirstName?.createUnexpectedNodes(), firstName: firstName, unexpectedBetweenFirstNameAndSecondName: unexpectedBetweenFirstNameAndSecondName?.createUnexpectedNodes(), secondName: secondName, unexpectedBetweenSecondNameAndColon: unexpectedBetweenSecondNameAndColon?.createUnexpectedNodes(), colon: colon, unexpectedBetweenColonAndType: unexpectedBetweenColonAndType?.createUnexpectedNodes(), type: type?.createTypeBuildable(), unexpectedBetweenTypeAndEllipsis: unexpectedBetweenTypeAndEllipsis?.createUnexpectedNodes(), ellipsis: ellipsis, unexpectedBetweenEllipsisAndDefaultArgument: unexpectedBetweenEllipsisAndDefaultArgument?.createUnexpectedNodes(), defaultArgument: defaultArgument?.createInitializerClause(), unexpectedBetweenDefaultArgumentAndTrailingComma: unexpectedBetweenDefaultArgumentAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: FunctionParameterSyntax) {
+  public init(_ constructedNode: FunctionParameterSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `FunctionParameterSyntax`.
@@ -10235,12 +10217,12 @@ public struct FunctionParameter: SyntaxBuildable, ExpressibleAsFunctionParameter
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -10249,13 +10231,13 @@ public struct FunctionParameter: SyntaxBuildable, ExpressibleAsFunctionParameter
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -10263,12 +10245,12 @@ public struct FunctionParameter: SyntaxBuildable, ExpressibleAsFunctionParameter
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -10334,7 +10316,7 @@ public struct FunctionDecl: DeclBuildable, ExpressibleAsFunctionDecl {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndFuncKeyword: unexpectedBetweenModifiersAndFuncKeyword, funcKeyword: funcKeyword, unexpectedBetweenFuncKeywordAndIdentifier: unexpectedBetweenFuncKeywordAndIdentifier, identifier: identifier, unexpectedBetweenIdentifierAndGenericParameterClause: unexpectedBetweenIdentifierAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature: unexpectedBetweenGenericParameterClauseAndSignature, signature: signature, unexpectedBetweenSignatureAndGenericWhereClause: unexpectedBetweenSignatureAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndBody: unexpectedBetweenGenericWhereClauseAndBody, body: bodyBuilder())
   }
-  public init (_ constructedNode: FunctionDeclSyntax) {
+  public init(_ constructedNode: FunctionDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `FunctionDeclSyntax`.
@@ -10383,13 +10365,13 @@ public struct FunctionDecl: DeclBuildable, ExpressibleAsFunctionDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -10397,12 +10379,12 @@ public struct FunctionDecl: DeclBuildable, ExpressibleAsFunctionDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -10469,7 +10451,7 @@ public struct InitializerDecl: DeclBuildable, ExpressibleAsInitializerDecl {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndInitKeyword: unexpectedBetweenModifiersAndInitKeyword, initKeyword: initKeyword, unexpectedBetweenInitKeywordAndOptionalMark: unexpectedBetweenInitKeywordAndOptionalMark, optionalMark: optionalMark, unexpectedBetweenOptionalMarkAndGenericParameterClause: unexpectedBetweenOptionalMarkAndGenericParameterClause, genericParameterClause: genericParameterClause, unexpectedBetweenGenericParameterClauseAndSignature: unexpectedBetweenGenericParameterClauseAndSignature, signature: signature, unexpectedBetweenSignatureAndGenericWhereClause: unexpectedBetweenSignatureAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndBody: unexpectedBetweenGenericWhereClauseAndBody, body: bodyBuilder())
   }
-  public init (_ constructedNode: InitializerDeclSyntax) {
+  public init(_ constructedNode: InitializerDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `InitializerDeclSyntax`.
@@ -10518,13 +10500,13 @@ public struct InitializerDecl: DeclBuildable, ExpressibleAsInitializerDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -10532,12 +10514,12 @@ public struct InitializerDecl: DeclBuildable, ExpressibleAsInitializerDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -10587,7 +10569,7 @@ public struct DeinitializerDecl: DeclBuildable, ExpressibleAsDeinitializerDecl {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndDeinitKeyword: unexpectedBetweenModifiersAndDeinitKeyword, deinitKeyword: deinitKeyword, unexpectedBetweenDeinitKeywordAndBody: unexpectedBetweenDeinitKeywordAndBody, body: bodyBuilder())
   }
-  public init (_ constructedNode: DeinitializerDeclSyntax) {
+  public init(_ constructedNode: DeinitializerDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DeinitializerDeclSyntax`.
@@ -10636,13 +10618,13 @@ public struct DeinitializerDecl: DeclBuildable, ExpressibleAsDeinitializerDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -10650,12 +10632,12 @@ public struct DeinitializerDecl: DeclBuildable, ExpressibleAsDeinitializerDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -10713,7 +10695,7 @@ public struct SubscriptDecl: DeclBuildable, ExpressibleAsSubscriptDecl {
     assert(subscriptKeyword.text == #"subscript"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes?.createUnexpectedNodes(), attributes: attributes?.createAttributeList(), unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes(), modifiers: modifiers?.createModifierList(), unexpectedBetweenModifiersAndSubscriptKeyword: unexpectedBetweenModifiersAndSubscriptKeyword?.createUnexpectedNodes(), subscriptKeyword: subscriptKeyword, unexpectedBetweenSubscriptKeywordAndGenericParameterClause: unexpectedBetweenSubscriptKeywordAndGenericParameterClause?.createUnexpectedNodes(), genericParameterClause: genericParameterClause?.createGenericParameterClause(), unexpectedBetweenGenericParameterClauseAndIndices: unexpectedBetweenGenericParameterClauseAndIndices?.createUnexpectedNodes(), indices: indices.createParameterClause(), unexpectedBetweenIndicesAndResult: unexpectedBetweenIndicesAndResult?.createUnexpectedNodes(), result: result.createReturnClause(), unexpectedBetweenResultAndGenericWhereClause: unexpectedBetweenResultAndGenericWhereClause?.createUnexpectedNodes(), genericWhereClause: genericWhereClause?.createGenericWhereClause(), unexpectedBetweenGenericWhereClauseAndAccessor: unexpectedBetweenGenericWhereClauseAndAccessor?.createUnexpectedNodes(), accessor: accessor?.createSyntaxBuildable()))
   }
-  public init (_ constructedNode: SubscriptDeclSyntax) {
+  public init(_ constructedNode: SubscriptDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `SubscriptDeclSyntax`.
@@ -10762,13 +10744,13 @@ public struct SubscriptDecl: DeclBuildable, ExpressibleAsSubscriptDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -10776,12 +10758,12 @@ public struct SubscriptDecl: DeclBuildable, ExpressibleAsSubscriptDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -10820,7 +10802,7 @@ public struct AccessLevelModifier: SyntaxBuildable, ExpressibleAsAccessLevelModi
   public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndModifier: ExpressibleAsUnexpectedNodes? = nil, modifier: ExpressibleAsDeclModifierDetail? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeName: unexpectedBeforeName, name: Token.`identifier`(name), unexpectedBetweenNameAndModifier: unexpectedBetweenNameAndModifier, modifier: modifier)
   }
-  public init (_ constructedNode: AccessLevelModifierSyntax) {
+  public init(_ constructedNode: AccessLevelModifierSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AccessLevelModifierSyntax`.
@@ -10862,13 +10844,13 @@ public struct AccessLevelModifier: SyntaxBuildable, ExpressibleAsAccessLevelModi
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -10876,12 +10858,12 @@ public struct AccessLevelModifier: SyntaxBuildable, ExpressibleAsAccessLevelModi
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -10921,7 +10903,7 @@ public struct AccessPathComponent: SyntaxBuildable, ExpressibleAsAccessPathCompo
   public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndTrailingDot: ExpressibleAsUnexpectedNodes? = nil, trailingDot: Token? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeName: unexpectedBeforeName, name: Token.`identifier`(name), unexpectedBetweenNameAndTrailingDot: unexpectedBetweenNameAndTrailingDot, trailingDot: trailingDot)
   }
-  public init (_ constructedNode: AccessPathComponentSyntax) {
+  public init(_ constructedNode: AccessPathComponentSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AccessPathComponentSyntax`.
@@ -10963,13 +10945,13 @@ public struct AccessPathComponent: SyntaxBuildable, ExpressibleAsAccessPathCompo
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -10977,12 +10959,12 @@ public struct AccessPathComponent: SyntaxBuildable, ExpressibleAsAccessPathCompo
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -11029,7 +11011,7 @@ public struct ImportDecl: DeclBuildable, ExpressibleAsImportDecl {
     assert(importKind == nil || importKind!.text == #"typealias"# || importKind!.text == #"struct"# || importKind!.text == #"class"# || importKind!.text == #"enum"# || importKind!.text == #"protocol"# || importKind!.text == #"var"# || importKind!.text == #"let"# || importKind!.text == #"func"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes?.createUnexpectedNodes(), attributes: attributes?.createAttributeList(), unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes(), modifiers: modifiers?.createModifierList(), unexpectedBetweenModifiersAndImportTok: unexpectedBetweenModifiersAndImportTok?.createUnexpectedNodes(), importTok: importTok, unexpectedBetweenImportTokAndImportKind: unexpectedBetweenImportTokAndImportKind?.createUnexpectedNodes(), importKind: importKind, unexpectedBetweenImportKindAndPath: unexpectedBetweenImportKindAndPath?.createUnexpectedNodes(), path: path.createAccessPath()))
   }
-  public init (_ constructedNode: ImportDeclSyntax) {
+  public init(_ constructedNode: ImportDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ImportDeclSyntax`.
@@ -11078,13 +11060,13 @@ public struct ImportDecl: DeclBuildable, ExpressibleAsImportDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -11092,12 +11074,12 @@ public struct ImportDecl: DeclBuildable, ExpressibleAsImportDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -11142,7 +11124,7 @@ public struct AccessorParameter: SyntaxBuildable, ExpressibleAsAccessorParameter
   public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndName: ExpressibleAsUnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLeftParen: unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndName: unexpectedBetweenLeftParenAndName, name: Token.`identifier`(name), unexpectedBetweenNameAndRightParen: unexpectedBetweenNameAndRightParen, rightParen: rightParen)
   }
-  public init (_ constructedNode: AccessorParameterSyntax) {
+  public init(_ constructedNode: AccessorParameterSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AccessorParameterSyntax`.
@@ -11184,13 +11166,13 @@ public struct AccessorParameter: SyntaxBuildable, ExpressibleAsAccessorParameter
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -11198,12 +11180,12 @@ public struct AccessorParameter: SyntaxBuildable, ExpressibleAsAccessorParameter
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -11265,11 +11247,9 @@ public struct AccessorDecl: DeclBuildable, ExpressibleAsAccessorDecl {
   public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifier: ExpressibleAsUnexpectedNodes? = nil, modifier: ExpressibleAsDeclModifier? = nil, unexpectedBetweenModifierAndAccessorKind: ExpressibleAsUnexpectedNodes? = nil, accessorKind: Token, unexpectedBetweenAccessorKindAndParameter: ExpressibleAsUnexpectedNodes? = nil, parameter: ExpressibleAsAccessorParameter? = nil, unexpectedBetweenParameterAndAsyncKeyword: ExpressibleAsUnexpectedNodes? = nil, asyncKeyword: String?, unexpectedBetweenAsyncKeywordAndThrowsKeyword: ExpressibleAsUnexpectedNodes? = nil, throwsKeyword: Token? = nil, unexpectedBetweenThrowsKeywordAndBody: ExpressibleAsUnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> ExpressibleAsCodeBlockItemList? =  {
     nil
   }) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifier: unexpectedBetweenAttributesAndModifier, modifier: modifier, unexpectedBetweenModifierAndAccessorKind: unexpectedBetweenModifierAndAccessorKind, accessorKind: accessorKind, unexpectedBetweenAccessorKindAndParameter: unexpectedBetweenAccessorKindAndParameter, parameter: parameter, unexpectedBetweenParameterAndAsyncKeyword: unexpectedBetweenParameterAndAsyncKeyword, asyncKeyword: asyncKeyword.map {
-      Token.`contextualKeyword`($0)
-    }, unexpectedBetweenAsyncKeywordAndThrowsKeyword: unexpectedBetweenAsyncKeywordAndThrowsKeyword, throwsKeyword: throwsKeyword, unexpectedBetweenThrowsKeywordAndBody: unexpectedBetweenThrowsKeywordAndBody, body: bodyBuilder())
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifier: unexpectedBetweenAttributesAndModifier, modifier: modifier, unexpectedBetweenModifierAndAccessorKind: unexpectedBetweenModifierAndAccessorKind, accessorKind: accessorKind, unexpectedBetweenAccessorKindAndParameter: unexpectedBetweenAccessorKindAndParameter, parameter: parameter, unexpectedBetweenParameterAndAsyncKeyword: unexpectedBetweenParameterAndAsyncKeyword, asyncKeyword: asyncKeyword.map { Token.`contextualKeyword`($0) }, unexpectedBetweenAsyncKeywordAndThrowsKeyword: unexpectedBetweenAsyncKeywordAndThrowsKeyword, throwsKeyword: throwsKeyword, unexpectedBetweenThrowsKeywordAndBody: unexpectedBetweenThrowsKeywordAndBody, body: bodyBuilder())
   }
-  public init (_ constructedNode: AccessorDeclSyntax) {
+  public init(_ constructedNode: AccessorDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AccessorDeclSyntax`.
@@ -11318,13 +11298,13 @@ public struct AccessorDecl: DeclBuildable, ExpressibleAsAccessorDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -11332,12 +11312,12 @@ public struct AccessorDecl: DeclBuildable, ExpressibleAsAccessorDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -11376,7 +11356,7 @@ public struct AccessorBlock: SyntaxBuildable, ExpressibleAsAccessorBlock {
     assert(rightBrace.text == #"}"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLeftBrace: unexpectedBeforeLeftBrace?.createUnexpectedNodes(), leftBrace: leftBrace, unexpectedBetweenLeftBraceAndAccessors: unexpectedBetweenLeftBraceAndAccessors?.createUnexpectedNodes(), accessors: accessors.createAccessorList(), unexpectedBetweenAccessorsAndRightBrace: unexpectedBetweenAccessorsAndRightBrace?.createUnexpectedNodes(), rightBrace: rightBrace))
   }
-  public init (_ constructedNode: AccessorBlockSyntax) {
+  public init(_ constructedNode: AccessorBlockSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AccessorBlockSyntax`.
@@ -11418,13 +11398,13 @@ public struct AccessorBlock: SyntaxBuildable, ExpressibleAsAccessorBlock {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -11432,12 +11412,12 @@ public struct AccessorBlock: SyntaxBuildable, ExpressibleAsAccessorBlock {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -11469,9 +11449,9 @@ public struct PatternBinding: SyntaxBuildable, ExpressibleAsPatternBinding, HasT
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -11491,7 +11471,7 @@ public struct PatternBinding: SyntaxBuildable, ExpressibleAsPatternBinding, HasT
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePattern: unexpectedBeforePattern?.createUnexpectedNodes(), pattern: pattern.createPatternBuildable(), unexpectedBetweenPatternAndTypeAnnotation: unexpectedBetweenPatternAndTypeAnnotation?.createUnexpectedNodes(), typeAnnotation: typeAnnotation?.createTypeAnnotation(), unexpectedBetweenTypeAnnotationAndInitializer: unexpectedBetweenTypeAnnotationAndInitializer?.createUnexpectedNodes(), initializer: initializer?.createInitializerClause(), unexpectedBetweenInitializerAndAccessor: unexpectedBetweenInitializerAndAccessor?.createUnexpectedNodes(), accessor: accessor?.createSyntaxBuildable(), unexpectedBetweenAccessorAndTrailingComma: unexpectedBetweenAccessorAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: PatternBindingSyntax) {
+  public init(_ constructedNode: PatternBindingSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PatternBindingSyntax`.
@@ -11534,12 +11514,12 @@ public struct PatternBinding: SyntaxBuildable, ExpressibleAsPatternBinding, HasT
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -11548,13 +11528,13 @@ public struct PatternBinding: SyntaxBuildable, ExpressibleAsPatternBinding, HasT
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -11562,12 +11542,12 @@ public struct PatternBinding: SyntaxBuildable, ExpressibleAsPatternBinding, HasT
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -11617,7 +11597,7 @@ public struct VariableDecl: DeclBuildable, ExpressibleAsVariableDecl {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndLetOrVarKeyword: unexpectedBetweenModifiersAndLetOrVarKeyword, letOrVarKeyword: letOrVarKeyword, unexpectedBetweenLetOrVarKeywordAndBindings: unexpectedBetweenLetOrVarKeywordAndBindings, bindings: bindingsBuilder())
   }
-  public init (_ constructedNode: VariableDeclSyntax) {
+  public init(_ constructedNode: VariableDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `VariableDeclSyntax`.
@@ -11666,13 +11646,13 @@ public struct VariableDecl: DeclBuildable, ExpressibleAsVariableDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -11680,12 +11660,12 @@ public struct VariableDecl: DeclBuildable, ExpressibleAsVariableDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -11716,9 +11696,9 @@ public struct EnumCaseElement: SyntaxBuildable, ExpressibleAsEnumCaseElement, Ha
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -11742,7 +11722,7 @@ public struct EnumCaseElement: SyntaxBuildable, ExpressibleAsEnumCaseElement, Ha
   public init (leadingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndAssociatedValue: ExpressibleAsUnexpectedNodes? = nil, associatedValue: ExpressibleAsParameterClause? = nil, unexpectedBetweenAssociatedValueAndRawValue: ExpressibleAsUnexpectedNodes? = nil, rawValue: ExpressibleAsInitializerClause? = nil, unexpectedBetweenRawValueAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeIdentifier: unexpectedBeforeIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndAssociatedValue: unexpectedBetweenIdentifierAndAssociatedValue, associatedValue: associatedValue, unexpectedBetweenAssociatedValueAndRawValue: unexpectedBetweenAssociatedValueAndRawValue, rawValue: rawValue, unexpectedBetweenRawValueAndTrailingComma: unexpectedBetweenRawValueAndTrailingComma, trailingComma: trailingComma)
   }
-  public init (_ constructedNode: EnumCaseElementSyntax) {
+  public init(_ constructedNode: EnumCaseElementSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `EnumCaseElementSyntax`.
@@ -11785,12 +11765,12 @@ public struct EnumCaseElement: SyntaxBuildable, ExpressibleAsEnumCaseElement, Ha
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -11799,13 +11779,13 @@ public struct EnumCaseElement: SyntaxBuildable, ExpressibleAsEnumCaseElement, Ha
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -11813,12 +11793,12 @@ public struct EnumCaseElement: SyntaxBuildable, ExpressibleAsEnumCaseElement, Ha
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -11869,7 +11849,7 @@ public struct EnumCaseDecl: DeclBuildable, ExpressibleAsEnumCaseDecl {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndCaseKeyword: unexpectedBetweenModifiersAndCaseKeyword, caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndElements: unexpectedBetweenCaseKeywordAndElements, elements: elementsBuilder())
   }
-  public init (_ constructedNode: EnumCaseDeclSyntax) {
+  public init(_ constructedNode: EnumCaseDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `EnumCaseDeclSyntax`.
@@ -11918,13 +11898,13 @@ public struct EnumCaseDecl: DeclBuildable, ExpressibleAsEnumCaseDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -11932,12 +11912,12 @@ public struct EnumCaseDecl: DeclBuildable, ExpressibleAsEnumCaseDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -12004,7 +11984,7 @@ public struct EnumDecl: DeclBuildable, ExpressibleAsEnumDecl {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndEnumKeyword: unexpectedBetweenModifiersAndEnumKeyword, enumKeyword: enumKeyword, unexpectedBetweenEnumKeywordAndIdentifier: unexpectedBetweenEnumKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndGenericParameters: unexpectedBetweenIdentifierAndGenericParameters, genericParameters: genericParameters, unexpectedBetweenGenericParametersAndInheritanceClause: unexpectedBetweenGenericParametersAndInheritanceClause, inheritanceClause: inheritanceClause, unexpectedBetweenInheritanceClauseAndGenericWhereClause: unexpectedBetweenInheritanceClauseAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndMembers: unexpectedBetweenGenericWhereClauseAndMembers, members: membersBuilder())
   }
-  public init (_ constructedNode: EnumDeclSyntax) {
+  public init(_ constructedNode: EnumDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `EnumDeclSyntax`.
@@ -12053,13 +12033,13 @@ public struct EnumDecl: DeclBuildable, ExpressibleAsEnumDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -12067,12 +12047,12 @@ public struct EnumDecl: DeclBuildable, ExpressibleAsEnumDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -12119,7 +12099,7 @@ public struct OperatorDecl: DeclBuildable, ExpressibleAsOperatorDecl {
     assert(operatorKeyword.text == #"operator"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes?.createUnexpectedNodes(), attributes: attributes?.createAttributeList(), unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers?.createUnexpectedNodes(), modifiers: modifiers?.createModifierList(), unexpectedBetweenModifiersAndOperatorKeyword: unexpectedBetweenModifiersAndOperatorKeyword?.createUnexpectedNodes(), operatorKeyword: operatorKeyword, unexpectedBetweenOperatorKeywordAndIdentifier: unexpectedBetweenOperatorKeywordAndIdentifier?.createUnexpectedNodes(), identifier: identifier, unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes: unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes?.createUnexpectedNodes(), operatorPrecedenceAndTypes: operatorPrecedenceAndTypes?.createOperatorPrecedenceAndTypes()))
   }
-  public init (_ constructedNode: OperatorDeclSyntax) {
+  public init(_ constructedNode: OperatorDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `OperatorDeclSyntax`.
@@ -12168,13 +12148,13 @@ public struct OperatorDecl: DeclBuildable, ExpressibleAsOperatorDecl {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -12182,12 +12162,12 @@ public struct OperatorDecl: DeclBuildable, ExpressibleAsOperatorDecl {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -12227,7 +12207,7 @@ public struct DesignatedTypeElement: SyntaxBuildable, ExpressibleAsDesignatedTyp
   public init (leadingTrivia: Trivia = [], unexpectedBeforeLeadingComma: ExpressibleAsUnexpectedNodes? = nil, leadingComma: Token = Token.`comma`, unexpectedBetweenLeadingCommaAndName: ExpressibleAsUnexpectedNodes? = nil, name: String) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLeadingComma: unexpectedBeforeLeadingComma, leadingComma: leadingComma, unexpectedBetweenLeadingCommaAndName: unexpectedBetweenLeadingCommaAndName, name: Token.`identifier`(name))
   }
-  public init (_ constructedNode: DesignatedTypeElementSyntax) {
+  public init(_ constructedNode: DesignatedTypeElementSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DesignatedTypeElementSyntax`.
@@ -12269,13 +12249,13 @@ public struct DesignatedTypeElement: SyntaxBuildable, ExpressibleAsDesignatedTyp
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -12283,12 +12263,12 @@ public struct DesignatedTypeElement: SyntaxBuildable, ExpressibleAsDesignatedTyp
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -12333,7 +12313,7 @@ public struct OperatorPrecedenceAndTypes: SyntaxBuildable, ExpressibleAsOperator
   public init (leadingTrivia: Trivia = [], unexpectedBeforeColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndPrecedenceGroup: ExpressibleAsUnexpectedNodes? = nil, precedenceGroup: String, unexpectedBetweenPrecedenceGroupAndDesignatedTypes: ExpressibleAsUnexpectedNodes? = nil, designatedTypes: ExpressibleAsDesignatedTypeList) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeColon: unexpectedBeforeColon, colon: colon, unexpectedBetweenColonAndPrecedenceGroup: unexpectedBetweenColonAndPrecedenceGroup, precedenceGroup: Token.`identifier`(precedenceGroup), unexpectedBetweenPrecedenceGroupAndDesignatedTypes: unexpectedBetweenPrecedenceGroupAndDesignatedTypes, designatedTypes: designatedTypes)
   }
-  public init (_ constructedNode: OperatorPrecedenceAndTypesSyntax) {
+  public init(_ constructedNode: OperatorPrecedenceAndTypesSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `OperatorPrecedenceAndTypesSyntax`.
@@ -12375,13 +12355,13 @@ public struct OperatorPrecedenceAndTypes: SyntaxBuildable, ExpressibleAsOperator
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -12389,12 +12369,12 @@ public struct OperatorPrecedenceAndTypes: SyntaxBuildable, ExpressibleAsOperator
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -12457,7 +12437,7 @@ public struct PrecedenceGroupDecl: DeclBuildable, ExpressibleAsPrecedenceGroupDe
   public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndModifiers: ExpressibleAsUnexpectedNodes? = nil, modifiers: ExpressibleAsModifierList? = nil, unexpectedBetweenModifiersAndPrecedencegroupKeyword: ExpressibleAsUnexpectedNodes? = nil, precedencegroupKeyword: Token = Token.`precedencegroup`, unexpectedBetweenPrecedencegroupKeywordAndIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: String, unexpectedBetweenIdentifierAndLeftBrace: ExpressibleAsUnexpectedNodes? = nil, leftBrace: Token = Token.`leftBrace`, unexpectedBetweenLeftBraceAndGroupAttributes: ExpressibleAsUnexpectedNodes? = nil, groupAttributes: ExpressibleAsPrecedenceGroupAttributeList, unexpectedBetweenGroupAttributesAndRightBrace: ExpressibleAsUnexpectedNodes? = nil, rightBrace: Token = Token.`rightBrace`) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndModifiers: unexpectedBetweenAttributesAndModifiers, modifiers: modifiers, unexpectedBetweenModifiersAndPrecedencegroupKeyword: unexpectedBetweenModifiersAndPrecedencegroupKeyword, precedencegroupKeyword: precedencegroupKeyword, unexpectedBetweenPrecedencegroupKeywordAndIdentifier: unexpectedBetweenPrecedencegroupKeywordAndIdentifier, identifier: Token.`identifier`(identifier), unexpectedBetweenIdentifierAndLeftBrace: unexpectedBetweenIdentifierAndLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndGroupAttributes: unexpectedBetweenLeftBraceAndGroupAttributes, groupAttributes: groupAttributes, unexpectedBetweenGroupAttributesAndRightBrace: unexpectedBetweenGroupAttributesAndRightBrace, rightBrace: rightBrace)
   }
-  public init (_ constructedNode: PrecedenceGroupDeclSyntax) {
+  public init(_ constructedNode: PrecedenceGroupDeclSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PrecedenceGroupDeclSyntax`.
@@ -12506,13 +12486,13 @@ public struct PrecedenceGroupDecl: DeclBuildable, ExpressibleAsPrecedenceGroupDe
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -12520,12 +12500,12 @@ public struct PrecedenceGroupDecl: DeclBuildable, ExpressibleAsPrecedenceGroupDe
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -12571,7 +12551,7 @@ public struct PrecedenceGroupRelation: SyntaxBuildable, ExpressibleAsPrecedenceG
   public init (leadingTrivia: Trivia = [], unexpectedBeforeHigherThanOrLowerThan: ExpressibleAsUnexpectedNodes? = nil, higherThanOrLowerThan: String, unexpectedBetweenHigherThanOrLowerThanAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndOtherNames: ExpressibleAsUnexpectedNodes? = nil, otherNames: ExpressibleAsPrecedenceGroupNameList) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeHigherThanOrLowerThan: unexpectedBeforeHigherThanOrLowerThan, higherThanOrLowerThan: Token.`identifier`(higherThanOrLowerThan), unexpectedBetweenHigherThanOrLowerThanAndColon: unexpectedBetweenHigherThanOrLowerThanAndColon, colon: colon, unexpectedBetweenColonAndOtherNames: unexpectedBetweenColonAndOtherNames, otherNames: otherNames)
   }
-  public init (_ constructedNode: PrecedenceGroupRelationSyntax) {
+  public init(_ constructedNode: PrecedenceGroupRelationSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PrecedenceGroupRelationSyntax`.
@@ -12613,13 +12593,13 @@ public struct PrecedenceGroupRelation: SyntaxBuildable, ExpressibleAsPrecedenceG
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -12627,12 +12607,12 @@ public struct PrecedenceGroupRelation: SyntaxBuildable, ExpressibleAsPrecedenceG
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -12672,7 +12652,7 @@ public struct PrecedenceGroupNameElement: SyntaxBuildable, ExpressibleAsPreceden
   public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeName: unexpectedBeforeName, name: Token.`identifier`(name), unexpectedBetweenNameAndTrailingComma: unexpectedBetweenNameAndTrailingComma, trailingComma: trailingComma)
   }
-  public init (_ constructedNode: PrecedenceGroupNameElementSyntax) {
+  public init(_ constructedNode: PrecedenceGroupNameElementSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PrecedenceGroupNameElementSyntax`.
@@ -12714,13 +12694,13 @@ public struct PrecedenceGroupNameElement: SyntaxBuildable, ExpressibleAsPreceden
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -12728,12 +12708,12 @@ public struct PrecedenceGroupNameElement: SyntaxBuildable, ExpressibleAsPreceden
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -12780,7 +12760,7 @@ public struct PrecedenceGroupAssignment: SyntaxBuildable, ExpressibleAsPrecedenc
   public init (leadingTrivia: Trivia = [], unexpectedBeforeAssignmentKeyword: ExpressibleAsUnexpectedNodes? = nil, assignmentKeyword: String, unexpectedBetweenAssignmentKeywordAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndFlag: ExpressibleAsUnexpectedNodes? = nil, flag: Token) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAssignmentKeyword: unexpectedBeforeAssignmentKeyword, assignmentKeyword: Token.`identifier`(assignmentKeyword), unexpectedBetweenAssignmentKeywordAndColon: unexpectedBetweenAssignmentKeywordAndColon, colon: colon, unexpectedBetweenColonAndFlag: unexpectedBetweenColonAndFlag, flag: flag)
   }
-  public init (_ constructedNode: PrecedenceGroupAssignmentSyntax) {
+  public init(_ constructedNode: PrecedenceGroupAssignmentSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PrecedenceGroupAssignmentSyntax`.
@@ -12822,13 +12802,13 @@ public struct PrecedenceGroupAssignment: SyntaxBuildable, ExpressibleAsPrecedenc
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -12836,12 +12816,12 @@ public struct PrecedenceGroupAssignment: SyntaxBuildable, ExpressibleAsPrecedenc
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -12888,7 +12868,7 @@ public struct PrecedenceGroupAssociativity: SyntaxBuildable, ExpressibleAsPreced
   public init (leadingTrivia: Trivia = [], unexpectedBeforeAssociativityKeyword: ExpressibleAsUnexpectedNodes? = nil, associativityKeyword: String, unexpectedBetweenAssociativityKeywordAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: ExpressibleAsUnexpectedNodes? = nil, value: String) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAssociativityKeyword: unexpectedBeforeAssociativityKeyword, associativityKeyword: Token.`identifier`(associativityKeyword), unexpectedBetweenAssociativityKeywordAndColon: unexpectedBetweenAssociativityKeywordAndColon, colon: colon, unexpectedBetweenColonAndValue: unexpectedBetweenColonAndValue, value: Token.`identifier`(value))
   }
-  public init (_ constructedNode: PrecedenceGroupAssociativitySyntax) {
+  public init(_ constructedNode: PrecedenceGroupAssociativitySyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PrecedenceGroupAssociativitySyntax`.
@@ -12930,13 +12910,13 @@ public struct PrecedenceGroupAssociativity: SyntaxBuildable, ExpressibleAsPreced
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -12944,12 +12924,12 @@ public struct PrecedenceGroupAssociativity: SyntaxBuildable, ExpressibleAsPreced
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -13006,7 +12986,7 @@ public struct CustomAttribute: SyntaxBuildable, ExpressibleAsCustomAttribute {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAtSignToken: unexpectedBeforeAtSignToken, atSignToken: atSignToken, unexpectedBetweenAtSignTokenAndAttributeName: unexpectedBetweenAtSignTokenAndAttributeName, attributeName: attributeName, unexpectedBetweenAttributeNameAndLeftParen: unexpectedBetweenAttributeNameAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndArgumentList: unexpectedBetweenLeftParenAndArgumentList, argumentList: argumentListBuilder(), unexpectedBetweenArgumentListAndRightParen: unexpectedBetweenArgumentListAndRightParen, rightParen: rightParen)
   }
-  public init (_ constructedNode: CustomAttributeSyntax) {
+  public init(_ constructedNode: CustomAttributeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `CustomAttributeSyntax`.
@@ -13048,13 +13028,13 @@ public struct CustomAttribute: SyntaxBuildable, ExpressibleAsCustomAttribute {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -13062,12 +13042,12 @@ public struct CustomAttribute: SyntaxBuildable, ExpressibleAsCustomAttribute {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -13120,7 +13100,7 @@ public struct Attribute: SyntaxBuildable, ExpressibleAsAttribute {
     assert(rightParen == nil || rightParen!.text == #")"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeAtSignToken: unexpectedBeforeAtSignToken?.createUnexpectedNodes(), atSignToken: atSignToken, unexpectedBetweenAtSignTokenAndAttributeName: unexpectedBetweenAtSignTokenAndAttributeName?.createUnexpectedNodes(), attributeName: attributeName, unexpectedBetweenAttributeNameAndLeftParen: unexpectedBetweenAttributeNameAndLeftParen?.createUnexpectedNodes(), leftParen: leftParen, unexpectedBetweenLeftParenAndArgument: unexpectedBetweenLeftParenAndArgument?.createUnexpectedNodes(), argument: argument?.createSyntaxBuildable(), unexpectedBetweenArgumentAndRightParen: unexpectedBetweenArgumentAndRightParen?.createUnexpectedNodes(), rightParen: rightParen, unexpectedBetweenRightParenAndTokenList: unexpectedBetweenRightParenAndTokenList?.createUnexpectedNodes(), tokenList: tokenList?.createTokenList()))
   }
-  public init (_ constructedNode: AttributeSyntax) {
+  public init(_ constructedNode: AttributeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AttributeSyntax`.
@@ -13162,13 +13142,13 @@ public struct Attribute: SyntaxBuildable, ExpressibleAsAttribute {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -13176,12 +13156,12 @@ public struct Attribute: SyntaxBuildable, ExpressibleAsAttribute {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -13231,7 +13211,7 @@ public struct AvailabilityEntry: SyntaxBuildable, ExpressibleAsAvailabilityEntry
   public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: String, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndAvailabilityList: ExpressibleAsUnexpectedNodes? = nil, availabilityList: ExpressibleAsAvailabilitySpecList, unexpectedBetweenAvailabilityListAndSemicolon: ExpressibleAsUnexpectedNodes? = nil, semicolon: Token = Token.`semicolon`) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLabel: unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon: unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndAvailabilityList: unexpectedBetweenColonAndAvailabilityList, availabilityList: availabilityList, unexpectedBetweenAvailabilityListAndSemicolon: unexpectedBetweenAvailabilityListAndSemicolon, semicolon: semicolon)
   }
-  public init (_ constructedNode: AvailabilityEntrySyntax) {
+  public init(_ constructedNode: AvailabilityEntrySyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AvailabilityEntrySyntax`.
@@ -13273,13 +13253,13 @@ public struct AvailabilityEntry: SyntaxBuildable, ExpressibleAsAvailabilityEntry
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -13287,12 +13267,12 @@ public struct AvailabilityEntry: SyntaxBuildable, ExpressibleAsAvailabilityEntry
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -13323,9 +13303,9 @@ public struct LabeledSpecializeEntry: SyntaxBuildable, ExpressibleAsLabeledSpeci
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -13350,7 +13330,7 @@ public struct LabeledSpecializeEntry: SyntaxBuildable, ExpressibleAsLabeledSpeci
   public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: String, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: ExpressibleAsUnexpectedNodes? = nil, value: Token, unexpectedBetweenValueAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLabel: unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon: unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndValue: unexpectedBetweenColonAndValue, value: value, unexpectedBetweenValueAndTrailingComma: unexpectedBetweenValueAndTrailingComma, trailingComma: trailingComma)
   }
-  public init (_ constructedNode: LabeledSpecializeEntrySyntax) {
+  public init(_ constructedNode: LabeledSpecializeEntrySyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `LabeledSpecializeEntrySyntax`.
@@ -13393,12 +13373,12 @@ public struct LabeledSpecializeEntry: SyntaxBuildable, ExpressibleAsLabeledSpeci
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -13407,13 +13387,13 @@ public struct LabeledSpecializeEntry: SyntaxBuildable, ExpressibleAsLabeledSpeci
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -13421,12 +13401,12 @@ public struct LabeledSpecializeEntry: SyntaxBuildable, ExpressibleAsLabeledSpeci
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -13457,9 +13437,9 @@ public struct TargetFunctionEntry: SyntaxBuildable, ExpressibleAsTargetFunctionE
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -13484,7 +13464,7 @@ public struct TargetFunctionEntry: SyntaxBuildable, ExpressibleAsTargetFunctionE
   public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: String, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndDeclname: ExpressibleAsUnexpectedNodes? = nil, declname: ExpressibleAsDeclName, unexpectedBetweenDeclnameAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLabel: unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon: unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndDeclname: unexpectedBetweenColonAndDeclname, declname: declname, unexpectedBetweenDeclnameAndTrailingComma: unexpectedBetweenDeclnameAndTrailingComma, trailingComma: trailingComma)
   }
-  public init (_ constructedNode: TargetFunctionEntrySyntax) {
+  public init(_ constructedNode: TargetFunctionEntrySyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `TargetFunctionEntrySyntax`.
@@ -13527,12 +13507,12 @@ public struct TargetFunctionEntry: SyntaxBuildable, ExpressibleAsTargetFunctionE
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -13541,13 +13521,13 @@ public struct TargetFunctionEntry: SyntaxBuildable, ExpressibleAsTargetFunctionE
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -13555,12 +13535,12 @@ public struct TargetFunctionEntry: SyntaxBuildable, ExpressibleAsTargetFunctionE
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -13599,7 +13579,7 @@ public struct NamedAttributeStringArgument: SyntaxBuildable, ExpressibleAsNamedA
     assert(colon.text == #":"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeNameTok: unexpectedBeforeNameTok?.createUnexpectedNodes(), nameTok: nameTok, unexpectedBetweenNameTokAndColon: unexpectedBetweenNameTokAndColon?.createUnexpectedNodes(), colon: colon, unexpectedBetweenColonAndStringOrDeclname: unexpectedBetweenColonAndStringOrDeclname?.createUnexpectedNodes(), stringOrDeclname: stringOrDeclname.createSyntaxBuildable()))
   }
-  public init (_ constructedNode: NamedAttributeStringArgumentSyntax) {
+  public init(_ constructedNode: NamedAttributeStringArgumentSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `NamedAttributeStringArgumentSyntax`.
@@ -13641,13 +13621,13 @@ public struct NamedAttributeStringArgument: SyntaxBuildable, ExpressibleAsNamedA
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -13655,12 +13635,12 @@ public struct NamedAttributeStringArgument: SyntaxBuildable, ExpressibleAsNamedA
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -13693,7 +13673,7 @@ public struct DeclName: SyntaxBuildable, ExpressibleAsDeclName {
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDeclBaseName: ExpressibleAsUnexpectedNodes? = nil, declBaseName: ExpressibleAsSyntaxBuildable, unexpectedBetweenDeclBaseNameAndDeclNameArguments: ExpressibleAsUnexpectedNodes? = nil, declNameArguments: ExpressibleAsDeclNameArguments? = nil) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeDeclBaseName: unexpectedBeforeDeclBaseName?.createUnexpectedNodes(), declBaseName: declBaseName.createSyntaxBuildable(), unexpectedBetweenDeclBaseNameAndDeclNameArguments: unexpectedBetweenDeclBaseNameAndDeclNameArguments?.createUnexpectedNodes(), declNameArguments: declNameArguments?.createDeclNameArguments()))
   }
-  public init (_ constructedNode: DeclNameSyntax) {
+  public init(_ constructedNode: DeclNameSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DeclNameSyntax`.
@@ -13735,13 +13715,13 @@ public struct DeclName: SyntaxBuildable, ExpressibleAsDeclName {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -13749,12 +13729,12 @@ public struct DeclName: SyntaxBuildable, ExpressibleAsDeclName {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -13797,7 +13777,7 @@ public struct ImplementsAttributeArguments: SyntaxBuildable, ExpressibleAsImplem
     assert(comma.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeType: unexpectedBeforeType?.createUnexpectedNodes(), type: type.createTypeBuildable(), unexpectedBetweenTypeAndComma: unexpectedBetweenTypeAndComma?.createUnexpectedNodes(), comma: comma, unexpectedBetweenCommaAndDeclBaseName: unexpectedBetweenCommaAndDeclBaseName?.createUnexpectedNodes(), declBaseName: declBaseName, unexpectedBetweenDeclBaseNameAndDeclNameArguments: unexpectedBetweenDeclBaseNameAndDeclNameArguments?.createUnexpectedNodes(), declNameArguments: declNameArguments?.createDeclNameArguments()))
   }
-  public init (_ constructedNode: ImplementsAttributeArgumentsSyntax) {
+  public init(_ constructedNode: ImplementsAttributeArgumentsSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ImplementsAttributeArgumentsSyntax`.
@@ -13839,13 +13819,13 @@ public struct ImplementsAttributeArguments: SyntaxBuildable, ExpressibleAsImplem
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -13853,12 +13833,12 @@ public struct ImplementsAttributeArguments: SyntaxBuildable, ExpressibleAsImplem
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -13897,11 +13877,9 @@ public struct ObjCSelectorPiece: SyntaxBuildable, ExpressibleAsObjCSelectorPiece
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: String?, unexpectedBetweenNameAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeName: unexpectedBeforeName, name: name.map {
-      Token.`identifier`($0)
-    }, unexpectedBetweenNameAndColon: unexpectedBetweenNameAndColon, colon: colon)
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeName: unexpectedBeforeName, name: name.map { Token.`identifier`($0) }, unexpectedBetweenNameAndColon: unexpectedBetweenNameAndColon, colon: colon)
   }
-  public init (_ constructedNode: ObjCSelectorPieceSyntax) {
+  public init(_ constructedNode: ObjCSelectorPieceSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ObjCSelectorPieceSyntax`.
@@ -13943,13 +13921,13 @@ public struct ObjCSelectorPiece: SyntaxBuildable, ExpressibleAsObjCSelectorPiece
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -13957,12 +13935,12 @@ public struct ObjCSelectorPiece: SyntaxBuildable, ExpressibleAsObjCSelectorPiece
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -14015,11 +13993,9 @@ public struct DifferentiableAttributeArguments: SyntaxBuildable, ExpressibleAsDi
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforeDiffKind: ExpressibleAsUnexpectedNodes? = nil, diffKind: String?, unexpectedBetweenDiffKindAndDiffKindComma: ExpressibleAsUnexpectedNodes? = nil, diffKindComma: Token? = nil, unexpectedBetweenDiffKindCommaAndDiffParams: ExpressibleAsUnexpectedNodes? = nil, diffParams: ExpressibleAsDifferentiabilityParamsClause? = nil, unexpectedBetweenDiffParamsAndDiffParamsComma: ExpressibleAsUnexpectedNodes? = nil, diffParamsComma: Token? = nil, unexpectedBetweenDiffParamsCommaAndWhereClause: ExpressibleAsUnexpectedNodes? = nil, whereClause: ExpressibleAsGenericWhereClause? = nil) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeDiffKind: unexpectedBeforeDiffKind, diffKind: diffKind.map {
-      Token.`identifier`($0)
-    }, unexpectedBetweenDiffKindAndDiffKindComma: unexpectedBetweenDiffKindAndDiffKindComma, diffKindComma: diffKindComma, unexpectedBetweenDiffKindCommaAndDiffParams: unexpectedBetweenDiffKindCommaAndDiffParams, diffParams: diffParams, unexpectedBetweenDiffParamsAndDiffParamsComma: unexpectedBetweenDiffParamsAndDiffParamsComma, diffParamsComma: diffParamsComma, unexpectedBetweenDiffParamsCommaAndWhereClause: unexpectedBetweenDiffParamsCommaAndWhereClause, whereClause: whereClause)
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeDiffKind: unexpectedBeforeDiffKind, diffKind: diffKind.map { Token.`identifier`($0) }, unexpectedBetweenDiffKindAndDiffKindComma: unexpectedBetweenDiffKindAndDiffKindComma, diffKindComma: diffKindComma, unexpectedBetweenDiffKindCommaAndDiffParams: unexpectedBetweenDiffKindCommaAndDiffParams, diffParams: diffParams, unexpectedBetweenDiffParamsAndDiffParamsComma: unexpectedBetweenDiffParamsAndDiffParamsComma, diffParamsComma: diffParamsComma, unexpectedBetweenDiffParamsCommaAndWhereClause: unexpectedBetweenDiffParamsCommaAndWhereClause, whereClause: whereClause)
   }
-  public init (_ constructedNode: DifferentiableAttributeArgumentsSyntax) {
+  public init(_ constructedNode: DifferentiableAttributeArgumentsSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DifferentiableAttributeArgumentsSyntax`.
@@ -14061,13 +14037,13 @@ public struct DifferentiableAttributeArguments: SyntaxBuildable, ExpressibleAsDi
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -14075,12 +14051,12 @@ public struct DifferentiableAttributeArguments: SyntaxBuildable, ExpressibleAsDi
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -14126,7 +14102,7 @@ public struct DifferentiabilityParamsClause: SyntaxBuildable, ExpressibleAsDiffe
   public init (leadingTrivia: Trivia = [], unexpectedBeforeWrtLabel: ExpressibleAsUnexpectedNodes? = nil, wrtLabel: String, unexpectedBetweenWrtLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndParameters: ExpressibleAsUnexpectedNodes? = nil, parameters: ExpressibleAsSyntaxBuildable) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeWrtLabel: unexpectedBeforeWrtLabel, wrtLabel: Token.`identifier`(wrtLabel), unexpectedBetweenWrtLabelAndColon: unexpectedBetweenWrtLabelAndColon, colon: colon, unexpectedBetweenColonAndParameters: unexpectedBetweenColonAndParameters, parameters: parameters)
   }
-  public init (_ constructedNode: DifferentiabilityParamsClauseSyntax) {
+  public init(_ constructedNode: DifferentiabilityParamsClauseSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DifferentiabilityParamsClauseSyntax`.
@@ -14168,13 +14144,13 @@ public struct DifferentiabilityParamsClause: SyntaxBuildable, ExpressibleAsDiffe
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -14182,12 +14158,12 @@ public struct DifferentiabilityParamsClause: SyntaxBuildable, ExpressibleAsDiffe
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -14227,7 +14203,7 @@ public struct DifferentiabilityParams: SyntaxBuildable, ExpressibleAsDifferentia
     assert(rightParen.text == #")"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLeftParen: unexpectedBeforeLeftParen?.createUnexpectedNodes(), leftParen: leftParen, unexpectedBetweenLeftParenAndDiffParams: unexpectedBetweenLeftParenAndDiffParams?.createUnexpectedNodes(), diffParams: diffParams.createDifferentiabilityParamList(), unexpectedBetweenDiffParamsAndRightParen: unexpectedBetweenDiffParamsAndRightParen?.createUnexpectedNodes(), rightParen: rightParen))
   }
-  public init (_ constructedNode: DifferentiabilityParamsSyntax) {
+  public init(_ constructedNode: DifferentiabilityParamsSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DifferentiabilityParamsSyntax`.
@@ -14269,13 +14245,13 @@ public struct DifferentiabilityParams: SyntaxBuildable, ExpressibleAsDifferentia
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -14283,12 +14259,12 @@ public struct DifferentiabilityParams: SyntaxBuildable, ExpressibleAsDifferentia
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -14315,9 +14291,9 @@ public struct DifferentiabilityParam: SyntaxBuildable, ExpressibleAsDifferentiab
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -14331,7 +14307,7 @@ public struct DifferentiabilityParam: SyntaxBuildable, ExpressibleAsDifferentiab
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeParameter: unexpectedBeforeParameter?.createUnexpectedNodes(), parameter: parameter.createSyntaxBuildable(), unexpectedBetweenParameterAndTrailingComma: unexpectedBetweenParameterAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: DifferentiabilityParamSyntax) {
+  public init(_ constructedNode: DifferentiabilityParamSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DifferentiabilityParamSyntax`.
@@ -14374,12 +14350,12 @@ public struct DifferentiabilityParam: SyntaxBuildable, ExpressibleAsDifferentiab
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -14388,13 +14364,13 @@ public struct DifferentiabilityParam: SyntaxBuildable, ExpressibleAsDifferentiab
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -14402,12 +14378,12 @@ public struct DifferentiabilityParam: SyntaxBuildable, ExpressibleAsDifferentiab
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -14470,11 +14446,9 @@ public struct DerivativeRegistrationAttributeArguments: SyntaxBuildable, Express
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforeOfLabel: ExpressibleAsUnexpectedNodes? = nil, ofLabel: String, unexpectedBetweenOfLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndOriginalDeclName: ExpressibleAsUnexpectedNodes? = nil, originalDeclName: ExpressibleAsQualifiedDeclName, unexpectedBetweenOriginalDeclNameAndPeriod: ExpressibleAsUnexpectedNodes? = nil, period: Token? = nil, unexpectedBetweenPeriodAndAccessorKind: ExpressibleAsUnexpectedNodes? = nil, accessorKind: String?, unexpectedBetweenAccessorKindAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndDiffParams: ExpressibleAsUnexpectedNodes? = nil, diffParams: ExpressibleAsDifferentiabilityParamsClause? = nil) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeOfLabel: unexpectedBeforeOfLabel, ofLabel: Token.`identifier`(ofLabel), unexpectedBetweenOfLabelAndColon: unexpectedBetweenOfLabelAndColon, colon: colon, unexpectedBetweenColonAndOriginalDeclName: unexpectedBetweenColonAndOriginalDeclName, originalDeclName: originalDeclName, unexpectedBetweenOriginalDeclNameAndPeriod: unexpectedBetweenOriginalDeclNameAndPeriod, period: period, unexpectedBetweenPeriodAndAccessorKind: unexpectedBetweenPeriodAndAccessorKind, accessorKind: accessorKind.map {
-      Token.`identifier`($0)
-    }, unexpectedBetweenAccessorKindAndComma: unexpectedBetweenAccessorKindAndComma, comma: comma, unexpectedBetweenCommaAndDiffParams: unexpectedBetweenCommaAndDiffParams, diffParams: diffParams)
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeOfLabel: unexpectedBeforeOfLabel, ofLabel: Token.`identifier`(ofLabel), unexpectedBetweenOfLabelAndColon: unexpectedBetweenOfLabelAndColon, colon: colon, unexpectedBetweenColonAndOriginalDeclName: unexpectedBetweenColonAndOriginalDeclName, originalDeclName: originalDeclName, unexpectedBetweenOriginalDeclNameAndPeriod: unexpectedBetweenOriginalDeclNameAndPeriod, period: period, unexpectedBetweenPeriodAndAccessorKind: unexpectedBetweenPeriodAndAccessorKind, accessorKind: accessorKind.map { Token.`identifier`($0) }, unexpectedBetweenAccessorKindAndComma: unexpectedBetweenAccessorKindAndComma, comma: comma, unexpectedBetweenCommaAndDiffParams: unexpectedBetweenCommaAndDiffParams, diffParams: diffParams)
   }
-  public init (_ constructedNode: DerivativeRegistrationAttributeArgumentsSyntax) {
+  public init(_ constructedNode: DerivativeRegistrationAttributeArgumentsSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DerivativeRegistrationAttributeArgumentsSyntax`.
@@ -14516,13 +14490,13 @@ public struct DerivativeRegistrationAttributeArguments: SyntaxBuildable, Express
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -14530,12 +14504,12 @@ public struct DerivativeRegistrationAttributeArguments: SyntaxBuildable, Express
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -14578,7 +14552,7 @@ public struct QualifiedDeclName: SyntaxBuildable, ExpressibleAsQualifiedDeclName
     assert(dot == nil || dot!.text == #"."# || dot!.text == #"."#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeBaseType: unexpectedBeforeBaseType?.createUnexpectedNodes(), baseType: baseType?.createTypeBuildable(), unexpectedBetweenBaseTypeAndDot: unexpectedBetweenBaseTypeAndDot?.createUnexpectedNodes(), dot: dot, unexpectedBetweenDotAndName: unexpectedBetweenDotAndName?.createUnexpectedNodes(), name: name, unexpectedBetweenNameAndArguments: unexpectedBetweenNameAndArguments?.createUnexpectedNodes(), arguments: arguments?.createDeclNameArguments()))
   }
-  public init (_ constructedNode: QualifiedDeclNameSyntax) {
+  public init(_ constructedNode: QualifiedDeclNameSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `QualifiedDeclNameSyntax`.
@@ -14620,13 +14594,13 @@ public struct QualifiedDeclName: SyntaxBuildable, ExpressibleAsQualifiedDeclName
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -14634,12 +14608,12 @@ public struct QualifiedDeclName: SyntaxBuildable, ExpressibleAsQualifiedDeclName
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -14673,7 +14647,7 @@ public struct FunctionDeclName: SyntaxBuildable, ExpressibleAsFunctionDeclName {
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: ExpressibleAsSyntaxBuildable, unexpectedBetweenNameAndArguments: ExpressibleAsUnexpectedNodes? = nil, arguments: ExpressibleAsDeclNameArguments? = nil) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeName: unexpectedBeforeName?.createUnexpectedNodes(), name: name.createSyntaxBuildable(), unexpectedBetweenNameAndArguments: unexpectedBetweenNameAndArguments?.createUnexpectedNodes(), arguments: arguments?.createDeclNameArguments()))
   }
-  public init (_ constructedNode: FunctionDeclNameSyntax) {
+  public init(_ constructedNode: FunctionDeclNameSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `FunctionDeclNameSyntax`.
@@ -14715,13 +14689,13 @@ public struct FunctionDeclName: SyntaxBuildable, ExpressibleAsFunctionDeclName {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -14729,12 +14703,12 @@ public struct FunctionDeclName: SyntaxBuildable, ExpressibleAsFunctionDeclName {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -14780,7 +14754,7 @@ public struct BackDeployAttributeSpecList: SyntaxBuildable, ExpressibleAsBackDep
   public init (leadingTrivia: Trivia = [], unexpectedBeforeBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, beforeLabel: String, unexpectedBetweenBeforeLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndVersionList: ExpressibleAsUnexpectedNodes? = nil, versionList: ExpressibleAsBackDeployVersionList) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeBeforeLabel: unexpectedBeforeBeforeLabel, beforeLabel: Token.`identifier`(beforeLabel), unexpectedBetweenBeforeLabelAndColon: unexpectedBetweenBeforeLabelAndColon, colon: colon, unexpectedBetweenColonAndVersionList: unexpectedBetweenColonAndVersionList, versionList: versionList)
   }
-  public init (_ constructedNode: BackDeployAttributeSpecListSyntax) {
+  public init(_ constructedNode: BackDeployAttributeSpecListSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `BackDeployAttributeSpecListSyntax`.
@@ -14822,13 +14796,13 @@ public struct BackDeployAttributeSpecList: SyntaxBuildable, ExpressibleAsBackDep
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -14836,12 +14810,12 @@ public struct BackDeployAttributeSpecList: SyntaxBuildable, ExpressibleAsBackDep
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -14876,7 +14850,7 @@ public struct BackDeployVersionArgument: SyntaxBuildable, ExpressibleAsBackDeplo
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeAvailabilityVersionRestriction: unexpectedBeforeAvailabilityVersionRestriction?.createUnexpectedNodes(), availabilityVersionRestriction: availabilityVersionRestriction.createAvailabilityVersionRestriction(), unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma: unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: BackDeployVersionArgumentSyntax) {
+  public init(_ constructedNode: BackDeployVersionArgumentSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `BackDeployVersionArgumentSyntax`.
@@ -14918,13 +14892,13 @@ public struct BackDeployVersionArgument: SyntaxBuildable, ExpressibleAsBackDeplo
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -14932,12 +14906,12 @@ public struct BackDeployVersionArgument: SyntaxBuildable, ExpressibleAsBackDeplo
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -14982,7 +14956,7 @@ public struct OpaqueReturnTypeOfAttributeArguments: SyntaxBuildable, Expressible
   public init (leadingTrivia: Trivia = [], unexpectedBeforeMangledName: ExpressibleAsUnexpectedNodes? = nil, mangledName: String, unexpectedBetweenMangledNameAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token = Token.`comma`, unexpectedBetweenCommaAndOrdinal: ExpressibleAsUnexpectedNodes? = nil, ordinal: String) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeMangledName: unexpectedBeforeMangledName, mangledName: Token.`stringLiteral`(mangledName), unexpectedBetweenMangledNameAndComma: unexpectedBetweenMangledNameAndComma, comma: comma, unexpectedBetweenCommaAndOrdinal: unexpectedBetweenCommaAndOrdinal, ordinal: Token.`integerLiteral`(ordinal))
   }
-  public init (_ constructedNode: OpaqueReturnTypeOfAttributeArgumentsSyntax) {
+  public init(_ constructedNode: OpaqueReturnTypeOfAttributeArgumentsSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `OpaqueReturnTypeOfAttributeArgumentsSyntax`.
@@ -15024,13 +14998,13 @@ public struct OpaqueReturnTypeOfAttributeArguments: SyntaxBuildable, Expressible
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -15038,12 +15012,12 @@ public struct OpaqueReturnTypeOfAttributeArguments: SyntaxBuildable, Expressible
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -15097,13 +15071,9 @@ public struct ConventionAttributeArguments: SyntaxBuildable, ExpressibleAsConven
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforeConventionLabel: ExpressibleAsUnexpectedNodes? = nil, conventionLabel: String, unexpectedBetweenConventionLabelAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndCTypeLabel: ExpressibleAsUnexpectedNodes? = nil, cTypeLabel: String?, unexpectedBetweenCTypeLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndCTypeString: ExpressibleAsUnexpectedNodes? = nil, cTypeString: String?) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeConventionLabel: unexpectedBeforeConventionLabel, conventionLabel: Token.`identifier`(conventionLabel), unexpectedBetweenConventionLabelAndComma: unexpectedBetweenConventionLabelAndComma, comma: comma, unexpectedBetweenCommaAndCTypeLabel: unexpectedBetweenCommaAndCTypeLabel, cTypeLabel: cTypeLabel.map {
-      Token.`identifier`($0)
-    }, unexpectedBetweenCTypeLabelAndColon: unexpectedBetweenCTypeLabelAndColon, colon: colon, unexpectedBetweenColonAndCTypeString: unexpectedBetweenColonAndCTypeString, cTypeString: cTypeString.map {
-      Token.`stringLiteral`($0)
-    })
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeConventionLabel: unexpectedBeforeConventionLabel, conventionLabel: Token.`identifier`(conventionLabel), unexpectedBetweenConventionLabelAndComma: unexpectedBetweenConventionLabelAndComma, comma: comma, unexpectedBetweenCommaAndCTypeLabel: unexpectedBetweenCommaAndCTypeLabel, cTypeLabel: cTypeLabel.map { Token.`identifier`($0) }, unexpectedBetweenCTypeLabelAndColon: unexpectedBetweenCTypeLabelAndColon, colon: colon, unexpectedBetweenColonAndCTypeString: unexpectedBetweenColonAndCTypeString, cTypeString: cTypeString.map { Token.`stringLiteral`($0) })
   }
-  public init (_ constructedNode: ConventionAttributeArgumentsSyntax) {
+  public init(_ constructedNode: ConventionAttributeArgumentsSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ConventionAttributeArgumentsSyntax`.
@@ -15145,13 +15115,13 @@ public struct ConventionAttributeArguments: SyntaxBuildable, ExpressibleAsConven
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -15159,12 +15129,12 @@ public struct ConventionAttributeArguments: SyntaxBuildable, ExpressibleAsConven
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -15209,7 +15179,7 @@ public struct ConventionWitnessMethodAttributeArguments: SyntaxBuildable, Expres
   public init (leadingTrivia: Trivia = [], unexpectedBeforeWitnessMethodLabel: ExpressibleAsUnexpectedNodes? = nil, witnessMethodLabel: String, unexpectedBetweenWitnessMethodLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndProtocolName: ExpressibleAsUnexpectedNodes? = nil, protocolName: String) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeWitnessMethodLabel: unexpectedBeforeWitnessMethodLabel, witnessMethodLabel: Token.`identifier`(witnessMethodLabel), unexpectedBetweenWitnessMethodLabelAndColon: unexpectedBetweenWitnessMethodLabelAndColon, colon: colon, unexpectedBetweenColonAndProtocolName: unexpectedBetweenColonAndProtocolName, protocolName: Token.`identifier`(protocolName))
   }
-  public init (_ constructedNode: ConventionWitnessMethodAttributeArgumentsSyntax) {
+  public init(_ constructedNode: ConventionWitnessMethodAttributeArgumentsSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ConventionWitnessMethodAttributeArgumentsSyntax`.
@@ -15251,13 +15221,13 @@ public struct ConventionWitnessMethodAttributeArguments: SyntaxBuildable, Expres
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -15265,12 +15235,12 @@ public struct ConventionWitnessMethodAttributeArguments: SyntaxBuildable, Expres
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -15314,7 +15284,7 @@ public struct LabeledStmt: StmtBuildable, ExpressibleAsLabeledStmt {
   public init (leadingTrivia: Trivia = [], unexpectedBeforeLabelName: ExpressibleAsUnexpectedNodes? = nil, labelName: String, unexpectedBetweenLabelNameAndLabelColon: ExpressibleAsUnexpectedNodes? = nil, labelColon: Token = Token.`colon`, unexpectedBetweenLabelColonAndStatement: ExpressibleAsUnexpectedNodes? = nil, statement: ExpressibleAsStmtBuildable) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLabelName: unexpectedBeforeLabelName, labelName: Token.`identifier`(labelName), unexpectedBetweenLabelNameAndLabelColon: unexpectedBetweenLabelNameAndLabelColon, labelColon: labelColon, unexpectedBetweenLabelColonAndStatement: unexpectedBetweenLabelColonAndStatement, statement: statement)
   }
-  public init (_ constructedNode: LabeledStmtSyntax) {
+  public init(_ constructedNode: LabeledStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `LabeledStmtSyntax`.
@@ -15363,13 +15333,13 @@ public struct LabeledStmt: StmtBuildable, ExpressibleAsLabeledStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -15377,12 +15347,12 @@ public struct LabeledStmt: StmtBuildable, ExpressibleAsLabeledStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -15420,11 +15390,9 @@ public struct ContinueStmt: StmtBuildable, ExpressibleAsContinueStmt {
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforeContinueKeyword: ExpressibleAsUnexpectedNodes? = nil, continueKeyword: Token = Token.`continue`, unexpectedBetweenContinueKeywordAndLabel: ExpressibleAsUnexpectedNodes? = nil, label: String?) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeContinueKeyword: unexpectedBeforeContinueKeyword, continueKeyword: continueKeyword, unexpectedBetweenContinueKeywordAndLabel: unexpectedBetweenContinueKeywordAndLabel, label: label.map {
-      Token.`identifier`($0)
-    })
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeContinueKeyword: unexpectedBeforeContinueKeyword, continueKeyword: continueKeyword, unexpectedBetweenContinueKeywordAndLabel: unexpectedBetweenContinueKeywordAndLabel, label: label.map { Token.`identifier`($0) })
   }
-  public init (_ constructedNode: ContinueStmtSyntax) {
+  public init(_ constructedNode: ContinueStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ContinueStmtSyntax`.
@@ -15473,13 +15441,13 @@ public struct ContinueStmt: StmtBuildable, ExpressibleAsContinueStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -15487,12 +15455,12 @@ public struct ContinueStmt: StmtBuildable, ExpressibleAsContinueStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -15538,7 +15506,7 @@ public struct WhileStmt: StmtBuildable, ExpressibleAsWhileStmt {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeWhileKeyword: unexpectedBeforeWhileKeyword, whileKeyword: whileKeyword, unexpectedBetweenWhileKeywordAndConditions: unexpectedBetweenWhileKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndBody: unexpectedBetweenConditionsAndBody, body: bodyBuilder())
   }
-  public init (_ constructedNode: WhileStmtSyntax) {
+  public init(_ constructedNode: WhileStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `WhileStmtSyntax`.
@@ -15587,13 +15555,13 @@ public struct WhileStmt: StmtBuildable, ExpressibleAsWhileStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -15601,12 +15569,12 @@ public struct WhileStmt: StmtBuildable, ExpressibleAsWhileStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -15648,7 +15616,7 @@ public struct DeferStmt: StmtBuildable, ExpressibleAsDeferStmt {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeDeferKeyword: unexpectedBeforeDeferKeyword, deferKeyword: deferKeyword, unexpectedBetweenDeferKeywordAndBody: unexpectedBetweenDeferKeywordAndBody, body: bodyBuilder())
   }
-  public init (_ constructedNode: DeferStmtSyntax) {
+  public init(_ constructedNode: DeferStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DeferStmtSyntax`.
@@ -15697,13 +15665,13 @@ public struct DeferStmt: StmtBuildable, ExpressibleAsDeferStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -15711,12 +15679,12 @@ public struct DeferStmt: StmtBuildable, ExpressibleAsDeferStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -15745,7 +15713,7 @@ public struct ExpressionStmt: StmtBuildable, ExpressibleAsExpressionStmt {
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeExpression: unexpectedBeforeExpression?.createUnexpectedNodes(), expression: expression.createExprBuildable()))
   }
-  public init (_ constructedNode: ExpressionStmtSyntax) {
+  public init(_ constructedNode: ExpressionStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ExpressionStmtSyntax`.
@@ -15794,13 +15762,13 @@ public struct ExpressionStmt: StmtBuildable, ExpressibleAsExpressionStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -15808,12 +15776,12 @@ public struct ExpressionStmt: StmtBuildable, ExpressibleAsExpressionStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -15864,7 +15832,7 @@ public struct RepeatWhileStmt: StmtBuildable, ExpressibleAsRepeatWhileStmt {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeRepeatKeyword: unexpectedBeforeRepeatKeyword, repeatKeyword: repeatKeyword, unexpectedBetweenRepeatKeywordAndBody: unexpectedBetweenRepeatKeywordAndBody, body: bodyBuilder(), unexpectedBetweenBodyAndWhileKeyword: unexpectedBetweenBodyAndWhileKeyword, whileKeyword: whileKeyword, unexpectedBetweenWhileKeywordAndCondition: unexpectedBetweenWhileKeywordAndCondition, condition: condition)
   }
-  public init (_ constructedNode: RepeatWhileStmtSyntax) {
+  public init(_ constructedNode: RepeatWhileStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `RepeatWhileStmtSyntax`.
@@ -15913,13 +15881,13 @@ public struct RepeatWhileStmt: StmtBuildable, ExpressibleAsRepeatWhileStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -15927,12 +15895,12 @@ public struct RepeatWhileStmt: StmtBuildable, ExpressibleAsRepeatWhileStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -15983,7 +15951,7 @@ public struct GuardStmt: StmtBuildable, ExpressibleAsGuardStmt {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeGuardKeyword: unexpectedBeforeGuardKeyword, guardKeyword: guardKeyword, unexpectedBetweenGuardKeywordAndConditions: unexpectedBetweenGuardKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndElseKeyword: unexpectedBetweenConditionsAndElseKeyword, elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndBody: unexpectedBetweenElseKeywordAndBody, body: bodyBuilder())
   }
-  public init (_ constructedNode: GuardStmtSyntax) {
+  public init(_ constructedNode: GuardStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `GuardStmtSyntax`.
@@ -16032,13 +16000,13 @@ public struct GuardStmt: StmtBuildable, ExpressibleAsGuardStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -16046,12 +16014,12 @@ public struct GuardStmt: StmtBuildable, ExpressibleAsGuardStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -16085,7 +16053,7 @@ public struct WhereClause: SyntaxBuildable, ExpressibleAsWhereClause {
     assert(whereKeyword.text == #"where"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeWhereKeyword: unexpectedBeforeWhereKeyword?.createUnexpectedNodes(), whereKeyword: whereKeyword, unexpectedBetweenWhereKeywordAndGuardResult: unexpectedBetweenWhereKeywordAndGuardResult?.createUnexpectedNodes(), guardResult: guardResult.createExprBuildable()))
   }
-  public init (_ constructedNode: WhereClauseSyntax) {
+  public init(_ constructedNode: WhereClauseSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `WhereClauseSyntax`.
@@ -16127,13 +16095,13 @@ public struct WhereClause: SyntaxBuildable, ExpressibleAsWhereClause {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -16141,12 +16109,12 @@ public struct WhereClause: SyntaxBuildable, ExpressibleAsWhereClause {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -16222,11 +16190,9 @@ public struct ForInStmt: StmtBuildable, ExpressibleAsForInStmt {
   public init (leadingTrivia: Trivia = [], unexpectedBeforeForKeyword: ExpressibleAsUnexpectedNodes? = nil, forKeyword: Token = Token.`for`, unexpectedBetweenForKeywordAndTryKeyword: ExpressibleAsUnexpectedNodes? = nil, tryKeyword: Token? = nil, unexpectedBetweenTryKeywordAndAwaitKeyword: ExpressibleAsUnexpectedNodes? = nil, awaitKeyword: String?, unexpectedBetweenAwaitKeywordAndCaseKeyword: ExpressibleAsUnexpectedNodes? = nil, caseKeyword: Token? = nil, unexpectedBetweenCaseKeywordAndPattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndTypeAnnotation: ExpressibleAsUnexpectedNodes? = nil, typeAnnotation: ExpressibleAsTypeAnnotation? = nil, unexpectedBetweenTypeAnnotationAndInKeyword: ExpressibleAsUnexpectedNodes? = nil, inKeyword: Token = Token.`in`, unexpectedBetweenInKeywordAndSequenceExpr: ExpressibleAsUnexpectedNodes? = nil, sequenceExpr: ExpressibleAsExprBuildable, unexpectedBetweenSequenceExprAndWhereClause: ExpressibleAsUnexpectedNodes? = nil, whereClause: ExpressibleAsWhereClause? = nil, unexpectedBetweenWhereClauseAndBody: ExpressibleAsUnexpectedNodes? = nil, @CodeBlockItemListBuilder bodyBuilder: () -> ExpressibleAsCodeBlockItemList =  {
     CodeBlockItemList([])
   }) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeForKeyword: unexpectedBeforeForKeyword, forKeyword: forKeyword, unexpectedBetweenForKeywordAndTryKeyword: unexpectedBetweenForKeywordAndTryKeyword, tryKeyword: tryKeyword, unexpectedBetweenTryKeywordAndAwaitKeyword: unexpectedBetweenTryKeywordAndAwaitKeyword, awaitKeyword: awaitKeyword.map {
-      Token.`identifier`($0)
-    }, unexpectedBetweenAwaitKeywordAndCaseKeyword: unexpectedBetweenAwaitKeywordAndCaseKeyword, caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndPattern: unexpectedBetweenCaseKeywordAndPattern, pattern: pattern, unexpectedBetweenPatternAndTypeAnnotation: unexpectedBetweenPatternAndTypeAnnotation, typeAnnotation: typeAnnotation, unexpectedBetweenTypeAnnotationAndInKeyword: unexpectedBetweenTypeAnnotationAndInKeyword, inKeyword: inKeyword, unexpectedBetweenInKeywordAndSequenceExpr: unexpectedBetweenInKeywordAndSequenceExpr, sequenceExpr: sequenceExpr, unexpectedBetweenSequenceExprAndWhereClause: unexpectedBetweenSequenceExprAndWhereClause, whereClause: whereClause, unexpectedBetweenWhereClauseAndBody: unexpectedBetweenWhereClauseAndBody, body: bodyBuilder())
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeForKeyword: unexpectedBeforeForKeyword, forKeyword: forKeyword, unexpectedBetweenForKeywordAndTryKeyword: unexpectedBetweenForKeywordAndTryKeyword, tryKeyword: tryKeyword, unexpectedBetweenTryKeywordAndAwaitKeyword: unexpectedBetweenTryKeywordAndAwaitKeyword, awaitKeyword: awaitKeyword.map { Token.`identifier`($0) }, unexpectedBetweenAwaitKeywordAndCaseKeyword: unexpectedBetweenAwaitKeywordAndCaseKeyword, caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndPattern: unexpectedBetweenCaseKeywordAndPattern, pattern: pattern, unexpectedBetweenPatternAndTypeAnnotation: unexpectedBetweenPatternAndTypeAnnotation, typeAnnotation: typeAnnotation, unexpectedBetweenTypeAnnotationAndInKeyword: unexpectedBetweenTypeAnnotationAndInKeyword, inKeyword: inKeyword, unexpectedBetweenInKeywordAndSequenceExpr: unexpectedBetweenInKeywordAndSequenceExpr, sequenceExpr: sequenceExpr, unexpectedBetweenSequenceExprAndWhereClause: unexpectedBetweenSequenceExprAndWhereClause, whereClause: whereClause, unexpectedBetweenWhereClauseAndBody: unexpectedBetweenWhereClauseAndBody, body: bodyBuilder())
   }
-  public init (_ constructedNode: ForInStmtSyntax) {
+  public init(_ constructedNode: ForInStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ForInStmtSyntax`.
@@ -16275,13 +16241,13 @@ public struct ForInStmt: StmtBuildable, ExpressibleAsForInStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -16289,12 +16255,12 @@ public struct ForInStmt: StmtBuildable, ExpressibleAsForInStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -16350,7 +16316,7 @@ public struct SwitchStmt: StmtBuildable, ExpressibleAsSwitchStmt {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeSwitchKeyword: unexpectedBeforeSwitchKeyword, switchKeyword: switchKeyword, unexpectedBetweenSwitchKeywordAndExpression: unexpectedBetweenSwitchKeywordAndExpression, expression: expression, unexpectedBetweenExpressionAndLeftBrace: unexpectedBetweenExpressionAndLeftBrace, leftBrace: leftBrace, unexpectedBetweenLeftBraceAndCases: unexpectedBetweenLeftBraceAndCases, cases: casesBuilder(), unexpectedBetweenCasesAndRightBrace: unexpectedBetweenCasesAndRightBrace, rightBrace: rightBrace)
   }
-  public init (_ constructedNode: SwitchStmtSyntax) {
+  public init(_ constructedNode: SwitchStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `SwitchStmtSyntax`.
@@ -16399,13 +16365,13 @@ public struct SwitchStmt: StmtBuildable, ExpressibleAsSwitchStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -16413,12 +16379,12 @@ public struct SwitchStmt: StmtBuildable, ExpressibleAsSwitchStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -16464,7 +16430,7 @@ public struct DoStmt: StmtBuildable, ExpressibleAsDoStmt {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeDoKeyword: unexpectedBeforeDoKeyword, doKeyword: doKeyword, unexpectedBetweenDoKeywordAndBody: unexpectedBetweenDoKeywordAndBody, body: bodyBuilder(), unexpectedBetweenBodyAndCatchClauses: unexpectedBetweenBodyAndCatchClauses, catchClauses: catchClauses)
   }
-  public init (_ constructedNode: DoStmtSyntax) {
+  public init(_ constructedNode: DoStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DoStmtSyntax`.
@@ -16513,13 +16479,13 @@ public struct DoStmt: StmtBuildable, ExpressibleAsDoStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -16527,12 +16493,12 @@ public struct DoStmt: StmtBuildable, ExpressibleAsDoStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -16566,7 +16532,7 @@ public struct ReturnStmt: StmtBuildable, ExpressibleAsReturnStmt {
     assert(returnKeyword.text == #"return"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeReturnKeyword: unexpectedBeforeReturnKeyword?.createUnexpectedNodes(), returnKeyword: returnKeyword, unexpectedBetweenReturnKeywordAndExpression: unexpectedBetweenReturnKeywordAndExpression?.createUnexpectedNodes(), expression: expression?.createExprBuildable()))
   }
-  public init (_ constructedNode: ReturnStmtSyntax) {
+  public init(_ constructedNode: ReturnStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ReturnStmtSyntax`.
@@ -16615,13 +16581,13 @@ public struct ReturnStmt: StmtBuildable, ExpressibleAsReturnStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -16629,12 +16595,12 @@ public struct ReturnStmt: StmtBuildable, ExpressibleAsReturnStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -16668,7 +16634,7 @@ public struct YieldStmt: StmtBuildable, ExpressibleAsYieldStmt {
     assert(yieldKeyword.text == #"yield"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeYieldKeyword: unexpectedBeforeYieldKeyword?.createUnexpectedNodes(), yieldKeyword: yieldKeyword, unexpectedBetweenYieldKeywordAndYields: unexpectedBetweenYieldKeywordAndYields?.createUnexpectedNodes(), yields: yields.createSyntaxBuildable()))
   }
-  public init (_ constructedNode: YieldStmtSyntax) {
+  public init(_ constructedNode: YieldStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `YieldStmtSyntax`.
@@ -16717,13 +16683,13 @@ public struct YieldStmt: StmtBuildable, ExpressibleAsYieldStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -16731,12 +16697,12 @@ public struct YieldStmt: StmtBuildable, ExpressibleAsYieldStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -16788,7 +16754,7 @@ public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLeftParen: unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndElementList: unexpectedBetweenLeftParenAndElementList, elementList: elementListBuilder(), unexpectedBetweenElementListAndTrailingComma: unexpectedBetweenElementListAndTrailingComma, trailingComma: trailingComma, unexpectedBetweenTrailingCommaAndRightParen: unexpectedBetweenTrailingCommaAndRightParen, rightParen: rightParen)
   }
-  public init (_ constructedNode: YieldListSyntax) {
+  public init(_ constructedNode: YieldListSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `YieldListSyntax`.
@@ -16830,13 +16796,13 @@ public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -16844,12 +16810,12 @@ public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -16879,7 +16845,7 @@ public struct FallthroughStmt: StmtBuildable, ExpressibleAsFallthroughStmt {
     assert(fallthroughKeyword.text == #"fallthrough"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeFallthroughKeyword: unexpectedBeforeFallthroughKeyword?.createUnexpectedNodes(), fallthroughKeyword: fallthroughKeyword))
   }
-  public init (_ constructedNode: FallthroughStmtSyntax) {
+  public init(_ constructedNode: FallthroughStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `FallthroughStmtSyntax`.
@@ -16928,13 +16894,13 @@ public struct FallthroughStmt: StmtBuildable, ExpressibleAsFallthroughStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -16942,12 +16908,12 @@ public struct FallthroughStmt: StmtBuildable, ExpressibleAsFallthroughStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -16985,11 +16951,9 @@ public struct BreakStmt: StmtBuildable, ExpressibleAsBreakStmt {
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforeBreakKeyword: ExpressibleAsUnexpectedNodes? = nil, breakKeyword: Token = Token.`break`, unexpectedBetweenBreakKeywordAndLabel: ExpressibleAsUnexpectedNodes? = nil, label: String?) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeBreakKeyword: unexpectedBeforeBreakKeyword, breakKeyword: breakKeyword, unexpectedBetweenBreakKeywordAndLabel: unexpectedBetweenBreakKeywordAndLabel, label: label.map {
-      Token.`identifier`($0)
-    })
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeBreakKeyword: unexpectedBeforeBreakKeyword, breakKeyword: breakKeyword, unexpectedBetweenBreakKeywordAndLabel: unexpectedBetweenBreakKeywordAndLabel, label: label.map { Token.`identifier`($0) })
   }
-  public init (_ constructedNode: BreakStmtSyntax) {
+  public init(_ constructedNode: BreakStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `BreakStmtSyntax`.
@@ -17038,13 +17002,13 @@ public struct BreakStmt: StmtBuildable, ExpressibleAsBreakStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -17052,12 +17016,12 @@ public struct BreakStmt: StmtBuildable, ExpressibleAsBreakStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -17083,9 +17047,9 @@ public struct ConditionElement: SyntaxBuildable, ExpressibleAsConditionElement, 
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -17099,7 +17063,7 @@ public struct ConditionElement: SyntaxBuildable, ExpressibleAsConditionElement, 
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeCondition: unexpectedBeforeCondition?.createUnexpectedNodes(), condition: condition.createSyntaxBuildable(), unexpectedBetweenConditionAndTrailingComma: unexpectedBetweenConditionAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: ConditionElementSyntax) {
+  public init(_ constructedNode: ConditionElementSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ConditionElementSyntax`.
@@ -17142,12 +17106,12 @@ public struct ConditionElement: SyntaxBuildable, ExpressibleAsConditionElement, 
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -17156,13 +17120,13 @@ public struct ConditionElement: SyntaxBuildable, ExpressibleAsConditionElement, 
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -17170,12 +17134,12 @@ public struct ConditionElement: SyntaxBuildable, ExpressibleAsConditionElement, 
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -17219,7 +17183,7 @@ public struct AvailabilityCondition: SyntaxBuildable, ExpressibleAsAvailabilityC
     assert(rightParen.text == #")"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePoundAvailableKeyword: unexpectedBeforePoundAvailableKeyword?.createUnexpectedNodes(), poundAvailableKeyword: poundAvailableKeyword, unexpectedBetweenPoundAvailableKeywordAndLeftParen: unexpectedBetweenPoundAvailableKeywordAndLeftParen?.createUnexpectedNodes(), leftParen: leftParen, unexpectedBetweenLeftParenAndAvailabilitySpec: unexpectedBetweenLeftParenAndAvailabilitySpec?.createUnexpectedNodes(), availabilitySpec: availabilitySpec.createAvailabilitySpecList(), unexpectedBetweenAvailabilitySpecAndRightParen: unexpectedBetweenAvailabilitySpecAndRightParen?.createUnexpectedNodes(), rightParen: rightParen))
   }
-  public init (_ constructedNode: AvailabilityConditionSyntax) {
+  public init(_ constructedNode: AvailabilityConditionSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AvailabilityConditionSyntax`.
@@ -17261,13 +17225,13 @@ public struct AvailabilityCondition: SyntaxBuildable, ExpressibleAsAvailabilityC
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -17275,12 +17239,12 @@ public struct AvailabilityCondition: SyntaxBuildable, ExpressibleAsAvailabilityC
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -17322,7 +17286,7 @@ public struct MatchingPatternCondition: SyntaxBuildable, ExpressibleAsMatchingPa
     assert(caseKeyword.text == #"case"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeCaseKeyword: unexpectedBeforeCaseKeyword?.createUnexpectedNodes(), caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndPattern: unexpectedBetweenCaseKeywordAndPattern?.createUnexpectedNodes(), pattern: pattern.createPatternBuildable(), unexpectedBetweenPatternAndTypeAnnotation: unexpectedBetweenPatternAndTypeAnnotation?.createUnexpectedNodes(), typeAnnotation: typeAnnotation?.createTypeAnnotation(), unexpectedBetweenTypeAnnotationAndInitializer: unexpectedBetweenTypeAnnotationAndInitializer?.createUnexpectedNodes(), initializer: initializer.createInitializerClause()))
   }
-  public init (_ constructedNode: MatchingPatternConditionSyntax) {
+  public init(_ constructedNode: MatchingPatternConditionSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `MatchingPatternConditionSyntax`.
@@ -17364,13 +17328,13 @@ public struct MatchingPatternCondition: SyntaxBuildable, ExpressibleAsMatchingPa
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -17378,12 +17342,12 @@ public struct MatchingPatternCondition: SyntaxBuildable, ExpressibleAsMatchingPa
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -17425,7 +17389,7 @@ public struct OptionalBindingCondition: SyntaxBuildable, ExpressibleAsOptionalBi
     assert(letOrVarKeyword.text == #"let"# || letOrVarKeyword.text == #"var"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLetOrVarKeyword: unexpectedBeforeLetOrVarKeyword?.createUnexpectedNodes(), letOrVarKeyword: letOrVarKeyword, unexpectedBetweenLetOrVarKeywordAndPattern: unexpectedBetweenLetOrVarKeywordAndPattern?.createUnexpectedNodes(), pattern: pattern.createPatternBuildable(), unexpectedBetweenPatternAndTypeAnnotation: unexpectedBetweenPatternAndTypeAnnotation?.createUnexpectedNodes(), typeAnnotation: typeAnnotation?.createTypeAnnotation(), unexpectedBetweenTypeAnnotationAndInitializer: unexpectedBetweenTypeAnnotationAndInitializer?.createUnexpectedNodes(), initializer: initializer?.createInitializerClause()))
   }
-  public init (_ constructedNode: OptionalBindingConditionSyntax) {
+  public init(_ constructedNode: OptionalBindingConditionSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `OptionalBindingConditionSyntax`.
@@ -17467,13 +17431,13 @@ public struct OptionalBindingCondition: SyntaxBuildable, ExpressibleAsOptionalBi
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -17481,12 +17445,12 @@ public struct OptionalBindingCondition: SyntaxBuildable, ExpressibleAsOptionalBi
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -17530,7 +17494,7 @@ public struct UnavailabilityCondition: SyntaxBuildable, ExpressibleAsUnavailabil
     assert(rightParen.text == #")"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePoundUnavailableKeyword: unexpectedBeforePoundUnavailableKeyword?.createUnexpectedNodes(), poundUnavailableKeyword: poundUnavailableKeyword, unexpectedBetweenPoundUnavailableKeywordAndLeftParen: unexpectedBetweenPoundUnavailableKeywordAndLeftParen?.createUnexpectedNodes(), leftParen: leftParen, unexpectedBetweenLeftParenAndAvailabilitySpec: unexpectedBetweenLeftParenAndAvailabilitySpec?.createUnexpectedNodes(), availabilitySpec: availabilitySpec.createAvailabilitySpecList(), unexpectedBetweenAvailabilitySpecAndRightParen: unexpectedBetweenAvailabilitySpecAndRightParen?.createUnexpectedNodes(), rightParen: rightParen))
   }
-  public init (_ constructedNode: UnavailabilityConditionSyntax) {
+  public init(_ constructedNode: UnavailabilityConditionSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `UnavailabilityConditionSyntax`.
@@ -17572,13 +17536,13 @@ public struct UnavailabilityCondition: SyntaxBuildable, ExpressibleAsUnavailabil
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -17586,12 +17550,12 @@ public struct UnavailabilityCondition: SyntaxBuildable, ExpressibleAsUnavailabil
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -17634,7 +17598,7 @@ public struct HasSymbolCondition: SyntaxBuildable, ExpressibleAsHasSymbolConditi
     assert(rightParen.text == #")"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeHasSymbolKeyword: unexpectedBeforeHasSymbolKeyword?.createUnexpectedNodes(), hasSymbolKeyword: hasSymbolKeyword, unexpectedBetweenHasSymbolKeywordAndLeftParen: unexpectedBetweenHasSymbolKeywordAndLeftParen?.createUnexpectedNodes(), leftParen: leftParen, unexpectedBetweenLeftParenAndExpression: unexpectedBetweenLeftParenAndExpression?.createUnexpectedNodes(), expression: expression.createExprBuildable(), unexpectedBetweenExpressionAndRightParen: unexpectedBetweenExpressionAndRightParen?.createUnexpectedNodes(), rightParen: rightParen))
   }
-  public init (_ constructedNode: HasSymbolConditionSyntax) {
+  public init(_ constructedNode: HasSymbolConditionSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `HasSymbolConditionSyntax`.
@@ -17676,13 +17640,13 @@ public struct HasSymbolCondition: SyntaxBuildable, ExpressibleAsHasSymbolConditi
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -17690,12 +17654,12 @@ public struct HasSymbolCondition: SyntaxBuildable, ExpressibleAsHasSymbolConditi
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -17724,7 +17688,7 @@ public struct DeclarationStmt: StmtBuildable, ExpressibleAsDeclarationStmt {
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeDeclaration: ExpressibleAsUnexpectedNodes? = nil, declaration: ExpressibleAsDeclBuildable) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeDeclaration: unexpectedBeforeDeclaration?.createUnexpectedNodes(), declaration: declaration.createDeclBuildable()))
   }
-  public init (_ constructedNode: DeclarationStmtSyntax) {
+  public init(_ constructedNode: DeclarationStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DeclarationStmtSyntax`.
@@ -17773,13 +17737,13 @@ public struct DeclarationStmt: StmtBuildable, ExpressibleAsDeclarationStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -17787,12 +17751,12 @@ public struct DeclarationStmt: StmtBuildable, ExpressibleAsDeclarationStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -17826,7 +17790,7 @@ public struct ThrowStmt: StmtBuildable, ExpressibleAsThrowStmt {
     assert(throwKeyword.text == #"throw"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeThrowKeyword: unexpectedBeforeThrowKeyword?.createUnexpectedNodes(), throwKeyword: throwKeyword, unexpectedBetweenThrowKeywordAndExpression: unexpectedBetweenThrowKeywordAndExpression?.createUnexpectedNodes(), expression: expression.createExprBuildable()))
   }
-  public init (_ constructedNode: ThrowStmtSyntax) {
+  public init(_ constructedNode: ThrowStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ThrowStmtSyntax`.
@@ -17875,13 +17839,13 @@ public struct ThrowStmt: StmtBuildable, ExpressibleAsThrowStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -17889,12 +17853,12 @@ public struct ThrowStmt: StmtBuildable, ExpressibleAsThrowStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -17949,7 +17913,7 @@ public struct IfStmt: StmtBuildable, ExpressibleAsIfStmt {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeIfKeyword: unexpectedBeforeIfKeyword, ifKeyword: ifKeyword, unexpectedBetweenIfKeywordAndConditions: unexpectedBetweenIfKeywordAndConditions, conditions: conditions, unexpectedBetweenConditionsAndBody: unexpectedBetweenConditionsAndBody, body: bodyBuilder(), unexpectedBetweenBodyAndElseKeyword: unexpectedBetweenBodyAndElseKeyword, elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndElseBody: unexpectedBetweenElseKeywordAndElseBody, elseBody: elseBody)
   }
-  public init (_ constructedNode: IfStmtSyntax) {
+  public init(_ constructedNode: IfStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `IfStmtSyntax`.
@@ -17998,13 +17962,13 @@ public struct IfStmt: StmtBuildable, ExpressibleAsIfStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -18012,12 +17976,12 @@ public struct IfStmt: StmtBuildable, ExpressibleAsIfStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -18046,7 +18010,7 @@ public struct ElseIfContinuation: SyntaxBuildable, ExpressibleAsElseIfContinuati
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIfStatement: ExpressibleAsUnexpectedNodes? = nil, ifStatement: ExpressibleAsIfStmt) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeIfStatement: unexpectedBeforeIfStatement?.createUnexpectedNodes(), ifStatement: ifStatement.createIfStmt()))
   }
-  public init (_ constructedNode: ElseIfContinuationSyntax) {
+  public init(_ constructedNode: ElseIfContinuationSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ElseIfContinuationSyntax`.
@@ -18088,13 +18052,13 @@ public struct ElseIfContinuation: SyntaxBuildable, ExpressibleAsElseIfContinuati
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -18102,12 +18066,12 @@ public struct ElseIfContinuation: SyntaxBuildable, ExpressibleAsElseIfContinuati
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -18149,7 +18113,7 @@ public struct ElseBlock: SyntaxBuildable, ExpressibleAsElseBlock {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeElseKeyword: unexpectedBeforeElseKeyword, elseKeyword: elseKeyword, unexpectedBetweenElseKeywordAndBody: unexpectedBetweenElseKeywordAndBody, body: bodyBuilder())
   }
-  public init (_ constructedNode: ElseBlockSyntax) {
+  public init(_ constructedNode: ElseBlockSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ElseBlockSyntax`.
@@ -18191,13 +18155,13 @@ public struct ElseBlock: SyntaxBuildable, ExpressibleAsElseBlock {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -18205,12 +18169,12 @@ public struct ElseBlock: SyntaxBuildable, ExpressibleAsElseBlock {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -18255,7 +18219,7 @@ public struct SwitchCase: SyntaxBuildable, ExpressibleAsSwitchCase {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeUnknownAttr: unexpectedBeforeUnknownAttr, unknownAttr: unknownAttr, unexpectedBetweenUnknownAttrAndLabel: unexpectedBetweenUnknownAttrAndLabel, label: label, unexpectedBetweenLabelAndStatements: unexpectedBetweenLabelAndStatements, statements: statementsBuilder())
   }
-  public init (_ constructedNode: SwitchCaseSyntax) {
+  public init(_ constructedNode: SwitchCaseSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `SwitchCaseSyntax`.
@@ -18297,13 +18261,13 @@ public struct SwitchCase: SyntaxBuildable, ExpressibleAsSwitchCase {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -18311,12 +18275,12 @@ public struct SwitchCase: SyntaxBuildable, ExpressibleAsSwitchCase {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -18351,7 +18315,7 @@ public struct SwitchDefaultLabel: SyntaxBuildable, ExpressibleAsSwitchDefaultLab
     assert(colon.text == #":"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeDefaultKeyword: unexpectedBeforeDefaultKeyword?.createUnexpectedNodes(), defaultKeyword: defaultKeyword, unexpectedBetweenDefaultKeywordAndColon: unexpectedBetweenDefaultKeywordAndColon?.createUnexpectedNodes(), colon: colon))
   }
-  public init (_ constructedNode: SwitchDefaultLabelSyntax) {
+  public init(_ constructedNode: SwitchDefaultLabelSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `SwitchDefaultLabelSyntax`.
@@ -18393,13 +18357,13 @@ public struct SwitchDefaultLabel: SyntaxBuildable, ExpressibleAsSwitchDefaultLab
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -18407,12 +18371,12 @@ public struct SwitchDefaultLabel: SyntaxBuildable, ExpressibleAsSwitchDefaultLab
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -18440,9 +18404,9 @@ public struct CaseItem: SyntaxBuildable, ExpressibleAsCaseItem, HasTrailingComma
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -18458,7 +18422,7 @@ public struct CaseItem: SyntaxBuildable, ExpressibleAsCaseItem, HasTrailingComma
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePattern: unexpectedBeforePattern?.createUnexpectedNodes(), pattern: pattern.createPatternBuildable(), unexpectedBetweenPatternAndWhereClause: unexpectedBetweenPatternAndWhereClause?.createUnexpectedNodes(), whereClause: whereClause?.createWhereClause(), unexpectedBetweenWhereClauseAndTrailingComma: unexpectedBetweenWhereClauseAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: CaseItemSyntax) {
+  public init(_ constructedNode: CaseItemSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `CaseItemSyntax`.
@@ -18501,12 +18465,12 @@ public struct CaseItem: SyntaxBuildable, ExpressibleAsCaseItem, HasTrailingComma
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -18515,13 +18479,13 @@ public struct CaseItem: SyntaxBuildable, ExpressibleAsCaseItem, HasTrailingComma
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -18529,12 +18493,12 @@ public struct CaseItem: SyntaxBuildable, ExpressibleAsCaseItem, HasTrailingComma
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -18562,9 +18526,9 @@ public struct CatchItem: SyntaxBuildable, ExpressibleAsCatchItem, HasTrailingCom
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -18580,7 +18544,7 @@ public struct CatchItem: SyntaxBuildable, ExpressibleAsCatchItem, HasTrailingCom
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePattern: unexpectedBeforePattern?.createUnexpectedNodes(), pattern: pattern?.createPatternBuildable(), unexpectedBetweenPatternAndWhereClause: unexpectedBetweenPatternAndWhereClause?.createUnexpectedNodes(), whereClause: whereClause?.createWhereClause(), unexpectedBetweenWhereClauseAndTrailingComma: unexpectedBetweenWhereClauseAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: CatchItemSyntax) {
+  public init(_ constructedNode: CatchItemSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `CatchItemSyntax`.
@@ -18623,12 +18587,12 @@ public struct CatchItem: SyntaxBuildable, ExpressibleAsCatchItem, HasTrailingCom
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -18637,13 +18601,13 @@ public struct CatchItem: SyntaxBuildable, ExpressibleAsCatchItem, HasTrailingCom
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -18651,12 +18615,12 @@ public struct CatchItem: SyntaxBuildable, ExpressibleAsCatchItem, HasTrailingCom
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -18703,7 +18667,7 @@ public struct SwitchCaseLabel: SyntaxBuildable, ExpressibleAsSwitchCaseLabel {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeCaseKeyword: unexpectedBeforeCaseKeyword, caseKeyword: caseKeyword, unexpectedBetweenCaseKeywordAndCaseItems: unexpectedBetweenCaseKeywordAndCaseItems, caseItems: caseItemsBuilder(), unexpectedBetweenCaseItemsAndColon: unexpectedBetweenCaseItemsAndColon, colon: colon)
   }
-  public init (_ constructedNode: SwitchCaseLabelSyntax) {
+  public init(_ constructedNode: SwitchCaseLabelSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `SwitchCaseLabelSyntax`.
@@ -18745,13 +18709,13 @@ public struct SwitchCaseLabel: SyntaxBuildable, ExpressibleAsSwitchCaseLabel {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -18759,12 +18723,12 @@ public struct SwitchCaseLabel: SyntaxBuildable, ExpressibleAsSwitchCaseLabel {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -18810,7 +18774,7 @@ public struct CatchClause: SyntaxBuildable, ExpressibleAsCatchClause {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeCatchKeyword: unexpectedBeforeCatchKeyword, catchKeyword: catchKeyword, unexpectedBetweenCatchKeywordAndCatchItems: unexpectedBetweenCatchKeywordAndCatchItems, catchItems: catchItems, unexpectedBetweenCatchItemsAndBody: unexpectedBetweenCatchItemsAndBody, body: bodyBuilder())
   }
-  public init (_ constructedNode: CatchClauseSyntax) {
+  public init(_ constructedNode: CatchClauseSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `CatchClauseSyntax`.
@@ -18852,13 +18816,13 @@ public struct CatchClause: SyntaxBuildable, ExpressibleAsCatchClause {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -18866,12 +18830,12 @@ public struct CatchClause: SyntaxBuildable, ExpressibleAsCatchClause {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -18928,11 +18892,9 @@ public struct PoundAssertStmt: StmtBuildable, ExpressibleAsPoundAssertStmt {
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforePoundAssert: ExpressibleAsUnexpectedNodes? = nil, poundAssert: Token = Token.`poundAssert`, unexpectedBetweenPoundAssertAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndCondition: ExpressibleAsUnexpectedNodes? = nil, condition: ExpressibleAsExprBuildable, unexpectedBetweenConditionAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndMessage: ExpressibleAsUnexpectedNodes? = nil, message: String?, unexpectedBetweenMessageAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforePoundAssert: unexpectedBeforePoundAssert, poundAssert: poundAssert, unexpectedBetweenPoundAssertAndLeftParen: unexpectedBetweenPoundAssertAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndCondition: unexpectedBetweenLeftParenAndCondition, condition: condition, unexpectedBetweenConditionAndComma: unexpectedBetweenConditionAndComma, comma: comma, unexpectedBetweenCommaAndMessage: unexpectedBetweenCommaAndMessage, message: message.map {
-      Token.`stringLiteral`($0)
-    }, unexpectedBetweenMessageAndRightParen: unexpectedBetweenMessageAndRightParen, rightParen: rightParen)
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforePoundAssert: unexpectedBeforePoundAssert, poundAssert: poundAssert, unexpectedBetweenPoundAssertAndLeftParen: unexpectedBetweenPoundAssertAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndCondition: unexpectedBetweenLeftParenAndCondition, condition: condition, unexpectedBetweenConditionAndComma: unexpectedBetweenConditionAndComma, comma: comma, unexpectedBetweenCommaAndMessage: unexpectedBetweenCommaAndMessage, message: message.map { Token.`stringLiteral`($0) }, unexpectedBetweenMessageAndRightParen: unexpectedBetweenMessageAndRightParen, rightParen: rightParen)
   }
-  public init (_ constructedNode: PoundAssertStmtSyntax) {
+  public init(_ constructedNode: PoundAssertStmtSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PoundAssertStmtSyntax`.
@@ -18981,13 +18943,13 @@ public struct PoundAssertStmt: StmtBuildable, ExpressibleAsPoundAssertStmt {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -18995,12 +18957,12 @@ public struct PoundAssertStmt: StmtBuildable, ExpressibleAsPoundAssertStmt {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -19042,7 +19004,7 @@ public struct GenericWhereClause: SyntaxBuildable, ExpressibleAsGenericWhereClau
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeWhereKeyword: unexpectedBeforeWhereKeyword, whereKeyword: whereKeyword, unexpectedBetweenWhereKeywordAndRequirementList: unexpectedBetweenWhereKeywordAndRequirementList, requirementList: requirementListBuilder())
   }
-  public init (_ constructedNode: GenericWhereClauseSyntax) {
+  public init(_ constructedNode: GenericWhereClauseSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `GenericWhereClauseSyntax`.
@@ -19084,13 +19046,13 @@ public struct GenericWhereClause: SyntaxBuildable, ExpressibleAsGenericWhereClau
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -19098,12 +19060,12 @@ public struct GenericWhereClause: SyntaxBuildable, ExpressibleAsGenericWhereClau
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -19129,9 +19091,9 @@ public struct GenericRequirement: SyntaxBuildable, ExpressibleAsGenericRequireme
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -19145,7 +19107,7 @@ public struct GenericRequirement: SyntaxBuildable, ExpressibleAsGenericRequireme
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeBody: unexpectedBeforeBody?.createUnexpectedNodes(), body: body.createSyntaxBuildable(), unexpectedBetweenBodyAndTrailingComma: unexpectedBetweenBodyAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: GenericRequirementSyntax) {
+  public init(_ constructedNode: GenericRequirementSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `GenericRequirementSyntax`.
@@ -19188,12 +19150,12 @@ public struct GenericRequirement: SyntaxBuildable, ExpressibleAsGenericRequireme
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -19202,13 +19164,13 @@ public struct GenericRequirement: SyntaxBuildable, ExpressibleAsGenericRequireme
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -19216,12 +19178,12 @@ public struct GenericRequirement: SyntaxBuildable, ExpressibleAsGenericRequireme
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -19258,7 +19220,7 @@ public struct SameTypeRequirement: SyntaxBuildable, ExpressibleAsSameTypeRequire
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftTypeIdentifier: ExpressibleAsUnexpectedNodes? = nil, leftTypeIdentifier: ExpressibleAsTypeBuildable, unexpectedBetweenLeftTypeIdentifierAndEqualityToken: ExpressibleAsUnexpectedNodes? = nil, equalityToken: Token, unexpectedBetweenEqualityTokenAndRightTypeIdentifier: ExpressibleAsUnexpectedNodes? = nil, rightTypeIdentifier: ExpressibleAsTypeBuildable) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLeftTypeIdentifier: unexpectedBeforeLeftTypeIdentifier?.createUnexpectedNodes(), leftTypeIdentifier: leftTypeIdentifier.createTypeBuildable(), unexpectedBetweenLeftTypeIdentifierAndEqualityToken: unexpectedBetweenLeftTypeIdentifierAndEqualityToken?.createUnexpectedNodes(), equalityToken: equalityToken, unexpectedBetweenEqualityTokenAndRightTypeIdentifier: unexpectedBetweenEqualityTokenAndRightTypeIdentifier?.createUnexpectedNodes(), rightTypeIdentifier: rightTypeIdentifier.createTypeBuildable()))
   }
-  public init (_ constructedNode: SameTypeRequirementSyntax) {
+  public init(_ constructedNode: SameTypeRequirementSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `SameTypeRequirementSyntax`.
@@ -19300,13 +19262,13 @@ public struct SameTypeRequirement: SyntaxBuildable, ExpressibleAsSameTypeRequire
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -19314,12 +19276,12 @@ public struct SameTypeRequirement: SyntaxBuildable, ExpressibleAsSameTypeRequire
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -19384,13 +19346,9 @@ public struct LayoutRequirement: SyntaxBuildable, ExpressibleAsLayoutRequirement
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforeTypeIdentifier: ExpressibleAsUnexpectedNodes? = nil, typeIdentifier: ExpressibleAsTypeBuildable, unexpectedBetweenTypeIdentifierAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndLayoutConstraint: ExpressibleAsUnexpectedNodes? = nil, layoutConstraint: String, unexpectedBetweenLayoutConstraintAndLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token? = nil, unexpectedBetweenLeftParenAndSize: ExpressibleAsUnexpectedNodes? = nil, size: String?, unexpectedBetweenSizeAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token? = nil, unexpectedBetweenCommaAndAlignment: ExpressibleAsUnexpectedNodes? = nil, alignment: String?, unexpectedBetweenAlignmentAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token? = nil) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeTypeIdentifier: unexpectedBeforeTypeIdentifier, typeIdentifier: typeIdentifier, unexpectedBetweenTypeIdentifierAndColon: unexpectedBetweenTypeIdentifierAndColon, colon: colon, unexpectedBetweenColonAndLayoutConstraint: unexpectedBetweenColonAndLayoutConstraint, layoutConstraint: Token.`identifier`(layoutConstraint), unexpectedBetweenLayoutConstraintAndLeftParen: unexpectedBetweenLayoutConstraintAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndSize: unexpectedBetweenLeftParenAndSize, size: size.map {
-      Token.`integerLiteral`($0)
-    }, unexpectedBetweenSizeAndComma: unexpectedBetweenSizeAndComma, comma: comma, unexpectedBetweenCommaAndAlignment: unexpectedBetweenCommaAndAlignment, alignment: alignment.map {
-      Token.`integerLiteral`($0)
-    }, unexpectedBetweenAlignmentAndRightParen: unexpectedBetweenAlignmentAndRightParen, rightParen: rightParen)
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeTypeIdentifier: unexpectedBeforeTypeIdentifier, typeIdentifier: typeIdentifier, unexpectedBetweenTypeIdentifierAndColon: unexpectedBetweenTypeIdentifierAndColon, colon: colon, unexpectedBetweenColonAndLayoutConstraint: unexpectedBetweenColonAndLayoutConstraint, layoutConstraint: Token.`identifier`(layoutConstraint), unexpectedBetweenLayoutConstraintAndLeftParen: unexpectedBetweenLayoutConstraintAndLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndSize: unexpectedBetweenLeftParenAndSize, size: size.map { Token.`integerLiteral`($0) }, unexpectedBetweenSizeAndComma: unexpectedBetweenSizeAndComma, comma: comma, unexpectedBetweenCommaAndAlignment: unexpectedBetweenCommaAndAlignment, alignment: alignment.map { Token.`integerLiteral`($0) }, unexpectedBetweenAlignmentAndRightParen: unexpectedBetweenAlignmentAndRightParen, rightParen: rightParen)
   }
-  public init (_ constructedNode: LayoutRequirementSyntax) {
+  public init(_ constructedNode: LayoutRequirementSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `LayoutRequirementSyntax`.
@@ -19432,13 +19390,13 @@ public struct LayoutRequirement: SyntaxBuildable, ExpressibleAsLayoutRequirement
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -19446,12 +19404,12 @@ public struct LayoutRequirement: SyntaxBuildable, ExpressibleAsLayoutRequirement
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -19483,9 +19441,9 @@ public struct GenericParameter: SyntaxBuildable, ExpressibleAsGenericParameter, 
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -19512,7 +19470,7 @@ public struct GenericParameter: SyntaxBuildable, ExpressibleAsGenericParameter, 
   public init (leadingTrivia: Trivia = [], unexpectedBeforeAttributes: ExpressibleAsUnexpectedNodes? = nil, attributes: ExpressibleAsAttributeList? = nil, unexpectedBetweenAttributesAndName: ExpressibleAsUnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token? = nil, unexpectedBetweenColonAndInheritedType: ExpressibleAsUnexpectedNodes? = nil, inheritedType: ExpressibleAsTypeBuildable? = nil, unexpectedBetweenInheritedTypeAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeAttributes: unexpectedBeforeAttributes, attributes: attributes, unexpectedBetweenAttributesAndName: unexpectedBetweenAttributesAndName, name: Token.`identifier`(name), unexpectedBetweenNameAndColon: unexpectedBetweenNameAndColon, colon: colon, unexpectedBetweenColonAndInheritedType: unexpectedBetweenColonAndInheritedType, inheritedType: inheritedType, unexpectedBetweenInheritedTypeAndTrailingComma: unexpectedBetweenInheritedTypeAndTrailingComma, trailingComma: trailingComma)
   }
-  public init (_ constructedNode: GenericParameterSyntax) {
+  public init(_ constructedNode: GenericParameterSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `GenericParameterSyntax`.
@@ -19555,12 +19513,12 @@ public struct GenericParameter: SyntaxBuildable, ExpressibleAsGenericParameter, 
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -19569,13 +19527,13 @@ public struct GenericParameter: SyntaxBuildable, ExpressibleAsGenericParameter, 
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -19583,12 +19541,12 @@ public struct GenericParameter: SyntaxBuildable, ExpressibleAsGenericParameter, 
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -19614,9 +19572,9 @@ public struct PrimaryAssociatedType: SyntaxBuildable, ExpressibleAsPrimaryAssoci
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -19636,7 +19594,7 @@ public struct PrimaryAssociatedType: SyntaxBuildable, ExpressibleAsPrimaryAssoci
   public init (leadingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: String, unexpectedBetweenNameAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeName: unexpectedBeforeName, name: Token.`identifier`(name), unexpectedBetweenNameAndTrailingComma: unexpectedBetweenNameAndTrailingComma, trailingComma: trailingComma)
   }
-  public init (_ constructedNode: PrimaryAssociatedTypeSyntax) {
+  public init(_ constructedNode: PrimaryAssociatedTypeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PrimaryAssociatedTypeSyntax`.
@@ -19679,12 +19637,12 @@ public struct PrimaryAssociatedType: SyntaxBuildable, ExpressibleAsPrimaryAssoci
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -19693,13 +19651,13 @@ public struct PrimaryAssociatedType: SyntaxBuildable, ExpressibleAsPrimaryAssoci
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -19707,12 +19665,12 @@ public struct PrimaryAssociatedType: SyntaxBuildable, ExpressibleAsPrimaryAssoci
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -19763,7 +19721,7 @@ public struct GenericParameterClause: SyntaxBuildable, ExpressibleAsGenericParam
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLeftAngleBracket: unexpectedBeforeLeftAngleBracket, leftAngleBracket: leftAngleBracket, unexpectedBetweenLeftAngleBracketAndGenericParameterList: unexpectedBetweenLeftAngleBracketAndGenericParameterList, genericParameterList: genericParameterListBuilder(), unexpectedBetweenGenericParameterListAndGenericWhereClause: unexpectedBetweenGenericParameterListAndGenericWhereClause, genericWhereClause: genericWhereClause, unexpectedBetweenGenericWhereClauseAndRightAngleBracket: unexpectedBetweenGenericWhereClauseAndRightAngleBracket, rightAngleBracket: rightAngleBracket)
   }
-  public init (_ constructedNode: GenericParameterClauseSyntax) {
+  public init(_ constructedNode: GenericParameterClauseSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `GenericParameterClauseSyntax`.
@@ -19805,13 +19763,13 @@ public struct GenericParameterClause: SyntaxBuildable, ExpressibleAsGenericParam
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -19819,12 +19777,12 @@ public struct GenericParameterClause: SyntaxBuildable, ExpressibleAsGenericParam
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -19862,7 +19820,7 @@ public struct ConformanceRequirement: SyntaxBuildable, ExpressibleAsConformanceR
     assert(colon.text == #":"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLeftTypeIdentifier: unexpectedBeforeLeftTypeIdentifier?.createUnexpectedNodes(), leftTypeIdentifier: leftTypeIdentifier.createTypeBuildable(), unexpectedBetweenLeftTypeIdentifierAndColon: unexpectedBetweenLeftTypeIdentifierAndColon?.createUnexpectedNodes(), colon: colon, unexpectedBetweenColonAndRightTypeIdentifier: unexpectedBetweenColonAndRightTypeIdentifier?.createUnexpectedNodes(), rightTypeIdentifier: rightTypeIdentifier.createTypeBuildable()))
   }
-  public init (_ constructedNode: ConformanceRequirementSyntax) {
+  public init(_ constructedNode: ConformanceRequirementSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ConformanceRequirementSyntax`.
@@ -19904,13 +19862,13 @@ public struct ConformanceRequirement: SyntaxBuildable, ExpressibleAsConformanceR
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -19918,12 +19876,12 @@ public struct ConformanceRequirement: SyntaxBuildable, ExpressibleAsConformanceR
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -19962,7 +19920,7 @@ public struct PrimaryAssociatedTypeClause: SyntaxBuildable, ExpressibleAsPrimary
     assert(rightAngleBracket.text == #">"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLeftAngleBracket: unexpectedBeforeLeftAngleBracket?.createUnexpectedNodes(), leftAngleBracket: leftAngleBracket, unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList: unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList?.createUnexpectedNodes(), primaryAssociatedTypeList: primaryAssociatedTypeList.createPrimaryAssociatedTypeList(), unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket: unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket?.createUnexpectedNodes(), rightAngleBracket: rightAngleBracket))
   }
-  public init (_ constructedNode: PrimaryAssociatedTypeClauseSyntax) {
+  public init(_ constructedNode: PrimaryAssociatedTypeClauseSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PrimaryAssociatedTypeClauseSyntax`.
@@ -20004,13 +19962,13 @@ public struct PrimaryAssociatedTypeClause: SyntaxBuildable, ExpressibleAsPrimary
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -20018,12 +19976,12 @@ public struct PrimaryAssociatedTypeClause: SyntaxBuildable, ExpressibleAsPrimary
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -20056,7 +20014,7 @@ public struct SimpleTypeIdentifier: TypeBuildable, ExpressibleAsSimpleTypeIdenti
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeName: ExpressibleAsUnexpectedNodes? = nil, name: Token, unexpectedBetweenNameAndGenericArgumentClause: ExpressibleAsUnexpectedNodes? = nil, genericArgumentClause: ExpressibleAsGenericArgumentClause? = nil) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeName: unexpectedBeforeName?.createUnexpectedNodes(), name: name, unexpectedBetweenNameAndGenericArgumentClause: unexpectedBetweenNameAndGenericArgumentClause?.createUnexpectedNodes(), genericArgumentClause: genericArgumentClause?.createGenericArgumentClause()))
   }
-  public init (_ constructedNode: SimpleTypeIdentifierSyntax) {
+  public init(_ constructedNode: SimpleTypeIdentifierSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `SimpleTypeIdentifierSyntax`.
@@ -20105,13 +20063,13 @@ public struct SimpleTypeIdentifier: TypeBuildable, ExpressibleAsSimpleTypeIdenti
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -20119,12 +20077,12 @@ public struct SimpleTypeIdentifier: TypeBuildable, ExpressibleAsSimpleTypeIdenti
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -20166,7 +20124,7 @@ public struct MemberTypeIdentifier: TypeBuildable, ExpressibleAsMemberTypeIdenti
     assert(period.text == #"."# || period.text == #"."#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeBaseType: unexpectedBeforeBaseType?.createUnexpectedNodes(), baseType: baseType.createTypeBuildable(), unexpectedBetweenBaseTypeAndPeriod: unexpectedBetweenBaseTypeAndPeriod?.createUnexpectedNodes(), period: period, unexpectedBetweenPeriodAndName: unexpectedBetweenPeriodAndName?.createUnexpectedNodes(), name: name, unexpectedBetweenNameAndGenericArgumentClause: unexpectedBetweenNameAndGenericArgumentClause?.createUnexpectedNodes(), genericArgumentClause: genericArgumentClause?.createGenericArgumentClause()))
   }
-  public init (_ constructedNode: MemberTypeIdentifierSyntax) {
+  public init(_ constructedNode: MemberTypeIdentifierSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `MemberTypeIdentifierSyntax`.
@@ -20215,13 +20173,13 @@ public struct MemberTypeIdentifier: TypeBuildable, ExpressibleAsMemberTypeIdenti
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -20229,12 +20187,12 @@ public struct MemberTypeIdentifier: TypeBuildable, ExpressibleAsMemberTypeIdenti
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -20264,7 +20222,7 @@ public struct ClassRestrictionType: TypeBuildable, ExpressibleAsClassRestriction
     assert(classKeyword.text == #"class"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeClassKeyword: unexpectedBeforeClassKeyword?.createUnexpectedNodes(), classKeyword: classKeyword))
   }
-  public init (_ constructedNode: ClassRestrictionTypeSyntax) {
+  public init(_ constructedNode: ClassRestrictionTypeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ClassRestrictionTypeSyntax`.
@@ -20313,13 +20271,13 @@ public struct ClassRestrictionType: TypeBuildable, ExpressibleAsClassRestriction
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -20327,12 +20285,12 @@ public struct ClassRestrictionType: TypeBuildable, ExpressibleAsClassRestriction
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -20371,7 +20329,7 @@ public struct ArrayType: TypeBuildable, ExpressibleAsArrayType {
     assert(rightSquareBracket.text == #"]"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLeftSquareBracket: unexpectedBeforeLeftSquareBracket?.createUnexpectedNodes(), leftSquareBracket: leftSquareBracket, unexpectedBetweenLeftSquareBracketAndElementType: unexpectedBetweenLeftSquareBracketAndElementType?.createUnexpectedNodes(), elementType: elementType.createTypeBuildable(), unexpectedBetweenElementTypeAndRightSquareBracket: unexpectedBetweenElementTypeAndRightSquareBracket?.createUnexpectedNodes(), rightSquareBracket: rightSquareBracket))
   }
-  public init (_ constructedNode: ArrayTypeSyntax) {
+  public init(_ constructedNode: ArrayTypeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ArrayTypeSyntax`.
@@ -20420,13 +20378,13 @@ public struct ArrayType: TypeBuildable, ExpressibleAsArrayType {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -20434,12 +20392,12 @@ public struct ArrayType: TypeBuildable, ExpressibleAsArrayType {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -20487,7 +20445,7 @@ public struct DictionaryType: TypeBuildable, ExpressibleAsDictionaryType {
     assert(rightSquareBracket.text == #"]"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLeftSquareBracket: unexpectedBeforeLeftSquareBracket?.createUnexpectedNodes(), leftSquareBracket: leftSquareBracket, unexpectedBetweenLeftSquareBracketAndKeyType: unexpectedBetweenLeftSquareBracketAndKeyType?.createUnexpectedNodes(), keyType: keyType.createTypeBuildable(), unexpectedBetweenKeyTypeAndColon: unexpectedBetweenKeyTypeAndColon?.createUnexpectedNodes(), colon: colon, unexpectedBetweenColonAndValueType: unexpectedBetweenColonAndValueType?.createUnexpectedNodes(), valueType: valueType.createTypeBuildable(), unexpectedBetweenValueTypeAndRightSquareBracket: unexpectedBetweenValueTypeAndRightSquareBracket?.createUnexpectedNodes(), rightSquareBracket: rightSquareBracket))
   }
-  public init (_ constructedNode: DictionaryTypeSyntax) {
+  public init(_ constructedNode: DictionaryTypeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `DictionaryTypeSyntax`.
@@ -20536,13 +20494,13 @@ public struct DictionaryType: TypeBuildable, ExpressibleAsDictionaryType {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -20550,12 +20508,12 @@ public struct DictionaryType: TypeBuildable, ExpressibleAsDictionaryType {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -20600,7 +20558,7 @@ public struct MetatypeType: TypeBuildable, ExpressibleAsMetatypeType {
   public init (leadingTrivia: Trivia = [], unexpectedBeforeBaseType: ExpressibleAsUnexpectedNodes? = nil, baseType: ExpressibleAsTypeBuildable, unexpectedBetweenBaseTypeAndPeriod: ExpressibleAsUnexpectedNodes? = nil, period: Token = Token.`period`, unexpectedBetweenPeriodAndTypeOrProtocol: ExpressibleAsUnexpectedNodes? = nil, typeOrProtocol: String) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeBaseType: unexpectedBeforeBaseType, baseType: baseType, unexpectedBetweenBaseTypeAndPeriod: unexpectedBetweenBaseTypeAndPeriod, period: period, unexpectedBetweenPeriodAndTypeOrProtocol: unexpectedBetweenPeriodAndTypeOrProtocol, typeOrProtocol: Token.`identifier`(typeOrProtocol))
   }
-  public init (_ constructedNode: MetatypeTypeSyntax) {
+  public init(_ constructedNode: MetatypeTypeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `MetatypeTypeSyntax`.
@@ -20649,13 +20607,13 @@ public struct MetatypeType: TypeBuildable, ExpressibleAsMetatypeType {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -20663,12 +20621,12 @@ public struct MetatypeType: TypeBuildable, ExpressibleAsMetatypeType {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -20702,7 +20660,7 @@ public struct OptionalType: TypeBuildable, ExpressibleAsOptionalType {
     assert(questionMark.text == #"?"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeWrappedType: unexpectedBeforeWrappedType?.createUnexpectedNodes(), wrappedType: wrappedType.createTypeBuildable(), unexpectedBetweenWrappedTypeAndQuestionMark: unexpectedBetweenWrappedTypeAndQuestionMark?.createUnexpectedNodes(), questionMark: questionMark))
   }
-  public init (_ constructedNode: OptionalTypeSyntax) {
+  public init(_ constructedNode: OptionalTypeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `OptionalTypeSyntax`.
@@ -20751,13 +20709,13 @@ public struct OptionalType: TypeBuildable, ExpressibleAsOptionalType {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -20765,12 +20723,12 @@ public struct OptionalType: TypeBuildable, ExpressibleAsOptionalType {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -20810,7 +20768,7 @@ public struct ConstrainedSugarType: TypeBuildable, ExpressibleAsConstrainedSugar
   public init (leadingTrivia: Trivia = [], unexpectedBeforeSomeOrAnySpecifier: ExpressibleAsUnexpectedNodes? = nil, someOrAnySpecifier: String, unexpectedBetweenSomeOrAnySpecifierAndBaseType: ExpressibleAsUnexpectedNodes? = nil, baseType: ExpressibleAsTypeBuildable) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeSomeOrAnySpecifier: unexpectedBeforeSomeOrAnySpecifier, someOrAnySpecifier: Token.`identifier`(someOrAnySpecifier), unexpectedBetweenSomeOrAnySpecifierAndBaseType: unexpectedBetweenSomeOrAnySpecifierAndBaseType, baseType: baseType)
   }
-  public init (_ constructedNode: ConstrainedSugarTypeSyntax) {
+  public init(_ constructedNode: ConstrainedSugarTypeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ConstrainedSugarTypeSyntax`.
@@ -20859,13 +20817,13 @@ public struct ConstrainedSugarType: TypeBuildable, ExpressibleAsConstrainedSugar
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -20873,12 +20831,12 @@ public struct ConstrainedSugarType: TypeBuildable, ExpressibleAsConstrainedSugar
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -20912,7 +20870,7 @@ public struct ImplicitlyUnwrappedOptionalType: TypeBuildable, ExpressibleAsImpli
     assert(exclamationMark.text == #"!"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeWrappedType: unexpectedBeforeWrappedType?.createUnexpectedNodes(), wrappedType: wrappedType.createTypeBuildable(), unexpectedBetweenWrappedTypeAndExclamationMark: unexpectedBetweenWrappedTypeAndExclamationMark?.createUnexpectedNodes(), exclamationMark: exclamationMark))
   }
-  public init (_ constructedNode: ImplicitlyUnwrappedOptionalTypeSyntax) {
+  public init(_ constructedNode: ImplicitlyUnwrappedOptionalTypeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ImplicitlyUnwrappedOptionalTypeSyntax`.
@@ -20961,13 +20919,13 @@ public struct ImplicitlyUnwrappedOptionalType: TypeBuildable, ExpressibleAsImpli
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -20975,12 +20933,12 @@ public struct ImplicitlyUnwrappedOptionalType: TypeBuildable, ExpressibleAsImpli
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -21014,7 +20972,7 @@ public struct CompositionTypeElement: SyntaxBuildable, ExpressibleAsCompositionT
     assert(ampersand == nil || ampersand!.text == #"&"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeType: unexpectedBeforeType?.createUnexpectedNodes(), type: type.createTypeBuildable(), unexpectedBetweenTypeAndAmpersand: unexpectedBetweenTypeAndAmpersand?.createUnexpectedNodes(), ampersand: ampersand))
   }
-  public init (_ constructedNode: CompositionTypeElementSyntax) {
+  public init(_ constructedNode: CompositionTypeElementSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `CompositionTypeElementSyntax`.
@@ -21056,13 +21014,13 @@ public struct CompositionTypeElement: SyntaxBuildable, ExpressibleAsCompositionT
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -21070,12 +21028,12 @@ public struct CompositionTypeElement: SyntaxBuildable, ExpressibleAsCompositionT
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -21104,7 +21062,7 @@ public struct CompositionType: TypeBuildable, ExpressibleAsCompositionType {
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeElements: ExpressibleAsUnexpectedNodes? = nil, elements: ExpressibleAsCompositionTypeElementList) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeElements: unexpectedBeforeElements?.createUnexpectedNodes(), elements: elements.createCompositionTypeElementList()))
   }
-  public init (_ constructedNode: CompositionTypeSyntax) {
+  public init(_ constructedNode: CompositionTypeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `CompositionTypeSyntax`.
@@ -21153,13 +21111,13 @@ public struct CompositionType: TypeBuildable, ExpressibleAsCompositionType {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -21167,12 +21125,12 @@ public struct CompositionType: TypeBuildable, ExpressibleAsCompositionType {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -21206,7 +21164,7 @@ public struct PackExpansionType: TypeBuildable, ExpressibleAsPackExpansionType {
     assert(ellipsis.text == #"..."#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePatternType: unexpectedBeforePatternType?.createUnexpectedNodes(), patternType: patternType.createTypeBuildable(), unexpectedBetweenPatternTypeAndEllipsis: unexpectedBetweenPatternTypeAndEllipsis?.createUnexpectedNodes(), ellipsis: ellipsis))
   }
-  public init (_ constructedNode: PackExpansionTypeSyntax) {
+  public init(_ constructedNode: PackExpansionTypeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `PackExpansionTypeSyntax`.
@@ -21255,13 +21213,13 @@ public struct PackExpansionType: TypeBuildable, ExpressibleAsPackExpansionType {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -21269,12 +21227,12 @@ public struct PackExpansionType: TypeBuildable, ExpressibleAsPackExpansionType {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -21312,9 +21270,9 @@ public struct TupleTypeElement: SyntaxBuildable, ExpressibleAsTupleTypeElement, 
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -21343,7 +21301,7 @@ public struct TupleTypeElement: SyntaxBuildable, ExpressibleAsTupleTypeElement, 
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeInOut: unexpectedBeforeInOut?.createUnexpectedNodes(), inOut: inOut, unexpectedBetweenInOutAndName: unexpectedBetweenInOutAndName?.createUnexpectedNodes(), name: name, unexpectedBetweenNameAndSecondName: unexpectedBetweenNameAndSecondName?.createUnexpectedNodes(), secondName: secondName, unexpectedBetweenSecondNameAndColon: unexpectedBetweenSecondNameAndColon?.createUnexpectedNodes(), colon: colon, unexpectedBetweenColonAndType: unexpectedBetweenColonAndType?.createUnexpectedNodes(), type: type.createTypeBuildable(), unexpectedBetweenTypeAndEllipsis: unexpectedBetweenTypeAndEllipsis?.createUnexpectedNodes(), ellipsis: ellipsis, unexpectedBetweenEllipsisAndInitializer: unexpectedBetweenEllipsisAndInitializer?.createUnexpectedNodes(), initializer: initializer?.createInitializerClause(), unexpectedBetweenInitializerAndTrailingComma: unexpectedBetweenInitializerAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: TupleTypeElementSyntax) {
+  public init(_ constructedNode: TupleTypeElementSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `TupleTypeElementSyntax`.
@@ -21386,12 +21344,12 @@ public struct TupleTypeElement: SyntaxBuildable, ExpressibleAsTupleTypeElement, 
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -21400,13 +21358,13 @@ public struct TupleTypeElement: SyntaxBuildable, ExpressibleAsTupleTypeElement, 
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -21414,12 +21372,12 @@ public struct TupleTypeElement: SyntaxBuildable, ExpressibleAsTupleTypeElement, 
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -21458,7 +21416,7 @@ public struct TupleType: TypeBuildable, ExpressibleAsTupleType {
     assert(rightParen.text == #")"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLeftParen: unexpectedBeforeLeftParen?.createUnexpectedNodes(), leftParen: leftParen, unexpectedBetweenLeftParenAndElements: unexpectedBetweenLeftParenAndElements?.createUnexpectedNodes(), elements: elements.createTupleTypeElementList(), unexpectedBetweenElementsAndRightParen: unexpectedBetweenElementsAndRightParen?.createUnexpectedNodes(), rightParen: rightParen))
   }
-  public init (_ constructedNode: TupleTypeSyntax) {
+  public init(_ constructedNode: TupleTypeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `TupleTypeSyntax`.
@@ -21507,13 +21465,13 @@ public struct TupleType: TypeBuildable, ExpressibleAsTupleType {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -21521,12 +21479,12 @@ public struct TupleType: TypeBuildable, ExpressibleAsTupleType {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -21584,7 +21542,7 @@ public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
     assert(arrow.text == #"->"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLeftParen: unexpectedBeforeLeftParen?.createUnexpectedNodes(), leftParen: leftParen, unexpectedBetweenLeftParenAndArguments: unexpectedBetweenLeftParenAndArguments?.createUnexpectedNodes(), arguments: arguments.createTupleTypeElementList(), unexpectedBetweenArgumentsAndRightParen: unexpectedBetweenArgumentsAndRightParen?.createUnexpectedNodes(), rightParen: rightParen, unexpectedBetweenRightParenAndAsyncKeyword: unexpectedBetweenRightParenAndAsyncKeyword?.createUnexpectedNodes(), asyncKeyword: asyncKeyword, unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword: unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword?.createUnexpectedNodes(), throwsOrRethrowsKeyword: throwsOrRethrowsKeyword, unexpectedBetweenThrowsOrRethrowsKeywordAndArrow: unexpectedBetweenThrowsOrRethrowsKeywordAndArrow?.createUnexpectedNodes(), arrow: arrow, unexpectedBetweenArrowAndReturnType: unexpectedBetweenArrowAndReturnType?.createUnexpectedNodes(), returnType: returnType.createTypeBuildable()))
   }
-  public init (_ constructedNode: FunctionTypeSyntax) {
+  public init(_ constructedNode: FunctionTypeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `FunctionTypeSyntax`.
@@ -21633,13 +21591,13 @@ public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -21647,12 +21605,12 @@ public struct FunctionType: TypeBuildable, ExpressibleAsFunctionType {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -21690,7 +21648,7 @@ public struct AttributedType: TypeBuildable, ExpressibleAsAttributedType {
     assert(specifier == nil || specifier!.text == #"inout"# || specifier!.text == #"__shared"# || specifier!.text == #"__owned"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeSpecifier: unexpectedBeforeSpecifier?.createUnexpectedNodes(), specifier: specifier, unexpectedBetweenSpecifierAndAttributes: unexpectedBetweenSpecifierAndAttributes?.createUnexpectedNodes(), attributes: attributes?.createAttributeList(), unexpectedBetweenAttributesAndBaseType: unexpectedBetweenAttributesAndBaseType?.createUnexpectedNodes(), baseType: baseType.createTypeBuildable()))
   }
-  public init (_ constructedNode: AttributedTypeSyntax) {
+  public init(_ constructedNode: AttributedTypeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AttributedTypeSyntax`.
@@ -21739,13 +21697,13 @@ public struct AttributedType: TypeBuildable, ExpressibleAsAttributedType {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -21753,12 +21711,12 @@ public struct AttributedType: TypeBuildable, ExpressibleAsAttributedType {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -21784,9 +21742,9 @@ public struct GenericArgument: SyntaxBuildable, ExpressibleAsGenericArgument, Ha
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -21800,7 +21758,7 @@ public struct GenericArgument: SyntaxBuildable, ExpressibleAsGenericArgument, Ha
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeArgumentType: unexpectedBeforeArgumentType?.createUnexpectedNodes(), argumentType: argumentType.createTypeBuildable(), unexpectedBetweenArgumentTypeAndTrailingComma: unexpectedBetweenArgumentTypeAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: GenericArgumentSyntax) {
+  public init(_ constructedNode: GenericArgumentSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `GenericArgumentSyntax`.
@@ -21843,12 +21801,12 @@ public struct GenericArgument: SyntaxBuildable, ExpressibleAsGenericArgument, Ha
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -21857,13 +21815,13 @@ public struct GenericArgument: SyntaxBuildable, ExpressibleAsGenericArgument, Ha
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -21871,12 +21829,12 @@ public struct GenericArgument: SyntaxBuildable, ExpressibleAsGenericArgument, Ha
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -21923,7 +21881,7 @@ public struct GenericArgumentClause: SyntaxBuildable, ExpressibleAsGenericArgume
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLeftAngleBracket: unexpectedBeforeLeftAngleBracket, leftAngleBracket: leftAngleBracket, unexpectedBetweenLeftAngleBracketAndArguments: unexpectedBetweenLeftAngleBracketAndArguments, arguments: argumentsBuilder(), unexpectedBetweenArgumentsAndRightAngleBracket: unexpectedBetweenArgumentsAndRightAngleBracket, rightAngleBracket: rightAngleBracket)
   }
-  public init (_ constructedNode: GenericArgumentClauseSyntax) {
+  public init(_ constructedNode: GenericArgumentClauseSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `GenericArgumentClauseSyntax`.
@@ -21965,13 +21923,13 @@ public struct GenericArgumentClause: SyntaxBuildable, ExpressibleAsGenericArgume
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -21979,12 +21937,12 @@ public struct GenericArgumentClause: SyntaxBuildable, ExpressibleAsGenericArgume
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -22017,7 +21975,7 @@ public struct NamedOpaqueReturnType: TypeBuildable, ExpressibleAsNamedOpaqueRetu
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeGenericParameters: ExpressibleAsUnexpectedNodes? = nil, genericParameters: ExpressibleAsGenericParameterClause, unexpectedBetweenGenericParametersAndBaseType: ExpressibleAsUnexpectedNodes? = nil, baseType: ExpressibleAsTypeBuildable) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeGenericParameters: unexpectedBeforeGenericParameters?.createUnexpectedNodes(), genericParameters: genericParameters.createGenericParameterClause(), unexpectedBetweenGenericParametersAndBaseType: unexpectedBetweenGenericParametersAndBaseType?.createUnexpectedNodes(), baseType: baseType.createTypeBuildable()))
   }
-  public init (_ constructedNode: NamedOpaqueReturnTypeSyntax) {
+  public init(_ constructedNode: NamedOpaqueReturnTypeSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `NamedOpaqueReturnTypeSyntax`.
@@ -22066,13 +22024,13 @@ public struct NamedOpaqueReturnType: TypeBuildable, ExpressibleAsNamedOpaqueRetu
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -22080,12 +22038,12 @@ public struct NamedOpaqueReturnType: TypeBuildable, ExpressibleAsNamedOpaqueRetu
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -22119,7 +22077,7 @@ public struct TypeAnnotation: SyntaxBuildable, ExpressibleAsTypeAnnotation {
     assert(colon.text == #":"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeColon: unexpectedBeforeColon?.createUnexpectedNodes(), colon: colon, unexpectedBetweenColonAndType: unexpectedBetweenColonAndType?.createUnexpectedNodes(), type: type.createTypeBuildable()))
   }
-  public init (_ constructedNode: TypeAnnotationSyntax) {
+  public init(_ constructedNode: TypeAnnotationSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `TypeAnnotationSyntax`.
@@ -22161,13 +22119,13 @@ public struct TypeAnnotation: SyntaxBuildable, ExpressibleAsTypeAnnotation {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -22175,12 +22133,12 @@ public struct TypeAnnotation: SyntaxBuildable, ExpressibleAsTypeAnnotation {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -22228,7 +22186,7 @@ public struct EnumCasePattern: PatternBuildable, ExpressibleAsEnumCasePattern {
   public init (leadingTrivia: Trivia = [], unexpectedBeforeType: ExpressibleAsUnexpectedNodes? = nil, type: ExpressibleAsTypeBuildable? = nil, unexpectedBetweenTypeAndPeriod: ExpressibleAsUnexpectedNodes? = nil, period: Token = Token.`period`, unexpectedBetweenPeriodAndCaseName: ExpressibleAsUnexpectedNodes? = nil, caseName: String, unexpectedBetweenCaseNameAndAssociatedTuple: ExpressibleAsUnexpectedNodes? = nil, associatedTuple: ExpressibleAsTuplePattern? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeType: unexpectedBeforeType, type: type, unexpectedBetweenTypeAndPeriod: unexpectedBetweenTypeAndPeriod, period: period, unexpectedBetweenPeriodAndCaseName: unexpectedBetweenPeriodAndCaseName, caseName: Token.`identifier`(caseName), unexpectedBetweenCaseNameAndAssociatedTuple: unexpectedBetweenCaseNameAndAssociatedTuple, associatedTuple: associatedTuple)
   }
-  public init (_ constructedNode: EnumCasePatternSyntax) {
+  public init(_ constructedNode: EnumCasePatternSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `EnumCasePatternSyntax`.
@@ -22277,13 +22235,13 @@ public struct EnumCasePattern: PatternBuildable, ExpressibleAsEnumCasePattern {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -22291,12 +22249,12 @@ public struct EnumCasePattern: PatternBuildable, ExpressibleAsEnumCasePattern {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -22330,7 +22288,7 @@ public struct IsTypePattern: PatternBuildable, ExpressibleAsIsTypePattern {
     assert(isKeyword.text == #"is"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeIsKeyword: unexpectedBeforeIsKeyword?.createUnexpectedNodes(), isKeyword: isKeyword, unexpectedBetweenIsKeywordAndType: unexpectedBetweenIsKeywordAndType?.createUnexpectedNodes(), type: type.createTypeBuildable()))
   }
-  public init (_ constructedNode: IsTypePatternSyntax) {
+  public init(_ constructedNode: IsTypePatternSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `IsTypePatternSyntax`.
@@ -22379,13 +22337,13 @@ public struct IsTypePattern: PatternBuildable, ExpressibleAsIsTypePattern {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -22393,12 +22351,12 @@ public struct IsTypePattern: PatternBuildable, ExpressibleAsIsTypePattern {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -22432,7 +22390,7 @@ public struct OptionalPattern: PatternBuildable, ExpressibleAsOptionalPattern {
     assert(questionMark.text == #"?"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeSubPattern: unexpectedBeforeSubPattern?.createUnexpectedNodes(), subPattern: subPattern.createPatternBuildable(), unexpectedBetweenSubPatternAndQuestionMark: unexpectedBetweenSubPatternAndQuestionMark?.createUnexpectedNodes(), questionMark: questionMark))
   }
-  public init (_ constructedNode: OptionalPatternSyntax) {
+  public init(_ constructedNode: OptionalPatternSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `OptionalPatternSyntax`.
@@ -22481,13 +22439,13 @@ public struct OptionalPattern: PatternBuildable, ExpressibleAsOptionalPattern {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -22495,12 +22453,12 @@ public struct OptionalPattern: PatternBuildable, ExpressibleAsOptionalPattern {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -22529,7 +22487,7 @@ public struct IdentifierPattern: PatternBuildable, ExpressibleAsIdentifierPatter
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeIdentifier: ExpressibleAsUnexpectedNodes? = nil, identifier: Token) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeIdentifier: unexpectedBeforeIdentifier?.createUnexpectedNodes(), identifier: identifier))
   }
-  public init (_ constructedNode: IdentifierPatternSyntax) {
+  public init(_ constructedNode: IdentifierPatternSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `IdentifierPatternSyntax`.
@@ -22578,13 +22536,13 @@ public struct IdentifierPattern: PatternBuildable, ExpressibleAsIdentifierPatter
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -22592,12 +22550,12 @@ public struct IdentifierPattern: PatternBuildable, ExpressibleAsIdentifierPatter
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -22635,7 +22593,7 @@ public struct AsTypePattern: PatternBuildable, ExpressibleAsAsTypePattern {
     assert(asKeyword.text == #"as"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforePattern: unexpectedBeforePattern?.createUnexpectedNodes(), pattern: pattern.createPatternBuildable(), unexpectedBetweenPatternAndAsKeyword: unexpectedBetweenPatternAndAsKeyword?.createUnexpectedNodes(), asKeyword: asKeyword, unexpectedBetweenAsKeywordAndType: unexpectedBetweenAsKeywordAndType?.createUnexpectedNodes(), type: type.createTypeBuildable()))
   }
-  public init (_ constructedNode: AsTypePatternSyntax) {
+  public init(_ constructedNode: AsTypePatternSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AsTypePatternSyntax`.
@@ -22684,13 +22642,13 @@ public struct AsTypePattern: PatternBuildable, ExpressibleAsAsTypePattern {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -22698,12 +22656,12 @@ public struct AsTypePattern: PatternBuildable, ExpressibleAsAsTypePattern {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -22750,7 +22708,7 @@ public struct TuplePattern: PatternBuildable, ExpressibleAsTuplePattern {
   }) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLeftParen: unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndElements: unexpectedBetweenLeftParenAndElements, elements: elementsBuilder(), unexpectedBetweenElementsAndRightParen: unexpectedBetweenElementsAndRightParen, rightParen: rightParen)
   }
-  public init (_ constructedNode: TuplePatternSyntax) {
+  public init(_ constructedNode: TuplePatternSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `TuplePatternSyntax`.
@@ -22799,13 +22757,13 @@ public struct TuplePattern: PatternBuildable, ExpressibleAsTuplePattern {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -22813,12 +22771,12 @@ public struct TuplePattern: PatternBuildable, ExpressibleAsTuplePattern {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -22852,7 +22810,7 @@ public struct WildcardPattern: PatternBuildable, ExpressibleAsWildcardPattern {
     assert(wildcard.text == #"_"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeWildcard: unexpectedBeforeWildcard?.createUnexpectedNodes(), wildcard: wildcard, unexpectedBetweenWildcardAndTypeAnnotation: unexpectedBetweenWildcardAndTypeAnnotation?.createUnexpectedNodes(), typeAnnotation: typeAnnotation?.createTypeAnnotation()))
   }
-  public init (_ constructedNode: WildcardPatternSyntax) {
+  public init(_ constructedNode: WildcardPatternSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `WildcardPatternSyntax`.
@@ -22901,13 +22859,13 @@ public struct WildcardPattern: PatternBuildable, ExpressibleAsWildcardPattern {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -22915,12 +22873,12 @@ public struct WildcardPattern: PatternBuildable, ExpressibleAsWildcardPattern {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -22950,9 +22908,9 @@ public struct TuplePatternElement: SyntaxBuildable, ExpressibleAsTuplePatternEle
   private var data: Data
   var hasTrailingComma: Bool {
     switch data {
-    case .buildable(let buildableData): 
+    case .buildable(let buildableData):
       return buildableData.trailingComma != nil
-    case .constructed(let node): 
+    case .constructed(let node):
       return node.trailingComma != nil
     }
   }
@@ -22975,11 +22933,9 @@ public struct TuplePatternElement: SyntaxBuildable, ExpressibleAsTuplePatternEle
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforeLabelName: ExpressibleAsUnexpectedNodes? = nil, labelName: String?, unexpectedBetweenLabelNameAndLabelColon: ExpressibleAsUnexpectedNodes? = nil, labelColon: Token? = nil, unexpectedBetweenLabelColonAndPattern: ExpressibleAsUnexpectedNodes? = nil, pattern: ExpressibleAsPatternBuildable, unexpectedBetweenPatternAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLabelName: unexpectedBeforeLabelName, labelName: labelName.map {
-      Token.`identifier`($0)
-    }, unexpectedBetweenLabelNameAndLabelColon: unexpectedBetweenLabelNameAndLabelColon, labelColon: labelColon, unexpectedBetweenLabelColonAndPattern: unexpectedBetweenLabelColonAndPattern, pattern: pattern, unexpectedBetweenPatternAndTrailingComma: unexpectedBetweenPatternAndTrailingComma, trailingComma: trailingComma)
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLabelName: unexpectedBeforeLabelName, labelName: labelName.map { Token.`identifier`($0) }, unexpectedBetweenLabelNameAndLabelColon: unexpectedBetweenLabelNameAndLabelColon, labelColon: labelColon, unexpectedBetweenLabelColonAndPattern: unexpectedBetweenLabelColonAndPattern, pattern: pattern, unexpectedBetweenPatternAndTrailingComma: unexpectedBetweenPatternAndTrailingComma, trailingComma: trailingComma)
   }
-  public init (_ constructedNode: TuplePatternElementSyntax) {
+  public init(_ constructedNode: TuplePatternElementSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `TuplePatternElementSyntax`.
@@ -23022,12 +22978,12 @@ public struct TuplePatternElement: SyntaxBuildable, ExpressibleAsTuplePatternEle
   /// Conformance to `HasTrailingComma`.
   public func withTrailingComma(_ withComma: Bool) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingComma = withComma ? .comma : nil
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withComma = node.withTrailingComma(withComma ? .commaToken() : nil)
       var result = self
       result.data = .constructed(withComma)
@@ -23036,13 +22992,13 @@ public struct TuplePatternElement: SyntaxBuildable, ExpressibleAsTuplePatternEle
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -23050,12 +23006,12 @@ public struct TuplePatternElement: SyntaxBuildable, ExpressibleAsTuplePatternEle
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -23084,7 +23040,7 @@ public struct ExpressionPattern: PatternBuildable, ExpressibleAsExpressionPatter
   public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable) {
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeExpression: unexpectedBeforeExpression?.createUnexpectedNodes(), expression: expression.createExprBuildable()))
   }
-  public init (_ constructedNode: ExpressionPatternSyntax) {
+  public init(_ constructedNode: ExpressionPatternSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ExpressionPatternSyntax`.
@@ -23133,13 +23089,13 @@ public struct ExpressionPattern: PatternBuildable, ExpressibleAsExpressionPatter
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -23147,12 +23103,12 @@ public struct ExpressionPattern: PatternBuildable, ExpressibleAsExpressionPatter
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -23186,7 +23142,7 @@ public struct ValueBindingPattern: PatternBuildable, ExpressibleAsValueBindingPa
     assert(letOrVarKeyword.text == #"let"# || letOrVarKeyword.text == #"var"#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLetOrVarKeyword: unexpectedBeforeLetOrVarKeyword?.createUnexpectedNodes(), letOrVarKeyword: letOrVarKeyword, unexpectedBetweenLetOrVarKeywordAndValuePattern: unexpectedBetweenLetOrVarKeywordAndValuePattern?.createUnexpectedNodes(), valuePattern: valuePattern.createPatternBuildable()))
   }
-  public init (_ constructedNode: ValueBindingPatternSyntax) {
+  public init(_ constructedNode: ValueBindingPatternSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `ValueBindingPatternSyntax`.
@@ -23235,13 +23191,13 @@ public struct ValueBindingPattern: PatternBuildable, ExpressibleAsValueBindingPa
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -23249,12 +23205,12 @@ public struct ValueBindingPattern: PatternBuildable, ExpressibleAsValueBindingPa
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -23289,7 +23245,7 @@ public struct AvailabilityArgument: SyntaxBuildable, ExpressibleAsAvailabilityAr
     assert(trailingComma == nil || trailingComma!.text == #","#)
     self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeEntry: unexpectedBeforeEntry?.createUnexpectedNodes(), entry: entry.createSyntaxBuildable(), unexpectedBetweenEntryAndTrailingComma: unexpectedBetweenEntryAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma))
   }
-  public init (_ constructedNode: AvailabilityArgumentSyntax) {
+  public init(_ constructedNode: AvailabilityArgumentSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AvailabilityArgumentSyntax`.
@@ -23331,13 +23287,13 @@ public struct AvailabilityArgument: SyntaxBuildable, ExpressibleAsAvailabilityAr
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -23345,12 +23301,12 @@ public struct AvailabilityArgument: SyntaxBuildable, ExpressibleAsAvailabilityAr
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -23395,7 +23351,7 @@ public struct AvailabilityLabeledArgument: SyntaxBuildable, ExpressibleAsAvailab
   public init (leadingTrivia: Trivia = [], unexpectedBeforeLabel: ExpressibleAsUnexpectedNodes? = nil, label: String, unexpectedBetweenLabelAndColon: ExpressibleAsUnexpectedNodes? = nil, colon: Token = Token.`colon`, unexpectedBetweenColonAndValue: ExpressibleAsUnexpectedNodes? = nil, value: ExpressibleAsSyntaxBuildable) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLabel: unexpectedBeforeLabel, label: Token.`identifier`(label), unexpectedBetweenLabelAndColon: unexpectedBetweenLabelAndColon, colon: colon, unexpectedBetweenColonAndValue: unexpectedBetweenColonAndValue, value: value)
   }
-  public init (_ constructedNode: AvailabilityLabeledArgumentSyntax) {
+  public init(_ constructedNode: AvailabilityLabeledArgumentSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AvailabilityLabeledArgumentSyntax`.
@@ -23437,13 +23393,13 @@ public struct AvailabilityLabeledArgument: SyntaxBuildable, ExpressibleAsAvailab
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -23451,12 +23407,12 @@ public struct AvailabilityLabeledArgument: SyntaxBuildable, ExpressibleAsAvailab
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -23496,7 +23452,7 @@ public struct AvailabilityVersionRestriction: SyntaxBuildable, ExpressibleAsAvai
   public init (leadingTrivia: Trivia = [], unexpectedBeforePlatform: ExpressibleAsUnexpectedNodes? = nil, platform: String, unexpectedBetweenPlatformAndVersion: ExpressibleAsUnexpectedNodes? = nil, version: ExpressibleAsVersionTuple? = nil) {
     self.init(leadingTrivia: leadingTrivia, unexpectedBeforePlatform: unexpectedBeforePlatform, platform: Token.`identifier`(platform), unexpectedBetweenPlatformAndVersion: unexpectedBetweenPlatformAndVersion, version: version)
   }
-  public init (_ constructedNode: AvailabilityVersionRestrictionSyntax) {
+  public init(_ constructedNode: AvailabilityVersionRestrictionSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `AvailabilityVersionRestrictionSyntax`.
@@ -23538,13 +23494,13 @@ public struct AvailabilityVersionRestriction: SyntaxBuildable, ExpressibleAsAvai
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -23552,12 +23508,12 @@ public struct AvailabilityVersionRestriction: SyntaxBuildable, ExpressibleAsAvai
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
@@ -23600,11 +23556,9 @@ public struct VersionTuple: SyntaxBuildable, ExpressibleAsVersionTuple {
   ///  - Initializing syntax collections using result builders
   ///  - Initializing tokens without default text using strings
   public init (leadingTrivia: Trivia = [], unexpectedBeforeMajorMinor: ExpressibleAsUnexpectedNodes? = nil, majorMinor: ExpressibleAsSyntaxBuildable, unexpectedBetweenMajorMinorAndPatchPeriod: ExpressibleAsUnexpectedNodes? = nil, patchPeriod: Token? = nil, unexpectedBetweenPatchPeriodAndPatchVersion: ExpressibleAsUnexpectedNodes? = nil, patchVersion: String?) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeMajorMinor: unexpectedBeforeMajorMinor, majorMinor: majorMinor, unexpectedBetweenMajorMinorAndPatchPeriod: unexpectedBetweenMajorMinorAndPatchPeriod, patchPeriod: patchPeriod, unexpectedBetweenPatchPeriodAndPatchVersion: unexpectedBetweenPatchPeriodAndPatchVersion, patchVersion: patchVersion.map {
-      Token.`integerLiteral`($0)
-    })
+    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeMajorMinor: unexpectedBeforeMajorMinor, majorMinor: majorMinor, unexpectedBetweenMajorMinorAndPatchPeriod: unexpectedBetweenMajorMinorAndPatchPeriod, patchPeriod: patchPeriod, unexpectedBetweenPatchPeriodAndPatchVersion: unexpectedBetweenPatchPeriodAndPatchVersion, patchVersion: patchVersion.map { Token.`integerLiteral`($0) })
   }
-  public init (_ constructedNode: VersionTupleSyntax) {
+  public init(_ constructedNode: VersionTupleSyntax) {
     self.data = .constructed(constructedNode)
   }
   /// Builds a `VersionTupleSyntax`.
@@ -23646,13 +23600,13 @@ public struct VersionTuple: SyntaxBuildable, ExpressibleAsVersionTuple {
   }
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.leadingTrivia = leadingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
-      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+    case .constructed(let node):
+      let withNewTrivia = node.withLeadingTrivia(leadingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)
       return result
@@ -23660,12 +23614,12 @@ public struct VersionTuple: SyntaxBuildable, ExpressibleAsVersionTuple {
   }
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
     switch data {
-    case .buildable(var buildableData): 
+    case .buildable(var buildableData):
       buildableData.trailingTrivia = trailingTrivia
       var result = self
       result.data = .buildable(buildableData)
       return result
-    case .constructed(let node): 
+    case .constructed(let node):
       let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
       var result = self
       result.data = .constructed(withNewTrivia)

--- a/Sources/SwiftSyntaxBuilder/generated/Token.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/Token.swift
@@ -22,23 +22,32 @@ public struct Token: SyntaxBuildable, ExpressibleAsBinaryOperatorExpr, Expressib
   let tokenSyntax: TokenSyntax
   let leadingTrivia: Trivia?
   let trailingTrivia: Trivia?
+  var text: String { tokenSyntax.text }
   
-  var text: String {
-    tokenSyntax.text
-  }
-  
-  public init (tokenSyntax: TokenSyntax, leadingTrivia: Trivia? = nil, trailingTrivia: Trivia? = nil) {
+  public init(
+    tokenSyntax: TokenSyntax,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil
+  ) {
     self.tokenSyntax = tokenSyntax
     self.leadingTrivia = leadingTrivia
     self.trailingTrivia = trailingTrivia
   }
   
   public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Token {
-    Token(tokenSyntax: tokenSyntax, leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
+    Token(
+      tokenSyntax: tokenSyntax,
+      leadingTrivia: leadingTrivia,
+      trailingTrivia: trailingTrivia
+    )
   }
   
   public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Token {
-    Token(tokenSyntax: tokenSyntax, leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia)
+    Token(
+      tokenSyntax: tokenSyntax,
+      leadingTrivia: leadingTrivia,
+      trailingTrivia: trailingTrivia
+    )
   }
   
   public func buildToken(format: Format) -> TokenSyntax {


### PR DESCRIPTION
This starts using the parser integration in SwiftSyntaxBuilder that was added by https://github.com/apple/swift-syntax/pull/848 in the Code-Generation package. IMO it simplifies a lot of the static boilerplate code generation that was overly verbose with SwiftSyntaxBuilder.

The only changes in the generated files are formatting-related, so there’s no functionality change in SwiftSyntaxBuilder.