### PR TITLE
Don’t visit parts of the syntax tree that don’t contain any `SequenceExpr` in `SequenceFolder`

### DIFF
--- a/Sources/SwiftOperators/OperatorTable+Folding.swift
+++ b/Sources/SwiftOperators/OperatorTable+Folding.swift
@@ -435,6 +435,15 @@ extension OperatorTable {
       self.errorHandler = errorHandler
     }
 
+    override func visitAny(_ node: Syntax) -> Syntax? {
+      /// Return a non-nil value from `visitAny` to indicate to the SyntaxRewriter
+      /// that it shouldn't visit any of these node's children.
+      if !node.hasSequenceExpr {
+        return node
+      }
+      return nil
+    }
+
     override func visit(_ node: SequenceExprSyntax) -> ExprSyntax {
       // If the error handler threw in response to an error, don't
       // continue folding.

--- a/Sources/SwiftSyntax/Raw/RawSyntax.swift
+++ b/Sources/SwiftSyntax/Raw/RawSyntax.swift
@@ -25,6 +25,7 @@ struct RecursiveRawSyntaxFlags: OptionSet {
 
   /// Whether the tree contained by this layout has any missing or unexpected nodes.
   static let hasError = RecursiveRawSyntaxFlags(rawValue: 1 << 0)
+  static let hasSequenceExpr = RecursiveRawSyntaxFlags(rawValue: 1 << 1)
 }
 
 /// Node data for RawSyntax tree. Tagged union plus common data.
@@ -612,8 +613,12 @@ extension RawSyntax {
   ) -> RawSyntax {
     validateLayout(layout: layout, as: kind)
     let payload = RawSyntaxData.Layout(
-      kind: kind, layout: layout,
-      byteLength: byteLength, descendantCount: descendantCount, recursiveFlags: recursiveFlags)
+      kind: kind,
+      layout: layout,
+      byteLength: byteLength,
+      descendantCount: descendantCount,
+      recursiveFlags: recursiveFlags
+    )
     return RawSyntax(arena: arena, payload: .layout(payload))
   }
 
@@ -646,6 +651,9 @@ extension RawSyntax {
       descendantCount += node.totalNodes
       recursiveFlags.insert(node.recursiveFlags)
       arena.addChild(node.arenaReference)
+    }
+    if kind == .sequenceExpr {
+      recursiveFlags.insert(.hasSequenceExpr)
     }
     return .layout(
       kind: kind,

--- a/Sources/SwiftSyntax/Syntax.swift
+++ b/Sources/SwiftSyntax/Syntax.swift
@@ -192,6 +192,11 @@ public extension SyntaxProtocol {
     return raw.recursiveFlags.contains(.hasError)
   }
 
+  /// Whether this tree contains a missing token or unexpected node.
+  var hasSequenceExpr: Bool {
+    return raw.recursiveFlags.contains(.hasSequenceExpr)
+  }
+
   /// The parent of this syntax node, or `nil` if this node is the root.
   var parent: Syntax? {
     return data.parent.map(Syntax.init(_:))


### PR DESCRIPTION
Use a recursive bit to record whether a given subtree contains a `SequenceExpr` and skip any parts of the syntax tree that don’t contain `SequenceExpr`s in `SequenceFolder`.