### PR TITLE
Small fixes for regular expression literals.

### DIFF
--- a/Sources/SwiftParser/Lexer.swift
+++ b/Sources/SwiftParser/Lexer.swift
@@ -2078,6 +2078,7 @@ extension Lexer.Cursor {
     DELIMITLOOP: while true {
       defer { escaped = false }
 
+      let previousByte = Tmp.previous
       switch Tmp.advance() {
       case nil:
         return nil
@@ -2095,6 +2096,14 @@ extension Lexer.Cursor {
             continue DELIMITLOOP
           }
         }
+
+        // A regex literal may not end in a space or tab.
+        if !isMultiline && poundCount == 0 &&
+          (previousByte == UInt8(ascii: " ") ||
+           previousByte == UInt8(ascii: "\t")) {
+          return nil
+        }
+
         Tmp = EndLex
         break DELIMITLOOP
       case let .some(next) where !Unicode.Scalar(next).isASCII:

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -42,6 +42,18 @@ final class DeclarationTests: XCTestCase {
                   DiagnosticSpec(locationMarker: "DIAG1", message: "expected argument list in function declaration"),
                   DiagnosticSpec(locationMarker: "DIAG2", message: "expected '=' and right-hand type in same type requirement"),
                 ])
+
+    AssertParse("func /^/ (lhs: Int, rhs: Int) -> Int { 1 / 2 }")
+
+    AssertParse(
+      "func #^DIAG^#/^notoperator^/ (lhs: Int, rhs: Int) -> Int { 1 / 2 }",
+      diagnostics: [
+        DiagnosticSpec(message: "expected identifier in function"),
+        DiagnosticSpec(message: "unexpected text '/^notoperator^/' before parameter clause")
+      ]
+    )
+
+    AssertParse("func /^ (lhs: Int, rhs: Int) -> Int { 1 / 2 }")
   }
 
   func testFuncAfterUnbalancedClosingBrace() {


### PR DESCRIPTION
Two small fixes for regular expression literals:
* A regular expression literal cannot end in a space or a tab
* A regular expression literal might show up as the name of a function, where it should be an operator. Treat it as an operator.