### PR TITLE
Generalize "InVarOrLetPattern" to "PatternContext"

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -117,7 +117,7 @@ extension Parser {
         leftParen: nil, argumentList: nil, rightParen: nil,
         arena: self.arena)
     }
-    let arguments = self.parseArgumentListElements(inLetOrVar: false)
+    let arguments = self.parseArgumentListElements(pattern: .none)
     let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
     return RawCustomAttributeSyntax(
       unexpectedBeforeAtSign,

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -33,6 +33,23 @@ extension Parser {
     case trailingClosure
   }
 
+  public enum PatternContext {
+    case none
+    case matching
+    case `var`
+    case `let`
+    case implicitlyImmutable
+
+    var admitsBinding: Bool {
+      switch self {
+      case .implicitlyImmutable, .var, .let:
+        return true
+      case .none, .matching:
+        return false
+      }
+    }
+  }
+
   /// Parse an expression.
   ///
   /// Grammar
@@ -41,7 +58,7 @@ extension Parser {
   ///     expression → try-operator? await-operator? prefix-expression infix-expressions?
   ///     expression-list → expression | expression ',' expression-list
   @_spi(RawSyntax)
-  public mutating func parseExpression(_ flavor: ExprFlavor = .trailingClosure, inLetOrVar: Bool = false) -> RawExprSyntax {
+  public mutating func parseExpression(_ flavor: ExprFlavor = .trailingClosure, pattern: PatternContext = .none) -> RawExprSyntax {
     // If we are parsing a refutable pattern, check to see if this is the start
     // of a let/var/is pattern.  If so, parse it as an UnresolvedPatternExpr and
     // let pattern type checking determine its final form.
@@ -52,7 +69,7 @@ extension Parser {
       let pattern = self.parseMatchingPattern()
       return RawExprSyntax(RawUnresolvedPatternExprSyntax(pattern: pattern, arena: self.arena))
     }
-    return RawExprSyntax(self.parseSequenceExpression(flavor, inVarOrLet: inLetOrVar))
+    return RawExprSyntax(self.parseSequenceExpression(flavor, pattern: pattern))
   }
 }
 
@@ -71,7 +88,7 @@ extension Parser {
   public mutating func parseSequenceExpression(
     _ flavor: ExprFlavor,
     forDirective: Bool = false,
-    inVarOrLet: Bool = false
+    pattern: PatternContext = .none
   ) -> RawExprSyntax {
     if forDirective && self.currentToken.isAtStartOfLine {
       return RawExprSyntax(RawMissingExprSyntax(arena: self.arena))
@@ -87,7 +104,7 @@ extension Parser {
 
     lastElement = self.parseSequenceExpressionElement(flavor,
                                                       forDirective: forDirective,
-                                                      inVarOrLet: inVarOrLet)
+                                                      pattern: pattern)
 
     var loopCondition = LoopProgressCondition()
     while loopCondition.evaluate(currentToken) {
@@ -101,7 +118,7 @@ extension Parser {
       // Parse the operator.
       guard
         let (operatorExpr, rhsExpr) =
-          self.parseSequenceExpressionOperator(flavor, inVarOrLet: inVarOrLet)
+          self.parseSequenceExpressionOperator(flavor, pattern: pattern)
       else {
         // Not an operator. We're done.
         break
@@ -120,7 +137,7 @@ extension Parser {
       } else {
         lastElement = self.parseSequenceExpressionElement(flavor,
                                                           forDirective: forDirective,
-                                                          inVarOrLet: inVarOrLet)
+                                                          pattern: pattern)
       }
     }
 
@@ -160,7 +177,7 @@ extension Parser {
   ///     arrow-operator -> 'throws' '->'
   ///     arrow-operator -> 'async' 'throws' '->'
   mutating func parseSequenceExpressionOperator(
-    _ flavor: ExprFlavor, inVarOrLet: Bool
+    _ flavor: ExprFlavor, pattern: PatternContext
   ) -> (operator: RawExprSyntax, rhs: RawExprSyntax?)? {
     enum ExpectedTokenKind: RawTokenKindSubset {
       case spacedBinaryOperator
@@ -220,7 +237,7 @@ extension Parser {
     case (.infixQuestionMark, let handle)?:
       // Save the '?'.
       let question = self.eat(handle)
-      let firstChoice = self.parseSequenceExpression(flavor, inVarOrLet: inVarOrLet)
+      let firstChoice = self.parseSequenceExpression(flavor, pattern: pattern)
       // Make sure there's a matching ':' after the middle expr.
       let (unexpectedBeforeColon, colon) = self.expect(.colon)
 
@@ -243,9 +260,10 @@ extension Parser {
       return (RawExprSyntax(op), rhs)
 
     case (.equal, let handle)?:
-      if inVarOrLet {
+      switch pattern {
+      case .matching, .let, .var:
         return nil
-      } else {
+      case .none, .implicitlyImmutable:
         let eq = self.eat(handle)
         let op = RawAssignmentExprSyntax(
           assignToken: eq,
@@ -253,6 +271,7 @@ extension Parser {
         )
         return (RawExprSyntax(op), nil)
       }
+
       
     case (.isKeyword, let handle)?:
       let isKeyword = self.eat(handle)
@@ -320,7 +339,7 @@ extension Parser {
   public mutating func parseSequenceExpressionElement(
     _ flavor: ExprFlavor,
     forDirective: Bool = false,
-    inVarOrLet: Bool = false
+    pattern: PatternContext = .none
   ) -> RawExprSyntax {
     // Try to parse '@' sign or 'inout' as a attributed typerepr.
     if self.at(any: [.atSign, .inoutKeyword]) {
@@ -336,7 +355,7 @@ extension Parser {
     case (.awaitContextualKeyword, let handle)?:
       let awaitTok = self.eat(handle)
       let sub = self.parseSequenceExpressionElement(
-        flavor, forDirective: forDirective, inVarOrLet: inVarOrLet)
+        flavor, forDirective: forDirective, pattern: pattern)
       return RawExprSyntax(RawAwaitExprSyntax(
         awaitKeyword: awaitTok,
         expression: sub,
@@ -347,7 +366,7 @@ extension Parser {
       let mark = self.consume(ifAny: [.exclamationMark, .postfixQuestionMark])
 
       let expression = self.parseSequenceExpressionElement(
-        flavor, forDirective: forDirective, inVarOrLet: inVarOrLet)
+        flavor, forDirective: forDirective, pattern: pattern)
       return RawExprSyntax(RawTryExprSyntax(
         tryKeyword: tryKeyword,
         questionOrExclamationMark: mark,
@@ -357,13 +376,13 @@ extension Parser {
     case (._moveContextualKeyword, let handle)?:
       let moveTok = self.eat(handle)
       let sub = self.parseSequenceExpressionElement(
-        flavor, forDirective: forDirective, inVarOrLet: inVarOrLet)
+        flavor, forDirective: forDirective, pattern: pattern)
       return RawExprSyntax(RawMoveExprSyntax(
         moveKeyword: moveTok,
         expression: sub,
         arena: self.arena))
     case nil:
-      return self.parseUnaryExpression(flavor, forDirective: forDirective, inVarOrLet: inVarOrLet)
+      return self.parseUnaryExpression(flavor, forDirective: forDirective, pattern: pattern)
     }
   }
 
@@ -380,14 +399,14 @@ extension Parser {
   public mutating func parseUnaryExpression(
     _ flavor: ExprFlavor,
     forDirective: Bool = false,
-    inVarOrLet: Bool = false
+    pattern: PatternContext = .none
   ) -> RawExprSyntax {
     // First check to see if we have the start of a regex literal `/.../`.
     //    tryLexRegexLiteral(/*forUnappliedOperator*/ false)
     switch self.at(anyIn: ExpressionPrefixOperator.self) {
     case (.prefixAmpersand, let handle)?:
       let amp = self.eat(handle)
-      let expr = self.parseUnaryExpression(flavor, forDirective: forDirective, inVarOrLet: inVarOrLet)
+      let expr = self.parseUnaryExpression(flavor, forDirective: forDirective, pattern: pattern)
       return RawExprSyntax(RawInOutExprSyntax(
         ampersand: amp,
         expression: RawExprSyntax(expr),
@@ -395,11 +414,11 @@ extension Parser {
       ))
 
     case (.backslash, _)?:
-      return RawExprSyntax(self.parseKeyPathExpression(forDirective: forDirective, inVarOrLet: inVarOrLet))
+      return RawExprSyntax(self.parseKeyPathExpression(forDirective: forDirective, pattern: pattern))
 
     case (.prefixOperator, let handle)?:
       let op = self.eat(handle)
-      let postfix = self.parseUnaryExpression(flavor, forDirective: forDirective, inVarOrLet: inVarOrLet)
+      let postfix = self.parseUnaryExpression(flavor, forDirective: forDirective, pattern: pattern)
       return RawExprSyntax(RawPrefixOperatorExprSyntax(
         operatorToken: op,
         postfixExpression: postfix,
@@ -409,7 +428,7 @@ extension Parser {
     default:
       // If the next token is not an operator, just parse this as expr-postfix.
       return self.parsePostfixExpression(
-        flavor, forDirective: forDirective, inVarOrLet: inVarOrLet,
+        flavor, forDirective: forDirective, pattern: pattern,
         periodHasKeyPathBehavior: false)
     }
   }
@@ -432,16 +451,16 @@ extension Parser {
   public mutating func parsePostfixExpression(
     _ flavor: ExprFlavor,
     forDirective: Bool,
-    inVarOrLet: Bool,
+    pattern: PatternContext,
     periodHasKeyPathBehavior: Bool
   ) -> RawExprSyntax {
-    let head = self.parsePrimaryExpression(inVarOrLet: inVarOrLet)
+    let head = self.parsePrimaryExpression(pattern: pattern)
     guard !head.is(RawMissingExprSyntax.self) else {
       return head
     }
     return self.parsePostfixExpressionSuffix(
       head, flavor, forDirective: forDirective,
-      periodHasKeyPathBehavior: periodHasKeyPathBehavior, inLetOrVar: inVarOrLet)
+      periodHasKeyPathBehavior: periodHasKeyPathBehavior, pattern: pattern)
   }
 
   @_spi(RawSyntax)
@@ -503,7 +522,7 @@ extension Parser {
       let result = parser.parsePostfixExpressionSuffix(
         head, flavor, forDirective: forDirective,
         periodHasKeyPathBehavior: false,
-        inLetOrVar: false
+        pattern: .none
       )
 
       // TODO: diagnose and skip the remaining token in the current clause.
@@ -541,7 +560,7 @@ extension Parser {
     _ flavor: ExprFlavor,
     forDirective: Bool,
     periodHasKeyPathBehavior: Bool,
-    inLetOrVar: Bool
+    pattern: PatternContext
   ) -> RawExprSyntax {
     // Handle suffix expressions.
     var leadingExpr = start
@@ -568,7 +587,7 @@ extension Parser {
 
       // If there is an expr-call-suffix, parse it and form a call.
       if let lparen = self.consume(if: .leftParen, where: { !$0.isAtStartOfLine }) {
-        let args = self.parseArgumentListElements(inLetOrVar: inLetOrVar)
+        let args = self.parseArgumentListElements(pattern: pattern)
         let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
 
         // If we can parse trailing closures, do so.
@@ -600,7 +619,7 @@ extension Parser {
         if self.at(.rightSquareBracket) {
           args = []
         } else {
-          args = self.parseArgumentListElements(inLetOrVar: inLetOrVar)
+          args = self.parseArgumentListElements(pattern: pattern)
         }
         let (unexpectedBeforeRSquare, rsquare) = self.expect(.rightSquareBracket)
 
@@ -731,7 +750,7 @@ extension Parser {
   ///     key-path-postfixes → key-path-postfix key-path-postfixes?
   ///     key-path-postfix → '?' | '!' | 'self' | '[' function-call-argument-list ']'
   @_spi(RawSyntax)
-  public mutating func parseKeyPathExpression(forDirective: Bool, inVarOrLet: Bool) -> RawKeyPathExprSyntax {
+  public mutating func parseKeyPathExpression(forDirective: Bool, pattern: PatternContext) -> RawKeyPathExprSyntax {
     // Consume '\'.
     let (unexpectedBeforeBackslash, backslash) = self.expect(.backslash)
 
@@ -743,7 +762,7 @@ extension Parser {
     let root: RawExprSyntax?
     if !self.currentToken.starts(with: ".") {
       root = self.parsePostfixExpression(
-        .basic, forDirective: forDirective, inVarOrLet: inVarOrLet,
+        .basic, forDirective: forDirective, pattern: pattern,
         periodHasKeyPathBehavior: true)
     } else {
       root = nil
@@ -761,7 +780,7 @@ extension Parser {
       expression = self.parsePostfixExpressionSuffix(
         base, .basic, forDirective: forDirective,
         periodHasKeyPathBehavior: false,
-        inLetOrVar: inVarOrLet
+        pattern: pattern
       )
     } else if self.at(any: [.period, .prefixPeriod]) {
       // Inside a keypath's path, the period always behaves normally: the key path
@@ -770,7 +789,7 @@ extension Parser {
       expression = self.parsePostfixExpressionSuffix(
         base, .basic, forDirective: forDirective,
         periodHasKeyPathBehavior: false,
-        inLetOrVar: inVarOrLet
+        pattern: pattern
       )
     } else {
       expression = RawExprSyntax(RawMissingExprSyntax(arena: self.arena))
@@ -805,7 +824,7 @@ extension Parser {
   ///     primary-expression → selector-expression
   ///     primary-expression → key-path-string-expression
   @_spi(RawSyntax)
-  public mutating func parsePrimaryExpression(inVarOrLet: Bool) -> RawExprSyntax {
+  public mutating func parsePrimaryExpression(pattern: PatternContext) -> RawExprSyntax {
     switch self.at(anyIn: PrimaryExpressionStart.self) {
     case (.integerLiteral, let handle)?:
       let digits = self.eat(handle)
@@ -912,7 +931,7 @@ extension Parser {
       // If we have "case let x." or "case let x(", we parse x as a normal
       // name, not a binding, because it is the start of an enum pattern or
       // call pattern.
-      if inVarOrLet && !self.lookahead().isNextTokenCallPattern() {
+      if pattern.admitsBinding && !self.lookahead().isNextTokenCallPattern() {
         let identifier = self.eat(handle)
         let pattern = RawPatternSyntax(RawIdentifierPatternSyntax(
           identifier: identifier, arena: self.arena))
@@ -970,7 +989,7 @@ extension Parser {
       // only one element without label. However, libSyntax tree doesn't have this
       // differentiation. A tuple expression node in libSyntax can have a single
       // element without label.
-      return RawExprSyntax(self.parseTupleExpression(inLetOrVar: inVarOrLet))
+      return RawExprSyntax(self.parseTupleExpression(pattern: pattern))
 
     case (.leftSquareBracket, _)?:
       return self.parseCollectionLiteral()
@@ -1026,7 +1045,7 @@ extension Parser {
   public mutating func parseObjectLiteralExpression() -> RawObjectLiteralExprSyntax {
     let poundKeyword = self.consumeAnyToken()
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
-    let arguments = self.parseArgumentListElements(inLetOrVar: false)
+    let arguments = self.parseArgumentListElements(pattern: .none)
     let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)
     return RawObjectLiteralExprSyntax(
       identifier: poundKeyword,
@@ -1380,7 +1399,7 @@ extension Parser {
         expressionContent.withBuffer { buf in
           var subparser = Parser(buf, arena: self.arena)
           let (lunexpected, lparen) = subparser.expect(.leftParen)
-          let args = subparser.parseArgumentListElements(inLetOrVar: false)
+          let args = subparser.parseArgumentListElements(pattern: .none)
           // If we stopped parsing the expression before the expression segment is
           // over, eat the remaining tokens into a token list.
           var runexpectedTokens = [RawSyntax]()
@@ -1540,9 +1559,9 @@ extension Parser {
   ///     tuple-expression → '(' ')' | '(' tuple-element ',' tuple-element-list ')'
   ///     tuple-element-list → tuple-element | tuple-element ',' tuple-element-list
   @_spi(RawSyntax)
-  public mutating func parseTupleExpression(inLetOrVar: Bool) -> RawTupleExprSyntax {
+  public mutating func parseTupleExpression(pattern: PatternContext) -> RawTupleExprSyntax {
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
-    let elements = self.parseArgumentListElements(inLetOrVar: inLetOrVar)
+    let elements = self.parseArgumentListElements(pattern: pattern)
     let (unexpectedBeforeRParen, rparen) = self.expect(.rightParen)
     return RawTupleExprSyntax(
       unexpectedBeforeLParen,
@@ -2009,7 +2028,7 @@ extension Parser {
   ///
   ///     tuple-element → expression | identifier ':' expression
   @_spi(RawSyntax)
-  public mutating func parseArgumentListElements(inLetOrVar: Bool) -> [RawTupleExprElementSyntax] {
+  public mutating func parseArgumentListElements(pattern: PatternContext) -> [RawTupleExprElementSyntax] {
     guard !self.at(.rightParen) else {
       return []
     }
@@ -2031,7 +2050,7 @@ extension Parser {
         expr = RawExprSyntax(RawIdentifierExprSyntax(
           identifier: ident, declNameArguments: args, arena: self.arena))
       } else {
-        expr = self.parseExpression(inLetOrVar: inLetOrVar)
+        expr = self.parseExpression(pattern: pattern)
       }
       keepGoing = self.consume(if: .comma)
       result.append(RawTupleExprElementSyntax(
@@ -2056,9 +2075,9 @@ extension Parser {
   ///     tuple-expression → '(' ')' | '(' tuple-element ',' tuple-element-list ')'
   ///     tuple-element-list → tuple-element | tuple-element ',' tuple-element-list
   @_spi(RawSyntax)
-  public mutating func parseArgumentList(_ flavor: ExprFlavor, inLetOrVar: Bool) -> RawTupleExprSyntax {
+  public mutating func parseArgumentList(_ flavor: ExprFlavor, pattern: PatternContext) -> RawTupleExprSyntax {
     let (unexpectedBeforeLParen, lparen) = self.expect(.leftParen)
-    let args = self.parseArgumentListElements(inLetOrVar: inLetOrVar)
+    let args = self.parseArgumentListElements(pattern: pattern)
     let (unexpectedBeforeRightParen, rparen) = self.expect(.rightParen)
 
     // FIXME: Introduce new SyntaxKind for ArgumentList (rdar://81786229)

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -72,7 +72,6 @@ extension Parser {
         case .varKeyword: return .varKeyword
         }
       }
-
     }
 
     switch self.at(anyIn: ExpectedTokens.self) {
@@ -171,13 +170,13 @@ extension Parser {
 extension Parser {
   /// Parse a pattern that appears immediately under syntax for conditionals like
   /// for-in loops and guard clauses.
-  mutating func parseMatchingPattern() -> RawPatternSyntax {
+  mutating func parseMatchingPattern(context: PatternContext) -> RawPatternSyntax {
     // Parse productions that can only be patterns.
     switch self.at(anyIn: MatchingPatternStart.self) {
     case (.varKeyword, let handle)?,
-      (.letKeyword, let handle)?:
+         (.letKeyword, let handle)?:
       let letOrVar = self.eat(handle)
-      let value = self.parseMatchingPattern()
+      let value = self.parseMatchingPattern(context: .letOrVar)
       return RawPatternSyntax(RawValueBindingPatternSyntax(
         letOrVarKeyword: letOrVar, valuePattern: value, arena: self.arena))
     case (.isKeyword, let handle)?:
@@ -192,7 +191,7 @@ extension Parser {
       // matching-pattern ::= expr
       // Fall back to expression parsing for ambiguous forms. Name lookup will
       // disambiguate.
-      let patternSyntax = self.parseSequenceExpression(.basic, pattern: .matching)
+      let patternSyntax = self.parseSequenceExpression(.basic, pattern: context)
       if let pat = patternSyntax.as(RawUnresolvedPatternExprSyntax.self) {
         // The most common case here is to parse something that was a lexically
         // obvious pattern, which will come back wrapped in an immediate

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -101,7 +101,7 @@ extension Parser {
         arena: self.arena
       ))
     case (.letKeyword, let handle)?,
-      (.varKeyword, let handle)?:
+         (.varKeyword, let handle)?:
       let letOrVar = self.eat(handle)
       let value = self.parsePattern()
       return RawPatternSyntax(RawValueBindingPatternSyntax(
@@ -192,7 +192,7 @@ extension Parser {
       // matching-pattern ::= expr
       // Fall back to expression parsing for ambiguous forms. Name lookup will
       // disambiguate.
-      let patternSyntax = self.parseSequenceExpression(.basic, inVarOrLet: true)
+      let patternSyntax = self.parseSequenceExpression(.basic, pattern: .matching)
       if let pat = patternSyntax.as(RawUnresolvedPatternExprSyntax.self) {
         // The most common case here is to parse something that was a lexically
         // obvious pattern, which will come back wrapped in an immediate

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -261,11 +261,11 @@ extension Parser {
 
     let kind: BindingKind
     if let caseKeyword = self.consume(if: .caseKeyword) {
-      let pattern = self.parseMatchingPattern()
+      let pattern = self.parseMatchingPattern(context: .matching)
       kind = .pattern(caseKeyword, pattern)
     } else {
       let letOrVar = self.consumeAnyToken()
-      let pattern = self.parseMatchingPattern()
+      let pattern = self.parseMatchingPattern(context: .letOrVar)
       kind = .optional(letOrVar, pattern)
     }
 
@@ -563,7 +563,7 @@ extension Parser {
     let pattern: RawPatternSyntax
     let type: RawTypeAnnotationSyntax?
     if caseKeyword != nil {
-      pattern = self.parseMatchingPattern()
+      pattern = self.parseMatchingPattern(context: .matching)
       // Now parse an optional type annotation.
       if let colon = self.consume(if: .colon) {
         let resultType = self.parseType()
@@ -827,7 +827,7 @@ extension Parser {
       flavor = .basic
     }
 
-    let pattern = self.parseMatchingPattern()
+    let pattern = self.parseMatchingPattern(context: .matching)
 
     // Parse the optional 'where' guard, with this particular pattern's bound
     // vars in scope.

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -288,4 +288,72 @@ final class StatementTests: XCTestCase {
       ))
     )
   }
+
+  func testCaseContext() {
+    AssertParse(
+      """
+      graphQLMap["clientMutationId"] as? #^SPECIALIZATION^#Swift.Optional<String?> ?? Swift.Optional<String?>.none
+      """,
+//      0: MemberTypeIdentifierSyntax children=4
+//        0: SimpleTypeIdentifierSyntax children=1
+//          0: identifier("Swift")
+//        1: period
+//        2: identifier("Optional")
+//        3: GenericArgumentClauseSyntax children=3
+//          0: leftAngle
+//          1: GenericArgumentListSyntax children=1
+//            0: GenericArgumentSyntax children=1
+//              0: OptionalTypeSyntax children=2
+//                0: SimpleTypeIdentifierSyntax children=1
+//                  0: identifier("String")
+//                1: postfixQuestionMark
+//          2: rightAngle
+    substructure: Syntax(MemberTypeIdentifierSyntax(
+      baseType: TypeSyntax(SimpleTypeIdentifierSyntax(
+        name: .identifier("Swift"),
+        genericArgumentClause: nil)),
+      period: .periodToken(),
+      name: .identifier("Optional"),
+      genericArgumentClause: GenericArgumentClauseSyntax(
+        leftAngleBracket: .leftAngleToken(),
+        arguments: GenericArgumentListSyntax([
+          GenericArgumentSyntax(
+            argumentType: TypeSyntax(OptionalTypeSyntax(
+              wrappedType: TypeSyntax(SimpleTypeIdentifierSyntax(
+                name: .identifier("String"),
+                genericArgumentClause: nil)),
+              questionMark: .postfixQuestionMarkToken())),
+            trailingComma: nil)
+        ]),
+        rightAngleBracket: .rightAngleToken()))),
+    substructureAfterMarker: "SPECIALIZATION")
+
+    AssertParse(
+      """
+      if case #^SPECIALIZATION^#Optional<Any>.none = object["anyCol"] { }
+      """,
+//      0: SpecializeExprSyntax children=2
+//        0: IdentifierExprSyntax children=1
+//          0: identifier("Optional")
+//        1: GenericArgumentClauseSyntax children=3
+//          0: leftAngle
+//          1: GenericArgumentListSyntax children=1
+//            0: GenericArgumentSyntax children=1
+//              0: SimpleTypeIdentifierSyntax children=1
+//                0: anyKeyword
+//          2: rightAngle
+//      1: period
+//      2: identifier("none")
+      substructure: Syntax(SpecializeExprSyntax(
+        expression: ExprSyntax(IdentifierExprSyntax(
+          identifier: .identifier("Optional"), declNameArguments: nil)),
+        genericArgumentClause: GenericArgumentClauseSyntax(
+          leftAngleBracket: .leftAngleToken(), arguments: GenericArgumentListSyntax([
+        GenericArgumentSyntax(
+          argumentType: TypeSyntax(SimpleTypeIdentifierSyntax(
+            name: .anyKeyword(), genericArgumentClause: nil)),
+          trailingComma: nil)
+      ]), rightAngleBracket: .rightAngleToken()))),
+      substructureAfterMarker: "SPECIALIZATION")
+  }
 }

--- a/Tests/SwiftParserTest/translated/InvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidTests.swift
@@ -273,10 +273,10 @@ final class InvalidTests: XCTestCase {
         DiagnosticSpec(locationMarker: "DIAG_12", message: "expected identifier in function"),
         DiagnosticSpec(locationMarker: "DIAG_12", message: "expected argument list in function declaration"),
         DiagnosticSpec(locationMarker: "DIAG_13", message: "unexpected text '()' in 'repeat' statement"),
-        DiagnosticSpec(locationMarker: "DIAG_14", message: "expected 'while' in 'repeat' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_14", message: "expected 'while' and condition in 'repeat' statement"),
         // TODO: Old parser expected error on line 30: keyword 'for' cannot be used as an identifier here
         // TODO: Old parser expected note on line 30: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 5 - 8 = '`for`'
-        DiagnosticSpec(locationMarker: "DIAG_15", message: "expected expression in pattern"),
+        DiagnosticSpec(locationMarker: "DIAG_15", message: "expected pattern in variable"),
         DiagnosticSpec(locationMarker: "DIAG_16", message: "expected pattern, 'in' and expression in 'for' statement"),
         DiagnosticSpec(locationMarker: "DIAG_16", message: "expected '{' in 'for' statement"),
         DiagnosticSpec(locationMarker: "DIAG_16", message: "unexpected text '= 2' before function"),


### PR DESCRIPTION
The legacy parser maintains a stack of contexts that determine whether a matching pattern is being parsed, and whether a let or var is the introducer. This turns on and off a particular production in expression parsing that helps to meld patterns like

`Optional<String>.none`

into shape depending on whether it comes after the keyword "case" or after "let" or "var".