### PR TITLE
Fixup 'yield' Parsing

### DIFF
--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/ExprNodes.swift
@@ -1241,4 +1241,24 @@ public let EXPR_NODES: [Node] = [
                ])
        ]),
 
+  Node(name: "YieldExprList",
+       nameForDiagnostics: "yield list",
+       kind: "SyntaxCollection",
+       element: "YieldExprListElement",
+       elementName: "Yields"),
+
+  Node(name: "YieldExprListElement",
+       nameForDiagnostics: nil,
+       kind: "Syntax",
+       children: [
+         Child(name: "Expression",
+               kind: "Expr"),
+         Child(name: "Comma",
+               kind: "CommaToken",
+               isOptional: true,
+               tokenChoices: [
+                 "Comma"
+               ])
+       ]),
+
 ]

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/NodeSerializationCodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/NodeSerializationCodes.swift
@@ -290,4 +290,6 @@ public let SYNTAX_NODE_SERIALIZATION_CODES: [String: Int] = [
   "ConventionWitnessMethodAttributeArguments": 277,
   "DesignatedTypeElement": 278,
   "NamedOpaqueReturnType": 279,
+  "YieldExprList": 280,
+  "YieldExprListElement": 281,
 ]

--- a/CodeGeneration/Sources/SyntaxSupport/gyb_generated/StmtNodes.swift
+++ b/CodeGeneration/Sources/SyntaxSupport/gyb_generated/StmtNodes.swift
@@ -310,14 +310,8 @@ public let STMT_NODES: [Node] = [
                  "LeftParen"
                ]),
          Child(name: "ElementList",
-               kind: "ExprList",
+               kind: "YieldExprList",
                collectionElementName: "Element"),
