### PR TITLE
Disallow multiple statements on the same line

### DIFF
--- a/Sources/SwiftDiagnostics/FixIt.swift
+++ b/Sources/SwiftDiagnostics/FixIt.swift
@@ -29,6 +29,8 @@ public struct FixIt {
   public enum Change {
     /// Replace `oldNode` by `newNode`.
     case replace(oldNode: Syntax, newNode: Syntax)
+    /// Remove the trailing trivia of the given token
+    case removeTrailingTrivia(TokenSyntax)
   }
 
   /// A description of what this Fix-It performs.

--- a/Sources/SwiftParser/Diagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParser/Diagnostics/DiagnosticExtensions.swift
@@ -36,3 +36,20 @@ extension FixIt.Change {
     )
   }
 }
+
+extension Array where Element == FixIt.Change {
+  /// Makes the `token` present, moving it in front of the previous token's trivia.
+  static func makePresentBeforeTrivia(token: TokenSyntax) -> [FixIt.Change] {
+    if let previousToken = token.previousToken(viewMode: .sourceAccurate) {
+      let presentToken = PresentMaker().visit(token).withTrailingTrivia(previousToken.trailingTrivia)
+      return [
+        .removeTrailingTrivia(previousToken),
+        .replace(oldNode: Syntax(token), newNode: presentToken),
+      ]
+    } else {
+      return [
+        .makePresent(node: token)
+      ]
+    }
+  }
+}

--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -131,6 +131,16 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
 
   // MARK: - Specialized diagnostic generation
 
