### PR TITLE
Add `to match this opening <thing>` notes to the diagnostics

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/StmtNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/StmtNodes.swift
@@ -705,7 +705,7 @@ public let STMT_NODES: [Node] = [
        ]),
 
   Node(name: "PoundAssertStmt",
-       nameForDiagnostics: "'#assert' statement",
+       nameForDiagnostics: "'#assert' directive",
        kind: "Stmt",
        children: [
          Child(name: "PoundAssert",

--- a/Sources/SwiftDiagnostics/CMakeLists.txt
+++ b/Sources/SwiftDiagnostics/CMakeLists.txt
@@ -7,9 +7,10 @@
 # See http://swift.org/CONTRIBUTORS.txt for Swift project authors
 
 add_library(SwiftDiagnostics STATIC
+  Diagnostic.swift
   FixIt.swift
   Message.swift
-  Diagnostic.swift
+  Note.swift
 )
 
 target_link_libraries(SwiftDiagnostics PUBLIC

--- a/Sources/SwiftDiagnostics/FixIt.swift
+++ b/Sources/SwiftDiagnostics/FixIt.swift
@@ -16,7 +16,7 @@ import SwiftSyntax
 /// shown to the client.
 /// The messages should describe the change that the Fix-It will perform
 public protocol FixItMessage {
-  /// The diagnostic message that should be displayed in the client.
+  /// The Fix-It message that should be displayed in the client.
   var message: String { get }
 
   /// See ``MessageID``.
@@ -38,7 +38,7 @@ public struct FixIt {
   public let changes: [Change]
 
   public init(message: FixItMessage, changes: [Change]) {
-    assert(!changes.isEmpty, "A Fix-It must have at least one diagnostic associated with it")
+    assert(!changes.isEmpty, "A Fix-It must have at least one change associated with it")
     self.message = message
     self.changes = changes
   }

--- a/Sources/SwiftDiagnostics/Note.swift
+++ b/Sources/SwiftDiagnostics/Note.swift
@@ -1,4 +1,4 @@
-//===--- Diagnostics.swift ------------------------------------------------===//
+//===--- Note.swift -------------------------------------------------------===//
 //
 // This source file is part of the Swift.org open source project
 //
@@ -12,55 +12,45 @@
 
 import SwiftSyntax
 
-public struct Diagnostic: CustomDebugStringConvertible {
-  /// The message that should be displayed to the user
-  public let diagMessage: DiagnosticMessage
+/// Types conforming to this protocol represent note messages that can be
+/// shown to the client.
+/// The messages should describe what the note is pointing at.
+public protocol NoteMessage {
+  /// The message that should be displayed in the client.
+  var message: String { get }
 
-  /// The node at whose start location the message should be displayed.
+  /// See ``MessageID``.
+  var fixItID: MessageID { get }
+}
+
+/// A note that points to another node that's relevant for a Diagnostic.
+public struct Note: CustomDebugStringConvertible {
+  /// The node whose location the node is pointing.
   public let node: Syntax
 
   /// The position at which the location should be anchored.
   /// By default, this is the start location of `node`.
   public let position: AbsolutePosition
 
-  /// Nodes that should be highlighted in the source code.
-  public let highlights: [Syntax]
-
-  /// Notes that point to additional locations which are relevant for this diagnostic.
-  public let notes: [Note]
-
-  /// Fix-Its that can be applied to resolve this diagnostic.
-  /// Each Fix-It offers a different way to resolve the diagnostic. Usually, there's only one.
-  public let fixIts: [FixIt]
+  /// A description of what this note is pointing at.
+  public let noteMessage: NoteMessage
 
   public init(
     node: Syntax,
     position: AbsolutePosition? = nil,
-    message: DiagnosticMessage,
-    highlights: [Syntax] = [],
-    notes: [Note] = [],
-    fixIts: [FixIt] = []
+    message: NoteMessage
   ) {
     self.node = node
     self.position = position ?? node.positionAfterSkippingLeadingTrivia
-    self.diagMessage = message
-    self.highlights = highlights
-    self.notes = notes
-    self.fixIts = fixIts
+    self.noteMessage = message
   }
 
   /// The message that should be displayed to the user.
   public var message: String {
-    return diagMessage.message
+    return noteMessage.message
   }
 
-  /// An ID that identifies the diagnostic's message.
-  /// See ``MessageID``.
-  public var diagnosticID: MessageID {
-    return diagMessage.diagnosticID
-  }
-
-  /// The location at which the diagnostic should be displayed.
+  /// The location at which the note should be displayed.
   public func location(converter: SourceLocationConverter) -> SourceLocation {
     return converter.location(for: position)
   }

--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -51,15 +51,39 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
   // MARK: - Private helper functions
 
   /// Produce a diagnostic.
-  func addDiagnostic<T: SyntaxProtocol>(_ node: T, position: AbsolutePosition? = nil, _ message: DiagnosticMessage, highlights: [Syntax] = [], fixIts: [FixIt] = [], handledNodes: [SyntaxIdentifier] = []) {
+  func addDiagnostic<T: SyntaxProtocol>(
+    _ node: T,
+    position: AbsolutePosition? = nil,
+    _ message: DiagnosticMessage,
+    highlights: [Syntax] = [],
+    notes: [Note] = [],
+    fixIts: [FixIt] = [],
+    handledNodes: [SyntaxIdentifier] = []
+  ) {
     diagnostics.removeAll(where: { handledNodes.contains($0.node.id) })
-    diagnostics.append(Diagnostic(node: Syntax(node), position: position, message: message, highlights: highlights, fixIts: fixIts))
+    diagnostics.append(Diagnostic(node: Syntax(node), position: position, message: message, highlights: highlights, notes: notes, fixIts: fixIts))
     self.handledNodes.append(contentsOf: handledNodes)
   }
 
   /// Produce a diagnostic.
-  func addDiagnostic<T: SyntaxProtocol>(_ node: T,position: AbsolutePosition? = nil,  _ message: StaticParserError, highlights: [Syntax] = [], fixIts: [FixIt] = [], handledNodes: [SyntaxIdentifier] = []) {
-    addDiagnostic(node, position: position, message as DiagnosticMessage, highlights: highlights, fixIts: fixIts, handledNodes: handledNodes)
+  func addDiagnostic<T: SyntaxProtocol>(
+    _ node: T,
+    position: AbsolutePosition? = nil,
+    _ message: StaticParserError,
+    highlights: [Syntax] = [],
+    notes: [Note] = [],
+    fixIts: [FixIt] = [],
+    handledNodes: [SyntaxIdentifier] = []
+  ) {
+    addDiagnostic(
+      node,
+      position: position,
+      message as DiagnosticMessage,
+      highlights: highlights,
+      notes: notes,
+      fixIts: fixIts,
+      handledNodes: handledNodes
+    )
   }
 
   /// Whether the node should be skipped for diagnostic emission.

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -34,6 +34,20 @@ public extension ParserError {
   }
 }
 
+public protocol ParserNote: NoteMessage {
+  var fixItID: MessageID { get }
+}
+
+public extension ParserNote {
+  static var fixItID: MessageID {
+    return MessageID(domain: diagnosticDomain, id: "\(self)")
+  }
+
+  var fixItID: MessageID {
+    return Self.fixItID
+  }
+}
+
 public protocol ParserFixIt: FixItMessage {
   var fixItID: MessageID { get }
 }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -730,7 +730,7 @@ public enum SyntaxEnum {
     case .catchClause:
       return "'catch' clause"
     case .poundAssertStmt:
-      return "'#assert' statement"
+      return "'#assert' directive"
     case .genericWhereClause:
       return "'where' clause"
     case .genericRequirementList:

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -99,11 +99,13 @@ final class ExpressionTests: XCTestCase {
     AssertParse(
       #"""
       \a
-      c[#^DIAG^#
+      c#^NOTE^#[#^DIAG^#
       """#,
       diagnostics: [
         DiagnosticSpec(message: "expected value in subscript"),
-        DiagnosticSpec(message: "expected ']' to end subscript"),
+        DiagnosticSpec(message: "expected ']' to end subscript", notes: [
+          NoteSpec(message: "to match this opening '['")
+        ]),
       ]
     )
 
@@ -261,10 +263,12 @@ final class ExpressionTests: XCTestCase {
 
     AssertParse(
       #"""
-      "\",#^DIAG^#
+      #^NOTE^#"\",#^DIAG^#
       """#,
       diagnostics: [
-        DiagnosticSpec(message: #"expected '"' to end string literal"#)
+        DiagnosticSpec(message: #"expected '"' to end string literal"#, notes: [
+          NoteSpec(message: #"to match this opening '"'"#)
+        ])
       ]
     )
 
@@ -328,10 +332,12 @@ final class ExpressionTests: XCTestCase {
 
     AssertParse(
        ##"""
-       """"#^DIAG^#
+       #^NOTE^#""""#^DIAG^#
        """##,
        diagnostics: [
-         DiagnosticSpec(message: #"expected '"""' to end string literal"#)
+         DiagnosticSpec(message: #"expected '"""' to end string literal"#, notes: [
+          NoteSpec(message: #"to match this opening '"""'"#)
+         ])
        ]
      )
 
@@ -354,10 +360,10 @@ final class ExpressionTests: XCTestCase {
 
     AssertParse(
       ##"""
-      #"#^DIAG^#
+      #^NOTE^##"#^DIAG^#
       """##,
       diagnostics: [
-        DiagnosticSpec(message: ##"expected '"#' to end string literal"##),
+        DiagnosticSpec(message: ##"expected '"#' to end string literal"##, notes: []),
       ]
     )
 

--- a/Tests/SwiftParserTest/translated/ActorTests.swift
+++ b/Tests/SwiftParserTest/translated/ActorTests.swift
@@ -9,7 +9,6 @@ final class ActorTests: XCTestCase {
       actor MyActor1#^DIAG^#
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected '{' in actor
         DiagnosticSpec(message: "expected member block in actor"),
       ]
     )
@@ -18,17 +17,16 @@ final class ActorTests: XCTestCase {
   func testActor2() {
     AssertParse(
       """
-      actor MyActor2 { 
+      actor MyActor2 #^NOTE^#{
           init() {
           }
       func hello() { }#^DIAG^#
       """,
       diagnostics: [
-        // TODO: Old parser expected note on line 1: to match this opening '{'
-        DiagnosticSpec(message: "expected '}' to end actor"),
-        // TODO: Old parser expected error on line 5: expected '}' in actor
+        DiagnosticSpec(message: "expected '}' to end actor", notes: [
+          NoteSpec(message: "to match this opening '{'")
+        ]),
       ]
     )
   }
-
 }

--- a/Tests/SwiftParserTest/translated/AlwaysEmitConformanceMetadataAttrTests.swift
+++ b/Tests/SwiftParserTest/translated/AlwaysEmitConformanceMetadataAttrTests.swift
@@ -3,15 +3,7 @@
 import XCTest
 
 final class AlwaysEmitConformanceMetadataAttrTests: XCTestCase {
-  func testAlwaysEmitConformanceMetadataAttr1() {
-    AssertParse(
-      """
-      import Swift
-      """
-    )
-  }
-
-  func testAlwaysEmitConformanceMetadataAttr2() {
+  func testAlwaysEmitConformanceMetadataAttr() {
     AssertParse(
       """
       @_alwaysEmitConformanceMetadata

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryTests.swift
@@ -102,14 +102,14 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery8() {
     AssertParse(
       """
-      if #available( { 
+      if #available#^NOTE^#( {
       }#^DIAG^#
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected platform name
-        // TODO: Old parser expected error on line 1: expected ')'
-        // TODO: Old parser expected note on line 1: to match this opening '('
-        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+        DiagnosticSpec(message: "expected ')' to end '#availabile' condition", notes: [
+          NoteSpec(message: "to match this opening '('")
+        ]),
         DiagnosticSpec(message: "expected code block in 'if' statement"),
       ]
     )
@@ -132,14 +132,14 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery10() {
     AssertParse(
       """
-      if #available(OSX #^DIAG^#{ 
+      if #available#^NOTE^#(OSX #^DIAG^#{
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected version number
-        // TODO: Old parser expected error on line 1: expected ')'
-        // TODO: Old parser expected note on line 1: to match this opening '('
-        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+        DiagnosticSpec(message: "expected ')' to end '#availabile' condition", notes: [
+          NoteSpec(message: "to match this opening '('")
+        ]),
       ]
     )
   }
@@ -159,14 +159,14 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery12() {
     AssertParse(
       """
-      if #available(OSX 10.51 #^DIAG^#{ 
+      if #available#^NOTE^#(OSX 10.51 #^DIAG^#{
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected ')'
-        // TODO: Old parser expected note on line 1: to match this opening '('
-        // TODO: Old parser expected error on line 1: must handle potential future platforms with '*', Fix-It replacements: 24 - 24 = ', *'
-        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+        DiagnosticSpec(message: "expected ')' to end '#availabile' condition", notes: [
+          NoteSpec(message: "to match this opening '('")
+        ]),
       ]
     )
   }
@@ -281,13 +281,13 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery25() {
     AssertParse(
       """
-      if #available(* #^DIAG^#{ 
+      if #available#^NOTE^#(* #^DIAG^#{
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected ')' in availability query
-        // TODO: Old parser expected note on line 1: to match this opening '('
-        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+        DiagnosticSpec(message: "expected ')' to end '#availabile' condition", notes: [
+          NoteSpec(message: "to match this opening '('")
+        ]),
       ]
     )
   }
@@ -305,14 +305,14 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery27() {
     AssertParse(
       """
-      if #available(OSX 10.51, { 
+      if #available#^NOTE^#(OSX 10.51, {
       }#^DIAG^#
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected ')'
-        // TODO: Old parser expected note on line 1: to match this opening '('
         // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+        DiagnosticSpec(message: "expected ')' to end '#availabile' condition", notes: [
+          NoteSpec(message: "to match this opening '('")
+        ]),
         DiagnosticSpec(message: "expected code block in 'if' statement"),
       ]
     )
@@ -335,14 +335,14 @@ final class AvailabilityQueryTests: XCTestCase {
   func testAvailabilityQuery29() {
     AssertParse(
       """
-      if #available(OSX 10.51, iOS #^DIAG^#{ 
+      if #available#^NOTE^#(OSX 10.51, iOS #^DIAG^#{
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected ')'
-        // TODO: Old parser expected note on line 1: to match this opening '('
         // TODO: Old parser expected error on line 1: expected version number
-        DiagnosticSpec(message: "expected ')' to end '#availabile' condition"),
+        DiagnosticSpec(message: "expected ')' to end '#availabile' condition", notes: [
+          NoteSpec(message: "to match this opening '('")
+        ]),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -76,14 +76,14 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability5() {
     AssertParse(
       """
-      if #unavailable( { 
+      if #unavailable#^NOTE^#( { 
       }#^DIAG^#
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected platform name
-        // TODO: Old parser expected error on line 1: expected ')'
-        // TODO: Old parser expected note on line 1: to match this opening '('
-        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition", notes: [
+          NoteSpec(message: "to match this opening '('")
+        ]),
         DiagnosticSpec(message: "expected code block in 'if' statement"),
       ]
     )
@@ -106,14 +106,14 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability7() {
     AssertParse(
       """
-      if #unavailable(OSX #^DIAG^#{ 
+      if #unavailable#^NOTE^#(OSX #^DIAG^#{
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected version number
-        // TODO: Old parser expected error on line 1: expected ')'
-        // TODO: Old parser expected note on line 1: to match this opening '('
-        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition", notes: [
+          NoteSpec(message: "to match this opening '('")
+        ]),
       ]
     )
   }
@@ -133,13 +133,13 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability9() {
     AssertParse(
       """
-      if #unavailable(OSX 10.51 #^DIAG^#{ 
+      if #unavailable#^NOTE^#(OSX 10.51 #^DIAG^#{
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected ')'
-        // TODO: Old parser expected note on line 1: to match this opening '('
-        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition", notes: [
+          NoteSpec(message: "to match this opening '('")
+        ]),
       ]
     )
   }
@@ -244,13 +244,13 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability20() {
     AssertParse(
       """
-      if #unavailable(OSX 10 #^DIAG^#{ 
+      if #unavailable#^NOTE^#(OSX 10 #^DIAG^#{
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected ')' in availability query
-        // TODO: Old parser expected note on line 1: to match this opening '('
-        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition", notes: [
+          NoteSpec(message: "to match this opening '('")
+        ]),
       ]
     )
   }
@@ -268,14 +268,14 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability22() {
     AssertParse(
       """
-      if #unavailable(OSX 10.51, { 
+      if #unavailable#^NOTE^#(OSX 10.51, {
       }#^DIAG^#
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected ')'
-        // TODO: Old parser expected note on line 1: to match this opening '('
         // TODO: Old parser expected error on line 1: expected platform name
-        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition", notes: [
+          NoteSpec(message: "to match this opening '('")
+        ]),
         DiagnosticSpec(message: "expected code block in 'if' statement"),
       ]
     )
@@ -298,14 +298,14 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
   func testAvailabilityQueryUnavailability24() {
     AssertParse(
       """
-      if #unavailable(OSX 10.51, iOS #^DIAG^#{ 
+      if #unavailable#^NOTE^#(OSX 10.51, iOS #^DIAG^#{
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected ')'
-        // TODO: Old parser expected note on line 1: to match this opening '('
         // TODO: Old parser expected error on line 1: expected version number
-        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition"),
+        DiagnosticSpec(message: "expected ')' to end '#unavailable' condition", notes: [
+          NoteSpec(message: "to match this opening '('")
+        ]),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/BraceRecoveryEofTests.swift
+++ b/Tests/SwiftParserTest/translated/BraceRecoveryEofTests.swift
@@ -7,13 +7,13 @@ final class BraceRecoveryEofTests: XCTestCase {
     AssertParse(
       """
       // Make sure source ranges satisfy the verifier.
-      for foo in [1, 2] { 
+      for foo in [1, 2] #^NOTE^#{
         _ = foo#^DIAG^#
       """,
       diagnostics: [
-        // TODO: Old parser expected note on line 2: to match this opening '{'
-        DiagnosticSpec(message: "expected '}' to end 'for' statement"),
-        // TODO: Old parser expected error on line 4: expected '}' at end of brace statement
+        DiagnosticSpec(message: "expected '}' to end 'for' statement", notes: [
+          NoteSpec(message: "to match this opening '{'")
+        ]),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/DiagnoseDynamicReplacementTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseDynamicReplacementTests.swift
@@ -46,13 +46,14 @@ final class DiagnoseDynamicReplacementTests: XCTestCase {
   func testDiagnoseDynamicReplacement4() {
     AssertParse(
       """
-      @_dynamicReplacement(for: dynamically_replaceable() #^DIAG^#
+      @_dynamicReplacement#^NOTE^#(for: dynamically_replaceable() #^DIAG^#
       func test_dynamic_replacement_for3() {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected note on line 1: to match this opening '('
-        DiagnosticSpec(message: "expected ')' to end attribute"),
+        DiagnosticSpec(message: "expected ')' to end attribute", notes: [
+          NoteSpec(message: "to match this opening '('")
+        ]),
         // TODO: Old parser expected error on line 2: expected ')' after function name for @_dynamicReplacement
       ]
     )

--- a/Tests/SwiftParserTest/translated/PoundAssertTests.swift
+++ b/Tests/SwiftParserTest/translated/PoundAssertTests.swift
@@ -31,8 +31,7 @@ final class PoundAssertTests: XCTestCase {
       #assert #^DIAG^#true, "error message")
       """#,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: expected '(' in #assert directive
-        DiagnosticSpec(message: "expected '(' in '#assert' statement"),
+        DiagnosticSpec(message: "expected '(' in '#assert' directive"),
       ]
     )
   }
@@ -44,7 +43,7 @@ final class PoundAssertTests: XCTestCase {
       """#,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected a condition expression
-        DiagnosticSpec(message: "expected condition in '#assert' statement"),
+        DiagnosticSpec(message: "expected condition in '#assert' directive"),
       ]
     )
   }
@@ -53,13 +52,13 @@ final class PoundAssertTests: XCTestCase {
     AssertParse(
       """
       func unbalanced1() {
-        #assert(true #^DIAG^#
+        #assert#^NOTE^#(true #^DIAG^#
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: expected ')' in #assert directive
-        // TODO: Old parser expected note on line 2: to match this opening '('
-        DiagnosticSpec(message: "expected ')' to end '#assert' statement"),
+        DiagnosticSpec(message: "expected ')' to end '#assert' directive", notes: [
+          NoteSpec(message: "to match this opening '('")
+        ]),
       ]
     )
   }
@@ -68,13 +67,13 @@ final class PoundAssertTests: XCTestCase {
     AssertParse(
       #"""
       func unbalanced2() {
-        #assert(true, "hello world" #^DIAG^#
+        #assert#^NOTE^#(true, "hello world" #^DIAG^#
       }
       """#,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: expected ')' in #assert directive
-        // TODO: Old parser expected note on line 2: to match this opening '('
-        DiagnosticSpec(message: "expected ')' to end '#assert' statement"),
+        DiagnosticSpec(message: "expected ')' to end '#assert' directive", notes: [
+          NoteSpec(message: "to match this opening '('")
+        ]),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/SwitchIncompleteTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchIncompleteTests.swift
@@ -8,13 +8,13 @@ final class SwitchIncompleteTests: XCTestCase {
       """
       // <rdar://problem/15971438> Incomplete switch was parsing to an AST that
       // triggered an assertion failure.
-      switch 1 { 
+      switch 1 #^NOTE^#{ 
       case 1:#^DIAG^#
       """,
       diagnostics: [
-        // TODO: Old parser expected note on line 3: to match this opening '{'
-        DiagnosticSpec(message: "expected '}' to end 'switch' statement"),
-        // TODO: Old parser expected error on line 5: expected '}' at end of 'switch' statement
+        DiagnosticSpec(message: "expected '}' to end 'switch' statement", notes: [
+          NoteSpec(message: "to match this opening '{'")
+        ]),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/SwitchTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchTests.swift
@@ -1423,7 +1423,7 @@ final class SwitchTests: XCTestCase {
       func testIncompleteArrayLiteral() {
         switch x { 
         case 1:
-          _ = [1 #^DIAG^#
+          _ = #^NOTE^#[1 #^DIAG^#
         @unknown default: 
           ()
         }
@@ -1432,8 +1432,9 @@ final class SwitchTests: XCTestCase {
       diagnostics: [
         // TODO: Old parser expected error on line 2: switch must be exhaustive
         // TODO: Old parser expected error on line 4: expected ']' in container literal expression
-        // TODO: Old parser expected note on line 4: to match this opening '['
-        DiagnosticSpec(message: "expected ']' to end array"),
+        DiagnosticSpec(message: "expected ']' to end array", notes: [
+          NoteSpec(message: "to match this opening '['")
+        ]),
         // TODO: Old parser expected note on line 5: remove '@unknown' to handle remaining values
       ]
     )

--- a/gyb_syntax_support/StmtNodes.py
+++ b/gyb_syntax_support/StmtNodes.py
@@ -372,7 +372,7 @@ STMT_NODES = [
          ]),
 
     # e.g. #assert(1 == 2)
-    Node('PoundAssertStmt', name_for_diagnostics="'#assert' statement", kind='Stmt',
+    Node('PoundAssertStmt', name_for_diagnostics="'#assert' directive", kind='Stmt',
          children=[
              Child('PoundAssert', kind='PoundAssertToken'),
              Child('LeftParen', kind='LeftParenToken'),


### PR DESCRIPTION
For diagnostics like `expected '}' to end actor` issue a corresponding `to match this opening '{'`

This resolves 38 TODOs, down to 1025.