### PR TITLE
Skip subtrees that don’t contain any errors during diagnostic generation

### DIFF
--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -65,6 +65,9 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
   /// Whether the node should be skipped for diagnostic emission.
   /// Every visit method must check this at the beginning.
   func shouldSkip<T: SyntaxProtocol>(_ node: T) -> Bool {
+    if !node.hasError {
+      return true
+    }
     return handledNodes.contains(node.id)
   }
 


### PR DESCRIPTION
If a subtree doesn’t contain an error, we don’t need to walk it for diagnostics generation.