### PR TITLE
Remove superfluous marker that’s no longer needed

### DIFF
--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -450,7 +450,7 @@ final class ExpressionTests: XCTestCase {
 
     AssertParse(
       ##"""
-      #^NOTE^##"#^DIAG^#
+      #"#^DIAG^#
       """##,
       diagnostics: [
         DiagnosticSpec(message: ##"expected '"#' to end string literal"##, notes: []),


### PR DESCRIPTION
As discussed in https://github.com/apple/swift-syntax/pull/862#discussion_r987368733.