### PR TITLE
Added a formatter to pretty print diagnostics

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -152,6 +152,10 @@ let package = Package(
       dependencies: ["SwiftBasicFormat"]
     ),
     .testTarget(
+      name: "SwiftDiagnosticsTest",
+      dependencies: ["SwiftDiagnostics", "SwiftParser"]
+    ),
+    .testTarget(
       name: "SwiftSyntaxTest",
       dependencies: ["SwiftSyntax", "_SwiftSyntaxTestSupport"]
     ),

--- a/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
+++ b/Sources/SwiftDiagnostics/DiagnosticsFormatter.swift
@@ -1,0 +1,112 @@
+//===------------ DiagnosticsFormatter.swift - Formatter for diagnostics ----------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+import SwiftSyntax
+
+public struct DiagnosticsFormatter {
+  
+  /// A wrapper struct for a source line and its diagnostics
+  private struct AnnotatedSourceLine {
+    var diagnostics: [Diagnostic]
+    var sourceString: String
+  }
+  
+  /// Number of lines which should be printed before and after the diagnostic message
+  static let contextSize = 2
+  
+  /// Print given diagnostics for a given syntax tree on the command line
+  public static func annotatedSource(tree: SourceFileSyntax, diags: [Diagnostic]) -> String {
+    let slc = SourceLocationConverter(file: "", tree: tree)
+    
+    // First, we need to put each line and its diagnostics together
+    var annotatedSourceLines = [AnnotatedSourceLine]()
+    
+    for (sourceLineIndex, sourceLine) in slc.sourceLines.enumerated() {
+      let diagsForLine = diags.filter { diag in
+        return diag.location(converter: slc).line == (sourceLineIndex + 1)
+      }
+      annotatedSourceLines.append(AnnotatedSourceLine(diagnostics: diagsForLine, sourceString: sourceLine))
+    }
+    
+    // Only lines with diagnostic messages should be printed, but including some context
+    let rangesToPrint = annotatedSourceLines.enumerated().compactMap { (lineIndex, sourceLine) -> Range<Int>? in
+      let lineNumber = lineIndex + 1
+      if !sourceLine.diagnostics.isEmpty {
+        return Range<Int>(uncheckedBounds: (lower: lineNumber - Self.contextSize, upper: lineNumber + Self.contextSize + 1))
+      }
+      return nil
+    }
+    
+    var annotatedSource = ""
+    
+    /// Keep track if a line missing char should be printed
+    var hasLineBeenSkipped = false
+    
+    let maxNumberOfDigits = String(annotatedSourceLines.count).count
+    
+    for (lineIndex, annotatedLine) in annotatedSourceLines.enumerated() {
+      let lineNumber = lineIndex + 1
+      guard rangesToPrint.contains(where: { range in
+        range.contains(lineNumber)
+      }) else {
+        hasLineBeenSkipped = true
+        continue
+      }
+      
+      // line numbers should be right aligned
+      let lineNumberString = String(lineNumber)
+      let leadingSpaces = String(repeating: " ", count: maxNumberOfDigits - lineNumberString.count)
+      let linePrefix = "\(leadingSpaces)\(lineNumberString) │ "
+      
+      // If necessary, print a line that indicates that there was lines skipped in the source code
+      if hasLineBeenSkipped && !annotatedSource.isEmpty {
+        let lineMissingInfoLine = String(repeating: " ", count: maxNumberOfDigits) + " ┆"
+        annotatedSource.append("\(lineMissingInfoLine)\n")
+      }
+      hasLineBeenSkipped = false
+      
+      // print the source line
+      annotatedSource.append("\(linePrefix)\(annotatedLine.sourceString)")
+      
+      // If the line did not end with \n (e.g. the last line), append it manually
+      if annotatedSource.last != "\n" {
+        annotatedSource.append("\n")
+      }
+      
+      let columnsWithDiagnostics = Set(annotatedLine.diagnostics.map { $0.location(converter: slc).column ?? 0 })
+      let diagsPerColumn = Dictionary(grouping: annotatedLine.diagnostics) { diag in
+        diag.location(converter: slc).column ?? 0
+      }.sorted { lhs, rhs in
+        lhs.key > rhs.key
+      }
+      
+      for (column, diags) in diagsPerColumn {
+        // compute the string that is shown before each message
+        var preMessage = String(repeating: " ", count: maxNumberOfDigits) + " ∣"
+        for c in 0..<column {
+          if columnsWithDiagnostics.contains(c) {
+            preMessage.append("│")
+          } else {
+            preMessage.append(" ")
+          }
+        }
+        
+        for diag in diags.dropLast(1) {
+          annotatedSource.append("\(preMessage)├─ \(diag.message)\n")
+        }
+        annotatedSource.append("\(preMessage)╰─ \(diags.last!.message)\n")
+        
+      }
+    }
+    return annotatedSource
+  }
+}

