### PR TITLE
Respect Trailing Commas Better In Collection Element Parsing

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -1685,6 +1685,13 @@ extension Parser {
           }
         }
 
+        // If we saw a comma, that's a strong indicator we have more elements
+        // to process. If that's not the case, we have to do some legwork to
+        // determine if we should bail out.
+        guard comma == nil || self.at(any: [.rightSquareBracket, .eof]) else {
+          continue
+        }
+
         // If we found EOF or the closing square bracket, bailout.
         if self.at(any: [.rightSquareBracket, .eof]) {
           break

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -189,6 +189,36 @@ final class ExpressionTests: XCTestCase {
         DiagnosticSpec(message: "expected ']' to end dictionary"),
       ]
     )
+
+    AssertParse(
+      """
+      [
+        #line : Calendar(identifier: .gregorian),
+        #^STRUCTURE^##line : Calendar(identifier: .buddhist),
+      ]
+      """,
+      substructure: Syntax(DictionaryElementSyntax.init(
+        keyExpression: ExprSyntax(PoundLineExprSyntax(poundLine: .poundLineKeyword())),
+        colon: .colonToken(),
+        valueExpression: ExprSyntax(FunctionCallExprSyntax(
+          calledExpression: ExprSyntax(IdentifierExprSyntax(identifier: .identifier("Calendar"), declNameArguments: nil)),
+          leftParen: .leftParenToken(),
+          argumentList: TupleExprElementListSyntax([
+            TupleExprElementSyntax(
+              label: .identifier("identifier"),
+              colon: .colonToken(),
+              expression: ExprSyntax(MemberAccessExprSyntax(
+                base: nil,
+                dot: .prefixPeriodToken(),
+                name: .identifier("buddhist"),
+                declNameArguments: nil)),
+              trailingComma: nil)
+          ]),
+          rightParen: .rightParenToken(),
+          trailingClosure: nil,
+          additionalTrailingClosures: nil)),
+        trailingComma: .commaToken())),
+    substructureAfterMarker: "STRUCTURE")
   }
 
   func testInterpolatedStringLiterals() {


### PR DESCRIPTION
Match the C++ parser in its eagerness to process the next element after it sees a comma. This bug appears to have been masked by the rewrite of `atStartOfStatement`, which I reverted recently.