+  public override func visit(_ node: CodeBlockItemSyntax) -> SyntaxVisitorContinueKind {
+    if let semicolon = node.semicolon, semicolon.presence == .missing {
+      let position = semicolon.previousToken(viewMode: .sourceAccurate)?.endPositionBeforeTrailingTrivia
+      addDiagnostic(semicolon, position: position, .consecutiveStatementsOnSameLine, fixIts: [
+        FixIt(message: .insertSemicolon, changes: .makePresentBeforeTrivia(token: semicolon))
+      ], handledNodes: [semicolon.id])
+    }
+    return .visitChildren
+  }
+
   public override func visit(_ node: MissingDeclSyntax) -> SyntaxVisitorContinueKind {
     return handleMissingSyntax(node)
   }

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -66,6 +66,7 @@ public extension ParserFixIt {
 
 /// Please order the cases in this enum alphabetically by case name.
 public enum StaticParserError: String, DiagnosticMessage {
+  case consecutiveStatementsOnSameLine = "consecutive statements on a line must be separated by ';'"
   case cStyleForLoop = "C-style for statement has been removed in Swift 3"
   case missingColonInTernaryExprDiagnostic = "expected ':' after '? ...' in ternary expression"
   case missingFunctionParameterClause = "expected argument list in function declaration"
@@ -138,6 +139,7 @@ public struct UnexpectedNodesError: ParserError {
 // MARK: - Fix-Its (please sort alphabetically)
 
 public enum StaticParserFixIt: String, FixItMessage {
+  case insertSemicolon = "insert ';'"
   case insertAttributeArguments = "insert attribute argument"
   case moveThrowBeforeArrow = "move 'throws' before '->'"
 

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -135,6 +135,18 @@ class FixItApplier: SyntaxRewriter {
     return nil
   }
 
+  override func visit(_ node: TokenSyntax) -> Syntax {
+    for change in changes {
+      switch change {
+      case .removeTrailingTrivia(let changeNode) where changeNode.id == node.id:
+        return Syntax(node.withTrailingTrivia([]))
+      default:
+        break
+      }
+    }
+    return Syntax(node)
+  }
+
   /// Applies all Fix-Its in `diagnostics` to `tree` and returns the fixed syntax tree.
   public static func applyFixes<T: SyntaxProtocol>(in diagnostics: [Diagnostic], to tree: T) -> Syntax {
     let applier = FixItApplier(diagnostics: diagnostics)

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -498,6 +498,7 @@ final class ExpressionTests: XCTestCase {
       """##,
       diagnostics: [
         DiagnosticSpec(locationMarker: "AFTER_SLASH", message: "expected root in key path"),
+        DiagnosticSpec(locationMarker: "AFTER_SLASH", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "AFTER_PAREN", message: "expected ')' to end tuple type"),
       ]
     )
@@ -558,9 +559,10 @@ final class ExpressionTests: XCTestCase {
         \n    #^KEY_PATH_1^#
         if false != true {
           \n       #^KEY_PATH_2^#
-          print "\(i)\"\n#^END^#
+          print#^STMTS^# "\(i)\"\n#^END^#
       """#,
       diagnostics: [
+        DiagnosticSpec(locationMarker: "STMTS", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "END", message: #"expected '"' to end string literal"#),
         DiagnosticSpec(locationMarker: "END", message: "expected '}' to end 'if' statement"),
         DiagnosticSpec(locationMarker: "END", message: "expected '}' to end function"),
@@ -597,12 +599,13 @@ final class ExpressionTests: XCTestCase {
     AssertParse(
       """
       do {
-        true ? () : #^DIAG^#throw opaque_error()
+        true ? () :#^DIAG_1^# #^DIAG_2^#throw opaque_error()
       } catch _ {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected expression in 'do' statement")
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'do' statement"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -58,7 +58,7 @@ final class StatementTests: XCTestCase {
     for index in (0...nest) {
         let indent = String(repeating: "    ", count: index + 1)
         source += indent + "if false != true {\n"
-        source += indent + "   print \"\\(i)\"\n"
+        source += indent + "   print(\"\\(i)\")\n"
     }
 
     for index in (0...nest).reversed() {
@@ -367,13 +367,15 @@ final class StatementTests: XCTestCase {
         }
       }
       """,
-    substructure: Syntax(YieldStmtSyntax(
-      yieldKeyword: .contextualKeyword("yield"),
-      yields: Syntax(YieldListSyntax(
-        leftParen: .leftParenToken(),
-        elementList: YieldExprListSyntax([]),
-        rightParen: .rightParenToken())))),
-    substructureAfterMarker: "YIELD")
+      substructure: Syntax(YieldStmtSyntax(
+        yieldKeyword: .contextualKeyword("yield"),
+        yields: Syntax(YieldListSyntax(
+          leftParen: .leftParenToken(),
+          elementList: YieldExprListSyntax([]),
+          rightParen: .rightParenToken())
+        ))
+      ),
+      substructureAfterMarker: "YIELD")
 
     // Make sure these are not.
     AssertParse(

--- a/Tests/SwiftParserTest/translated/AsyncTests.swift
+++ b/Tests/SwiftParserTest/translated/AsyncTests.swift
@@ -16,10 +16,11 @@ final class AsyncTests: XCTestCase {
   func testAsync2() {
     AssertParse(
       """
-      func asyncGlobal3() throws async { }
+      func asyncGlobal3() throws#^DIAG^# async { }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: 'async' must precede 'throws', Fix-It replacements: 28 - 34 = '', 21 - 21 = 'async '
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
       ]
     )
   }
@@ -27,9 +28,10 @@ final class AsyncTests: XCTestCase {
   func testAsync3() {
     AssertParse(
       """
-      func asyncGlobal3(fn: () throws -> Int) rethrows async { }
+      func asyncGlobal3(fn: () throws -> Int) rethrows#^DIAG^# async { }
       """,
       diagnostics: [
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
         // TODO: Old parser expected error on line 1: 'async' must precede 'rethrows', Fix-It replacements: 50 - 56 = '', 41 - 41 = 'async '
       ]
     )
@@ -38,9 +40,10 @@ final class AsyncTests: XCTestCase {
   func testAsync4() {
     AssertParse(
       """
-      func asyncGlobal4() -> Int async { }
+      func asyncGlobal4() -> Int#^DIAG^# async { }
       """,
       diagnostics: [
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
         // TODO: Old parser expected error on line 1: 'async' may only occur before '->', Fix-It replacements: 28 - 34 = '', 21 - 21 = 'async '
       ]
     )
@@ -49,11 +52,12 @@ final class AsyncTests: XCTestCase {
   func testAsync5() {
     AssertParse(
       """
-      func asyncGlobal5() -> Int async throws #^DIAG^#{ }
+      func asyncGlobal5() -> Int#^STMTS^# async throws #^DIAG^#{ }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: 'async' may only occur before '->', Fix-It replacements: 28 - 34 = '', 21 - 21 = 'async '
         // TODO: Old parser expected error on line 1: 'throws' may only occur before '->', Fix-It replacements: 34 - 41 = '', 21 - 21 = 'throws '
+        DiagnosticSpec(locationMarker: "STMTS", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(message: "expected '->'"),
       ]
     )
@@ -75,9 +79,10 @@ final class AsyncTests: XCTestCase {
   func testAsync7() {
     AssertParse(
       """
-      func asyncGlobal7() throws -> Int async { }
+      func asyncGlobal7() throws -> Int#^DIAG^# async { }
       """,
       diagnostics: [
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
         // TODO: Old parser expected error on line 1: 'async' may only occur before '->', Fix-It replacements: 35 - 41 = '', 21 - 21 = 'async '
       ]
     )
@@ -86,9 +91,12 @@ final class AsyncTests: XCTestCase {
   func testAsync8() {
     AssertParse(
       """
-      func asyncGlobal8() async throws async -> async Int async {}
+      func asyncGlobal8() async throws#^DIAG_1^# async -> async#^DIAG_2^# Int#^DIAG_3^# async {}
       """,
       diagnostics: [
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "consecutive statements on a line must be separated by ';'"),
         // TODO: Old parser expected error on line 1: 'async' has already been specified, Fix-It replacements: 34 - 40 = ''
         // TODO: Old parser expected error on line 1: 'async' has already been specified, Fix-It replacements: 43 - 49 = ''
         // TODO: Old parser expected error on line 1: 'async' has already been specified, Fix-It replacements: 53 - 59 = ''

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -20,11 +20,11 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       if #unavailable(OSX 10.51, *) {} 
       // Disallow use as an expression.
       if (#^DIAG_1^##unavailable(OSX 10.51)) {}  
-      let x = #^DIAG_2^##unavailable(OSX 10.51)  
+      let x =#^DIAG_2A^# #^DIAG_2^##unavailable(OSX 10.51)
       (#unavailable(OSX 10.51) ? 1 : 0) 
       if !#unavailable(OSX 10.52) { 
       }
-      if let _ = Optional(5), #^DIAG_3^#!#^DIAG_4^##unavailable(OSX 10.52) { 
+      if let _ = Optional(5),#^DIAG_3A^# #^DIAG_3^#!#^DIAG_4^##unavailable(OSX 10.52) { 
       }
       """,
       diagnostics: [
@@ -33,11 +33,13 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
         DiagnosticSpec(locationMarker: "DIAG_1", message: "expected value in tuple"),
         DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '#unavailable(OSX 10.51)' in tuple"),
         // TODO: Old parser expected error on line 5: #unavailable may only be used as condition of
+        DiagnosticSpec(locationMarker: "DIAG_2A", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in variable"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text before variable"),
         // TODO: Old parser expected error on line 6: #unavailable may only be used as condition of an
         // TODO: Old parser expected error on line 7: #unavailable may only be used as condition of an
         // TODO: Old parser expected error on line 9: #unavailable may only be used as condition
+        DiagnosticSpec(locationMarker: "DIAG_3A", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_3", message: "expected pattern in variable"),
         DiagnosticSpec(locationMarker: "DIAG_4", message: "expected expression in prefix operator expression"),
         DiagnosticSpec(locationMarker: "DIAG_4", message: "extraneous code at top level"),

--- a/Tests/SwiftParserTest/translated/ConsecutiveStatementsTests.swift
+++ b/Tests/SwiftParserTest/translated/ConsecutiveStatementsTests.swift
@@ -3,6 +3,16 @@
 import XCTest
 
 final class ConsecutiveStatementsTests: XCTestCase {
+  func testSimple() {
+    AssertParse(
+      "let x = 2#^DIAG^# let y = 3",
+      diagnostics: [
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'", fixIts: ["insert ';'"]),
+      ],
+      fixedSource: "let x = 2; let y = 3"
+    )
+  }
+
   func testConsecutiveStatements1() {
     AssertParse(
       """
@@ -32,16 +42,16 @@ final class ConsecutiveStatementsTests: XCTestCase {
         let q : Int; i = j; j = i; _ = q
         if i != j { i = j }
         // Errors
-        i = j j = i 
-        let r : Int i = j 
-        let s : Int let t : Int 
+        i = j#^DIAG_1^# j = i
+        let r : Int#^DIAG_2^# i = j
+        let s : Int#^DIAG_3^# let t : Int
         _ = r; _ = s; _ = t
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 7: consecutive statements, Fix-It replacements: 8 - 8 = ';'
-        // TODO: Old parser expected error on line 8: consecutive statements, Fix-It replacements: 14 - 14 = ';'
-        // TODO: Old parser expected error on line 9: consecutive statements, Fix-It replacements: 14 - 14 = ';'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "consecutive statements on a line must be separated by ';'"),
       ]
     )
   }
@@ -57,21 +67,19 @@ final class ConsecutiveStatementsTests: XCTestCase {
         // Within property accessors
         subscript(i: Int) -> Float {
           get {
-            var x = i x = i + x return Float(x) 
+            var x = i#^DIAG_1^# x = i + x#^DIAG_2^# return Float(x)
           }
           set {
-            var x = i x = i + 1 
+            var x = i#^DIAG_3^# x = i + 1
             _ = x
           }
         }
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: consecutive declarations, Fix-It replacements: 17 - 17 = ';'
-        // TODO: Old parser expected error on line 5: consecutive declarations, Fix-It replacements: 4 - 4 = ';'
-        // TODO: Old parser expected error on line 9: consecutive statements, Fix-It replacements: 16 - 16 = ';'
-        // TODO: Old parser expected error on line 9: consecutive statements, Fix-It replacements: 26 - 26 = ';'
-        // TODO: Old parser expected error on line 12: consecutive statements, Fix-It replacements: 16 - 16 = ';'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "consecutive statements on a line must be separated by ';'"),
       ]
     )
   }
@@ -126,13 +134,12 @@ final class ConsecutiveStatementsTests: XCTestCase {
     AssertParse(
       """
       // At the top level
-      var i, j : Int i = j j = i
+      var i, j : Int#^DIAG_1^# i = j#^DIAG_2^# j = i
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: consecutive statements, Fix-It replacements: 15 - 15 = ';'
-        // TODO: Old parser expected error on line 2: consecutive statements, Fix-It replacements: 21 - 21 = ';'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "consecutive statements on a line must be separated by ';'"),
       ]
     )
   }
-
 }

--- a/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
+++ b/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
@@ -174,26 +174,37 @@ final class DeprecatedWhereTests: XCTestCase {
   func testDeprecatedWhere12() {
     AssertParse(
       """
-      func testCombinedConstraintsOld<T: #^DIAG_1^#protocol#^DIAG_2^#<ProtoA, ProtoB> where T: ProtoC>(x: T) {} 
-      func testCombinedConstraintsOld<T: #^DIAG_3^#protocol#^DIAG_4^#<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {}
+      func testCombinedConstraintsOld<T:#^STMTS^# #^DIAG_1^#protocol#^DIAG_2^#<ProtoA, ProtoB> where T: ProtoC>(x: T) {}
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 60 - 76 = '', 83 - 83 = ' where T: ProtoC'
         // TODO: Old parser expected error on line 1: 'protocol<...>' composition syntax has been removed
+        DiagnosticSpec(locationMarker: "STMTS", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_1", message: "expected inherited type in generic parameter"),
         DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '>' to end generic parameter clause"),
         DiagnosticSpec(locationMarker: "DIAG_1", message: "expected argument list in function declaration"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in protocol"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in protocol"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '<ProtoA, ProtoB> where T: ProtoC>(x: T) {}' before function"),
-        // TODO: Old parser expected error on line 2: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 60 - 76 = '', 84 - 89 = 'where T: ProtoC,'
-        // TODO: Old parser expected error on line 2: 'protocol<...>' composition syntax has been removed
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected inherited type in generic parameter"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected '>' to end generic parameter clause"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected argument list in function declaration"),
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected identifier in protocol"),
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected member block in protocol"),
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "extraneous '<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {}' at top level"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "extraneous '<ProtoA, ProtoB> where T: ProtoC>(x: T) {}' at top level"),
+      ]
+    )
+  }
+
+  func testDeprecatedWhere13() {
+    AssertParse(
+      """
+      func testCombinedConstraintsOld<T:#^STMTS^# #^DIAG_1^#protocol#^DIAG_2^#<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 60 - 76 = '', 84 - 89 = 'where T: ProtoC,'
+        // TODO: Old parser expected error on line 1: 'protocol<...>' composition syntax has been removed
+        DiagnosticSpec(locationMarker: "STMTS", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected inherited type in generic parameter"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '>' to end generic parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected argument list in function declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "extraneous '<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {}' at top level"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/DiagnoseInitializerAsTypedPatternTests.swift
+++ b/Tests/SwiftParserTest/translated/DiagnoseInitializerAsTypedPatternTests.swift
@@ -23,16 +23,20 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
   func testDiagnoseInitializerAsTypedPattern3() {
     AssertParse(
       """
-      let a:[X]()  
-      let b: [X]()  
-      let c :[X]()  
-      let d : [X]()
+      let a:[X]#^DIAG_1^#()
+      let b: [X]#^DIAG_2^#()
+      let c :[X]#^DIAG_3^#()
+      let d : [X]#^DIAG_4^#()
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' = '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
         // TODO: Old parser expected error on line 2: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' ='
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "consecutive statements on a line must be separated by ';'"),
         // TODO: Old parser expected error on line 3: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 7 - 8 = '= '
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "consecutive statements on a line must be separated by ';'"),
         // TODO: Old parser expected error on line 4: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 7 - 8 = '='
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "consecutive statements on a line must be separated by ';'"),
       ]
     )
   }
@@ -40,11 +44,12 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
   func testDiagnoseInitializerAsTypedPattern4() {
     AssertParse(
       """
-      let e: X()#^DIAG^#, ee: Int
+      let e: X#^DIAG_1^#()#^DIAG_2^#, ee: Int
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' ='
-        DiagnosticSpec(message: "extraneous ', ee: Int' at top level"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "extraneous ', ee: Int' at top level"),
       ]
     )
   }
@@ -52,10 +57,11 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
   func testDiagnoseInitializerAsTypedPattern5() {
     AssertParse(
       """
-      let f:/*comment*/[X]()
+      let f:/*comment*/[X]#^DIAG^#()
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' = '
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
       ]
     )
   }
@@ -83,18 +89,23 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
   func testDiagnoseInitializerAsTypedPattern8() {
     AssertParse(
       """
-      let g: X(x)  
-      let h: X(x, y)  
-      let i: X() { foo() }  
-      let j: X(x) { foo() }  
-      let k: X(x, y) { foo() }
+      let g: X#^DIAG_1^#(x)
+      let h: X#^DIAG_2^#(x, y)
+      let i: X#^DIAG_3^#() { foo() }
+      let j: X#^DIAG_4^#(x) { foo() }
+      let k: X#^DIAG_5^#(x, y) { foo() }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' ='
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
         // TODO: Old parser expected error on line 2: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' ='
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "consecutive statements on a line must be separated by ';'"),
         // TODO: Old parser expected error on line 3: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' ='
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "consecutive statements on a line must be separated by ';'"),
         // TODO: Old parser expected error on line 4: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' ='
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "consecutive statements on a line must be separated by ';'"),
         // TODO: Old parser expected error on line 5: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 6 - 7 = ' ='
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "consecutive statements on a line must be separated by ';'"),
       ]
     )
   }
@@ -103,18 +114,22 @@ final class DiagnoseInitializerAsTypedPatternTests: XCTestCase {
     AssertParse(
       """
       func nonTopLevel() {
-        let a:[X]()   
-        let i: X() { foo() }  
-        let j: X(x) { foo() }  
-        let k: X(x, y) { foo() }  
+        let a:[X]#^DIAG_1^#()
+        let i: X#^DIAG_2^#() { foo() }
+        let j: X#^DIAG_3^#(x) { foo() }
+        let k: X#^DIAG_4^#(x, y) { foo() }
         _ = (a, i, j, k)
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 8 - 9 = ' = '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
         // TODO: Old parser expected error on line 3: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 8 - 9 = ' ='
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "consecutive statements on a line must be separated by ';'"),
         // TODO: Old parser expected error on line 4: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 8 - 9 = ' ='
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "consecutive statements on a line must be separated by ';'"),
         // TODO: Old parser expected error on line 5: unexpected initializer in pattern; did you mean to use '='?, Fix-It replacements: 8 - 9 = ' ='
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "consecutive statements on a line must be separated by ';'"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
+++ b/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
@@ -13,49 +13,91 @@ final class DollarIdentifierTests: XCTestCase {
     )
   }
 
-  func testDollarIdentifier2() {
+  func testDollarIdentifier2a() {
     AssertParse(
       """
       func dollarVar() {
-        var #^DIAG_1^#$ #^DIAG_2^#: Int = 42 
-        $ += 1 
-        print($) 
-      }
-      func dollarLet() {
-        let #^DIAG_3^#$ = 42 
-        print($) 
-      }
-      func dollarClass() {
-        class #^DIAG_4^#$ {} 
-      }
-      func dollarEnum() {
-        enum #^DIAG_5^#$ {} 
-      }
-      func dollarStruct() {
-        struct #^DIAG_6^#$ {} 
+        var#^DIAG_1^# #^DIAG_2^#$ #^DIAG_3^#: Int = 42
+        $ += 1
+        print($)
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 7 - 8 = '`$`'
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected pattern in variable"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text in function"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected pattern in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text in function"),
         // TODO: Old parser expected error on line 3: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 3 - 4 = '`$`'
         // TODO: Old parser expected error on line 4: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 9 - 10 = '`$`'
-        // TODO: Old parser expected error on line 7: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 7 - 8 = '`$`'
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected pattern in variable"),
-        // TODO: Old parser expected error on line 8: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 9 - 10 = '`$`'
-        // TODO: Old parser expected error on line 11: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 9 - 10 = '`$`'
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected identifier in class"),
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected member block in class"),
-        // TODO: Old parser expected error on line 14: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 8 - 9 = '`$`'
-        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected identifier in enum"),
-        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected member block in enum"),
-        // TODO: Old parser expected error on line 17: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 10 - 11 = '`$`'
-        DiagnosticSpec(locationMarker: "DIAG_6", message: "expected identifier in struct"),
-        DiagnosticSpec(locationMarker: "DIAG_6", message: "expected member block in struct"),
       ]
     )
   }
+
+  func testDollarIdentifier2b() {
+    AssertParse(
+      """
+      func dollarLet() {
+        let#^DIAG_1^# #^DIAG_2^#$ = 42
+        print($)
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 7 - 8 = '`$`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected pattern in variable"),
+        // TODO: Old parser expected error on line 3: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 9 - 10 = '`$`'
+      ]
+    )
+  }
+
+  func testDollarIdentifier2c() {
+    AssertParse(
+      """
+      func dollarClass() {
+        class#^DIAG_1^# #^DIAG_2^#$ {}
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 9 - 10 = '`$`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in class"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in class"),
+      ]
+    )
+  }
+
+  func testDollarIdentifier2d() {
+    AssertParse(
+      """
+      func dollarEnum() {
+        enum#^DIAG_1^# #^DIAG_2^#$ {}
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 8 - 9 = '`$`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in enum"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in enum"),
+      ]
+    )
+  }
+
+  func testDollarIdentifier2e() {
+    AssertParse(
+      """
+      func dollarStruct() {
+        struct#^DIAG_1^# #^DIAG_2^#$ {}
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 10 - 11 = '`$`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in struct"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in struct"),
+      ]
+    )
+  }
+
 
   func testDollarIdentifier3() {
     AssertParse(

--- a/Tests/SwiftParserTest/translated/EffectfulPropertiesTests.swift
+++ b/Tests/SwiftParserTest/translated/EffectfulPropertiesTests.swift
@@ -143,7 +143,7 @@ final class EffectfulPropertiesTests: XCTestCase {
         private(set) var prop4 : Double {
           set {} 
           get async throws { 1.1 }
-          _modify { yield &prop4 } 
+          _modify { yield &prop4 }
         }
       }
       """,
@@ -219,8 +219,8 @@ final class EffectfulPropertiesTests: XCTestCase {
     AssertParse(
       """
       var bad3 : Int {
-        _read async { yield 0 } 
-        set(theValue) async { } 
+        _read async { yield 0 }
+        set(theValue) async { }
       }
       """,
       diagnostics: [

--- a/Tests/SwiftParserTest/translated/EnumTests.swift
+++ b/Tests/SwiftParserTest/translated/EnumTests.swift
@@ -1110,14 +1110,15 @@ final class EnumTests: XCTestCase {
   func testEnum82() {
     AssertParse(
       """
-      enum #^DIAG_1^#switch {}#^DIAG_2^#
+      enum#^DIAG_1^# #^DIAG_2^#switch {}#^DIAG_3^#
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: keyword 'switch' cannot be used as an identifier here
         // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 6 - 12 = '`switch`'
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in enum"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected member block in enum"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '{}' in 'switch' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in enum"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in enum"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected '{}' in 'switch' statement"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/IdentifiersTests.swift
+++ b/Tests/SwiftParserTest/translated/IdentifiersTests.swift
@@ -79,34 +79,64 @@ final class IdentifiersTests: XCTestCase {
     )
   }
 
-  func testIdentifiers8() {
+  func testIdentifiers8a() {
     AssertParse(
       """
       // Keywords as identifiers
-      class #^DIAG_1^#switch {} #^DIAG_2^#
-      struct Self {} 
-      protocol #^DIAG_3^#enum #^DIAG_4^#{} 
-      protocol test {
-        associatedtype #^DIAG_5^#public 
-      #^DIAG_6^#}
-      func #^DIAG_7^#_(_ x: Int) {}#^DIAG_8^#
+      class#^DIAG_1^# #^DIAG_2^#switch {} #^DIAG_3^#
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: keyword 'switch' cannot be used as an identifier here
         // TODO: Old parser expected note on line 2: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 7 - 13 = '`switch`'
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in class"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected member block in class"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '{}' in 'switch' statement"),
-        // TODO: Old parser expected error on line 3: keyword 'Self' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 3: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 12 = '`Self`'
-        // TODO: Old parser expected error on line 4: keyword 'enum' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 4: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 10 - 14 = '`enum`'
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected identifier in protocol"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected member block in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in class"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in class"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected '{}' in 'switch' statement"),
+      ]
+    )
+  }
+
+  func testIdentifiers8b() {
+    AssertParse(
+      """
+      struct Self {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: keyword 'Self' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 12 = '`Self`'
+      ]
+    )
+  }
+
+  func testIdentifiers8c() {
+    AssertParse(
+      """
+      protocol#^DIAG_1^# #^DIAG_2^#enum#^DIAG_3^# #^DIAG_4^#{}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: keyword 'enum' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 10 - 14 = '`enum`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_4", message: "expected identifier in enum"),
         DiagnosticSpec(locationMarker: "DIAG_4", message: "expected member block in enum"),
-        // TODO: Old parser expected error on line 6: keyword 'public' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 6: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 18 - 24 = '`public`'
+      ]
+    )
+  }
+
+  func testIdentifiers8d() {
+    AssertParse(
+      """
+      protocol test {
+        associatedtype #^DIAG_5^#public
+      #^DIAG_6^#}
+      func #^DIAG_7^#_(_ x: Int) {}#^DIAG_8^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: keyword 'public' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 2: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 18 - 24 = '`public`'
         DiagnosticSpec(locationMarker: "DIAG_5", message: "expected identifier in associatedtype declaration"),
         DiagnosticSpec(locationMarker: "DIAG_6", message: "unexpected text '}' in function"),
         // TODO: Old parser expected note on line 8: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 6 - 7 = '`_`'

--- a/Tests/SwiftParserTest/translated/InvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidTests.swift
@@ -3,69 +3,111 @@
 import XCTest
 
 final class InvalidTests: XCTestCase {
-  func testInvalid1() {
+  func testInvalid1a() {
     AssertParse(
       """
       // rdar://15946844
-      func test1(inout #^DIAG_1^#var x : Int#^DIAG_2^#) {}  
-      func test2(inout #^DIAG_3^#let x : Int#^DIAG_4^#) {}  
-      func test3(f : (inout _ #^DIAG_5^#x : Int) -> Void) {}
+      func test1(inout#^DIAG_1^# #^DIAG_2^#var x : Int#^DIAG_3^#) {}
       """,
       diagnostics: [
         // TODO: Old parser expected warning on line 2: 'var' in this position is interpreted as an argument label, Fix-It replacements: 18 - 21 = '`var`'
         // TODO: Old parser expected error on line 2: 'inout' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 12 - 17 = '', 26 - 26 = 'inout '
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected type in type"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text ') {}' before function"),
-        // TODO: Old parser expected warning on line 3: 'let' in this position is interpreted as an argument label, Fix-It replacements: 18 - 21 = '`let`'
-        // TODO: Old parser expected error on line 3: 'inout' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 12 - 17 = '', 26 - 26 = 'inout '
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected type in type"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "unexpected text ') {}' before function"),
-        // TODO: Old parser expected error on line 4: 'inout' before a parameter name is not allowed, place it before the parameter type instead
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous ') {}' at top level"),
+      ]
+    )
+  }
+
+  func testInvalid1b() {
+    AssertParse(
+      """
+      func test2(inout#^DIAG_1^# #^DIAG_2^#let x : Int#^DIAG_3^#) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: 'let' in this position is interpreted as an argument label, Fix-It replacements: 18 - 21 = '`let`'
+        // TODO: Old parser expected error on line 1: 'inout' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 12 - 17 = '', 26 - 26 = 'inout '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous ') {}' at top level"),
+      ]
+    )
+  }
+
+  func testInvalid1c() {
+    AssertParse(
+      """
+      func test3(f : (inout _ #^DIAG_5^#x : Int) -> Void) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'inout' before a parameter name is not allowed, place it before the parameter type instead
         DiagnosticSpec(locationMarker: "DIAG_5", message: "unexpected text 'x : Int' in function type"),
       ]
     )
   }
 
-  func testInvalid2() {
+  func testInvalid2a() {
     AssertParse(
       """
-      func test1s(__shared #^DIAG_1^#var x : Int#^DIAG_2^#) {}  
-      func test2s(__shared #^DIAG_3^#let x : Int#^DIAG_4^#) {}
+      func test1s(__shared#^DIAG_1^# #^DIAG_2^#var x : Int#^DIAG_3^#) {}
       """,
       diagnostics: [
         // TODO: Old parser expected warning on line 1: 'var' in this position is interpreted as an argument label, Fix-It replacements: 22 - 25 = '`var`'
         // TODO: Old parser expected error on line 1: '__shared' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 21 = '', 30 - 30 = '__shared '
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected type in type"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text ') {}' before function"),
-        // TODO: Old parser expected warning on line 2: 'let' in this position is interpreted as an argument label, Fix-It replacements: 22 - 25 = '`let`'
-        // TODO: Old parser expected error on line 2: '__shared' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 21 = '', 30 - 30 = '__shared '
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected type in type"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous ') {}' at top level"),
       ]
     )
   }
 
-  func testInvalid3() {
+  func testInvalid2b() {
     AssertParse(
       """
-      func test1o(__owned #^DIAG_1^#var x : Int#^DIAG_2^#) {}  
-      func test2o(__owned #^DIAG_3^#let x : Int#^DIAG_4^#) {}
+      func test2s(__shared#^DIAG_1^# #^DIAG_2^#let x : Int#^DIAG_3^#) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected warning on line 1: 'let' in this position is interpreted as an argument label, Fix-It replacements: 22 - 25 = '`let`'
+        // TODO: Old parser expected error on line 1: '__shared' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 21 = '', 30 - 30 = '__shared '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous ') {}' at top level"),
+      ]
+    )
+  }
+
+  func testInvalid3a() {
+    AssertParse(
+      """
+      func test1o(__owned#^DIAG_1^# #^DIAG_2^#var x : Int#^DIAG_3^#) {}
       """,
       diagnostics: [
         // TODO: Old parser expected warning on line 1: 'var' in this position is interpreted as an argument label, Fix-It replacements: 21 - 24 = '`var`'
         // TODO: Old parser expected error on line 1: '__owned' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 20 = ''
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected type in type"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text ') {}' before function"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous ') {}' at top level"),
+      ]
+    )
+  }
+
+  func testInvalid3b() {
+    AssertParse(
+      """
+      func test2o(__owned#^DIAG_1^# #^DIAG_2^#let x : Int#^DIAG_3^#) {}
+      """,
+      diagnostics: [
         // TODO: Old parser expected warning on line 2: 'let' in this position is interpreted as an argument label, Fix-It replacements: 21 - 24 = '`let`'
         // TODO: Old parser expected error on line 2: '__owned' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 20 = ''
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected type in type"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous ') {}' at top level"),
       ]
     )
   }
@@ -124,7 +166,7 @@ final class InvalidTests: XCTestCase {
     AssertParse(
       """
       switch state { #^DIAG_1^#
-        let duration : Int = 0 
+        let duration : Int = 0
         #^DIAG_2^#case 1:
           break
       }
@@ -141,12 +183,12 @@ final class InvalidTests: XCTestCase {
       #"""
       func testNotCoveredCase(x: Int) {
         switch x {#^DIAG_1^#
-          let y = "foo" 
+          let y = "foo"
           switch y {
             case "bar":
               blah blah // ignored
           }
-        #^DIAG_2^#case "baz": 
+        #^DIAG_2^#case "baz":
           break
         case 1:
           break
@@ -183,146 +225,433 @@ final class InvalidTests: XCTestCase {
   func testInvalid11() {
     AssertParse(
       """
-      #^DIAG_1^#}
       // rdar://problem/18507467
-      func d(_ b: #^DIAG_2^#String #^DIAG_3^#-> #^DIAG_4^#<T>() -> T#^DIAG_5^#) {} 
+      func d(_ b: #^DIAG_1^#String #^DIAG_2^#->#^DIAG_3^# #^DIAG_4^#<T>() -> T#^DIAG_5^#) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: expected type for function result
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '(' to start function type"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ')' in function type"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected type in function type"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "extraneous ') {}' at top level"),
+      ]
+    )
+  }
+
+  func testInvalid12() {
+    AssertParse(
+      """
       // <rdar://problem/22143680> QoI: terrible diagnostic when trying to form a generic protocol
-      protocol Animal<Food> {  
-        func feed(_ food: Food) 
+      protocol Animal<Food> {
+        func feed(_ food: Food)
       }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: an associated type named 'Food' must be declared in the protocol 'Animal' or a protocol it inherits
+        // TODO: Old parser expected error on line 3: cannot find type 'Food' in scope
+      ]
+    )
+  }
+
+  func testInvalid13() {
+    AssertParse(
+      """
       // https://github.com/apple/swift/issues/43190
       // Crash with invalid parameter declaration
       do {
         class Starfish {}
         struct Salmon {}
-        func f(s Starfish#^DIAG_6^#,  
+        func f(s Starfish#^DIAG^#,
                   _ ss: Salmon) -> [Int] {}
         func g() { f(Starfish(), Salmon()) }
       }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 6: expected ':' following argument label and parameter name
+        DiagnosticSpec(message: "expected ':' and type in function parameter"),
+      ]
+    )
+  }
+
+  func testInvalid14() {
+    AssertParse(
+      """
       // https://github.com/apple/swift/issues/43313
       do {
         func f(_ a: Int, b: Int) {}
-        f(1, b: 2,#^DIAG_7^#) 
-      }
-      // https://github.com/apple/swift/issues/43591
-      // Two inout crash compiler
-      func f1_43591(a : inout inout Int) {}  
-      func f2_43591(inout inout b#^DIAG_8^#: Int) {} 
-      func f3_43591(let let #^DIAG_9^#a: Int) {} 
-      func f4_43591(inout x#^DIAG_10^#: inout String) {} 
-      func f5_43591(inout i#^DIAG_11^#: inout Int) {} 
-      func #^DIAG_12^#repeat#^DIAG_13^#() {}#^DIAG_14^#
-      let #^DIAG_15^#for #^DIAG_16^#= 2
-      func dog #^DIAG_17^#cow() {} 
-      func cat #^DIAG_18^#Mouse() {} 
-      func friend #^DIAG_19^#ship<T>(x: T) {} 
-      func were#^DIAG_20^#
-      wolf#^DIAG_21^#() {} 
-      func hammer#^DIAG_22^#
-      leavings<T>#^DIAG_23^#(x: T) {} 
-      prefix operator %
-      prefix func %<T>(x: T) -> T { return x } // No error expected - the < is considered an identifier but is peeled off by the parser.
-      struct Weak<T: #^DIAG_24^#class#^DIAG_25^#> { 
-        weak let value: T 
-      }
-      let x: () = ()
-      !() 
-      !(()) 
-      !(x) 
-      !x 
-      // https://github.com/apple/swift/issues/50734
-      func f1_50734(@NSApplicationMain x: Int) {} 
-      func f2_50734(@available(iOS, deprecated: 0) x: Int) {} 
-      func f3_50734(@discardableResult x: Int) {} 
-      func f4_50734(@objcMembers x: String) {} 
-      func f5_50734(@weak x: String) {} 
-      class C_50734<@NSApplicationMain T: AnyObject> {} 
-      func f6_50734<@discardableResult T>(x: T) {} 
-      enum E_50734<@indirect T> {} 
-      protocol P {
-        @available(swift, introduced: 4.2) associatedtype Assoc 
+        f(1, b: 2,#^DIAG^#)
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '}' before function"),
-        // TODO: Old parser expected error on line 3: expected type for function result
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '(' to start function type"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected ')' in function type"),
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected type in function type"),
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "DIAG_5", message: "unexpected text ') {}' before protocol"),
-        // TODO: Old parser expected error on line 13: expected ':' following argument label and parameter name
-        DiagnosticSpec(locationMarker: "DIAG_6", message: "expected ':' and type in function parameter"),
-        // TODO: Old parser expected error on line 20: unexpected ',' separator
-        DiagnosticSpec(locationMarker: "DIAG_7", message: "expected value in function call"),
-        // TODO: Old parser expected error on line 24: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 19 - 25 = ''
-        // TODO: Old parser expected error on line 25: inout' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 15 - 20 = '', 30 - 30 = 'inout '
-        // TODO: Old parser expected error on line 25: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 21 - 27 = ''
-        DiagnosticSpec(locationMarker: "DIAG_8", message: "unexpected text ': Int' in parameter clause"),
-        // TODO: Old parser expected warning on line 26: 'let' in this position is interpreted as an argument label, Fix-It replacements: 15 - 18 = '`let`'
-        // TODO: Old parser expected error on line 26: expected ',' separator, Fix-It replacements: 22 - 22 = ','
-        // TODO: Old parser expected error on line 26: expected ':' following argument label and parameter name
-        // TODO: Old parser expected warning on line 26: extraneous duplicate parameter name; 'let' already has an argument label, Fix-It replacements: 15 - 19 = ''
-        DiagnosticSpec(locationMarker: "DIAG_9", message: "unexpected text 'a' in function parameter"),
-        // TODO: Old parser expected error on line 27: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 15 - 20 = ''
-        DiagnosticSpec(locationMarker: "DIAG_10", message: "unexpected text ': inout String' in parameter clause"),
-        // TODO: Old parser expected error on line 28: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 15 - 20 = ''
-        DiagnosticSpec(locationMarker: "DIAG_11", message: "unexpected text ': inout Int' in parameter clause"),
-        // TODO: Old parser expected error on line 29: keyword 'repeat' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 29: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 6 - 12 = '`repeat`'
-        DiagnosticSpec(locationMarker: "DIAG_12", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "DIAG_12", message: "expected argument list in function declaration"),
-        DiagnosticSpec(locationMarker: "DIAG_13", message: "unexpected text '()' in 'repeat' statement"),
-        DiagnosticSpec(locationMarker: "DIAG_14", message: "expected 'while' and condition in 'repeat' statement"),
-        // TODO: Old parser expected error on line 30: keyword 'for' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 30: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 5 - 8 = '`for`'
-        DiagnosticSpec(locationMarker: "DIAG_15", message: "expected pattern in variable"),
-        DiagnosticSpec(locationMarker: "DIAG_16", message: "expected pattern, 'in' and expression in 'for' statement"),
-        DiagnosticSpec(locationMarker: "DIAG_16", message: "expected '{' in 'for' statement"),
-        DiagnosticSpec(locationMarker: "DIAG_16", message: "unexpected text '= 2' before function"),
-        // TODO: Old parser expected error on line 31: found an unexpected second identifier in function declaration; is there an accidental break?
-        // TODO: Old parser expected note on line 31: join the identifiers together, Fix-It replacements: 6 - 13 = 'dogcow'
-        // TODO: Old parser expected note on line 31: join the identifiers together with camel-case, Fix-It replacements: 6 - 13 = 'dogCow'
-        DiagnosticSpec(locationMarker: "DIAG_17", message: "unexpected text 'cow' before parameter clause"),
-        // TODO: Old parser expected error on line 32: found an unexpected second identifier in function declaration; is there an accidental break?
-        // TODO: Old parser expected note on line 32: join the identifiers together, Fix-It replacements: 6 - 15 = 'catMouse'
-        DiagnosticSpec(locationMarker: "DIAG_18", message: "unexpected text 'Mouse' before parameter clause"),
-        // TODO: Old parser expected error on line 33: found an unexpected second identifier in function declaration; is there an accidental break?
-        // TODO: Old parser expected note on line 33: join the identifiers together, Fix-It replacements: 6 - 17 = 'friendship'
-        // TODO: Old parser expected note on line 33: join the identifiers together with camel-case, Fix-It replacements: 6 - 17 = 'friendShip'
-        DiagnosticSpec(locationMarker: "DIAG_19", message: "unexpected text 'ship<T>' before parameter clause"),
-        DiagnosticSpec(locationMarker: "DIAG_20", message: "expected '(' to start parameter clause"),
-        // TODO: Old parser expected error on line 35: found an unexpected second identifier in function declaration; is there an accidental break?
-        // TODO: Old parser expected note on line 35: join the identifiers together, Fix-It replacements: 6 - 5 = 'werewolf'
-        // TODO: Old parser expected note on line 35: join the identifiers together with camel-case, Fix-It replacements: 6 - 5 = 'wereWolf'
-        DiagnosticSpec(locationMarker: "DIAG_21", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "DIAG_22", message: "expected '(' to start parameter clause"),
-        // TODO: Old parser expected error on line 37: found an unexpected second identifier in function declaration; is there an accidental break?
-        // TODO: Old parser expected note on line 37: join the identifiers together, Fix-It replacements: 6 - 9 = 'hammerleavings'
-        // TODO: Old parser expected note on line 37: join the identifiers together with camel-case, Fix-It replacements: 6 - 9 = 'hammerLeavings'
-        DiagnosticSpec(locationMarker: "DIAG_23", message: "expected ')' to end parameter clause"),
-        // TODO: Old parser expected error on line 40: 'class' constraint can only appear on protocol declarations
-        // TODO: Old parser expected note on line 40: did you mean to write an 'AnyObject' constraint?, Fix-It replacements: 16 - 21 = 'AnyObject'
-        DiagnosticSpec(locationMarker: "DIAG_24", message: "expected '>' to end generic parameter clause"),
-        DiagnosticSpec(locationMarker: "DIAG_24", message: "expected '{' in struct"),
-        DiagnosticSpec(locationMarker: "DIAG_25", message: "expected identifier in class"),
-        DiagnosticSpec(locationMarker: "DIAG_25", message: "expected member block in class"),
-        DiagnosticSpec(locationMarker: "DIAG_25", message: "expected declaration in struct"),
-        DiagnosticSpec(locationMarker: "DIAG_25", message: "expected '}' to end struct"),
-        DiagnosticSpec(locationMarker: "DIAG_25", message: "expected '}' to end 'for' statement"),
-        DiagnosticSpec(locationMarker: "DIAG_25", message: "extraneous code at top level"),
-        // TODO: Old parser expected error on line 41: 'weak' must be a mutable variable, because it may change at runtime
-        // TODO: Old parser expected error on line 49: @NSApplicationMain may only be used on 'class' declarations
-        // TODO: Old parser expected error on line 50: '@available' attribute cannot be applied to this declaration
-        // TODO: Old parser expected error on line 51: '@discardableResult' attribute cannot be applied to this declaration
-        // TODO: Old parser expected error on line 52: @objcMembers may only be used on 'class' declarations
-        // TODO: Old parser expected error on line 53: 'weak' is a declaration modifier, not an attribute
-        // TODO: Old parser expected error on line 53: 'weak' may only be used on 'var' declarations
-        // TODO: Old parser expected error on line 54: @NSApplicationMain may only be used on 'class' declarations
-        // TODO: Old parser expected error on line 55: '@discardableResult' attribute cannot be applied to this declaration
-        // TODO: Old parser expected error on line 56: 'indirect' is a declaration modifier, not an attribute
-        // TODO: Old parser expected error on line 56: 'indirect' modifier cannot be applied to this declaration
-        // TODO: Old parser expected error on line 58: '@available' attribute cannot be applied to this declaration
+        // TODO: Old parser expected error on line 4: unexpected ',' separator
+        DiagnosticSpec(message: "expected value in function call"),
+      ]
+    )
+  }
+
+  func testInvalid15() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/43591
+      // Two inout crash compiler
+      """
+    )
+  }
+
+  func testInvalid16() {
+    AssertParse(
+      """
+      func f1_43591(a : inout inout Int) {}
+      func f2_43591(inout inout b#^DIAG_1^#: Int) {}
+      func f3_43591(let let #^DIAG_2^#a: Int) {}
+      func f4_43591(inout x#^DIAG_3^#: inout String) {}
+      func f5_43591(inout i#^DIAG_4^#: inout Int) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 19 - 25 = ''
+        // TODO: Old parser expected error on line 2: inout' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 15 - 20 = '', 30 - 30 = 'inout '
+        // TODO: Old parser expected error on line 2: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 21 - 27 = ''
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text ': Int' in parameter clause"),
+        // TODO: Old parser expected warning on line 3: 'let' in this position is interpreted as an argument label, Fix-It replacements: 15 - 18 = '`let`'
+        // TODO: Old parser expected error on line 3: expected ',' separator, Fix-It replacements: 22 - 22 = ','
+        // TODO: Old parser expected error on line 3: expected ':' following argument label and parameter name
+        // TODO: Old parser expected warning on line 3: extraneous duplicate parameter name; 'let' already has an argument label, Fix-It replacements: 15 - 19 = ''
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text 'a' in function parameter"),
+        // TODO: Old parser expected error on line 4: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 15 - 20 = ''
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text ': inout String' in parameter clause"),
+        // TODO: Old parser expected error on line 5: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 15 - 20 = ''
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "unexpected text ': inout Int' in parameter clause"),
+      ]
+    )
+  }
+
+  func testInvalid17() {
+    AssertParse(
+      """
+      func#^DIAG_1^# #^DIAG_2^#repeat#^DIAG_3^#() {}#^DIAG_4^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: keyword 'repeat' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 6 - 12 = '`repeat`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected argument list in function declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text '()' in 'repeat' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected 'while' and condition in 'repeat' statement"),
+      ]
+    )
+  }
+
+  func testInvalid18() {
+    AssertParse(
+      """
+      let#^DIAG_1^# #^DIAG_2^#for #^DIAG_3^#= 2
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: keyword 'for' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 5 - 8 = '`for`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected pattern in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected pattern, 'in' and expression in 'for' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected code block in 'for' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous '= 2' at top level"),
+      ]
+    )
+  }
+
+  func testInvalid19() {
+    AssertParse(
+      """
+      func f4_43591(inout x#^DIAG^#: inout String) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 15 - 20 = ''
+        DiagnosticSpec(message: "unexpected text ': inout String' in parameter clause"),
+      ]
+    )
+  }
+
+  func testInvalid20() {
+    AssertParse(
+      """
+      func f5_43591(inout i#^DIAG^#: inout Int) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: parameter must not have multiple '__owned', 'inout', or '__shared' specifiers, Fix-It replacements: 15 - 20 = ''
+        DiagnosticSpec(message: "unexpected text ': inout Int' in parameter clause"),
+      ]
+    )
+  }
+
+  func testInvalid21() {
+    AssertParse(
+      """
+      func#^DIAG_1^# #^DIAG_2^#repeat#^DIAG_3^#() {}#^DIAG_4^#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: keyword 'repeat' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 6 - 12 = '`repeat`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected argument list in function declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text '()' in 'repeat' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected 'while' and condition in 'repeat' statement"),
+      ]
+    )
+  }
+
+  func testInvalid22() {
+    AssertParse(
+      """
+      let#^DIAG_1^# #^DIAG_2^#for #^DIAG_3^#= 2
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: keyword 'for' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 5 - 8 = '`for`'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected pattern in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected pattern, 'in' and expression in 'for' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected code block in 'for' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous '= 2' at top level"),
+      ]
+    )
+  }
+
+  func testInvalid23() {
+    AssertParse(
+      """
+      func dog #^DIAG^#cow() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: found an unexpected second identifier in function declaration; is there an accidental break?
+        // TODO: Old parser expected note on line 1: join the identifiers together, Fix-It replacements: 6 - 13 = 'dogcow'
+        // TODO: Old parser expected note on line 1: join the identifiers together with camel-case, Fix-It replacements: 6 - 13 = 'dogCow'
+        DiagnosticSpec(message: "unexpected text 'cow' before parameter clause"),
+      ]
+    )
+  }
+
+  func testInvalid24() {
+    AssertParse(
+      """
+      func cat #^DIAG^#Mouse() {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: found an unexpected second identifier in function declaration; is there an accidental break?
+        // TODO: Old parser expected note on line 1: join the identifiers together, Fix-It replacements: 6 - 15 = 'catMouse'
+        DiagnosticSpec(message: "unexpected text 'Mouse' before parameter clause"),
+      ]
+    )
+  }
+
+  func testInvalid25() {
+    AssertParse(
+      """
+      func friend #^DIAG^#ship<T>(x: T) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: found an unexpected second identifier in function declaration; is there an accidental break?
+        // TODO: Old parser expected note on line 1: join the identifiers together, Fix-It replacements: 6 - 17 = 'friendship'
+        // TODO: Old parser expected note on line 1: join the identifiers together with camel-case, Fix-It replacements: 6 - 17 = 'friendShip'
+        DiagnosticSpec(message: "unexpected text 'ship<T>' before parameter clause"),
+      ]
+    )
+  }
+
+  func testInvalid26() {
+    AssertParse(
+      """
+      func were#^DIAG_1^#
+      wolf#^DIAG_2^#() {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '(' to start parameter clause"),
+        // TODO: Old parser expected error on line 2: found an unexpected second identifier in function declaration; is there an accidental break?
+        // TODO: Old parser expected note on line 2: join the identifiers together, Fix-It replacements: 6 - 5 = 'werewolf'
+        // TODO: Old parser expected note on line 2: join the identifiers together with camel-case, Fix-It replacements: 6 - 5 = 'wereWolf'
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "consecutive statements on a line must be separated by ';'"),
+      ]
+    )
+  }
+
+  func testInvalid27() {
+    AssertParse(
+      """
+      func hammer#^DIAG_1^#
+      leavings<T>#^DIAG_2^#(x: T) {}
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '(' to start parameter clause"),
+        // TODO: Old parser expected error on line 2: found an unexpected second identifier in function declaration; is there an accidental break?
+        // TODO: Old parser expected note on line 2: join the identifiers together, Fix-It replacements: 6 - 9 = 'hammerleavings'
+        // TODO: Old parser expected note on line 2: join the identifiers together with camel-case, Fix-It replacements: 6 - 9 = 'hammerLeavings'
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "consecutive statements on a line must be separated by ';'"),
+      ]
+    )
+  }
+
+  func testInvalid28() {
+    AssertParse(
+      """
+      prefix operator %
+      prefix func %<T>(x: T) -> T { return x } // No error expected - the < is considered an identifier but is peeled off by the parser.
+      """
+    )
+  }
+
+  func testInvalid29() {
+    AssertParse(
+      """
+      struct Weak<T: #^DIAG_1^#class#^DIAG_2^#> {
+        weak let value: T
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'class' constraint can only appear on protocol declarations
+        // TODO: Old parser expected note on line 1: did you mean to write an 'AnyObject' constraint?, Fix-It replacements: 16 - 21 = 'AnyObject'
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '>' to end generic parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '{' in struct"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in class"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in class"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected declaration in struct"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '}' to end struct"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "extraneous code at top level"),
+        // TODO: Old parser expected error on line 2: 'weak' must be a mutable variable, because it may change at runtime
+        // TODO: Old parser expected error on line 2: 'weak' variable should have optional type 'T?'
+        // TODO: Old parser expected error on line 2: 'weak' must not be applied to non-class-bound 'T'; consider adding a protocol conformance that has a class bound
+      ]
+    )
+  }
+
+  func testInvalid30() {
+    AssertParse(
+      """
+      let x: () = ()
+      !()
+      !(())
+      !(x)
+      !x
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: cannot convert value of type '()' to expected argument type 'Bool'
+        // TODO: Old parser expected error on line 3: cannot convert value of type '()' to expected argument type 'Bool'
+        // TODO: Old parser expected error on line 4: cannot convert value of type '()' to expected argument type 'Bool'
+        // TODO: Old parser expected error on line 5: cannot convert value of type '()' to expected argument type 'Bool'
+      ]
+    )
+  }
+
+  func testInvalid31() {
+    AssertParse(
+      """
+      // https://github.com/apple/swift/issues/50734
+      """
+    )
+  }
+
+  func testInvalid32() {
+    AssertParse(
+      """
+      func f1_50734(@NSApplicationMain x: Int) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: @NSApplicationMain may only be used on 'class' declarations
+      ]
+    )
+  }
+
+  func testInvalid33() {
+    AssertParse(
+      """
+      func f2_50734(@available(iOS, deprecated: 0) x: Int) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '@available' attribute cannot be applied to this declaration
+      ]
+    )
+  }
+
+  func testInvalid34() {
+    AssertParse(
+      """
+      func f3_50734(@discardableResult x: Int) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '@discardableResult' attribute cannot be applied to this declaration
+      ]
+    )
+  }
+
+  func testInvalid35() {
+    AssertParse(
+      """
+      func f4_50734(@objcMembers x: String) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: @objcMembers may only be used on 'class' declarations
+      ]
+    )
+  }
+
+  func testInvalid36() {
+    AssertParse(
+      """
+      func f5_50734(@weak x: String) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'weak' is a declaration modifier, not an attribute
+        // TODO: Old parser expected error on line 1: 'weak' may only be used on 'var' declarations
+      ]
+    )
+  }
+
+  func testInvalid37() {
+    AssertParse(
+      """
+      class C_50734<@NSApplicationMain T: AnyObject> {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: @NSApplicationMain may only be used on 'class' declarations
+      ]
+    )
+  }
+
+  func testInvalid38() {
+    AssertParse(
+      """
+      func f6_50734<@discardableResult T>(x: T) {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '@discardableResult' attribute cannot be applied to this declaration
+      ]
+    )
+  }
+
+  func testInvalid39() {
+    AssertParse(
+      """
+      enum E_50734<@indirect T> {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'indirect' is a declaration modifier, not an attribute
+        // TODO: Old parser expected error on line 1: 'indirect' modifier cannot be applied to this declaration
+      ]
+    )
+  }
+
+  func testInvalid40() {
+    AssertParse(
+      """
+      protocol P {
+        @available(swift, introduced: 4.2) associatedtype Assoc
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 2: '@available' attribute cannot be applied to this declaration
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/NumberIdentifierErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/NumberIdentifierErrorsTests.swift
@@ -34,39 +34,60 @@ final class NumberIdentifierErrorsTests: XCTestCase {
     )
   }
 
-  func testNumberIdentifierErrors3() {
+  func testNumberIdentifierErrors3a() {
     AssertParse(
       """
-      protocol #^DIAG_1^#4 {
-        associatedtype #^DIAG_2^#5
+      protocol#^DIAG_1^# #^DIAG_2^#4 {
+        associatedtype #^DIAG_3^#5
       }
-      protocol #^DIAG_3^#6.0 {
-        associatedtype #^DIAG_4^#7.0
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: protocol name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in protocol"),
+        // TODO: Old parser expected error on line 2: associatedtype name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected identifier in associatedtype declaration"),
+      ]
+    )
+  }
+
+  func testNumberIdentifierErrors3b() {
+    AssertParse(
+      """
+      protocol#^DIAG_1^# #^DIAG_2^#6.0 {
+        associatedtype #^DIAG_3^#7.0
       }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: protocol name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in protocol"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in protocol"),
+        // TODO: Old parser expected error on line 2: associatedtype name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected identifier in associatedtype declaration"),
+      ]
+    )
+  }
+
+  func testNumberIdentifierErrors3c() {
+    AssertParse(
+      """
       protocol #^DIAG_5^#8protocol {
         associatedtype #^DIAG_6^#9associatedtype
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: protocol name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in protocol"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected member block in protocol"),
-        // TODO: Old parser expected error on line 2: associatedtype name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in associatedtype declaration"),
-        // TODO: Old parser expected error on line 4: protocol name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected identifier in protocol"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected member block in protocol"),
-        // TODO: Old parser expected error on line 5: associatedtype name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected identifier in associatedtype declaration"),
-        // TODO: Old parser expected error on line 7: protocol name can only start with a letter or underscore, not a number
-        // TODO: Old parser expected error on line 7: 'p' is not a valid digit in integer literal
+        // TODO: Old parser expected error on line 1: 'p' is not a valid digit in integer literal
         DiagnosticSpec(locationMarker: "DIAG_5", message: "identifier can only start with a letter or underscore, not a number"),
-        // TODO: Old parser expected error on line 8: associatedtype name can only start with a letter or underscore, not a number
-        // TODO: Old parser expected error on line 8: 'a' is not a valid digit in integer literal
+        // TODO: Old parser expected error on line 2: associatedtype name can only start with a letter or underscore, not a number
+        // TODO: Old parser expected error on line 2: 'a' is not a valid digit in integer literal
         DiagnosticSpec(locationMarker: "DIAG_6", message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
+
 
   func testNumberIdentifierErrors4() {
     AssertParse(
@@ -89,74 +110,126 @@ final class NumberIdentifierErrorsTests: XCTestCase {
     )
   }
 
-  func testNumberIdentifierErrors5() {
+  func testNumberIdentifierErrors5a() {
     AssertParse(
       """
-      struct #^DIAG_1^#13 {}
-      struct #^DIAG_2^#14.0 {}
-      struct #^DIAG_3^#15struct {}
+      struct#^DIAG_1^# #^DIAG_2^#13 {}
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: struct name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in struct"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected member block in struct"),
-        // TODO: Old parser expected error on line 2: struct name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in struct"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in struct"),
-        // TODO: Old parser expected error on line 3: struct name can only start with a letter or underscore, not a number
-        // TODO: Old parser expected error on line 3: 's' is not a valid digit in integer literal
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
 
-  func testNumberIdentifierErrors6() {
+  func testNumberIdentifierErrors5b() {
     AssertParse(
       """
-      enum #^DIAG_1^#16 {}
-      enum #^DIAG_2^#17.0 {}
-      enum #^DIAG_3^#18enum {}
+      struct#^DIAG_1^# #^DIAG_2^#14.0 {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: struct name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in struct"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in struct"),
+      ]
+    )
+  }
+
+  func testNumberIdentifierErrors5c() {
+    AssertParse(
+      """
+      struct #^DIAG^#15struct {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: struct name can only start with a letter or underscore, not a number
+        // TODO: Old parser expected error on line 1: 's' is not a valid digit in integer literal
+        DiagnosticSpec(message: "identifier can only start with a letter or underscore, not a number"),
+      ]
+    )
+  }
+
+  func testNumberIdentifierErrors6a() {
+    AssertParse(
+      """
+      enum#^DIAG_1^# #^DIAG_2^#16 {}
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: enum name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in enum"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected member block in enum"),
-        // TODO: Old parser expected error on line 2: enum name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in enum"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in enum"),
-        // TODO: Old parser expected error on line 3: enum name can only start with a letter or underscore, not a number
-        // TODO: Old parser expected error on line 3: 'n' is not a valid digit in floating point exponent
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "identifier can only start with a letter or underscore, not a number"),
       ]
     )
   }
 
-  func testNumberIdentifierErrors7() {
+  func testNumberIdentifierErrors6b() {
     AssertParse(
       """
-      class #^DIAG_1^#19 {
-        func #^DIAG_2^#20() {}
-      }
-      class #^DIAG_3^#21.0 {
-        func #^DIAG_4^#22.0() {}
+      enum#^DIAG_1^# #^DIAG_2^#17.0 {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: enum name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in enum"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in enum"),
+      ]
+    )
+  }
+
+  func testNumberIdentifierErrors6c() {
+    AssertParse(
+      """
+      enum #^DIAG^#18enum {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: enum name can only start with a letter or underscore, not a number
+        // TODO: Old parser expected error on line 1: 'n' is not a valid digit in floating point exponent
+        DiagnosticSpec(message: "identifier can only start with a letter or underscore, not a number"),
+      ]
+    )
+  }
+
+  func testNumberIdentifierErrors7a() {
+    AssertParse(
+      """
+      class#^DIAG_1^# #^DIAG_2^#19 {
+        func #^DIAG_3^#20() {}
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: class name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in class"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected member block in class"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in class"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in class"),
         // TODO: Old parser expected error on line 2: function name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '20' before parameter clause"),
-        // TODO: Old parser expected error on line 4: class name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected identifier in class"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected member block in class"),
-        // TODO: Old parser expected error on line 5: function name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "unexpected text '22.0' before parameter clause"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text '20' before parameter clause"),
       ]
     )
   }
+
+  func testNumberIdentifierErrors7b() {
+    AssertParse(
+      """
+      class#^DIAG_1^# #^DIAG_2^#21.0 {
+        func #^DIAG_3^#22.0() {}
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: class name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in class"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected member block in class"),
+        // TODO: Old parser expected error on line 2: function name can only start with a letter or underscore, not a number
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text '22.0' before parameter clause"),
+      ]
+    )
+  }
+
 
   func testNumberIdentifierErrors8() {
     AssertParse(

--- a/Tests/SwiftParserTest/translated/ObjectLiteralsTests.swift
+++ b/Tests/SwiftParserTest/translated/ObjectLiteralsTests.swift
@@ -21,44 +21,82 @@ final class ObjectLiteralsTests: XCTestCase {
     )
   }
 
-  func testObjectLiterals2() {
+  func testObjectLiterals2a() {
     AssertParse(
       """
-      let _ = #^DIAG_1^##Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha) 
-      let _ = #^DIAG_2^##Image(imageLiteral: localResourceNameAsString) 
-      let _ = #^DIAG_3^##FileReference(fileReferenceLiteral: localResourceNameAsString)
+      let _ = #^DIAG^##Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha)
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: '#Color(...)' has been renamed to '#colorLiteral(...), Fix-It replacements: 10 - 15 = 'colorLiteral', 16 - 31 = 'red'
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in variable"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '#Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha)' before variable"),
-        // TODO: Old parser expected error on line 2: '#Image(...)' has been renamed to '#imageLiteral(...)', Fix-It replacements: 10 - 15 = 'imageLiteral', 16 - 28 = 'resourceName'
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in variable"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '#Image(imageLiteral: localResourceNameAsString)' before variable"),
-        // TODO: Old parser expected error on line 3: '#FileReference(...)' has been renamed to '#fileLiteral(...)', Fix-It replacements: 10 - 23 = 'fileLiteral', 24 - 44 = 'resourceName'
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in variable"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous '#FileReference(fileReferenceLiteral: localResourceNameAsString)' at top level"),
+        DiagnosticSpec(message: "expected expression in variable"),
+        DiagnosticSpec(message: "extraneous '#Color(colorLiteralRed: red, green: green, blue: blue, alpha: alpha)' at top level"),
       ]
     )
   }
 
-  func testObjectLiterals3() {
+  func testObjectLiterals2b() {
     AssertParse(
       """
-      let _ = #^DIAG_1^##notAPound 
-      let _ = #^DIAG_2^##notAPound(1, 2) 
-      let _ = #^DIAG_3^##Color //  {{none}}
+      let _ = #^DIAG^##Image(imageLiteral: localResourceNameAsString)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '#Image(...)' has been renamed to '#imageLiteral(...)', Fix-It replacements: 10 - 15 = 'imageLiteral', 16 - 28 = 'resourceName'
+        DiagnosticSpec(message: "expected expression in variable"),
+        DiagnosticSpec(message: "extraneous '#Image(imageLiteral: localResourceNameAsString)' at top level"),
+      ]
+    )
+  }
+
+
+  func testObjectLiterals2c() {
+    AssertParse(
+      """
+      let _ = #^DIAG^##FileReference(fileReferenceLiteral: localResourceNameAsString)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '#FileReference(...)' has been renamed to '#fileLiteral(...)', Fix-It replacements: 10 - 23 = 'fileLiteral', 24 - 44 = 'resourceName'
+        DiagnosticSpec(message: "expected expression in variable"),
+        DiagnosticSpec(message: "extraneous '#FileReference(fileReferenceLiteral: localResourceNameAsString)' at top level"),
+      ]
+    )
+  }
+
+
+  func testObjectLiterals3a() {
+    AssertParse(
+      """
+      let _ = #^DIAG^##notAPound
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: use of unknown directive '#notAPound'
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in variable"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '#notAPound' before variable"),
-        // TODO: Old parser expected error on line 2: use of unknown directive '#notAPound'
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in variable"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '#notAPound(1, 2)' before variable"),
-        // TODO: Old parser expected error on line 3: expected argument list in object literal
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in variable"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous '#Color' at top level"),
+        DiagnosticSpec(message: "expected expression in variable"),
+        DiagnosticSpec(message: "extraneous '#notAPound' at top level"),
+      ]
+    )
+  }
+
+  func testObjectLiterals3b() {
+    AssertParse(
+      """
+      let _ = #^DIAG^##notAPound(1, 2)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: use of unknown directive '#notAPound'
+        DiagnosticSpec(message: "expected expression in variable"),
+        DiagnosticSpec(message: "extraneous '#notAPound(1, 2)' at top level"),
+      ]
+    )
+  }
+
+  func testObjectLiterals3c() {
+    AssertParse(
+      """
+      let _ = #^DIAG^##Color //  {{none}}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected argument list in object literal
+        DiagnosticSpec(message: "expected expression in variable"),
+        DiagnosticSpec(message: "extraneous '#Color' at top level"),
       ]
     )
   }
@@ -66,28 +104,63 @@ final class ObjectLiteralsTests: XCTestCase {
   func testObjectLiterals4() {
     AssertParse(
       """
-      let _ = [#^DIAG_1^###] //  {{none}}
-      let _ = [#^DIAG_2^##Color(_: 1, green: 1, 2) 
-      let _ = [#^DIAG_3^##Color(red: 1, green: 1, blue: 1)# 
-      let _ = [#^DIAG_4^##Color(withRed: 1, green: 1, whatever: 2)#] 
-      let _ = #^DIAG_5^##Color(_: 1, green: 1)
+      let _ = [#^DIAG^###] //  {{none}}
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: expected expression in container literal
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text '##' in array"),
-        // TODO: Old parser expected error on line 2: '[#Color(...)#]' has been renamed to '#colorLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 16 = 'colorLiteral', 17 - 18 = 'red'
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ']' to end array"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text '#Color(_: 1, green: 1, 2)' before variable"),
-        // TODO: Old parser expected error on line 3: '[#Color(...)#]' has been renamed to '#colorLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 16 = 'colorLiteral', 17 - 20 = 'red', 43 - 44 = ''
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected ']' to end array"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text '#Color(red: 1, green: 1, blue: 1)#' before variable"),
-        // TODO: Old parser expected error on line 4: '[#Color(...)#]' has been renamed to '#colorLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 16 = 'colorLiteral', 17 - 24 = 'red', 51 - 53 = ''
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "unexpected text '#Color(withRed: 1, green: 1, whatever: 2)#' in array"),
-        // TODO: Old parser expected error on line 5: '#Color(...)' has been renamed to '#colorLiteral(...)', Fix-It replacements: 10 - 15 = 'colorLiteral', 16 - 17 = 'red'
-        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected expression in variable"),
-        DiagnosticSpec(locationMarker: "DIAG_5", message: "extraneous '#Color(_: 1, green: 1)' at top level"),
+        DiagnosticSpec(message: "unexpected text '##' in array"),
       ]
     )
   }
 
+  func testObjectLiterals5() {
+    AssertParse(
+      """
+      let _ = [#^DIAG^##Color(_: 1, green: 1, 2)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '[#Color(...)#]' has been renamed to '#colorLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 16 = 'colorLiteral', 17 - 18 = 'red'
+        DiagnosticSpec(message: "expected ']' to end array"),
+        DiagnosticSpec(message: "extraneous '#Color(_: 1, green: 1, 2)' at top level"),
+      ]
+    )
+  }
+
+  func testObjectLiterals6() {
+    AssertParse(
+      """
+      let _ = [#^DIAG^##Color(red: 1, green: 1, blue: 1)#
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '[#Color(...)#]' has been renamed to '#colorLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 16 = 'colorLiteral', 17 - 20 = 'red', 43 - 44 = ''
+        DiagnosticSpec(message: "expected ']' to end array"),
+        DiagnosticSpec(message: "extraneous '#Color(red: 1, green: 1, blue: 1)#' at top level"),
+      ]
+    )
+  }
+
+  func testObjectLiterals7() {
+    AssertParse(
+      """
+      let _ = [#^DIAG^##Color(withRed: 1, green: 1, whatever: 2)#]
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '[#Color(...)#]' has been renamed to '#colorLiteral(...)', Fix-It replacements: 9 - 10 = '', 11 - 16 = 'colorLiteral', 17 - 24 = 'red', 51 - 53 = ''
+        DiagnosticSpec(message: "unexpected text '#Color(withRed: 1, green: 1, whatever: 2)#' in array"),
+      ]
+    )
+  }
+
+  func testObjectLiterals8() {
+    AssertParse(
+      """
+      let _ = #^DIAG^##Color(_: 1, green: 1)
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '#Color(...)' has been renamed to '#colorLiteral(...)', Fix-It replacements: 10 - 15 = 'colorLiteral', 16 - 17 = 'red'
+        DiagnosticSpec(message: "expected expression in variable"),
+        DiagnosticSpec(message: "extraneous '#Color(_: 1, green: 1)' at top level"),
+      ]
+    )
+  }
 }

--- a/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorDeclTests.swift
@@ -3,35 +3,78 @@
 import XCTest
 
 final class OperatorDeclTests: XCTestCase {
-  func testOperatorDecl1() {
+  func testOperatorDecl1a() {
     AssertParse(
       """
-      prefix operator +++ {} 
-      postfix operator +++ {} 
-      infix operator +++ {} 
-      infix operator +++* { //  {{none}}
-        associativity right
-      }
-      infix operator +++*+ : A { }
+      prefix operator +++#^DIAG^# {}
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: operator should no longer be declared with body, Fix-It replacements: 20 - 23 = ''
-        // TODO: Old parser expected error on line 2: operator should no longer be declared with body, Fix-It replacements: 21 - 24 = ''
-        // TODO: Old parser expected error on line 3: operator should no longer be declared with body, Fix-It replacements: 19 - 22 = ''
-        // TODO: Old parser expected error on line 4: operator should no longer be declared with body; use a precedence group instead
-        // TODO: Old parser expected error on line 7: operator should no longer be declared with body, Fix-It replacements: 25 - 29 = ''
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
       ]
     )
   }
 
+  func testOperatorDecl1b() {
+    AssertParse(
+      """
+      postfix operator +++#^DIAG^# {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: operator should no longer be declared with body, Fix-It replacements: 21 - 24 = ''
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
+      ]
+    )
+  }
+
+  func testOperatorDecl1c() {
+    AssertParse(
+      """
+      infix operator +++#^DIAG^# {}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: operator should no longer be declared with body, Fix-It replacements: 19 - 22 = ''
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
+      ]
+    )
+  }
+
+  func testOperatorDecl1d() {
+    AssertParse(
+      """
+      infix operator +++*#^DIAG^# { //  {{none}}
+        associativity right
+      }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: operator should no longer be declared with body; use a precedence group instead
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
+      ]
+    )
+  }
+
+  func testOperatorDecl1e() {
+    AssertParse(
+      """
+      infix operator +++*+ : A#^DIAG^# { }
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: operator should no longer be declared with body, Fix-It replacements: 25 - 29 = ''
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
+      ]
+    )
+  }
+
+
   func testOperatorDecl2() {
     AssertParse(
       """
-      prefix operator +++** : A { }
+      prefix operator +++** : A#^DIAG^# { }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: only infix operators may declare a precedence, Fix-It replacements: 23 - 27 = ''
         // TODO: Old parser expected error on line 1: operator should no longer be declared with body, Fix-It replacements: 26 - 30 = ''
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
       ]
     )
   }
@@ -50,11 +93,12 @@ final class OperatorDeclTests: XCTestCase {
   func testOperatorDecl4() {
     AssertParse(
       """
-      postfix operator ++*+* : A { }
+      postfix operator ++*+* : A#^DIAG^# { }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: only infix operators may declare a precedence, Fix-It replacements: 24 - 28 = ''
         // TODO: Old parser expected error on line 1: operator should no longer be declared with body, Fix-It replacements: 27 - 31 = ''
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
       ]
     )
   }
@@ -84,11 +128,12 @@ final class OperatorDeclTests: XCTestCase {
   func testOperatorDecl7() {
     AssertParse(
       """
-      operator +*+++ { }
+      operator +*+++#^DIAG^# { }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: operator must be declared as 'prefix', 'postfix', or 'infix'
         // TODO: Old parser expected error on line 1: operator should no longer be declared with body, Fix-It replacements: 15 - 19 = ''
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
       ]
     )
   }
@@ -96,11 +141,12 @@ final class OperatorDeclTests: XCTestCase {
   func testOperatorDecl8() {
     AssertParse(
       """
-      operator +*++* : A { }
+      operator +*++* : A#^DIAG^# { }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: operator must be declared as 'prefix', 'postfix', or 'infix'
         // TODO: Old parser expected error on line 1: operator should no longer be declared with body, Fix-It replacements: 19 - 23 = ''
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
       ]
     )
   }
@@ -128,49 +174,142 @@ final class OperatorDeclTests: XCTestCase {
     )
   }
 
-  func testOperatorDecl11() {
+  func testOperatorDecl11a() {
     AssertParse(
       """
       prefix operator ??
-      postfix operator ?? 
-      prefix operator !!
-      postfix operator !! 
-      postfix operator ?$$
+      """
+    )
+  }
+
+  func testOperatorDecl11b() {
+    AssertParse(
+      """
+      postfix operator ??
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: postfix operator names starting with '?' or '!' are disallowed to avoid collisions with built-in unwrapping operators
-        // TODO: Old parser expected error on line 4: postfix operator names starting with '?' or '!' are disallowed to avoid collisions with built-in unwrapping operators
-        // TODO: Old parser expected error on line 5: postfix operator names starting with '?' or '!' are disallowed
-        // TODO: Old parser expected error on line 5: '$$' is considered an identifier
+        // TODO: Old parser expected error on line 1: postfix operator names starting with '?' or '!' are disallowed to avoid collisions with built-in unwrapping operators
       ]
     )
   }
 
-  func testOperatorDecl12() {
+  func testOperatorDecl11c() {
     AssertParse(
       """
-      infix operator --aa 
-      infix operator aa#^DIAG_1^#--: A 
-      infix operator <<$$@#^DIAG_2^#< 
-      infix operator !!@aa 
-      infix operator ##^DIAG_3^#++= 
-      infix operator ++=#^DIAG_4^## 
-      infix operator ->#^DIAG_5^##
+      prefix operator !!
+      """
+    )
+  }
+
+  func testOperatorDecl11d() {
+    AssertParse(
+      """
+      postfix operator !!
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: postfix operator names starting with '?' or '!' are disallowed to avoid collisions with built-in unwrapping operators
+      ]
+    )
+  }
+
+  func testOperatorDecl11e() {
+    AssertParse(
+      """
+      postfix operator ?#^DIAG^#$$
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: postfix operator names starting with '?' or '!' are disallowed
+        // TODO: Old parser expected error on line 1: '$$' is considered an identifier
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'"),
+      ]
+    )
+  }
+
+  func testOperatorDecl12a() {
+    AssertParse(
+      """
+      infix operator --#^DIAG^#aa
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: 'aa' is considered an identifier and must not appear within an operator name
-        // TODO: Old parser expected error on line 2: 'aa' is considered an identifier and must not appear within an operator name
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text before operator"),
-        // TODO: Old parser expected error on line 3: '$$' is considered an identifier and must not appear within an operator name
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected name in attribute"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text in operator"),
-        // TODO: Old parser expected error on line 4: '@' is not allowed in operator names
-        // TODO: Old parser expected error on line 5: '#' is not allowed in operator names
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text before operator"),
-        // TODO: Old parser expected error on line 6: '#' is not allowed in operator names
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "unexpected text before operator"),
-        // TODO: Old parser expected error on line 7: '#' is not allowed in operator names
-        DiagnosticSpec(locationMarker: "DIAG_5", message: "extraneous '#' at top level"),
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
+      ]
+    )
+  }
+
+  func testOperatorDecl12b() {
+    AssertParse(
+      """
+      infix operator aa#^DIAG^#--: A
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'aa' is considered an identifier and must not appear within an operator name
+        DiagnosticSpec(message: "extraneous '--: A' at top level"),
+      ]
+    )
+  }
+
+  func testOperatorDecl12c() {
+    AssertParse(
+      """
+      infix operator <<#^DIAG_1^#$$#^DIAG_2^#@#^DIAG_3^#<
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "consecutive statements on a line must be separated by ';'"),
+        // TODO: Old parser expected error on line 1: '$$' is considered an identifier and must not appear within an operator name
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected name in attribute"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected declaration after attribute"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous '<' at top level"),
+      ]
+    )
+  }
+
+  func testOperatorDecl12d() {
+    AssertParse(
+      """
+      infix operator !!#^DIAG_1^#@aa#^DIAG_2^#
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        // TODO: Old parser expected error on line 1: '@' is not allowed in operator names
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected declaration after attribute"),
+      ]
+    )
+  }
+
+  func testOperatorDecl12e() {
+    AssertParse(
+      """
+      infix operator ##^DIAG^#++=
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '#' is not allowed in operator names
+        DiagnosticSpec(message: "extraneous '++=' at top level"),
+      ]
+    )
+  }
+
+  func testOperatorDecl12f() {
+    AssertParse(
+      """
+      infix operator ++=#^DIAG^##
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '#' is not allowed in operator names
+        DiagnosticSpec(message: "extraneous '#' at top level"),
+      ]
+    )
+  }
+
+  func testOperatorDecl12g() {
+    AssertParse(
+      """
+      infix operator ->#^DIAG^##
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: '#' is not allowed in operator names
+        DiagnosticSpec(message: "extraneous '#' at top level"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/OperatorsTests.swift
+++ b/Tests/SwiftParserTest/translated/OperatorsTests.swift
@@ -302,23 +302,44 @@ final class OperatorsTests: XCTestCase {
     AssertParse(
       """
       func !!(x: Man, y: Man) {}
-      let foo = Man()
-      let bar = TheDevil()
-      foo!!foo
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 4: consecutive statements, Fix-It replacements: 6 - 6 = ';'
-      ]
+      """
     )
   }
 
   func testOperators32() {
     AssertParse(
       """
-      foo??bar
+      let foo = Man()
+      """
+    )
+  }
+
+  func testOperators33() {
+    AssertParse(
+      """
+      let bar = TheDevil()
+      """
+    )
+  }
+
+  func testOperators34() {
+    AssertParse(
+      """
+      foo!!#^DIAG^#foo
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: consecutive statements, Fix-It replacements: 6 - 6 = ';'
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
+      ]
+    )
+  }
+
+  func testOperators35() {
+    AssertParse(
+      """
+      foo??#^DIAG^#bar
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/SelfRebindingTests.swift
+++ b/Tests/SwiftParserTest/translated/SelfRebindingTests.swift
@@ -46,14 +46,15 @@ final class SelfRebindingTests: XCTestCase {
       struct T {
           var mutable: Int = 0
           func f() {
-              let #^DIAG^#self = self
+              let#^DIAG_1^# #^DIAG_2^#self = self
           }
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 4: keyword 'self' cannot be used as an identifier here
         // TODO: Old parser expected note on line 4: if this name is unavoidable, use backticks to escape it
-        DiagnosticSpec(message: "expected pattern in variable"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected pattern in variable"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/SuperTests.swift
+++ b/Tests/SwiftParserTest/translated/SuperTests.swift
@@ -65,6 +65,7 @@ final class SuperTests: XCTestCase {
       """#,
       diagnostics: [
         DiagnosticSpec(message: "expected identifier in member access"),
+        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
         // TODO: Old parser expected error on line 33: expected '.' or '[' after 'super'
         // TODO: Old parser expected error on line 36: expected '.' or '[' after 'super'
       ]

--- a/Tests/SwiftParserTest/translated/SwitchTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchTests.swift
@@ -19,15 +19,16 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       func parseError1(x: Int) {
-        switch #^DIAG_1^#func #^DIAG_2^#{} 
+        switch#^DIAG_1^# #^DIAG_2^#func #^DIAG_3^#{} 
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: expected expression in 'switch' statement
         // TODO: Old parser expected error on line 2: expected identifier in function declaration
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression and '{}' to end 'switch' statement"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected argument list in function declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression and '{}' to end 'switch' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected argument list in function declaration")
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
+++ b/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
@@ -152,7 +152,7 @@ final class TrailingClosuresTests: XCTestCase {
         func fn(f: () -> Void, g: () -> Void) {}
         fn {} g: {} // Ok
         fn {} _: {} //  {{none}}
-        fn {} g#^DIAG^#: <#T##() -> Void#> 
+        fn {}#^DIAG_1^# g#^DIAG_2^#: <#T##() -> Void#>
         func multiple(_: () -> Void, _: () -> Void) {}
         multiple {} _: { }
         func mixed_args_1(a: () -> Void, _: () -> Void) {}
@@ -166,7 +166,9 @@ final class TrailingClosuresTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 5: editor placeholder in source file
-        DiagnosticSpec(message: "unexpected text ': <#T##() -> Void#>' before function"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text ': <#T##() -> Void#>' before function"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/TrailingSemiTests.swift
+++ b/Tests/SwiftParserTest/translated/TrailingSemiTests.swift
@@ -22,9 +22,9 @@ final class TrailingSemiTests: XCTestCase {
         #^DIAG_1^#; 
         var a : Int ; #^DIAG_2^#; 
         func b () {};#^DIAG_3^#
-        ; #^DIAG_4^#static func c () {};  #^DIAG_5^#
-        ;#^DIAG_6^#;
-      #^DIAG_7^#}
+        ;#^DIAG_4^# #^DIAG_5^#static func c () {};  #^DIAG_6^#
+        ;#^DIAG_7^#;
+      #^DIAG_8^#}
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: unexpected ';' separator, Fix-It replacements: 3 - 5 = ''
@@ -33,12 +33,13 @@ final class TrailingSemiTests: XCTestCase {
         DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text ';' before function"),
         DiagnosticSpec(locationMarker: "DIAG_3", message: "expected declaration in struct"),
         // TODO: Old parser expected error on line 5: unexpected ';' separator, Fix-It replacements: 3 - 5 = ''
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected '}' to end struct"),
-        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected expression"),
+        DiagnosticSpec(locationMarker: "DIAG_4", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected '}' to end struct"),
+        DiagnosticSpec(locationMarker: "DIAG_6", message: "expected expression"),
         // TODO: Old parser expected error on line 6: unexpected ';' separator, Fix-It replacements: 3 - 4 = ''
         // TODO: Old parser expected error on line 6: unexpected ';' separator, Fix-It replacements: 4 - 5 = ''
-        DiagnosticSpec(locationMarker: "DIAG_6", message: "expected expression"),
-        DiagnosticSpec(locationMarker: "DIAG_7", message: "extraneous '}' at top level"),
+        DiagnosticSpec(locationMarker: "DIAG_7", message: "expected expression"),
+        DiagnosticSpec(locationMarker: "DIAG_8", message: "extraneous '}' at top level"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/TrySwift5Tests.swift
+++ b/Tests/SwiftParserTest/translated/TrySwift5Tests.swift
@@ -122,38 +122,97 @@ final class TrySwift5Tests: XCTestCase {
     )
   }
 
-  func testTrySwift511() {
+  func testTrySwift511a() {
     AssertParse(
       """
-      try #^DIAG_1^#let singleLet = foo() 
-      try #^DIAG_2^#var singleVar = foo() 
-      try #^DIAG_3^#let uninit: Int 
-      try #^DIAG_4^#let (destructure1, destructure2) = (foo(), bar()) 
-      try #^DIAG_5^#let multi1 = foo(), multi2 = bar() //  expected-error 2 {{call can throw but is not marked with 'try'}}
-      class TryDecl { 
-        #^DIAG_6^#try let singleLet = foo() 
-        #^DIAG_7^#try var singleVar = foo() 
-        #^DIAG_8^#try 
+      try#^DIAG_1^# #^DIAG_2^#let singleLet = foo()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 21 - 21 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
+      ]
+    )
+  }
+
+  func testTrySwift511b() {
+    AssertParse(
+      """
+      try#^DIAG_1^# #^DIAG_2^#var singleVar = foo()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 21 - 21 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
+      ]
+    )
+  }
+
+  func testTrySwift511c() {
+    AssertParse(
+      """
+      try#^DIAG_1^# #^DIAG_2^#let uninit: Int
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
+      ]
+    )
+  }
+
+  func testTrySwift511d() {
+    AssertParse(
+      """
+      try#^DIAG_1^# #^DIAG_2^#let (destructure1, destructure2) = (foo(), bar())
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 40 - 40 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
+      ]
+    )
+  }
+
+  func testTrySwift511e() {
+    AssertParse(
+      """
+      try#^DIAG_1^# #^DIAG_2^#let multi1 = foo(), multi2 = bar() //  expected-error 2 {{call can throw but is not marked with 'try'}}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression
+        // TODO: Old parser expected note on line 1: did you mean to use 'try'?, Fix-It replacements: 18 - 18 = 'try '
+        // TODO: Old parser expected note on line 1: did you mean to use 'try'?, Fix-It replacements: 34 - 34 = 'try '
+        // TODO: Old parser expected note on line 1: did you mean to handle error as optional value?, Fix-It replacements: 18 - 18 = 'try? '
+        // TODO: Old parser expected note on line 1: did you mean to handle error as optional value?, Fix-It replacements: 34 - 34 = 'try? '
+        // TODO: Old parser expected note on line 1: did you mean to disable error propagation?, Fix-It replacements: 18 - 18 = 'try! '
+        // TODO: Old parser expected note on line 1: did you mean to disable error propagation?, Fix-It replacements: 34 - 34 = 'try! '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
+      ]
+    )
+  }
+
+  func testTrySwift511f() {
+    AssertParse(
+      """
+      class TryDecl {
+        #^DIAG_1^#try let singleLet = foo()
+        #^DIAG_2^#try var singleVar = foo()
+        #^DIAG_3^#try
         func method() {}
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 21 - 21 = 'try '
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in 'try' expression"),
-        // TODO: Old parser expected error on line 2: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 21 - 21 = 'try '
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
-        // TODO: Old parser expected error on line 3: 'try' must be placed on the initial value expression
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in 'try' expression"),
-        // TODO: Old parser expected error on line 4: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 40 - 40 = 'try '
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected expression in 'try' expression"),
-        // TODO: Old parser expected error on line 5: 'try' must be placed on the initial value expression
-        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected expression in 'try' expression"),
-        // TODO: Old parser expected error on line 7: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
-        DiagnosticSpec(locationMarker: "DIAG_6", message: "unexpected text 'try' before variable"),
-        // TODO: Old parser expected error on line 8: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
-        DiagnosticSpec(locationMarker: "DIAG_7", message: "unexpected text 'try' before variable"),
-        // TODO: Old parser expected error on line 9: expected declaration
-        DiagnosticSpec(locationMarker: "DIAG_8", message: "unexpected text 'try' before function"),
+        // TODO: Old parser expected note on line 1: in declaration of 'TryDecl'
+        // TODO: Old parser expected error on line 2: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
+        // TODO: Old parser expected error on line 2: call can throw, but errors cannot be thrown out of a property initializer
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text 'try' before variable"),
+        // TODO: Old parser expected error on line 3: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
+        // TODO: Old parser expected error on line 3: call can throw, but errors cannot be thrown out of a property initializer
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text 'try' before variable"),
+        // TODO: Old parser expected error on line 4: expected declaration
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text 'try' before function"),
       ]
     )
   }
@@ -162,31 +221,37 @@ final class TrySwift5Tests: XCTestCase {
     AssertParse(
       """
       func test() throws -> Int {
-        try #^DIAG_1^#while true { 
-          try #^DIAG_2^#break 
+        try#^DIAG_1A^# #^DIAG_1^#while true {
+          try#^DIAG_2A^# #^DIAG_2^#break
         }
-        try #^DIAG_3^#throw #^DIAG_4^#
+        try#^DIAG_3A^# #^DIAG_3^#throw #^DIAG_4^#
         ; // Reset parser.
-        try #^DIAG_5^#return 
+        try#^DIAG_5A^# #^DIAG_5^#return
         ; // Reset parser.
-        try #^DIAG_6^#throw foo() 
-        try #^DIAG_7^#return foo() 
+        try#^DIAG_6A^# #^DIAG_6^#throw foo()
+        try#^DIAG_7A^# #^DIAG_7^#return foo()
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: 'try' cannot be used with 'while'
+        DiagnosticSpec(locationMarker: "DIAG_1A", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in 'try' expression"),
         // TODO: Old parser expected error on line 3: 'try' cannot be used with 'break'
+        DiagnosticSpec(locationMarker: "DIAG_2A", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
         // TODO: Old parser expected error on line 5: 'try' must be placed on the thrown expression, Fix-It replacements: 3 - 7 = '', 3 - 3 = 'try '
         // TODO: Old parser expected error on line 5: expected expression in 'throw' statement
+        DiagnosticSpec(locationMarker: "DIAG_3A", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in 'try' expression"),
         DiagnosticSpec(locationMarker: "DIAG_4", message: "expected expression in 'throw' statement"),
         // TODO: Old parser expected error on line 7: 'try' cannot be used with 'return'
+        DiagnosticSpec(locationMarker: "DIAG_5A", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_5", message: "expected expression in 'try' expression"),
         // TODO: Old parser expected error on line 9: 'try' must be placed on the thrown expression, Fix-It replacements: 3 - 7 = '', 13 - 13 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_6A", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_6", message: "expected expression in 'try' expression"),
         // TODO: Old parser expected error on line 10: 'try' must be placed on the returned expression, Fix-It replacements: 3 - 7 = '', 14 - 14 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_7A", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_7", message: "expected expression in 'try' expression"),
       ]
     )

--- a/Tests/SwiftParserTest/translated/TryTests.swift
+++ b/Tests/SwiftParserTest/translated/TryTests.swift
@@ -122,47 +122,97 @@ final class TryTests: XCTestCase {
     )
   }
 
-  func testTry11() {
+  func testTry11a() {
     AssertParse(
       """
-      try #^DIAG_1^#let singleLet = foo() 
-      try #^DIAG_2^#var singleVar = foo() 
-      try #^DIAG_3^#let uninit: Int 
-      try #^DIAG_4^#let (destructure1, destructure2) = (foo(), bar()) 
-      try #^DIAG_5^#let multi1 = foo(), multi2 = bar() //  expected-error 2 {{call can throw but is not marked with 'try'}}
-      class TryDecl { 
-        #^DIAG_6^#try let singleLet = foo() 
-        #^DIAG_7^#try var singleVar = foo() 
-        #^DIAG_8^#try 
+      try#^DIAG_1^# #^DIAG_2^#let singleLet = foo()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 21 - 21 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
+      ]
+    )
+  }
+
+  func testTry11b() {
+    AssertParse(
+      """
+      try#^DIAG_1^# #^DIAG_2^#var singleVar = foo()
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 21 - 21 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
+      ]
+    )
+  }
+
+  func testTry11c() {
+    AssertParse(
+      """
+      try#^DIAG_1^# #^DIAG_2^#let uninit: Int
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
+      ]
+    )
+  }
+
+  func testTry11d() {
+    AssertParse(
+      """
+      try#^DIAG_1^# #^DIAG_2^#let (destructure1, destructure2) = (foo(), bar())
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 40 - 40 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
+      ]
+    )
+  }
+
+  func testTry11e() {
+    AssertParse(
+      """
+      try#^DIAG_1^# #^DIAG_2^#let multi1 = foo(), multi2 = bar() //  expected-error 2 {{call can throw but is not marked with 'try'}}
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression
+        // TODO: Old parser expected note on line 1: did you mean to use 'try'?, Fix-It replacements: 18 - 18 = 'try '
+        // TODO: Old parser expected note on line 1: did you mean to use 'try'?, Fix-It replacements: 34 - 34 = 'try '
+        // TODO: Old parser expected note on line 1: did you mean to handle error as optional value?, Fix-It replacements: 18 - 18 = 'try? '
+        // TODO: Old parser expected note on line 1: did you mean to handle error as optional value?, Fix-It replacements: 34 - 34 = 'try? '
+        // TODO: Old parser expected note on line 1: did you mean to disable error propagation?, Fix-It replacements: 18 - 18 = 'try! '
+        // TODO: Old parser expected note on line 1: did you mean to disable error propagation?, Fix-It replacements: 34 - 34 = 'try! '
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
+      ]
+    )
+  }
+
+  func testTry11f() {
+    AssertParse(
+      """
+      class TryDecl {
+        #^DIAG_1^#try let singleLet = foo()
+        #^DIAG_2^#try var singleVar = foo()
+        #^DIAG_3^#try
         func method() {}
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 21 - 21 = 'try '
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in 'try' expression"),
-        // TODO: Old parser expected error on line 2: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 21 - 21 = 'try '
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
-        // TODO: Old parser expected error on line 3: 'try' must be placed on the initial value expression
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in 'try' expression"),
-        // TODO: Old parser expected error on line 4: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 40 - 40 = 'try '
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected expression in 'try' expression"),
-        // TODO: Old parser expected error on line 5: 'try' must be placed on the initial value expression
-        // TODO: Old parser expected note on line 5: did you mean to use 'try'?, Fix-It replacements: 18 - 18 = 'try '
-        // TODO: Old parser expected note on line 5: did you mean to use 'try'?, Fix-It replacements: 34 - 34 = 'try '
-        // TODO: Old parser expected note on line 5: did you mean to handle error as optional value?, Fix-It replacements: 18 - 18 = 'try? '
-        // TODO: Old parser expected note on line 5: did you mean to handle error as optional value?, Fix-It replacements: 34 - 34 = 'try? '
-        // TODO: Old parser expected note on line 5: did you mean to disable error propagation?, Fix-It replacements: 18 - 18 = 'try! '
-        // TODO: Old parser expected note on line 5: did you mean to disable error propagation?, Fix-It replacements: 34 - 34 = 'try! '
-        DiagnosticSpec(locationMarker: "DIAG_5", message: "expected expression in 'try' expression"),
-        // TODO: Old parser expected note on line 6: in declaration of 'TryDecl'
-        // TODO: Old parser expected error on line 7: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
-        // TODO: Old parser expected error on line 7: call can throw, but errors cannot be thrown out of a property initializer
-        DiagnosticSpec(locationMarker: "DIAG_6", message: "unexpected text 'try' before variable"),
-        // TODO: Old parser expected error on line 8: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
-        // TODO: Old parser expected error on line 8: call can throw, but errors cannot be thrown out of a property initializer
-        DiagnosticSpec(locationMarker: "DIAG_7", message: "unexpected text 'try' before variable"),
-        // TODO: Old parser expected error on line 9: expected declaration
-        DiagnosticSpec(locationMarker: "DIAG_8", message: "unexpected text 'try' before function"),
+        // TODO: Old parser expected note on line 1: in declaration of 'TryDecl'
+        // TODO: Old parser expected error on line 2: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
+        // TODO: Old parser expected error on line 2: call can throw, but errors cannot be thrown out of a property initializer
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text 'try' before variable"),
+        // TODO: Old parser expected error on line 3: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
+        // TODO: Old parser expected error on line 3: call can throw, but errors cannot be thrown out of a property initializer
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text 'try' before variable"),
+        // TODO: Old parser expected error on line 4: expected declaration
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text 'try' before function"),
       ]
     )
   }
@@ -171,33 +221,37 @@ final class TryTests: XCTestCase {
     AssertParse(
       """
       func test() throws -> Int {
-        try #^DIAG_1^#while true { 
-          try #^DIAG_2^#break 
+        try#^DIAG_1A^# #^DIAG_1^#while true {
+          try#^DIAG_2A^# #^DIAG_2^#break
         }
-        try #^DIAG_3^#throw #^DIAG_4^#
+        try#^DIAG_3A^# #^DIAG_3^#throw #^DIAG_4^#
         ; // Reset parser.
-        try #^DIAG_5^#return 
+        try#^DIAG_5A^# #^DIAG_5^#return
         ; // Reset parser.
-        try #^DIAG_6^#throw foo() 
-        try #^DIAG_7^#return foo() 
+        try#^DIAG_6A^# #^DIAG_6^#throw foo()
+        try#^DIAG_7A^# #^DIAG_7^#return foo()
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: 'try' cannot be used with 'while'
+        DiagnosticSpec(locationMarker: "DIAG_1A", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in 'try' expression"),
         // TODO: Old parser expected error on line 3: 'try' cannot be used with 'break'
+        DiagnosticSpec(locationMarker: "DIAG_2A", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression in 'try' expression"),
         // TODO: Old parser expected error on line 5: 'try' must be placed on the thrown expression, Fix-It replacements: 3 - 7 = '', 3 - 3 = 'try '
         // TODO: Old parser expected error on line 5: expected expression in 'throw' statement
+        DiagnosticSpec(locationMarker: "DIAG_3A", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression in 'try' expression"),
         DiagnosticSpec(locationMarker: "DIAG_4", message: "expected expression in 'throw' statement"),
         // TODO: Old parser expected error on line 7: 'try' cannot be used with 'return'
-        // TODO: Old parser expected error on line 7: non-void function should return a value
+        DiagnosticSpec(locationMarker: "DIAG_5A", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_5", message: "expected expression in 'try' expression"),
         // TODO: Old parser expected error on line 9: 'try' must be placed on the thrown expression, Fix-It replacements: 3 - 7 = '', 13 - 13 = 'try '
-        // TODO: Old parser expected error on line 9: thrown expression type 'Int' does not conform to 'Error'
+        DiagnosticSpec(locationMarker: "DIAG_6A", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_6", message: "expected expression in 'try' expression"),
         // TODO: Old parser expected error on line 10: 'try' must be placed on the returned expression, Fix-It replacements: 3 - 7 = '', 14 - 14 = 'try '
+        DiagnosticSpec(locationMarker: "DIAG_7A", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "DIAG_7", message: "expected expression in 'try' expression"),
       ]
     )

--- a/Tests/SwiftParserTest/translated/TypealiasTests.swift
+++ b/Tests/SwiftParserTest/translated/TypealiasTests.swift
@@ -3,56 +3,88 @@
 import XCTest
 
 final class TypealiasTests: XCTestCase {
-  func testTypealias1() {
+  func testTypealias2a() {
     AssertParse(
       """
-      //===--- Simple positive tests.
+      typealias IntPair = (Int, Int)
       """
     )
   }
 
-  func testTypealias2() {
+  func testTypealias2b() {
     AssertParse(
       """
-      typealias IntPair = (Int, Int)
       typealias IntTriple = (Int, Int, Int)
+      """
+    )
+  }
+
+  func testTypealias2c() {
+    AssertParse(
+      """
       typealias FiveInts = (IntPair, IntTriple)
+      """
+    )
+  }
+
+  func testTypealias2d() {
+    AssertParse(
+      """
       var fiveInts : FiveInts = ((4,2), (1,2,3))
       """
     )
   }
 
-  func testTypealias3() {
+  func testTypealias3a() {
     AssertParse(
       """
       // <rdar://problem/13339798> QoI: poor diagnostic in malformed typealias
-      typealias Foo1 #^DIAG_1^#: Int  
-      typealias Foo2#^DIAG_2^#: Int  
-      typealias Foo3 #^DIAG_3^#:Int  
-      typealias Foo4#^DIAG_4^#:/*comment*/Int
+      typealias Foo1 #^DIAG^#: Int
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: expected '=' in type alias declaration, Fix-It replacements: 16 - 17 = '='
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '=' and value in typealias declaration"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text ': Int' before typealias declaration"),
-        // TODO: Old parser expected error on line 3: expected '=' in type alias declaration, Fix-It replacements: 15 - 16 = ' ='
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '=' and value in typealias declaration"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "unexpected text ': Int' before typealias declaration"),
-        // TODO: Old parser expected error on line 4: expected '=' in type alias declaration, Fix-It replacements: 16 - 17 = '= '
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected '=' and value in typealias declaration"),
-        DiagnosticSpec(locationMarker: "DIAG_3", message: "unexpected text ':Int' before typealias declaration"),
-        // TODO: Old parser expected error on line 5: expected '=' in type alias declaration, Fix-It replacements: 15 - 16 = ' = '
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "expected '=' and value in typealias declaration"),
-        DiagnosticSpec(locationMarker: "DIAG_4", message: "extraneous ':/*comment*/Int' at top level"),
+        DiagnosticSpec(message: "expected '=' and value in typealias declaration"),
+        DiagnosticSpec(message: "extraneous ': Int' at top level"),
       ]
     )
   }
 
-  func testTypealias4() {
+  func testTypealias3b() {
     AssertParse(
       """
-      //===--- Tests for error recovery.
+      typealias Foo2#^DIAG^#: Int
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected '=' in type alias declaration, Fix-It replacements: 15 - 16 = ' ='
+        DiagnosticSpec(message: "expected '=' and value in typealias declaration"),
+        DiagnosticSpec(message: "extraneous ': Int' at top level"),
+      ]
+    )
+  }
+
+  func testTypealias3c() {
+    AssertParse(
       """
+      typealias Foo3 #^DIAG^#:Int
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected '=' in type alias declaration, Fix-It replacements: 16 - 17 = '= '
+        DiagnosticSpec(message: "expected '=' and value in typealias declaration"),
+        DiagnosticSpec(message: "extraneous ':Int' at top level"),
+      ]
+    )
+  }
+
+  func testTypealias3d() {
+    AssertParse(
+      """
+      typealias Foo4#^DIAG^#:/*comment*/Int
+      """,
+      diagnostics: [
+        // TODO: Old parser expected error on line 1: expected '=' in type alias declaration, Fix-It replacements: 15 - 16 = ' = '
+        DiagnosticSpec(message: "expected '=' and value in typealias declaration"),
+        DiagnosticSpec(message: "extraneous ':/*comment*/Int' at top level"),
+      ]
     )
   }
 
@@ -138,15 +170,16 @@ final class TypealiasTests: XCTestCase {
   func testTypealias11() {
     AssertParse(
       """
-      typealias #^DIAG_1^#switch #^DIAG_2^#= Int
+      typealias#^DIAG_1^# #^DIAG_2^#switch #^DIAG_3^#= Int
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: keyword 'switch' cannot be used as an identifier here
         // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 11 - 17 = '`switch`'
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected identifier in typealias declaration"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '=' and value in typealias declaration"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected expression and '{}' to end 'switch' statement"),
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "extraneous '= Int' at top level"),
+        DiagnosticSpec(locationMarker: "DIAG_1", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected identifier in typealias declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '=' and value in typealias declaration"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "expected expression and '{}' to end 'switch' statement"),
+        DiagnosticSpec(locationMarker: "DIAG_3", message: "extraneous '= Int' at top level"),
       ]
     )
   }


### PR DESCRIPTION
Before, the new parser allowed multiple declarations on the same line.

This produces a bunch more diagnostics but all of those are at locations at which we already produce diagnostics and where we need to improve recovery anyway.