### PR TITLE
Lookahead Through Balanced Brackets In Closure Capture Lists

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -2231,11 +2231,7 @@ extension Parser.Lookahead {
 
     // Skip by a closure capture list if present.
     if lookahead.consume(if: .leftSquareBracket) != nil {
-      var captureListProgress = LoopProgressCondition()
-      while !lookahead.at(any: [.eof, .rightSquareBracket]) && captureListProgress.evaluate(lookahead.currentToken) {
-        lookahead.consumeAnyToken()
-      }
-
+      lookahead.skipUntil(.rightSquareBracket, .rightSquareBracket)
       if lookahead.consume(if: .rightSquareBracket) == nil {
         return false
       }

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -593,4 +593,21 @@ final class ExpressionTests: XCTestCase {
       substructureAfterMarker: "PLUS"
     )
   }
+
+  func testBogusCaptureLists() {
+    // N.B. This test ensures that capture list lookahead doesn't try to pair
+    // the opening square bracket from the array literal with the closing
+    // square bracket from the capture list.
+    AssertParse(
+      """
+      {
+          [
+              AboutItem(title: TextContent.legalAndMore, accessoryType: .disclosureIndicator, action: { [weak self] context in
+                  self?.tracker.buttonPressed(.legal)
+                  context.showSubmenu(title: TextContent.legalAndMore, configuration: LegalAndMoreSubmenuConfiguration())
+              }),
+          ]
+      }()
+      """)
+  }
 }


### PR DESCRIPTION
Lookahead here was trying to eat its way to the nearest right bracket rather than the nearest *balanced* right bracket.