### PR TITLE
Add a member on `SyntaxProtocol` that returns an expression to reconstruct a syntax tree

### DIFF
--- a/CodeGeneration/Sources/generate-swiftbasicformat/BasicFormatFile.swift
+++ b/CodeGeneration/Sources/generate-swiftbasicformat/BasicFormatFile.swift
@@ -25,7 +25,7 @@ let basicFormatFile = SourceFile {
   ClassDecl(modifiers: [Token.open], identifier: "BasicFormat", inheritanceClause: TypeInheritanceClause { InheritedType(typeName: "SyntaxRewriter") }) {
     VariableDecl("public var indentationLevel: Int = 0")
     VariableDecl("open var indentation: TriviaPiece { .spaces(indentationLevel * 4) }")
-    VariableDecl("private var indentedNewline: Trivia { Trivia(pieces: [.newlines(1), indentation]) }")
+    VariableDecl("public var indentedNewline: Trivia { Trivia(pieces: [.newlines(1), indentation]) }")
     VariableDecl("private var lastRewrittenToken: TokenSyntax?")
 
     for node in SYNTAX_NODES where !node.isBase {

--- a/Package.swift
+++ b/Package.swift
@@ -111,7 +111,7 @@ let package = Package(
     ),
     .target(
       name: "_SwiftSyntaxTestSupport",
-      dependencies: ["SwiftSyntax"]
+      dependencies: ["SwiftBasicFormat", "SwiftSyntax", "SwiftSyntaxBuilder"]
     ),
     .target(
       name: "SwiftParser",
@@ -143,8 +143,8 @@ let package = Package(
     ),
     .executableTarget(
       name: "swift-parser-cli",
-      dependencies: ["SwiftDiagnostics", "SwiftSyntax", "SwiftParser",
-                     "SwiftOperators",
+      dependencies: ["_SwiftSyntaxTestSupport", "SwiftDiagnostics",
+                     "SwiftSyntax", "SwiftParser", "SwiftOperators",
                      .product(name: "ArgumentParser", package: "swift-argument-parser")]
     ),
     .testTarget(

--- a/Sources/SwiftBasicFormat/generated/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat.swift
@@ -17,7 +17,7 @@ import SwiftSyntax
 open class BasicFormat: SyntaxRewriter {
   public var indentationLevel: Int = 0
   open var indentation: TriviaPiece { .spaces(indentationLevel * 4) }
-  private var indentedNewline: Trivia { Trivia(pieces: [.newlines(1), indentation]) }
+  public var indentedNewline: Trivia { Trivia(pieces: [.newlines(1), indentation]) }
   private var lastRewrittenToken: TokenSyntax?
   
   open override func visit(_ node: UnknownDeclSyntax) -> DeclSyntax {

--- a/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
+++ b/Sources/_SwiftSyntaxTestSupport/SyntaxProtocol+Initializer.swift
@@ -1,0 +1,167 @@
+import SwiftBasicFormat
+@_spi(RawSyntax) import SwiftSyntax
+import SwiftSyntaxBuilder
+
+private class InitializerExprFormat: BasicFormat {
+  override var indentation: TriviaPiece { return .spaces(indentationLevel * 2) }
+
+  private func formatChildrenSeparatedByNewline<SyntaxType: SyntaxProtocol>(children: SyntaxChildren, elementType: SyntaxType.Type) -> [SyntaxType] {
+    indentationLevel += 1
+    var formattedChildren = children.map {
+      self.visit($0).as(SyntaxType.self)!
+    }
+    formattedChildren = formattedChildren.map {
+      if $0.leadingTrivia?.first?.isNewline == true {
+        return $0
+      } else {
+        return $0.withLeadingTrivia(indentedNewline + ($0.leadingTrivia ?? []))
+      }
+    }
+    indentationLevel -= 1
+    if !formattedChildren.isEmpty {
+      formattedChildren[formattedChildren.count - 1] = formattedChildren[formattedChildren.count - 1].withTrailingTrivia(indentedNewline)
+    }
+    return formattedChildren
+  }
+
+  override func visit(_ node: TupleExprElementListSyntax) -> Syntax {
+    let children = node.children(viewMode: .all)
+    // If the function only takes a single argument, display it on the same line
+    if children.count > 1 {
+      return Syntax(TupleExprElementListSyntax(formatChildrenSeparatedByNewline(children: children, elementType: TupleExprElementSyntax.self)))
+    } else {
+      return super.visit(node)
+    }
+  }
+
+  override func visit(_ node: ArrayElementListSyntax) -> Syntax {
+    let children = node.children(viewMode: .all)
+    // Short array literals are presented on one line, list each element on a different line.
+    if node.description.count > 30 {
+      return Syntax(ArrayElementListSyntax(formatChildrenSeparatedByNewline(children: children, elementType: ArrayElementSyntax.self)))
+    } else {
+      return super.visit(node)
+    }
+  }
+}
+
+private extension TriviaPiece {
+  var initializerExpr: ExprBuildable {
+    let (label, value) = Mirror(reflecting: self).children.first!
+    switch value {
+    case let value as String:
+      return FunctionCallExpr(calledExpression: MemberAccessExpr(name: label!)) {
+        TupleExprElement(expression: StringLiteralExpr(value))
+      }
+    case let value as Int:
+      return FunctionCallExpr(calledExpression: MemberAccessExpr(name: label!)) {
+        TupleExprElement(expression: IntegerLiteralExpr(value))
+      }
+    default:
+      fatalError("Unknown associated value type")
+    }
+  }
+}
+
+private extension Trivia {
+  var initializerExpr: ExprBuildable {
+    if pieces.count == 1 {
+      switch pieces.first {
+      case .spaces(1):
+        return MemberAccessExpr(name: "space")
+      case .newlines(1):
+        return MemberAccessExpr(name: "newline")
+      default:
+        break
+      }
+    }
+    return ArrayExpr() {
+      for piece in pieces {
+        ArrayElement(expression: piece.initializerExpr)
+      }
+    }
+  }
+}
+
+extension SyntaxProtocol {
+  /// Returns a Swift expression that, when parsed, constructs this syntax node
+  /// (or at least an expression that's very close to constructing this node, the addition of a few manual upcast by hand is still needed).
+  /// The intended use case for this is to print a syntax tree and create a substructure assertion from the generated expression.
+  public var debugInitCall: String {
+    return self.debugInitCallExpr.build(format: InitializerExprFormat()).description
+  }
+
+  private var debugInitCallExpr: ExprBuildable {
+    let mirror = Mirror(reflecting: self)
+    if self.isCollection {
+      return FunctionCallExpr(calledExpression: "\(type(of: self))") {
+        TupleExprElement(
+          expression: ArrayExpr() {
+            for child in mirror.children {
+              let value = child.value as! SyntaxProtocol?
+              ArrayElement(expression: value?.debugInitCallExpr ?? NilLiteralExpr())
+            }
+          }
+        )
+      }
+    } else if let token = Syntax(self).as(TokenSyntax.self) {
+      let tokenKind = token.tokenKind
+      let tokenInitializerName: String
+      let requiresExplicitText: Bool
+      if tokenKind.isKeyword || tokenKind == .eof {
+        tokenInitializerName = String(describing: tokenKind)
+        requiresExplicitText = false
+      } else if tokenKind.decomposeToRaw().rawKind.defaultText != nil {
+        tokenInitializerName = "\(String(describing: tokenKind))Token"
+        requiresExplicitText = false
+      } else {
+        let tokenKindStr = String(describing: tokenKind)
+        tokenInitializerName = String(tokenKindStr[..<tokenKindStr.firstIndex(of: "(")!])
+        requiresExplicitText = true
+      }
+      return FunctionCallExpr(calledExpression: MemberAccessExpr(name: tokenInitializerName)) {
+        if requiresExplicitText {
+          TupleExprElement(
+            expression: StringLiteralExpr(token.text)
+          )
+        }
+        if !token.leadingTrivia.isEmpty {
+          TupleExprElement(
+            label: .identifier("leadingTrivia"),
+            colon: .colon,
+            expression: token.leadingTrivia.initializerExpr
+          )
+        }
+        if !token.trailingTrivia.isEmpty {
+          TupleExprElement(
+            label: .identifier("trailingTrivia"),
+            colon: .colon,
+            expression: token.trailingTrivia.initializerExpr
+          )
+        }
+        if token.presence != .present {
+          TupleExprElement(
+            label: .identifier("presence"),
+            colon: .colon,
+            expression: MemberAccessExpr(name: "missing")
+          )
+        }
+      }
+    } else {
+      return FunctionCallExpr(calledExpression: "\(type(of: self))") {
+        for child in mirror.children {
+          let label = child.label!
+          let value = child.value as! SyntaxProtocol?
+          let isUnexpected = label.hasPrefix("unexpected")
+          if !isUnexpected || value != nil {
+            TupleExprElement(
+              label: isUnexpected ? nil : .identifier(label),
+              colon: isUnexpected ? nil : .colon,
+              expression: value?.debugInitCallExpr ?? NilLiteralExpr()
+            )
+          }
+        }
+      }
+    }
+  }
+}

--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -10,7 +10,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-
+import _SwiftSyntaxTestSupport
 import SwiftDiagnostics
 import SwiftSyntax
 import SwiftParser
@@ -98,8 +98,7 @@ class VerifyRoundTrip: ParsableCommand {
   @Option(name: .long, help: "Enable or disable the use of forward slash regular-expression literal syntax")
   var enableBareSlashRegex: Bool?
 
-  @Flag(name: .long,
-          help: "Perform sequence folding with the standard operators")
+  @Flag(name: .long, help: "Perform sequence folding with the standard operators")
   var foldSequences: Bool = false
 
   enum Error: Swift.Error, CustomStringConvertible {
@@ -165,8 +164,7 @@ class PrintDiags: ParsableCommand {
   @Option(name: .long, help: "Enable or disable the use of forward slash regular-expression literal syntax")
   var enableBareSlashRegex: Bool?
 
-  @Flag(name: .long,
-          help: "Perform sequence folding with the standard operators")
+  @Flag(name: .long, help: "Perform sequence folding with the standard operators")
   var foldSequences: Bool = false
 
   func run() throws {
@@ -193,6 +191,45 @@ class PrintDiags: ParsableCommand {
   }
 }
 
+class PrintInitCall: ParsableCommand {
+  static var configuration = CommandConfiguration(
+    commandName: "print-init",
+    abstract: "Print a Swift expression that creates this tree"
+  )
+
+  required init() {}
+
+  @Argument(help: "The source file that should be parsed; if omitted, use stdin")
+  var sourceFile: String?
+
+  @Option(name: .long, help: "Interpret input according to a specific Swift language version number")
+  var swiftVersion: String?
+
+  @Option(name: .long, help: "Enable or disable the use of forward slash regular-expression literal syntax")
+  var enableBareSlashRegex: Bool?
+
+  @Flag(name: .long, help: "Perform sequence folding with the standard operators")
+  var foldSequences: Bool = false
+
+  func run() throws {
+    let source = try getContentsOfSourceFile(at: sourceFile)
+
+    try source.withUnsafeBufferPointer { sourceBuffer in
+      var tree = try Parser.parse(
+        source: sourceBuffer,
+        languageVersion: swiftVersion,
+        enableBareSlashRegexLiteral: enableBareSlashRegex
+      )
+
+      if foldSequences {
+        tree = foldAllSequences(tree).0.as(SourceFileSyntax.self)!
+      }
+
+      print(tree.debugInitCall)
+    }
+  }
+}
+
 class PrintTree: ParsableCommand {
   static var configuration = CommandConfiguration(
     commandName: "print-tree",
@@ -210,8 +247,7 @@ class PrintTree: ParsableCommand {
   @Option(name: .long, help: "Enable or disable the use of forward slash regular-expression literal syntax")
   var enableBareSlashRegex: Bool?
 
-  @Flag(name: .long,
-          help: "Perform sequence folding with the standard operators")
+  @Flag(name: .long, help: "Perform sequence folding with the standard operators")
   var foldSequences: Bool = false
 
   func run() throws {
@@ -253,8 +289,7 @@ class Reduce: ParsableCommand {
   @Option(name: .long, help: "Enable or disable the use of forward slash regular-expression literal syntax")
   var enableBareSlashRegex: Bool?
 
-  @Flag(name: .long,
-          help: "Perform sequence folding with the standard operators")
+  @Flag(name: .long, help: "Perform sequence folding with the standard operators")
   var foldSequences: Bool = false
 
   @Flag(help: "Print status updates while reducing the test case")


### PR DESCRIPTION
My hope is that this can be used to create more substructure assertions in the test suite because currently, writing out the substructure by hand is quite laborious.

For example if I have 
```swift
/// Comment
func foo() -> String
func bar() -> Int
```

parsing this code into a syntax tree and printing `tree.initializer` emits

```swift
SourceFileSyntax(
  statements: CodeBlockItemListSyntax([
    CodeBlockItemSyntax(
      item: FunctionDeclSyntax(
        attributes: nil, 
        modifiers: nil, 
        funcKeyword: .funcKeyword(
          leadingTrivia: [
            .docLineComment("/// Comment"), 
            .newlines(1)
          ], 
          trailingTrivia: .space
        ), 
        identifier: .identifier("foo"), 
        genericParameterClause: nil, 
        signature: FunctionSignatureSyntax(
          input: ParameterClauseSyntax(
            leftParen: .leftParenToken(), 
            parameterList: FunctionParameterListSyntax([]), 
            rightParen: .rightParenToken(trailingTrivia: .space)
          ), 
          asyncOrReasyncKeyword: nil, 
          throwsOrRethrowsKeyword: nil, 
          output: ReturnClauseSyntax(
            arrow: .arrowToken(trailingTrivia: .space), 
            returnType: SimpleTypeIdentifierSyntax(
              name: .identifier("String"), 
              genericArgumentClause: nil
            )
          )
        ), 
        genericWhereClause: nil, 
        body: nil
      ), 
      semicolon: nil, 
      errorTokens: nil
    ), 
    CodeBlockItemSyntax(
      item: FunctionDeclSyntax(
        attributes: nil, 
        modifiers: nil, 
        funcKeyword: .funcKeyword(
          leadingTrivia: .newline, 
          trailingTrivia: .space
        ), 
        identifier: .identifier("bar"), 
        genericParameterClause: nil, 
        signature: FunctionSignatureSyntax(
          input: ParameterClauseSyntax(
            leftParen: .leftParenToken(), 
            parameterList: FunctionParameterListSyntax([]), 
            rightParen: .rightParenToken(trailingTrivia: .space)
          ), 
          asyncOrReasyncKeyword: nil, 
          throwsOrRethrowsKeyword: nil, 
          output: ReturnClauseSyntax(
            arrow: .arrowToken(trailingTrivia: .space), 
            returnType: SimpleTypeIdentifierSyntax(
              name: .identifier("Int"), 
              genericArgumentClause: nil
            )
          )
        ), 
        genericWhereClause: nil, 
        body: nil
      ), 
      semicolon: nil, 
      errorTokens: nil
    )
  ]), 
  eofToken: .eof()
)
```

The idea is that you can pick parts of this syntax tree to create a substructure assertion in `AssertParse`.