### PR TITLE
SyntaxArena: thread safety part 2

### DIFF
--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -122,7 +122,8 @@ extension Parser {
 /// tokens as needed to disambiguate a parse. However, because lookahead
 /// operates on a copy of the lexical stream, no input tokens are lost..
 public struct Parser: TokenConsumer {
-  let arena: SyntaxArena
+  @_spi(RawSyntax)
+  public var arena: SyntaxArena
   /// A view of the sequence of lexemes in the input.
   var lexemes: Lexer.LexemeSequence
   /// The current token. If there was no input, this token will have a kind of `.eof`.

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -42,8 +42,10 @@ extension Parser {
     // Extended lifetime is required because `SyntaxArena` in the parser must
     // be alive until `Syntax(raw:)` retains the arena.
     return withExtendedLifetime(parser) {
-      let rawSourceFile =  parser.parseSourceFile()
-      return rawSourceFile.syntax
+      parser.arena.assumingSingleThread {
+        let rawSourceFile =  parser.parseSourceFile()
+        return rawSourceFile.syntax
+      }
     }
   }
 }

--- a/Sources/SwiftSyntax/CMakeLists.txt
+++ b/Sources/SwiftSyntax/CMakeLists.txt
@@ -10,6 +10,7 @@ add_library(SwiftSyntax STATIC
   AbsolutePosition.swift
   BumpPtrAllocator.swift
   IncrementalParseTransition.swift
+  PlatformMutex.swift
   SourceLength.swift
   SourceLocation.swift
   SourcePresence.swift

--- a/Sources/SwiftSyntax/PlatformMutex.swift
+++ b/Sources/SwiftSyntax/PlatformMutex.swift
@@ -1,0 +1,82 @@
+//===------ PlatformMutex.swift - Platform-specific Mutual Exclusion  -----===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Darwin)
+@_implementationOnly import Darwin
+#elseif canImport(Glibc)
+@_implementationOnly import Glibc
+#elseif canImport(WinSDK)
+@_implementationOnly import WinSDK
+#endif
+
+/// A protocol that platform-specific mutual exclusion primitives should conform to.
+struct PlatformMutex {
+  // FIXME: Use os_unfair_lock when we bump to macOS 12.0 on Darwin
+#if canImport(Darwin) || canImport(Glibc)
+  typealias Primitive = pthread_mutex_t
+#elseif canImport(WinSDK)
+  typealias Primitive = SRWLOCK
+#endif
+  typealias PlatformLock = UnsafeMutablePointer<Primitive>
+
+  private let lock: PlatformLock
+
+  /// Allocate memory for, and initialize, the mutex in a platform-specific fashion.
+  ///
+  /// - Parameter allocator: An allocator
+  init(allocator: BumpPtrAllocator) {
+    let storage = allocator.allocate(Primitive.self, count: 1).baseAddress!
+    storage.initialize(to: Primitive())
+#if canImport(Darwin) || canImport(Glibc)
+    pthread_mutex_init(storage, nil)
+#elseif canImport(WinSDK)
+    InitializeSRWLock(storage)
+#endif
+    self.lock = storage
+  }
+
+  /// Deinitialize the memory associated with the mutex.
+  ///
+  /// - Warning: Do not call `.deallocate()` on  any pointers allocated by the
+  ///            `BumpPtrAllocator` here.
+  func deinitialize() {
+#if canImport(Darwin) || canImport(Glibc)
+    pthread_mutex_destroy(self.lock)
+#endif
+    self.lock.deinitialize(count: 1)
+  }
+
+  /// Invoke the provided block under the protection of the mutex.
+  func withGuard<T>(body: () throws -> T) rethrows -> T {
+    Self.lock(self.lock)
+    defer { Self.unlock(self.lock) }
+    return try body()
+  }
+}
+
+extension PlatformMutex {
+  private static func lock(_ platformLock: PlatformLock) {
+#if canImport(Darwin) || canImport(Glibc)
+    pthread_mutex_lock(platformLock)
+#elseif canImport(WinSDK)
+    AcquireSRWLockExclusive(platformLock)
+#endif
+  }
+
+  private static func unlock(_ platformLock: PlatformLock) {
+#if canImport(Darwin) || canImport(Glibc)
+    pthread_mutex_unlock(platformLock)
+#elseif canImport(WinSDK)
+    ReleaseSRWLockExclusive(platformLock)
+#endif
+  }
+}

--- a/Sources/SwiftSyntax/SyntaxArena.swift
+++ b/Sources/SwiftSyntax/SyntaxArena.swift
@@ -15,10 +15,6 @@ public class SyntaxArena {
   @_spi(RawSyntax)
   public typealias ParseTriviaFunction = (_ source: SyntaxText, _ position: TriviaPosition) -> [RawTriviaPiece]
 
-  /// Thread safe guard.
-  private let lock: PlatformMutex
-  private var singleThreadMode: Bool
-
   /// Bump-pointer allocator for all "intern" methods.
   private let allocator: BumpPtrAllocator
   /// Source file buffer the Syntax tree represents.
@@ -32,15 +28,18 @@ public class SyntaxArena {
   private var hasParent: Bool
   private var parseTriviaFunction: ParseTriviaFunction
 
+  /// Thread safe guard.
+  private let lock: PlatformMutex
+  private var singleThreadMode: Bool
+
   @_spi(RawSyntax)
   public init(parseTriviaFunction: @escaping ParseTriviaFunction) {
-    let allocator = BumpPtrAllocator()
-    self.lock = PlatformMutex(allocator: allocator)
+    self.allocator = BumpPtrAllocator()
+    self.lock = PlatformMutex(allocator: self.allocator)
     self.singleThreadMode = false
-    self.allocator = allocator
-    children = []
-    sourceBuffer = .init(start: nil, count: 0)
-    hasParent = false
+    self.children = []
+    self.sourceBuffer = .init(start: nil, count: 0)
+    self.hasParent = false
     self.parseTriviaFunction = parseTriviaFunction
   }
 

--- a/Sources/SwiftSyntax/SyntaxText.swift
+++ b/Sources/SwiftSyntax/SyntaxText.swift
@@ -11,9 +11,9 @@
 //===----------------------------------------------------------------------===//
 
 #if canImport(Darwin)
-import Darwin
+@_implementationOnly import Darwin
 #elseif canImport(Glibc)
-import Glibc
+@_implementationOnly import Glibc
 #endif
 
 /// Represent a string.

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -1,6 +1,5 @@
-@_spi(RawSyntax)
-import SwiftSyntax
-import SwiftParser
+@_spi(RawSyntax) import SwiftSyntax
+@_spi(RawSyntax) import SwiftParser
 
 /// An individual interpolated syntax node.
 struct InterpolatedSyntaxNode {

--- a/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
+++ b/Sources/SwiftSyntaxBuilder/Syntax+StringInterpolation.swift
@@ -101,7 +101,9 @@ extension SyntaxExpressibleByStringInterpolation {
       var parser = Parser(buffer)
       // FIXME: When the parser supports incremental parsing, put the
       // interpolatedSyntaxNodes in so we don't have to parse them again.
-      return Self.parse(from: &parser)
+      return parser.arena.assumingSingleThread {
+        return Self.parse(from: &parser)
+      }
     }
   }
 

--- a/Tests/SwiftParserTest/Linkage.swift
+++ b/Tests/SwiftParserTest/Linkage.swift
@@ -32,7 +32,6 @@ final class LinkageTest: XCTestCase {
       .library("-lswiftCompatibility56", condition: .mayBeAbsent("Starting in Xcode 14 this library is not always autolinked")),
       .library("-lswiftCompatibilityConcurrency"),
       .library("-lswiftCore"),
-      .library("-lswiftDarwin"),
       .library("-lswiftSwiftOnoneSupport", condition: .when(configuration: .debug)),
       .library("-lswift_Concurrency"),
       .library("-lswift_StringProcessing", condition: .when(swiftVersionAtLeast: .v5_7)),

--- a/Tests/SwiftSyntaxTest/MultithreadingTests.swift
+++ b/Tests/SwiftSyntaxTest/MultithreadingTests.swift
@@ -29,8 +29,13 @@ public class MultithreadingTests: XCTestCase {
           presence: .present,
           arena: arena)
       }
-      let token = Syntax(raw: RawSyntax(tokenRaw)).as(TokenSyntax.self)!
-      XCTAssertEqual(token.text, "ident\(i)")
+      let identifierExprRaw = RawIdentifierExprSyntax(
+        identifier: tokenRaw,
+        declNameArguments: nil,
+        arena: arena)
+
+      let expr = Syntax(raw: RawSyntax(identifierExprRaw)).as(IdentifierExprSyntax.self)!
+      XCTAssertEqual(expr.identifier.text, "ident\(i)")
     }
   }
 

--- a/Tests/SwiftSyntaxTest/MultithreadingTests.swift
+++ b/Tests/SwiftSyntaxTest/MultithreadingTests.swift
@@ -1,5 +1,6 @@
 import XCTest
-import SwiftSyntax
+@_spi(RawSyntax) import SwiftSyntax
+
 
 public class MultithreadingTests: XCTestCase {
 
@@ -12,6 +13,24 @@ public class MultithreadingTests: XCTestCase {
 
     DispatchQueue.concurrentPerform(iterations: 100) { _ in
       XCTAssertEqual(tuple.leftParen, tuple.leftParen)
+    }
+  }
+
+  public func testConcurrentArena() {
+    let arena = SyntaxArena()
+
+    DispatchQueue.concurrentPerform(iterations: 100) { i in
+      var identStr = " ident\(i) "
+      let tokenRaw = identStr.withSyntaxText { text in
+        RawTokenSyntax(
+          kind: .identifier,
+          wholeText: arena.intern(text),
+          textRange: 1..<(text.count-1),
+          presence: .present,
+          arena: arena)
+      }
+      let token = Syntax(raw: RawSyntax(tokenRaw)).as(TokenSyntax.self)!
+      XCTAssertEqual(token.text, "ident\(i)")
     }
   }
 

--- a/utils/group.json
+++ b/utils/group.json
@@ -56,5 +56,6 @@
     "SyntaxArena.swift",
     "SyntaxVerifier.swift",
     "BumpPtrAllocator.swift",
+    "PlatformMutex.swift",
   ]
 }


### PR DESCRIPTION
Restore Rintaro's original patch with a few adjustments:

- Sequester the platform-specific bits into a common type. If a platform is not present here, it'll just blow up instead of enabling data races.
- Expand the available platforms supported to include Windows
- Use pthread_mutex_t on Darwin platforms for now - which was the driver of the revert