--- a/Sources/swift-parser-test/swift-parser-test.swift
+++ b/Sources/swift-parser-test/swift-parser-test.swift
@@ -163,17 +163,16 @@ class PrintDiags: ParsableCommand {
         languageVersion: swiftVersion,
         enableBareSlashRegexLiteral: enableBareSlashRegex
       )
+      
       var diags = ParseDiagnosticsGenerator.diagnostics(for: tree)
-
+      print(DiagnosticsFormatter.annotatedSource(tree: tree, diags: diags))
+      
       if foldSequences {
         diags += foldAllSequences(tree).1
       }
 
       if diags.isEmpty {
         print("No diagnostics produced")
-      }
-      for diag in diags {
-        print("\(diag.debugDescription)")
       }
     }
   }

--- a/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
@@ -1,0 +1,81 @@
+//===------------------ DiagnosticsFormatterTests.swift -------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+import XCTest
+import SwiftDiagnostics
+import SwiftParser
+
+final class DiagnosticsFormatterTests: XCTestCase {
+  
+  func annotate(source: String) throws -> String {
+    let tree = try Parser.parse(source: source)
+    let diags = ParseDiagnosticsGenerator.diagnostics(for: tree)
+    return DiagnosticsFormatter.annotatedSource(tree: tree, diags: diags)
+  }
+  
+  func testSingleDiagnostic() throws {
+    let source = """
+    var foo = bar +
+    """
+    let expectedOutput = """
+    1 │ var foo = bar +
+      ∣                ╰─ expected expression in variable
+    
+    """
+    XCTAssertEqual(expectedOutput, try annotate(source: source))
+  }
+  
+  func testMultipleDiagnosticsInOneLine() throws {
+    let source = """
+    foo.[].[].[]
+    """
+    let expectedOutput = """
+    1 │ foo.[].[].[]
+      ∣     │  │  ╰─ expected identifier in member access
+      ∣     │  ╰─ expected identifier in member access
+      ∣     ╰─ expected identifier in member access
+    
+    """
+    XCTAssertEqual(expectedOutput, try annotate(source: source))
+  }
+  
+  func testLineSkipping() throws {
+    let source = """
+    var i = 1
+    i = 2
+    i = foo(
+    i = 4
+    i = 5
+    i = 6
+    i = 7
+    i = 8
+    i = 9
+    i = 10
+    i = bar(
+    """
+    let expectedOutput = """
+     2 │ i = 2
+     3 │ i = foo(
+     4 │ i = 4
+       ∣      ╰─ expected ')' to end function call
+     5 │ i = 5
+     6 │ i = 6
+       ┆
+     9 │ i = 9
+    10 │ i = 10
+    11 │ i = bar(
+       ∣         ├─ expected value in function call
+       ∣         ╰─ expected ')' to end function call
+
+    """
+    XCTAssertEqual(expectedOutput, try annotate(source: source))
+  }
+}


### PR DESCRIPTION
Hello swift-syntax team 👋,

in my first PR for this project I want to add a diagnostics formatter to this project. The output from `swift-parser-test print-diags` was not very pretty:
<img width="374" alt="image" src="https://user-images.githubusercontent.com/1114404/193467490-fcff18da-94e6-48a5-9f29-a53b586723da.png">

With this PR the output will look like the following:
<img width="611" alt="image" src="https://user-images.githubusercontent.com/1114404/193467509-853b1026-69a5-488d-b588-a523f9db04be.png">

Currently, the formatter will print any number of error messages next to the original source lines. It is already even capable of printing only affected lines in bigger files, including some context:

<img width="384" alt="193467557-e64cbe07-9bf6-482e-8ccb-60f11067fe09 copy" src="https://user-images.githubusercontent.com/1114404/193467656-110a5d53-6796-4ffa-9f6e-5e52be376b10.png">

In future pull request I want to add more functionality to this, including colored output and display of hints, fixits and notes.