-         Child(name: "TrailingComma",
-               kind: "CommaToken",
-               isOptional: true,
-               tokenChoices: [
-                 "Comma"
-               ]),
          Child(name: "RightParen",
                kind: "RightParenToken",
                tokenChoices: [

--- a/Sources/SwiftBasicFormat/generated/Format.swift
+++ b/Sources/SwiftBasicFormat/generated/Format.swift
@@ -617,6 +617,17 @@ extension Format {
     }
     return result
   }
+  public func format(syntax: YieldExprListSyntax) -> YieldExprListSyntax {
+    syntax
+  }
+  public func format(syntax: YieldExprListElementSyntax) -> YieldExprListElementSyntax {
+    var result = syntax
+    let leadingTrivia = result.leadingTrivia ?? []
+    if !leadingTrivia.isEmpty {
+      result = result.withLeadingTrivia(leadingTrivia)
+    }
+    return result
+  }
   public func format(syntax: TypeInitializerClauseSyntax) -> TypeInitializerClauseSyntax {
     var result = syntax
     let leadingTrivia = result.leadingTrivia ?? []

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -14,7 +14,7 @@
 
 extension TokenConsumer {
   func atStartOfDeclaration(
-    isAtTopLevel: Bool = false,
+    context: Parser.ItemContext? = nil,
     allowRecovery: Bool = false
   ) -> Bool {
     if self.at(anyIn: PoundDeclarationStart.self) != nil {
@@ -58,7 +58,7 @@ extension TokenConsumer {
     if allowRecovery {
       declStartKeyword = subparser.canRecoverTo(
         anyIn: DeclarationStart.self,
-        recoveryPrecedence: isAtTopLevel ? nil : .closingBrace
+        recoveryPrecedence: context == .topLevel ? nil : .closingBrace
       )?.0
     } else {
       declStartKeyword = subparser.at(anyIn: DeclarationStart.self)?.0
@@ -85,7 +85,7 @@ extension TokenConsumer {
       if subparser.at(anyIn: ContextualDeclKeyword.self)?.0 != nil {
         subparser.consumeAnyToken()
         return subparser.atStartOfDeclaration(
-          isAtTopLevel: isAtTopLevel, allowRecovery: allowRecovery)
+          context: context, allowRecovery: allowRecovery)
       }
       return false
     default: return true
@@ -1636,6 +1636,25 @@ extension Parser {
     case mutableAddressWithNativeOwner = "mutableAddressWithNativeOwner"
     case _read = "_read"
     case _modify = "_modify"
+
+    var isCoroutineAccessor: Bool {
+      switch self {
+      case ._read,
+           ._modify:
+        return true
+      case .`get`,
+          .`set`,
+          .`didSet`,
+          .`willSet`,
+          .unsafeAddress,
+          .addressWithOwner,
+          .addressWithNativeOwner,
+          .unsafeMutableAddress,
+          .mutableAddressWithOwner,
+          .mutableAddressWithNativeOwner:
+        return false
+      }
+    }
   }
 
   struct AccessorIntroducer {
@@ -1755,8 +1774,8 @@ extension Parser {
           var body = [RawCodeBlockItemSyntax]()
           var codeBlockProgress = LoopProgressCondition()
           while !self.at(.rightBrace),
-                  let newItem = self.parseCodeBlockItem(),
-                  codeBlockProgress.evaluate(currentToken) {
+                let newItem = self.parseCodeBlockItem(),
+                codeBlockProgress.evaluate(currentToken) {
             body.append(newItem)
           }
           let (unexpectedBeforeRBrace, rbrace) = self.expect(.rightBrace)
@@ -1801,7 +1820,10 @@ extension Parser {
           throwsKeyword = nil
         }
 
-        let body = self.parseOptionalCodeBlock()
+        let context: ItemContext? = introducer.kind.isCoroutineAccessor
+                                  ? .coroutineAccessor
+                                  : nil
+        let body = self.parseOptionalCodeBlock(context: context)
 
         elements.append(RawAccessorDeclSyntax(
           attributes: introducer.attributes,

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -108,12 +108,10 @@ extension Parser {
       return label(self.parseDoStatement(), with: optLabel)
 
     case (.poundAssertKeyword, _)?:
-      // FIXME: This drops `optLabel`.
-      return RawStmtSyntax(self.parsePoundAssertStatement())
+      return label(self.parsePoundAssertStatement(), with: optLabel)
     case (.yieldAsIdentifier, _)?,
-      (.yield, _)?:
-      // FIXME: This drops `optLabel`.
-      return RawStmtSyntax(self.parseYieldStatement())
+         (.yield, _)?:
+      return label(self.parseYieldStatement(), with: optLabel)
     case nil:
       let missingStmt = RawStmtSyntax(RawMissingStmtSyntax(arena: self.arena))
       return label(missingStmt, with: optLabel)

--- a/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
+++ b/Sources/SwiftSyntax/Documentation.docc/gyb_generated/SwiftSyntax.md
@@ -217,6 +217,8 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/MultipleTrailingClosureElementSyntax>
 - <doc:SwiftSyntax/ObjcNameSyntax>
 - <doc:SwiftSyntax/ObjcNamePieceSyntax>
+- <doc:SwiftSyntax/YieldExprListSyntax>
+- <doc:SwiftSyntax/YieldExprListElementSyntax>
 - <doc:SwiftSyntax/FunctionParameterListSyntax>
 - <doc:SwiftSyntax/FunctionParameterSyntax>
 - <doc:SwiftSyntax/IfConfigClauseListSyntax>
@@ -301,6 +303,8 @@ allows Swift tools to parse, inspect, generate, and transform Swift source code.
 - <doc:SwiftSyntax/ExpressionSegmentSyntax>
 - <doc:SwiftSyntax/ObjcNamePieceSyntax>
 - <doc:SwiftSyntax/ObjcNameSyntax>
+- <doc:SwiftSyntax/YieldExprListSyntax>
+- <doc:SwiftSyntax/YieldExprListElementSyntax>
 - <doc:SwiftSyntax/TypeInitializerClauseSyntax>
 - <doc:SwiftSyntax/FunctionParameterListSyntax>
 - <doc:SwiftSyntax/ParameterClauseSyntax>

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -5080,6 +5080,101 @@ public struct RawObjectLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
 }
 
 @_spi(RawSyntax)
+public struct RawYieldExprListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  public typealias SyntaxType = YieldExprListSyntax
+
+  var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .yieldExprList
+  }
+
+  public var raw: RawSyntax
+  init(raw: RawSyntax) {
+    assert(Self.isKindOf(raw))
+    self.raw = raw
+  }
+
+  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+    guard Self.isKindOf(other.raw) else { return nil }
+    self.init(raw: other.raw)
+  }
+
+  public init(elements: [RawYieldExprListElementSyntax], arena: __shared SyntaxArena) {
+    let raw = RawSyntax.makeLayout(
+      kind: .yieldExprList, uninitializedCount: elements.count, arena: arena) { layout in
+      guard var ptr = layout.baseAddress else { return }
+      for elem in elements {
+        ptr.initialize(to: elem.raw)
+        ptr += 1
+      }
+    }
+    self.init(raw: raw)
+  }
+
+  public var elements: [RawYieldExprListElementSyntax] {
+    layoutView.children.map { RawYieldExprListElementSyntax(raw: $0!) }
+  }
+}
+
+@_spi(RawSyntax)
+public struct RawYieldExprListElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
+  public typealias SyntaxType = YieldExprListElementSyntax
+
+  var layoutView: RawSyntaxLayoutView {
+    return raw.layoutView!
+  }
+
+  public static func isKindOf(_ raw: RawSyntax) -> Bool {
+    return raw.kind == .yieldExprListElement
+  }
+
+  public var raw: RawSyntax
+  init(raw: RawSyntax) {
+    assert(Self.isKindOf(raw))
+    self.raw = raw
+  }
+
+  public init?<Node: RawSyntaxNodeProtocol>(_ other: Node) {
+    guard Self.isKindOf(other.raw) else { return nil }
+    self.init(raw: other.raw)
+  }
+
+  public init(
+    _ unexpectedBeforeExpression: RawUnexpectedNodesSyntax? = nil,
+    expression: RawExprSyntax,
+    _ unexpectedBetweenExpressionAndComma: RawUnexpectedNodesSyntax? = nil,
+    comma: RawTokenSyntax?,
+    arena: __shared SyntaxArena
+  ) {
+    let raw = RawSyntax.makeLayout(
+      kind: .yieldExprListElement, uninitializedCount: 4, arena: arena) { layout in
+      layout.initialize(repeating: nil)
+      layout[0] = unexpectedBeforeExpression?.raw
+      layout[1] = expression.raw
+      layout[2] = unexpectedBetweenExpressionAndComma?.raw
+      layout[3] = comma?.raw
+    }
+    self.init(raw: raw)
+  }
+
+  public var unexpectedBeforeExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[0].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var expression: RawExprSyntax {
+    layoutView.children[1].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedBetweenExpressionAndComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
+  public var comma: RawTokenSyntax? {
+    layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+}
+
+@_spi(RawSyntax)
 public struct RawTypeInitializerClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public typealias SyntaxType = TypeInitializerClauseSyntax
 
@@ -12231,24 +12326,20 @@ public struct RawYieldListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     _ unexpectedBeforeLeftParen: RawUnexpectedNodesSyntax? = nil,
     leftParen: RawTokenSyntax,
     _ unexpectedBetweenLeftParenAndElementList: RawUnexpectedNodesSyntax? = nil,
-    elementList: RawExprListSyntax,
-    _ unexpectedBetweenElementListAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
-    trailingComma: RawTokenSyntax?,
-    _ unexpectedBetweenTrailingCommaAndRightParen: RawUnexpectedNodesSyntax? = nil,
+    elementList: RawYieldExprListSyntax,
+    _ unexpectedBetweenElementListAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .yieldList, uninitializedCount: 8, arena: arena) { layout in
+      kind: .yieldList, uninitializedCount: 6, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftParen?.raw
       layout[1] = leftParen.raw
       layout[2] = unexpectedBetweenLeftParenAndElementList?.raw
       layout[3] = elementList.raw
-      layout[4] = unexpectedBetweenElementListAndTrailingComma?.raw
-      layout[5] = trailingComma?.raw
-      layout[6] = unexpectedBetweenTrailingCommaAndRightParen?.raw
-      layout[7] = rightParen.raw
+      layout[4] = unexpectedBetweenElementListAndRightParen?.raw
+      layout[5] = rightParen.raw
     }
     self.init(raw: raw)
   }
@@ -12262,20 +12353,14 @@ public struct RawYieldListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public var unexpectedBetweenLeftParenAndElementList: RawUnexpectedNodesSyntax? {
     layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
-  public var elementList: RawExprListSyntax {
-    layoutView.children[3].map(RawExprListSyntax.init(raw:))!
+  public var elementList: RawYieldExprListSyntax {
+    layoutView.children[3].map(RawYieldExprListSyntax.init(raw:))!
   }
-  public var unexpectedBetweenElementListAndTrailingComma: RawUnexpectedNodesSyntax? {
+  public var unexpectedBetweenElementListAndRightParen: RawUnexpectedNodesSyntax? {
     layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
-  public var trailingComma: RawTokenSyntax? {
-    layoutView.children[5].map(RawTokenSyntax.init(raw:))
-  }
-  public var unexpectedBetweenTrailingCommaAndRightParen: RawUnexpectedNodesSyntax? {
-    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
-  }
   public var rightParen: RawTokenSyntax {
-    layoutView.children[7].map(RawTokenSyntax.init(raw:))!
+    layoutView.children[5].map(RawTokenSyntax.init(raw:))!
   }
 }
 

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
@@ -667,6 +667,18 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax.self)
     break
+  case .yieldExprList:
+    for element in layout {
+      _verify(element, as: RawYieldExprListElementSyntax.self)
+    }
+    break
+  case .yieldExprListElement:
+    assert(layout.count == 4)
+    _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[1], as: RawExprSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
+    _verify(layout[3], as: RawTokenSyntax?.self)
+    break
   case .typeInitializerClause:
     assert(layout.count == 4)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
@@ -1698,15 +1710,13 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[3], as: RawSyntax.self)
     break
   case .yieldList:
-    assert(layout.count == 8)
+    assert(layout.count == 6)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
-    _verify(layout[3], as: RawExprListSyntax.self)
+    _verify(layout[3], as: RawYieldExprListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
-    _verify(layout[5], as: RawTokenSyntax?.self)
-    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
-    _verify(layout[7], as: RawTokenSyntax.self)
+    _verify(layout[5], as: RawTokenSyntax.self)
     break
   case .fallthroughStmt:
     assert(layout.count == 2)

--- a/Sources/SwiftSyntax/gyb_generated/Misc.swift
+++ b/Sources/SwiftSyntax/gyb_generated/Misc.swift
@@ -211,6 +211,10 @@ extension Syntax {
       return node
     case .objectLiteralExpr(let node):
       return node
+    case .yieldExprList(let node):
+      return node
+    case .yieldExprListElement(let node):
+      return node
     case .typeInitializerClause(let node):
       return node
     case .typealiasDecl(let node):
@@ -760,6 +764,10 @@ extension Syntax {
       return node.childNameForDiagnostics(index)
     case .objectLiteralExpr(let node):
       return node.childNameForDiagnostics(index)
+    case .yieldExprList(let node):
+      return node.childNameForDiagnostics(index)
+    case .yieldExprListElement(let node):
+      return node.childNameForDiagnostics(index)
     case .typeInitializerClause(let node):
       return node.childNameForDiagnostics(index)
     case .typealiasDecl(let node):
@@ -1218,6 +1226,8 @@ extension SyntaxKind {
     case .postfixIfConfigExpr: return PostfixIfConfigExprSyntax.self
     case .editorPlaceholderExpr: return EditorPlaceholderExprSyntax.self
     case .objectLiteralExpr: return ObjectLiteralExprSyntax.self
+    case .yieldExprList: return YieldExprListSyntax.self
+    case .yieldExprListElement: return YieldExprListElementSyntax.self
     case .typeInitializerClause: return TypeInitializerClauseSyntax.self
     case .typealiasDecl: return TypealiasDeclSyntax.self
     case .associatedtypeDecl: return AssociatedtypeDeclSyntax.self

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxAnyVisitor.swift
@@ -698,6 +698,20 @@ open class SyntaxAnyVisitor: SyntaxVisitor {
   override open func visitPost(_ node: ObjectLiteralExprSyntax) {
     visitAnyPost(node._syntaxNode)
   }
+  override open func visit(_ node: YieldExprListSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: YieldExprListSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
+  override open func visit(_ node: YieldExprListElementSyntax) -> SyntaxVisitorContinueKind {
+    return visitAny(node._syntaxNode)
+  }
+
+  override open func visitPost(_ node: YieldExprListElementSyntax) {
+    visitAnyPost(node._syntaxNode)
+  }
   override open func visit(_ node: TypeInitializerClauseSyntax) -> SyntaxVisitorContinueKind {
     return visitAny(node._syntaxNode)
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxCollections.swift
@@ -3054,6 +3054,259 @@ extension ObjcNameSyntax: BidirectionalCollection {
   }
 }
 
+/// `YieldExprListSyntax` represents a collection of one or more
+/// `YieldExprListElementSyntax` nodes. YieldExprListSyntax behaves
+/// as a regular Swift collection, and has accessors that return new
+/// versions of the collection with different children.
+public struct YieldExprListSyntax: SyntaxCollection, SyntaxHashable {
+  public let _syntaxNode: Syntax
+
+  var layoutView: RawSyntaxLayoutView {
+    data.raw.layoutView!
+  }
+
+  /// Converts the given `Syntax` node to a `YieldExprListSyntax` if possible. Returns 
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .yieldExprList else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a Syntax node from the provided root and data. This assumes 
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .yieldExprList)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public init(_ children: [YieldExprListElementSyntax]) {
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprList,
+      from: children.map { $0.raw }, arena: .default)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
+  /// The number of elements, `present` or `missing`, in this collection.
+  public var count: Int { return raw.layoutView!.children.count }
+
+  /// Creates a new `YieldExprListSyntax` by replacing the underlying layout with
+  /// a different set of raw syntax nodes.
+  ///
+  /// - Parameter layout: The new list of raw syntax nodes underlying this
+  ///                     collection.
+  /// - Returns: A new `YieldExprListSyntax` with the new layout underlying it.
+  internal func replacingLayout(
+    _ layout: [RawSyntax?]) -> YieldExprListSyntax {
+    let newRaw = layoutView.replacingLayout(with: layout, arena: .default)
+    let newData = data.replacingSelf(newRaw)
+    return YieldExprListSyntax(newData)
+  }
+
+  /// Creates a new `YieldExprListSyntax` by appending the provided syntax element
+  /// to the children.
+  ///
+  /// - Parameter syntax: The element to append.
+  /// - Returns: A new `YieldExprListSyntax` with that element appended to the end.
+  public func appending(
+    _ syntax: YieldExprListElementSyntax) -> YieldExprListSyntax {
+    var newLayout = layoutView.formLayoutArray()
+    newLayout.append(syntax.raw)
+    return replacingLayout(newLayout)
+  }
+
+  /// Creates a new `YieldExprListSyntax` by prepending the provided syntax element
+  /// to the children.
+  ///
+  /// - Parameter syntax: The element to prepend.
+  /// - Returns: A new `YieldExprListSyntax` with that element prepended to the
+  ///            beginning.
+  public func prepending(
+    _ syntax: YieldExprListElementSyntax) -> YieldExprListSyntax {
+    return inserting(syntax, at: 0)
+  }
+
+  /// Creates a new `YieldExprListSyntax` by inserting the provided syntax element
+  /// at the provided index in the children.
+  ///
+  /// - Parameters:
+  ///   - syntax: The element to insert.
+  ///   - index: The index at which to insert the element in the collection.
+  ///
+  /// - Returns: A new `YieldExprListSyntax` with that element appended to the end.
+  public func inserting(_ syntax: YieldExprListElementSyntax,
+                        at index: Int) -> YieldExprListSyntax {
+    var newLayout = layoutView.formLayoutArray()
+    /// Make sure the index is a valid insertion index (0 to 1 past the end)
+    precondition((newLayout.startIndex...newLayout.endIndex).contains(index),
+                 "inserting node at invalid index \(index)")
+    newLayout.insert(syntax.raw, at: index)
+    return replacingLayout(newLayout)
+  }
+
+  /// Creates a new `YieldExprListSyntax` by replacing the syntax element
+  /// at the provided index.
+  ///
+  /// - Parameters:
+  ///   - index: The index at which to replace the element in the collection.
+  ///   - syntax: The element to replace with.
+  ///
+  /// - Returns: A new `YieldExprListSyntax` with the new element at the provided index.
+  public func replacing(childAt index: Int,
+                        with syntax: YieldExprListElementSyntax) -> YieldExprListSyntax {
+    var newLayout = layoutView.formLayoutArray()
+    /// Make sure the index is a valid index for replacing
+    precondition((newLayout.startIndex..<newLayout.endIndex).contains(index),
+                 "replacing node at invalid index \(index)")
+    newLayout[index] = syntax.raw
+    return replacingLayout(newLayout)
+  }
+
+  /// Creates a new `YieldExprListSyntax` by removing the syntax element at the
+  /// provided index.
+  ///
+  /// - Parameter index: The index of the element to remove from the collection.
+  /// - Returns: A new `YieldExprListSyntax` with the element at the provided index
+  ///            removed.
+  public func removing(childAt index: Int) -> YieldExprListSyntax {
+    var newLayout = layoutView.formLayoutArray()
+    newLayout.remove(at: index)
+    return replacingLayout(newLayout)
+  }
+
+  /// Creates a new `YieldExprListSyntax` by removing the first element.
+  ///
+  /// - Returns: A new `YieldExprListSyntax` with the first element removed.
+  public func removingFirst() -> YieldExprListSyntax {
+    var newLayout = layoutView.formLayoutArray()
+    newLayout.removeFirst()
+    return replacingLayout(newLayout)
+  }
+
+  /// Creates a new `YieldExprListSyntax` by removing the last element.
+  ///
+  /// - Returns: A new `YieldExprListSyntax` with the last element removed.
+  public func removingLast() -> YieldExprListSyntax {
+    var newLayout = layoutView.formLayoutArray()
+    newLayout.removeLast()
+    return replacingLayout(newLayout)
+  }
+
+  /// Returns a new `YieldExprListSyntax` with its leading trivia replaced
+  /// by the provided trivia.
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> YieldExprListSyntax {
+    return YieldExprListSyntax(data.withLeadingTrivia(leadingTrivia))
+  }
+
+  /// Returns a new `YieldExprListSyntax` with its trailing trivia replaced
+  /// by the provided trivia.
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> YieldExprListSyntax {
+    return YieldExprListSyntax(data.withTrailingTrivia(trailingTrivia))
+  }
+
+  /// Returns a new `YieldExprListSyntax` with its leading trivia removed.
+  public func withoutLeadingTrivia() -> YieldExprListSyntax {
+    return withLeadingTrivia([])
+  }
+
+  /// Returns a new `YieldExprListSyntax` with its trailing trivia removed.
+  public func withoutTrailingTrivia() -> YieldExprListSyntax {
+    return withTrailingTrivia([])
+  }
+
+  /// Returns a new `YieldExprListSyntax` with all trivia removed.
+  public func withoutTrivia() -> YieldExprListSyntax {
+    return withoutLeadingTrivia().withoutTrailingTrivia()
+  }
+
+  /// The leading trivia (spaces, newlines, etc.) associated with this `YieldExprListSyntax`.
+  public var leadingTrivia: Trivia? {
+    get {
+      return raw.formLeadingTrivia()
+    }
+    set {
+      self = withLeadingTrivia(newValue ?? [])
+    }
+  }
+
+  /// The trailing trivia (spaces, newlines, etc.) associated with this `YieldExprListSyntax`.
+  public var trailingTrivia: Trivia? {
+    get {
+      return raw.formTrailingTrivia()
+    }
+    set {
+      self = withTrailingTrivia(newValue ?? [])
+    }
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    return nil
+  }
+}
+
+/// Conformance for `YieldExprListSyntax` to the `BidirectionalCollection` protocol.
+extension YieldExprListSyntax: BidirectionalCollection {
+  public typealias Element = YieldExprListElementSyntax
+  public typealias Index = SyntaxChildrenIndex
+
+  public struct Iterator: IteratorProtocol {
+    private let parent: Syntax
+    private var iterator: RawSyntaxChildren.Iterator
+
+    init(parent: Syntax, rawChildren: RawSyntaxChildren) {
+      self.parent = parent
+      self.iterator = rawChildren.makeIterator()
+    }
+
+    public mutating func next() -> YieldExprListElementSyntax? {
+      guard let (raw, info) = self.iterator.next() else {
+        return nil
+      }
+      let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
+      let data = SyntaxData(absoluteRaw, parent: parent)
+      return YieldExprListElementSyntax(data)
+    }
+  }
+
+  public func makeIterator() -> Iterator {
+    return Iterator(parent: Syntax(self), rawChildren: rawChildren)
+  }
+
+  private var rawChildren: RawSyntaxChildren {
+    // We know children in a syntax collection cannot be missing. So we can 
+    // use the low-level and faster RawSyntaxChildren collection instead of
+    // NonNilRawSyntaxChildren.
+    return RawSyntaxChildren(self.data.absoluteRaw)
+  }
+
+  public var startIndex: SyntaxChildrenIndex {
+    return rawChildren.startIndex
+  }
+  public var endIndex: SyntaxChildrenIndex {
+    return rawChildren.endIndex
+  }
+
+  public func index(after index: SyntaxChildrenIndex) -> SyntaxChildrenIndex {
+    return rawChildren.index(after: index)
+  }
+
+  public func index(before index: SyntaxChildrenIndex) -> SyntaxChildrenIndex {
+    return rawChildren.index(before: index)
+  }
+
+  public func distance(from start: SyntaxChildrenIndex, to end: SyntaxChildrenIndex)
+      -> Int {
+    return rawChildren.distance(from: start, to: end)
+  }
+
+  public subscript(position: SyntaxChildrenIndex) -> YieldExprListElementSyntax {
+    let (raw, info) = rawChildren[position]
+    let absoluteRaw = AbsoluteRawSyntax(raw: raw!, info: info)
+    let data = SyntaxData(absoluteRaw, parent: Syntax(self))
+    return YieldExprListElementSyntax(data)
+  }
+}
+
 /// `FunctionParameterListSyntax` represents a collection of one or more
 /// `FunctionParameterSyntax` nodes. FunctionParameterListSyntax behaves
 /// as a regular Swift collection, and has accessors that return new
@@ -11202,6 +11455,11 @@ extension MultipleTrailingClosureElementListSyntax: CustomReflectable {
   }
 }
 extension ObjcNameSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, unlabeledChildren: self.map{ $0 })
+  }
+}
+extension YieldExprListSyntax: CustomReflectable {
   public var customMirror: Mirror {
     return Mirror(self, unlabeledChildren: self.map{ $0 })
   }

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxEnum.swift
@@ -107,6 +107,8 @@ public enum SyntaxEnum {
   case postfixIfConfigExpr(PostfixIfConfigExprSyntax)
   case editorPlaceholderExpr(EditorPlaceholderExprSyntax)
   case objectLiteralExpr(ObjectLiteralExprSyntax)
+  case yieldExprList(YieldExprListSyntax)
+  case yieldExprListElement(YieldExprListElementSyntax)
   case typeInitializerClause(TypeInitializerClauseSyntax)
   case typealiasDecl(TypealiasDeclSyntax)
   case associatedtypeDecl(AssociatedtypeDeclSyntax)
@@ -475,6 +477,10 @@ public enum SyntaxEnum {
       return "editor placeholder"
     case .objectLiteralExpr:
       return "object literal"
+    case .yieldExprList:
+      return "yield list"
+    case .yieldExprListElement:
+      return nil
     case .typeInitializerClause:
       return nil
     case .typealiasDecl:
@@ -1027,6 +1033,10 @@ public extension Syntax {
       return .editorPlaceholderExpr(EditorPlaceholderExprSyntax(self)!)
     case .objectLiteralExpr:
       return .objectLiteralExpr(ObjectLiteralExprSyntax(self)!)
+    case .yieldExprList:
+      return .yieldExprList(YieldExprListSyntax(self)!)
+    case .yieldExprListElement:
+      return .yieldExprListElement(YieldExprListElementSyntax(self)!)
     case .typeInitializerClause:
       return .typeInitializerClause(TypeInitializerClauseSyntax(self)!)
     case .typealiasDecl:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -2181,6 +2181,47 @@ public enum SyntaxFactory {
     ], arena: .default))
     return ObjectLiteralExprSyntax(data)
   }
+  @available(*, deprecated, message: "Use initializer on YieldExprListSyntax")
+  public static func makeYieldExprList(
+    _ elements: [YieldExprListElementSyntax]) -> YieldExprListSyntax {
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprList,
+      from: elements.map { $0.raw }, arena: .default)
+    let data = SyntaxData.forRoot(raw)
+    return YieldExprListSyntax(data)
+  }
+
+  @available(*, deprecated, message: "Use initializer on YieldExprListSyntax")
+  public static func makeBlankYieldExprList(presence: SourcePresence = .present) -> YieldExprListSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .yieldExprList,
+      from: [
+    ], arena: .default))
+    return YieldExprListSyntax(data)
+  }
+  @available(*, deprecated, message: "Use initializer on YieldExprListElementSyntax")
+  public static func makeYieldExprListElement(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?) -> YieldExprListElementSyntax {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeExpression?.raw,
+      expression.raw,
+      unexpectedBetweenExpressionAndComma?.raw,
+      comma?.raw,
+    ]
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprListElement,
+      from: layout, arena: .default)
+    let data = SyntaxData.forRoot(raw)
+    return YieldExprListElementSyntax(data)
+  }
+
+  @available(*, deprecated, message: "Use initializer on YieldExprListElementSyntax")
+  public static func makeBlankYieldExprListElement(presence: SourcePresence = .present) -> YieldExprListElementSyntax {
+    let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .yieldExprListElement,
+      from: [
+      nil,
+      RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
+      nil,
+    ], arena: .default))
+    return YieldExprListElementSyntax(data)
+  }
   @available(*, deprecated, message: "Use initializer on TypeInitializerClauseSyntax")
   public static func makeTypeInitializerClause(_ unexpectedBeforeEqual: UnexpectedNodesSyntax? = nil, equal: TokenSyntax, _ unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? = nil, value: TypeSyntax) -> TypeInitializerClauseSyntax {
     let layout: [RawSyntax?] = [
@@ -5281,15 +5322,13 @@ public enum SyntaxFactory {
     return YieldStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on YieldListSyntax")
-  public static func makeYieldList(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil, elementList: ExprListSyntax, _ unexpectedBetweenElementListAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedBetweenTrailingCommaAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> YieldListSyntax {
+  public static func makeYieldList(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil, elementList: YieldExprListSyntax, _ unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> YieldListSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
       leftParen.raw,
       unexpectedBetweenLeftParenAndElementList?.raw,
       elementList.raw,
-      unexpectedBetweenElementListAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedBetweenTrailingCommaAndRightParen?.raw,
+      unexpectedBetweenElementListAndRightParen?.raw,
       rightParen.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldList,
@@ -5305,9 +5344,7 @@ public enum SyntaxFactory {
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.leftParen, arena: .default),
       nil,
-      RawSyntax.makeEmptyLayout(kind: SyntaxKind.exprList, arena: .default),
-      nil,
-      nil,
+      RawSyntax.makeEmptyLayout(kind: SyntaxKind.yieldExprList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
     ], arena: .default))

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxKind.swift
@@ -108,6 +108,8 @@ public enum SyntaxKind {
   case postfixIfConfigExpr
   case editorPlaceholderExpr
   case objectLiteralExpr
+  case yieldExprList
+  case yieldExprListElement
   case typeInitializerClause
   case typealiasDecl
   case associatedtypeDecl
@@ -302,6 +304,7 @@ public enum SyntaxKind {
     case .closureParamList: return true
     case .multipleTrailingClosureElementList: return true
     case .objcName: return true
+    case .yieldExprList: return true
     case .functionParameterList: return true
     case .ifConfigClauseList: return true
     case .inheritedTypeList: return true

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxRewriter.swift
@@ -660,6 +660,20 @@ open class SyntaxRewriter {
     return ExprSyntax(visitChildren(node))
   }
 
+  /// Visit a `YieldExprListSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: YieldExprListSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
+  /// Visit a `YieldExprListElementSyntax`.
+  ///   - Parameter node: the node that is being visited
+  ///   - Returns: the rewritten node
+  open func visit(_ node: YieldExprListElementSyntax) -> Syntax {
+    return Syntax(visitChildren(node))
+  }
+
   /// Visit a `TypeInitializerClauseSyntax`.
   ///   - Parameter node: the node that is being visited
   ///   - Returns: the rewritten node
@@ -2915,6 +2929,26 @@ open class SyntaxRewriter {
   }
 
   /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplYieldExprListSyntax(_ data: SyntaxData) -> Syntax {
+      let node = YieldExprListSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
+  private func visitImplYieldExprListElementSyntax(_ data: SyntaxData) -> Syntax {
+      let node = YieldExprListElementSyntax(data)
+      // Accessing _syntaxNode directly is faster than calling Syntax(node)
+      visitPre(node._syntaxNode)
+      defer { visitPost(node._syntaxNode) }
+      if let newNode = visitAny(node._syntaxNode) { return newNode }
+      return visit(node)
+  }
+
+  /// Implementation detail of visit(_:). Do not call directly.
   private func visitImplTypeInitializerClauseSyntax(_ data: SyntaxData) -> Syntax {
       let node = TypeInitializerClauseSyntax(data)
       // Accessing _syntaxNode directly is faster than calling Syntax(node)
@@ -4938,6 +4972,10 @@ open class SyntaxRewriter {
       return visitImplEditorPlaceholderExprSyntax
     case .objectLiteralExpr:
       return visitImplObjectLiteralExprSyntax
+    case .yieldExprList:
+      return visitImplYieldExprListSyntax
+    case .yieldExprListElement:
+      return visitImplYieldExprListElementSyntax
     case .typeInitializerClause:
       return visitImplTypeInitializerClauseSyntax
     case .typealiasDecl:
@@ -5493,6 +5531,10 @@ open class SyntaxRewriter {
       return visitImplEditorPlaceholderExprSyntax(data)
     case .objectLiteralExpr:
       return visitImplObjectLiteralExprSyntax(data)
+    case .yieldExprList:
+      return visitImplYieldExprListSyntax(data)
+    case .yieldExprListElement:
+      return visitImplYieldExprListElementSyntax(data)
     case .typeInitializerClause:
       return visitImplTypeInitializerClauseSyntax(data)
     case .typealiasDecl:

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxTransform.swift
@@ -384,6 +384,14 @@ public protocol SyntaxTransformVisitor {
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
   func visit(_ node: ObjectLiteralExprSyntax) -> ResultType
+  /// Visiting `YieldExprListSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: YieldExprListSyntax) -> ResultType
+  /// Visiting `YieldExprListElementSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: the sum of whatever the child visitors return.
+  func visit(_ node: YieldExprListElementSyntax) -> ResultType
   /// Visiting `TypeInitializerClauseSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: the sum of whatever the child visitors return.
@@ -1657,6 +1665,18 @@ extension SyntaxTransformVisitor {
   public func visit(_ node: ObjectLiteralExprSyntax) -> ResultType {
     visitAny(Syntax(node))
   }
+  /// Visiting `YieldExprListSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: YieldExprListSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
+  /// Visiting `YieldExprListElementSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: nil by default.
+  public func visit(_ node: YieldExprListElementSyntax) -> ResultType {
+    visitAny(Syntax(node))
+  }
   /// Visiting `TypeInitializerClauseSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: nil by default.
@@ -2919,6 +2939,10 @@ extension SyntaxTransformVisitor {
     case .editorPlaceholderExpr(let derived):
       return visit(derived)
     case .objectLiteralExpr(let derived):
+      return visit(derived)
+    case .yieldExprList(let derived):
+      return visit(derived)
+    case .yieldExprListElement(let derived):
       return visit(derived)
     case .typeInitializerClause(let derived):
       return visit(derived)

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxVisitor.swift
@@ -951,6 +951,26 @@ open class SyntaxVisitor {
   /// The function called after visiting `ObjectLiteralExprSyntax` and its descendents.
   ///   - node: the node we just finished visiting.
   open func visitPost(_ node: ObjectLiteralExprSyntax) {}
+  /// Visiting `YieldExprListSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: YieldExprListSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `YieldExprListSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: YieldExprListSyntax) {}
+  /// Visiting `YieldExprListElementSyntax` specifically.
+  ///   - Parameter node: the node we are visiting.
+  ///   - Returns: how should we continue visiting.
+  open func visit(_ node: YieldExprListElementSyntax) -> SyntaxVisitorContinueKind {
+    return .visitChildren
+  }
+
+  /// The function called after visiting `YieldExprListElementSyntax` and its descendents.
+  ///   - node: the node we just finished visiting.
+  open func visitPost(_ node: YieldExprListElementSyntax) {}
   /// Visiting `TypeInitializerClauseSyntax` specifically.
   ///   - Parameter node: the node we are visiting.
   ///   - Returns: how should we continue visiting.
@@ -3821,6 +3841,28 @@ open class SyntaxVisitor {
   }
 
   /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplYieldExprListSyntax(_ data: SyntaxData) {
+      let node = YieldExprListSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && !node.raw.layoutView!.children.isEmpty {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
+  private func visitImplYieldExprListElementSyntax(_ data: SyntaxData) {
+      let node = YieldExprListElementSyntax(data)
+      let needsChildren = (visit(node) == .visitChildren)
+      // Avoid calling into visitChildren if possible.
+      if needsChildren && !node.raw.layoutView!.children.isEmpty {
+        visitChildren(node)
+      }
+      visitPost(node)
+  }
+
+  /// Implementation detail of doVisit(_:_:). Do not call directly.
   private func visitImplTypeInitializerClauseSyntax(_ data: SyntaxData) {
       let node = TypeInitializerClauseSyntax(data)
       let needsChildren = (visit(node) == .visitChildren)
@@ -5991,6 +6033,10 @@ open class SyntaxVisitor {
       visitImplEditorPlaceholderExprSyntax(data)
     case .objectLiteralExpr:
       visitImplObjectLiteralExprSyntax(data)
+    case .yieldExprList:
+      visitImplYieldExprListSyntax(data)
+    case .yieldExprListElement:
+      visitImplYieldExprListElementSyntax(data)
     case .typeInitializerClause:
       visitImplTypeInitializerClauseSyntax(data)
     case .typealiasDecl:

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -3369,6 +3369,154 @@ extension ObjcNamePieceSyntax: CustomReflectable {
   }
 }
 
+// MARK: - YieldExprListElementSyntax
+
+public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
+  public let _syntaxNode: Syntax
+
+  /// Converts the given `Syntax` node to a `YieldExprListElementSyntax` if possible. Returns
+  /// `nil` if the conversion is not possible.
+  public init?(_ syntax: Syntax) {
+    guard syntax.raw.kind == .yieldExprListElement else { return nil }
+    self._syntaxNode = syntax
+  }
+
+  /// Creates a `YieldExprListElementSyntax` node from the given `SyntaxData`. This assumes
+  /// that the `SyntaxData` is of the correct kind. If it is not, the behaviour
+  /// is undefined.
+  internal init(_ data: SyntaxData) {
+    assert(data.raw.kind == .yieldExprListElement)
+    self._syntaxNode = Syntax(data)
+  }
+
+  public init(
+    _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
+    expression: ExprSyntax,
+    _ unexpectedBetweenExpressionAndComma: UnexpectedNodesSyntax? = nil,
+    comma: TokenSyntax?
+  ) {
+    let layout: [RawSyntax?] = [
+      unexpectedBeforeExpression?.raw,
+      expression.raw,
+      unexpectedBetweenExpressionAndComma?.raw,
+      comma?.raw,
+    ]
+    let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprListElement,
+      from: layout, arena: .default)
+    let data = SyntaxData.forRoot(raw)
+    self.init(data)
+  }
+
+  public var unexpectedBeforeExpression: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 0, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBeforeExpression(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBeforeExpression` replaced.
+  /// - param newChild: The new `unexpectedBeforeExpression` to replace the node's
+  ///                   current `unexpectedBeforeExpression`, if present.
+  public func withUnexpectedBeforeExpression(
+    _ newChild: UnexpectedNodesSyntax?) -> YieldExprListElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 0)
+    return YieldExprListElementSyntax(newData)
+  }
+
+  public var expression: ExprSyntax {
+    get {
+      let childData = data.child(at: 1, parent: Syntax(self))
+      return ExprSyntax(childData!)
+    }
+    set(value) {
+      self = withExpression(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `expression` replaced.
+  /// - param newChild: The new `expression` to replace the node's
+  ///                   current `expression`, if present.
+  public func withExpression(
+    _ newChild: ExprSyntax?) -> YieldExprListElementSyntax {
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default)
+    let newData = data.replacingChild(raw, at: 1)
+    return YieldExprListElementSyntax(newData)
+  }
+
+  public var unexpectedBetweenExpressionAndComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedBetweenExpressionAndComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedBetweenExpressionAndComma` replaced.
+  /// - param newChild: The new `unexpectedBetweenExpressionAndComma` to replace the node's
+  ///                   current `unexpectedBetweenExpressionAndComma`, if present.
+  public func withUnexpectedBetweenExpressionAndComma(
+    _ newChild: UnexpectedNodesSyntax?) -> YieldExprListElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return YieldExprListElementSyntax(newData)
+  }
+
+  public var comma: TokenSyntax? {
+    get {
+      let childData = data.child(at: 3, parent: Syntax(self))
+      if childData == nil { return nil }
+      return TokenSyntax(childData!)
+    }
+    set(value) {
+      self = withComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `comma` replaced.
+  /// - param newChild: The new `comma` to replace the node's
+  ///                   current `comma`, if present.
+  public func withComma(
+    _ newChild: TokenSyntax?) -> YieldExprListElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 3)
+    return YieldExprListElementSyntax(newData)
+  }
+
+  public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
+    switch index.data?.indexInParent {
+    case 0:
+      return nil
+    case 1:
+      return nil
+    case 2:
+      return nil
+    case 3:
+      return nil
+    default:
+      fatalError("Invalid index")
+    }
+  }
+}
+
+extension YieldExprListElementSyntax: CustomReflectable {
+  public var customMirror: Mirror {
+    return Mirror(self, children: [
+      "unexpectedBeforeExpression": unexpectedBeforeExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "unexpectedBetweenExpressionAndComma": unexpectedBetweenExpressionAndComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "comma": comma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+    ])
+  }
+}
+
 // MARK: - TypeInitializerClauseSyntax
 
 public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
@@ -14389,10 +14537,8 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil,
     leftParen: TokenSyntax,
     _ unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil,
-    elementList: ExprListSyntax,
-    _ unexpectedBetweenElementListAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?,
-    _ unexpectedBetweenTrailingCommaAndRightParen: UnexpectedNodesSyntax? = nil,
+    elementList: YieldExprListSyntax,
+    _ unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? = nil,
     rightParen: TokenSyntax
   ) {
     let layout: [RawSyntax?] = [
@@ -14400,9 +14546,7 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
       leftParen.raw,
       unexpectedBetweenLeftParenAndElementList?.raw,
       elementList.raw,
-      unexpectedBetweenElementListAndTrailingComma?.raw,
-      trailingComma?.raw,
-      unexpectedBetweenTrailingCommaAndRightParen?.raw,
+      unexpectedBetweenElementListAndRightParen?.raw,
       rightParen.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldList,
@@ -14473,10 +14617,10 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
     return YieldListSyntax(newData)
   }
 
-  public var elementList: ExprListSyntax {
+  public var elementList: YieldExprListSyntax {
     get {
       let childData = data.child(at: 3, parent: Syntax(self))
-      return ExprListSyntax(childData!)
+      return YieldExprListSyntax(childData!)
     }
     set(value) {
       self = withElementList(value)
@@ -14489,12 +14633,12 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   ///                  `elementList` collection.
   /// - returns: A copy of the receiver with the provided `Element`
   ///            appended to its `elementList` collection.
-  public func addElement(_ element: ExprSyntax) -> YieldListSyntax {
+  public func addElement(_ element: YieldExprListElementSyntax) -> YieldListSyntax {
     var collection: RawSyntax
     if let col = raw.layoutView!.children[3] {
       collection = col.layoutView!.appending(element.raw, arena: .default)
     } else {
-      collection = RawSyntax.makeLayout(kind: SyntaxKind.exprList,
+      collection = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprList,
         from: [element.raw], arena: .default)
     }
     let newData = data.replacingChild(collection, at: 3)
@@ -14505,78 +14649,36 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   /// - param newChild: The new `elementList` to replace the node's
   ///                   current `elementList`, if present.
   public func withElementList(
-    _ newChild: ExprListSyntax?) -> YieldListSyntax {
-    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.exprList, arena: .default)
+    _ newChild: YieldExprListSyntax?) -> YieldListSyntax {
+    let raw = newChild?.raw ?? RawSyntax.makeEmptyLayout(kind: SyntaxKind.yieldExprList, arena: .default)
     let newData = data.replacingChild(raw, at: 3)
     return YieldListSyntax(newData)
   }
 
-  public var unexpectedBetweenElementListAndTrailingComma: UnexpectedNodesSyntax? {
+  public var unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? {
     get {
       let childData = data.child(at: 4, parent: Syntax(self))
       if childData == nil { return nil }
       return UnexpectedNodesSyntax(childData!)
     }
     set(value) {
-      self = withUnexpectedBetweenElementListAndTrailingComma(value)
+      self = withUnexpectedBetweenElementListAndRightParen(value)
     }
   }
 
-  /// Returns a copy of the receiver with its `unexpectedBetweenElementListAndTrailingComma` replaced.
-  /// - param newChild: The new `unexpectedBetweenElementListAndTrailingComma` to replace the node's
-  ///                   current `unexpectedBetweenElementListAndTrailingComma`, if present.
-  public func withUnexpectedBetweenElementListAndTrailingComma(
+  /// Returns a copy of the receiver with its `unexpectedBetweenElementListAndRightParen` replaced.
+  /// - param newChild: The new `unexpectedBetweenElementListAndRightParen` to replace the node's
+  ///                   current `unexpectedBetweenElementListAndRightParen`, if present.
+  public func withUnexpectedBetweenElementListAndRightParen(
     _ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
     let raw = newChild?.raw
     let newData = data.replacingChild(raw, at: 4)
     return YieldListSyntax(newData)
   }
 
-  public var trailingComma: TokenSyntax? {
-    get {
-      let childData = data.child(at: 5, parent: Syntax(self))
-      if childData == nil { return nil }
-      return TokenSyntax(childData!)
-    }
-    set(value) {
-      self = withTrailingComma(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `trailingComma` replaced.
-  /// - param newChild: The new `trailingComma` to replace the node's
-  ///                   current `trailingComma`, if present.
-  public func withTrailingComma(
-    _ newChild: TokenSyntax?) -> YieldListSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 5)
-    return YieldListSyntax(newData)
-  }
-
-  public var unexpectedBetweenTrailingCommaAndRightParen: UnexpectedNodesSyntax? {
-    get {
-      let childData = data.child(at: 6, parent: Syntax(self))
-      if childData == nil { return nil }
-      return UnexpectedNodesSyntax(childData!)
-    }
-    set(value) {
-      self = withUnexpectedBetweenTrailingCommaAndRightParen(value)
-    }
-  }
-
-  /// Returns a copy of the receiver with its `unexpectedBetweenTrailingCommaAndRightParen` replaced.
-  /// - param newChild: The new `unexpectedBetweenTrailingCommaAndRightParen` to replace the node's
-  ///                   current `unexpectedBetweenTrailingCommaAndRightParen`, if present.
-  public func withUnexpectedBetweenTrailingCommaAndRightParen(
-    _ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
-    let raw = newChild?.raw
-    let newData = data.replacingChild(raw, at: 6)
-    return YieldListSyntax(newData)
-  }
-
   public var rightParen: TokenSyntax {
     get {
-      let childData = data.child(at: 7, parent: Syntax(self))
+      let childData = data.child(at: 5, parent: Syntax(self))
       return TokenSyntax(childData!)
     }
     set(value) {
@@ -14590,7 +14692,7 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
   public func withRightParen(
     _ newChild: TokenSyntax?) -> YieldListSyntax {
     let raw = newChild?.raw ?? RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default)
-    let newData = data.replacingChild(raw, at: 7)
+    let newData = data.replacingChild(raw, at: 5)
     return YieldListSyntax(newData)
   }
 
@@ -14608,10 +14710,6 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 5:
       return nil
-    case 6:
-      return nil
-    case 7:
-      return nil
     default:
       fatalError("Invalid index")
     }
@@ -14625,9 +14723,7 @@ extension YieldListSyntax: CustomReflectable {
       "leftParen": Syntax(leftParen).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenLeftParenAndElementList": unexpectedBetweenLeftParenAndElementList.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "elementList": Syntax(elementList).asProtocol(SyntaxProtocol.self),
-      "unexpectedBetweenElementListAndTrailingComma": unexpectedBetweenElementListAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
-      "unexpectedBetweenTrailingCommaAndRightParen": unexpectedBetweenTrailingCommaAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedBetweenElementListAndRightParen": unexpectedBetweenElementListAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
     ])
   }

--- a/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/BuildableNodes.swift
@@ -7307,6 +7307,101 @@ public struct ObjectLiteralExpr: ExprBuildable, ExpressibleAsObjectLiteralExpr {
     }
   }
 }
+public struct YieldExprListElement: SyntaxBuildable, ExpressibleAsYieldExprListElement {
+  struct BuildableData {
+    /// The leading trivia attached to this syntax node once built.
+    var leadingTrivia: Trivia
+    /// The trailing trivia attached to this syntax node once built.
+    var trailingTrivia: Trivia
+    var unexpectedBeforeExpression: UnexpectedNodes?
+    var expression: ExprBuildable
+    var unexpectedBetweenExpressionAndComma: UnexpectedNodes?
+    var comma: Token?
+  }
+  enum Data {
+    case buildable(BuildableData)
+    case constructed(YieldExprListElementSyntax)
+  }
+  private var data: Data
+  /// Creates a `YieldExprListElement` using the provided parameters.
+  /// - Parameters:
+  ///   - unexpectedBeforeExpression: 
+  ///   - expression: 
+  ///   - unexpectedBetweenExpressionAndComma: 
+  ///   - comma: 
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeExpression: ExpressibleAsUnexpectedNodes? = nil, expression: ExpressibleAsExprBuildable, unexpectedBetweenExpressionAndComma: ExpressibleAsUnexpectedNodes? = nil, comma: Token? = nil) {
+    assert(comma == nil || comma!.text == #","#)
+    self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeExpression: unexpectedBeforeExpression?.createUnexpectedNodes(), expression: expression.createExprBuildable(), unexpectedBetweenExpressionAndComma: unexpectedBetweenExpressionAndComma?.createUnexpectedNodes(), comma: comma))
+  }
+  public init (_ constructedNode: YieldExprListElementSyntax) {
+    self.data = .constructed(constructedNode)
+  }
+  /// Builds a `YieldExprListElementSyntax`.
+  /// - Parameter format: The `Format` to use.
+  /// - Parameter leadingTrivia: Additional leading trivia to attach, typically used for indentation.
+  /// - Returns: The built `YieldExprListElementSyntax`.
+  func buildYieldExprListElement(format: Format) -> YieldExprListElementSyntax {
+    switch data {
+    case .buildable(let buildableData): 
+      var result = YieldExprListElementSyntax(buildableData.unexpectedBeforeExpression?.buildUnexpectedNodes(format: format), expression: buildableData.expression.buildExpr(format: format), buildableData.unexpectedBetweenExpressionAndComma?.buildUnexpectedNodes(format: format), comma: buildableData.comma?.buildToken(format: format))
+      if !buildableData.leadingTrivia.isEmpty {
+        let trivia = (buildableData.leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
+        result = result.withLeadingTrivia(trivia)
+      }
+      if !buildableData.trailingTrivia.isEmpty {
+        let trivia = (buildableData.trailingTrivia + (result.trailingTrivia ?? [])).indented(indentation: format.indentTrivia)
+        result = result.withTrailingTrivia(trivia)
+      }
+      return format.format(syntax: result)
+    case .constructed(let node): 
+      return Indenter.indent(node, indentation: format.indentTrivia)
+    }
+  }
+  /// Conformance to `SyntaxBuildable`.
+  public func buildSyntax(format: Format) -> Syntax {
+    let result = buildYieldExprListElement(format: format)
+    return Syntax(result)
+  }
+  /// Conformance to `ExpressibleAsYieldExprListElement`.
+  public func createYieldExprListElement() -> YieldExprListElement {
+    return self
+  }
+  /// Conformance to `ExpressibleAsSyntaxBuildable`.
+  /// `YieldExprListElement` may conform to `ExpressibleAsSyntaxBuildable` via different `ExpressibleAs*` paths.
+  /// Thus, there are multiple default implementations of `createSyntaxBuildable`, some of which perform conversions
+  /// through `ExpressibleAs*` protocols. To resolve the ambiguity, provie a fixed implementation that doesn't perform any conversions.
+  public func createSyntaxBuildable() -> SyntaxBuildable {
+    return self
+  }
+  public func withLeadingTrivia(_ leadingTrivia: Trivia) -> Self {
+    switch data {
+    case .buildable(var buildableData): 
+      buildableData.leadingTrivia = leadingTrivia
+      var result = self
+      result.data = .buildable(buildableData)
+      return result
+    case .constructed(let node): 
+      let withNewTrivia = node.withTrailingTrivia(leadingTrivia)
+      var result = self
+      result.data = .constructed(withNewTrivia)
+      return result
+    }
+  }
+  public func withTrailingTrivia(_ trailingTrivia: Trivia) -> Self {
+    switch data {
+    case .buildable(var buildableData): 
+      buildableData.trailingTrivia = trailingTrivia
+      var result = self
+      result.data = .buildable(buildableData)
+      return result
+    case .constructed(let node): 
+      let withNewTrivia = node.withTrailingTrivia(trailingTrivia)
+      var result = self
+      result.data = .constructed(withNewTrivia)
+      return result
+    }
+  }
+}
 public struct TypeInitializerClause: SyntaxBuildable, ExpressibleAsTypeInitializerClause {
   struct BuildableData {
     /// The leading trivia attached to this syntax node once built.
@@ -16753,10 +16848,8 @@ public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
     var unexpectedBeforeLeftParen: UnexpectedNodes?
     var leftParen: Token
     var unexpectedBetweenLeftParenAndElementList: UnexpectedNodes?
-    var elementList: ExprList
-    var unexpectedBetweenElementListAndTrailingComma: UnexpectedNodes?
-    var trailingComma: Token?
-    var unexpectedBetweenTrailingCommaAndRightParen: UnexpectedNodes?
+    var elementList: YieldExprList
+    var unexpectedBetweenElementListAndRightParen: UnexpectedNodes?
     var rightParen: Token
   }
   enum Data {
@@ -16770,23 +16863,12 @@ public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
   ///   - leftParen: 
   ///   - unexpectedBetweenLeftParenAndElementList: 
   ///   - elementList: 
-  ///   - unexpectedBetweenElementListAndTrailingComma: 
-  ///   - trailingComma: 
-  ///   - unexpectedBetweenTrailingCommaAndRightParen: 
+  ///   - unexpectedBetweenElementListAndRightParen: 
   ///   - rightParen: 
-  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElementList: ExpressibleAsUnexpectedNodes? = nil, elementList: ExpressibleAsExprList, unexpectedBetweenElementListAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil, unexpectedBetweenTrailingCommaAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
+  public init (leadingTrivia: Trivia = [], trailingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElementList: ExpressibleAsUnexpectedNodes? = nil, elementList: ExpressibleAsYieldExprList, unexpectedBetweenElementListAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`) {
     assert(leftParen.text == #"("#)
-    assert(trailingComma == nil || trailingComma!.text == #","#)
     assert(rightParen.text == #")"#)
-    self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLeftParen: unexpectedBeforeLeftParen?.createUnexpectedNodes(), leftParen: leftParen, unexpectedBetweenLeftParenAndElementList: unexpectedBetweenLeftParenAndElementList?.createUnexpectedNodes(), elementList: elementList.createExprList(), unexpectedBetweenElementListAndTrailingComma: unexpectedBetweenElementListAndTrailingComma?.createUnexpectedNodes(), trailingComma: trailingComma, unexpectedBetweenTrailingCommaAndRightParen: unexpectedBetweenTrailingCommaAndRightParen?.createUnexpectedNodes(), rightParen: rightParen))
-  }
-  /// A convenience initializer that allows:
-  ///  - Initializing syntax collections using result builders
-  ///  - Initializing tokens without default text using strings
-  public init (leadingTrivia: Trivia = [], unexpectedBeforeLeftParen: ExpressibleAsUnexpectedNodes? = nil, leftParen: Token = Token.`leftParen`, unexpectedBetweenLeftParenAndElementList: ExpressibleAsUnexpectedNodes? = nil, unexpectedBetweenElementListAndTrailingComma: ExpressibleAsUnexpectedNodes? = nil, trailingComma: Token? = nil, unexpectedBetweenTrailingCommaAndRightParen: ExpressibleAsUnexpectedNodes? = nil, rightParen: Token = Token.`rightParen`, @ExprListBuilder elementListBuilder: () -> ExpressibleAsExprList =  {
-    ExprList([])
-  }) {
-    self.init(leadingTrivia: leadingTrivia, unexpectedBeforeLeftParen: unexpectedBeforeLeftParen, leftParen: leftParen, unexpectedBetweenLeftParenAndElementList: unexpectedBetweenLeftParenAndElementList, elementList: elementListBuilder(), unexpectedBetweenElementListAndTrailingComma: unexpectedBetweenElementListAndTrailingComma, trailingComma: trailingComma, unexpectedBetweenTrailingCommaAndRightParen: unexpectedBetweenTrailingCommaAndRightParen, rightParen: rightParen)
+    self.data = .buildable(BuildableData(leadingTrivia: leadingTrivia, trailingTrivia: trailingTrivia, unexpectedBeforeLeftParen: unexpectedBeforeLeftParen?.createUnexpectedNodes(), leftParen: leftParen, unexpectedBetweenLeftParenAndElementList: unexpectedBetweenLeftParenAndElementList?.createUnexpectedNodes(), elementList: elementList.createYieldExprList(), unexpectedBetweenElementListAndRightParen: unexpectedBetweenElementListAndRightParen?.createUnexpectedNodes(), rightParen: rightParen))
   }
   public init (_ constructedNode: YieldListSyntax) {
     self.data = .constructed(constructedNode)
@@ -16798,7 +16880,7 @@ public struct YieldList: SyntaxBuildable, ExpressibleAsYieldList {
   func buildYieldList(format: Format) -> YieldListSyntax {
     switch data {
     case .buildable(let buildableData): 
-      var result = YieldListSyntax(buildableData.unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format), leftParen: buildableData.leftParen.buildToken(format: format), buildableData.unexpectedBetweenLeftParenAndElementList?.buildUnexpectedNodes(format: format), elementList: buildableData.elementList.buildExprList(format: format), buildableData.unexpectedBetweenElementListAndTrailingComma?.buildUnexpectedNodes(format: format), trailingComma: buildableData.trailingComma?.buildToken(format: format), buildableData.unexpectedBetweenTrailingCommaAndRightParen?.buildUnexpectedNodes(format: format), rightParen: buildableData.rightParen.buildToken(format: format))
+      var result = YieldListSyntax(buildableData.unexpectedBeforeLeftParen?.buildUnexpectedNodes(format: format), leftParen: buildableData.leftParen.buildToken(format: format), buildableData.unexpectedBetweenLeftParenAndElementList?.buildUnexpectedNodes(format: format), elementList: buildableData.elementList.buildYieldExprList(format: format), buildableData.unexpectedBetweenElementListAndRightParen?.buildUnexpectedNodes(format: format), rightParen: buildableData.rightParen.buildToken(format: format))
       if !buildableData.leadingTrivia.isEmpty {
         let trivia = (buildableData.leadingTrivia + (result.leadingTrivia ?? [])).indented(indentation: format.indentTrivia)
         result = result.withLeadingTrivia(trivia)

--- a/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
+++ b/Sources/SwiftSyntaxBuilder/generated/ExpressibleAsProtocols.swift
@@ -744,6 +744,21 @@ public extension ExpressibleAsObjectLiteralExpr {
     return createObjectLiteralExpr()
   }
 }
+public protocol ExpressibleAsYieldExprList {
+  func createYieldExprList() -> YieldExprList
+}
+public protocol ExpressibleAsYieldExprListElement: ExpressibleAsYieldExprList, ExpressibleAsSyntaxBuildable {
+  func createYieldExprListElement() -> YieldExprListElement
+}
+public extension ExpressibleAsYieldExprListElement {
+  /// Conformance to `ExpressibleAsYieldExprList`
+  func createYieldExprList() -> YieldExprList {
+    return YieldExprList([self])
+  }
+  func createSyntaxBuildable() -> SyntaxBuildable {
+    return createYieldExprListElement()
+  }
+}
 public protocol ExpressibleAsTypeInitializerClause: ExpressibleAsSyntaxBuildable {
   func createTypeInitializerClause() -> TypeInitializerClause
 }

--- a/Sources/SwiftSyntaxBuilder/gyb_generated/ResultBuilders.swift
+++ b/Sources/SwiftSyntaxBuilder/gyb_generated/ResultBuilders.swift
@@ -935,6 +935,81 @@ public extension ObjcName {
 }
 
 @resultBuilder
+public struct YieldExprListBuilder {
+
+  /// The type of individual statement expressions in the transformed function,
+  /// which defaults to Component if buildExpression() is not provided.
+  public typealias Expression = ExpressibleAsYieldExprListElement
+
+  /// The type of a partial result, which will be carried through all of the
+  /// build methods.
+  public typealias Component = [ExpressibleAsYieldExprListElement]
+
+  /// The type of the final returned result, which defaults to Component if
+  /// buildFinalResult() is not provided.
+  public typealias FinalResult = YieldExprList
+
+  /// Required by every result builder to build combined results from
+  /// statement blocks.
+  public static func buildBlock(_ components: Component...) -> Component {
+    return components.flatMap { $0 }
+  }
+
+  /// If declared, provides contextual type information for statement
+  /// expressions to translate them into partial results.
+  public static func buildExpression(_ expression: Expression) -> Component {
+    return [expression]
+  }
+  
+  /// Add all the elements of `expression` to this result builder, effectively flattening them.
+  public static func buildExpression(_ expression: ExpressibleAsYieldExprList) -> Component {
+    return expression.createYieldExprList().elements
+  }
+  
+  /// Enables support for `if` statements that do not have an `else`.
+  public static func buildOptional(_ component: Component?) -> Component {
+    return component ?? []
+  }
+
+  /// With buildEither(second:), enables support for 'if-else' and 'switch'
+  /// statements by folding conditional results into a single result.
+  public static func buildEither(first component: Component) -> Component {
+    return component
+  }
+
+  /// With buildEither(first:), enables support for 'if-else' and 'switch'
+  /// statements by folding conditional results into a single result.
+  public static func buildEither(second component: Component) -> Component {
+    return component
+  }
+
+  /// Enables support for 'for..in' loops by combining the
+  /// results of all iterations into a single result.
+  public static func buildArray(_ components: [Component]) -> Component {
+    return components.flatMap { $0 }
+  }
+
+  /// If declared, this will be called on the partial result of an 'if
+  /// #available' block to allow the result builder to erase type
+  /// information.
+  public static func buildLimitedAvailability(_ component: Component) -> Component {
+    return component
+  }
+
+  /// If declared, this will be called on the partial result from the outermost
+  /// block statement to produce the final returned result.
+  public static func buildFinalResult(_ component: Component) -> FinalResult {
+    return .init(component.map { $0.createYieldExprListElement() })
+  }
+}
+
+public extension YieldExprList {
+  init(@YieldExprListBuilder itemsBuilder: () -> YieldExprList) {
+    self = itemsBuilder()
+  }
+}
+
+@resultBuilder
 public struct FunctionParameterListBuilder {
 
   /// The type of individual statement expressions in the transformed function,

--- a/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
@@ -17,6 +17,6 @@
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "a0a58a61b07dd635250d011a68bdd8eb3a311bbf"
+      "13783a3ca0c71bd27a187f7af53a4d3bb6f486a6"
   }
 }

--- a/Sources/SwiftSyntaxParser/gyb_generated/Serialization.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/Serialization.swift
@@ -110,6 +110,8 @@ extension SyntaxKind {
     case 250: self = .postfixIfConfigExpr
     case 69: self = .editorPlaceholderExpr
     case 70: self = .objectLiteralExpr
+    case 280: self = .yieldExprList
+    case 281: self = .yieldExprListElement
     case 107: self = .typeInitializerClause
     case 3: self = .typealiasDecl
     case 4: self = .associatedtypeDecl

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -356,4 +356,66 @@ final class StatementTests: XCTestCase {
       ]), rightAngleBracket: .rightAngleToken()))),
       substructureAfterMarker: "SPECIALIZATION")
   }
+
+  func testYield() {
+    // Make sure these are always considered a yield statement
+    AssertParse(
+      """
+      var x: Int {
+        _read {
+          #^YIELD^#yield ()
+        }
+      }
+      """,
+    substructure: Syntax(YieldStmtSyntax(
+      yieldKeyword: .contextualKeyword("yield"),
+      yields: Syntax(YieldListSyntax(
+        leftParen: .leftParenToken(),
+        elementList: YieldExprListSyntax([]),
+        rightParen: .rightParenToken())))),
+    substructureAfterMarker: "YIELD")
+
+    // Make sure these are not.
+    AssertParse(
+      """
+      var x: Int {
+        get {
+          #^YIELD^#yield ()
+        }
+      }
+      """,
+      substructure: Syntax(FunctionCallExprSyntax(
+        calledExpression: ExprSyntax(IdentifierExprSyntax(
+          identifier: .identifier("yield"),
+          declNameArguments: nil)),
+        leftParen: .leftParenToken(),
+        argumentList: TupleExprElementListSyntax([]),
+        rightParen: .rightParenToken(),
+        trailingClosure: nil,
+        additionalTrailingClosures: nil)),
+    substructureAfterMarker: "YIELD")
+
+    AssertParse(
+      """
+      yield([])
+      """,
+      substructure: Syntax(FunctionCallExprSyntax(
+        calledExpression: ExprSyntax(IdentifierExprSyntax(
+          identifier: .identifier("yield"),
+          declNameArguments: nil)),
+        leftParen: .leftParenToken(),
+        argumentList: TupleExprElementListSyntax([
+          TupleExprElementSyntax(
+            label: nil,
+            colon: nil,
+            expression: ExprSyntax(ArrayExprSyntax(
+              leftSquare: .leftSquareBracketToken(),
+              elements: ArrayElementListSyntax([]),
+              rightSquare: .rightSquareBracketToken())),
+            trailingComma: nil),
+        ]),
+        rightParen: .rightParenToken(),
+        trailingClosure: nil,
+        additionalTrailingClosures: nil)))
+  }
 }

--- a/gyb_syntax_support/ExprNodes.py
+++ b/gyb_syntax_support/ExprNodes.py
@@ -699,4 +699,14 @@ EXPR_NODES = [
                    collection_element_name='Argument'),
              Child('RightParen', kind='RightParenToken'),
          ]),
+
+    Node('YieldExprList', name_for_diagnostics='yield list',
+         kind='SyntaxCollection',
+         element='YieldExprListElement',
+         element_name='Yields'),
+    Node('YieldExprListElement', name_for_diagnostics=None, kind='Syntax',
+     children=[
+         Child('Expression', kind='Expr'),
+         Child('Comma', kind='CommaToken', is_optional=True),
+     ]),
 ]

--- a/gyb_syntax_support/NodeSerializationCodes.py
+++ b/gyb_syntax_support/NodeSerializationCodes.py
@@ -281,6 +281,8 @@ SYNTAX_NODE_SERIALIZATION_CODES = {
     'ConventionWitnessMethodAttributeArguments': 277,
     'DesignatedTypeElement': 278,
     'NamedOpaqueReturnType': 279,
+    'YieldExprList': 280,
+    'YieldExprListElement': 281,
 }
 
 

--- a/gyb_syntax_support/StmtNodes.py
+++ b/gyb_syntax_support/StmtNodes.py
@@ -149,9 +149,8 @@ STMT_NODES = [
     Node('YieldList', name_for_diagnostics=None, kind='Syntax',
          children=[
              Child('LeftParen', kind='LeftParenToken'),
-             Child('ElementList', kind='ExprList',
+             Child('ElementList', kind='YieldExprList',
                    collection_element_name='Element'),
-             Child('TrailingComma', kind='CommaToken', is_optional=True),
              Child('RightParen', kind='RightParenToken'),
          ]),
 


### PR DESCRIPTION
- Fixup the modeling of multi-yields by adding custom nodes for a yield list 
- Fixup the parsing of yield by plumbing the coroutine context through
- Fixup statement lookahead to take all of this into account.

Fixes #828
Fixes rdar://100248814
Fixes https://github.com/apple/swift-collections/pull/188