### PR TITLE
Add diagnostic to move 'async' and 'throws' in 'ArrowExpr' in front of '->'

### DIFF
--- a/CodeGeneration/Sources/generate-swiftbasicformat/BasicFormatFile.swift
+++ b/CodeGeneration/Sources/generate-swiftbasicformat/BasicFormatFile.swift
@@ -168,7 +168,7 @@ private func createTokenFormatFunction() -> FunctionDecl {
   ) {
     VariableDecl("var node = node")
     SwitchStmt(expression: MemberAccessExpr(base: "node", name: "tokenKind")) {
-      for token in SYNTAX_TOKENS {
+      for token in SYNTAX_TOKENS where token.name != "ContextualKeyword" {
         SwitchCase(label: SwitchCaseLabel(caseItems: CaseItem(pattern: ExpressionPattern(expression: MemberAccessExpr(name: token.swiftKind))))) {
           if token.requiresLeadingSpace {
             IfStmt(
@@ -195,6 +195,20 @@ private func createTokenFormatFunction() -> FunctionDecl {
       }
       SwitchCase(label: SwitchCaseLabel(caseItems: CaseItem(pattern: ExpressionPattern(expression: MemberAccessExpr(name: "eof"))))) {
         BreakStmt("break")
+      }
+      SwitchCase(label: SwitchCaseLabel(caseItems: CaseItem(pattern: ExpressionPattern(expression: MemberAccessExpr(name: "contextualKeyword"))))) {
+        SwitchStmt(
+          """
+          switch node.text {
+            case "async":
+              if node.trailingTrivia.isEmpty {
+                node.trailingTrivia += .space
+              }
+            default:
+              break
+          }
+          """
+        )
       }
     }
     SequenceExpr("node.leadingTrivia = node.leadingTrivia.indented(indentation: indentation)")

--- a/Sources/SwiftBasicFormat/generated/BasicFormat.swift
+++ b/Sources/SwiftBasicFormat/generated/BasicFormat.swift
@@ -3147,8 +3147,6 @@ open class BasicFormat: SyntaxRewriter {
       break
     case .dollarIdentifier: 
       break
-    case .contextualKeyword: 
-      break
     case .rawStringDelimiter: 
       break
     case .stringSegment: 
@@ -3159,6 +3157,15 @@ open class BasicFormat: SyntaxRewriter {
       break
     case .eof: 
       break
+    case .contextualKeyword: 
+      switch node.text {
+        case "async":
+          if node.trailingTrivia.isEmpty {
+            node.trailingTrivia += .space
+          }
+        default:
+          break
+      }
     }
     node.leadingTrivia = node.leadingTrivia.indented(indentation: indentation)
     node.trailingTrivia = node.trailingTrivia.indented(indentation: indentation)

--- a/Sources/SwiftDiagnostics/FixIt.swift
+++ b/Sources/SwiftDiagnostics/FixIt.swift
@@ -26,21 +26,39 @@ public protocol FixItMessage {
 
 /// A Fix-It that can be applied to resolve a diagnostic.
 public struct FixIt {
+  public struct Changes: ExpressibleByArrayLiteral {
+    public var changes: [Change]
+
+    public init(changes: [Change]) {
+      self.changes = changes
+    }
+
+    public init(arrayLiteral elements: FixIt.Change...) {
+      self.init(changes: elements)
+    }
+
+    public init(combining: [Changes]) {
+      self.init(changes: combining.flatMap(\.changes))
+    }
+  }
+
   public enum Change {
     /// Replace `oldNode` by `newNode`.
     case replace(oldNode: Syntax, newNode: Syntax)
-    /// Remove the trailing trivia of the given token
-    case removeTrailingTrivia(TokenSyntax)
+    /// Replace the leading trivia on the given token
+    case replaceLeadingTrivia(token: TokenSyntax, newTrivia: Trivia)
+    /// Replace the trailing trivia on the given token
+    case replaceTrailingTrivia(token: TokenSyntax, newTrivia: Trivia)
   }
 
   /// A description of what this Fix-It performs.
   public let message: FixItMessage
 
   /// The changes that need to be performed when the Fix-It is applied.
-  public let changes: [Change]
+  public let changes: Changes
 
-  public init(message: FixItMessage, changes: [Change]) {
-    assert(!changes.isEmpty, "A Fix-It must have at least one change associated with it")
+  public init(message: FixItMessage, changes: Changes) {
+    assert(!changes.changes.isEmpty, "A Fix-It must have at least one change associated with it")
     self.message = message
     self.changes = changes
   }

--- a/Sources/SwiftParser/Diagnostics/DiagnosticExtensions.swift
+++ b/Sources/SwiftParser/Diagnostics/DiagnosticExtensions.swift
@@ -14,42 +14,72 @@ import SwiftDiagnostics
 import SwiftSyntax
 
 extension FixIt {
-  init(message: StaticParserFixIt, changes: [Change]) {
+  init(message: StaticParserFixIt, changes: Changes) {
     self.init(message: message as FixItMessage, changes: changes)
   }
-}
 
-extension FixIt.Change {
-  /// Replaced a present node with a missing node
-  static func makeMissing(node: TokenSyntax) -> FixIt.Change {
-    assert(node.presence == .present)
-    return .replace(
-      oldNode: Syntax(node),
-      newNode: Syntax(TokenSyntax(node.tokenKind, leadingTrivia: [], trailingTrivia: [], presence: .missing))
-    )
+  public init(message: FixItMessage, changes: [Changes]) {
+    self.init(message: message, changes: FixIt.Changes(combining: changes))
   }
 
-  static func makePresent<T: SyntaxProtocol>(node: T) -> FixIt.Change {
-    return .replace(
+  init(message: StaticParserFixIt, changes: [Changes]) {
+    self.init(message: message as FixItMessage, changes: FixIt.Changes(combining: changes))
+  }
+}
+
+extension FixIt.Changes {
+  /// Replaced a present node with a missing node
+  static func makeMissing(node: TokenSyntax) -> Self {
+    assert(node.presence == .present)
+    var changes = [
+      FixIt.Change.replace(
+        oldNode: Syntax(node),
+        newNode: Syntax(TokenSyntax(node.tokenKind, leadingTrivia: [], trailingTrivia: [], presence: .missing))
+      )
+    ]
+    if !node.leadingTrivia.isEmpty, let nextToken = node.nextToken(viewMode: .sourceAccurate) {
+      changes.append(.replaceLeadingTrivia(token: nextToken, newTrivia: node.leadingTrivia))
+    }
+    return FixIt.Changes(changes: changes)
+  }
+
+  static func makePresent<T: SyntaxProtocol>(node: T) -> Self {
+    return [.replace(
       oldNode: Syntax(node),
       newNode: PresentMaker().visit(Syntax(node))
-    )
+    )]
   }
-}
 
-extension Array where Element == FixIt.Change {
+  /// Make a token present. If `leadingTrivia` or `trailingTrivia` is specified,
+  /// override the default leading/trailing trivia inferred from `BasicFormat`.
+  static func makePresent(
+    node: TokenSyntax,
+    leadingTrivia: Trivia? = nil,
+    trailingTrivia: Trivia? = nil
+  ) -> Self {
+    var presentNode = PresentMaker().visit(Syntax(node)).as(TokenSyntax.self)!
+    if let leadingTrivia = leadingTrivia {
+      presentNode.leadingTrivia = leadingTrivia
+    }
+    if let trailingTrivia = trailingTrivia {
+      presentNode.trailingTrivia = trailingTrivia
+    }
+    return [.replace(
+      oldNode: Syntax(node),
+      newNode: Syntax(presentNode)
+    )]
+  }
+
   /// Makes the `token` present, moving it in front of the previous token's trivia.
-  static func makePresentBeforeTrivia(token: TokenSyntax) -> [FixIt.Change] {
+  static func makePresentBeforeTrivia(token: TokenSyntax) -> Self {
     if let previousToken = token.previousToken(viewMode: .sourceAccurate) {
       let presentToken = PresentMaker().visit(token).withTrailingTrivia(previousToken.trailingTrivia)
       return [
-        .removeTrailingTrivia(previousToken),
+        .replaceTrailingTrivia(token: previousToken, newTrivia: []),
         .replace(oldNode: Syntax(token), newNode: presentToken),
       ]
     } else {
-      return [
-        .makePresent(node: token)
-      ]
+      return .makePresent(node: token)
     }
   }
 }

--- a/Sources/SwiftParser/Diagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParser/Diagnostics/MissingNodesError.swift
@@ -17,9 +17,11 @@ import SwiftBasicFormat
 // MARK: - Shared code
 
 /// Returns a string that describes `missingNodes`.
-/// `missingNodes` are expected to all be children of `commonParent`.
-private func missingNodesDescription(missingNodes: [Syntax], commonParent: Syntax?) -> String {
-  assert(missingNodes.allSatisfy({ $0.parent == commonParent }))
+/// If `commonParent` is not `nil`, `missingNodes` are expected to all be children of `commonParent`.
+func missingNodesDescription(missingNodes: [Syntax], commonParent: Syntax?) -> String {
+  if commonParent != nil {
+    assert(missingNodes.allSatisfy({ $0.parent == commonParent }))
+  }
 
   // If all tokens in the parent are missing, return the parent type name.
   if let commonParent = commonParent,

--- a/Sources/SwiftParser/Diagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParser/Diagnostics/MissingNodesError.swift
@@ -256,7 +256,7 @@ extension ParseDiagnosticsGenerator {
 
     let fixIt = FixIt(
       message: InsertTokenFixIt(missingNodes: missingNodes),
-      changes: missingNodes.map(FixIt.Change.makePresent)
+      changes: missingNodes.map(FixIt.Changes.makePresent)
     )
 
     var notes: [Note] = []

--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -95,6 +95,51 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     return handledNodes.contains(node.id)
   }
 
+  /// Utility function to emit a diagnostic that removes a misplaced token and instead inserts an equivalent token at the corrected location.
+  ///
+  /// If `incorrectContainer` contains only tokens that satisfy `unexpectedTokenCondition`, emit a diagnostic with message `message` that marks this token as misplaced.
+  /// If `correctTokens` contains missing tokens, also emit a Fix-It with message `fixIt` that marks the unexpected token as missing and instead inserts `correctTokens`.
+  public func exchangeTokens(
+    unexpected: UnexpectedNodesSyntax?,
+    unexpectedTokenCondition: (TokenSyntax) -> Bool,
+    correctTokens: [TokenSyntax?],
+    message: (_ misplacedTokens: [TokenSyntax]) -> DiagnosticMessage,
+    fixIt: (_ misplacedTokens: [TokenSyntax]) -> FixItMessage
+  ) {
+    guard let incorrectContainer = unexpected,
+          let misplacedTokens = incorrectContainer.onlyTokens(satisfying: unexpectedTokenCondition) else {
+      // If there are no unexpected nodes or the unexpected contain multiple tokens, don't emit a diagnostic.
+      return
+    }
+
+    // Ignore `correctTokens` that are already present.
+    let correctTokens = correctTokens.compactMap({ $0 }).filter({ $0.presence == .missing })
+    var changes = misplacedTokens.map(FixIt.Changes.makeMissing)
+    for correctToken in correctTokens {
+      if misplacedTokens.count == 1, let misplacedToken = misplacedTokens.first,
+         misplacedToken.nextToken(viewMode: .all) == correctToken || misplacedToken.previousToken(viewMode: .all) == correctToken {
+        changes.append(FixIt.Changes.makePresent(
+          node: correctToken,
+          leadingTrivia: misplacedToken.leadingTrivia,
+          trailingTrivia: misplacedToken.trailingTrivia
+        ))
+      } else {
+        changes.append(FixIt.Changes.makePresent(
+          node: correctToken,
+          leadingTrivia: nil,
+          trailingTrivia: nil
+        ))
+      }
+    }
+    var fixIts: [FixIt] = []
+    if changes.count > 1 {
+      // Only emit a Fix-It if we are moving a token, i.e. also making a token present.
+      fixIts.append(FixIt(message: fixIt(misplacedTokens), changes: changes))
+    }
+
+    addDiagnostic(incorrectContainer, message(misplacedTokens), fixIts: fixIts, handledNodes: [incorrectContainer.id] + correctTokens.map(\.id))
+  }
+
   // MARK: - Generic diagnostic generation
 
   public override func visitAny(_ node: Syntax) -> SyntaxVisitorContinueKind {
@@ -180,6 +225,20 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
     return .visitChildren
   }
 
+  public override func visit(_ node: ArrowExprSyntax) -> SyntaxVisitorContinueKind {
+    if shouldSkip(node) {
+      return .skipChildren
+    }
+    exchangeTokens(
+      unexpected: node.unexpectedAfterArrowToken,
+      unexpectedTokenCondition: { $0.tokenKind == .contextualKeyword("async") || $0.tokenKind == .throwsKeyword },
+      correctTokens: [node.asyncKeyword, node.throwsToken],
+      message: { EffectsSpecifierAfterArrow(effectsSpecifiersAfterArrow: $0) },
+      fixIt: { MoveTokensInFrontOfFixIt(movedTokens: $0, inFrontOf: .arrow) }
+    )
+    return .visitChildren
+  }
+
   public override func visit(_ node: ForInStmtSyntax) -> SyntaxVisitorContinueKind {
     if shouldSkip(node) {
       return .skipChildren
@@ -221,7 +280,7 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
        let unexpectedBeforeReturnType = output.unexpectedBetweenArrowAndReturnType,
        let throwsInReturnPosition = unexpectedBeforeReturnType.tokens(withKind: .throwsKeyword).first {
       addDiagnostic(throwsInReturnPosition, .throwsInReturnPosition, fixIts: [
-        FixIt(message: .moveThrowBeforeArrow, changes: [
+        FixIt(message: MoveTokensInFrontOfFixIt(movedTokens: [missingThrowsKeyword], inFrontOf: .arrow), changes: [
           .makeMissing(node: throwsInReturnPosition),
           .makePresent(node: missingThrowsKeyword),
         ])

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -83,6 +83,14 @@ public enum StaticParserError: String, DiagnosticMessage {
 
 // MARK: - Diagnostics (please sort alphabetically)
 
+public struct EffectsSpecifierAfterArrow: ParserError {
+  public let effectsSpecifiersAfterArrow: [TokenSyntax]
+
+  public var message: String {
+    "\(missingNodesDescription(missingNodes: effectsSpecifiersAfterArrow.map(Syntax.init), commonParent: nil)) may only occur before '->'"
+  }
+}
+
 public struct ExtaneousCodeAtTopLevel: ParserError {
   public let extraneousCode: UnexpectedNodesSyntax
 
@@ -141,7 +149,6 @@ public struct UnexpectedNodesError: ParserError {
 public enum StaticParserFixIt: String, FixItMessage {
   case insertSemicolon = "insert ';'"
   case insertAttributeArguments = "insert attribute argument"
-  case moveThrowBeforeArrow = "move 'throws' before '->'"
 
   public var message: String { self.rawValue }
 
@@ -149,3 +156,16 @@ public enum StaticParserFixIt: String, FixItMessage {
     MessageID(domain: diagnosticDomain, id: "\(type(of: self)).\(self)")
   }
 }
+
+public struct MoveTokensInFrontOfFixIt: ParserFixIt {
+  /// The token that should be moved
+  public let movedTokens: [TokenSyntax]
+
+  /// The token after which 'try' should be moved
+  public let inFrontOf: RawTokenKind
+
+  public var message: String {
+    "move \(missingNodesDescription(missingNodes: movedTokens.map(Syntax.init), commonParent: nil)) in front of '\(inFrontOf.nameForDiagnostics)'"
+  }
+}
+

--- a/Sources/SwiftParser/Diagnostics/SyntaxExtensions.swift
+++ b/Sources/SwiftParser/Diagnostics/SyntaxExtensions.swift
@@ -20,6 +20,30 @@ extension UnexpectedNodesSyntax {
   func tokens(withKind kind: TokenKind) -> [TokenSyntax] {
     return self.tokens(satisfying: { $0.tokenKind == kind })
   }
+
+  /// If this only contains a single item that is a token, return that token, otherwise return `nil`.
+  var onlyToken: TokenSyntax? {
+    return onlyToken(where: { _ in true })
+  }
+
+  /// If this only contains a single item, which is a token satisfying `condition`, return that token, otherwise return `nil`.
+  func onlyToken(where condition: (TokenSyntax) -> Bool) -> TokenSyntax? {
+    if self.count == 1, let token = self.first?.as(TokenSyntax.self), condition(token) {
+      return token
+    } else {
+      return nil
+    }
+  }
+
+  /// If this only contains tokens satisfying `condition`, return an array containing those tokens, otherwise return `nil`.
+  func onlyTokens(satisfying condition: (TokenSyntax) -> Bool) -> [TokenSyntax]? {
+    let tokens = tokens(satisfying: condition)
+    if tokens.count == self.count {
+      return tokens
+    } else {
+      return nil
+    }
+  }
 }
 
 extension Syntax {

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxNodes.swift
@@ -364,15 +364,17 @@ public struct RawMissingDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax
     attributes: RawAttributeListSyntax?,
     _ unexpectedBetweenAttributesAndModifiers: RawUnexpectedNodesSyntax? = nil,
     modifiers: RawModifierListSyntax?,
+    _ unexpectedAfterModifiers: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .missingDecl, uninitializedCount: 4, arena: arena) { layout in
+      kind: .missingDecl, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
       layout[2] = unexpectedBetweenAttributesAndModifiers?.raw
       layout[3] = modifiers?.raw
+      layout[4] = unexpectedAfterModifiers?.raw
     }
     self.init(raw: raw)
   }
@@ -388,6 +390,9 @@ public struct RawMissingDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax
   }
   public var modifiers: RawModifierListSyntax? {
     layoutView.children[3].map(RawModifierListSyntax.init(raw:))
+  }
+  public var unexpectedAfterModifiers: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -549,10 +554,11 @@ public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     semicolon: RawTokenSyntax?,
     _ unexpectedBetweenSemicolonAndErrorTokens: RawUnexpectedNodesSyntax? = nil,
     errorTokens: RawSyntax?,
+    _ unexpectedAfterErrorTokens: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .codeBlockItem, uninitializedCount: 6, arena: arena) { layout in
+      kind: .codeBlockItem, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeItem?.raw
       layout[1] = item.raw
@@ -560,6 +566,7 @@ public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = semicolon?.raw
       layout[4] = unexpectedBetweenSemicolonAndErrorTokens?.raw
       layout[5] = errorTokens?.raw
+      layout[6] = unexpectedAfterErrorTokens?.raw
     }
     self.init(raw: raw)
   }
@@ -581,6 +588,9 @@ public struct RawCodeBlockItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var errorTokens: RawSyntax? {
     layoutView.children[5]
+  }
+  public var unexpectedAfterErrorTokens: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -654,10 +664,11 @@ public struct RawCodeBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     statements: RawCodeBlockItemListSyntax,
     _ unexpectedBetweenStatementsAndRightBrace: RawUnexpectedNodesSyntax? = nil,
     rightBrace: RawTokenSyntax,
+    _ unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .codeBlock, uninitializedCount: 6, arena: arena) { layout in
+      kind: .codeBlock, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftBrace?.raw
       layout[1] = leftBrace.raw
@@ -665,6 +676,7 @@ public struct RawCodeBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = statements.raw
       layout[4] = unexpectedBetweenStatementsAndRightBrace?.raw
       layout[5] = rightBrace.raw
+      layout[6] = unexpectedAfterRightBrace?.raw
     }
     self.init(raw: raw)
   }
@@ -686,6 +698,9 @@ public struct RawCodeBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var rightBrace: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -757,15 +772,17 @@ public struct RawInOutExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
     ampersand: RawTokenSyntax,
     _ unexpectedBetweenAmpersandAndExpression: RawUnexpectedNodesSyntax? = nil,
     expression: RawExprSyntax,
+    _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .inOutExpr, uninitializedCount: 4, arena: arena) { layout in
+      kind: .inOutExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAmpersand?.raw
       layout[1] = ampersand.raw
       layout[2] = unexpectedBetweenAmpersandAndExpression?.raw
       layout[3] = expression.raw
+      layout[4] = unexpectedAfterExpression?.raw
     }
     self.init(raw: raw)
   }
@@ -781,6 +798,9 @@ public struct RawInOutExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var expression: RawExprSyntax {
     layoutView.children[3].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -810,13 +830,15 @@ public struct RawPoundColumnExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
   public init(
     _ unexpectedBeforePoundColumn: RawUnexpectedNodesSyntax? = nil,
     poundColumn: RawTokenSyntax,
+    _ unexpectedAfterPoundColumn: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .poundColumnExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .poundColumnExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePoundColumn?.raw
       layout[1] = poundColumn.raw
+      layout[2] = unexpectedAfterPoundColumn?.raw
     }
     self.init(raw: raw)
   }
@@ -826,6 +848,9 @@ public struct RawPoundColumnExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
   }
   public var poundColumn: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterPoundColumn: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1019,10 +1044,11 @@ public struct RawTryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
     questionOrExclamationMark: RawTokenSyntax?,
     _ unexpectedBetweenQuestionOrExclamationMarkAndExpression: RawUnexpectedNodesSyntax? = nil,
     expression: RawExprSyntax,
+    _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .tryExpr, uninitializedCount: 6, arena: arena) { layout in
+      kind: .tryExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeTryKeyword?.raw
       layout[1] = tryKeyword.raw
@@ -1030,6 +1056,7 @@ public struct RawTryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = questionOrExclamationMark?.raw
       layout[4] = unexpectedBetweenQuestionOrExclamationMarkAndExpression?.raw
       layout[5] = expression.raw
+      layout[6] = unexpectedAfterExpression?.raw
     }
     self.init(raw: raw)
   }
@@ -1051,6 +1078,9 @@ public struct RawTryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var expression: RawExprSyntax {
     layoutView.children[5].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1082,15 +1112,17 @@ public struct RawAwaitExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
     awaitKeyword: RawTokenSyntax,
     _ unexpectedBetweenAwaitKeywordAndExpression: RawUnexpectedNodesSyntax? = nil,
     expression: RawExprSyntax,
+    _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .awaitExpr, uninitializedCount: 4, arena: arena) { layout in
+      kind: .awaitExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAwaitKeyword?.raw
       layout[1] = awaitKeyword.raw
       layout[2] = unexpectedBetweenAwaitKeywordAndExpression?.raw
       layout[3] = expression.raw
+      layout[4] = unexpectedAfterExpression?.raw
     }
     self.init(raw: raw)
   }
@@ -1106,6 +1138,9 @@ public struct RawAwaitExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var expression: RawExprSyntax {
     layoutView.children[3].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1137,15 +1172,17 @@ public struct RawMoveExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
     moveKeyword: RawTokenSyntax,
     _ unexpectedBetweenMoveKeywordAndExpression: RawUnexpectedNodesSyntax? = nil,
     expression: RawExprSyntax,
+    _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .moveExpr, uninitializedCount: 4, arena: arena) { layout in
+      kind: .moveExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeMoveKeyword?.raw
       layout[1] = moveKeyword.raw
       layout[2] = unexpectedBetweenMoveKeywordAndExpression?.raw
       layout[3] = expression.raw
+      layout[4] = unexpectedAfterExpression?.raw
     }
     self.init(raw: raw)
   }
@@ -1161,6 +1198,9 @@ public struct RawMoveExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var expression: RawExprSyntax {
     layoutView.children[3].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1192,15 +1232,17 @@ public struct RawDeclNameArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
     name: RawTokenSyntax,
     _ unexpectedBetweenNameAndColon: RawUnexpectedNodesSyntax? = nil,
     colon: RawTokenSyntax,
+    _ unexpectedAfterColon: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .declNameArgument, uninitializedCount: 4, arena: arena) { layout in
+      kind: .declNameArgument, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeName?.raw
       layout[1] = name.raw
       layout[2] = unexpectedBetweenNameAndColon?.raw
       layout[3] = colon.raw
+      layout[4] = unexpectedAfterColon?.raw
     }
     self.init(raw: raw)
   }
@@ -1216,6 +1258,9 @@ public struct RawDeclNameArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var colon: RawTokenSyntax {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterColon: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1289,10 +1334,11 @@ public struct RawDeclNameArgumentsSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
     arguments: RawDeclNameArgumentListSyntax,
     _ unexpectedBetweenArgumentsAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .declNameArguments, uninitializedCount: 6, arena: arena) { layout in
+      kind: .declNameArguments, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftParen?.raw
       layout[1] = leftParen.raw
@@ -1300,6 +1346,7 @@ public struct RawDeclNameArgumentsSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
       layout[3] = arguments.raw
       layout[4] = unexpectedBetweenArgumentsAndRightParen?.raw
       layout[5] = rightParen.raw
+      layout[6] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -1321,6 +1368,9 @@ public struct RawDeclNameArgumentsSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1352,15 +1402,17 @@ public struct RawIdentifierExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
     identifier: RawTokenSyntax,
     _ unexpectedBetweenIdentifierAndDeclNameArguments: RawUnexpectedNodesSyntax? = nil,
     declNameArguments: RawDeclNameArgumentsSyntax?,
+    _ unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .identifierExpr, uninitializedCount: 4, arena: arena) { layout in
+      kind: .identifierExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeIdentifier?.raw
       layout[1] = identifier.raw
       layout[2] = unexpectedBetweenIdentifierAndDeclNameArguments?.raw
       layout[3] = declNameArguments?.raw
+      layout[4] = unexpectedAfterDeclNameArguments?.raw
     }
     self.init(raw: raw)
   }
@@ -1376,6 +1428,9 @@ public struct RawIdentifierExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var declNameArguments: RawDeclNameArgumentsSyntax? {
     layoutView.children[3].map(RawDeclNameArgumentsSyntax.init(raw:))
+  }
+  public var unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1405,13 +1460,15 @@ public struct RawSuperRefExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynta
   public init(
     _ unexpectedBeforeSuperKeyword: RawUnexpectedNodesSyntax? = nil,
     superKeyword: RawTokenSyntax,
+    _ unexpectedAfterSuperKeyword: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .superRefExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .superRefExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeSuperKeyword?.raw
       layout[1] = superKeyword.raw
+      layout[2] = unexpectedAfterSuperKeyword?.raw
     }
     self.init(raw: raw)
   }
@@ -1421,6 +1478,9 @@ public struct RawSuperRefExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var superKeyword: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterSuperKeyword: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1450,13 +1510,15 @@ public struct RawNilLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
   public init(
     _ unexpectedBeforeNilKeyword: RawUnexpectedNodesSyntax? = nil,
     nilKeyword: RawTokenSyntax,
+    _ unexpectedAfterNilKeyword: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .nilLiteralExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .nilLiteralExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeNilKeyword?.raw
       layout[1] = nilKeyword.raw
+      layout[2] = unexpectedAfterNilKeyword?.raw
     }
     self.init(raw: raw)
   }
@@ -1466,6 +1528,9 @@ public struct RawNilLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var nilKeyword: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterNilKeyword: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1495,13 +1560,15 @@ public struct RawDiscardAssignmentExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
   public init(
     _ unexpectedBeforeWildcard: RawUnexpectedNodesSyntax? = nil,
     wildcard: RawTokenSyntax,
+    _ unexpectedAfterWildcard: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .discardAssignmentExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .discardAssignmentExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeWildcard?.raw
       layout[1] = wildcard.raw
+      layout[2] = unexpectedAfterWildcard?.raw
     }
     self.init(raw: raw)
   }
@@ -1511,6 +1578,9 @@ public struct RawDiscardAssignmentExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
   }
   public var wildcard: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterWildcard: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1540,13 +1610,15 @@ public struct RawAssignmentExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
   public init(
     _ unexpectedBeforeAssignToken: RawUnexpectedNodesSyntax? = nil,
     assignToken: RawTokenSyntax,
+    _ unexpectedAfterAssignToken: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .assignmentExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .assignmentExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAssignToken?.raw
       layout[1] = assignToken.raw
+      layout[2] = unexpectedAfterAssignToken?.raw
     }
     self.init(raw: raw)
   }
@@ -1556,6 +1628,9 @@ public struct RawAssignmentExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var assignToken: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterAssignToken: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1585,13 +1660,15 @@ public struct RawSequenceExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynta
   public init(
     _ unexpectedBeforeElements: RawUnexpectedNodesSyntax? = nil,
     elements: RawExprListSyntax,
+    _ unexpectedAfterElements: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .sequenceExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .sequenceExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeElements?.raw
       layout[1] = elements.raw
+      layout[2] = unexpectedAfterElements?.raw
     }
     self.init(raw: raw)
   }
@@ -1601,6 +1678,9 @@ public struct RawSequenceExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var elements: RawExprListSyntax {
     layoutView.children[1].map(RawExprListSyntax.init(raw:))!
+  }
+  public var unexpectedAfterElements: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1670,13 +1750,15 @@ public struct RawPoundLineExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynt
   public init(
     _ unexpectedBeforePoundLine: RawUnexpectedNodesSyntax? = nil,
     poundLine: RawTokenSyntax,
+    _ unexpectedAfterPoundLine: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .poundLineExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .poundLineExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePoundLine?.raw
       layout[1] = poundLine.raw
+      layout[2] = unexpectedAfterPoundLine?.raw
     }
     self.init(raw: raw)
   }
@@ -1686,6 +1768,9 @@ public struct RawPoundLineExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynt
   }
   public var poundLine: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterPoundLine: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1715,13 +1800,15 @@ public struct RawPoundFileExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynt
   public init(
     _ unexpectedBeforePoundFile: RawUnexpectedNodesSyntax? = nil,
     poundFile: RawTokenSyntax,
+    _ unexpectedAfterPoundFile: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .poundFileExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .poundFileExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePoundFile?.raw
       layout[1] = poundFile.raw
+      layout[2] = unexpectedAfterPoundFile?.raw
     }
     self.init(raw: raw)
   }
@@ -1731,6 +1818,9 @@ public struct RawPoundFileExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynt
   }
   public var poundFile: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterPoundFile: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1760,13 +1850,15 @@ public struct RawPoundFileIDExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
   public init(
     _ unexpectedBeforePoundFileID: RawUnexpectedNodesSyntax? = nil,
     poundFileID: RawTokenSyntax,
+    _ unexpectedAfterPoundFileID: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .poundFileIDExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .poundFileIDExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePoundFileID?.raw
       layout[1] = poundFileID.raw
+      layout[2] = unexpectedAfterPoundFileID?.raw
     }
     self.init(raw: raw)
   }
@@ -1776,6 +1868,9 @@ public struct RawPoundFileIDExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
   }
   public var poundFileID: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterPoundFileID: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1805,13 +1900,15 @@ public struct RawPoundFilePathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
   public init(
     _ unexpectedBeforePoundFilePath: RawUnexpectedNodesSyntax? = nil,
     poundFilePath: RawTokenSyntax,
+    _ unexpectedAfterPoundFilePath: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .poundFilePathExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .poundFilePathExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePoundFilePath?.raw
       layout[1] = poundFilePath.raw
+      layout[2] = unexpectedAfterPoundFilePath?.raw
     }
     self.init(raw: raw)
   }
@@ -1821,6 +1918,9 @@ public struct RawPoundFilePathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
   }
   public var poundFilePath: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterPoundFilePath: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1850,13 +1950,15 @@ public struct RawPoundFunctionExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
   public init(
     _ unexpectedBeforePoundFunction: RawUnexpectedNodesSyntax? = nil,
     poundFunction: RawTokenSyntax,
+    _ unexpectedAfterPoundFunction: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .poundFunctionExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .poundFunctionExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePoundFunction?.raw
       layout[1] = poundFunction.raw
+      layout[2] = unexpectedAfterPoundFunction?.raw
     }
     self.init(raw: raw)
   }
@@ -1866,6 +1968,9 @@ public struct RawPoundFunctionExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
   }
   public var poundFunction: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterPoundFunction: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1895,13 +2000,15 @@ public struct RawPoundDsohandleExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
   public init(
     _ unexpectedBeforePoundDsohandle: RawUnexpectedNodesSyntax? = nil,
     poundDsohandle: RawTokenSyntax,
+    _ unexpectedAfterPoundDsohandle: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .poundDsohandleExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .poundDsohandleExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePoundDsohandle?.raw
       layout[1] = poundDsohandle.raw
+      layout[2] = unexpectedAfterPoundDsohandle?.raw
     }
     self.init(raw: raw)
   }
@@ -1911,6 +2018,9 @@ public struct RawPoundDsohandleExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
   }
   public var poundDsohandle: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterPoundDsohandle: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1942,15 +2052,17 @@ public struct RawSymbolicReferenceExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
     identifier: RawTokenSyntax,
     _ unexpectedBetweenIdentifierAndGenericArgumentClause: RawUnexpectedNodesSyntax? = nil,
     genericArgumentClause: RawGenericArgumentClauseSyntax?,
+    _ unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .symbolicReferenceExpr, uninitializedCount: 4, arena: arena) { layout in
+      kind: .symbolicReferenceExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeIdentifier?.raw
       layout[1] = identifier.raw
       layout[2] = unexpectedBetweenIdentifierAndGenericArgumentClause?.raw
       layout[3] = genericArgumentClause?.raw
+      layout[4] = unexpectedAfterGenericArgumentClause?.raw
     }
     self.init(raw: raw)
   }
@@ -1966,6 +2078,9 @@ public struct RawSymbolicReferenceExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
   }
   public var genericArgumentClause: RawGenericArgumentClauseSyntax? {
     layoutView.children[3].map(RawGenericArgumentClauseSyntax.init(raw:))
+  }
+  public var unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -1997,15 +2112,17 @@ public struct RawPrefixOperatorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
     operatorToken: RawTokenSyntax?,
     _ unexpectedBetweenOperatorTokenAndPostfixExpression: RawUnexpectedNodesSyntax? = nil,
     postfixExpression: RawExprSyntax,
+    _ unexpectedAfterPostfixExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .prefixOperatorExpr, uninitializedCount: 4, arena: arena) { layout in
+      kind: .prefixOperatorExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeOperatorToken?.raw
       layout[1] = operatorToken?.raw
       layout[2] = unexpectedBetweenOperatorTokenAndPostfixExpression?.raw
       layout[3] = postfixExpression.raw
+      layout[4] = unexpectedAfterPostfixExpression?.raw
     }
     self.init(raw: raw)
   }
@@ -2021,6 +2138,9 @@ public struct RawPrefixOperatorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
   }
   public var postfixExpression: RawExprSyntax {
     layoutView.children[3].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterPostfixExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2050,13 +2170,15 @@ public struct RawBinaryOperatorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
   public init(
     _ unexpectedBeforeOperatorToken: RawUnexpectedNodesSyntax? = nil,
     operatorToken: RawTokenSyntax,
+    _ unexpectedAfterOperatorToken: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .binaryOperatorExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .binaryOperatorExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeOperatorToken?.raw
       layout[1] = operatorToken.raw
+      layout[2] = unexpectedAfterOperatorToken?.raw
     }
     self.init(raw: raw)
   }
@@ -2066,6 +2188,9 @@ public struct RawBinaryOperatorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
   }
   public var operatorToken: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterOperatorToken: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2099,10 +2224,11 @@ public struct RawArrowExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
     throwsToken: RawTokenSyntax?,
     _ unexpectedBetweenThrowsTokenAndArrowToken: RawUnexpectedNodesSyntax? = nil,
     arrowToken: RawTokenSyntax,
+    _ unexpectedAfterArrowToken: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .arrowExpr, uninitializedCount: 6, arena: arena) { layout in
+      kind: .arrowExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAsyncKeyword?.raw
       layout[1] = asyncKeyword?.raw
@@ -2110,6 +2236,7 @@ public struct RawArrowExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = throwsToken?.raw
       layout[4] = unexpectedBetweenThrowsTokenAndArrowToken?.raw
       layout[5] = arrowToken.raw
+      layout[6] = unexpectedAfterArrowToken?.raw
     }
     self.init(raw: raw)
   }
@@ -2131,6 +2258,9 @@ public struct RawArrowExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var arrowToken: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterArrowToken: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2164,10 +2294,11 @@ public struct RawInfixOperatorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
     operatorOperand: RawExprSyntax,
     _ unexpectedBetweenOperatorOperandAndRightOperand: RawUnexpectedNodesSyntax? = nil,
     rightOperand: RawExprSyntax,
+    _ unexpectedAfterRightOperand: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .infixOperatorExpr, uninitializedCount: 6, arena: arena) { layout in
+      kind: .infixOperatorExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftOperand?.raw
       layout[1] = leftOperand.raw
@@ -2175,6 +2306,7 @@ public struct RawInfixOperatorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
       layout[3] = operatorOperand.raw
       layout[4] = unexpectedBetweenOperatorOperandAndRightOperand?.raw
       layout[5] = rightOperand.raw
+      layout[6] = unexpectedAfterRightOperand?.raw
     }
     self.init(raw: raw)
   }
@@ -2196,6 +2328,9 @@ public struct RawInfixOperatorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
   }
   public var rightOperand: RawExprSyntax {
     layoutView.children[5].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightOperand: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2225,13 +2360,15 @@ public struct RawFloatLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
   public init(
     _ unexpectedBeforeFloatingDigits: RawUnexpectedNodesSyntax? = nil,
     floatingDigits: RawTokenSyntax,
+    _ unexpectedAfterFloatingDigits: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .floatLiteralExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .floatLiteralExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeFloatingDigits?.raw
       layout[1] = floatingDigits.raw
+      layout[2] = unexpectedAfterFloatingDigits?.raw
     }
     self.init(raw: raw)
   }
@@ -2241,6 +2378,9 @@ public struct RawFloatLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
   }
   public var floatingDigits: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterFloatingDigits: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2274,10 +2414,11 @@ public struct RawTupleExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
     elementList: RawTupleExprElementListSyntax,
     _ unexpectedBetweenElementListAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .tupleExpr, uninitializedCount: 6, arena: arena) { layout in
+      kind: .tupleExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftParen?.raw
       layout[1] = leftParen.raw
@@ -2285,6 +2426,7 @@ public struct RawTupleExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = elementList.raw
       layout[4] = unexpectedBetweenElementListAndRightParen?.raw
       layout[5] = rightParen.raw
+      layout[6] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -2306,6 +2448,9 @@ public struct RawTupleExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2339,10 +2484,11 @@ public struct RawArrayExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
     elements: RawArrayElementListSyntax,
     _ unexpectedBetweenElementsAndRightSquare: RawUnexpectedNodesSyntax? = nil,
     rightSquare: RawTokenSyntax,
+    _ unexpectedAfterRightSquare: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .arrayExpr, uninitializedCount: 6, arena: arena) { layout in
+      kind: .arrayExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftSquare?.raw
       layout[1] = leftSquare.raw
@@ -2350,6 +2496,7 @@ public struct RawArrayExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = elements.raw
       layout[4] = unexpectedBetweenElementsAndRightSquare?.raw
       layout[5] = rightSquare.raw
+      layout[6] = unexpectedAfterRightSquare?.raw
     }
     self.init(raw: raw)
   }
@@ -2371,6 +2518,9 @@ public struct RawArrayExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var rightSquare: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightSquare: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2404,10 +2554,11 @@ public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
     content: RawSyntax,
     _ unexpectedBetweenContentAndRightSquare: RawUnexpectedNodesSyntax? = nil,
     rightSquare: RawTokenSyntax,
+    _ unexpectedAfterRightSquare: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .dictionaryExpr, uninitializedCount: 6, arena: arena) { layout in
+      kind: .dictionaryExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftSquare?.raw
       layout[1] = leftSquare.raw
@@ -2415,6 +2566,7 @@ public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
       layout[3] = content.raw
       layout[4] = unexpectedBetweenContentAndRightSquare?.raw
       layout[5] = rightSquare.raw
+      layout[6] = unexpectedAfterRightSquare?.raw
     }
     self.init(raw: raw)
   }
@@ -2436,6 +2588,9 @@ public struct RawDictionaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var rightSquare: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightSquare: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2471,10 +2626,11 @@ public struct RawTupleExprElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
     expression: RawExprSyntax,
     _ unexpectedBetweenExpressionAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .tupleExprElement, uninitializedCount: 8, arena: arena) { layout in
+      kind: .tupleExprElement, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLabel?.raw
       layout[1] = label?.raw
@@ -2484,6 +2640,7 @@ public struct RawTupleExprElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
       layout[5] = expression.raw
       layout[6] = unexpectedBetweenExpressionAndTrailingComma?.raw
       layout[7] = trailingComma?.raw
+      layout[8] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -2511,6 +2668,9 @@ public struct RawTupleExprElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2542,15 +2702,17 @@ public struct RawArrayElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     expression: RawExprSyntax,
     _ unexpectedBetweenExpressionAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .arrayElement, uninitializedCount: 4, arena: arena) { layout in
+      kind: .arrayElement, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeExpression?.raw
       layout[1] = expression.raw
       layout[2] = unexpectedBetweenExpressionAndTrailingComma?.raw
       layout[3] = trailingComma?.raw
+      layout[4] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -2566,6 +2728,9 @@ public struct RawArrayElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2601,10 +2766,11 @@ public struct RawDictionaryElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
     valueExpression: RawExprSyntax,
     _ unexpectedBetweenValueExpressionAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .dictionaryElement, uninitializedCount: 8, arena: arena) { layout in
+      kind: .dictionaryElement, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeKeyExpression?.raw
       layout[1] = keyExpression.raw
@@ -2614,6 +2780,7 @@ public struct RawDictionaryElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
       layout[5] = valueExpression.raw
       layout[6] = unexpectedBetweenValueExpressionAndTrailingComma?.raw
       layout[7] = trailingComma?.raw
+      layout[8] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -2641,6 +2808,9 @@ public struct RawDictionaryElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2670,13 +2840,15 @@ public struct RawIntegerLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
   public init(
     _ unexpectedBeforeDigits: RawUnexpectedNodesSyntax? = nil,
     digits: RawTokenSyntax,
+    _ unexpectedAfterDigits: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .integerLiteralExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .integerLiteralExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeDigits?.raw
       layout[1] = digits.raw
+      layout[2] = unexpectedAfterDigits?.raw
     }
     self.init(raw: raw)
   }
@@ -2686,6 +2858,9 @@ public struct RawIntegerLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
   }
   public var digits: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterDigits: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2715,13 +2890,15 @@ public struct RawBooleanLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
   public init(
     _ unexpectedBeforeBooleanLiteral: RawUnexpectedNodesSyntax? = nil,
     booleanLiteral: RawTokenSyntax,
+    _ unexpectedAfterBooleanLiteral: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .booleanLiteralExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .booleanLiteralExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeBooleanLiteral?.raw
       layout[1] = booleanLiteral.raw
+      layout[2] = unexpectedAfterBooleanLiteral?.raw
     }
     self.init(raw: raw)
   }
@@ -2731,6 +2908,9 @@ public struct RawBooleanLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxT
   }
   public var booleanLiteral: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterBooleanLiteral: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2764,10 +2944,11 @@ public struct RawUnresolvedTernaryExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
     firstChoice: RawExprSyntax,
     _ unexpectedBetweenFirstChoiceAndColonMark: RawUnexpectedNodesSyntax? = nil,
     colonMark: RawTokenSyntax,
+    _ unexpectedAfterColonMark: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .unresolvedTernaryExpr, uninitializedCount: 6, arena: arena) { layout in
+      kind: .unresolvedTernaryExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeQuestionMark?.raw
       layout[1] = questionMark.raw
@@ -2775,6 +2956,7 @@ public struct RawUnresolvedTernaryExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
       layout[3] = firstChoice.raw
       layout[4] = unexpectedBetweenFirstChoiceAndColonMark?.raw
       layout[5] = colonMark.raw
+      layout[6] = unexpectedAfterColonMark?.raw
     }
     self.init(raw: raw)
   }
@@ -2796,6 +2978,9 @@ public struct RawUnresolvedTernaryExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
   }
   public var colonMark: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterColonMark: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2833,10 +3018,11 @@ public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax
     colonMark: RawTokenSyntax,
     _ unexpectedBetweenColonMarkAndSecondChoice: RawUnexpectedNodesSyntax? = nil,
     secondChoice: RawExprSyntax,
+    _ unexpectedAfterSecondChoice: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .ternaryExpr, uninitializedCount: 10, arena: arena) { layout in
+      kind: .ternaryExpr, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeConditionExpression?.raw
       layout[1] = conditionExpression.raw
@@ -2848,6 +3034,7 @@ public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax
       layout[7] = colonMark.raw
       layout[8] = unexpectedBetweenColonMarkAndSecondChoice?.raw
       layout[9] = secondChoice.raw
+      layout[10] = unexpectedAfterSecondChoice?.raw
     }
     self.init(raw: raw)
   }
@@ -2881,6 +3068,9 @@ public struct RawTernaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax
   }
   public var secondChoice: RawExprSyntax {
     layoutView.children[9].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterSecondChoice: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2916,10 +3106,11 @@ public struct RawMemberAccessExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
     name: RawTokenSyntax,
     _ unexpectedBetweenNameAndDeclNameArguments: RawUnexpectedNodesSyntax? = nil,
     declNameArguments: RawDeclNameArgumentsSyntax?,
+    _ unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .memberAccessExpr, uninitializedCount: 8, arena: arena) { layout in
+      kind: .memberAccessExpr, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeBase?.raw
       layout[1] = base?.raw
@@ -2929,6 +3120,7 @@ public struct RawMemberAccessExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
       layout[5] = name.raw
       layout[6] = unexpectedBetweenNameAndDeclNameArguments?.raw
       layout[7] = declNameArguments?.raw
+      layout[8] = unexpectedAfterDeclNameArguments?.raw
     }
     self.init(raw: raw)
   }
@@ -2956,6 +3148,9 @@ public struct RawMemberAccessExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
   }
   public var declNameArguments: RawDeclNameArgumentsSyntax? {
     layoutView.children[7].map(RawDeclNameArgumentsSyntax.init(raw:))
+  }
+  public var unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -2985,13 +3180,15 @@ public struct RawUnresolvedIsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
   public init(
     _ unexpectedBeforeIsTok: RawUnexpectedNodesSyntax? = nil,
     isTok: RawTokenSyntax,
+    _ unexpectedAfterIsTok: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .unresolvedIsExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .unresolvedIsExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeIsTok?.raw
       layout[1] = isTok.raw
+      layout[2] = unexpectedAfterIsTok?.raw
     }
     self.init(raw: raw)
   }
@@ -3001,6 +3198,9 @@ public struct RawUnresolvedIsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
   }
   public var isTok: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterIsTok: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -3034,10 +3234,11 @@ public struct RawIsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
     isTok: RawTokenSyntax,
     _ unexpectedBetweenIsTokAndTypeName: RawUnexpectedNodesSyntax? = nil,
     typeName: RawTypeSyntax,
+    _ unexpectedAfterTypeName: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .isExpr, uninitializedCount: 6, arena: arena) { layout in
+      kind: .isExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeExpression?.raw
       layout[1] = expression.raw
@@ -3045,6 +3246,7 @@ public struct RawIsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = isTok.raw
       layout[4] = unexpectedBetweenIsTokAndTypeName?.raw
       layout[5] = typeName.raw
+      layout[6] = unexpectedAfterTypeName?.raw
     }
     self.init(raw: raw)
   }
@@ -3066,6 +3268,9 @@ public struct RawIsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var typeName: RawTypeSyntax {
     layoutView.children[5].map(RawTypeSyntax.init(raw:))!
+  }
+  public var unexpectedAfterTypeName: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -3097,15 +3302,17 @@ public struct RawUnresolvedAsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
     asTok: RawTokenSyntax,
     _ unexpectedBetweenAsTokAndQuestionOrExclamationMark: RawUnexpectedNodesSyntax? = nil,
     questionOrExclamationMark: RawTokenSyntax?,
+    _ unexpectedAfterQuestionOrExclamationMark: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .unresolvedAsExpr, uninitializedCount: 4, arena: arena) { layout in
+      kind: .unresolvedAsExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAsTok?.raw
       layout[1] = asTok.raw
       layout[2] = unexpectedBetweenAsTokAndQuestionOrExclamationMark?.raw
       layout[3] = questionOrExclamationMark?.raw
+      layout[4] = unexpectedAfterQuestionOrExclamationMark?.raw
     }
     self.init(raw: raw)
   }
@@ -3121,6 +3328,9 @@ public struct RawUnresolvedAsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
   }
   public var questionOrExclamationMark: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterQuestionOrExclamationMark: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -3156,10 +3366,11 @@ public struct RawAsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
     questionOrExclamationMark: RawTokenSyntax?,
     _ unexpectedBetweenQuestionOrExclamationMarkAndTypeName: RawUnexpectedNodesSyntax? = nil,
     typeName: RawTypeSyntax,
+    _ unexpectedAfterTypeName: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .asExpr, uninitializedCount: 8, arena: arena) { layout in
+      kind: .asExpr, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeExpression?.raw
       layout[1] = expression.raw
@@ -3169,6 +3380,7 @@ public struct RawAsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[5] = questionOrExclamationMark?.raw
       layout[6] = unexpectedBetweenQuestionOrExclamationMarkAndTypeName?.raw
       layout[7] = typeName.raw
+      layout[8] = unexpectedAfterTypeName?.raw
     }
     self.init(raw: raw)
   }
@@ -3196,6 +3408,9 @@ public struct RawAsExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var typeName: RawTypeSyntax {
     layoutView.children[7].map(RawTypeSyntax.init(raw:))!
+  }
+  public var unexpectedAfterTypeName: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -3225,13 +3440,15 @@ public struct RawTypeExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   public init(
     _ unexpectedBeforeType: RawUnexpectedNodesSyntax? = nil,
     type: RawTypeSyntax,
+    _ unexpectedAfterType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .typeExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .typeExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeType?.raw
       layout[1] = type.raw
+      layout[2] = unexpectedAfterType?.raw
     }
     self.init(raw: raw)
   }
@@ -3241,6 +3458,9 @@ public struct RawTypeExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var type: RawTypeSyntax {
     layoutView.children[1].map(RawTypeSyntax.init(raw:))!
+  }
+  public var unexpectedAfterType: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -3278,10 +3498,11 @@ public struct RawClosureCaptureItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
     expression: RawExprSyntax,
     _ unexpectedBetweenExpressionAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .closureCaptureItem, uninitializedCount: 10, arena: arena) { layout in
+      kind: .closureCaptureItem, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeSpecifier?.raw
       layout[1] = specifier?.raw
@@ -3293,6 +3514,7 @@ public struct RawClosureCaptureItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
       layout[7] = expression.raw
       layout[8] = unexpectedBetweenExpressionAndTrailingComma?.raw
       layout[9] = trailingComma?.raw
+      layout[10] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -3326,6 +3548,9 @@ public struct RawClosureCaptureItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[9].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -3399,10 +3624,11 @@ public struct RawClosureCaptureSignatureSyntax: RawSyntaxNodeProtocol, RawSyntax
     items: RawClosureCaptureItemListSyntax?,
     _ unexpectedBetweenItemsAndRightSquare: RawUnexpectedNodesSyntax? = nil,
     rightSquare: RawTokenSyntax,
+    _ unexpectedAfterRightSquare: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .closureCaptureSignature, uninitializedCount: 6, arena: arena) { layout in
+      kind: .closureCaptureSignature, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftSquare?.raw
       layout[1] = leftSquare.raw
@@ -3410,6 +3636,7 @@ public struct RawClosureCaptureSignatureSyntax: RawSyntaxNodeProtocol, RawSyntax
       layout[3] = items?.raw
       layout[4] = unexpectedBetweenItemsAndRightSquare?.raw
       layout[5] = rightSquare.raw
+      layout[6] = unexpectedAfterRightSquare?.raw
     }
     self.init(raw: raw)
   }
@@ -3431,6 +3658,9 @@ public struct RawClosureCaptureSignatureSyntax: RawSyntaxNodeProtocol, RawSyntax
   }
   public var rightSquare: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightSquare: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -3462,15 +3692,17 @@ public struct RawClosureParamSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     name: RawTokenSyntax,
     _ unexpectedBetweenNameAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .closureParam, uninitializedCount: 4, arena: arena) { layout in
+      kind: .closureParam, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeName?.raw
       layout[1] = name.raw
       layout[2] = unexpectedBetweenNameAndTrailingComma?.raw
       layout[3] = trailingComma?.raw
+      layout[4] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -3486,6 +3718,9 @@ public struct RawClosureParamSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -3567,10 +3802,11 @@ public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
     output: RawReturnClauseSyntax?,
     _ unexpectedBetweenOutputAndInTok: RawUnexpectedNodesSyntax? = nil,
     inTok: RawTokenSyntax,
+    _ unexpectedAfterInTok: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .closureSignature, uninitializedCount: 14, arena: arena) { layout in
+      kind: .closureSignature, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -3586,6 +3822,7 @@ public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
       layout[11] = output?.raw
       layout[12] = unexpectedBetweenOutputAndInTok?.raw
       layout[13] = inTok.raw
+      layout[14] = unexpectedAfterInTok?.raw
     }
     self.init(raw: raw)
   }
@@ -3632,6 +3869,9 @@ public struct RawClosureSignatureSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
   public var inTok: RawTokenSyntax {
     layoutView.children[13].map(RawTokenSyntax.init(raw:))!
   }
+  public var unexpectedAfterInTok: RawUnexpectedNodesSyntax? {
+    layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -3666,10 +3906,11 @@ public struct RawClosureExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax
     statements: RawCodeBlockItemListSyntax,
     _ unexpectedBetweenStatementsAndRightBrace: RawUnexpectedNodesSyntax? = nil,
     rightBrace: RawTokenSyntax,
+    _ unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .closureExpr, uninitializedCount: 8, arena: arena) { layout in
+      kind: .closureExpr, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftBrace?.raw
       layout[1] = leftBrace.raw
@@ -3679,6 +3920,7 @@ public struct RawClosureExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax
       layout[5] = statements.raw
       layout[6] = unexpectedBetweenStatementsAndRightBrace?.raw
       layout[7] = rightBrace.raw
+      layout[8] = unexpectedAfterRightBrace?.raw
     }
     self.init(raw: raw)
   }
@@ -3706,6 +3948,9 @@ public struct RawClosureExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax
   }
   public var rightBrace: RawTokenSyntax {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -3735,13 +3980,15 @@ public struct RawUnresolvedPatternExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
   public init(
     _ unexpectedBeforePattern: RawUnexpectedNodesSyntax? = nil,
     pattern: RawPatternSyntax,
+    _ unexpectedAfterPattern: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .unresolvedPatternExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .unresolvedPatternExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePattern?.raw
       layout[1] = pattern.raw
+      layout[2] = unexpectedAfterPattern?.raw
     }
     self.init(raw: raw)
   }
@@ -3751,6 +3998,9 @@ public struct RawUnresolvedPatternExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
   }
   public var pattern: RawPatternSyntax {
     layoutView.children[1].map(RawPatternSyntax.init(raw:))!
+  }
+  public var unexpectedAfterPattern: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -3784,10 +4034,11 @@ public struct RawMultipleTrailingClosureElementSyntax: RawSyntaxNodeProtocol, Ra
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndClosure: RawUnexpectedNodesSyntax? = nil,
     closure: RawClosureExprSyntax,
+    _ unexpectedAfterClosure: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .multipleTrailingClosureElement, uninitializedCount: 6, arena: arena) { layout in
+      kind: .multipleTrailingClosureElement, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLabel?.raw
       layout[1] = label.raw
@@ -3795,6 +4046,7 @@ public struct RawMultipleTrailingClosureElementSyntax: RawSyntaxNodeProtocol, Ra
       layout[3] = colon.raw
       layout[4] = unexpectedBetweenColonAndClosure?.raw
       layout[5] = closure.raw
+      layout[6] = unexpectedAfterClosure?.raw
     }
     self.init(raw: raw)
   }
@@ -3816,6 +4068,9 @@ public struct RawMultipleTrailingClosureElementSyntax: RawSyntaxNodeProtocol, Ra
   }
   public var closure: RawClosureExprSyntax {
     layoutView.children[5].map(RawClosureExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterClosure: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -3895,10 +4150,11 @@ public struct RawFunctionCallExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
     trailingClosure: RawClosureExprSyntax?,
     _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: RawUnexpectedNodesSyntax? = nil,
     additionalTrailingClosures: RawMultipleTrailingClosureElementListSyntax?,
+    _ unexpectedAfterAdditionalTrailingClosures: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .functionCallExpr, uninitializedCount: 12, arena: arena) { layout in
+      kind: .functionCallExpr, uninitializedCount: 13, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeCalledExpression?.raw
       layout[1] = calledExpression.raw
@@ -3912,6 +4168,7 @@ public struct RawFunctionCallExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
       layout[9] = trailingClosure?.raw
       layout[10] = unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.raw
       layout[11] = additionalTrailingClosures?.raw
+      layout[12] = unexpectedAfterAdditionalTrailingClosures?.raw
     }
     self.init(raw: raw)
   }
@@ -3952,6 +4209,9 @@ public struct RawFunctionCallExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
   public var additionalTrailingClosures: RawMultipleTrailingClosureElementListSyntax? {
     layoutView.children[11].map(RawMultipleTrailingClosureElementListSyntax.init(raw:))
   }
+  public var unexpectedAfterAdditionalTrailingClosures: RawUnexpectedNodesSyntax? {
+    layoutView.children[12].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -3990,10 +4250,11 @@ public struct RawSubscriptExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynt
     trailingClosure: RawClosureExprSyntax?,
     _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: RawUnexpectedNodesSyntax? = nil,
     additionalTrailingClosures: RawMultipleTrailingClosureElementListSyntax?,
+    _ unexpectedAfterAdditionalTrailingClosures: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .subscriptExpr, uninitializedCount: 12, arena: arena) { layout in
+      kind: .subscriptExpr, uninitializedCount: 13, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeCalledExpression?.raw
       layout[1] = calledExpression.raw
@@ -4007,6 +4268,7 @@ public struct RawSubscriptExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynt
       layout[9] = trailingClosure?.raw
       layout[10] = unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.raw
       layout[11] = additionalTrailingClosures?.raw
+      layout[12] = unexpectedAfterAdditionalTrailingClosures?.raw
     }
     self.init(raw: raw)
   }
@@ -4047,6 +4309,9 @@ public struct RawSubscriptExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSynt
   public var additionalTrailingClosures: RawMultipleTrailingClosureElementListSyntax? {
     layoutView.children[11].map(RawMultipleTrailingClosureElementListSyntax.init(raw:))
   }
+  public var unexpectedAfterAdditionalTrailingClosures: RawUnexpectedNodesSyntax? {
+    layoutView.children[12].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -4077,15 +4342,17 @@ public struct RawOptionalChainingExprSyntax: RawExprSyntaxNodeProtocol, RawSynta
     expression: RawExprSyntax,
     _ unexpectedBetweenExpressionAndQuestionMark: RawUnexpectedNodesSyntax? = nil,
     questionMark: RawTokenSyntax,
+    _ unexpectedAfterQuestionMark: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .optionalChainingExpr, uninitializedCount: 4, arena: arena) { layout in
+      kind: .optionalChainingExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeExpression?.raw
       layout[1] = expression.raw
       layout[2] = unexpectedBetweenExpressionAndQuestionMark?.raw
       layout[3] = questionMark.raw
+      layout[4] = unexpectedAfterQuestionMark?.raw
     }
     self.init(raw: raw)
   }
@@ -4101,6 +4368,9 @@ public struct RawOptionalChainingExprSyntax: RawExprSyntaxNodeProtocol, RawSynta
   }
   public var questionMark: RawTokenSyntax {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterQuestionMark: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -4132,15 +4402,17 @@ public struct RawForcedValueExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
     expression: RawExprSyntax,
     _ unexpectedBetweenExpressionAndExclamationMark: RawUnexpectedNodesSyntax? = nil,
     exclamationMark: RawTokenSyntax,
+    _ unexpectedAfterExclamationMark: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .forcedValueExpr, uninitializedCount: 4, arena: arena) { layout in
+      kind: .forcedValueExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeExpression?.raw
       layout[1] = expression.raw
       layout[2] = unexpectedBetweenExpressionAndExclamationMark?.raw
       layout[3] = exclamationMark.raw
+      layout[4] = unexpectedAfterExclamationMark?.raw
     }
     self.init(raw: raw)
   }
@@ -4156,6 +4428,9 @@ public struct RawForcedValueExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
   }
   public var exclamationMark: RawTokenSyntax {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterExclamationMark: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -4187,15 +4462,17 @@ public struct RawPostfixUnaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
     expression: RawExprSyntax,
     _ unexpectedBetweenExpressionAndOperatorToken: RawUnexpectedNodesSyntax? = nil,
     operatorToken: RawTokenSyntax,
+    _ unexpectedAfterOperatorToken: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .postfixUnaryExpr, uninitializedCount: 4, arena: arena) { layout in
+      kind: .postfixUnaryExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeExpression?.raw
       layout[1] = expression.raw
       layout[2] = unexpectedBetweenExpressionAndOperatorToken?.raw
       layout[3] = operatorToken.raw
+      layout[4] = unexpectedAfterOperatorToken?.raw
     }
     self.init(raw: raw)
   }
@@ -4211,6 +4488,9 @@ public struct RawPostfixUnaryExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
   }
   public var operatorToken: RawTokenSyntax {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterOperatorToken: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -4242,15 +4522,17 @@ public struct RawSpecializeExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
     expression: RawExprSyntax,
     _ unexpectedBetweenExpressionAndGenericArgumentClause: RawUnexpectedNodesSyntax? = nil,
     genericArgumentClause: RawGenericArgumentClauseSyntax,
+    _ unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .specializeExpr, uninitializedCount: 4, arena: arena) { layout in
+      kind: .specializeExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeExpression?.raw
       layout[1] = expression.raw
       layout[2] = unexpectedBetweenExpressionAndGenericArgumentClause?.raw
       layout[3] = genericArgumentClause.raw
+      layout[4] = unexpectedAfterGenericArgumentClause?.raw
     }
     self.init(raw: raw)
   }
@@ -4266,6 +4548,9 @@ public struct RawSpecializeExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var genericArgumentClause: RawGenericArgumentClauseSyntax {
     layoutView.children[3].map(RawGenericArgumentClauseSyntax.init(raw:))!
+  }
+  public var unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -4295,13 +4580,15 @@ public struct RawStringSegmentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   public init(
     _ unexpectedBeforeContent: RawUnexpectedNodesSyntax? = nil,
     content: RawTokenSyntax,
+    _ unexpectedAfterContent: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .stringSegment, uninitializedCount: 2, arena: arena) { layout in
+      kind: .stringSegment, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeContent?.raw
       layout[1] = content.raw
+      layout[2] = unexpectedAfterContent?.raw
     }
     self.init(raw: raw)
   }
@@ -4311,6 +4598,9 @@ public struct RawStringSegmentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var content: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterContent: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -4348,10 +4638,11 @@ public struct RawExpressionSegmentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
     expressions: RawTupleExprElementListSyntax,
     _ unexpectedBetweenExpressionsAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .expressionSegment, uninitializedCount: 10, arena: arena) { layout in
+      kind: .expressionSegment, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeBackslash?.raw
       layout[1] = backslash.raw
@@ -4363,6 +4654,7 @@ public struct RawExpressionSegmentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
       layout[7] = expressions.raw
       layout[8] = unexpectedBetweenExpressionsAndRightParen?.raw
       layout[9] = rightParen.raw
+      layout[10] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -4396,6 +4688,9 @@ public struct RawExpressionSegmentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[9].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -4433,10 +4728,11 @@ public struct RawStringLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
     closeQuote: RawTokenSyntax,
     _ unexpectedBetweenCloseQuoteAndCloseDelimiter: RawUnexpectedNodesSyntax? = nil,
     closeDelimiter: RawTokenSyntax?,
+    _ unexpectedAfterCloseDelimiter: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .stringLiteralExpr, uninitializedCount: 10, arena: arena) { layout in
+      kind: .stringLiteralExpr, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeOpenDelimiter?.raw
       layout[1] = openDelimiter?.raw
@@ -4448,6 +4744,7 @@ public struct RawStringLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
       layout[7] = closeQuote.raw
       layout[8] = unexpectedBetweenCloseQuoteAndCloseDelimiter?.raw
       layout[9] = closeDelimiter?.raw
+      layout[10] = unexpectedAfterCloseDelimiter?.raw
     }
     self.init(raw: raw)
   }
@@ -4482,6 +4779,9 @@ public struct RawStringLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
   public var closeDelimiter: RawTokenSyntax? {
     layoutView.children[9].map(RawTokenSyntax.init(raw:))
   }
+  public var unexpectedAfterCloseDelimiter: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -4510,13 +4810,15 @@ public struct RawRegexLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
   public init(
     _ unexpectedBeforeRegex: RawUnexpectedNodesSyntax? = nil,
     regex: RawTokenSyntax,
+    _ unexpectedAfterRegex: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .regexLiteralExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .regexLiteralExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeRegex?.raw
       layout[1] = regex.raw
+      layout[2] = unexpectedAfterRegex?.raw
     }
     self.init(raw: raw)
   }
@@ -4526,6 +4828,9 @@ public struct RawRegexLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
   }
   public var regex: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRegex: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -4559,10 +4864,11 @@ public struct RawKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax
     root: RawTypeSyntax?,
     _ unexpectedBetweenRootAndComponents: RawUnexpectedNodesSyntax? = nil,
     components: RawKeyPathComponentListSyntax,
+    _ unexpectedAfterComponents: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .keyPathExpr, uninitializedCount: 6, arena: arena) { layout in
+      kind: .keyPathExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeBackslash?.raw
       layout[1] = backslash.raw
@@ -4570,6 +4876,7 @@ public struct RawKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax
       layout[3] = root?.raw
       layout[4] = unexpectedBetweenRootAndComponents?.raw
       layout[5] = components.raw
+      layout[6] = unexpectedAfterComponents?.raw
     }
     self.init(raw: raw)
   }
@@ -4591,6 +4898,9 @@ public struct RawKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyntax
   }
   public var components: RawKeyPathComponentListSyntax {
     layoutView.children[5].map(RawKeyPathComponentListSyntax.init(raw:))!
+  }
+  public var unexpectedAfterComponents: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -4662,15 +4972,17 @@ public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
     period: RawTokenSyntax?,
     _ unexpectedBetweenPeriodAndComponent: RawUnexpectedNodesSyntax? = nil,
     component: RawSyntax,
+    _ unexpectedAfterComponent: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .keyPathComponent, uninitializedCount: 4, arena: arena) { layout in
+      kind: .keyPathComponent, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePeriod?.raw
       layout[1] = period?.raw
       layout[2] = unexpectedBetweenPeriodAndComponent?.raw
       layout[3] = component.raw
+      layout[4] = unexpectedAfterComponent?.raw
     }
     self.init(raw: raw)
   }
@@ -4686,6 +4998,9 @@ public struct RawKeyPathComponentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var component: RawSyntax {
     layoutView.children[3]!
+  }
+  public var unexpectedAfterComponent: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -4719,10 +5034,11 @@ public struct RawKeyPathPropertyComponentSyntax: RawSyntaxNodeProtocol, RawSynta
     declNameArguments: RawDeclNameArgumentsSyntax?,
     _ unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause: RawUnexpectedNodesSyntax? = nil,
     genericArgumentClause: RawGenericArgumentClauseSyntax?,
+    _ unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .keyPathPropertyComponent, uninitializedCount: 6, arena: arena) { layout in
+      kind: .keyPathPropertyComponent, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeIdentifier?.raw
       layout[1] = identifier.raw
@@ -4730,6 +5046,7 @@ public struct RawKeyPathPropertyComponentSyntax: RawSyntaxNodeProtocol, RawSynta
       layout[3] = declNameArguments?.raw
       layout[4] = unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause?.raw
       layout[5] = genericArgumentClause?.raw
+      layout[6] = unexpectedAfterGenericArgumentClause?.raw
     }
     self.init(raw: raw)
   }
@@ -4751,6 +5068,9 @@ public struct RawKeyPathPropertyComponentSyntax: RawSyntaxNodeProtocol, RawSynta
   }
   public var genericArgumentClause: RawGenericArgumentClauseSyntax? {
     layoutView.children[5].map(RawGenericArgumentClauseSyntax.init(raw:))
+  }
+  public var unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -4784,10 +5104,11 @@ public struct RawKeyPathSubscriptComponentSyntax: RawSyntaxNodeProtocol, RawSynt
     argumentList: RawTupleExprElementListSyntax,
     _ unexpectedBetweenArgumentListAndRightBracket: RawUnexpectedNodesSyntax? = nil,
     rightBracket: RawTokenSyntax,
+    _ unexpectedAfterRightBracket: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .keyPathSubscriptComponent, uninitializedCount: 6, arena: arena) { layout in
+      kind: .keyPathSubscriptComponent, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftBracket?.raw
       layout[1] = leftBracket.raw
@@ -4795,6 +5116,7 @@ public struct RawKeyPathSubscriptComponentSyntax: RawSyntaxNodeProtocol, RawSynt
       layout[3] = argumentList.raw
       layout[4] = unexpectedBetweenArgumentListAndRightBracket?.raw
       layout[5] = rightBracket.raw
+      layout[6] = unexpectedAfterRightBracket?.raw
     }
     self.init(raw: raw)
   }
@@ -4816,6 +5138,9 @@ public struct RawKeyPathSubscriptComponentSyntax: RawSyntaxNodeProtocol, RawSynt
   }
   public var rightBracket: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightBracket: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -4845,13 +5170,15 @@ public struct RawKeyPathOptionalComponentSyntax: RawSyntaxNodeProtocol, RawSynta
   public init(
     _ unexpectedBeforeQuestionOrExclamationMark: RawUnexpectedNodesSyntax? = nil,
     questionOrExclamationMark: RawTokenSyntax,
+    _ unexpectedAfterQuestionOrExclamationMark: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .keyPathOptionalComponent, uninitializedCount: 2, arena: arena) { layout in
+      kind: .keyPathOptionalComponent, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeQuestionOrExclamationMark?.raw
       layout[1] = questionOrExclamationMark.raw
+      layout[2] = unexpectedAfterQuestionOrExclamationMark?.raw
     }
     self.init(raw: raw)
   }
@@ -4861,6 +5188,9 @@ public struct RawKeyPathOptionalComponentSyntax: RawSyntaxNodeProtocol, RawSynta
   }
   public var questionOrExclamationMark: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterQuestionOrExclamationMark: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -4894,10 +5224,11 @@ public struct RawOldKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
     rootExpr: RawExprSyntax?,
     _ unexpectedBetweenRootExprAndExpression: RawUnexpectedNodesSyntax? = nil,
     expression: RawExprSyntax,
+    _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .oldKeyPathExpr, uninitializedCount: 6, arena: arena) { layout in
+      kind: .oldKeyPathExpr, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeBackslash?.raw
       layout[1] = backslash.raw
@@ -4905,6 +5236,7 @@ public struct RawOldKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
       layout[3] = rootExpr?.raw
       layout[4] = unexpectedBetweenRootExprAndExpression?.raw
       layout[5] = expression.raw
+      layout[6] = unexpectedAfterExpression?.raw
     }
     self.init(raw: raw)
   }
@@ -4926,6 +5258,9 @@ public struct RawOldKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var expression: RawExprSyntax {
     layoutView.children[5].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -4955,13 +5290,15 @@ public struct RawKeyPathBaseExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
   public init(
     _ unexpectedBeforePeriod: RawUnexpectedNodesSyntax? = nil,
     period: RawTokenSyntax,
+    _ unexpectedAfterPeriod: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .keyPathBaseExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .keyPathBaseExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePeriod?.raw
       layout[1] = period.raw
+      layout[2] = unexpectedAfterPeriod?.raw
     }
     self.init(raw: raw)
   }
@@ -4971,6 +5308,9 @@ public struct RawKeyPathBaseExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
   }
   public var period: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterPeriod: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -5002,15 +5342,17 @@ public struct RawObjcNamePieceSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     name: RawTokenSyntax,
     _ unexpectedBetweenNameAndDot: RawUnexpectedNodesSyntax? = nil,
     dot: RawTokenSyntax?,
+    _ unexpectedAfterDot: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .objcNamePiece, uninitializedCount: 4, arena: arena) { layout in
+      kind: .objcNamePiece, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeName?.raw
       layout[1] = name.raw
       layout[2] = unexpectedBetweenNameAndDot?.raw
       layout[3] = dot?.raw
+      layout[4] = unexpectedAfterDot?.raw
     }
     self.init(raw: raw)
   }
@@ -5026,6 +5368,9 @@ public struct RawObjcNamePieceSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var dot: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterDot: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -5101,10 +5446,11 @@ public struct RawObjcKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
     name: RawObjcNameSyntax,
     _ unexpectedBetweenNameAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .objcKeyPathExpr, uninitializedCount: 8, arena: arena) { layout in
+      kind: .objcKeyPathExpr, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeKeyPath?.raw
       layout[1] = keyPath.raw
@@ -5114,6 +5460,7 @@ public struct RawObjcKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
       layout[5] = name.raw
       layout[6] = unexpectedBetweenNameAndRightParen?.raw
       layout[7] = rightParen.raw
+      layout[8] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -5141,6 +5488,9 @@ public struct RawObjcKeyPathExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToSy
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -5180,10 +5530,11 @@ public struct RawObjcSelectorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
     name: RawExprSyntax,
     _ unexpectedBetweenNameAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .objcSelectorExpr, uninitializedCount: 12, arena: arena) { layout in
+      kind: .objcSelectorExpr, uninitializedCount: 13, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePoundSelector?.raw
       layout[1] = poundSelector.raw
@@ -5197,6 +5548,7 @@ public struct RawObjcSelectorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
       layout[9] = name.raw
       layout[10] = unexpectedBetweenNameAndRightParen?.raw
       layout[11] = rightParen.raw
+      layout[12] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -5237,6 +5589,9 @@ public struct RawObjcSelectorExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxToS
   public var rightParen: RawTokenSyntax {
     layoutView.children[11].map(RawTokenSyntax.init(raw:))!
   }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[12].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -5267,15 +5622,17 @@ public struct RawPostfixIfConfigExprSyntax: RawExprSyntaxNodeProtocol, RawSyntax
     base: RawExprSyntax?,
     _ unexpectedBetweenBaseAndConfig: RawUnexpectedNodesSyntax? = nil,
     config: RawIfConfigDeclSyntax,
+    _ unexpectedAfterConfig: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .postfixIfConfigExpr, uninitializedCount: 4, arena: arena) { layout in
+      kind: .postfixIfConfigExpr, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeBase?.raw
       layout[1] = base?.raw
       layout[2] = unexpectedBetweenBaseAndConfig?.raw
       layout[3] = config.raw
+      layout[4] = unexpectedAfterConfig?.raw
     }
     self.init(raw: raw)
   }
@@ -5291,6 +5648,9 @@ public struct RawPostfixIfConfigExprSyntax: RawExprSyntaxNodeProtocol, RawSyntax
   }
   public var config: RawIfConfigDeclSyntax {
     layoutView.children[3].map(RawIfConfigDeclSyntax.init(raw:))!
+  }
+  public var unexpectedAfterConfig: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -5320,13 +5680,15 @@ public struct RawEditorPlaceholderExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
   public init(
     _ unexpectedBeforeIdentifier: RawUnexpectedNodesSyntax? = nil,
     identifier: RawTokenSyntax,
+    _ unexpectedAfterIdentifier: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .editorPlaceholderExpr, uninitializedCount: 2, arena: arena) { layout in
+      kind: .editorPlaceholderExpr, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeIdentifier?.raw
       layout[1] = identifier.raw
+      layout[2] = unexpectedAfterIdentifier?.raw
     }
     self.init(raw: raw)
   }
@@ -5336,6 +5698,9 @@ public struct RawEditorPlaceholderExprSyntax: RawExprSyntaxNodeProtocol, RawSynt
   }
   public var identifier: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterIdentifier: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -5371,10 +5736,11 @@ public struct RawObjectLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
     arguments: RawTupleExprElementListSyntax,
     _ unexpectedBetweenArgumentsAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .objectLiteralExpr, uninitializedCount: 8, arena: arena) { layout in
+      kind: .objectLiteralExpr, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeIdentifier?.raw
       layout[1] = identifier.raw
@@ -5384,6 +5750,7 @@ public struct RawObjectLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
       layout[5] = arguments.raw
       layout[6] = unexpectedBetweenArgumentsAndRightParen?.raw
       layout[7] = rightParen.raw
+      layout[8] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -5411,6 +5778,9 @@ public struct RawObjectLiteralExprSyntax: RawExprSyntaxNodeProtocol, RawSyntaxTo
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -5482,15 +5852,17 @@ public struct RawYieldExprListElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
     expression: RawExprSyntax,
     _ unexpectedBetweenExpressionAndComma: RawUnexpectedNodesSyntax? = nil,
     comma: RawTokenSyntax?,
+    _ unexpectedAfterComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .yieldExprListElement, uninitializedCount: 4, arena: arena) { layout in
+      kind: .yieldExprListElement, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeExpression?.raw
       layout[1] = expression.raw
       layout[2] = unexpectedBetweenExpressionAndComma?.raw
       layout[3] = comma?.raw
+      layout[4] = unexpectedAfterComma?.raw
     }
     self.init(raw: raw)
   }
@@ -5506,6 +5878,9 @@ public struct RawYieldExprListElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
   }
   public var comma: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -5537,15 +5912,17 @@ public struct RawTypeInitializerClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
     equal: RawTokenSyntax,
     _ unexpectedBetweenEqualAndValue: RawUnexpectedNodesSyntax? = nil,
     value: RawTypeSyntax,
+    _ unexpectedAfterValue: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .typeInitializerClause, uninitializedCount: 4, arena: arena) { layout in
+      kind: .typeInitializerClause, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeEqual?.raw
       layout[1] = equal.raw
       layout[2] = unexpectedBetweenEqualAndValue?.raw
       layout[3] = value.raw
+      layout[4] = unexpectedAfterValue?.raw
     }
     self.init(raw: raw)
   }
@@ -5561,6 +5938,9 @@ public struct RawTypeInitializerClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
   }
   public var value: RawTypeSyntax {
     layoutView.children[3].map(RawTypeSyntax.init(raw:))!
+  }
+  public var unexpectedAfterValue: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -5602,10 +5982,11 @@ public struct RawTypealiasDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynt
     initializer: RawTypeInitializerClauseSyntax,
     _ unexpectedBetweenInitializerAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil,
     genericWhereClause: RawGenericWhereClauseSyntax?,
+    _ unexpectedAfterGenericWhereClause: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .typealiasDecl, uninitializedCount: 14, arena: arena) { layout in
+      kind: .typealiasDecl, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -5621,6 +6002,7 @@ public struct RawTypealiasDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynt
       layout[11] = initializer.raw
       layout[12] = unexpectedBetweenInitializerAndGenericWhereClause?.raw
       layout[13] = genericWhereClause?.raw
+      layout[14] = unexpectedAfterGenericWhereClause?.raw
     }
     self.init(raw: raw)
   }
@@ -5667,6 +6049,9 @@ public struct RawTypealiasDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynt
   public var genericWhereClause: RawGenericWhereClauseSyntax? {
     layoutView.children[13].map(RawGenericWhereClauseSyntax.init(raw:))
   }
+  public var unexpectedAfterGenericWhereClause: RawUnexpectedNodesSyntax? {
+    layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -5707,10 +6092,11 @@ public struct RawAssociatedtypeDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxT
     initializer: RawTypeInitializerClauseSyntax?,
     _ unexpectedBetweenInitializerAndGenericWhereClause: RawUnexpectedNodesSyntax? = nil,
     genericWhereClause: RawGenericWhereClauseSyntax?,
+    _ unexpectedAfterGenericWhereClause: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .associatedtypeDecl, uninitializedCount: 14, arena: arena) { layout in
+      kind: .associatedtypeDecl, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -5726,6 +6112,7 @@ public struct RawAssociatedtypeDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxT
       layout[11] = initializer?.raw
       layout[12] = unexpectedBetweenInitializerAndGenericWhereClause?.raw
       layout[13] = genericWhereClause?.raw
+      layout[14] = unexpectedAfterGenericWhereClause?.raw
     }
     self.init(raw: raw)
   }
@@ -5771,6 +6158,9 @@ public struct RawAssociatedtypeDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxT
   }
   public var genericWhereClause: RawGenericWhereClauseSyntax? {
     layoutView.children[13].map(RawGenericWhereClauseSyntax.init(raw:))
+  }
+  public var unexpectedAfterGenericWhereClause: RawUnexpectedNodesSyntax? {
+    layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -5844,10 +6234,11 @@ public struct RawParameterClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
     parameterList: RawFunctionParameterListSyntax,
     _ unexpectedBetweenParameterListAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .parameterClause, uninitializedCount: 6, arena: arena) { layout in
+      kind: .parameterClause, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftParen?.raw
       layout[1] = leftParen.raw
@@ -5855,6 +6246,7 @@ public struct RawParameterClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
       layout[3] = parameterList.raw
       layout[4] = unexpectedBetweenParameterListAndRightParen?.raw
       layout[5] = rightParen.raw
+      layout[6] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -5876,6 +6268,9 @@ public struct RawParameterClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -5907,15 +6302,17 @@ public struct RawReturnClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     arrow: RawTokenSyntax,
     _ unexpectedBetweenArrowAndReturnType: RawUnexpectedNodesSyntax? = nil,
     returnType: RawTypeSyntax,
+    _ unexpectedAfterReturnType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .returnClause, uninitializedCount: 4, arena: arena) { layout in
+      kind: .returnClause, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeArrow?.raw
       layout[1] = arrow.raw
       layout[2] = unexpectedBetweenArrowAndReturnType?.raw
       layout[3] = returnType.raw
+      layout[4] = unexpectedAfterReturnType?.raw
     }
     self.init(raw: raw)
   }
@@ -5931,6 +6328,9 @@ public struct RawReturnClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var returnType: RawTypeSyntax {
     layoutView.children[3].map(RawTypeSyntax.init(raw:))!
+  }
+  public var unexpectedAfterReturnType: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -5966,10 +6366,11 @@ public struct RawFunctionSignatureSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
     throwsOrRethrowsKeyword: RawTokenSyntax?,
     _ unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: RawUnexpectedNodesSyntax? = nil,
     output: RawReturnClauseSyntax?,
+    _ unexpectedAfterOutput: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .functionSignature, uninitializedCount: 8, arena: arena) { layout in
+      kind: .functionSignature, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeInput?.raw
       layout[1] = input.raw
@@ -5979,6 +6380,7 @@ public struct RawFunctionSignatureSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
       layout[5] = throwsOrRethrowsKeyword?.raw
       layout[6] = unexpectedBetweenThrowsOrRethrowsKeywordAndOutput?.raw
       layout[7] = output?.raw
+      layout[8] = unexpectedAfterOutput?.raw
     }
     self.init(raw: raw)
   }
@@ -6006,6 +6408,9 @@ public struct RawFunctionSignatureSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
   }
   public var output: RawReturnClauseSyntax? {
     layoutView.children[7].map(RawReturnClauseSyntax.init(raw:))
+  }
+  public var unexpectedAfterOutput: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -6039,10 +6444,11 @@ public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax 
     condition: RawExprSyntax?,
     _ unexpectedBetweenConditionAndElements: RawUnexpectedNodesSyntax? = nil,
     elements: RawSyntax,
+    _ unexpectedAfterElements: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .ifConfigClause, uninitializedCount: 6, arena: arena) { layout in
+      kind: .ifConfigClause, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePoundKeyword?.raw
       layout[1] = poundKeyword.raw
@@ -6050,6 +6456,7 @@ public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax 
       layout[3] = condition?.raw
       layout[4] = unexpectedBetweenConditionAndElements?.raw
       layout[5] = elements.raw
+      layout[6] = unexpectedAfterElements?.raw
     }
     self.init(raw: raw)
   }
@@ -6071,6 +6478,9 @@ public struct RawIfConfigClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax 
   }
   public var elements: RawSyntax {
     layoutView.children[5]!
+  }
+  public var unexpectedAfterElements: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -6142,15 +6552,17 @@ public struct RawIfConfigDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
     clauses: RawIfConfigClauseListSyntax,
     _ unexpectedBetweenClausesAndPoundEndif: RawUnexpectedNodesSyntax? = nil,
     poundEndif: RawTokenSyntax,
+    _ unexpectedAfterPoundEndif: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .ifConfigDecl, uninitializedCount: 4, arena: arena) { layout in
+      kind: .ifConfigDecl, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeClauses?.raw
       layout[1] = clauses.raw
       layout[2] = unexpectedBetweenClausesAndPoundEndif?.raw
       layout[3] = poundEndif.raw
+      layout[4] = unexpectedAfterPoundEndif?.raw
     }
     self.init(raw: raw)
   }
@@ -6166,6 +6578,9 @@ public struct RawIfConfigDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var poundEndif: RawTokenSyntax {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterPoundEndif: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -6201,10 +6616,11 @@ public struct RawPoundErrorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyn
     message: RawStringLiteralExprSyntax,
     _ unexpectedBetweenMessageAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .poundErrorDecl, uninitializedCount: 8, arena: arena) { layout in
+      kind: .poundErrorDecl, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePoundError?.raw
       layout[1] = poundError.raw
@@ -6214,6 +6630,7 @@ public struct RawPoundErrorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyn
       layout[5] = message.raw
       layout[6] = unexpectedBetweenMessageAndRightParen?.raw
       layout[7] = rightParen.raw
+      layout[8] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -6241,6 +6658,9 @@ public struct RawPoundErrorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -6276,10 +6696,11 @@ public struct RawPoundWarningDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToS
     message: RawStringLiteralExprSyntax,
     _ unexpectedBetweenMessageAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .poundWarningDecl, uninitializedCount: 8, arena: arena) { layout in
+      kind: .poundWarningDecl, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePoundWarning?.raw
       layout[1] = poundWarning.raw
@@ -6289,6 +6710,7 @@ public struct RawPoundWarningDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToS
       layout[5] = message.raw
       layout[6] = unexpectedBetweenMessageAndRightParen?.raw
       layout[7] = rightParen.raw
+      layout[8] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -6316,6 +6738,9 @@ public struct RawPoundWarningDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToS
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -6351,10 +6776,11 @@ public struct RawPoundSourceLocationSyntax: RawDeclSyntaxNodeProtocol, RawSyntax
     args: RawPoundSourceLocationArgsSyntax?,
     _ unexpectedBetweenArgsAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .poundSourceLocation, uninitializedCount: 8, arena: arena) { layout in
+      kind: .poundSourceLocation, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePoundSourceLocation?.raw
       layout[1] = poundSourceLocation.raw
@@ -6364,6 +6790,7 @@ public struct RawPoundSourceLocationSyntax: RawDeclSyntaxNodeProtocol, RawSyntax
       layout[5] = args?.raw
       layout[6] = unexpectedBetweenArgsAndRightParen?.raw
       layout[7] = rightParen.raw
+      layout[8] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -6391,6 +6818,9 @@ public struct RawPoundSourceLocationSyntax: RawDeclSyntaxNodeProtocol, RawSyntax
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -6432,10 +6862,11 @@ public struct RawPoundSourceLocationArgsSyntax: RawSyntaxNodeProtocol, RawSyntax
     lineArgColon: RawTokenSyntax,
     _ unexpectedBetweenLineArgColonAndLineNumber: RawUnexpectedNodesSyntax? = nil,
     lineNumber: RawTokenSyntax,
+    _ unexpectedAfterLineNumber: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .poundSourceLocationArgs, uninitializedCount: 14, arena: arena) { layout in
+      kind: .poundSourceLocationArgs, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeFileArgLabel?.raw
       layout[1] = fileArgLabel.raw
@@ -6451,6 +6882,7 @@ public struct RawPoundSourceLocationArgsSyntax: RawSyntaxNodeProtocol, RawSyntax
       layout[11] = lineArgColon.raw
       layout[12] = unexpectedBetweenLineArgColonAndLineNumber?.raw
       layout[13] = lineNumber.raw
+      layout[14] = unexpectedAfterLineNumber?.raw
     }
     self.init(raw: raw)
   }
@@ -6497,6 +6929,9 @@ public struct RawPoundSourceLocationArgsSyntax: RawSyntaxNodeProtocol, RawSyntax
   public var lineNumber: RawTokenSyntax {
     layoutView.children[13].map(RawTokenSyntax.init(raw:))!
   }
+  public var unexpectedAfterLineNumber: RawUnexpectedNodesSyntax? {
+    layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -6529,10 +6964,11 @@ public struct RawDeclModifierDetailSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
     detail: RawTokenSyntax,
     _ unexpectedBetweenDetailAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .declModifierDetail, uninitializedCount: 6, arena: arena) { layout in
+      kind: .declModifierDetail, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftParen?.raw
       layout[1] = leftParen.raw
@@ -6540,6 +6976,7 @@ public struct RawDeclModifierDetailSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
       layout[3] = detail.raw
       layout[4] = unexpectedBetweenDetailAndRightParen?.raw
       layout[5] = rightParen.raw
+      layout[6] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -6561,6 +6998,9 @@ public struct RawDeclModifierDetailSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -6592,15 +7032,17 @@ public struct RawDeclModifierSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     name: RawTokenSyntax,
     _ unexpectedBetweenNameAndDetail: RawUnexpectedNodesSyntax? = nil,
     detail: RawDeclModifierDetailSyntax?,
+    _ unexpectedAfterDetail: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .declModifier, uninitializedCount: 4, arena: arena) { layout in
+      kind: .declModifier, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeName?.raw
       layout[1] = name.raw
       layout[2] = unexpectedBetweenNameAndDetail?.raw
       layout[3] = detail?.raw
+      layout[4] = unexpectedAfterDetail?.raw
     }
     self.init(raw: raw)
   }
@@ -6616,6 +7058,9 @@ public struct RawDeclModifierSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var detail: RawDeclModifierDetailSyntax? {
     layoutView.children[3].map(RawDeclModifierDetailSyntax.init(raw:))
+  }
+  public var unexpectedAfterDetail: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -6647,15 +7092,17 @@ public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     typeName: RawTypeSyntax,
     _ unexpectedBetweenTypeNameAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .inheritedType, uninitializedCount: 4, arena: arena) { layout in
+      kind: .inheritedType, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeTypeName?.raw
       layout[1] = typeName.raw
       layout[2] = unexpectedBetweenTypeNameAndTrailingComma?.raw
       layout[3] = trailingComma?.raw
+      layout[4] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -6671,6 +7118,9 @@ public struct RawInheritedTypeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -6742,15 +7192,17 @@ public struct RawTypeInheritanceClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndInheritedTypeCollection: RawUnexpectedNodesSyntax? = nil,
     inheritedTypeCollection: RawInheritedTypeListSyntax,
+    _ unexpectedAfterInheritedTypeCollection: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .typeInheritanceClause, uninitializedCount: 4, arena: arena) { layout in
+      kind: .typeInheritanceClause, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeColon?.raw
       layout[1] = colon.raw
       layout[2] = unexpectedBetweenColonAndInheritedTypeCollection?.raw
       layout[3] = inheritedTypeCollection.raw
+      layout[4] = unexpectedAfterInheritedTypeCollection?.raw
     }
     self.init(raw: raw)
   }
@@ -6766,6 +7218,9 @@ public struct RawTypeInheritanceClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
   }
   public var inheritedTypeCollection: RawInheritedTypeListSyntax {
     layoutView.children[3].map(RawInheritedTypeListSyntax.init(raw:))!
+  }
+  public var unexpectedAfterInheritedTypeCollection: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -6809,10 +7264,11 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? = nil,
     members: RawMemberDeclBlockSyntax,
+    _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .classDecl, uninitializedCount: 16, arena: arena) { layout in
+      kind: .classDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -6830,6 +7286,7 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[13] = genericWhereClause?.raw
       layout[14] = unexpectedBetweenGenericWhereClauseAndMembers?.raw
       layout[15] = members.raw
+      layout[16] = unexpectedAfterMembers?.raw
     }
     self.init(raw: raw)
   }
@@ -6882,6 +7339,9 @@ public struct RawClassDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public var members: RawMemberDeclBlockSyntax {
     layoutView.children[15].map(RawMemberDeclBlockSyntax.init(raw:))!
   }
+  public var unexpectedAfterMembers: RawUnexpectedNodesSyntax? {
+    layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -6924,10 +7384,11 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? = nil,
     members: RawMemberDeclBlockSyntax,
+    _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .actorDecl, uninitializedCount: 16, arena: arena) { layout in
+      kind: .actorDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -6945,6 +7406,7 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[13] = genericWhereClause?.raw
       layout[14] = unexpectedBetweenGenericWhereClauseAndMembers?.raw
       layout[15] = members.raw
+      layout[16] = unexpectedAfterMembers?.raw
     }
     self.init(raw: raw)
   }
@@ -6997,6 +7459,9 @@ public struct RawActorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public var members: RawMemberDeclBlockSyntax {
     layoutView.children[15].map(RawMemberDeclBlockSyntax.init(raw:))!
   }
+  public var unexpectedAfterMembers: RawUnexpectedNodesSyntax? {
+    layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -7039,10 +7504,11 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax 
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? = nil,
     members: RawMemberDeclBlockSyntax,
+    _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .structDecl, uninitializedCount: 16, arena: arena) { layout in
+      kind: .structDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -7060,6 +7526,7 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax 
       layout[13] = genericWhereClause?.raw
       layout[14] = unexpectedBetweenGenericWhereClauseAndMembers?.raw
       layout[15] = members.raw
+      layout[16] = unexpectedAfterMembers?.raw
     }
     self.init(raw: raw)
   }
@@ -7112,6 +7579,9 @@ public struct RawStructDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax 
   public var members: RawMemberDeclBlockSyntax {
     layoutView.children[15].map(RawMemberDeclBlockSyntax.init(raw:))!
   }
+  public var unexpectedAfterMembers: RawUnexpectedNodesSyntax? {
+    layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -7154,10 +7624,11 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? = nil,
     members: RawMemberDeclBlockSyntax,
+    _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .protocolDecl, uninitializedCount: 16, arena: arena) { layout in
+      kind: .protocolDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -7175,6 +7646,7 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
       layout[13] = genericWhereClause?.raw
       layout[14] = unexpectedBetweenGenericWhereClauseAndMembers?.raw
       layout[15] = members.raw
+      layout[16] = unexpectedAfterMembers?.raw
     }
     self.init(raw: raw)
   }
@@ -7227,6 +7699,9 @@ public struct RawProtocolDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
   public var members: RawMemberDeclBlockSyntax {
     layoutView.children[15].map(RawMemberDeclBlockSyntax.init(raw:))!
   }
+  public var unexpectedAfterMembers: RawUnexpectedNodesSyntax? {
+    layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -7267,10 +7742,11 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynt
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? = nil,
     members: RawMemberDeclBlockSyntax,
+    _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .extensionDecl, uninitializedCount: 14, arena: arena) { layout in
+      kind: .extensionDecl, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -7286,6 +7762,7 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynt
       layout[11] = genericWhereClause?.raw
       layout[12] = unexpectedBetweenGenericWhereClauseAndMembers?.raw
       layout[13] = members.raw
+      layout[14] = unexpectedAfterMembers?.raw
     }
     self.init(raw: raw)
   }
@@ -7332,6 +7809,9 @@ public struct RawExtensionDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynt
   public var members: RawMemberDeclBlockSyntax {
     layoutView.children[13].map(RawMemberDeclBlockSyntax.init(raw:))!
   }
+  public var unexpectedAfterMembers: RawUnexpectedNodesSyntax? {
+    layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -7364,10 +7844,11 @@ public struct RawMemberDeclBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
     members: RawMemberDeclListSyntax,
     _ unexpectedBetweenMembersAndRightBrace: RawUnexpectedNodesSyntax? = nil,
     rightBrace: RawTokenSyntax,
+    _ unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .memberDeclBlock, uninitializedCount: 6, arena: arena) { layout in
+      kind: .memberDeclBlock, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftBrace?.raw
       layout[1] = leftBrace.raw
@@ -7375,6 +7856,7 @@ public struct RawMemberDeclBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
       layout[3] = members.raw
       layout[4] = unexpectedBetweenMembersAndRightBrace?.raw
       layout[5] = rightBrace.raw
+      layout[6] = unexpectedAfterRightBrace?.raw
     }
     self.init(raw: raw)
   }
@@ -7396,6 +7878,9 @@ public struct RawMemberDeclBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
   }
   public var rightBrace: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -7467,15 +7952,17 @@ public struct RawMemberDeclListItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
     decl: RawDeclSyntax,
     _ unexpectedBetweenDeclAndSemicolon: RawUnexpectedNodesSyntax? = nil,
     semicolon: RawTokenSyntax?,
+    _ unexpectedAfterSemicolon: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .memberDeclListItem, uninitializedCount: 4, arena: arena) { layout in
+      kind: .memberDeclListItem, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeDecl?.raw
       layout[1] = decl.raw
       layout[2] = unexpectedBetweenDeclAndSemicolon?.raw
       layout[3] = semicolon?.raw
+      layout[4] = unexpectedAfterSemicolon?.raw
     }
     self.init(raw: raw)
   }
@@ -7491,6 +7978,9 @@ public struct RawMemberDeclListItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var semicolon: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterSemicolon: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -7522,15 +8012,17 @@ public struct RawSourceFileSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     statements: RawCodeBlockItemListSyntax,
     _ unexpectedBetweenStatementsAndEOFToken: RawUnexpectedNodesSyntax? = nil,
     eofToken: RawTokenSyntax,
+    _ unexpectedAfterEOFToken: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .sourceFile, uninitializedCount: 4, arena: arena) { layout in
+      kind: .sourceFile, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeStatements?.raw
       layout[1] = statements.raw
       layout[2] = unexpectedBetweenStatementsAndEOFToken?.raw
       layout[3] = eofToken.raw
+      layout[4] = unexpectedAfterEOFToken?.raw
     }
     self.init(raw: raw)
   }
@@ -7546,6 +8038,9 @@ public struct RawSourceFileSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var eofToken: RawTokenSyntax {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterEOFToken: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -7577,15 +8072,17 @@ public struct RawInitializerClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
     equal: RawTokenSyntax,
     _ unexpectedBetweenEqualAndValue: RawUnexpectedNodesSyntax? = nil,
     value: RawExprSyntax,
+    _ unexpectedAfterValue: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .initializerClause, uninitializedCount: 4, arena: arena) { layout in
+      kind: .initializerClause, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeEqual?.raw
       layout[1] = equal.raw
       layout[2] = unexpectedBetweenEqualAndValue?.raw
       layout[3] = value.raw
+      layout[4] = unexpectedAfterValue?.raw
     }
     self.init(raw: raw)
   }
@@ -7601,6 +8098,9 @@ public struct RawInitializerClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
   }
   public var value: RawExprSyntax {
     layoutView.children[3].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterValue: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -7646,10 +8146,11 @@ public struct RawFunctionParameterSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
     defaultArgument: RawInitializerClauseSyntax?,
     _ unexpectedBetweenDefaultArgumentAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .functionParameter, uninitializedCount: 18, arena: arena) { layout in
+      kind: .functionParameter, uninitializedCount: 19, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -7669,6 +8170,7 @@ public struct RawFunctionParameterSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
       layout[15] = defaultArgument?.raw
       layout[16] = unexpectedBetweenDefaultArgumentAndTrailingComma?.raw
       layout[17] = trailingComma?.raw
+      layout[18] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -7726,6 +8228,9 @@ public struct RawFunctionParameterSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[17].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[18].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -7809,10 +8314,11 @@ public struct RawFunctionDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndBody: RawUnexpectedNodesSyntax? = nil,
     body: RawCodeBlockSyntax?,
+    _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .functionDecl, uninitializedCount: 16, arena: arena) { layout in
+      kind: .functionDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -7830,6 +8336,7 @@ public struct RawFunctionDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
       layout[13] = genericWhereClause?.raw
       layout[14] = unexpectedBetweenGenericWhereClauseAndBody?.raw
       layout[15] = body?.raw
+      layout[16] = unexpectedAfterBody?.raw
     }
     self.init(raw: raw)
   }
@@ -7882,6 +8389,9 @@ public struct RawFunctionDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
   public var body: RawCodeBlockSyntax? {
     layoutView.children[15].map(RawCodeBlockSyntax.init(raw:))
   }
+  public var unexpectedAfterBody: RawUnexpectedNodesSyntax? {
+    layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -7924,10 +8434,11 @@ public struct RawInitializerDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSy
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndBody: RawUnexpectedNodesSyntax? = nil,
     body: RawCodeBlockSyntax?,
+    _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .initializerDecl, uninitializedCount: 16, arena: arena) { layout in
+      kind: .initializerDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -7945,6 +8456,7 @@ public struct RawInitializerDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSy
       layout[13] = genericWhereClause?.raw
       layout[14] = unexpectedBetweenGenericWhereClauseAndBody?.raw
       layout[15] = body?.raw
+      layout[16] = unexpectedAfterBody?.raw
     }
     self.init(raw: raw)
   }
@@ -7997,6 +8509,9 @@ public struct RawInitializerDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSy
   public var body: RawCodeBlockSyntax? {
     layoutView.children[15].map(RawCodeBlockSyntax.init(raw:))
   }
+  public var unexpectedAfterBody: RawUnexpectedNodesSyntax? {
+    layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -8031,10 +8546,11 @@ public struct RawDeinitializerDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxTo
     deinitKeyword: RawTokenSyntax,
     _ unexpectedBetweenDeinitKeywordAndBody: RawUnexpectedNodesSyntax? = nil,
     body: RawCodeBlockSyntax?,
+    _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .deinitializerDecl, uninitializedCount: 8, arena: arena) { layout in
+      kind: .deinitializerDecl, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -8044,6 +8560,7 @@ public struct RawDeinitializerDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxTo
       layout[5] = deinitKeyword.raw
       layout[6] = unexpectedBetweenDeinitKeywordAndBody?.raw
       layout[7] = body?.raw
+      layout[8] = unexpectedAfterBody?.raw
     }
     self.init(raw: raw)
   }
@@ -8071,6 +8588,9 @@ public struct RawDeinitializerDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxTo
   }
   public var body: RawCodeBlockSyntax? {
     layoutView.children[7].map(RawCodeBlockSyntax.init(raw:))
+  }
+  public var unexpectedAfterBody: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -8114,10 +8634,11 @@ public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynt
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndAccessor: RawUnexpectedNodesSyntax? = nil,
     accessor: RawSyntax?,
+    _ unexpectedAfterAccessor: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .subscriptDecl, uninitializedCount: 16, arena: arena) { layout in
+      kind: .subscriptDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -8135,6 +8656,7 @@ public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynt
       layout[13] = genericWhereClause?.raw
       layout[14] = unexpectedBetweenGenericWhereClauseAndAccessor?.raw
       layout[15] = accessor?.raw
+      layout[16] = unexpectedAfterAccessor?.raw
     }
     self.init(raw: raw)
   }
@@ -8187,6 +8709,9 @@ public struct RawSubscriptDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynt
   public var accessor: RawSyntax? {
     layoutView.children[15]
   }
+  public var unexpectedAfterAccessor: RawUnexpectedNodesSyntax? {
+    layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -8217,15 +8742,17 @@ public struct RawAccessLevelModifierSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
     name: RawTokenSyntax,
     _ unexpectedBetweenNameAndModifier: RawUnexpectedNodesSyntax? = nil,
     modifier: RawDeclModifierDetailSyntax?,
+    _ unexpectedAfterModifier: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .accessLevelModifier, uninitializedCount: 4, arena: arena) { layout in
+      kind: .accessLevelModifier, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeName?.raw
       layout[1] = name.raw
       layout[2] = unexpectedBetweenNameAndModifier?.raw
       layout[3] = modifier?.raw
+      layout[4] = unexpectedAfterModifier?.raw
     }
     self.init(raw: raw)
   }
@@ -8241,6 +8768,9 @@ public struct RawAccessLevelModifierSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
   }
   public var modifier: RawDeclModifierDetailSyntax? {
     layoutView.children[3].map(RawDeclModifierDetailSyntax.init(raw:))
+  }
+  public var unexpectedAfterModifier: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -8272,15 +8802,17 @@ public struct RawAccessPathComponentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
     name: RawTokenSyntax,
     _ unexpectedBetweenNameAndTrailingDot: RawUnexpectedNodesSyntax? = nil,
     trailingDot: RawTokenSyntax?,
+    _ unexpectedAfterTrailingDot: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .accessPathComponent, uninitializedCount: 4, arena: arena) { layout in
+      kind: .accessPathComponent, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeName?.raw
       layout[1] = name.raw
       layout[2] = unexpectedBetweenNameAndTrailingDot?.raw
       layout[3] = trailingDot?.raw
+      layout[4] = unexpectedAfterTrailingDot?.raw
     }
     self.init(raw: raw)
   }
@@ -8296,6 +8828,9 @@ public struct RawAccessPathComponentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
   }
   public var trailingDot: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingDot: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -8373,10 +8908,11 @@ public struct RawImportDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax 
     importKind: RawTokenSyntax?,
     _ unexpectedBetweenImportKindAndPath: RawUnexpectedNodesSyntax? = nil,
     path: RawAccessPathSyntax,
+    _ unexpectedAfterPath: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .importDecl, uninitializedCount: 10, arena: arena) { layout in
+      kind: .importDecl, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -8388,6 +8924,7 @@ public struct RawImportDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax 
       layout[7] = importKind?.raw
       layout[8] = unexpectedBetweenImportKindAndPath?.raw
       layout[9] = path.raw
+      layout[10] = unexpectedAfterPath?.raw
     }
     self.init(raw: raw)
   }
@@ -8422,6 +8959,9 @@ public struct RawImportDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax 
   public var path: RawAccessPathSyntax {
     layoutView.children[9].map(RawAccessPathSyntax.init(raw:))!
   }
+  public var unexpectedAfterPath: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -8454,10 +8994,11 @@ public struct RawAccessorParameterSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
     name: RawTokenSyntax,
     _ unexpectedBetweenNameAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .accessorParameter, uninitializedCount: 6, arena: arena) { layout in
+      kind: .accessorParameter, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftParen?.raw
       layout[1] = leftParen.raw
@@ -8465,6 +9006,7 @@ public struct RawAccessorParameterSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
       layout[3] = name.raw
       layout[4] = unexpectedBetweenNameAndRightParen?.raw
       layout[5] = rightParen.raw
+      layout[6] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -8486,6 +9028,9 @@ public struct RawAccessorParameterSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -8527,10 +9072,11 @@ public struct RawAccessorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
     throwsKeyword: RawTokenSyntax?,
     _ unexpectedBetweenThrowsKeywordAndBody: RawUnexpectedNodesSyntax? = nil,
     body: RawCodeBlockSyntax?,
+    _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .accessorDecl, uninitializedCount: 14, arena: arena) { layout in
+      kind: .accessorDecl, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -8546,6 +9092,7 @@ public struct RawAccessorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
       layout[11] = throwsKeyword?.raw
       layout[12] = unexpectedBetweenThrowsKeywordAndBody?.raw
       layout[13] = body?.raw
+      layout[14] = unexpectedAfterBody?.raw
     }
     self.init(raw: raw)
   }
@@ -8591,6 +9138,9 @@ public struct RawAccessorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var body: RawCodeBlockSyntax? {
     layoutView.children[13].map(RawCodeBlockSyntax.init(raw:))
+  }
+  public var unexpectedAfterBody: RawUnexpectedNodesSyntax? {
+    layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -8664,10 +9214,11 @@ public struct RawAccessorBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     accessors: RawAccessorListSyntax,
     _ unexpectedBetweenAccessorsAndRightBrace: RawUnexpectedNodesSyntax? = nil,
     rightBrace: RawTokenSyntax,
+    _ unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .accessorBlock, uninitializedCount: 6, arena: arena) { layout in
+      kind: .accessorBlock, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftBrace?.raw
       layout[1] = leftBrace.raw
@@ -8675,6 +9226,7 @@ public struct RawAccessorBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = accessors.raw
       layout[4] = unexpectedBetweenAccessorsAndRightBrace?.raw
       layout[5] = rightBrace.raw
+      layout[6] = unexpectedAfterRightBrace?.raw
     }
     self.init(raw: raw)
   }
@@ -8696,6 +9248,9 @@ public struct RawAccessorBlockSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var rightBrace: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -8733,10 +9288,11 @@ public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax 
     accessor: RawSyntax?,
     _ unexpectedBetweenAccessorAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .patternBinding, uninitializedCount: 10, arena: arena) { layout in
+      kind: .patternBinding, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePattern?.raw
       layout[1] = pattern.raw
@@ -8748,6 +9304,7 @@ public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax 
       layout[7] = accessor?.raw
       layout[8] = unexpectedBetweenAccessorAndTrailingComma?.raw
       layout[9] = trailingComma?.raw
+      layout[10] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -8781,6 +9338,9 @@ public struct RawPatternBindingSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax 
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[9].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -8856,10 +9416,11 @@ public struct RawVariableDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
     letOrVarKeyword: RawTokenSyntax,
     _ unexpectedBetweenLetOrVarKeywordAndBindings: RawUnexpectedNodesSyntax? = nil,
     bindings: RawPatternBindingListSyntax,
+    _ unexpectedAfterBindings: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .variableDecl, uninitializedCount: 8, arena: arena) { layout in
+      kind: .variableDecl, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -8869,6 +9430,7 @@ public struct RawVariableDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
       layout[5] = letOrVarKeyword.raw
       layout[6] = unexpectedBetweenLetOrVarKeywordAndBindings?.raw
       layout[7] = bindings.raw
+      layout[8] = unexpectedAfterBindings?.raw
     }
     self.init(raw: raw)
   }
@@ -8896,6 +9458,9 @@ public struct RawVariableDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var bindings: RawPatternBindingListSyntax {
     layoutView.children[7].map(RawPatternBindingListSyntax.init(raw:))!
+  }
+  public var unexpectedAfterBindings: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -8931,10 +9496,11 @@ public struct RawEnumCaseElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
     rawValue: RawInitializerClauseSyntax?,
     _ unexpectedBetweenRawValueAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .enumCaseElement, uninitializedCount: 8, arena: arena) { layout in
+      kind: .enumCaseElement, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeIdentifier?.raw
       layout[1] = identifier.raw
@@ -8944,6 +9510,7 @@ public struct RawEnumCaseElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
       layout[5] = rawValue?.raw
       layout[6] = unexpectedBetweenRawValueAndTrailingComma?.raw
       layout[7] = trailingComma?.raw
+      layout[8] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -8971,6 +9538,9 @@ public struct RawEnumCaseElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -9046,10 +9616,11 @@ public struct RawEnumCaseDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
     caseKeyword: RawTokenSyntax,
     _ unexpectedBetweenCaseKeywordAndElements: RawUnexpectedNodesSyntax? = nil,
     elements: RawEnumCaseElementListSyntax,
+    _ unexpectedAfterElements: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .enumCaseDecl, uninitializedCount: 8, arena: arena) { layout in
+      kind: .enumCaseDecl, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -9059,6 +9630,7 @@ public struct RawEnumCaseDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
       layout[5] = caseKeyword.raw
       layout[6] = unexpectedBetweenCaseKeywordAndElements?.raw
       layout[7] = elements.raw
+      layout[8] = unexpectedAfterElements?.raw
     }
     self.init(raw: raw)
   }
@@ -9086,6 +9658,9 @@ public struct RawEnumCaseDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var elements: RawEnumCaseElementListSyntax {
     layoutView.children[7].map(RawEnumCaseElementListSyntax.init(raw:))!
+  }
+  public var unexpectedAfterElements: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -9129,10 +9704,11 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMembers: RawUnexpectedNodesSyntax? = nil,
     members: RawMemberDeclBlockSyntax,
+    _ unexpectedAfterMembers: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .enumDecl, uninitializedCount: 16, arena: arena) { layout in
+      kind: .enumDecl, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -9150,6 +9726,7 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[13] = genericWhereClause?.raw
       layout[14] = unexpectedBetweenGenericWhereClauseAndMembers?.raw
       layout[15] = members.raw
+      layout[16] = unexpectedAfterMembers?.raw
     }
     self.init(raw: raw)
   }
@@ -9202,6 +9779,9 @@ public struct RawEnumDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSyntax {
   public var members: RawMemberDeclBlockSyntax {
     layoutView.children[15].map(RawMemberDeclBlockSyntax.init(raw:))!
   }
+  public var unexpectedAfterMembers: RawUnexpectedNodesSyntax? {
+    layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -9238,10 +9818,11 @@ public struct RawOperatorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
     identifier: RawTokenSyntax,
     _ unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes: RawUnexpectedNodesSyntax? = nil,
     operatorPrecedenceAndTypes: RawOperatorPrecedenceAndTypesSyntax?,
+    _ unexpectedAfterOperatorPrecedenceAndTypes: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .operatorDecl, uninitializedCount: 10, arena: arena) { layout in
+      kind: .operatorDecl, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -9253,6 +9834,7 @@ public struct RawOperatorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
       layout[7] = identifier.raw
       layout[8] = unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes?.raw
       layout[9] = operatorPrecedenceAndTypes?.raw
+      layout[10] = unexpectedAfterOperatorPrecedenceAndTypes?.raw
     }
     self.init(raw: raw)
   }
@@ -9286,6 +9868,9 @@ public struct RawOperatorDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var operatorPrecedenceAndTypes: RawOperatorPrecedenceAndTypesSyntax? {
     layoutView.children[9].map(RawOperatorPrecedenceAndTypesSyntax.init(raw:))
+  }
+  public var unexpectedAfterOperatorPrecedenceAndTypes: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -9357,15 +9942,17 @@ public struct RawDesignatedTypeElementSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
     leadingComma: RawTokenSyntax,
     _ unexpectedBetweenLeadingCommaAndName: RawUnexpectedNodesSyntax? = nil,
     name: RawTokenSyntax,
+    _ unexpectedAfterName: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .designatedTypeElement, uninitializedCount: 4, arena: arena) { layout in
+      kind: .designatedTypeElement, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeadingComma?.raw
       layout[1] = leadingComma.raw
       layout[2] = unexpectedBetweenLeadingCommaAndName?.raw
       layout[3] = name.raw
+      layout[4] = unexpectedAfterName?.raw
     }
     self.init(raw: raw)
   }
@@ -9381,6 +9968,9 @@ public struct RawDesignatedTypeElementSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
   }
   public var name: RawTokenSyntax {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterName: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -9414,10 +10004,11 @@ public struct RawOperatorPrecedenceAndTypesSyntax: RawSyntaxNodeProtocol, RawSyn
     precedenceGroup: RawTokenSyntax,
     _ unexpectedBetweenPrecedenceGroupAndDesignatedTypes: RawUnexpectedNodesSyntax? = nil,
     designatedTypes: RawDesignatedTypeListSyntax,
+    _ unexpectedAfterDesignatedTypes: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .operatorPrecedenceAndTypes, uninitializedCount: 6, arena: arena) { layout in
+      kind: .operatorPrecedenceAndTypes, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeColon?.raw
       layout[1] = colon.raw
@@ -9425,6 +10016,7 @@ public struct RawOperatorPrecedenceAndTypesSyntax: RawSyntaxNodeProtocol, RawSyn
       layout[3] = precedenceGroup.raw
       layout[4] = unexpectedBetweenPrecedenceGroupAndDesignatedTypes?.raw
       layout[5] = designatedTypes.raw
+      layout[6] = unexpectedAfterDesignatedTypes?.raw
     }
     self.init(raw: raw)
   }
@@ -9446,6 +10038,9 @@ public struct RawOperatorPrecedenceAndTypesSyntax: RawSyntaxNodeProtocol, RawSyn
   }
   public var designatedTypes: RawDesignatedTypeListSyntax {
     layoutView.children[5].map(RawDesignatedTypeListSyntax.init(raw:))!
+  }
+  public var unexpectedAfterDesignatedTypes: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -9487,10 +10082,11 @@ public struct RawPrecedenceGroupDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntax
     groupAttributes: RawPrecedenceGroupAttributeListSyntax,
     _ unexpectedBetweenGroupAttributesAndRightBrace: RawUnexpectedNodesSyntax? = nil,
     rightBrace: RawTokenSyntax,
+    _ unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .precedenceGroupDecl, uninitializedCount: 14, arena: arena) { layout in
+      kind: .precedenceGroupDecl, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -9506,6 +10102,7 @@ public struct RawPrecedenceGroupDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntax
       layout[11] = groupAttributes.raw
       layout[12] = unexpectedBetweenGroupAttributesAndRightBrace?.raw
       layout[13] = rightBrace.raw
+      layout[14] = unexpectedAfterRightBrace?.raw
     }
     self.init(raw: raw)
   }
@@ -9551,6 +10148,9 @@ public struct RawPrecedenceGroupDeclSyntax: RawDeclSyntaxNodeProtocol, RawSyntax
   }
   public var rightBrace: RawTokenSyntax {
     layoutView.children[13].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? {
+    layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -9624,10 +10224,11 @@ public struct RawPrecedenceGroupRelationSyntax: RawSyntaxNodeProtocol, RawSyntax
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndOtherNames: RawUnexpectedNodesSyntax? = nil,
     otherNames: RawPrecedenceGroupNameListSyntax,
+    _ unexpectedAfterOtherNames: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .precedenceGroupRelation, uninitializedCount: 6, arena: arena) { layout in
+      kind: .precedenceGroupRelation, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeHigherThanOrLowerThan?.raw
       layout[1] = higherThanOrLowerThan.raw
@@ -9635,6 +10236,7 @@ public struct RawPrecedenceGroupRelationSyntax: RawSyntaxNodeProtocol, RawSyntax
       layout[3] = colon.raw
       layout[4] = unexpectedBetweenColonAndOtherNames?.raw
       layout[5] = otherNames.raw
+      layout[6] = unexpectedAfterOtherNames?.raw
     }
     self.init(raw: raw)
   }
@@ -9656,6 +10258,9 @@ public struct RawPrecedenceGroupRelationSyntax: RawSyntaxNodeProtocol, RawSyntax
   }
   public var otherNames: RawPrecedenceGroupNameListSyntax {
     layoutView.children[5].map(RawPrecedenceGroupNameListSyntax.init(raw:))!
+  }
+  public var unexpectedAfterOtherNames: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -9727,15 +10332,17 @@ public struct RawPrecedenceGroupNameElementSyntax: RawSyntaxNodeProtocol, RawSyn
     name: RawTokenSyntax,
     _ unexpectedBetweenNameAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .precedenceGroupNameElement, uninitializedCount: 4, arena: arena) { layout in
+      kind: .precedenceGroupNameElement, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeName?.raw
       layout[1] = name.raw
       layout[2] = unexpectedBetweenNameAndTrailingComma?.raw
       layout[3] = trailingComma?.raw
+      layout[4] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -9751,6 +10358,9 @@ public struct RawPrecedenceGroupNameElementSyntax: RawSyntaxNodeProtocol, RawSyn
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -9784,10 +10394,11 @@ public struct RawPrecedenceGroupAssignmentSyntax: RawSyntaxNodeProtocol, RawSynt
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndFlag: RawUnexpectedNodesSyntax? = nil,
     flag: RawTokenSyntax,
+    _ unexpectedAfterFlag: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .precedenceGroupAssignment, uninitializedCount: 6, arena: arena) { layout in
+      kind: .precedenceGroupAssignment, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAssignmentKeyword?.raw
       layout[1] = assignmentKeyword.raw
@@ -9795,6 +10406,7 @@ public struct RawPrecedenceGroupAssignmentSyntax: RawSyntaxNodeProtocol, RawSynt
       layout[3] = colon.raw
       layout[4] = unexpectedBetweenColonAndFlag?.raw
       layout[5] = flag.raw
+      layout[6] = unexpectedAfterFlag?.raw
     }
     self.init(raw: raw)
   }
@@ -9816,6 +10428,9 @@ public struct RawPrecedenceGroupAssignmentSyntax: RawSyntaxNodeProtocol, RawSynt
   }
   public var flag: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterFlag: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -9849,10 +10464,11 @@ public struct RawPrecedenceGroupAssociativitySyntax: RawSyntaxNodeProtocol, RawS
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndValue: RawUnexpectedNodesSyntax? = nil,
     value: RawTokenSyntax,
+    _ unexpectedAfterValue: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .precedenceGroupAssociativity, uninitializedCount: 6, arena: arena) { layout in
+      kind: .precedenceGroupAssociativity, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAssociativityKeyword?.raw
       layout[1] = associativityKeyword.raw
@@ -9860,6 +10476,7 @@ public struct RawPrecedenceGroupAssociativitySyntax: RawSyntaxNodeProtocol, RawS
       layout[3] = colon.raw
       layout[4] = unexpectedBetweenColonAndValue?.raw
       layout[5] = value.raw
+      layout[6] = unexpectedAfterValue?.raw
     }
     self.init(raw: raw)
   }
@@ -9881,6 +10498,9 @@ public struct RawPrecedenceGroupAssociativitySyntax: RawSyntaxNodeProtocol, RawS
   }
   public var value: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterValue: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -9998,10 +10618,11 @@ public struct RawCustomAttributeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
     argumentList: RawTupleExprElementListSyntax?,
     _ unexpectedBetweenArgumentListAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax?,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .customAttribute, uninitializedCount: 10, arena: arena) { layout in
+      kind: .customAttribute, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAtSignToken?.raw
       layout[1] = atSignToken.raw
@@ -10013,6 +10634,7 @@ public struct RawCustomAttributeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
       layout[7] = argumentList?.raw
       layout[8] = unexpectedBetweenArgumentListAndRightParen?.raw
       layout[9] = rightParen?.raw
+      layout[10] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -10046,6 +10668,9 @@ public struct RawCustomAttributeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
   }
   public var rightParen: RawTokenSyntax? {
     layoutView.children[9].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -10085,10 +10710,11 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     rightParen: RawTokenSyntax?,
     _ unexpectedBetweenRightParenAndTokenList: RawUnexpectedNodesSyntax? = nil,
     tokenList: RawTokenListSyntax?,
+    _ unexpectedAfterTokenList: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .attribute, uninitializedCount: 12, arena: arena) { layout in
+      kind: .attribute, uninitializedCount: 13, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAtSignToken?.raw
       layout[1] = atSignToken.raw
@@ -10102,6 +10728,7 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[9] = rightParen?.raw
       layout[10] = unexpectedBetweenRightParenAndTokenList?.raw
       layout[11] = tokenList?.raw
+      layout[12] = unexpectedAfterTokenList?.raw
     }
     self.init(raw: raw)
   }
@@ -10141,6 +10768,9 @@ public struct RawAttributeSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var tokenList: RawTokenListSyntax? {
     layoutView.children[11].map(RawTokenListSyntax.init(raw:))
+  }
+  public var unexpectedAfterTokenList: RawUnexpectedNodesSyntax? {
+    layoutView.children[12].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -10256,10 +10886,11 @@ public struct RawAvailabilityEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
     availabilityList: RawAvailabilitySpecListSyntax,
     _ unexpectedBetweenAvailabilityListAndSemicolon: RawUnexpectedNodesSyntax? = nil,
     semicolon: RawTokenSyntax,
+    _ unexpectedAfterSemicolon: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .availabilityEntry, uninitializedCount: 8, arena: arena) { layout in
+      kind: .availabilityEntry, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLabel?.raw
       layout[1] = label.raw
@@ -10269,6 +10900,7 @@ public struct RawAvailabilityEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
       layout[5] = availabilityList.raw
       layout[6] = unexpectedBetweenAvailabilityListAndSemicolon?.raw
       layout[7] = semicolon.raw
+      layout[8] = unexpectedAfterSemicolon?.raw
     }
     self.init(raw: raw)
   }
@@ -10296,6 +10928,9 @@ public struct RawAvailabilityEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
   }
   public var semicolon: RawTokenSyntax {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterSemicolon: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -10331,10 +10966,11 @@ public struct RawLabeledSpecializeEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxT
     value: RawTokenSyntax,
     _ unexpectedBetweenValueAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .labeledSpecializeEntry, uninitializedCount: 8, arena: arena) { layout in
+      kind: .labeledSpecializeEntry, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLabel?.raw
       layout[1] = label.raw
@@ -10344,6 +10980,7 @@ public struct RawLabeledSpecializeEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxT
       layout[5] = value.raw
       layout[6] = unexpectedBetweenValueAndTrailingComma?.raw
       layout[7] = trailingComma?.raw
+      layout[8] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -10371,6 +11008,9 @@ public struct RawLabeledSpecializeEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxT
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -10406,10 +11046,11 @@ public struct RawTargetFunctionEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
     declname: RawDeclNameSyntax,
     _ unexpectedBetweenDeclnameAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .targetFunctionEntry, uninitializedCount: 8, arena: arena) { layout in
+      kind: .targetFunctionEntry, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLabel?.raw
       layout[1] = label.raw
@@ -10419,6 +11060,7 @@ public struct RawTargetFunctionEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
       layout[5] = declname.raw
       layout[6] = unexpectedBetweenDeclnameAndTrailingComma?.raw
       layout[7] = trailingComma?.raw
+      layout[8] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -10446,6 +11088,9 @@ public struct RawTargetFunctionEntrySyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -10479,10 +11124,11 @@ public struct RawNamedAttributeStringArgumentSyntax: RawSyntaxNodeProtocol, RawS
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndStringOrDeclname: RawUnexpectedNodesSyntax? = nil,
     stringOrDeclname: RawSyntax,
+    _ unexpectedAfterStringOrDeclname: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .namedAttributeStringArgument, uninitializedCount: 6, arena: arena) { layout in
+      kind: .namedAttributeStringArgument, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeNameTok?.raw
       layout[1] = nameTok.raw
@@ -10490,6 +11136,7 @@ public struct RawNamedAttributeStringArgumentSyntax: RawSyntaxNodeProtocol, RawS
       layout[3] = colon.raw
       layout[4] = unexpectedBetweenColonAndStringOrDeclname?.raw
       layout[5] = stringOrDeclname.raw
+      layout[6] = unexpectedAfterStringOrDeclname?.raw
     }
     self.init(raw: raw)
   }
@@ -10511,6 +11158,9 @@ public struct RawNamedAttributeStringArgumentSyntax: RawSyntaxNodeProtocol, RawS
   }
   public var stringOrDeclname: RawSyntax {
     layoutView.children[5]!
+  }
+  public var unexpectedAfterStringOrDeclname: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -10542,15 +11192,17 @@ public struct RawDeclNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     declBaseName: RawSyntax,
     _ unexpectedBetweenDeclBaseNameAndDeclNameArguments: RawUnexpectedNodesSyntax? = nil,
     declNameArguments: RawDeclNameArgumentsSyntax?,
+    _ unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .declName, uninitializedCount: 4, arena: arena) { layout in
+      kind: .declName, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeDeclBaseName?.raw
       layout[1] = declBaseName.raw
       layout[2] = unexpectedBetweenDeclBaseNameAndDeclNameArguments?.raw
       layout[3] = declNameArguments?.raw
+      layout[4] = unexpectedAfterDeclNameArguments?.raw
     }
     self.init(raw: raw)
   }
@@ -10566,6 +11218,9 @@ public struct RawDeclNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var declNameArguments: RawDeclNameArgumentsSyntax? {
     layoutView.children[3].map(RawDeclNameArgumentsSyntax.init(raw:))
+  }
+  public var unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -10601,10 +11256,11 @@ public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol, RawS
     declBaseName: RawTokenSyntax,
     _ unexpectedBetweenDeclBaseNameAndDeclNameArguments: RawUnexpectedNodesSyntax? = nil,
     declNameArguments: RawDeclNameArgumentsSyntax?,
+    _ unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .implementsAttributeArguments, uninitializedCount: 8, arena: arena) { layout in
+      kind: .implementsAttributeArguments, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeType?.raw
       layout[1] = type.raw
@@ -10614,6 +11270,7 @@ public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol, RawS
       layout[5] = declBaseName.raw
       layout[6] = unexpectedBetweenDeclBaseNameAndDeclNameArguments?.raw
       layout[7] = declNameArguments?.raw
+      layout[8] = unexpectedAfterDeclNameArguments?.raw
     }
     self.init(raw: raw)
   }
@@ -10641,6 +11298,9 @@ public struct RawImplementsAttributeArgumentsSyntax: RawSyntaxNodeProtocol, RawS
   }
   public var declNameArguments: RawDeclNameArgumentsSyntax? {
     layoutView.children[7].map(RawDeclNameArgumentsSyntax.init(raw:))
+  }
+  public var unexpectedAfterDeclNameArguments: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -10672,15 +11332,17 @@ public struct RawObjCSelectorPieceSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
     name: RawTokenSyntax?,
     _ unexpectedBetweenNameAndColon: RawUnexpectedNodesSyntax? = nil,
     colon: RawTokenSyntax?,
+    _ unexpectedAfterColon: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .objCSelectorPiece, uninitializedCount: 4, arena: arena) { layout in
+      kind: .objCSelectorPiece, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeName?.raw
       layout[1] = name?.raw
       layout[2] = unexpectedBetweenNameAndColon?.raw
       layout[3] = colon?.raw
+      layout[4] = unexpectedAfterColon?.raw
     }
     self.init(raw: raw)
   }
@@ -10696,6 +11358,9 @@ public struct RawObjCSelectorPieceSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
   }
   public var colon: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterColon: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -10773,10 +11438,11 @@ public struct RawDifferentiableAttributeArgumentsSyntax: RawSyntaxNodeProtocol, 
     diffParamsComma: RawTokenSyntax?,
     _ unexpectedBetweenDiffParamsCommaAndWhereClause: RawUnexpectedNodesSyntax? = nil,
     whereClause: RawGenericWhereClauseSyntax?,
+    _ unexpectedAfterWhereClause: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .differentiableAttributeArguments, uninitializedCount: 10, arena: arena) { layout in
+      kind: .differentiableAttributeArguments, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeDiffKind?.raw
       layout[1] = diffKind?.raw
@@ -10788,6 +11454,7 @@ public struct RawDifferentiableAttributeArgumentsSyntax: RawSyntaxNodeProtocol, 
       layout[7] = diffParamsComma?.raw
       layout[8] = unexpectedBetweenDiffParamsCommaAndWhereClause?.raw
       layout[9] = whereClause?.raw
+      layout[10] = unexpectedAfterWhereClause?.raw
     }
     self.init(raw: raw)
   }
@@ -10822,6 +11489,9 @@ public struct RawDifferentiableAttributeArgumentsSyntax: RawSyntaxNodeProtocol, 
   public var whereClause: RawGenericWhereClauseSyntax? {
     layoutView.children[9].map(RawGenericWhereClauseSyntax.init(raw:))
   }
+  public var unexpectedAfterWhereClause: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -10854,10 +11524,11 @@ public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol, Raw
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndParameters: RawUnexpectedNodesSyntax? = nil,
     parameters: RawSyntax,
+    _ unexpectedAfterParameters: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .differentiabilityParamsClause, uninitializedCount: 6, arena: arena) { layout in
+      kind: .differentiabilityParamsClause, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeWrtLabel?.raw
       layout[1] = wrtLabel.raw
@@ -10865,6 +11536,7 @@ public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol, Raw
       layout[3] = colon.raw
       layout[4] = unexpectedBetweenColonAndParameters?.raw
       layout[5] = parameters.raw
+      layout[6] = unexpectedAfterParameters?.raw
     }
     self.init(raw: raw)
   }
@@ -10886,6 +11558,9 @@ public struct RawDifferentiabilityParamsClauseSyntax: RawSyntaxNodeProtocol, Raw
   }
   public var parameters: RawSyntax {
     layoutView.children[5]!
+  }
+  public var unexpectedAfterParameters: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -10919,10 +11594,11 @@ public struct RawDifferentiabilityParamsSyntax: RawSyntaxNodeProtocol, RawSyntax
     diffParams: RawDifferentiabilityParamListSyntax,
     _ unexpectedBetweenDiffParamsAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .differentiabilityParams, uninitializedCount: 6, arena: arena) { layout in
+      kind: .differentiabilityParams, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftParen?.raw
       layout[1] = leftParen.raw
@@ -10930,6 +11606,7 @@ public struct RawDifferentiabilityParamsSyntax: RawSyntaxNodeProtocol, RawSyntax
       layout[3] = diffParams.raw
       layout[4] = unexpectedBetweenDiffParamsAndRightParen?.raw
       layout[5] = rightParen.raw
+      layout[6] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -10951,6 +11628,9 @@ public struct RawDifferentiabilityParamsSyntax: RawSyntaxNodeProtocol, RawSyntax
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -11022,15 +11702,17 @@ public struct RawDifferentiabilityParamSyntax: RawSyntaxNodeProtocol, RawSyntaxT
     parameter: RawSyntax,
     _ unexpectedBetweenParameterAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .differentiabilityParam, uninitializedCount: 4, arena: arena) { layout in
+      kind: .differentiabilityParam, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeParameter?.raw
       layout[1] = parameter.raw
       layout[2] = unexpectedBetweenParameterAndTrailingComma?.raw
       layout[3] = trailingComma?.raw
+      layout[4] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -11046,6 +11728,9 @@ public struct RawDifferentiabilityParamSyntax: RawSyntaxNodeProtocol, RawSyntaxT
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -11087,10 +11772,11 @@ public struct RawDerivativeRegistrationAttributeArgumentsSyntax: RawSyntaxNodePr
     comma: RawTokenSyntax?,
     _ unexpectedBetweenCommaAndDiffParams: RawUnexpectedNodesSyntax? = nil,
     diffParams: RawDifferentiabilityParamsClauseSyntax?,
+    _ unexpectedAfterDiffParams: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .derivativeRegistrationAttributeArguments, uninitializedCount: 14, arena: arena) { layout in
+      kind: .derivativeRegistrationAttributeArguments, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeOfLabel?.raw
       layout[1] = ofLabel.raw
@@ -11106,6 +11792,7 @@ public struct RawDerivativeRegistrationAttributeArgumentsSyntax: RawSyntaxNodePr
       layout[11] = comma?.raw
       layout[12] = unexpectedBetweenCommaAndDiffParams?.raw
       layout[13] = diffParams?.raw
+      layout[14] = unexpectedAfterDiffParams?.raw
     }
     self.init(raw: raw)
   }
@@ -11152,6 +11839,9 @@ public struct RawDerivativeRegistrationAttributeArgumentsSyntax: RawSyntaxNodePr
   public var diffParams: RawDifferentiabilityParamsClauseSyntax? {
     layoutView.children[13].map(RawDifferentiabilityParamsClauseSyntax.init(raw:))
   }
+  public var unexpectedAfterDiffParams: RawUnexpectedNodesSyntax? {
+    layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -11186,10 +11876,11 @@ public struct RawQualifiedDeclNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
     name: RawTokenSyntax,
     _ unexpectedBetweenNameAndArguments: RawUnexpectedNodesSyntax? = nil,
     arguments: RawDeclNameArgumentsSyntax?,
+    _ unexpectedAfterArguments: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .qualifiedDeclName, uninitializedCount: 8, arena: arena) { layout in
+      kind: .qualifiedDeclName, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeBaseType?.raw
       layout[1] = baseType?.raw
@@ -11199,6 +11890,7 @@ public struct RawQualifiedDeclNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
       layout[5] = name.raw
       layout[6] = unexpectedBetweenNameAndArguments?.raw
       layout[7] = arguments?.raw
+      layout[8] = unexpectedAfterArguments?.raw
     }
     self.init(raw: raw)
   }
@@ -11226,6 +11918,9 @@ public struct RawQualifiedDeclNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
   }
   public var arguments: RawDeclNameArgumentsSyntax? {
     layoutView.children[7].map(RawDeclNameArgumentsSyntax.init(raw:))
+  }
+  public var unexpectedAfterArguments: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -11257,15 +11952,17 @@ public struct RawFunctionDeclNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
     name: RawSyntax,
     _ unexpectedBetweenNameAndArguments: RawUnexpectedNodesSyntax? = nil,
     arguments: RawDeclNameArgumentsSyntax?,
+    _ unexpectedAfterArguments: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .functionDeclName, uninitializedCount: 4, arena: arena) { layout in
+      kind: .functionDeclName, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeName?.raw
       layout[1] = name.raw
       layout[2] = unexpectedBetweenNameAndArguments?.raw
       layout[3] = arguments?.raw
+      layout[4] = unexpectedAfterArguments?.raw
     }
     self.init(raw: raw)
   }
@@ -11281,6 +11978,9 @@ public struct RawFunctionDeclNameSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var arguments: RawDeclNameArgumentsSyntax? {
     layoutView.children[3].map(RawDeclNameArgumentsSyntax.init(raw:))
+  }
+  public var unexpectedAfterArguments: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -11314,10 +12014,11 @@ public struct RawBackDeployAttributeSpecListSyntax: RawSyntaxNodeProtocol, RawSy
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndVersionList: RawUnexpectedNodesSyntax? = nil,
     versionList: RawBackDeployVersionListSyntax,
+    _ unexpectedAfterVersionList: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .backDeployAttributeSpecList, uninitializedCount: 6, arena: arena) { layout in
+      kind: .backDeployAttributeSpecList, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeBeforeLabel?.raw
       layout[1] = beforeLabel.raw
@@ -11325,6 +12026,7 @@ public struct RawBackDeployAttributeSpecListSyntax: RawSyntaxNodeProtocol, RawSy
       layout[3] = colon.raw
       layout[4] = unexpectedBetweenColonAndVersionList?.raw
       layout[5] = versionList.raw
+      layout[6] = unexpectedAfterVersionList?.raw
     }
     self.init(raw: raw)
   }
@@ -11346,6 +12048,9 @@ public struct RawBackDeployAttributeSpecListSyntax: RawSyntaxNodeProtocol, RawSy
   }
   public var versionList: RawBackDeployVersionListSyntax {
     layoutView.children[5].map(RawBackDeployVersionListSyntax.init(raw:))!
+  }
+  public var unexpectedAfterVersionList: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -11417,15 +12122,17 @@ public struct RawBackDeployVersionArgumentSyntax: RawSyntaxNodeProtocol, RawSynt
     availabilityVersionRestriction: RawAvailabilityVersionRestrictionSyntax,
     _ unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .backDeployVersionArgument, uninitializedCount: 4, arena: arena) { layout in
+      kind: .backDeployVersionArgument, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAvailabilityVersionRestriction?.raw
       layout[1] = availabilityVersionRestriction.raw
       layout[2] = unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma?.raw
       layout[3] = trailingComma?.raw
+      layout[4] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -11441,6 +12148,9 @@ public struct RawBackDeployVersionArgumentSyntax: RawSyntaxNodeProtocol, RawSynt
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -11474,10 +12184,11 @@ public struct RawOpaqueReturnTypeOfAttributeArgumentsSyntax: RawSyntaxNodeProtoc
     comma: RawTokenSyntax,
     _ unexpectedBetweenCommaAndOrdinal: RawUnexpectedNodesSyntax? = nil,
     ordinal: RawTokenSyntax,
+    _ unexpectedAfterOrdinal: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .opaqueReturnTypeOfAttributeArguments, uninitializedCount: 6, arena: arena) { layout in
+      kind: .opaqueReturnTypeOfAttributeArguments, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeMangledName?.raw
       layout[1] = mangledName.raw
@@ -11485,6 +12196,7 @@ public struct RawOpaqueReturnTypeOfAttributeArgumentsSyntax: RawSyntaxNodeProtoc
       layout[3] = comma.raw
       layout[4] = unexpectedBetweenCommaAndOrdinal?.raw
       layout[5] = ordinal.raw
+      layout[6] = unexpectedAfterOrdinal?.raw
     }
     self.init(raw: raw)
   }
@@ -11506,6 +12218,9 @@ public struct RawOpaqueReturnTypeOfAttributeArgumentsSyntax: RawSyntaxNodeProtoc
   }
   public var ordinal: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterOrdinal: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -11543,10 +12258,11 @@ public struct RawConventionAttributeArgumentsSyntax: RawSyntaxNodeProtocol, RawS
     colon: RawTokenSyntax?,
     _ unexpectedBetweenColonAndCTypeString: RawUnexpectedNodesSyntax? = nil,
     cTypeString: RawTokenSyntax?,
+    _ unexpectedAfterCTypeString: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .conventionAttributeArguments, uninitializedCount: 10, arena: arena) { layout in
+      kind: .conventionAttributeArguments, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeConventionLabel?.raw
       layout[1] = conventionLabel.raw
@@ -11558,6 +12274,7 @@ public struct RawConventionAttributeArgumentsSyntax: RawSyntaxNodeProtocol, RawS
       layout[7] = colon?.raw
       layout[8] = unexpectedBetweenColonAndCTypeString?.raw
       layout[9] = cTypeString?.raw
+      layout[10] = unexpectedAfterCTypeString?.raw
     }
     self.init(raw: raw)
   }
@@ -11592,6 +12309,9 @@ public struct RawConventionAttributeArgumentsSyntax: RawSyntaxNodeProtocol, RawS
   public var cTypeString: RawTokenSyntax? {
     layoutView.children[9].map(RawTokenSyntax.init(raw:))
   }
+  public var unexpectedAfterCTypeString: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -11624,10 +12344,11 @@ public struct RawConventionWitnessMethodAttributeArgumentsSyntax: RawSyntaxNodeP
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndProtocolName: RawUnexpectedNodesSyntax? = nil,
     protocolName: RawTokenSyntax,
+    _ unexpectedAfterProtocolName: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .conventionWitnessMethodAttributeArguments, uninitializedCount: 6, arena: arena) { layout in
+      kind: .conventionWitnessMethodAttributeArguments, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeWitnessMethodLabel?.raw
       layout[1] = witnessMethodLabel.raw
@@ -11635,6 +12356,7 @@ public struct RawConventionWitnessMethodAttributeArgumentsSyntax: RawSyntaxNodeP
       layout[3] = colon.raw
       layout[4] = unexpectedBetweenColonAndProtocolName?.raw
       layout[5] = protocolName.raw
+      layout[6] = unexpectedAfterProtocolName?.raw
     }
     self.init(raw: raw)
   }
@@ -11656,6 +12378,9 @@ public struct RawConventionWitnessMethodAttributeArgumentsSyntax: RawSyntaxNodeP
   }
   public var protocolName: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterProtocolName: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -11689,10 +12414,11 @@ public struct RawLabeledStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax
     labelColon: RawTokenSyntax,
     _ unexpectedBetweenLabelColonAndStatement: RawUnexpectedNodesSyntax? = nil,
     statement: RawStmtSyntax,
+    _ unexpectedAfterStatement: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .labeledStmt, uninitializedCount: 6, arena: arena) { layout in
+      kind: .labeledStmt, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLabelName?.raw
       layout[1] = labelName.raw
@@ -11700,6 +12426,7 @@ public struct RawLabeledStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax
       layout[3] = labelColon.raw
       layout[4] = unexpectedBetweenLabelColonAndStatement?.raw
       layout[5] = statement.raw
+      layout[6] = unexpectedAfterStatement?.raw
     }
     self.init(raw: raw)
   }
@@ -11721,6 +12448,9 @@ public struct RawLabeledStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax
   }
   public var statement: RawStmtSyntax {
     layoutView.children[5].map(RawStmtSyntax.init(raw:))!
+  }
+  public var unexpectedAfterStatement: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -11752,15 +12482,17 @@ public struct RawContinueStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSynta
     continueKeyword: RawTokenSyntax,
     _ unexpectedBetweenContinueKeywordAndLabel: RawUnexpectedNodesSyntax? = nil,
     label: RawTokenSyntax?,
+    _ unexpectedAfterLabel: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .continueStmt, uninitializedCount: 4, arena: arena) { layout in
+      kind: .continueStmt, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeContinueKeyword?.raw
       layout[1] = continueKeyword.raw
       layout[2] = unexpectedBetweenContinueKeywordAndLabel?.raw
       layout[3] = label?.raw
+      layout[4] = unexpectedAfterLabel?.raw
     }
     self.init(raw: raw)
   }
@@ -11776,6 +12508,9 @@ public struct RawContinueStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var label: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterLabel: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -11809,10 +12544,11 @@ public struct RawWhileStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
     conditions: RawConditionElementListSyntax,
     _ unexpectedBetweenConditionsAndBody: RawUnexpectedNodesSyntax? = nil,
     body: RawCodeBlockSyntax,
+    _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .whileStmt, uninitializedCount: 6, arena: arena) { layout in
+      kind: .whileStmt, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeWhileKeyword?.raw
       layout[1] = whileKeyword.raw
@@ -11820,6 +12556,7 @@ public struct RawWhileStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = conditions.raw
       layout[4] = unexpectedBetweenConditionsAndBody?.raw
       layout[5] = body.raw
+      layout[6] = unexpectedAfterBody?.raw
     }
     self.init(raw: raw)
   }
@@ -11841,6 +12578,9 @@ public struct RawWhileStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var body: RawCodeBlockSyntax {
     layoutView.children[5].map(RawCodeBlockSyntax.init(raw:))!
+  }
+  public var unexpectedAfterBody: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -11872,15 +12612,17 @@ public struct RawDeferStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
     deferKeyword: RawTokenSyntax,
     _ unexpectedBetweenDeferKeywordAndBody: RawUnexpectedNodesSyntax? = nil,
     body: RawCodeBlockSyntax,
+    _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .deferStmt, uninitializedCount: 4, arena: arena) { layout in
+      kind: .deferStmt, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeDeferKeyword?.raw
       layout[1] = deferKeyword.raw
       layout[2] = unexpectedBetweenDeferKeywordAndBody?.raw
       layout[3] = body.raw
+      layout[4] = unexpectedAfterBody?.raw
     }
     self.init(raw: raw)
   }
@@ -11896,6 +12638,9 @@ public struct RawDeferStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var body: RawCodeBlockSyntax {
     layoutView.children[3].map(RawCodeBlockSyntax.init(raw:))!
+  }
+  public var unexpectedAfterBody: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -11925,13 +12670,15 @@ public struct RawExpressionStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyn
   public init(
     _ unexpectedBeforeExpression: RawUnexpectedNodesSyntax? = nil,
     expression: RawExprSyntax,
+    _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .expressionStmt, uninitializedCount: 2, arena: arena) { layout in
+      kind: .expressionStmt, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeExpression?.raw
       layout[1] = expression.raw
+      layout[2] = unexpectedAfterExpression?.raw
     }
     self.init(raw: raw)
   }
@@ -11941,6 +12688,9 @@ public struct RawExpressionStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var expression: RawExprSyntax {
     layoutView.children[1].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -12016,10 +12766,11 @@ public struct RawRepeatWhileStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSy
     whileKeyword: RawTokenSyntax,
     _ unexpectedBetweenWhileKeywordAndCondition: RawUnexpectedNodesSyntax? = nil,
     condition: RawExprSyntax,
+    _ unexpectedAfterCondition: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .repeatWhileStmt, uninitializedCount: 8, arena: arena) { layout in
+      kind: .repeatWhileStmt, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeRepeatKeyword?.raw
       layout[1] = repeatKeyword.raw
@@ -12029,6 +12780,7 @@ public struct RawRepeatWhileStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSy
       layout[5] = whileKeyword.raw
       layout[6] = unexpectedBetweenWhileKeywordAndCondition?.raw
       layout[7] = condition.raw
+      layout[8] = unexpectedAfterCondition?.raw
     }
     self.init(raw: raw)
   }
@@ -12056,6 +12808,9 @@ public struct RawRepeatWhileStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSy
   }
   public var condition: RawExprSyntax {
     layoutView.children[7].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterCondition: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -12091,10 +12846,11 @@ public struct RawGuardStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
     elseKeyword: RawTokenSyntax,
     _ unexpectedBetweenElseKeywordAndBody: RawUnexpectedNodesSyntax? = nil,
     body: RawCodeBlockSyntax,
+    _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .guardStmt, uninitializedCount: 8, arena: arena) { layout in
+      kind: .guardStmt, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeGuardKeyword?.raw
       layout[1] = guardKeyword.raw
@@ -12104,6 +12860,7 @@ public struct RawGuardStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[5] = elseKeyword.raw
       layout[6] = unexpectedBetweenElseKeywordAndBody?.raw
       layout[7] = body.raw
+      layout[8] = unexpectedAfterBody?.raw
     }
     self.init(raw: raw)
   }
@@ -12131,6 +12888,9 @@ public struct RawGuardStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var body: RawCodeBlockSyntax {
     layoutView.children[7].map(RawCodeBlockSyntax.init(raw:))!
+  }
+  public var unexpectedAfterBody: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -12162,15 +12922,17 @@ public struct RawWhereClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     whereKeyword: RawTokenSyntax,
     _ unexpectedBetweenWhereKeywordAndGuardResult: RawUnexpectedNodesSyntax? = nil,
     guardResult: RawExprSyntax,
+    _ unexpectedAfterGuardResult: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .whereClause, uninitializedCount: 4, arena: arena) { layout in
+      kind: .whereClause, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeWhereKeyword?.raw
       layout[1] = whereKeyword.raw
       layout[2] = unexpectedBetweenWhereKeywordAndGuardResult?.raw
       layout[3] = guardResult.raw
+      layout[4] = unexpectedAfterGuardResult?.raw
     }
     self.init(raw: raw)
   }
@@ -12186,6 +12948,9 @@ public struct RawWhereClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var guardResult: RawExprSyntax {
     layoutView.children[3].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterGuardResult: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -12233,10 +12998,11 @@ public struct RawForInStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
     whereClause: RawWhereClauseSyntax?,
     _ unexpectedBetweenWhereClauseAndBody: RawUnexpectedNodesSyntax? = nil,
     body: RawCodeBlockSyntax,
+    _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .forInStmt, uninitializedCount: 20, arena: arena) { layout in
+      kind: .forInStmt, uninitializedCount: 21, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeForKeyword?.raw
       layout[1] = forKeyword.raw
@@ -12258,6 +13024,7 @@ public struct RawForInStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[17] = whereClause?.raw
       layout[18] = unexpectedBetweenWhereClauseAndBody?.raw
       layout[19] = body.raw
+      layout[20] = unexpectedAfterBody?.raw
     }
     self.init(raw: raw)
   }
@@ -12322,6 +13089,9 @@ public struct RawForInStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public var body: RawCodeBlockSyntax {
     layoutView.children[19].map(RawCodeBlockSyntax.init(raw:))!
   }
+  public var unexpectedAfterBody: RawUnexpectedNodesSyntax? {
+    layoutView.children[20].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -12358,10 +13128,11 @@ public struct RawSwitchStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax 
     cases: RawSwitchCaseListSyntax,
     _ unexpectedBetweenCasesAndRightBrace: RawUnexpectedNodesSyntax? = nil,
     rightBrace: RawTokenSyntax,
+    _ unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .switchStmt, uninitializedCount: 10, arena: arena) { layout in
+      kind: .switchStmt, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeSwitchKeyword?.raw
       layout[1] = switchKeyword.raw
@@ -12373,6 +13144,7 @@ public struct RawSwitchStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax 
       layout[7] = cases.raw
       layout[8] = unexpectedBetweenCasesAndRightBrace?.raw
       layout[9] = rightBrace.raw
+      layout[10] = unexpectedAfterRightBrace?.raw
     }
     self.init(raw: raw)
   }
@@ -12406,6 +13178,9 @@ public struct RawSwitchStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax 
   }
   public var rightBrace: RawTokenSyntax {
     layoutView.children[9].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightBrace: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -12479,10 +13254,11 @@ public struct RawDoStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
     body: RawCodeBlockSyntax,
     _ unexpectedBetweenBodyAndCatchClauses: RawUnexpectedNodesSyntax? = nil,
     catchClauses: RawCatchClauseListSyntax?,
+    _ unexpectedAfterCatchClauses: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .doStmt, uninitializedCount: 6, arena: arena) { layout in
+      kind: .doStmt, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeDoKeyword?.raw
       layout[1] = doKeyword.raw
@@ -12490,6 +13266,7 @@ public struct RawDoStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = body.raw
       layout[4] = unexpectedBetweenBodyAndCatchClauses?.raw
       layout[5] = catchClauses?.raw
+      layout[6] = unexpectedAfterCatchClauses?.raw
     }
     self.init(raw: raw)
   }
@@ -12511,6 +13288,9 @@ public struct RawDoStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var catchClauses: RawCatchClauseListSyntax? {
     layoutView.children[5].map(RawCatchClauseListSyntax.init(raw:))
+  }
+  public var unexpectedAfterCatchClauses: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -12542,15 +13322,17 @@ public struct RawReturnStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax 
     returnKeyword: RawTokenSyntax,
     _ unexpectedBetweenReturnKeywordAndExpression: RawUnexpectedNodesSyntax? = nil,
     expression: RawExprSyntax?,
+    _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .returnStmt, uninitializedCount: 4, arena: arena) { layout in
+      kind: .returnStmt, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeReturnKeyword?.raw
       layout[1] = returnKeyword.raw
       layout[2] = unexpectedBetweenReturnKeywordAndExpression?.raw
       layout[3] = expression?.raw
+      layout[4] = unexpectedAfterExpression?.raw
     }
     self.init(raw: raw)
   }
@@ -12566,6 +13348,9 @@ public struct RawReturnStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax 
   }
   public var expression: RawExprSyntax? {
     layoutView.children[3].map(RawExprSyntax.init(raw:))
+  }
+  public var unexpectedAfterExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -12597,15 +13382,17 @@ public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
     yieldKeyword: RawTokenSyntax,
     _ unexpectedBetweenYieldKeywordAndYields: RawUnexpectedNodesSyntax? = nil,
     yields: RawSyntax,
+    _ unexpectedAfterYields: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .yieldStmt, uninitializedCount: 4, arena: arena) { layout in
+      kind: .yieldStmt, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeYieldKeyword?.raw
       layout[1] = yieldKeyword.raw
       layout[2] = unexpectedBetweenYieldKeywordAndYields?.raw
       layout[3] = yields.raw
+      layout[4] = unexpectedAfterYields?.raw
     }
     self.init(raw: raw)
   }
@@ -12621,6 +13408,9 @@ public struct RawYieldStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var yields: RawSyntax {
     layoutView.children[3]!
+  }
+  public var unexpectedAfterYields: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -12654,10 +13444,11 @@ public struct RawYieldListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     elementList: RawYieldExprListSyntax,
     _ unexpectedBetweenElementListAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .yieldList, uninitializedCount: 6, arena: arena) { layout in
+      kind: .yieldList, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftParen?.raw
       layout[1] = leftParen.raw
@@ -12665,6 +13456,7 @@ public struct RawYieldListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = elementList.raw
       layout[4] = unexpectedBetweenElementListAndRightParen?.raw
       layout[5] = rightParen.raw
+      layout[6] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -12686,6 +13478,9 @@ public struct RawYieldListSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -12715,13 +13510,15 @@ public struct RawFallthroughStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSy
   public init(
     _ unexpectedBeforeFallthroughKeyword: RawUnexpectedNodesSyntax? = nil,
     fallthroughKeyword: RawTokenSyntax,
+    _ unexpectedAfterFallthroughKeyword: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .fallthroughStmt, uninitializedCount: 2, arena: arena) { layout in
+      kind: .fallthroughStmt, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeFallthroughKeyword?.raw
       layout[1] = fallthroughKeyword.raw
+      layout[2] = unexpectedAfterFallthroughKeyword?.raw
     }
     self.init(raw: raw)
   }
@@ -12731,6 +13528,9 @@ public struct RawFallthroughStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSy
   }
   public var fallthroughKeyword: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterFallthroughKeyword: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -12762,15 +13562,17 @@ public struct RawBreakStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
     breakKeyword: RawTokenSyntax,
     _ unexpectedBetweenBreakKeywordAndLabel: RawUnexpectedNodesSyntax? = nil,
     label: RawTokenSyntax?,
+    _ unexpectedAfterLabel: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .breakStmt, uninitializedCount: 4, arena: arena) { layout in
+      kind: .breakStmt, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeBreakKeyword?.raw
       layout[1] = breakKeyword.raw
       layout[2] = unexpectedBetweenBreakKeywordAndLabel?.raw
       layout[3] = label?.raw
+      layout[4] = unexpectedAfterLabel?.raw
     }
     self.init(raw: raw)
   }
@@ -12786,6 +13588,9 @@ public struct RawBreakStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var label: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterLabel: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -12897,15 +13702,17 @@ public struct RawConditionElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
     condition: RawSyntax,
     _ unexpectedBetweenConditionAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .conditionElement, uninitializedCount: 4, arena: arena) { layout in
+      kind: .conditionElement, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeCondition?.raw
       layout[1] = condition.raw
       layout[2] = unexpectedBetweenConditionAndTrailingComma?.raw
       layout[3] = trailingComma?.raw
+      layout[4] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -12921,6 +13728,9 @@ public struct RawConditionElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -12956,10 +13766,11 @@ public struct RawAvailabilityConditionSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
     availabilitySpec: RawAvailabilitySpecListSyntax,
     _ unexpectedBetweenAvailabilitySpecAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .availabilityCondition, uninitializedCount: 8, arena: arena) { layout in
+      kind: .availabilityCondition, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePoundAvailableKeyword?.raw
       layout[1] = poundAvailableKeyword.raw
@@ -12969,6 +13780,7 @@ public struct RawAvailabilityConditionSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
       layout[5] = availabilitySpec.raw
       layout[6] = unexpectedBetweenAvailabilitySpecAndRightParen?.raw
       layout[7] = rightParen.raw
+      layout[8] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -12996,6 +13808,9 @@ public struct RawAvailabilityConditionSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -13031,10 +13846,11 @@ public struct RawMatchingPatternConditionSyntax: RawSyntaxNodeProtocol, RawSynta
     typeAnnotation: RawTypeAnnotationSyntax?,
     _ unexpectedBetweenTypeAnnotationAndInitializer: RawUnexpectedNodesSyntax? = nil,
     initializer: RawInitializerClauseSyntax,
+    _ unexpectedAfterInitializer: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .matchingPatternCondition, uninitializedCount: 8, arena: arena) { layout in
+      kind: .matchingPatternCondition, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeCaseKeyword?.raw
       layout[1] = caseKeyword.raw
@@ -13044,6 +13860,7 @@ public struct RawMatchingPatternConditionSyntax: RawSyntaxNodeProtocol, RawSynta
       layout[5] = typeAnnotation?.raw
       layout[6] = unexpectedBetweenTypeAnnotationAndInitializer?.raw
       layout[7] = initializer.raw
+      layout[8] = unexpectedAfterInitializer?.raw
     }
     self.init(raw: raw)
   }
@@ -13071,6 +13888,9 @@ public struct RawMatchingPatternConditionSyntax: RawSyntaxNodeProtocol, RawSynta
   }
   public var initializer: RawInitializerClauseSyntax {
     layoutView.children[7].map(RawInitializerClauseSyntax.init(raw:))!
+  }
+  public var unexpectedAfterInitializer: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -13106,10 +13926,11 @@ public struct RawOptionalBindingConditionSyntax: RawSyntaxNodeProtocol, RawSynta
     typeAnnotation: RawTypeAnnotationSyntax?,
     _ unexpectedBetweenTypeAnnotationAndInitializer: RawUnexpectedNodesSyntax? = nil,
     initializer: RawInitializerClauseSyntax?,
+    _ unexpectedAfterInitializer: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .optionalBindingCondition, uninitializedCount: 8, arena: arena) { layout in
+      kind: .optionalBindingCondition, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLetOrVarKeyword?.raw
       layout[1] = letOrVarKeyword.raw
@@ -13119,6 +13940,7 @@ public struct RawOptionalBindingConditionSyntax: RawSyntaxNodeProtocol, RawSynta
       layout[5] = typeAnnotation?.raw
       layout[6] = unexpectedBetweenTypeAnnotationAndInitializer?.raw
       layout[7] = initializer?.raw
+      layout[8] = unexpectedAfterInitializer?.raw
     }
     self.init(raw: raw)
   }
@@ -13146,6 +13968,9 @@ public struct RawOptionalBindingConditionSyntax: RawSyntaxNodeProtocol, RawSynta
   }
   public var initializer: RawInitializerClauseSyntax? {
     layoutView.children[7].map(RawInitializerClauseSyntax.init(raw:))
+  }
+  public var unexpectedAfterInitializer: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -13181,10 +14006,11 @@ public struct RawUnavailabilityConditionSyntax: RawSyntaxNodeProtocol, RawSyntax
     availabilitySpec: RawAvailabilitySpecListSyntax,
     _ unexpectedBetweenAvailabilitySpecAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .unavailabilityCondition, uninitializedCount: 8, arena: arena) { layout in
+      kind: .unavailabilityCondition, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePoundUnavailableKeyword?.raw
       layout[1] = poundUnavailableKeyword.raw
@@ -13194,6 +14020,7 @@ public struct RawUnavailabilityConditionSyntax: RawSyntaxNodeProtocol, RawSyntax
       layout[5] = availabilitySpec.raw
       layout[6] = unexpectedBetweenAvailabilitySpecAndRightParen?.raw
       layout[7] = rightParen.raw
+      layout[8] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -13221,6 +14048,9 @@ public struct RawUnavailabilityConditionSyntax: RawSyntaxNodeProtocol, RawSyntax
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -13256,10 +14086,11 @@ public struct RawHasSymbolConditionSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
     expression: RawExprSyntax,
     _ unexpectedBetweenExpressionAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .hasSymbolCondition, uninitializedCount: 8, arena: arena) { layout in
+      kind: .hasSymbolCondition, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeHasSymbolKeyword?.raw
       layout[1] = hasSymbolKeyword.raw
@@ -13269,6 +14100,7 @@ public struct RawHasSymbolConditionSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
       layout[5] = expression.raw
       layout[6] = unexpectedBetweenExpressionAndRightParen?.raw
       layout[7] = rightParen.raw
+      layout[8] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -13296,6 +14128,9 @@ public struct RawHasSymbolConditionSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -13365,13 +14200,15 @@ public struct RawDeclarationStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSy
   public init(
     _ unexpectedBeforeDeclaration: RawUnexpectedNodesSyntax? = nil,
     declaration: RawDeclSyntax,
+    _ unexpectedAfterDeclaration: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .declarationStmt, uninitializedCount: 2, arena: arena) { layout in
+      kind: .declarationStmt, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeDeclaration?.raw
       layout[1] = declaration.raw
+      layout[2] = unexpectedAfterDeclaration?.raw
     }
     self.init(raw: raw)
   }
@@ -13381,6 +14218,9 @@ public struct RawDeclarationStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSy
   }
   public var declaration: RawDeclSyntax {
     layoutView.children[1].map(RawDeclSyntax.init(raw:))!
+  }
+  public var unexpectedAfterDeclaration: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -13412,15 +14252,17 @@ public struct RawThrowStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
     throwKeyword: RawTokenSyntax,
     _ unexpectedBetweenThrowKeywordAndExpression: RawUnexpectedNodesSyntax? = nil,
     expression: RawExprSyntax,
+    _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .throwStmt, uninitializedCount: 4, arena: arena) { layout in
+      kind: .throwStmt, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeThrowKeyword?.raw
       layout[1] = throwKeyword.raw
       layout[2] = unexpectedBetweenThrowKeywordAndExpression?.raw
       layout[3] = expression.raw
+      layout[4] = unexpectedAfterExpression?.raw
     }
     self.init(raw: raw)
   }
@@ -13436,6 +14278,9 @@ public struct RawThrowStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var expression: RawExprSyntax {
     layoutView.children[3].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -13473,10 +14318,11 @@ public struct RawIfStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
     elseKeyword: RawTokenSyntax?,
     _ unexpectedBetweenElseKeywordAndElseBody: RawUnexpectedNodesSyntax? = nil,
     elseBody: RawSyntax?,
+    _ unexpectedAfterElseBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .ifStmt, uninitializedCount: 10, arena: arena) { layout in
+      kind: .ifStmt, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeIfKeyword?.raw
       layout[1] = ifKeyword.raw
@@ -13488,6 +14334,7 @@ public struct RawIfStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[7] = elseKeyword?.raw
       layout[8] = unexpectedBetweenElseKeywordAndElseBody?.raw
       layout[9] = elseBody?.raw
+      layout[10] = unexpectedAfterElseBody?.raw
     }
     self.init(raw: raw)
   }
@@ -13522,6 +14369,9 @@ public struct RawIfStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSyntax {
   public var elseBody: RawSyntax? {
     layoutView.children[9]
   }
+  public var unexpectedAfterElseBody: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -13554,10 +14404,11 @@ public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     label: RawSyntax,
     _ unexpectedBetweenLabelAndStatements: RawUnexpectedNodesSyntax? = nil,
     statements: RawCodeBlockItemListSyntax,
+    _ unexpectedAfterStatements: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .switchCase, uninitializedCount: 6, arena: arena) { layout in
+      kind: .switchCase, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeUnknownAttr?.raw
       layout[1] = unknownAttr?.raw
@@ -13565,6 +14416,7 @@ public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = label.raw
       layout[4] = unexpectedBetweenLabelAndStatements?.raw
       layout[5] = statements.raw
+      layout[6] = unexpectedAfterStatements?.raw
     }
     self.init(raw: raw)
   }
@@ -13586,6 +14438,9 @@ public struct RawSwitchCaseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var statements: RawCodeBlockItemListSyntax {
     layoutView.children[5].map(RawCodeBlockItemListSyntax.init(raw:))!
+  }
+  public var unexpectedAfterStatements: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -13617,15 +14472,17 @@ public struct RawSwitchDefaultLabelSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
     defaultKeyword: RawTokenSyntax,
     _ unexpectedBetweenDefaultKeywordAndColon: RawUnexpectedNodesSyntax? = nil,
     colon: RawTokenSyntax,
+    _ unexpectedAfterColon: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .switchDefaultLabel, uninitializedCount: 4, arena: arena) { layout in
+      kind: .switchDefaultLabel, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeDefaultKeyword?.raw
       layout[1] = defaultKeyword.raw
       layout[2] = unexpectedBetweenDefaultKeywordAndColon?.raw
       layout[3] = colon.raw
+      layout[4] = unexpectedAfterColon?.raw
     }
     self.init(raw: raw)
   }
@@ -13641,6 +14498,9 @@ public struct RawSwitchDefaultLabelSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var colon: RawTokenSyntax {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterColon: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -13674,10 +14534,11 @@ public struct RawCaseItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     whereClause: RawWhereClauseSyntax?,
     _ unexpectedBetweenWhereClauseAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .caseItem, uninitializedCount: 6, arena: arena) { layout in
+      kind: .caseItem, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePattern?.raw
       layout[1] = pattern.raw
@@ -13685,6 +14546,7 @@ public struct RawCaseItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = whereClause?.raw
       layout[4] = unexpectedBetweenWhereClauseAndTrailingComma?.raw
       layout[5] = trailingComma?.raw
+      layout[6] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -13706,6 +14568,9 @@ public struct RawCaseItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -13739,10 +14604,11 @@ public struct RawCatchItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     whereClause: RawWhereClauseSyntax?,
     _ unexpectedBetweenWhereClauseAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .catchItem, uninitializedCount: 6, arena: arena) { layout in
+      kind: .catchItem, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePattern?.raw
       layout[1] = pattern?.raw
@@ -13750,6 +14616,7 @@ public struct RawCatchItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = whereClause?.raw
       layout[4] = unexpectedBetweenWhereClauseAndTrailingComma?.raw
       layout[5] = trailingComma?.raw
+      layout[6] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -13771,6 +14638,9 @@ public struct RawCatchItemSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -13804,10 +14674,11 @@ public struct RawSwitchCaseLabelSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
     caseItems: RawCaseItemListSyntax,
     _ unexpectedBetweenCaseItemsAndColon: RawUnexpectedNodesSyntax? = nil,
     colon: RawTokenSyntax,
+    _ unexpectedAfterColon: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .switchCaseLabel, uninitializedCount: 6, arena: arena) { layout in
+      kind: .switchCaseLabel, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeCaseKeyword?.raw
       layout[1] = caseKeyword.raw
@@ -13815,6 +14686,7 @@ public struct RawSwitchCaseLabelSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
       layout[3] = caseItems.raw
       layout[4] = unexpectedBetweenCaseItemsAndColon?.raw
       layout[5] = colon.raw
+      layout[6] = unexpectedAfterColon?.raw
     }
     self.init(raw: raw)
   }
@@ -13836,6 +14708,9 @@ public struct RawSwitchCaseLabelSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
   }
   public var colon: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterColon: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -13869,10 +14744,11 @@ public struct RawCatchClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     catchItems: RawCatchItemListSyntax?,
     _ unexpectedBetweenCatchItemsAndBody: RawUnexpectedNodesSyntax? = nil,
     body: RawCodeBlockSyntax,
+    _ unexpectedAfterBody: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .catchClause, uninitializedCount: 6, arena: arena) { layout in
+      kind: .catchClause, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeCatchKeyword?.raw
       layout[1] = catchKeyword.raw
@@ -13880,6 +14756,7 @@ public struct RawCatchClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = catchItems?.raw
       layout[4] = unexpectedBetweenCatchItemsAndBody?.raw
       layout[5] = body.raw
+      layout[6] = unexpectedAfterBody?.raw
     }
     self.init(raw: raw)
   }
@@ -13901,6 +14778,9 @@ public struct RawCatchClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var body: RawCodeBlockSyntax {
     layoutView.children[5].map(RawCodeBlockSyntax.init(raw:))!
+  }
+  public var unexpectedAfterBody: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -13940,10 +14820,11 @@ public struct RawPoundAssertStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSy
     message: RawTokenSyntax?,
     _ unexpectedBetweenMessageAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .poundAssertStmt, uninitializedCount: 12, arena: arena) { layout in
+      kind: .poundAssertStmt, uninitializedCount: 13, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePoundAssert?.raw
       layout[1] = poundAssert.raw
@@ -13957,6 +14838,7 @@ public struct RawPoundAssertStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSy
       layout[9] = message?.raw
       layout[10] = unexpectedBetweenMessageAndRightParen?.raw
       layout[11] = rightParen.raw
+      layout[12] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -13997,6 +14879,9 @@ public struct RawPoundAssertStmtSyntax: RawStmtSyntaxNodeProtocol, RawSyntaxToSy
   public var rightParen: RawTokenSyntax {
     layoutView.children[11].map(RawTokenSyntax.init(raw:))!
   }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[12].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -14027,15 +14912,17 @@ public struct RawGenericWhereClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
     whereKeyword: RawTokenSyntax,
     _ unexpectedBetweenWhereKeywordAndRequirementList: RawUnexpectedNodesSyntax? = nil,
     requirementList: RawGenericRequirementListSyntax,
+    _ unexpectedAfterRequirementList: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .genericWhereClause, uninitializedCount: 4, arena: arena) { layout in
+      kind: .genericWhereClause, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeWhereKeyword?.raw
       layout[1] = whereKeyword.raw
       layout[2] = unexpectedBetweenWhereKeywordAndRequirementList?.raw
       layout[3] = requirementList.raw
+      layout[4] = unexpectedAfterRequirementList?.raw
     }
     self.init(raw: raw)
   }
@@ -14051,6 +14938,9 @@ public struct RawGenericWhereClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var requirementList: RawGenericRequirementListSyntax {
     layoutView.children[3].map(RawGenericRequirementListSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRequirementList: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -14122,15 +15012,17 @@ public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
     body: RawSyntax,
     _ unexpectedBetweenBodyAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .genericRequirement, uninitializedCount: 4, arena: arena) { layout in
+      kind: .genericRequirement, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeBody?.raw
       layout[1] = body.raw
       layout[2] = unexpectedBetweenBodyAndTrailingComma?.raw
       layout[3] = trailingComma?.raw
+      layout[4] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -14146,6 +15038,9 @@ public struct RawGenericRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -14179,10 +15074,11 @@ public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
     equalityToken: RawTokenSyntax,
     _ unexpectedBetweenEqualityTokenAndRightTypeIdentifier: RawUnexpectedNodesSyntax? = nil,
     rightTypeIdentifier: RawTypeSyntax,
+    _ unexpectedAfterRightTypeIdentifier: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .sameTypeRequirement, uninitializedCount: 6, arena: arena) { layout in
+      kind: .sameTypeRequirement, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftTypeIdentifier?.raw
       layout[1] = leftTypeIdentifier.raw
@@ -14190,6 +15086,7 @@ public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
       layout[3] = equalityToken.raw
       layout[4] = unexpectedBetweenEqualityTokenAndRightTypeIdentifier?.raw
       layout[5] = rightTypeIdentifier.raw
+      layout[6] = unexpectedAfterRightTypeIdentifier?.raw
     }
     self.init(raw: raw)
   }
@@ -14211,6 +15108,9 @@ public struct RawSameTypeRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
   }
   public var rightTypeIdentifier: RawTypeSyntax {
     layoutView.children[5].map(RawTypeSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightTypeIdentifier: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -14254,10 +15154,11 @@ public struct RawLayoutRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
     alignment: RawTokenSyntax?,
     _ unexpectedBetweenAlignmentAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax?,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .layoutRequirement, uninitializedCount: 16, arena: arena) { layout in
+      kind: .layoutRequirement, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeTypeIdentifier?.raw
       layout[1] = typeIdentifier.raw
@@ -14275,6 +15176,7 @@ public struct RawLayoutRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
       layout[13] = alignment?.raw
       layout[14] = unexpectedBetweenAlignmentAndRightParen?.raw
       layout[15] = rightParen?.raw
+      layout[16] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -14326,6 +15228,9 @@ public struct RawLayoutRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynt
   }
   public var rightParen: RawTokenSyntax? {
     layoutView.children[15].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -14403,10 +15308,11 @@ public struct RawGenericParameterSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
     inheritedType: RawTypeSyntax?,
     _ unexpectedBetweenInheritedTypeAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .genericParameter, uninitializedCount: 10, arena: arena) { layout in
+      kind: .genericParameter, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeAttributes?.raw
       layout[1] = attributes?.raw
@@ -14418,6 +15324,7 @@ public struct RawGenericParameterSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
       layout[7] = inheritedType?.raw
       layout[8] = unexpectedBetweenInheritedTypeAndTrailingComma?.raw
       layout[9] = trailingComma?.raw
+      layout[10] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -14451,6 +15358,9 @@ public struct RawGenericParameterSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[9].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -14522,15 +15432,17 @@ public struct RawPrimaryAssociatedTypeSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
     name: RawTokenSyntax,
     _ unexpectedBetweenNameAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .primaryAssociatedType, uninitializedCount: 4, arena: arena) { layout in
+      kind: .primaryAssociatedType, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeName?.raw
       layout[1] = name.raw
       layout[2] = unexpectedBetweenNameAndTrailingComma?.raw
       layout[3] = trailingComma?.raw
+      layout[4] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -14546,6 +15458,9 @@ public struct RawPrimaryAssociatedTypeSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -14581,10 +15496,11 @@ public struct RawGenericParameterClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxT
     genericWhereClause: RawGenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndRightAngleBracket: RawUnexpectedNodesSyntax? = nil,
     rightAngleBracket: RawTokenSyntax,
+    _ unexpectedAfterRightAngleBracket: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .genericParameterClause, uninitializedCount: 8, arena: arena) { layout in
+      kind: .genericParameterClause, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftAngleBracket?.raw
       layout[1] = leftAngleBracket.raw
@@ -14594,6 +15510,7 @@ public struct RawGenericParameterClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxT
       layout[5] = genericWhereClause?.raw
       layout[6] = unexpectedBetweenGenericWhereClauseAndRightAngleBracket?.raw
       layout[7] = rightAngleBracket.raw
+      layout[8] = unexpectedAfterRightAngleBracket?.raw
     }
     self.init(raw: raw)
   }
@@ -14621,6 +15538,9 @@ public struct RawGenericParameterClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxT
   }
   public var rightAngleBracket: RawTokenSyntax {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightAngleBracket: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -14654,10 +15574,11 @@ public struct RawConformanceRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxT
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndRightTypeIdentifier: RawUnexpectedNodesSyntax? = nil,
     rightTypeIdentifier: RawTypeSyntax,
+    _ unexpectedAfterRightTypeIdentifier: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .conformanceRequirement, uninitializedCount: 6, arena: arena) { layout in
+      kind: .conformanceRequirement, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftTypeIdentifier?.raw
       layout[1] = leftTypeIdentifier.raw
@@ -14665,6 +15586,7 @@ public struct RawConformanceRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxT
       layout[3] = colon.raw
       layout[4] = unexpectedBetweenColonAndRightTypeIdentifier?.raw
       layout[5] = rightTypeIdentifier.raw
+      layout[6] = unexpectedAfterRightTypeIdentifier?.raw
     }
     self.init(raw: raw)
   }
@@ -14686,6 +15608,9 @@ public struct RawConformanceRequirementSyntax: RawSyntaxNodeProtocol, RawSyntaxT
   }
   public var rightTypeIdentifier: RawTypeSyntax {
     layoutView.children[5].map(RawTypeSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightTypeIdentifier: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -14719,10 +15644,11 @@ public struct RawPrimaryAssociatedTypeClauseSyntax: RawSyntaxNodeProtocol, RawSy
     primaryAssociatedTypeList: RawPrimaryAssociatedTypeListSyntax,
     _ unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket: RawUnexpectedNodesSyntax? = nil,
     rightAngleBracket: RawTokenSyntax,
+    _ unexpectedAfterRightAngleBracket: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .primaryAssociatedTypeClause, uninitializedCount: 6, arena: arena) { layout in
+      kind: .primaryAssociatedTypeClause, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftAngleBracket?.raw
       layout[1] = leftAngleBracket.raw
@@ -14730,6 +15656,7 @@ public struct RawPrimaryAssociatedTypeClauseSyntax: RawSyntaxNodeProtocol, RawSy
       layout[3] = primaryAssociatedTypeList.raw
       layout[4] = unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket?.raw
       layout[5] = rightAngleBracket.raw
+      layout[6] = unexpectedAfterRightAngleBracket?.raw
     }
     self.init(raw: raw)
   }
@@ -14751,6 +15678,9 @@ public struct RawPrimaryAssociatedTypeClauseSyntax: RawSyntaxNodeProtocol, RawSy
   }
   public var rightAngleBracket: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightAngleBracket: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -14782,15 +15712,17 @@ public struct RawSimpleTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol, RawSynta
     name: RawTokenSyntax,
     _ unexpectedBetweenNameAndGenericArgumentClause: RawUnexpectedNodesSyntax? = nil,
     genericArgumentClause: RawGenericArgumentClauseSyntax?,
+    _ unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .simpleTypeIdentifier, uninitializedCount: 4, arena: arena) { layout in
+      kind: .simpleTypeIdentifier, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeName?.raw
       layout[1] = name.raw
       layout[2] = unexpectedBetweenNameAndGenericArgumentClause?.raw
       layout[3] = genericArgumentClause?.raw
+      layout[4] = unexpectedAfterGenericArgumentClause?.raw
     }
     self.init(raw: raw)
   }
@@ -14806,6 +15738,9 @@ public struct RawSimpleTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol, RawSynta
   }
   public var genericArgumentClause: RawGenericArgumentClauseSyntax? {
     layoutView.children[3].map(RawGenericArgumentClauseSyntax.init(raw:))
+  }
+  public var unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -14841,10 +15776,11 @@ public struct RawMemberTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol, RawSynta
     name: RawTokenSyntax,
     _ unexpectedBetweenNameAndGenericArgumentClause: RawUnexpectedNodesSyntax? = nil,
     genericArgumentClause: RawGenericArgumentClauseSyntax?,
+    _ unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .memberTypeIdentifier, uninitializedCount: 8, arena: arena) { layout in
+      kind: .memberTypeIdentifier, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeBaseType?.raw
       layout[1] = baseType.raw
@@ -14854,6 +15790,7 @@ public struct RawMemberTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol, RawSynta
       layout[5] = name.raw
       layout[6] = unexpectedBetweenNameAndGenericArgumentClause?.raw
       layout[7] = genericArgumentClause?.raw
+      layout[8] = unexpectedAfterGenericArgumentClause?.raw
     }
     self.init(raw: raw)
   }
@@ -14881,6 +15818,9 @@ public struct RawMemberTypeIdentifierSyntax: RawTypeSyntaxNodeProtocol, RawSynta
   }
   public var genericArgumentClause: RawGenericArgumentClauseSyntax? {
     layoutView.children[7].map(RawGenericArgumentClauseSyntax.init(raw:))
+  }
+  public var unexpectedAfterGenericArgumentClause: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -14910,13 +15850,15 @@ public struct RawClassRestrictionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSynta
   public init(
     _ unexpectedBeforeClassKeyword: RawUnexpectedNodesSyntax? = nil,
     classKeyword: RawTokenSyntax,
+    _ unexpectedAfterClassKeyword: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .classRestrictionType, uninitializedCount: 2, arena: arena) { layout in
+      kind: .classRestrictionType, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeClassKeyword?.raw
       layout[1] = classKeyword.raw
+      layout[2] = unexpectedAfterClassKeyword?.raw
     }
     self.init(raw: raw)
   }
@@ -14926,6 +15868,9 @@ public struct RawClassRestrictionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSynta
   }
   public var classKeyword: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterClassKeyword: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -14959,10 +15904,11 @@ public struct RawArrayTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
     elementType: RawTypeSyntax,
     _ unexpectedBetweenElementTypeAndRightSquareBracket: RawUnexpectedNodesSyntax? = nil,
     rightSquareBracket: RawTokenSyntax,
+    _ unexpectedAfterRightSquareBracket: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .arrayType, uninitializedCount: 6, arena: arena) { layout in
+      kind: .arrayType, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftSquareBracket?.raw
       layout[1] = leftSquareBracket.raw
@@ -14970,6 +15916,7 @@ public struct RawArrayTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = elementType.raw
       layout[4] = unexpectedBetweenElementTypeAndRightSquareBracket?.raw
       layout[5] = rightSquareBracket.raw
+      layout[6] = unexpectedAfterRightSquareBracket?.raw
     }
     self.init(raw: raw)
   }
@@ -14991,6 +15938,9 @@ public struct RawArrayTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var rightSquareBracket: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightSquareBracket: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -15028,10 +15978,11 @@ public struct RawDictionaryTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyn
     valueType: RawTypeSyntax,
     _ unexpectedBetweenValueTypeAndRightSquareBracket: RawUnexpectedNodesSyntax? = nil,
     rightSquareBracket: RawTokenSyntax,
+    _ unexpectedAfterRightSquareBracket: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .dictionaryType, uninitializedCount: 10, arena: arena) { layout in
+      kind: .dictionaryType, uninitializedCount: 11, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftSquareBracket?.raw
       layout[1] = leftSquareBracket.raw
@@ -15043,6 +15994,7 @@ public struct RawDictionaryTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyn
       layout[7] = valueType.raw
       layout[8] = unexpectedBetweenValueTypeAndRightSquareBracket?.raw
       layout[9] = rightSquareBracket.raw
+      layout[10] = unexpectedAfterRightSquareBracket?.raw
     }
     self.init(raw: raw)
   }
@@ -15077,6 +16029,9 @@ public struct RawDictionaryTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyn
   public var rightSquareBracket: RawTokenSyntax {
     layoutView.children[9].map(RawTokenSyntax.init(raw:))!
   }
+  public var unexpectedAfterRightSquareBracket: RawUnexpectedNodesSyntax? {
+    layoutView.children[10].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -15109,10 +16064,11 @@ public struct RawMetatypeTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSynta
     period: RawTokenSyntax,
     _ unexpectedBetweenPeriodAndTypeOrProtocol: RawUnexpectedNodesSyntax? = nil,
     typeOrProtocol: RawTokenSyntax,
+    _ unexpectedAfterTypeOrProtocol: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .metatypeType, uninitializedCount: 6, arena: arena) { layout in
+      kind: .metatypeType, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeBaseType?.raw
       layout[1] = baseType.raw
@@ -15120,6 +16076,7 @@ public struct RawMetatypeTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSynta
       layout[3] = period.raw
       layout[4] = unexpectedBetweenPeriodAndTypeOrProtocol?.raw
       layout[5] = typeOrProtocol.raw
+      layout[6] = unexpectedAfterTypeOrProtocol?.raw
     }
     self.init(raw: raw)
   }
@@ -15141,6 +16098,9 @@ public struct RawMetatypeTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var typeOrProtocol: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterTypeOrProtocol: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -15172,15 +16132,17 @@ public struct RawOptionalTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSynta
     wrappedType: RawTypeSyntax,
     _ unexpectedBetweenWrappedTypeAndQuestionMark: RawUnexpectedNodesSyntax? = nil,
     questionMark: RawTokenSyntax,
+    _ unexpectedAfterQuestionMark: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .optionalType, uninitializedCount: 4, arena: arena) { layout in
+      kind: .optionalType, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeWrappedType?.raw
       layout[1] = wrappedType.raw
       layout[2] = unexpectedBetweenWrappedTypeAndQuestionMark?.raw
       layout[3] = questionMark.raw
+      layout[4] = unexpectedAfterQuestionMark?.raw
     }
     self.init(raw: raw)
   }
@@ -15196,6 +16158,9 @@ public struct RawOptionalTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var questionMark: RawTokenSyntax {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterQuestionMark: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -15227,15 +16192,17 @@ public struct RawConstrainedSugarTypeSyntax: RawTypeSyntaxNodeProtocol, RawSynta
     someOrAnySpecifier: RawTokenSyntax,
     _ unexpectedBetweenSomeOrAnySpecifierAndBaseType: RawUnexpectedNodesSyntax? = nil,
     baseType: RawTypeSyntax,
+    _ unexpectedAfterBaseType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .constrainedSugarType, uninitializedCount: 4, arena: arena) { layout in
+      kind: .constrainedSugarType, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeSomeOrAnySpecifier?.raw
       layout[1] = someOrAnySpecifier.raw
       layout[2] = unexpectedBetweenSomeOrAnySpecifierAndBaseType?.raw
       layout[3] = baseType.raw
+      layout[4] = unexpectedAfterBaseType?.raw
     }
     self.init(raw: raw)
   }
@@ -15251,6 +16218,9 @@ public struct RawConstrainedSugarTypeSyntax: RawTypeSyntaxNodeProtocol, RawSynta
   }
   public var baseType: RawTypeSyntax {
     layoutView.children[3].map(RawTypeSyntax.init(raw:))!
+  }
+  public var unexpectedAfterBaseType: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -15282,15 +16252,17 @@ public struct RawImplicitlyUnwrappedOptionalTypeSyntax: RawTypeSyntaxNodeProtoco
     wrappedType: RawTypeSyntax,
     _ unexpectedBetweenWrappedTypeAndExclamationMark: RawUnexpectedNodesSyntax? = nil,
     exclamationMark: RawTokenSyntax,
+    _ unexpectedAfterExclamationMark: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .implicitlyUnwrappedOptionalType, uninitializedCount: 4, arena: arena) { layout in
+      kind: .implicitlyUnwrappedOptionalType, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeWrappedType?.raw
       layout[1] = wrappedType.raw
       layout[2] = unexpectedBetweenWrappedTypeAndExclamationMark?.raw
       layout[3] = exclamationMark.raw
+      layout[4] = unexpectedAfterExclamationMark?.raw
     }
     self.init(raw: raw)
   }
@@ -15306,6 +16278,9 @@ public struct RawImplicitlyUnwrappedOptionalTypeSyntax: RawTypeSyntaxNodeProtoco
   }
   public var exclamationMark: RawTokenSyntax {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterExclamationMark: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -15337,15 +16312,17 @@ public struct RawCompositionTypeElementSyntax: RawSyntaxNodeProtocol, RawSyntaxT
     type: RawTypeSyntax,
     _ unexpectedBetweenTypeAndAmpersand: RawUnexpectedNodesSyntax? = nil,
     ampersand: RawTokenSyntax?,
+    _ unexpectedAfterAmpersand: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .compositionTypeElement, uninitializedCount: 4, arena: arena) { layout in
+      kind: .compositionTypeElement, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeType?.raw
       layout[1] = type.raw
       layout[2] = unexpectedBetweenTypeAndAmpersand?.raw
       layout[3] = ampersand?.raw
+      layout[4] = unexpectedAfterAmpersand?.raw
     }
     self.init(raw: raw)
   }
@@ -15361,6 +16338,9 @@ public struct RawCompositionTypeElementSyntax: RawSyntaxNodeProtocol, RawSyntaxT
   }
   public var ampersand: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterAmpersand: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -15430,13 +16410,15 @@ public struct RawCompositionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSy
   public init(
     _ unexpectedBeforeElements: RawUnexpectedNodesSyntax? = nil,
     elements: RawCompositionTypeElementListSyntax,
+    _ unexpectedAfterElements: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .compositionType, uninitializedCount: 2, arena: arena) { layout in
+      kind: .compositionType, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeElements?.raw
       layout[1] = elements.raw
+      layout[2] = unexpectedAfterElements?.raw
     }
     self.init(raw: raw)
   }
@@ -15446,6 +16428,9 @@ public struct RawCompositionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSy
   }
   public var elements: RawCompositionTypeElementListSyntax {
     layoutView.children[1].map(RawCompositionTypeElementListSyntax.init(raw:))!
+  }
+  public var unexpectedAfterElements: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -15477,15 +16462,17 @@ public struct RawPackExpansionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxTo
     patternType: RawTypeSyntax,
     _ unexpectedBetweenPatternTypeAndEllipsis: RawUnexpectedNodesSyntax? = nil,
     ellipsis: RawTokenSyntax,
+    _ unexpectedAfterEllipsis: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .packExpansionType, uninitializedCount: 4, arena: arena) { layout in
+      kind: .packExpansionType, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePatternType?.raw
       layout[1] = patternType.raw
       layout[2] = unexpectedBetweenPatternTypeAndEllipsis?.raw
       layout[3] = ellipsis.raw
+      layout[4] = unexpectedAfterEllipsis?.raw
     }
     self.init(raw: raw)
   }
@@ -15501,6 +16488,9 @@ public struct RawPackExpansionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxTo
   }
   public var ellipsis: RawTokenSyntax {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterEllipsis: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -15544,10 +16534,11 @@ public struct RawTupleTypeElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
     initializer: RawInitializerClauseSyntax?,
     _ unexpectedBetweenInitializerAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .tupleTypeElement, uninitializedCount: 16, arena: arena) { layout in
+      kind: .tupleTypeElement, uninitializedCount: 17, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeInOut?.raw
       layout[1] = inOut?.raw
@@ -15565,6 +16556,7 @@ public struct RawTupleTypeElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
       layout[13] = initializer?.raw
       layout[14] = unexpectedBetweenInitializerAndTrailingComma?.raw
       layout[15] = trailingComma?.raw
+      layout[16] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -15616,6 +16608,9 @@ public struct RawTupleTypeElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSynta
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[15].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[16].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -15689,10 +16684,11 @@ public struct RawTupleTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
     elements: RawTupleTypeElementListSyntax,
     _ unexpectedBetweenElementsAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .tupleType, uninitializedCount: 6, arena: arena) { layout in
+      kind: .tupleType, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftParen?.raw
       layout[1] = leftParen.raw
@@ -15700,6 +16696,7 @@ public struct RawTupleTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = elements.raw
       layout[4] = unexpectedBetweenElementsAndRightParen?.raw
       layout[5] = rightParen.raw
+      layout[6] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -15721,6 +16718,9 @@ public struct RawTupleTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -15762,10 +16762,11 @@ public struct RawFunctionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSynta
     arrow: RawTokenSyntax,
     _ unexpectedBetweenArrowAndReturnType: RawUnexpectedNodesSyntax? = nil,
     returnType: RawTypeSyntax,
+    _ unexpectedAfterReturnType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .functionType, uninitializedCount: 14, arena: arena) { layout in
+      kind: .functionType, uninitializedCount: 15, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftParen?.raw
       layout[1] = leftParen.raw
@@ -15781,6 +16782,7 @@ public struct RawFunctionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSynta
       layout[11] = arrow.raw
       layout[12] = unexpectedBetweenArrowAndReturnType?.raw
       layout[13] = returnType.raw
+      layout[14] = unexpectedAfterReturnType?.raw
     }
     self.init(raw: raw)
   }
@@ -15827,6 +16829,9 @@ public struct RawFunctionTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSynta
   public var returnType: RawTypeSyntax {
     layoutView.children[13].map(RawTypeSyntax.init(raw:))!
   }
+  public var unexpectedAfterReturnType: RawUnexpectedNodesSyntax? {
+    layoutView.children[14].map(RawUnexpectedNodesSyntax.init(raw:))
+  }
 }
 
 @_spi(RawSyntax)
@@ -15859,10 +16864,11 @@ public struct RawAttributedTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyn
     attributes: RawAttributeListSyntax?,
     _ unexpectedBetweenAttributesAndBaseType: RawUnexpectedNodesSyntax? = nil,
     baseType: RawTypeSyntax,
+    _ unexpectedAfterBaseType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .attributedType, uninitializedCount: 6, arena: arena) { layout in
+      kind: .attributedType, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeSpecifier?.raw
       layout[1] = specifier?.raw
@@ -15870,6 +16876,7 @@ public struct RawAttributedTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyn
       layout[3] = attributes?.raw
       layout[4] = unexpectedBetweenAttributesAndBaseType?.raw
       layout[5] = baseType.raw
+      layout[6] = unexpectedAfterBaseType?.raw
     }
     self.init(raw: raw)
   }
@@ -15891,6 +16898,9 @@ public struct RawAttributedTypeSyntax: RawTypeSyntaxNodeProtocol, RawSyntaxToSyn
   }
   public var baseType: RawTypeSyntax {
     layoutView.children[5].map(RawTypeSyntax.init(raw:))!
+  }
+  public var unexpectedAfterBaseType: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -15962,15 +16972,17 @@ public struct RawGenericArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
     argumentType: RawTypeSyntax,
     _ unexpectedBetweenArgumentTypeAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .genericArgument, uninitializedCount: 4, arena: arena) { layout in
+      kind: .genericArgument, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeArgumentType?.raw
       layout[1] = argumentType.raw
       layout[2] = unexpectedBetweenArgumentTypeAndTrailingComma?.raw
       layout[3] = trailingComma?.raw
+      layout[4] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -15986,6 +16998,9 @@ public struct RawGenericArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16019,10 +17034,11 @@ public struct RawGenericArgumentClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
     arguments: RawGenericArgumentListSyntax,
     _ unexpectedBetweenArgumentsAndRightAngleBracket: RawUnexpectedNodesSyntax? = nil,
     rightAngleBracket: RawTokenSyntax,
+    _ unexpectedAfterRightAngleBracket: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .genericArgumentClause, uninitializedCount: 6, arena: arena) { layout in
+      kind: .genericArgumentClause, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftAngleBracket?.raw
       layout[1] = leftAngleBracket.raw
@@ -16030,6 +17046,7 @@ public struct RawGenericArgumentClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
       layout[3] = arguments.raw
       layout[4] = unexpectedBetweenArgumentsAndRightAngleBracket?.raw
       layout[5] = rightAngleBracket.raw
+      layout[6] = unexpectedAfterRightAngleBracket?.raw
     }
     self.init(raw: raw)
   }
@@ -16051,6 +17068,9 @@ public struct RawGenericArgumentClauseSyntax: RawSyntaxNodeProtocol, RawSyntaxTo
   }
   public var rightAngleBracket: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightAngleBracket: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16082,15 +17102,17 @@ public struct RawNamedOpaqueReturnTypeSyntax: RawTypeSyntaxNodeProtocol, RawSynt
     genericParameters: RawGenericParameterClauseSyntax,
     _ unexpectedBetweenGenericParametersAndBaseType: RawUnexpectedNodesSyntax? = nil,
     baseType: RawTypeSyntax,
+    _ unexpectedAfterBaseType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .namedOpaqueReturnType, uninitializedCount: 4, arena: arena) { layout in
+      kind: .namedOpaqueReturnType, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeGenericParameters?.raw
       layout[1] = genericParameters.raw
       layout[2] = unexpectedBetweenGenericParametersAndBaseType?.raw
       layout[3] = baseType.raw
+      layout[4] = unexpectedAfterBaseType?.raw
     }
     self.init(raw: raw)
   }
@@ -16106,6 +17128,9 @@ public struct RawNamedOpaqueReturnTypeSyntax: RawTypeSyntaxNodeProtocol, RawSynt
   }
   public var baseType: RawTypeSyntax {
     layoutView.children[3].map(RawTypeSyntax.init(raw:))!
+  }
+  public var unexpectedAfterBaseType: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16137,15 +17162,17 @@ public struct RawTypeAnnotationSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax 
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndType: RawUnexpectedNodesSyntax? = nil,
     type: RawTypeSyntax,
+    _ unexpectedAfterType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .typeAnnotation, uninitializedCount: 4, arena: arena) { layout in
+      kind: .typeAnnotation, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeColon?.raw
       layout[1] = colon.raw
       layout[2] = unexpectedBetweenColonAndType?.raw
       layout[3] = type.raw
+      layout[4] = unexpectedAfterType?.raw
     }
     self.init(raw: raw)
   }
@@ -16161,6 +17188,9 @@ public struct RawTypeAnnotationSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax 
   }
   public var type: RawTypeSyntax {
     layoutView.children[3].map(RawTypeSyntax.init(raw:))!
+  }
+  public var unexpectedAfterType: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16196,10 +17226,11 @@ public struct RawEnumCasePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxT
     caseName: RawTokenSyntax,
     _ unexpectedBetweenCaseNameAndAssociatedTuple: RawUnexpectedNodesSyntax? = nil,
     associatedTuple: RawTuplePatternSyntax?,
+    _ unexpectedAfterAssociatedTuple: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .enumCasePattern, uninitializedCount: 8, arena: arena) { layout in
+      kind: .enumCasePattern, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeType?.raw
       layout[1] = type?.raw
@@ -16209,6 +17240,7 @@ public struct RawEnumCasePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxT
       layout[5] = caseName.raw
       layout[6] = unexpectedBetweenCaseNameAndAssociatedTuple?.raw
       layout[7] = associatedTuple?.raw
+      layout[8] = unexpectedAfterAssociatedTuple?.raw
     }
     self.init(raw: raw)
   }
@@ -16236,6 +17268,9 @@ public struct RawEnumCasePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxT
   }
   public var associatedTuple: RawTuplePatternSyntax? {
     layoutView.children[7].map(RawTuplePatternSyntax.init(raw:))
+  }
+  public var unexpectedAfterAssociatedTuple: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16267,15 +17302,17 @@ public struct RawIsTypePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToS
     isKeyword: RawTokenSyntax,
     _ unexpectedBetweenIsKeywordAndType: RawUnexpectedNodesSyntax? = nil,
     type: RawTypeSyntax,
+    _ unexpectedAfterType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .isTypePattern, uninitializedCount: 4, arena: arena) { layout in
+      kind: .isTypePattern, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeIsKeyword?.raw
       layout[1] = isKeyword.raw
       layout[2] = unexpectedBetweenIsKeywordAndType?.raw
       layout[3] = type.raw
+      layout[4] = unexpectedAfterType?.raw
     }
     self.init(raw: raw)
   }
@@ -16291,6 +17328,9 @@ public struct RawIsTypePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToS
   }
   public var type: RawTypeSyntax {
     layoutView.children[3].map(RawTypeSyntax.init(raw:))!
+  }
+  public var unexpectedAfterType: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16322,15 +17362,17 @@ public struct RawOptionalPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxT
     subPattern: RawPatternSyntax,
     _ unexpectedBetweenSubPatternAndQuestionMark: RawUnexpectedNodesSyntax? = nil,
     questionMark: RawTokenSyntax,
+    _ unexpectedAfterQuestionMark: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .optionalPattern, uninitializedCount: 4, arena: arena) { layout in
+      kind: .optionalPattern, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeSubPattern?.raw
       layout[1] = subPattern.raw
       layout[2] = unexpectedBetweenSubPatternAndQuestionMark?.raw
       layout[3] = questionMark.raw
+      layout[4] = unexpectedAfterQuestionMark?.raw
     }
     self.init(raw: raw)
   }
@@ -16346,6 +17388,9 @@ public struct RawOptionalPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxT
   }
   public var questionMark: RawTokenSyntax {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterQuestionMark: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16375,13 +17420,15 @@ public struct RawIdentifierPatternSyntax: RawPatternSyntaxNodeProtocol, RawSynta
   public init(
     _ unexpectedBeforeIdentifier: RawUnexpectedNodesSyntax? = nil,
     identifier: RawTokenSyntax,
+    _ unexpectedAfterIdentifier: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .identifierPattern, uninitializedCount: 2, arena: arena) { layout in
+      kind: .identifierPattern, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeIdentifier?.raw
       layout[1] = identifier.raw
+      layout[2] = unexpectedAfterIdentifier?.raw
     }
     self.init(raw: raw)
   }
@@ -16391,6 +17438,9 @@ public struct RawIdentifierPatternSyntax: RawPatternSyntaxNodeProtocol, RawSynta
   }
   public var identifier: RawTokenSyntax {
     layoutView.children[1].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterIdentifier: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16424,10 +17474,11 @@ public struct RawAsTypePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToS
     asKeyword: RawTokenSyntax,
     _ unexpectedBetweenAsKeywordAndType: RawUnexpectedNodesSyntax? = nil,
     type: RawTypeSyntax,
+    _ unexpectedAfterType: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .asTypePattern, uninitializedCount: 6, arena: arena) { layout in
+      kind: .asTypePattern, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePattern?.raw
       layout[1] = pattern.raw
@@ -16435,6 +17486,7 @@ public struct RawAsTypePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToS
       layout[3] = asKeyword.raw
       layout[4] = unexpectedBetweenAsKeywordAndType?.raw
       layout[5] = type.raw
+      layout[6] = unexpectedAfterType?.raw
     }
     self.init(raw: raw)
   }
@@ -16456,6 +17508,9 @@ public struct RawAsTypePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToS
   }
   public var type: RawTypeSyntax {
     layoutView.children[5].map(RawTypeSyntax.init(raw:))!
+  }
+  public var unexpectedAfterType: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16489,10 +17544,11 @@ public struct RawTuplePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSy
     elements: RawTuplePatternElementListSyntax,
     _ unexpectedBetweenElementsAndRightParen: RawUnexpectedNodesSyntax? = nil,
     rightParen: RawTokenSyntax,
+    _ unexpectedAfterRightParen: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .tuplePattern, uninitializedCount: 6, arena: arena) { layout in
+      kind: .tuplePattern, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLeftParen?.raw
       layout[1] = leftParen.raw
@@ -16500,6 +17556,7 @@ public struct RawTuplePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSy
       layout[3] = elements.raw
       layout[4] = unexpectedBetweenElementsAndRightParen?.raw
       layout[5] = rightParen.raw
+      layout[6] = unexpectedAfterRightParen?.raw
     }
     self.init(raw: raw)
   }
@@ -16521,6 +17578,9 @@ public struct RawTuplePatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxToSy
   }
   public var rightParen: RawTokenSyntax {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))!
+  }
+  public var unexpectedAfterRightParen: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16552,15 +17612,17 @@ public struct RawWildcardPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxT
     wildcard: RawTokenSyntax,
     _ unexpectedBetweenWildcardAndTypeAnnotation: RawUnexpectedNodesSyntax? = nil,
     typeAnnotation: RawTypeAnnotationSyntax?,
+    _ unexpectedAfterTypeAnnotation: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .wildcardPattern, uninitializedCount: 4, arena: arena) { layout in
+      kind: .wildcardPattern, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeWildcard?.raw
       layout[1] = wildcard.raw
       layout[2] = unexpectedBetweenWildcardAndTypeAnnotation?.raw
       layout[3] = typeAnnotation?.raw
+      layout[4] = unexpectedAfterTypeAnnotation?.raw
     }
     self.init(raw: raw)
   }
@@ -16576,6 +17638,9 @@ public struct RawWildcardPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyntaxT
   }
   public var typeAnnotation: RawTypeAnnotationSyntax? {
     layoutView.children[3].map(RawTypeAnnotationSyntax.init(raw:))
+  }
+  public var unexpectedAfterTypeAnnotation: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16611,10 +17676,11 @@ public struct RawTuplePatternElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
     pattern: RawPatternSyntax,
     _ unexpectedBetweenPatternAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .tuplePatternElement, uninitializedCount: 8, arena: arena) { layout in
+      kind: .tuplePatternElement, uninitializedCount: 9, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLabelName?.raw
       layout[1] = labelName?.raw
@@ -16624,6 +17690,7 @@ public struct RawTuplePatternElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
       layout[5] = pattern.raw
       layout[6] = unexpectedBetweenPatternAndTrailingComma?.raw
       layout[7] = trailingComma?.raw
+      layout[8] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -16651,6 +17718,9 @@ public struct RawTuplePatternElementSyntax: RawSyntaxNodeProtocol, RawSyntaxToSy
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[7].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[8].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16680,13 +17750,15 @@ public struct RawExpressionPatternSyntax: RawPatternSyntaxNodeProtocol, RawSynta
   public init(
     _ unexpectedBeforeExpression: RawUnexpectedNodesSyntax? = nil,
     expression: RawExprSyntax,
+    _ unexpectedAfterExpression: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .expressionPattern, uninitializedCount: 2, arena: arena) { layout in
+      kind: .expressionPattern, uninitializedCount: 3, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeExpression?.raw
       layout[1] = expression.raw
+      layout[2] = unexpectedAfterExpression?.raw
     }
     self.init(raw: raw)
   }
@@ -16696,6 +17768,9 @@ public struct RawExpressionPatternSyntax: RawPatternSyntaxNodeProtocol, RawSynta
   }
   public var expression: RawExprSyntax {
     layoutView.children[1].map(RawExprSyntax.init(raw:))!
+  }
+  public var unexpectedAfterExpression: RawUnexpectedNodesSyntax? {
+    layoutView.children[2].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16767,15 +17842,17 @@ public struct RawValueBindingPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyn
     letOrVarKeyword: RawTokenSyntax,
     _ unexpectedBetweenLetOrVarKeywordAndValuePattern: RawUnexpectedNodesSyntax? = nil,
     valuePattern: RawPatternSyntax,
+    _ unexpectedAfterValuePattern: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .valueBindingPattern, uninitializedCount: 4, arena: arena) { layout in
+      kind: .valueBindingPattern, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLetOrVarKeyword?.raw
       layout[1] = letOrVarKeyword.raw
       layout[2] = unexpectedBetweenLetOrVarKeywordAndValuePattern?.raw
       layout[3] = valuePattern.raw
+      layout[4] = unexpectedAfterValuePattern?.raw
     }
     self.init(raw: raw)
   }
@@ -16791,6 +17868,9 @@ public struct RawValueBindingPatternSyntax: RawPatternSyntaxNodeProtocol, RawSyn
   }
   public var valuePattern: RawPatternSyntax {
     layoutView.children[3].map(RawPatternSyntax.init(raw:))!
+  }
+  public var unexpectedAfterValuePattern: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16862,15 +17942,17 @@ public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
     entry: RawSyntax,
     _ unexpectedBetweenEntryAndTrailingComma: RawUnexpectedNodesSyntax? = nil,
     trailingComma: RawTokenSyntax?,
+    _ unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .availabilityArgument, uninitializedCount: 4, arena: arena) { layout in
+      kind: .availabilityArgument, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeEntry?.raw
       layout[1] = entry.raw
       layout[2] = unexpectedBetweenEntryAndTrailingComma?.raw
       layout[3] = trailingComma?.raw
+      layout[4] = unexpectedAfterTrailingComma?.raw
     }
     self.init(raw: raw)
   }
@@ -16886,6 +17968,9 @@ public struct RawAvailabilityArgumentSyntax: RawSyntaxNodeProtocol, RawSyntaxToS
   }
   public var trailingComma: RawTokenSyntax? {
     layoutView.children[3].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterTrailingComma: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16919,10 +18004,11 @@ public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol, RawSy
     colon: RawTokenSyntax,
     _ unexpectedBetweenColonAndValue: RawUnexpectedNodesSyntax? = nil,
     value: RawSyntax,
+    _ unexpectedAfterValue: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .availabilityLabeledArgument, uninitializedCount: 6, arena: arena) { layout in
+      kind: .availabilityLabeledArgument, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeLabel?.raw
       layout[1] = label.raw
@@ -16930,6 +18016,7 @@ public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol, RawSy
       layout[3] = colon.raw
       layout[4] = unexpectedBetweenColonAndValue?.raw
       layout[5] = value.raw
+      layout[6] = unexpectedAfterValue?.raw
     }
     self.init(raw: raw)
   }
@@ -16951,6 +18038,9 @@ public struct RawAvailabilityLabeledArgumentSyntax: RawSyntaxNodeProtocol, RawSy
   }
   public var value: RawSyntax {
     layoutView.children[5]!
+  }
+  public var unexpectedAfterValue: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -16982,15 +18072,17 @@ public struct RawAvailabilityVersionRestrictionSyntax: RawSyntaxNodeProtocol, Ra
     platform: RawTokenSyntax,
     _ unexpectedBetweenPlatformAndVersion: RawUnexpectedNodesSyntax? = nil,
     version: RawVersionTupleSyntax?,
+    _ unexpectedAfterVersion: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .availabilityVersionRestriction, uninitializedCount: 4, arena: arena) { layout in
+      kind: .availabilityVersionRestriction, uninitializedCount: 5, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforePlatform?.raw
       layout[1] = platform.raw
       layout[2] = unexpectedBetweenPlatformAndVersion?.raw
       layout[3] = version?.raw
+      layout[4] = unexpectedAfterVersion?.raw
     }
     self.init(raw: raw)
   }
@@ -17006,6 +18098,9 @@ public struct RawAvailabilityVersionRestrictionSyntax: RawSyntaxNodeProtocol, Ra
   }
   public var version: RawVersionTupleSyntax? {
     layoutView.children[3].map(RawVersionTupleSyntax.init(raw:))
+  }
+  public var unexpectedAfterVersion: RawUnexpectedNodesSyntax? {
+    layoutView.children[4].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }
 
@@ -17039,10 +18134,11 @@ public struct RawVersionTupleSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
     patchPeriod: RawTokenSyntax?,
     _ unexpectedBetweenPatchPeriodAndPatchVersion: RawUnexpectedNodesSyntax? = nil,
     patchVersion: RawTokenSyntax?,
+    _ unexpectedAfterPatchVersion: RawUnexpectedNodesSyntax? = nil,
     arena: __shared SyntaxArena
   ) {
     let raw = RawSyntax.makeLayout(
-      kind: .versionTuple, uninitializedCount: 6, arena: arena) { layout in
+      kind: .versionTuple, uninitializedCount: 7, arena: arena) { layout in
       layout.initialize(repeating: nil)
       layout[0] = unexpectedBeforeMajorMinor?.raw
       layout[1] = majorMinor.raw
@@ -17050,6 +18146,7 @@ public struct RawVersionTupleSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
       layout[3] = patchPeriod?.raw
       layout[4] = unexpectedBetweenPatchPeriodAndPatchVersion?.raw
       layout[5] = patchVersion?.raw
+      layout[6] = unexpectedAfterPatchVersion?.raw
     }
     self.init(raw: raw)
   }
@@ -17071,5 +18168,8 @@ public struct RawVersionTupleSyntax: RawSyntaxNodeProtocol, RawSyntaxToSyntax {
   }
   public var patchVersion: RawTokenSyntax? {
     layoutView.children[5].map(RawTokenSyntax.init(raw:))
+  }
+  public var unexpectedAfterPatchVersion: RawUnexpectedNodesSyntax? {
+    layoutView.children[6].map(RawUnexpectedNodesSyntax.init(raw:))
   }
 }

--- a/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
+++ b/Sources/SwiftSyntax/Raw/gyb_generated/RawSyntaxValidation.swift
@@ -45,11 +45,12 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assert(layout.count == 0)
     break
   case .missingDecl:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawModifierListSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .missingExpr:
     assert(layout.count == 0)
@@ -64,13 +65,14 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     assert(layout.count == 0)
     break
   case .codeBlockItem:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawSyntax?.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .codeBlockItemList:
     for element in layout {
@@ -78,13 +80,14 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .codeBlock:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawCodeBlockItemListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .unexpectedNodes:
     for element in layout {
@@ -92,16 +95,18 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .inOutExpr:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawExprSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .poundColumnExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .tupleExprElementList:
     for element in layout {
@@ -124,34 +129,38 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .tryExpr:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawExprSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .awaitExpr:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawExprSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .moveExpr:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawExprSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .declNameArgument:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .declNameArgumentList:
     for element in layout {
@@ -159,45 +168,52 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .declNameArguments:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawDeclNameArgumentListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .identifierExpr:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawDeclNameArgumentsSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .superRefExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .nilLiteralExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .discardAssignmentExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .assignmentExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .sequenceExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprListSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .exprList:
     for element in layout {
@@ -205,106 +221,121 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .poundLineExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .poundFileExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .poundFileIDExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .poundFilePathExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .poundFunctionExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .poundDsohandleExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .symbolicReferenceExpr:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawGenericArgumentClauseSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .prefixOperatorExpr:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawExprSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .binaryOperatorExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .arrowExpr:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .infixOperatorExpr:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawExprSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawExprSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .floatLiteralExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .tupleExpr:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTupleExprElementListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .arrayExpr:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawArrayElementListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .dictionaryExpr:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .tupleExprElement:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -313,16 +344,18 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawExprSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax?.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .arrayElement:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .dictionaryElement:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -331,28 +364,32 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawExprSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax?.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .integerLiteralExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .booleanLiteralExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .unresolvedTernaryExpr:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawExprSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .ternaryExpr:
-    assert(layout.count == 10)
+    assert(layout.count == 11)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -363,9 +400,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[7], as: RawTokenSyntax.self)
     _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[9], as: RawExprSyntax.self)
+    _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     break
   case .memberAccessExpr:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -374,30 +412,34 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTokenSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawDeclNameArgumentsSyntax?.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .unresolvedIsExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .isExpr:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTypeSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .unresolvedAsExpr:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .asExpr:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -406,14 +448,16 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTokenSyntax?.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTypeSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .typeExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTypeSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .closureCaptureItem:
-    assert(layout.count == 10)
+    assert(layout.count == 11)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -424,6 +468,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[7], as: RawExprSyntax.self)
     _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[9], as: RawTokenSyntax?.self)
+    _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     break
   case .closureCaptureItemList:
     for element in layout {
@@ -431,20 +476,22 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .closureCaptureSignature:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawClosureCaptureItemListSyntax?.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .closureParam:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .closureParamList:
     for element in layout {
@@ -452,7 +499,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .closureSignature:
-    assert(layout.count == 14)
+    assert(layout.count == 15)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -467,9 +514,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[11], as: RawReturnClauseSyntax?.self)
     _verify(layout[12], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[13], as: RawTokenSyntax.self)
+    _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     break
   case .closureExpr:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -478,20 +526,23 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawCodeBlockItemListSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .unresolvedPatternExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawPatternSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .multipleTrailingClosureElement:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawClosureExprSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .multipleTrailingClosureElementList:
     for element in layout {
@@ -499,7 +550,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .functionCallExpr:
-    assert(layout.count == 12)
+    assert(layout.count == 13)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -512,9 +563,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[9], as: RawClosureExprSyntax?.self)
     _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[11], as: RawMultipleTrailingClosureElementListSyntax?.self)
+    _verify(layout[12], as: RawUnexpectedNodesSyntax?.self)
     break
   case .subscriptExpr:
-    assert(layout.count == 12)
+    assert(layout.count == 13)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -527,42 +579,48 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[9], as: RawClosureExprSyntax?.self)
     _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[11], as: RawMultipleTrailingClosureElementListSyntax?.self)
+    _verify(layout[12], as: RawUnexpectedNodesSyntax?.self)
     break
   case .optionalChainingExpr:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .forcedValueExpr:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .postfixUnaryExpr:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .specializeExpr:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawGenericArgumentClauseSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .stringSegment:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .expressionSegment:
-    assert(layout.count == 10)
+    assert(layout.count == 11)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -573,9 +631,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[7], as: RawTupleExprElementListSyntax.self)
     _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[9], as: RawTokenSyntax.self)
+    _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     break
   case .stringLiteralExpr:
-    assert(layout.count == 10)
+    assert(layout.count == 11)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -586,20 +645,23 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[7], as: RawTokenSyntax.self)
     _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[9], as: RawTokenSyntax?.self)
+    _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     break
   case .regexLiteralExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .keyPathExpr:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTypeSyntax?.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawKeyPathComponentListSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .keyPathComponentList:
     for element in layout {
@@ -607,55 +669,62 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .keyPathComponent:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .keyPathPropertyComponent:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawDeclNameArgumentsSyntax?.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawGenericArgumentClauseSyntax?.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .keyPathSubscriptComponent:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTupleExprElementListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .keyPathOptionalComponent:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .oldKeyPathExpr:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawExprSyntax?.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawExprSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .keyPathBaseExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .objcNamePiece:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .objcName:
     for element in layout {
@@ -663,7 +732,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .objcKeyPathExpr:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -672,9 +741,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawObjcNameSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .objcSelectorExpr:
-    assert(layout.count == 12)
+    assert(layout.count == 13)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -687,21 +757,24 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[9], as: RawExprSyntax.self)
     _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[11], as: RawTokenSyntax.self)
+    _verify(layout[12], as: RawUnexpectedNodesSyntax?.self)
     break
   case .postfixIfConfigExpr:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawIfConfigDeclSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .editorPlaceholderExpr:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .objectLiteralExpr:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -710,6 +783,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTupleExprElementListSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .yieldExprList:
     for element in layout {
@@ -717,21 +791,23 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .yieldExprListElement:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .typeInitializerClause:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTypeSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .typealiasDecl:
-    assert(layout.count == 14)
+    assert(layout.count == 15)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -746,9 +822,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[11], as: RawTypeInitializerClauseSyntax.self)
     _verify(layout[12], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[13], as: RawGenericWhereClauseSyntax?.self)
+    _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     break
   case .associatedtypeDecl:
-    assert(layout.count == 14)
+    assert(layout.count == 15)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -763,6 +840,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[11], as: RawTypeInitializerClauseSyntax?.self)
     _verify(layout[12], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[13], as: RawGenericWhereClauseSyntax?.self)
+    _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     break
   case .functionParameterList:
     for element in layout {
@@ -770,23 +848,25 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .parameterClause:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawFunctionParameterListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .returnClause:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTypeSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .functionSignature:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawParameterClauseSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -795,15 +875,17 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTokenSyntax?.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawReturnClauseSyntax?.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .ifConfigClause:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawExprSyntax?.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .ifConfigClauseList:
     for element in layout {
@@ -811,14 +893,15 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .ifConfigDecl:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawIfConfigClauseListSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .poundErrorDecl:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -827,9 +910,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawStringLiteralExprSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .poundWarningDecl:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -838,9 +922,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawStringLiteralExprSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .poundSourceLocation:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -849,9 +934,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawPoundSourceLocationArgsSyntax?.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .poundSourceLocationArgs:
-    assert(layout.count == 14)
+    assert(layout.count == 15)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -866,29 +952,33 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[11], as: RawTokenSyntax.self)
     _verify(layout[12], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[13], as: RawTokenSyntax.self)
+    _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     break
   case .declModifierDetail:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .declModifier:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawDeclModifierDetailSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .inheritedType:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTypeSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .inheritedTypeList:
     for element in layout {
@@ -896,14 +986,15 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .typeInheritanceClause:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawInheritedTypeListSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .classDecl:
-    assert(layout.count == 16)
+    assert(layout.count == 17)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -920,9 +1011,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[13], as: RawGenericWhereClauseSyntax?.self)
     _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[15], as: RawMemberDeclBlockSyntax.self)
+    _verify(layout[16], as: RawUnexpectedNodesSyntax?.self)
     break
   case .actorDecl:
-    assert(layout.count == 16)
+    assert(layout.count == 17)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -939,9 +1031,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[13], as: RawGenericWhereClauseSyntax?.self)
     _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[15], as: RawMemberDeclBlockSyntax.self)
+    _verify(layout[16], as: RawUnexpectedNodesSyntax?.self)
     break
   case .structDecl:
-    assert(layout.count == 16)
+    assert(layout.count == 17)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -958,9 +1051,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[13], as: RawGenericWhereClauseSyntax?.self)
     _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[15], as: RawMemberDeclBlockSyntax.self)
+    _verify(layout[16], as: RawUnexpectedNodesSyntax?.self)
     break
   case .protocolDecl:
-    assert(layout.count == 16)
+    assert(layout.count == 17)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -977,9 +1071,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[13], as: RawGenericWhereClauseSyntax?.self)
     _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[15], as: RawMemberDeclBlockSyntax.self)
+    _verify(layout[16], as: RawUnexpectedNodesSyntax?.self)
     break
   case .extensionDecl:
-    assert(layout.count == 14)
+    assert(layout.count == 15)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -994,15 +1089,17 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[11], as: RawGenericWhereClauseSyntax?.self)
     _verify(layout[12], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[13], as: RawMemberDeclBlockSyntax.self)
+    _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     break
   case .memberDeclBlock:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawMemberDeclListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .memberDeclList:
     for element in layout {
@@ -1010,28 +1107,31 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .memberDeclListItem:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawDeclSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .sourceFile:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawCodeBlockItemListSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .initializerClause:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawExprSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .functionParameter:
-    assert(layout.count == 18)
+    assert(layout.count == 19)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1050,6 +1150,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[15], as: RawInitializerClauseSyntax?.self)
     _verify(layout[16], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[17], as: RawTokenSyntax?.self)
+    _verify(layout[18], as: RawUnexpectedNodesSyntax?.self)
     break
   case .modifierList:
     for element in layout {
@@ -1057,7 +1158,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .functionDecl:
-    assert(layout.count == 16)
+    assert(layout.count == 17)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1074,9 +1175,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[13], as: RawGenericWhereClauseSyntax?.self)
     _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[15], as: RawCodeBlockSyntax?.self)
+    _verify(layout[16], as: RawUnexpectedNodesSyntax?.self)
     break
   case .initializerDecl:
-    assert(layout.count == 16)
+    assert(layout.count == 17)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1093,9 +1195,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[13], as: RawGenericWhereClauseSyntax?.self)
     _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[15], as: RawCodeBlockSyntax?.self)
+    _verify(layout[16], as: RawUnexpectedNodesSyntax?.self)
     break
   case .deinitializerDecl:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1104,9 +1207,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTokenSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawCodeBlockSyntax?.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .subscriptDecl:
-    assert(layout.count == 16)
+    assert(layout.count == 17)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1123,20 +1227,23 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[13], as: RawGenericWhereClauseSyntax?.self)
     _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[15], as: RawSyntax?.self)
+    _verify(layout[16], as: RawUnexpectedNodesSyntax?.self)
     break
   case .accessLevelModifier:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawDeclModifierDetailSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .accessPathComponent:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .accessPath:
     for element in layout {
@@ -1144,7 +1251,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .importDecl:
-    assert(layout.count == 10)
+    assert(layout.count == 11)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1155,18 +1262,20 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[7], as: RawTokenSyntax?.self)
     _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[9], as: RawAccessPathSyntax.self)
+    _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     break
   case .accessorParameter:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .accessorDecl:
-    assert(layout.count == 14)
+    assert(layout.count == 15)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1181,6 +1290,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[11], as: RawTokenSyntax?.self)
     _verify(layout[12], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[13], as: RawCodeBlockSyntax?.self)
+    _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     break
   case .accessorList:
     for element in layout {
@@ -1188,16 +1298,17 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .accessorBlock:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawAccessorListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .patternBinding:
-    assert(layout.count == 10)
+    assert(layout.count == 11)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawPatternSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1208,6 +1319,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[7], as: RawSyntax?.self)
     _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[9], as: RawTokenSyntax?.self)
+    _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     break
   case .patternBindingList:
     for element in layout {
@@ -1215,7 +1327,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .variableDecl:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1224,9 +1336,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTokenSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawPatternBindingListSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .enumCaseElement:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1235,6 +1348,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawInitializerClauseSyntax?.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax?.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .enumCaseElementList:
     for element in layout {
@@ -1242,7 +1356,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .enumCaseDecl:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1251,9 +1365,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTokenSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawEnumCaseElementListSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .enumDecl:
-    assert(layout.count == 16)
+    assert(layout.count == 17)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1270,9 +1385,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[13], as: RawGenericWhereClauseSyntax?.self)
     _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[15], as: RawMemberDeclBlockSyntax.self)
+    _verify(layout[16], as: RawUnexpectedNodesSyntax?.self)
     break
   case .operatorDecl:
-    assert(layout.count == 10)
+    assert(layout.count == 11)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1283,6 +1399,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[7], as: RawTokenSyntax.self)
     _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[9], as: RawOperatorPrecedenceAndTypesSyntax?.self)
+    _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     break
   case .designatedTypeList:
     for element in layout {
@@ -1290,23 +1407,25 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .designatedTypeElement:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .operatorPrecedenceAndTypes:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawDesignatedTypeListSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .precedenceGroupDecl:
-    assert(layout.count == 14)
+    assert(layout.count == 15)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1321,6 +1440,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[11], as: RawPrecedenceGroupAttributeListSyntax.self)
     _verify(layout[12], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[13], as: RawTokenSyntax.self)
+    _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     break
   case .precedenceGroupAttributeList:
     for element in layout {
@@ -1328,13 +1448,14 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .precedenceGroupRelation:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawPrecedenceGroupNameListSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .precedenceGroupNameList:
     for element in layout {
@@ -1342,29 +1463,32 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .precedenceGroupNameElement:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .precedenceGroupAssignment:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .precedenceGroupAssociativity:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .tokenList:
     for element in layout {
@@ -1377,7 +1501,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .customAttribute:
-    assert(layout.count == 10)
+    assert(layout.count == 11)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1388,9 +1512,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[7], as: RawTupleExprElementListSyntax?.self)
     _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[9], as: RawTokenSyntax?.self)
+    _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     break
   case .attribute:
-    assert(layout.count == 12)
+    assert(layout.count == 13)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1403,6 +1528,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[9], as: RawTokenSyntax?.self)
     _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[11], as: RawTokenListSyntax?.self)
+    _verify(layout[12], as: RawUnexpectedNodesSyntax?.self)
     break
   case .attributeList:
     for element in layout {
@@ -1415,7 +1541,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .availabilityEntry:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1424,9 +1550,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawAvailabilitySpecListSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .labeledSpecializeEntry:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1435,9 +1562,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTokenSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax?.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .targetFunctionEntry:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1446,25 +1574,28 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawDeclNameSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax?.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .namedAttributeStringArgument:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .declName:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawDeclNameArgumentsSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .implementsAttributeArguments:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTypeSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1473,13 +1604,15 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTokenSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawDeclNameArgumentsSyntax?.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .objCSelectorPiece:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .objCSelector:
     for element in layout {
@@ -1487,7 +1620,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .differentiableAttributeArguments:
-    assert(layout.count == 10)
+    assert(layout.count == 11)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1498,24 +1631,27 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[7], as: RawTokenSyntax?.self)
     _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[9], as: RawGenericWhereClauseSyntax?.self)
+    _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     break
   case .differentiabilityParamsClause:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .differentiabilityParams:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawDifferentiabilityParamListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .differentiabilityParamList:
     for element in layout {
@@ -1523,14 +1659,15 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .differentiabilityParam:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .derivativeRegistrationAttributeArguments:
-    assert(layout.count == 14)
+    assert(layout.count == 15)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1545,9 +1682,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[11], as: RawTokenSyntax?.self)
     _verify(layout[12], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[13], as: RawDifferentiabilityParamsClauseSyntax?.self)
+    _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     break
   case .qualifiedDeclName:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTypeSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1556,22 +1694,25 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTokenSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawDeclNameArgumentsSyntax?.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .functionDeclName:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawDeclNameArgumentsSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .backDeployAttributeSpecList:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawBackDeployVersionListSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .backDeployVersionList:
     for element in layout {
@@ -1579,23 +1720,25 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .backDeployVersionArgument:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAvailabilityVersionRestrictionSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .opaqueReturnTypeOfAttributeArguments:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .conventionAttributeArguments:
-    assert(layout.count == 10)
+    assert(layout.count == 11)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1606,52 +1749,59 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[7], as: RawTokenSyntax?.self)
     _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[9], as: RawTokenSyntax?.self)
+    _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     break
   case .conventionWitnessMethodAttributeArguments:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .labeledStmt:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawStmtSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .continueStmt:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .whileStmt:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawConditionElementListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawCodeBlockSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .deferStmt:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawCodeBlockSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .expressionStmt:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .switchCaseList:
     for element in layout {
@@ -1659,7 +1809,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .repeatWhileStmt:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1668,9 +1818,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTokenSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawExprSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .guardStmt:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1679,16 +1830,18 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTokenSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawCodeBlockSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .whereClause:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawExprSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .forInStmt:
-    assert(layout.count == 20)
+    assert(layout.count == 21)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1709,9 +1862,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[17], as: RawWhereClauseSyntax?.self)
     _verify(layout[18], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[19], as: RawCodeBlockSyntax.self)
+    _verify(layout[20], as: RawUnexpectedNodesSyntax?.self)
     break
   case .switchStmt:
-    assert(layout.count == 10)
+    assert(layout.count == 11)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1722,6 +1876,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[7], as: RawSwitchCaseListSyntax.self)
     _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[9], as: RawTokenSyntax.self)
+    _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     break
   case .catchClauseList:
     for element in layout {
@@ -1729,48 +1884,54 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .doStmt:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawCodeBlockSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawCatchClauseListSyntax?.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .returnStmt:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawExprSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .yieldStmt:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .yieldList:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawYieldExprListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .fallthroughStmt:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .breakStmt:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .caseItemList:
     for element in layout {
@@ -1783,14 +1944,15 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .conditionElement:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .availabilityCondition:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1799,9 +1961,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawAvailabilitySpecListSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .matchingPatternCondition:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1810,9 +1973,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTypeAnnotationSyntax?.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawInitializerClauseSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .optionalBindingCondition:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1821,9 +1985,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTypeAnnotationSyntax?.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawInitializerClauseSyntax?.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .unavailabilityCondition:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1832,9 +1997,10 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawAvailabilitySpecListSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .hasSymbolCondition:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1843,6 +2009,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawExprSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .conditionElementList:
     for element in layout {
@@ -1850,19 +2017,21 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .declarationStmt:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawDeclSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .throwStmt:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawExprSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .ifStmt:
-    assert(layout.count == 10)
+    assert(layout.count == 11)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1873,61 +2042,68 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[7], as: RawTokenSyntax?.self)
     _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[9], as: RawSyntax?.self)
+    _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     break
   case .switchCase:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawCodeBlockItemListSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .switchDefaultLabel:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .caseItem:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawPatternSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawWhereClauseSyntax?.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax?.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .catchItem:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawPatternSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawWhereClauseSyntax?.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax?.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .switchCaseLabel:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawCaseItemListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .catchClause:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawCatchItemListSyntax?.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawCodeBlockSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .poundAssertStmt:
-    assert(layout.count == 12)
+    assert(layout.count == 13)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1940,13 +2116,15 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[9], as: RawTokenSyntax?.self)
     _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[11], as: RawTokenSyntax.self)
+    _verify(layout[12], as: RawUnexpectedNodesSyntax?.self)
     break
   case .genericWhereClause:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawGenericRequirementListSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .genericRequirementList:
     for element in layout {
@@ -1954,23 +2132,25 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .genericRequirement:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .sameTypeRequirement:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTypeSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTypeSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .layoutRequirement:
-    assert(layout.count == 16)
+    assert(layout.count == 17)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTypeSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -1987,6 +2167,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[13], as: RawTokenSyntax?.self)
     _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[15], as: RawTokenSyntax?.self)
+    _verify(layout[16], as: RawUnexpectedNodesSyntax?.self)
     break
   case .genericParameterList:
     for element in layout {
@@ -1994,7 +2175,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .genericParameter:
-    assert(layout.count == 10)
+    assert(layout.count == 11)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawAttributeListSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -2005,6 +2186,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[7], as: RawTypeSyntax?.self)
     _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[9], as: RawTokenSyntax?.self)
+    _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     break
   case .primaryAssociatedTypeList:
     for element in layout {
@@ -2012,14 +2194,15 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .primaryAssociatedType:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .genericParameterClause:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -2028,34 +2211,38 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawGenericWhereClauseSyntax?.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .conformanceRequirement:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTypeSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTypeSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .primaryAssociatedTypeClause:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawPrimaryAssociatedTypeListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .simpleTypeIdentifier:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawGenericArgumentClauseSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .memberTypeIdentifier:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTypeSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -2064,23 +2251,26 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTokenSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawGenericArgumentClauseSyntax?.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .classRestrictionType:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .arrayType:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTypeSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .dictionaryType:
-    assert(layout.count == 10)
+    assert(layout.count == 11)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -2091,43 +2281,49 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[7], as: RawTypeSyntax.self)
     _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[9], as: RawTokenSyntax.self)
+    _verify(layout[10], as: RawUnexpectedNodesSyntax?.self)
     break
   case .metatypeType:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTypeSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .optionalType:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTypeSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .constrainedSugarType:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTypeSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .implicitlyUnwrappedOptionalType:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTypeSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .compositionTypeElement:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTypeSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .compositionTypeElementList:
     for element in layout {
@@ -2135,19 +2331,21 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .compositionType:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawCompositionTypeElementListSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .packExpansionType:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTypeSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .tupleTypeElement:
-    assert(layout.count == 16)
+    assert(layout.count == 17)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -2164,6 +2362,7 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[13], as: RawInitializerClauseSyntax?.self)
     _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[15], as: RawTokenSyntax?.self)
+    _verify(layout[16], as: RawUnexpectedNodesSyntax?.self)
     break
   case .tupleTypeElementList:
     for element in layout {
@@ -2171,16 +2370,17 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .tupleType:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTupleTypeElementListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .functionType:
-    assert(layout.count == 14)
+    assert(layout.count == 15)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -2195,15 +2395,17 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[11], as: RawTokenSyntax.self)
     _verify(layout[12], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[13], as: RawTypeSyntax.self)
+    _verify(layout[14], as: RawUnexpectedNodesSyntax?.self)
     break
   case .attributedType:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawAttributeListSyntax?.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTypeSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .genericArgumentList:
     for element in layout {
@@ -2211,37 +2413,41 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .genericArgument:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTypeSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .genericArgumentClause:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawGenericArgumentListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .namedOpaqueReturnType:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawGenericParameterClauseSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTypeSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .typeAnnotation:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTypeSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .enumCasePattern:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTypeSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -2250,53 +2456,60 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawTokenSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTuplePatternSyntax?.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .isTypePattern:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTypeSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .optionalPattern:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawPatternSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .identifierPattern:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .asTypePattern:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawPatternSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTypeSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .tuplePattern:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTuplePatternElementListSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .wildcardPattern:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTypeAnnotationSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .tuplePatternElement:
-    assert(layout.count == 8)
+    assert(layout.count == 9)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax?.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
@@ -2305,11 +2518,13 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     _verify(layout[5], as: RawPatternSyntax.self)
     _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[7], as: RawTokenSyntax?.self)
+    _verify(layout[8], as: RawUnexpectedNodesSyntax?.self)
     break
   case .expressionPattern:
-    assert(layout.count == 2)
+    assert(layout.count == 3)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawExprSyntax.self)
+    _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     break
   case .tuplePatternElementList:
     for element in layout {
@@ -2317,11 +2532,12 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .valueBindingPattern:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawPatternSyntax.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .availabilitySpecList:
     for element in layout {
@@ -2329,36 +2545,40 @@ func validateLayout(layout: RawSyntaxBuffer, as kind: SyntaxKind) {
     }
     break
   case .availabilityArgument:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .availabilityLabeledArgument:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawSyntax.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   case .availabilityVersionRestriction:
-    assert(layout.count == 4)
+    assert(layout.count == 5)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawTokenSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawVersionTupleSyntax?.self)
+    _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     break
   case .versionTuple:
-    assert(layout.count == 6)
+    assert(layout.count == 7)
     _verify(layout[0], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[1], as: RawSyntax.self)
     _verify(layout[2], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[3], as: RawTokenSyntax?.self)
     _verify(layout[4], as: RawUnexpectedNodesSyntax?.self)
     _verify(layout[5], as: RawTokenSyntax?.self)
+    _verify(layout[6], as: RawUnexpectedNodesSyntax?.self)
     break
   }
 #endif

--- a/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
+++ b/Sources/SwiftSyntax/gyb_generated/SyntaxFactory.swift
@@ -97,12 +97,13 @@ public enum SyntaxFactory {
     return MissingSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on MissingDeclSyntax")
-  public static func makeMissingDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?) -> MissingDeclSyntax {
+  public static func makeMissingDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedAfterModifiers: UnexpectedNodesSyntax? = nil) -> MissingDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
       unexpectedBetweenAttributesAndModifiers?.raw,
       modifiers?.raw,
+      unexpectedAfterModifiers?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingDecl,
       from: layout, arena: .default)
@@ -114,6 +115,7 @@ public enum SyntaxFactory {
   public static func makeBlankMissingDecl(presence: SourcePresence = .missing) -> MissingDeclSyntax {
     let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .missingDecl,
       from: [
+      nil,
       nil,
       nil,
       nil,
@@ -154,7 +156,7 @@ public enum SyntaxFactory {
     return MissingPatternSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on CodeBlockItemSyntax")
-  public static func makeCodeBlockItem(_ unexpectedBeforeItem: UnexpectedNodesSyntax? = nil, item: Syntax, _ unexpectedBetweenItemAndSemicolon: UnexpectedNodesSyntax? = nil, semicolon: TokenSyntax?, _ unexpectedBetweenSemicolonAndErrorTokens: UnexpectedNodesSyntax? = nil, errorTokens: Syntax?) -> CodeBlockItemSyntax {
+  public static func makeCodeBlockItem(_ unexpectedBeforeItem: UnexpectedNodesSyntax? = nil, item: Syntax, _ unexpectedBetweenItemAndSemicolon: UnexpectedNodesSyntax? = nil, semicolon: TokenSyntax?, _ unexpectedBetweenSemicolonAndErrorTokens: UnexpectedNodesSyntax? = nil, errorTokens: Syntax?, _ unexpectedAfterErrorTokens: UnexpectedNodesSyntax? = nil) -> CodeBlockItemSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeItem?.raw,
       item.raw,
@@ -162,6 +164,7 @@ public enum SyntaxFactory {
       semicolon?.raw,
       unexpectedBetweenSemicolonAndErrorTokens?.raw,
       errorTokens?.raw,
+      unexpectedAfterErrorTokens?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItem,
       from: layout, arena: .default)
@@ -175,6 +178,7 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
+      nil,
       nil,
       nil,
       nil,
@@ -199,7 +203,7 @@ public enum SyntaxFactory {
     return CodeBlockItemListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on CodeBlockSyntax")
-  public static func makeCodeBlock(_ unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndStatements: UnexpectedNodesSyntax? = nil, statements: CodeBlockItemListSyntax, _ unexpectedBetweenStatementsAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax) -> CodeBlockSyntax {
+  public static func makeCodeBlock(_ unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndStatements: UnexpectedNodesSyntax? = nil, statements: CodeBlockItemListSyntax, _ unexpectedBetweenStatementsAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax, _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil) -> CodeBlockSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftBrace?.raw,
       leftBrace.raw,
@@ -207,6 +211,7 @@ public enum SyntaxFactory {
       statements.raw,
       unexpectedBetweenStatementsAndRightBrace?.raw,
       rightBrace.raw,
+      unexpectedAfterRightBrace?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlock,
       from: layout, arena: .default)
@@ -224,6 +229,7 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default),
+      nil,
     ], arena: .default))
     return CodeBlockSyntax(data)
   }
@@ -244,12 +250,13 @@ public enum SyntaxFactory {
     return UnexpectedNodesSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on InOutExprSyntax")
-  public static func makeInOutExpr(_ unexpectedBeforeAmpersand: UnexpectedNodesSyntax? = nil, ampersand: TokenSyntax, _ unexpectedBetweenAmpersandAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax) -> InOutExprSyntax {
+  public static func makeInOutExpr(_ unexpectedBeforeAmpersand: UnexpectedNodesSyntax? = nil, ampersand: TokenSyntax, _ unexpectedBetweenAmpersandAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> InOutExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAmpersand?.raw,
       ampersand.raw,
       unexpectedBetweenAmpersandAndExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.inOutExpr,
       from: layout, arena: .default)
@@ -265,14 +272,16 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.prefixAmpersand, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
     ], arena: .default))
     return InOutExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PoundColumnExprSyntax")
-  public static func makePoundColumnExpr(_ unexpectedBeforePoundColumn: UnexpectedNodesSyntax? = nil, poundColumn: TokenSyntax) -> PoundColumnExprSyntax {
+  public static func makePoundColumnExpr(_ unexpectedBeforePoundColumn: UnexpectedNodesSyntax? = nil, poundColumn: TokenSyntax, _ unexpectedAfterPoundColumn: UnexpectedNodesSyntax? = nil) -> PoundColumnExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundColumn?.raw,
       poundColumn.raw,
+      unexpectedAfterPoundColumn?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundColumnExpr,
       from: layout, arena: .default)
@@ -286,6 +295,7 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.poundColumnKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return PoundColumnExprSyntax(data)
   }
@@ -354,7 +364,7 @@ public enum SyntaxFactory {
     return StringLiteralSegmentsSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on TryExprSyntax")
-  public static func makeTryExpr(_ unexpectedBeforeTryKeyword: UnexpectedNodesSyntax? = nil, tryKeyword: TokenSyntax, _ unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil, questionOrExclamationMark: TokenSyntax?, _ unexpectedBetweenQuestionOrExclamationMarkAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax) -> TryExprSyntax {
+  public static func makeTryExpr(_ unexpectedBeforeTryKeyword: UnexpectedNodesSyntax? = nil, tryKeyword: TokenSyntax, _ unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil, questionOrExclamationMark: TokenSyntax?, _ unexpectedBetweenQuestionOrExclamationMarkAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> TryExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeTryKeyword?.raw,
       tryKeyword.raw,
@@ -362,6 +372,7 @@ public enum SyntaxFactory {
       questionOrExclamationMark?.raw,
       unexpectedBetweenQuestionOrExclamationMarkAndExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tryExpr,
       from: layout, arena: .default)
@@ -379,16 +390,18 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
     ], arena: .default))
     return TryExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AwaitExprSyntax")
-  public static func makeAwaitExpr(_ unexpectedBeforeAwaitKeyword: UnexpectedNodesSyntax? = nil, awaitKeyword: TokenSyntax, _ unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax) -> AwaitExprSyntax {
+  public static func makeAwaitExpr(_ unexpectedBeforeAwaitKeyword: UnexpectedNodesSyntax? = nil, awaitKeyword: TokenSyntax, _ unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> AwaitExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAwaitKeyword?.raw,
       awaitKeyword.raw,
       unexpectedBetweenAwaitKeywordAndExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.awaitExpr,
       from: layout, arena: .default)
@@ -404,16 +417,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
     ], arena: .default))
     return AwaitExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on MoveExprSyntax")
-  public static func makeMoveExpr(_ unexpectedBeforeMoveKeyword: UnexpectedNodesSyntax? = nil, moveKeyword: TokenSyntax, _ unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax) -> MoveExprSyntax {
+  public static func makeMoveExpr(_ unexpectedBeforeMoveKeyword: UnexpectedNodesSyntax? = nil, moveKeyword: TokenSyntax, _ unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> MoveExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeMoveKeyword?.raw,
       moveKeyword.raw,
       unexpectedBetweenMoveKeywordAndExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.moveExpr,
       from: layout, arena: .default)
@@ -429,16 +444,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.contextualKeyword(""), arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
     ], arena: .default))
     return MoveExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DeclNameArgumentSyntax")
-  public static func makeDeclNameArgument(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax) -> DeclNameArgumentSyntax {
+  public static func makeDeclNameArgument(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil) -> DeclNameArgumentSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndColon?.raw,
       colon.raw,
+      unexpectedAfterColon?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgument,
       from: layout, arena: .default)
@@ -454,6 +471,7 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
+      nil,
     ], arena: .default))
     return DeclNameArgumentSyntax(data)
   }
@@ -474,7 +492,7 @@ public enum SyntaxFactory {
     return DeclNameArgumentListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DeclNameArgumentsSyntax")
-  public static func makeDeclNameArguments(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil, arguments: DeclNameArgumentListSyntax, _ unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> DeclNameArgumentsSyntax {
+  public static func makeDeclNameArguments(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil, arguments: DeclNameArgumentListSyntax, _ unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> DeclNameArgumentsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
       leftParen.raw,
@@ -482,6 +500,7 @@ public enum SyntaxFactory {
       arguments.raw,
       unexpectedBetweenArgumentsAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArguments,
       from: layout, arena: .default)
@@ -499,16 +518,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.declNameArgumentList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return DeclNameArgumentsSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on IdentifierExprSyntax")
-  public static func makeIdentifierExpr(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?) -> IdentifierExprSyntax {
+  public static func makeIdentifierExpr(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?, _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil) -> IdentifierExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
       identifier.raw,
       unexpectedBetweenIdentifierAndDeclNameArguments?.raw,
       declNameArguments?.raw,
+      unexpectedAfterDeclNameArguments?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.identifierExpr,
       from: layout, arena: .default)
@@ -524,14 +545,16 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return IdentifierExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on SuperRefExprSyntax")
-  public static func makeSuperRefExpr(_ unexpectedBeforeSuperKeyword: UnexpectedNodesSyntax? = nil, superKeyword: TokenSyntax) -> SuperRefExprSyntax {
+  public static func makeSuperRefExpr(_ unexpectedBeforeSuperKeyword: UnexpectedNodesSyntax? = nil, superKeyword: TokenSyntax, _ unexpectedAfterSuperKeyword: UnexpectedNodesSyntax? = nil) -> SuperRefExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSuperKeyword?.raw,
       superKeyword.raw,
+      unexpectedAfterSuperKeyword?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.superRefExpr,
       from: layout, arena: .default)
@@ -545,14 +568,16 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.superKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return SuperRefExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on NilLiteralExprSyntax")
-  public static func makeNilLiteralExpr(_ unexpectedBeforeNilKeyword: UnexpectedNodesSyntax? = nil, nilKeyword: TokenSyntax) -> NilLiteralExprSyntax {
+  public static func makeNilLiteralExpr(_ unexpectedBeforeNilKeyword: UnexpectedNodesSyntax? = nil, nilKeyword: TokenSyntax, _ unexpectedAfterNilKeyword: UnexpectedNodesSyntax? = nil) -> NilLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeNilKeyword?.raw,
       nilKeyword.raw,
+      unexpectedAfterNilKeyword?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.nilLiteralExpr,
       from: layout, arena: .default)
@@ -566,14 +591,16 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.nilKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return NilLiteralExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DiscardAssignmentExprSyntax")
-  public static func makeDiscardAssignmentExpr(_ unexpectedBeforeWildcard: UnexpectedNodesSyntax? = nil, wildcard: TokenSyntax) -> DiscardAssignmentExprSyntax {
+  public static func makeDiscardAssignmentExpr(_ unexpectedBeforeWildcard: UnexpectedNodesSyntax? = nil, wildcard: TokenSyntax, _ unexpectedAfterWildcard: UnexpectedNodesSyntax? = nil) -> DiscardAssignmentExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWildcard?.raw,
       wildcard.raw,
+      unexpectedAfterWildcard?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.discardAssignmentExpr,
       from: layout, arena: .default)
@@ -587,14 +614,16 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.wildcardKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return DiscardAssignmentExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AssignmentExprSyntax")
-  public static func makeAssignmentExpr(_ unexpectedBeforeAssignToken: UnexpectedNodesSyntax? = nil, assignToken: TokenSyntax) -> AssignmentExprSyntax {
+  public static func makeAssignmentExpr(_ unexpectedBeforeAssignToken: UnexpectedNodesSyntax? = nil, assignToken: TokenSyntax, _ unexpectedAfterAssignToken: UnexpectedNodesSyntax? = nil) -> AssignmentExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAssignToken?.raw,
       assignToken.raw,
+      unexpectedAfterAssignToken?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.assignmentExpr,
       from: layout, arena: .default)
@@ -608,14 +637,16 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: .default),
+      nil,
     ], arena: .default))
     return AssignmentExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on SequenceExprSyntax")
-  public static func makeSequenceExpr(_ unexpectedBeforeElements: UnexpectedNodesSyntax? = nil, elements: ExprListSyntax) -> SequenceExprSyntax {
+  public static func makeSequenceExpr(_ unexpectedBeforeElements: UnexpectedNodesSyntax? = nil, elements: ExprListSyntax, _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil) -> SequenceExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeElements?.raw,
       elements.raw,
+      unexpectedAfterElements?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.sequenceExpr,
       from: layout, arena: .default)
@@ -629,6 +660,7 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.exprList, arena: .default),
+      nil,
     ], arena: .default))
     return SequenceExprSyntax(data)
   }
@@ -649,10 +681,11 @@ public enum SyntaxFactory {
     return ExprListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PoundLineExprSyntax")
-  public static func makePoundLineExpr(_ unexpectedBeforePoundLine: UnexpectedNodesSyntax? = nil, poundLine: TokenSyntax) -> PoundLineExprSyntax {
+  public static func makePoundLineExpr(_ unexpectedBeforePoundLine: UnexpectedNodesSyntax? = nil, poundLine: TokenSyntax, _ unexpectedAfterPoundLine: UnexpectedNodesSyntax? = nil) -> PoundLineExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundLine?.raw,
       poundLine.raw,
+      unexpectedAfterPoundLine?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundLineExpr,
       from: layout, arena: .default)
@@ -666,14 +699,16 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.poundLineKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return PoundLineExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PoundFileExprSyntax")
-  public static func makePoundFileExpr(_ unexpectedBeforePoundFile: UnexpectedNodesSyntax? = nil, poundFile: TokenSyntax) -> PoundFileExprSyntax {
+  public static func makePoundFileExpr(_ unexpectedBeforePoundFile: UnexpectedNodesSyntax? = nil, poundFile: TokenSyntax, _ unexpectedAfterPoundFile: UnexpectedNodesSyntax? = nil) -> PoundFileExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundFile?.raw,
       poundFile.raw,
+      unexpectedAfterPoundFile?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFileExpr,
       from: layout, arena: .default)
@@ -687,14 +722,16 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.poundFileKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return PoundFileExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PoundFileIDExprSyntax")
-  public static func makePoundFileIDExpr(_ unexpectedBeforePoundFileID: UnexpectedNodesSyntax? = nil, poundFileID: TokenSyntax) -> PoundFileIDExprSyntax {
+  public static func makePoundFileIDExpr(_ unexpectedBeforePoundFileID: UnexpectedNodesSyntax? = nil, poundFileID: TokenSyntax, _ unexpectedAfterPoundFileID: UnexpectedNodesSyntax? = nil) -> PoundFileIDExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundFileID?.raw,
       poundFileID.raw,
+      unexpectedAfterPoundFileID?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFileIDExpr,
       from: layout, arena: .default)
@@ -708,14 +745,16 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.poundFileIDKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return PoundFileIDExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PoundFilePathExprSyntax")
-  public static func makePoundFilePathExpr(_ unexpectedBeforePoundFilePath: UnexpectedNodesSyntax? = nil, poundFilePath: TokenSyntax) -> PoundFilePathExprSyntax {
+  public static func makePoundFilePathExpr(_ unexpectedBeforePoundFilePath: UnexpectedNodesSyntax? = nil, poundFilePath: TokenSyntax, _ unexpectedAfterPoundFilePath: UnexpectedNodesSyntax? = nil) -> PoundFilePathExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundFilePath?.raw,
       poundFilePath.raw,
+      unexpectedAfterPoundFilePath?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFilePathExpr,
       from: layout, arena: .default)
@@ -729,14 +768,16 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.poundFilePathKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return PoundFilePathExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PoundFunctionExprSyntax")
-  public static func makePoundFunctionExpr(_ unexpectedBeforePoundFunction: UnexpectedNodesSyntax? = nil, poundFunction: TokenSyntax) -> PoundFunctionExprSyntax {
+  public static func makePoundFunctionExpr(_ unexpectedBeforePoundFunction: UnexpectedNodesSyntax? = nil, poundFunction: TokenSyntax, _ unexpectedAfterPoundFunction: UnexpectedNodesSyntax? = nil) -> PoundFunctionExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundFunction?.raw,
       poundFunction.raw,
+      unexpectedAfterPoundFunction?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFunctionExpr,
       from: layout, arena: .default)
@@ -750,14 +791,16 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.poundFunctionKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return PoundFunctionExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PoundDsohandleExprSyntax")
-  public static func makePoundDsohandleExpr(_ unexpectedBeforePoundDsohandle: UnexpectedNodesSyntax? = nil, poundDsohandle: TokenSyntax) -> PoundDsohandleExprSyntax {
+  public static func makePoundDsohandleExpr(_ unexpectedBeforePoundDsohandle: UnexpectedNodesSyntax? = nil, poundDsohandle: TokenSyntax, _ unexpectedAfterPoundDsohandle: UnexpectedNodesSyntax? = nil) -> PoundDsohandleExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundDsohandle?.raw,
       poundDsohandle.raw,
+      unexpectedAfterPoundDsohandle?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundDsohandleExpr,
       from: layout, arena: .default)
@@ -771,16 +814,18 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.poundDsohandleKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return PoundDsohandleExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on SymbolicReferenceExprSyntax")
-  public static func makeSymbolicReferenceExpr(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericArgumentClause: UnexpectedNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax?) -> SymbolicReferenceExprSyntax {
+  public static func makeSymbolicReferenceExpr(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericArgumentClause: UnexpectedNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax?, _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil) -> SymbolicReferenceExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
       identifier.raw,
       unexpectedBetweenIdentifierAndGenericArgumentClause?.raw,
       genericArgumentClause?.raw,
+      unexpectedAfterGenericArgumentClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.symbolicReferenceExpr,
       from: layout, arena: .default)
@@ -796,16 +841,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return SymbolicReferenceExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PrefixOperatorExprSyntax")
-  public static func makePrefixOperatorExpr(_ unexpectedBeforeOperatorToken: UnexpectedNodesSyntax? = nil, operatorToken: TokenSyntax?, _ unexpectedBetweenOperatorTokenAndPostfixExpression: UnexpectedNodesSyntax? = nil, postfixExpression: ExprSyntax) -> PrefixOperatorExprSyntax {
+  public static func makePrefixOperatorExpr(_ unexpectedBeforeOperatorToken: UnexpectedNodesSyntax? = nil, operatorToken: TokenSyntax?, _ unexpectedBetweenOperatorTokenAndPostfixExpression: UnexpectedNodesSyntax? = nil, postfixExpression: ExprSyntax, _ unexpectedAfterPostfixExpression: UnexpectedNodesSyntax? = nil) -> PrefixOperatorExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeOperatorToken?.raw,
       operatorToken?.raw,
       unexpectedBetweenOperatorTokenAndPostfixExpression?.raw,
       postfixExpression.raw,
+      unexpectedAfterPostfixExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.prefixOperatorExpr,
       from: layout, arena: .default)
@@ -821,14 +868,16 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
     ], arena: .default))
     return PrefixOperatorExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on BinaryOperatorExprSyntax")
-  public static func makeBinaryOperatorExpr(_ unexpectedBeforeOperatorToken: UnexpectedNodesSyntax? = nil, operatorToken: TokenSyntax) -> BinaryOperatorExprSyntax {
+  public static func makeBinaryOperatorExpr(_ unexpectedBeforeOperatorToken: UnexpectedNodesSyntax? = nil, operatorToken: TokenSyntax, _ unexpectedAfterOperatorToken: UnexpectedNodesSyntax? = nil) -> BinaryOperatorExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeOperatorToken?.raw,
       operatorToken.raw,
+      unexpectedAfterOperatorToken?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.binaryOperatorExpr,
       from: layout, arena: .default)
@@ -842,11 +891,12 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
+      nil,
     ], arena: .default))
     return BinaryOperatorExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ArrowExprSyntax")
-  public static func makeArrowExpr(_ unexpectedBeforeAsyncKeyword: UnexpectedNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ unexpectedBetweenAsyncKeywordAndThrowsToken: UnexpectedNodesSyntax? = nil, throwsToken: TokenSyntax?, _ unexpectedBetweenThrowsTokenAndArrowToken: UnexpectedNodesSyntax? = nil, arrowToken: TokenSyntax) -> ArrowExprSyntax {
+  public static func makeArrowExpr(_ unexpectedBeforeAsyncKeyword: UnexpectedNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ unexpectedBetweenAsyncKeywordAndThrowsToken: UnexpectedNodesSyntax? = nil, throwsToken: TokenSyntax?, _ unexpectedBetweenThrowsTokenAndArrowToken: UnexpectedNodesSyntax? = nil, arrowToken: TokenSyntax, _ unexpectedAfterArrowToken: UnexpectedNodesSyntax? = nil) -> ArrowExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAsyncKeyword?.raw,
       asyncKeyword?.raw,
@@ -854,6 +904,7 @@ public enum SyntaxFactory {
       throwsToken?.raw,
       unexpectedBetweenThrowsTokenAndArrowToken?.raw,
       arrowToken.raw,
+      unexpectedAfterArrowToken?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrowExpr,
       from: layout, arena: .default)
@@ -871,11 +922,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: .default),
+      nil,
     ], arena: .default))
     return ArrowExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on InfixOperatorExprSyntax")
-  public static func makeInfixOperatorExpr(_ unexpectedBeforeLeftOperand: UnexpectedNodesSyntax? = nil, leftOperand: ExprSyntax, _ unexpectedBetweenLeftOperandAndOperatorOperand: UnexpectedNodesSyntax? = nil, operatorOperand: ExprSyntax, _ unexpectedBetweenOperatorOperandAndRightOperand: UnexpectedNodesSyntax? = nil, rightOperand: ExprSyntax) -> InfixOperatorExprSyntax {
+  public static func makeInfixOperatorExpr(_ unexpectedBeforeLeftOperand: UnexpectedNodesSyntax? = nil, leftOperand: ExprSyntax, _ unexpectedBetweenLeftOperandAndOperatorOperand: UnexpectedNodesSyntax? = nil, operatorOperand: ExprSyntax, _ unexpectedBetweenOperatorOperandAndRightOperand: UnexpectedNodesSyntax? = nil, rightOperand: ExprSyntax, _ unexpectedAfterRightOperand: UnexpectedNodesSyntax? = nil) -> InfixOperatorExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftOperand?.raw,
       leftOperand.raw,
@@ -883,6 +935,7 @@ public enum SyntaxFactory {
       operatorOperand.raw,
       unexpectedBetweenOperatorOperandAndRightOperand?.raw,
       rightOperand.raw,
+      unexpectedAfterRightOperand?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.infixOperatorExpr,
       from: layout, arena: .default)
@@ -900,14 +953,16 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
     ], arena: .default))
     return InfixOperatorExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on FloatLiteralExprSyntax")
-  public static func makeFloatLiteralExpr(_ unexpectedBeforeFloatingDigits: UnexpectedNodesSyntax? = nil, floatingDigits: TokenSyntax) -> FloatLiteralExprSyntax {
+  public static func makeFloatLiteralExpr(_ unexpectedBeforeFloatingDigits: UnexpectedNodesSyntax? = nil, floatingDigits: TokenSyntax, _ unexpectedAfterFloatingDigits: UnexpectedNodesSyntax? = nil) -> FloatLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeFloatingDigits?.raw,
       floatingDigits.raw,
+      unexpectedAfterFloatingDigits?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.floatLiteralExpr,
       from: layout, arena: .default)
@@ -921,11 +976,12 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.floatingLiteral(""), arena: .default),
+      nil,
     ], arena: .default))
     return FloatLiteralExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on TupleExprSyntax")
-  public static func makeTupleExpr(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil, elementList: TupleExprElementListSyntax, _ unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> TupleExprSyntax {
+  public static func makeTupleExpr(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil, elementList: TupleExprElementListSyntax, _ unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> TupleExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
       leftParen.raw,
@@ -933,6 +989,7 @@ public enum SyntaxFactory {
       elementList.raw,
       unexpectedBetweenElementListAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExpr,
       from: layout, arena: .default)
@@ -950,11 +1007,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return TupleExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ArrayExprSyntax")
-  public static func makeArrayExpr(_ unexpectedBeforeLeftSquare: UnexpectedNodesSyntax? = nil, leftSquare: TokenSyntax, _ unexpectedBetweenLeftSquareAndElements: UnexpectedNodesSyntax? = nil, elements: ArrayElementListSyntax, _ unexpectedBetweenElementsAndRightSquare: UnexpectedNodesSyntax? = nil, rightSquare: TokenSyntax) -> ArrayExprSyntax {
+  public static func makeArrayExpr(_ unexpectedBeforeLeftSquare: UnexpectedNodesSyntax? = nil, leftSquare: TokenSyntax, _ unexpectedBetweenLeftSquareAndElements: UnexpectedNodesSyntax? = nil, elements: ArrayElementListSyntax, _ unexpectedBetweenElementsAndRightSquare: UnexpectedNodesSyntax? = nil, rightSquare: TokenSyntax, _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil) -> ArrayExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftSquare?.raw,
       leftSquare.raw,
@@ -962,6 +1020,7 @@ public enum SyntaxFactory {
       elements.raw,
       unexpectedBetweenElementsAndRightSquare?.raw,
       rightSquare.raw,
+      unexpectedAfterRightSquare?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayExpr,
       from: layout, arena: .default)
@@ -979,11 +1038,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.arrayElementList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default),
+      nil,
     ], arena: .default))
     return ArrayExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DictionaryExprSyntax")
-  public static func makeDictionaryExpr(_ unexpectedBeforeLeftSquare: UnexpectedNodesSyntax? = nil, leftSquare: TokenSyntax, _ unexpectedBetweenLeftSquareAndContent: UnexpectedNodesSyntax? = nil, content: Syntax, _ unexpectedBetweenContentAndRightSquare: UnexpectedNodesSyntax? = nil, rightSquare: TokenSyntax) -> DictionaryExprSyntax {
+  public static func makeDictionaryExpr(_ unexpectedBeforeLeftSquare: UnexpectedNodesSyntax? = nil, leftSquare: TokenSyntax, _ unexpectedBetweenLeftSquareAndContent: UnexpectedNodesSyntax? = nil, content: Syntax, _ unexpectedBetweenContentAndRightSquare: UnexpectedNodesSyntax? = nil, rightSquare: TokenSyntax, _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil) -> DictionaryExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftSquare?.raw,
       leftSquare.raw,
@@ -991,6 +1051,7 @@ public enum SyntaxFactory {
       content.raw,
       unexpectedBetweenContentAndRightSquare?.raw,
       rightSquare.raw,
+      unexpectedAfterRightSquare?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryExpr,
       from: layout, arena: .default)
@@ -1008,11 +1069,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default),
+      nil,
     ], arena: .default))
     return DictionaryExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on TupleExprElementSyntax")
-  public static func makeTupleExprElement(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax?, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> TupleExprElementSyntax {
+  public static func makeTupleExprElement(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax?, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> TupleExprElementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabel?.raw,
       label?.raw,
@@ -1022,6 +1084,7 @@ public enum SyntaxFactory {
       expression.raw,
       unexpectedBetweenExpressionAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElement,
       from: layout, arena: .default)
@@ -1041,16 +1104,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return TupleExprElementSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ArrayElementSyntax")
-  public static func makeArrayElement(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> ArrayElementSyntax {
+  public static func makeArrayElement(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> ArrayElementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
       unexpectedBetweenExpressionAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayElement,
       from: layout, arena: .default)
@@ -1066,11 +1131,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return ArrayElementSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DictionaryElementSyntax")
-  public static func makeDictionaryElement(_ unexpectedBeforeKeyExpression: UnexpectedNodesSyntax? = nil, keyExpression: ExprSyntax, _ unexpectedBetweenKeyExpressionAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValueExpression: UnexpectedNodesSyntax? = nil, valueExpression: ExprSyntax, _ unexpectedBetweenValueExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> DictionaryElementSyntax {
+  public static func makeDictionaryElement(_ unexpectedBeforeKeyExpression: UnexpectedNodesSyntax? = nil, keyExpression: ExprSyntax, _ unexpectedBetweenKeyExpressionAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValueExpression: UnexpectedNodesSyntax? = nil, valueExpression: ExprSyntax, _ unexpectedBetweenValueExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> DictionaryElementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeKeyExpression?.raw,
       keyExpression.raw,
@@ -1080,6 +1146,7 @@ public enum SyntaxFactory {
       valueExpression.raw,
       unexpectedBetweenValueExpressionAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryElement,
       from: layout, arena: .default)
@@ -1099,14 +1166,16 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return DictionaryElementSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on IntegerLiteralExprSyntax")
-  public static func makeIntegerLiteralExpr(_ unexpectedBeforeDigits: UnexpectedNodesSyntax? = nil, digits: TokenSyntax) -> IntegerLiteralExprSyntax {
+  public static func makeIntegerLiteralExpr(_ unexpectedBeforeDigits: UnexpectedNodesSyntax? = nil, digits: TokenSyntax, _ unexpectedAfterDigits: UnexpectedNodesSyntax? = nil) -> IntegerLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDigits?.raw,
       digits.raw,
+      unexpectedAfterDigits?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.integerLiteralExpr,
       from: layout, arena: .default)
@@ -1120,14 +1189,16 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default),
+      nil,
     ], arena: .default))
     return IntegerLiteralExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on BooleanLiteralExprSyntax")
-  public static func makeBooleanLiteralExpr(_ unexpectedBeforeBooleanLiteral: UnexpectedNodesSyntax? = nil, booleanLiteral: TokenSyntax) -> BooleanLiteralExprSyntax {
+  public static func makeBooleanLiteralExpr(_ unexpectedBeforeBooleanLiteral: UnexpectedNodesSyntax? = nil, booleanLiteral: TokenSyntax, _ unexpectedAfterBooleanLiteral: UnexpectedNodesSyntax? = nil) -> BooleanLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBooleanLiteral?.raw,
       booleanLiteral.raw,
+      unexpectedAfterBooleanLiteral?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.booleanLiteralExpr,
       from: layout, arena: .default)
@@ -1141,11 +1212,12 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.trueKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return BooleanLiteralExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on UnresolvedTernaryExprSyntax")
-  public static func makeUnresolvedTernaryExpr(_ unexpectedBeforeQuestionMark: UnexpectedNodesSyntax? = nil, questionMark: TokenSyntax, _ unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? = nil, firstChoice: ExprSyntax, _ unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? = nil, colonMark: TokenSyntax) -> UnresolvedTernaryExprSyntax {
+  public static func makeUnresolvedTernaryExpr(_ unexpectedBeforeQuestionMark: UnexpectedNodesSyntax? = nil, questionMark: TokenSyntax, _ unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? = nil, firstChoice: ExprSyntax, _ unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? = nil, colonMark: TokenSyntax, _ unexpectedAfterColonMark: UnexpectedNodesSyntax? = nil) -> UnresolvedTernaryExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeQuestionMark?.raw,
       questionMark.raw,
@@ -1153,6 +1225,7 @@ public enum SyntaxFactory {
       firstChoice.raw,
       unexpectedBetweenFirstChoiceAndColonMark?.raw,
       colonMark.raw,
+      unexpectedAfterColonMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedTernaryExpr,
       from: layout, arena: .default)
@@ -1170,11 +1243,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
+      nil,
     ], arena: .default))
     return UnresolvedTernaryExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on TernaryExprSyntax")
-  public static func makeTernaryExpr(_ unexpectedBeforeConditionExpression: UnexpectedNodesSyntax? = nil, conditionExpression: ExprSyntax, _ unexpectedBetweenConditionExpressionAndQuestionMark: UnexpectedNodesSyntax? = nil, questionMark: TokenSyntax, _ unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? = nil, firstChoice: ExprSyntax, _ unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? = nil, colonMark: TokenSyntax, _ unexpectedBetweenColonMarkAndSecondChoice: UnexpectedNodesSyntax? = nil, secondChoice: ExprSyntax) -> TernaryExprSyntax {
+  public static func makeTernaryExpr(_ unexpectedBeforeConditionExpression: UnexpectedNodesSyntax? = nil, conditionExpression: ExprSyntax, _ unexpectedBetweenConditionExpressionAndQuestionMark: UnexpectedNodesSyntax? = nil, questionMark: TokenSyntax, _ unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? = nil, firstChoice: ExprSyntax, _ unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? = nil, colonMark: TokenSyntax, _ unexpectedBetweenColonMarkAndSecondChoice: UnexpectedNodesSyntax? = nil, secondChoice: ExprSyntax, _ unexpectedAfterSecondChoice: UnexpectedNodesSyntax? = nil) -> TernaryExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeConditionExpression?.raw,
       conditionExpression.raw,
@@ -1186,6 +1260,7 @@ public enum SyntaxFactory {
       colonMark.raw,
       unexpectedBetweenColonMarkAndSecondChoice?.raw,
       secondChoice.raw,
+      unexpectedAfterSecondChoice?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.ternaryExpr,
       from: layout, arena: .default)
@@ -1207,11 +1282,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
     ], arena: .default))
     return TernaryExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on MemberAccessExprSyntax")
-  public static func makeMemberAccessExpr(_ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil, base: ExprSyntax?, _ unexpectedBetweenBaseAndDot: UnexpectedNodesSyntax? = nil, dot: TokenSyntax, _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?) -> MemberAccessExprSyntax {
+  public static func makeMemberAccessExpr(_ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil, base: ExprSyntax?, _ unexpectedBetweenBaseAndDot: UnexpectedNodesSyntax? = nil, dot: TokenSyntax, _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?, _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil) -> MemberAccessExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBase?.raw,
       base?.raw,
@@ -1221,6 +1297,7 @@ public enum SyntaxFactory {
       name.raw,
       unexpectedBetweenNameAndDeclNameArguments?.raw,
       declNameArguments?.raw,
+      unexpectedAfterDeclNameArguments?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberAccessExpr,
       from: layout, arena: .default)
@@ -1240,14 +1317,16 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return MemberAccessExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on UnresolvedIsExprSyntax")
-  public static func makeUnresolvedIsExpr(_ unexpectedBeforeIsTok: UnexpectedNodesSyntax? = nil, isTok: TokenSyntax) -> UnresolvedIsExprSyntax {
+  public static func makeUnresolvedIsExpr(_ unexpectedBeforeIsTok: UnexpectedNodesSyntax? = nil, isTok: TokenSyntax, _ unexpectedAfterIsTok: UnexpectedNodesSyntax? = nil) -> UnresolvedIsExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIsTok?.raw,
       isTok.raw,
+      unexpectedAfterIsTok?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedIsExpr,
       from: layout, arena: .default)
@@ -1261,11 +1340,12 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return UnresolvedIsExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on IsExprSyntax")
-  public static func makeIsExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndIsTok: UnexpectedNodesSyntax? = nil, isTok: TokenSyntax, _ unexpectedBetweenIsTokAndTypeName: UnexpectedNodesSyntax? = nil, typeName: TypeSyntax) -> IsExprSyntax {
+  public static func makeIsExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndIsTok: UnexpectedNodesSyntax? = nil, isTok: TokenSyntax, _ unexpectedBetweenIsTokAndTypeName: UnexpectedNodesSyntax? = nil, typeName: TypeSyntax, _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil) -> IsExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
@@ -1273,6 +1353,7 @@ public enum SyntaxFactory {
       isTok.raw,
       unexpectedBetweenIsTokAndTypeName?.raw,
       typeName.raw,
+      unexpectedAfterTypeName?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.isExpr,
       from: layout, arena: .default)
@@ -1290,16 +1371,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
     ], arena: .default))
     return IsExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on UnresolvedAsExprSyntax")
-  public static func makeUnresolvedAsExpr(_ unexpectedBeforeAsTok: UnexpectedNodesSyntax? = nil, asTok: TokenSyntax, _ unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil, questionOrExclamationMark: TokenSyntax?) -> UnresolvedAsExprSyntax {
+  public static func makeUnresolvedAsExpr(_ unexpectedBeforeAsTok: UnexpectedNodesSyntax? = nil, asTok: TokenSyntax, _ unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil, questionOrExclamationMark: TokenSyntax?, _ unexpectedAfterQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil) -> UnresolvedAsExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAsTok?.raw,
       asTok.raw,
       unexpectedBetweenAsTokAndQuestionOrExclamationMark?.raw,
       questionOrExclamationMark?.raw,
+      unexpectedAfterQuestionOrExclamationMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedAsExpr,
       from: layout, arena: .default)
@@ -1315,11 +1398,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return UnresolvedAsExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AsExprSyntax")
-  public static func makeAsExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndAsTok: UnexpectedNodesSyntax? = nil, asTok: TokenSyntax, _ unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil, questionOrExclamationMark: TokenSyntax?, _ unexpectedBetweenQuestionOrExclamationMarkAndTypeName: UnexpectedNodesSyntax? = nil, typeName: TypeSyntax) -> AsExprSyntax {
+  public static func makeAsExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndAsTok: UnexpectedNodesSyntax? = nil, asTok: TokenSyntax, _ unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil, questionOrExclamationMark: TokenSyntax?, _ unexpectedBetweenQuestionOrExclamationMarkAndTypeName: UnexpectedNodesSyntax? = nil, typeName: TypeSyntax, _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil) -> AsExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
@@ -1329,6 +1413,7 @@ public enum SyntaxFactory {
       questionOrExclamationMark?.raw,
       unexpectedBetweenQuestionOrExclamationMarkAndTypeName?.raw,
       typeName.raw,
+      unexpectedAfterTypeName?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.asExpr,
       from: layout, arena: .default)
@@ -1348,14 +1433,16 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
     ], arena: .default))
     return AsExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on TypeExprSyntax")
-  public static func makeTypeExpr(_ unexpectedBeforeType: UnexpectedNodesSyntax? = nil, type: TypeSyntax) -> TypeExprSyntax {
+  public static func makeTypeExpr(_ unexpectedBeforeType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedAfterType: UnexpectedNodesSyntax? = nil) -> TypeExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeType?.raw,
       type.raw,
+      unexpectedAfterType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeExpr,
       from: layout, arena: .default)
@@ -1369,11 +1456,12 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
     ], arena: .default))
     return TypeExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ClosureCaptureItemSyntax")
-  public static func makeClosureCaptureItem(_ unexpectedBeforeSpecifier: UnexpectedNodesSyntax? = nil, specifier: TokenListSyntax?, _ unexpectedBetweenSpecifierAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax?, _ unexpectedBetweenNameAndAssignToken: UnexpectedNodesSyntax? = nil, assignToken: TokenSyntax?, _ unexpectedBetweenAssignTokenAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> ClosureCaptureItemSyntax {
+  public static func makeClosureCaptureItem(_ unexpectedBeforeSpecifier: UnexpectedNodesSyntax? = nil, specifier: TokenListSyntax?, _ unexpectedBetweenSpecifierAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax?, _ unexpectedBetweenNameAndAssignToken: UnexpectedNodesSyntax? = nil, assignToken: TokenSyntax?, _ unexpectedBetweenAssignTokenAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> ClosureCaptureItemSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSpecifier?.raw,
       specifier?.raw,
@@ -1385,6 +1473,7 @@ public enum SyntaxFactory {
       expression.raw,
       unexpectedBetweenExpressionAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItem,
       from: layout, arena: .default)
@@ -1404,6 +1493,7 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
       nil,
       nil,
     ], arena: .default))
@@ -1426,7 +1516,7 @@ public enum SyntaxFactory {
     return ClosureCaptureItemListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ClosureCaptureSignatureSyntax")
-  public static func makeClosureCaptureSignature(_ unexpectedBeforeLeftSquare: UnexpectedNodesSyntax? = nil, leftSquare: TokenSyntax, _ unexpectedBetweenLeftSquareAndItems: UnexpectedNodesSyntax? = nil, items: ClosureCaptureItemListSyntax?, _ unexpectedBetweenItemsAndRightSquare: UnexpectedNodesSyntax? = nil, rightSquare: TokenSyntax) -> ClosureCaptureSignatureSyntax {
+  public static func makeClosureCaptureSignature(_ unexpectedBeforeLeftSquare: UnexpectedNodesSyntax? = nil, leftSquare: TokenSyntax, _ unexpectedBetweenLeftSquareAndItems: UnexpectedNodesSyntax? = nil, items: ClosureCaptureItemListSyntax?, _ unexpectedBetweenItemsAndRightSquare: UnexpectedNodesSyntax? = nil, rightSquare: TokenSyntax, _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil) -> ClosureCaptureSignatureSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftSquare?.raw,
       leftSquare.raw,
@@ -1434,6 +1524,7 @@ public enum SyntaxFactory {
       items?.raw,
       unexpectedBetweenItemsAndRightSquare?.raw,
       rightSquare.raw,
+      unexpectedAfterRightSquare?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureSignature,
       from: layout, arena: .default)
@@ -1451,16 +1542,18 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default),
+      nil,
     ], arena: .default))
     return ClosureCaptureSignatureSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ClosureParamSyntax")
-  public static func makeClosureParam(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> ClosureParamSyntax {
+  public static func makeClosureParam(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> ClosureParamSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParam,
       from: layout, arena: .default)
@@ -1474,6 +1567,7 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+      nil,
       nil,
       nil,
     ], arena: .default))
@@ -1496,7 +1590,7 @@ public enum SyntaxFactory {
     return ClosureParamListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ClosureSignatureSyntax")
-  public static func makeClosureSignature(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndCapture: UnexpectedNodesSyntax? = nil, capture: ClosureCaptureSignatureSyntax?, _ unexpectedBetweenCaptureAndInput: UnexpectedNodesSyntax? = nil, input: Syntax?, _ unexpectedBetweenInputAndAsyncKeyword: UnexpectedNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ unexpectedBetweenAsyncKeywordAndThrowsTok: UnexpectedNodesSyntax? = nil, throwsTok: TokenSyntax?, _ unexpectedBetweenThrowsTokAndOutput: UnexpectedNodesSyntax? = nil, output: ReturnClauseSyntax?, _ unexpectedBetweenOutputAndInTok: UnexpectedNodesSyntax? = nil, inTok: TokenSyntax) -> ClosureSignatureSyntax {
+  public static func makeClosureSignature(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndCapture: UnexpectedNodesSyntax? = nil, capture: ClosureCaptureSignatureSyntax?, _ unexpectedBetweenCaptureAndInput: UnexpectedNodesSyntax? = nil, input: Syntax?, _ unexpectedBetweenInputAndAsyncKeyword: UnexpectedNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ unexpectedBetweenAsyncKeywordAndThrowsTok: UnexpectedNodesSyntax? = nil, throwsTok: TokenSyntax?, _ unexpectedBetweenThrowsTokAndOutput: UnexpectedNodesSyntax? = nil, output: ReturnClauseSyntax?, _ unexpectedBetweenOutputAndInTok: UnexpectedNodesSyntax? = nil, inTok: TokenSyntax, _ unexpectedAfterInTok: UnexpectedNodesSyntax? = nil) -> ClosureSignatureSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -1512,6 +1606,7 @@ public enum SyntaxFactory {
       output?.raw,
       unexpectedBetweenOutputAndInTok?.raw,
       inTok.raw,
+      unexpectedAfterInTok?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureSignature,
       from: layout, arena: .default)
@@ -1537,11 +1632,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.inKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return ClosureSignatureSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ClosureExprSyntax")
-  public static func makeClosureExpr(_ unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndSignature: UnexpectedNodesSyntax? = nil, signature: ClosureSignatureSyntax?, _ unexpectedBetweenSignatureAndStatements: UnexpectedNodesSyntax? = nil, statements: CodeBlockItemListSyntax, _ unexpectedBetweenStatementsAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax) -> ClosureExprSyntax {
+  public static func makeClosureExpr(_ unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndSignature: UnexpectedNodesSyntax? = nil, signature: ClosureSignatureSyntax?, _ unexpectedBetweenSignatureAndStatements: UnexpectedNodesSyntax? = nil, statements: CodeBlockItemListSyntax, _ unexpectedBetweenStatementsAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax, _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil) -> ClosureExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftBrace?.raw,
       leftBrace.raw,
@@ -1551,6 +1647,7 @@ public enum SyntaxFactory {
       statements.raw,
       unexpectedBetweenStatementsAndRightBrace?.raw,
       rightBrace.raw,
+      unexpectedAfterRightBrace?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureExpr,
       from: layout, arena: .default)
@@ -1570,14 +1667,16 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default),
+      nil,
     ], arena: .default))
     return ClosureExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on UnresolvedPatternExprSyntax")
-  public static func makeUnresolvedPatternExpr(_ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax) -> UnresolvedPatternExprSyntax {
+  public static func makeUnresolvedPatternExpr(_ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedAfterPattern: UnexpectedNodesSyntax? = nil) -> UnresolvedPatternExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePattern?.raw,
       pattern.raw,
+      unexpectedAfterPattern?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedPatternExpr,
       from: layout, arena: .default)
@@ -1591,11 +1690,12 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default),
+      nil,
     ], arena: .default))
     return UnresolvedPatternExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on MultipleTrailingClosureElementSyntax")
-  public static func makeMultipleTrailingClosureElement(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndClosure: UnexpectedNodesSyntax? = nil, closure: ClosureExprSyntax) -> MultipleTrailingClosureElementSyntax {
+  public static func makeMultipleTrailingClosureElement(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndClosure: UnexpectedNodesSyntax? = nil, closure: ClosureExprSyntax, _ unexpectedAfterClosure: UnexpectedNodesSyntax? = nil) -> MultipleTrailingClosureElementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabel?.raw,
       label.raw,
@@ -1603,6 +1703,7 @@ public enum SyntaxFactory {
       colon.raw,
       unexpectedBetweenColonAndClosure?.raw,
       closure.raw,
+      unexpectedAfterClosure?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElement,
       from: layout, arena: .default)
@@ -1620,6 +1721,7 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.closureExpr, arena: .default),
+      nil,
     ], arena: .default))
     return MultipleTrailingClosureElementSyntax(data)
   }
@@ -1640,7 +1742,7 @@ public enum SyntaxFactory {
     return MultipleTrailingClosureElementListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on FunctionCallExprSyntax")
-  public static func makeFunctionCallExpr(_ unexpectedBeforeCalledExpression: UnexpectedNodesSyntax? = nil, calledExpression: ExprSyntax, _ unexpectedBetweenCalledExpressionAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax?, _ unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? = nil, argumentList: TupleExprElementListSyntax, _ unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax?, _ unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodesSyntax? = nil, trailingClosure: ClosureExprSyntax?, _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil, additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?) -> FunctionCallExprSyntax {
+  public static func makeFunctionCallExpr(_ unexpectedBeforeCalledExpression: UnexpectedNodesSyntax? = nil, calledExpression: ExprSyntax, _ unexpectedBetweenCalledExpressionAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax?, _ unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? = nil, argumentList: TupleExprElementListSyntax, _ unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax?, _ unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodesSyntax? = nil, trailingClosure: ClosureExprSyntax?, _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil, additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?, _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil) -> FunctionCallExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeCalledExpression?.raw,
       calledExpression.raw,
@@ -1654,6 +1756,7 @@ public enum SyntaxFactory {
       trailingClosure?.raw,
       unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.raw,
       additionalTrailingClosures?.raw,
+      unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionCallExpr,
       from: layout, arena: .default)
@@ -1677,11 +1780,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return FunctionCallExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on SubscriptExprSyntax")
-  public static func makeSubscriptExpr(_ unexpectedBeforeCalledExpression: UnexpectedNodesSyntax? = nil, calledExpression: ExprSyntax, _ unexpectedBetweenCalledExpressionAndLeftBracket: UnexpectedNodesSyntax? = nil, leftBracket: TokenSyntax, _ unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodesSyntax? = nil, argumentList: TupleExprElementListSyntax, _ unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodesSyntax? = nil, rightBracket: TokenSyntax, _ unexpectedBetweenRightBracketAndTrailingClosure: UnexpectedNodesSyntax? = nil, trailingClosure: ClosureExprSyntax?, _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil, additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?) -> SubscriptExprSyntax {
+  public static func makeSubscriptExpr(_ unexpectedBeforeCalledExpression: UnexpectedNodesSyntax? = nil, calledExpression: ExprSyntax, _ unexpectedBetweenCalledExpressionAndLeftBracket: UnexpectedNodesSyntax? = nil, leftBracket: TokenSyntax, _ unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodesSyntax? = nil, argumentList: TupleExprElementListSyntax, _ unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodesSyntax? = nil, rightBracket: TokenSyntax, _ unexpectedBetweenRightBracketAndTrailingClosure: UnexpectedNodesSyntax? = nil, trailingClosure: ClosureExprSyntax?, _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil, additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?, _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil) -> SubscriptExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeCalledExpression?.raw,
       calledExpression.raw,
@@ -1695,6 +1799,7 @@ public enum SyntaxFactory {
       trailingClosure?.raw,
       unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.raw,
       additionalTrailingClosures?.raw,
+      unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.subscriptExpr,
       from: layout, arena: .default)
@@ -1718,16 +1823,18 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return SubscriptExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on OptionalChainingExprSyntax")
-  public static func makeOptionalChainingExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndQuestionMark: UnexpectedNodesSyntax? = nil, questionMark: TokenSyntax) -> OptionalChainingExprSyntax {
+  public static func makeOptionalChainingExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndQuestionMark: UnexpectedNodesSyntax? = nil, questionMark: TokenSyntax, _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil) -> OptionalChainingExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
       unexpectedBetweenExpressionAndQuestionMark?.raw,
       questionMark.raw,
+      unexpectedAfterQuestionMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalChainingExpr,
       from: layout, arena: .default)
@@ -1743,16 +1850,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: .default),
+      nil,
     ], arena: .default))
     return OptionalChainingExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ForcedValueExprSyntax")
-  public static func makeForcedValueExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndExclamationMark: UnexpectedNodesSyntax? = nil, exclamationMark: TokenSyntax) -> ForcedValueExprSyntax {
+  public static func makeForcedValueExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndExclamationMark: UnexpectedNodesSyntax? = nil, exclamationMark: TokenSyntax, _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil) -> ForcedValueExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
       unexpectedBetweenExpressionAndExclamationMark?.raw,
       exclamationMark.raw,
+      unexpectedAfterExclamationMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.forcedValueExpr,
       from: layout, arena: .default)
@@ -1768,16 +1877,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.exclamationMark, arena: .default),
+      nil,
     ], arena: .default))
     return ForcedValueExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PostfixUnaryExprSyntax")
-  public static func makePostfixUnaryExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndOperatorToken: UnexpectedNodesSyntax? = nil, operatorToken: TokenSyntax) -> PostfixUnaryExprSyntax {
+  public static func makePostfixUnaryExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndOperatorToken: UnexpectedNodesSyntax? = nil, operatorToken: TokenSyntax, _ unexpectedAfterOperatorToken: UnexpectedNodesSyntax? = nil) -> PostfixUnaryExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
       unexpectedBetweenExpressionAndOperatorToken?.raw,
       operatorToken.raw,
+      unexpectedAfterOperatorToken?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.postfixUnaryExpr,
       from: layout, arena: .default)
@@ -1793,16 +1904,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.postfixOperator(""), arena: .default),
+      nil,
     ], arena: .default))
     return PostfixUnaryExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on SpecializeExprSyntax")
-  public static func makeSpecializeExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndGenericArgumentClause: UnexpectedNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax) -> SpecializeExprSyntax {
+  public static func makeSpecializeExpr(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndGenericArgumentClause: UnexpectedNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax, _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil) -> SpecializeExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
       unexpectedBetweenExpressionAndGenericArgumentClause?.raw,
       genericArgumentClause.raw,
+      unexpectedAfterGenericArgumentClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.specializeExpr,
       from: layout, arena: .default)
@@ -1818,14 +1931,16 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericArgumentClause, arena: .default),
+      nil,
     ], arena: .default))
     return SpecializeExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on StringSegmentSyntax")
-  public static func makeStringSegment(_ unexpectedBeforeContent: UnexpectedNodesSyntax? = nil, content: TokenSyntax) -> StringSegmentSyntax {
+  public static func makeStringSegment(_ unexpectedBeforeContent: UnexpectedNodesSyntax? = nil, content: TokenSyntax, _ unexpectedAfterContent: UnexpectedNodesSyntax? = nil) -> StringSegmentSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeContent?.raw,
       content.raw,
+      unexpectedAfterContent?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringSegment,
       from: layout, arena: .default)
@@ -1839,11 +1954,12 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.stringSegment(""), arena: .default),
+      nil,
     ], arena: .default))
     return StringSegmentSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ExpressionSegmentSyntax")
-  public static func makeExpressionSegment(_ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil, backslash: TokenSyntax, _ unexpectedBetweenBackslashAndDelimiter: UnexpectedNodesSyntax? = nil, delimiter: TokenSyntax?, _ unexpectedBetweenDelimiterAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndExpressions: UnexpectedNodesSyntax? = nil, expressions: TupleExprElementListSyntax, _ unexpectedBetweenExpressionsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> ExpressionSegmentSyntax {
+  public static func makeExpressionSegment(_ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil, backslash: TokenSyntax, _ unexpectedBetweenBackslashAndDelimiter: UnexpectedNodesSyntax? = nil, delimiter: TokenSyntax?, _ unexpectedBetweenDelimiterAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndExpressions: UnexpectedNodesSyntax? = nil, expressions: TupleExprElementListSyntax, _ unexpectedBetweenExpressionsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> ExpressionSegmentSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBackslash?.raw,
       backslash.raw,
@@ -1855,6 +1971,7 @@ public enum SyntaxFactory {
       expressions.raw,
       unexpectedBetweenExpressionsAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionSegment,
       from: layout, arena: .default)
@@ -1876,11 +1993,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.stringInterpolationAnchor, arena: .default),
+      nil,
     ], arena: .default))
     return ExpressionSegmentSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on StringLiteralExprSyntax")
-  public static func makeStringLiteralExpr(_ unexpectedBeforeOpenDelimiter: UnexpectedNodesSyntax? = nil, openDelimiter: TokenSyntax?, _ unexpectedBetweenOpenDelimiterAndOpenQuote: UnexpectedNodesSyntax? = nil, openQuote: TokenSyntax, _ unexpectedBetweenOpenQuoteAndSegments: UnexpectedNodesSyntax? = nil, segments: StringLiteralSegmentsSyntax, _ unexpectedBetweenSegmentsAndCloseQuote: UnexpectedNodesSyntax? = nil, closeQuote: TokenSyntax, _ unexpectedBetweenCloseQuoteAndCloseDelimiter: UnexpectedNodesSyntax? = nil, closeDelimiter: TokenSyntax?) -> StringLiteralExprSyntax {
+  public static func makeStringLiteralExpr(_ unexpectedBeforeOpenDelimiter: UnexpectedNodesSyntax? = nil, openDelimiter: TokenSyntax?, _ unexpectedBetweenOpenDelimiterAndOpenQuote: UnexpectedNodesSyntax? = nil, openQuote: TokenSyntax, _ unexpectedBetweenOpenQuoteAndSegments: UnexpectedNodesSyntax? = nil, segments: StringLiteralSegmentsSyntax, _ unexpectedBetweenSegmentsAndCloseQuote: UnexpectedNodesSyntax? = nil, closeQuote: TokenSyntax, _ unexpectedBetweenCloseQuoteAndCloseDelimiter: UnexpectedNodesSyntax? = nil, closeDelimiter: TokenSyntax?, _ unexpectedAfterCloseDelimiter: UnexpectedNodesSyntax? = nil) -> StringLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeOpenDelimiter?.raw,
       openDelimiter?.raw,
@@ -1892,6 +2010,7 @@ public enum SyntaxFactory {
       closeQuote.raw,
       unexpectedBetweenCloseQuoteAndCloseDelimiter?.raw,
       closeDelimiter?.raw,
+      unexpectedAfterCloseDelimiter?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralExpr,
       from: layout, arena: .default)
@@ -1913,14 +2032,16 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.stringQuote, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return StringLiteralExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on RegexLiteralExprSyntax")
-  public static func makeRegexLiteralExpr(_ unexpectedBeforeRegex: UnexpectedNodesSyntax? = nil, regex: TokenSyntax) -> RegexLiteralExprSyntax {
+  public static func makeRegexLiteralExpr(_ unexpectedBeforeRegex: UnexpectedNodesSyntax? = nil, regex: TokenSyntax, _ unexpectedAfterRegex: UnexpectedNodesSyntax? = nil) -> RegexLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeRegex?.raw,
       regex.raw,
+      unexpectedAfterRegex?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.regexLiteralExpr,
       from: layout, arena: .default)
@@ -1934,11 +2055,12 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.regexLiteral(""), arena: .default),
+      nil,
     ], arena: .default))
     return RegexLiteralExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on KeyPathExprSyntax")
-  public static func makeKeyPathExpr(_ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil, backslash: TokenSyntax, _ unexpectedBetweenBackslashAndRoot: UnexpectedNodesSyntax? = nil, root: TypeSyntax?, _ unexpectedBetweenRootAndComponents: UnexpectedNodesSyntax? = nil, components: KeyPathComponentListSyntax) -> KeyPathExprSyntax {
+  public static func makeKeyPathExpr(_ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil, backslash: TokenSyntax, _ unexpectedBetweenBackslashAndRoot: UnexpectedNodesSyntax? = nil, root: TypeSyntax?, _ unexpectedBetweenRootAndComponents: UnexpectedNodesSyntax? = nil, components: KeyPathComponentListSyntax, _ unexpectedAfterComponents: UnexpectedNodesSyntax? = nil) -> KeyPathExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBackslash?.raw,
       backslash.raw,
@@ -1946,6 +2068,7 @@ public enum SyntaxFactory {
       root?.raw,
       unexpectedBetweenRootAndComponents?.raw,
       components.raw,
+      unexpectedAfterComponents?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathExpr,
       from: layout, arena: .default)
@@ -1963,6 +2086,7 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.keyPathComponentList, arena: .default),
+      nil,
     ], arena: .default))
     return KeyPathExprSyntax(data)
   }
@@ -1983,12 +2107,13 @@ public enum SyntaxFactory {
     return KeyPathComponentListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on KeyPathComponentSyntax")
-  public static func makeKeyPathComponent(_ unexpectedBeforePeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax?, _ unexpectedBetweenPeriodAndComponent: UnexpectedNodesSyntax? = nil, component: Syntax) -> KeyPathComponentSyntax {
+  public static func makeKeyPathComponent(_ unexpectedBeforePeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax?, _ unexpectedBetweenPeriodAndComponent: UnexpectedNodesSyntax? = nil, component: Syntax, _ unexpectedAfterComponent: UnexpectedNodesSyntax? = nil) -> KeyPathComponentSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePeriod?.raw,
       period?.raw,
       unexpectedBetweenPeriodAndComponent?.raw,
       component.raw,
+      unexpectedAfterComponent?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathComponent,
       from: layout, arena: .default)
@@ -2004,11 +2129,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
+      nil,
     ], arena: .default))
     return KeyPathComponentSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on KeyPathPropertyComponentSyntax")
-  public static func makeKeyPathPropertyComponent(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?, _ unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause: UnexpectedNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax?) -> KeyPathPropertyComponentSyntax {
+  public static func makeKeyPathPropertyComponent(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?, _ unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause: UnexpectedNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax?, _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil) -> KeyPathPropertyComponentSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
       identifier.raw,
@@ -2016,6 +2142,7 @@ public enum SyntaxFactory {
       declNameArguments?.raw,
       unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause?.raw,
       genericArgumentClause?.raw,
+      unexpectedAfterGenericArgumentClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathPropertyComponent,
       from: layout, arena: .default)
@@ -2033,11 +2160,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return KeyPathPropertyComponentSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on KeyPathSubscriptComponentSyntax")
-  public static func makeKeyPathSubscriptComponent(_ unexpectedBeforeLeftBracket: UnexpectedNodesSyntax? = nil, leftBracket: TokenSyntax, _ unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodesSyntax? = nil, argumentList: TupleExprElementListSyntax, _ unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodesSyntax? = nil, rightBracket: TokenSyntax) -> KeyPathSubscriptComponentSyntax {
+  public static func makeKeyPathSubscriptComponent(_ unexpectedBeforeLeftBracket: UnexpectedNodesSyntax? = nil, leftBracket: TokenSyntax, _ unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodesSyntax? = nil, argumentList: TupleExprElementListSyntax, _ unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodesSyntax? = nil, rightBracket: TokenSyntax, _ unexpectedAfterRightBracket: UnexpectedNodesSyntax? = nil) -> KeyPathSubscriptComponentSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftBracket?.raw,
       leftBracket.raw,
@@ -2045,6 +2173,7 @@ public enum SyntaxFactory {
       argumentList.raw,
       unexpectedBetweenArgumentListAndRightBracket?.raw,
       rightBracket.raw,
+      unexpectedAfterRightBracket?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathSubscriptComponent,
       from: layout, arena: .default)
@@ -2062,14 +2191,16 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default),
+      nil,
     ], arena: .default))
     return KeyPathSubscriptComponentSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on KeyPathOptionalComponentSyntax")
-  public static func makeKeyPathOptionalComponent(_ unexpectedBeforeQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil, questionOrExclamationMark: TokenSyntax) -> KeyPathOptionalComponentSyntax {
+  public static func makeKeyPathOptionalComponent(_ unexpectedBeforeQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil, questionOrExclamationMark: TokenSyntax, _ unexpectedAfterQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil) -> KeyPathOptionalComponentSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeQuestionOrExclamationMark?.raw,
       questionOrExclamationMark.raw,
+      unexpectedAfterQuestionOrExclamationMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathOptionalComponent,
       from: layout, arena: .default)
@@ -2083,11 +2214,12 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: .default),
+      nil,
     ], arena: .default))
     return KeyPathOptionalComponentSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on OldKeyPathExprSyntax")
-  public static func makeOldKeyPathExpr(_ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil, backslash: TokenSyntax, _ unexpectedBetweenBackslashAndRootExpr: UnexpectedNodesSyntax? = nil, rootExpr: ExprSyntax?, _ unexpectedBetweenRootExprAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax) -> OldKeyPathExprSyntax {
+  public static func makeOldKeyPathExpr(_ unexpectedBeforeBackslash: UnexpectedNodesSyntax? = nil, backslash: TokenSyntax, _ unexpectedBetweenBackslashAndRootExpr: UnexpectedNodesSyntax? = nil, rootExpr: ExprSyntax?, _ unexpectedBetweenRootExprAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> OldKeyPathExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBackslash?.raw,
       backslash.raw,
@@ -2095,6 +2227,7 @@ public enum SyntaxFactory {
       rootExpr?.raw,
       unexpectedBetweenRootExprAndExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.oldKeyPathExpr,
       from: layout, arena: .default)
@@ -2112,14 +2245,16 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
     ], arena: .default))
     return OldKeyPathExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on KeyPathBaseExprSyntax")
-  public static func makeKeyPathBaseExpr(_ unexpectedBeforePeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax) -> KeyPathBaseExprSyntax {
+  public static func makeKeyPathBaseExpr(_ unexpectedBeforePeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax, _ unexpectedAfterPeriod: UnexpectedNodesSyntax? = nil) -> KeyPathBaseExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePeriod?.raw,
       period.raw,
+      unexpectedAfterPeriod?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathBaseExpr,
       from: layout, arena: .default)
@@ -2133,16 +2268,18 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default),
+      nil,
     ], arena: .default))
     return KeyPathBaseExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ObjcNamePieceSyntax")
-  public static func makeObjcNamePiece(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndDot: UnexpectedNodesSyntax? = nil, dot: TokenSyntax?) -> ObjcNamePieceSyntax {
+  public static func makeObjcNamePiece(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndDot: UnexpectedNodesSyntax? = nil, dot: TokenSyntax?, _ unexpectedAfterDot: UnexpectedNodesSyntax? = nil) -> ObjcNamePieceSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndDot?.raw,
       dot?.raw,
+      unexpectedAfterDot?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcNamePiece,
       from: layout, arena: .default)
@@ -2156,6 +2293,7 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+      nil,
       nil,
       nil,
     ], arena: .default))
@@ -2178,7 +2316,7 @@ public enum SyntaxFactory {
     return ObjcNameSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ObjcKeyPathExprSyntax")
-  public static func makeObjcKeyPathExpr(_ unexpectedBeforeKeyPath: UnexpectedNodesSyntax? = nil, keyPath: TokenSyntax, _ unexpectedBetweenKeyPathAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndName: UnexpectedNodesSyntax? = nil, name: ObjcNameSyntax, _ unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> ObjcKeyPathExprSyntax {
+  public static func makeObjcKeyPathExpr(_ unexpectedBeforeKeyPath: UnexpectedNodesSyntax? = nil, keyPath: TokenSyntax, _ unexpectedBetweenKeyPathAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndName: UnexpectedNodesSyntax? = nil, name: ObjcNameSyntax, _ unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> ObjcKeyPathExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeKeyPath?.raw,
       keyPath.raw,
@@ -2188,6 +2326,7 @@ public enum SyntaxFactory {
       name.raw,
       unexpectedBetweenNameAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcKeyPathExpr,
       from: layout, arena: .default)
@@ -2207,11 +2346,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.objcName, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return ObjcKeyPathExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ObjcSelectorExprSyntax")
-  public static func makeObjcSelectorExpr(_ unexpectedBeforePoundSelector: UnexpectedNodesSyntax? = nil, poundSelector: TokenSyntax, _ unexpectedBetweenPoundSelectorAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndKind: UnexpectedNodesSyntax? = nil, kind: TokenSyntax?, _ unexpectedBetweenKindAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndName: UnexpectedNodesSyntax? = nil, name: ExprSyntax, _ unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> ObjcSelectorExprSyntax {
+  public static func makeObjcSelectorExpr(_ unexpectedBeforePoundSelector: UnexpectedNodesSyntax? = nil, poundSelector: TokenSyntax, _ unexpectedBetweenPoundSelectorAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndKind: UnexpectedNodesSyntax? = nil, kind: TokenSyntax?, _ unexpectedBetweenKindAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndName: UnexpectedNodesSyntax? = nil, name: ExprSyntax, _ unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> ObjcSelectorExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundSelector?.raw,
       poundSelector.raw,
@@ -2225,6 +2365,7 @@ public enum SyntaxFactory {
       name.raw,
       unexpectedBetweenNameAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcSelectorExpr,
       from: layout, arena: .default)
@@ -2248,16 +2389,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return ObjcSelectorExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PostfixIfConfigExprSyntax")
-  public static func makePostfixIfConfigExpr(_ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil, base: ExprSyntax?, _ unexpectedBetweenBaseAndConfig: UnexpectedNodesSyntax? = nil, config: IfConfigDeclSyntax) -> PostfixIfConfigExprSyntax {
+  public static func makePostfixIfConfigExpr(_ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil, base: ExprSyntax?, _ unexpectedBetweenBaseAndConfig: UnexpectedNodesSyntax? = nil, config: IfConfigDeclSyntax, _ unexpectedAfterConfig: UnexpectedNodesSyntax? = nil) -> PostfixIfConfigExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBase?.raw,
       base?.raw,
       unexpectedBetweenBaseAndConfig?.raw,
       config.raw,
+      unexpectedAfterConfig?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.postfixIfConfigExpr,
       from: layout, arena: .default)
@@ -2273,14 +2416,16 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifConfigDecl, arena: .default),
+      nil,
     ], arena: .default))
     return PostfixIfConfigExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on EditorPlaceholderExprSyntax")
-  public static func makeEditorPlaceholderExpr(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax) -> EditorPlaceholderExprSyntax {
+  public static func makeEditorPlaceholderExpr(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedAfterIdentifier: UnexpectedNodesSyntax? = nil) -> EditorPlaceholderExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
       identifier.raw,
+      unexpectedAfterIdentifier?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.editorPlaceholderExpr,
       from: layout, arena: .default)
@@ -2294,11 +2439,12 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+      nil,
     ], arena: .default))
     return EditorPlaceholderExprSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ObjectLiteralExprSyntax")
-  public static func makeObjectLiteralExpr(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil, arguments: TupleExprElementListSyntax, _ unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> ObjectLiteralExprSyntax {
+  public static func makeObjectLiteralExpr(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil, arguments: TupleExprElementListSyntax, _ unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> ObjectLiteralExprSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
       identifier.raw,
@@ -2308,6 +2454,7 @@ public enum SyntaxFactory {
       arguments.raw,
       unexpectedBetweenArgumentsAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.objectLiteralExpr,
       from: layout, arena: .default)
@@ -2327,6 +2474,7 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleExprElementList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return ObjectLiteralExprSyntax(data)
   }
@@ -2347,12 +2495,13 @@ public enum SyntaxFactory {
     return YieldExprListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on YieldExprListElementSyntax")
-  public static func makeYieldExprListElement(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?) -> YieldExprListElementSyntax {
+  public static func makeYieldExprListElement(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedAfterComma: UnexpectedNodesSyntax? = nil) -> YieldExprListElementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
       unexpectedBetweenExpressionAndComma?.raw,
       comma?.raw,
+      unexpectedAfterComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprListElement,
       from: layout, arena: .default)
@@ -2368,16 +2517,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return YieldExprListElementSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on TypeInitializerClauseSyntax")
-  public static func makeTypeInitializerClause(_ unexpectedBeforeEqual: UnexpectedNodesSyntax? = nil, equal: TokenSyntax, _ unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? = nil, value: TypeSyntax) -> TypeInitializerClauseSyntax {
+  public static func makeTypeInitializerClause(_ unexpectedBeforeEqual: UnexpectedNodesSyntax? = nil, equal: TokenSyntax, _ unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? = nil, value: TypeSyntax, _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil) -> TypeInitializerClauseSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeEqual?.raw,
       equal.raw,
       unexpectedBetweenEqualAndValue?.raw,
       value.raw,
+      unexpectedAfterValue?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeInitializerClause,
       from: layout, arena: .default)
@@ -2393,11 +2544,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
     ], arena: .default))
     return TypeInitializerClauseSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on TypealiasDeclSyntax")
-  public static func makeTypealiasDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndTypealiasKeyword: UnexpectedNodesSyntax? = nil, typealiasKeyword: TokenSyntax, _ unexpectedBetweenTypealiasKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndInitializer: UnexpectedNodesSyntax? = nil, initializer: TypeInitializerClauseSyntax, _ unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?) -> TypealiasDeclSyntax {
+  public static func makeTypealiasDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndTypealiasKeyword: UnexpectedNodesSyntax? = nil, typealiasKeyword: TokenSyntax, _ unexpectedBetweenTypealiasKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndInitializer: UnexpectedNodesSyntax? = nil, initializer: TypeInitializerClauseSyntax, _ unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil) -> TypealiasDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -2413,6 +2565,7 @@ public enum SyntaxFactory {
       initializer.raw,
       unexpectedBetweenInitializerAndGenericWhereClause?.raw,
       genericWhereClause?.raw,
+      unexpectedAfterGenericWhereClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.typealiasDecl,
       from: layout, arena: .default)
@@ -2438,11 +2591,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.typeInitializerClause, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return TypealiasDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AssociatedtypeDeclSyntax")
-  public static func makeAssociatedtypeDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndAssociatedtypeKeyword: UnexpectedNodesSyntax? = nil, associatedtypeKeyword: TokenSyntax, _ unexpectedBetweenAssociatedtypeKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndInitializer: UnexpectedNodesSyntax? = nil, initializer: TypeInitializerClauseSyntax?, _ unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?) -> AssociatedtypeDeclSyntax {
+  public static func makeAssociatedtypeDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndAssociatedtypeKeyword: UnexpectedNodesSyntax? = nil, associatedtypeKeyword: TokenSyntax, _ unexpectedBetweenAssociatedtypeKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndInitializer: UnexpectedNodesSyntax? = nil, initializer: TypeInitializerClauseSyntax?, _ unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil) -> AssociatedtypeDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -2458,6 +2612,7 @@ public enum SyntaxFactory {
       initializer?.raw,
       unexpectedBetweenInitializerAndGenericWhereClause?.raw,
       genericWhereClause?.raw,
+      unexpectedAfterGenericWhereClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.associatedtypeDecl,
       from: layout, arena: .default)
@@ -2477,6 +2632,7 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.associatedtypeKeyword, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+      nil,
       nil,
       nil,
       nil,
@@ -2503,7 +2659,7 @@ public enum SyntaxFactory {
     return FunctionParameterListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ParameterClauseSyntax")
-  public static func makeParameterClause(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndParameterList: UnexpectedNodesSyntax? = nil, parameterList: FunctionParameterListSyntax, _ unexpectedBetweenParameterListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> ParameterClauseSyntax {
+  public static func makeParameterClause(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndParameterList: UnexpectedNodesSyntax? = nil, parameterList: FunctionParameterListSyntax, _ unexpectedBetweenParameterListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> ParameterClauseSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
       leftParen.raw,
@@ -2511,6 +2667,7 @@ public enum SyntaxFactory {
       parameterList.raw,
       unexpectedBetweenParameterListAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.parameterClause,
       from: layout, arena: .default)
@@ -2528,16 +2685,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.functionParameterList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return ParameterClauseSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ReturnClauseSyntax")
-  public static func makeReturnClause(_ unexpectedBeforeArrow: UnexpectedNodesSyntax? = nil, arrow: TokenSyntax, _ unexpectedBetweenArrowAndReturnType: UnexpectedNodesSyntax? = nil, returnType: TypeSyntax) -> ReturnClauseSyntax {
+  public static func makeReturnClause(_ unexpectedBeforeArrow: UnexpectedNodesSyntax? = nil, arrow: TokenSyntax, _ unexpectedBetweenArrowAndReturnType: UnexpectedNodesSyntax? = nil, returnType: TypeSyntax, _ unexpectedAfterReturnType: UnexpectedNodesSyntax? = nil) -> ReturnClauseSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeArrow?.raw,
       arrow.raw,
       unexpectedBetweenArrowAndReturnType?.raw,
       returnType.raw,
+      unexpectedAfterReturnType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.returnClause,
       from: layout, arena: .default)
@@ -2553,11 +2712,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
     ], arena: .default))
     return ReturnClauseSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on FunctionSignatureSyntax")
-  public static func makeFunctionSignature(_ unexpectedBeforeInput: UnexpectedNodesSyntax? = nil, input: ParameterClauseSyntax, _ unexpectedBetweenInputAndAsyncOrReasyncKeyword: UnexpectedNodesSyntax? = nil, asyncOrReasyncKeyword: TokenSyntax?, _ unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodesSyntax? = nil, throwsOrRethrowsKeyword: TokenSyntax?, _ unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: UnexpectedNodesSyntax? = nil, output: ReturnClauseSyntax?) -> FunctionSignatureSyntax {
+  public static func makeFunctionSignature(_ unexpectedBeforeInput: UnexpectedNodesSyntax? = nil, input: ParameterClauseSyntax, _ unexpectedBetweenInputAndAsyncOrReasyncKeyword: UnexpectedNodesSyntax? = nil, asyncOrReasyncKeyword: TokenSyntax?, _ unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodesSyntax? = nil, throwsOrRethrowsKeyword: TokenSyntax?, _ unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: UnexpectedNodesSyntax? = nil, output: ReturnClauseSyntax?, _ unexpectedAfterOutput: UnexpectedNodesSyntax? = nil) -> FunctionSignatureSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeInput?.raw,
       input.raw,
@@ -2567,6 +2727,7 @@ public enum SyntaxFactory {
       throwsOrRethrowsKeyword?.raw,
       unexpectedBetweenThrowsOrRethrowsKeywordAndOutput?.raw,
       output?.raw,
+      unexpectedAfterOutput?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionSignature,
       from: layout, arena: .default)
@@ -2586,11 +2747,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return FunctionSignatureSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on IfConfigClauseSyntax")
-  public static func makeIfConfigClause(_ unexpectedBeforePoundKeyword: UnexpectedNodesSyntax? = nil, poundKeyword: TokenSyntax, _ unexpectedBetweenPoundKeywordAndCondition: UnexpectedNodesSyntax? = nil, condition: ExprSyntax?, _ unexpectedBetweenConditionAndElements: UnexpectedNodesSyntax? = nil, elements: Syntax) -> IfConfigClauseSyntax {
+  public static func makeIfConfigClause(_ unexpectedBeforePoundKeyword: UnexpectedNodesSyntax? = nil, poundKeyword: TokenSyntax, _ unexpectedBetweenPoundKeywordAndCondition: UnexpectedNodesSyntax? = nil, condition: ExprSyntax?, _ unexpectedBetweenConditionAndElements: UnexpectedNodesSyntax? = nil, elements: Syntax, _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil) -> IfConfigClauseSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundKeyword?.raw,
       poundKeyword.raw,
@@ -2598,6 +2760,7 @@ public enum SyntaxFactory {
       condition?.raw,
       unexpectedBetweenConditionAndElements?.raw,
       elements.raw,
+      unexpectedAfterElements?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClause,
       from: layout, arena: .default)
@@ -2615,6 +2778,7 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
+      nil,
     ], arena: .default))
     return IfConfigClauseSyntax(data)
   }
@@ -2635,12 +2799,13 @@ public enum SyntaxFactory {
     return IfConfigClauseListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on IfConfigDeclSyntax")
-  public static func makeIfConfigDecl(_ unexpectedBeforeClauses: UnexpectedNodesSyntax? = nil, clauses: IfConfigClauseListSyntax, _ unexpectedBetweenClausesAndPoundEndif: UnexpectedNodesSyntax? = nil, poundEndif: TokenSyntax) -> IfConfigDeclSyntax {
+  public static func makeIfConfigDecl(_ unexpectedBeforeClauses: UnexpectedNodesSyntax? = nil, clauses: IfConfigClauseListSyntax, _ unexpectedBetweenClausesAndPoundEndif: UnexpectedNodesSyntax? = nil, poundEndif: TokenSyntax, _ unexpectedAfterPoundEndif: UnexpectedNodesSyntax? = nil) -> IfConfigDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeClauses?.raw,
       clauses.raw,
       unexpectedBetweenClausesAndPoundEndif?.raw,
       poundEndif.raw,
+      unexpectedAfterPoundEndif?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigDecl,
       from: layout, arena: .default)
@@ -2656,11 +2821,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.ifConfigClauseList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.poundEndifKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return IfConfigDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PoundErrorDeclSyntax")
-  public static func makePoundErrorDecl(_ unexpectedBeforePoundError: UnexpectedNodesSyntax? = nil, poundError: TokenSyntax, _ unexpectedBetweenPoundErrorAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndMessage: UnexpectedNodesSyntax? = nil, message: StringLiteralExprSyntax, _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> PoundErrorDeclSyntax {
+  public static func makePoundErrorDecl(_ unexpectedBeforePoundError: UnexpectedNodesSyntax? = nil, poundError: TokenSyntax, _ unexpectedBetweenPoundErrorAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndMessage: UnexpectedNodesSyntax? = nil, message: StringLiteralExprSyntax, _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> PoundErrorDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundError?.raw,
       poundError.raw,
@@ -2670,6 +2836,7 @@ public enum SyntaxFactory {
       message.raw,
       unexpectedBetweenMessageAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundErrorDecl,
       from: layout, arena: .default)
@@ -2689,11 +2856,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return PoundErrorDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PoundWarningDeclSyntax")
-  public static func makePoundWarningDecl(_ unexpectedBeforePoundWarning: UnexpectedNodesSyntax? = nil, poundWarning: TokenSyntax, _ unexpectedBetweenPoundWarningAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndMessage: UnexpectedNodesSyntax? = nil, message: StringLiteralExprSyntax, _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> PoundWarningDeclSyntax {
+  public static func makePoundWarningDecl(_ unexpectedBeforePoundWarning: UnexpectedNodesSyntax? = nil, poundWarning: TokenSyntax, _ unexpectedBetweenPoundWarningAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndMessage: UnexpectedNodesSyntax? = nil, message: StringLiteralExprSyntax, _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> PoundWarningDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundWarning?.raw,
       poundWarning.raw,
@@ -2703,6 +2871,7 @@ public enum SyntaxFactory {
       message.raw,
       unexpectedBetweenMessageAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundWarningDecl,
       from: layout, arena: .default)
@@ -2722,11 +2891,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.stringLiteralExpr, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return PoundWarningDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PoundSourceLocationSyntax")
-  public static func makePoundSourceLocation(_ unexpectedBeforePoundSourceLocation: UnexpectedNodesSyntax? = nil, poundSourceLocation: TokenSyntax, _ unexpectedBetweenPoundSourceLocationAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndArgs: UnexpectedNodesSyntax? = nil, args: PoundSourceLocationArgsSyntax?, _ unexpectedBetweenArgsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> PoundSourceLocationSyntax {
+  public static func makePoundSourceLocation(_ unexpectedBeforePoundSourceLocation: UnexpectedNodesSyntax? = nil, poundSourceLocation: TokenSyntax, _ unexpectedBetweenPoundSourceLocationAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndArgs: UnexpectedNodesSyntax? = nil, args: PoundSourceLocationArgsSyntax?, _ unexpectedBetweenArgsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> PoundSourceLocationSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundSourceLocation?.raw,
       poundSourceLocation.raw,
@@ -2736,6 +2906,7 @@ public enum SyntaxFactory {
       args?.raw,
       unexpectedBetweenArgsAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundSourceLocation,
       from: layout, arena: .default)
@@ -2755,11 +2926,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return PoundSourceLocationSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PoundSourceLocationArgsSyntax")
-  public static func makePoundSourceLocationArgs(_ unexpectedBeforeFileArgLabel: UnexpectedNodesSyntax? = nil, fileArgLabel: TokenSyntax, _ unexpectedBetweenFileArgLabelAndFileArgColon: UnexpectedNodesSyntax? = nil, fileArgColon: TokenSyntax, _ unexpectedBetweenFileArgColonAndFileName: UnexpectedNodesSyntax? = nil, fileName: TokenSyntax, _ unexpectedBetweenFileNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndLineArgLabel: UnexpectedNodesSyntax? = nil, lineArgLabel: TokenSyntax, _ unexpectedBetweenLineArgLabelAndLineArgColon: UnexpectedNodesSyntax? = nil, lineArgColon: TokenSyntax, _ unexpectedBetweenLineArgColonAndLineNumber: UnexpectedNodesSyntax? = nil, lineNumber: TokenSyntax) -> PoundSourceLocationArgsSyntax {
+  public static func makePoundSourceLocationArgs(_ unexpectedBeforeFileArgLabel: UnexpectedNodesSyntax? = nil, fileArgLabel: TokenSyntax, _ unexpectedBetweenFileArgLabelAndFileArgColon: UnexpectedNodesSyntax? = nil, fileArgColon: TokenSyntax, _ unexpectedBetweenFileArgColonAndFileName: UnexpectedNodesSyntax? = nil, fileName: TokenSyntax, _ unexpectedBetweenFileNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndLineArgLabel: UnexpectedNodesSyntax? = nil, lineArgLabel: TokenSyntax, _ unexpectedBetweenLineArgLabelAndLineArgColon: UnexpectedNodesSyntax? = nil, lineArgColon: TokenSyntax, _ unexpectedBetweenLineArgColonAndLineNumber: UnexpectedNodesSyntax? = nil, lineNumber: TokenSyntax, _ unexpectedAfterLineNumber: UnexpectedNodesSyntax? = nil) -> PoundSourceLocationArgsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeFileArgLabel?.raw,
       fileArgLabel.raw,
@@ -2775,6 +2947,7 @@ public enum SyntaxFactory {
       lineArgColon.raw,
       unexpectedBetweenLineArgColonAndLineNumber?.raw,
       lineNumber.raw,
+      unexpectedAfterLineNumber?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundSourceLocationArgs,
       from: layout, arena: .default)
@@ -2800,11 +2973,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default),
+      nil,
     ], arena: .default))
     return PoundSourceLocationArgsSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DeclModifierDetailSyntax")
-  public static func makeDeclModifierDetail(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndDetail: UnexpectedNodesSyntax? = nil, detail: TokenSyntax, _ unexpectedBetweenDetailAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> DeclModifierDetailSyntax {
+  public static func makeDeclModifierDetail(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndDetail: UnexpectedNodesSyntax? = nil, detail: TokenSyntax, _ unexpectedBetweenDetailAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> DeclModifierDetailSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
       leftParen.raw,
@@ -2812,6 +2986,7 @@ public enum SyntaxFactory {
       detail.raw,
       unexpectedBetweenDetailAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.declModifierDetail,
       from: layout, arena: .default)
@@ -2829,16 +3004,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return DeclModifierDetailSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DeclModifierSyntax")
-  public static func makeDeclModifier(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndDetail: UnexpectedNodesSyntax? = nil, detail: DeclModifierDetailSyntax?) -> DeclModifierSyntax {
+  public static func makeDeclModifier(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndDetail: UnexpectedNodesSyntax? = nil, detail: DeclModifierDetailSyntax?, _ unexpectedAfterDetail: UnexpectedNodesSyntax? = nil) -> DeclModifierSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndDetail?.raw,
       detail?.raw,
+      unexpectedAfterDetail?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.declModifier,
       from: layout, arena: .default)
@@ -2854,16 +3031,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return DeclModifierSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on InheritedTypeSyntax")
-  public static func makeInheritedType(_ unexpectedBeforeTypeName: UnexpectedNodesSyntax? = nil, typeName: TypeSyntax, _ unexpectedBetweenTypeNameAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> InheritedTypeSyntax {
+  public static func makeInheritedType(_ unexpectedBeforeTypeName: UnexpectedNodesSyntax? = nil, typeName: TypeSyntax, _ unexpectedBetweenTypeNameAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> InheritedTypeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeTypeName?.raw,
       typeName.raw,
       unexpectedBetweenTypeNameAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.inheritedType,
       from: layout, arena: .default)
@@ -2877,6 +3056,7 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
       nil,
       nil,
     ], arena: .default))
@@ -2899,12 +3079,13 @@ public enum SyntaxFactory {
     return InheritedTypeListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on TypeInheritanceClauseSyntax")
-  public static func makeTypeInheritanceClause(_ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndInheritedTypeCollection: UnexpectedNodesSyntax? = nil, inheritedTypeCollection: InheritedTypeListSyntax) -> TypeInheritanceClauseSyntax {
+  public static func makeTypeInheritanceClause(_ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndInheritedTypeCollection: UnexpectedNodesSyntax? = nil, inheritedTypeCollection: InheritedTypeListSyntax, _ unexpectedAfterInheritedTypeCollection: UnexpectedNodesSyntax? = nil) -> TypeInheritanceClauseSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeColon?.raw,
       colon.raw,
       unexpectedBetweenColonAndInheritedTypeCollection?.raw,
       inheritedTypeCollection.raw,
+      unexpectedAfterInheritedTypeCollection?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeInheritanceClause,
       from: layout, arena: .default)
@@ -2920,11 +3101,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.inheritedTypeList, arena: .default),
+      nil,
     ], arena: .default))
     return TypeInheritanceClauseSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ClassDeclSyntax")
-  public static func makeClassDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndClassKeyword: UnexpectedNodesSyntax? = nil, classKeyword: TokenSyntax, _ unexpectedBetweenClassKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax) -> ClassDeclSyntax {
+  public static func makeClassDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndClassKeyword: UnexpectedNodesSyntax? = nil, classKeyword: TokenSyntax, _ unexpectedBetweenClassKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax, _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil) -> ClassDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -2942,6 +3124,7 @@ public enum SyntaxFactory {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndMembers?.raw,
       members.raw,
+      unexpectedAfterMembers?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.classDecl,
       from: layout, arena: .default)
@@ -2969,11 +3152,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default),
+      nil,
     ], arena: .default))
     return ClassDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ActorDeclSyntax")
-  public static func makeActorDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndActorKeyword: UnexpectedNodesSyntax? = nil, actorKeyword: TokenSyntax, _ unexpectedBetweenActorKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax) -> ActorDeclSyntax {
+  public static func makeActorDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndActorKeyword: UnexpectedNodesSyntax? = nil, actorKeyword: TokenSyntax, _ unexpectedBetweenActorKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax, _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil) -> ActorDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -2991,6 +3175,7 @@ public enum SyntaxFactory {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndMembers?.raw,
       members.raw,
+      unexpectedAfterMembers?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.actorDecl,
       from: layout, arena: .default)
@@ -3018,11 +3203,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default),
+      nil,
     ], arena: .default))
     return ActorDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on StructDeclSyntax")
-  public static func makeStructDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndStructKeyword: UnexpectedNodesSyntax? = nil, structKeyword: TokenSyntax, _ unexpectedBetweenStructKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax) -> StructDeclSyntax {
+  public static func makeStructDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndStructKeyword: UnexpectedNodesSyntax? = nil, structKeyword: TokenSyntax, _ unexpectedBetweenStructKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax, _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil) -> StructDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -3040,6 +3226,7 @@ public enum SyntaxFactory {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndMembers?.raw,
       members.raw,
+      unexpectedAfterMembers?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.structDecl,
       from: layout, arena: .default)
@@ -3067,11 +3254,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default),
+      nil,
     ], arena: .default))
     return StructDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ProtocolDeclSyntax")
-  public static func makeProtocolDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndProtocolKeyword: UnexpectedNodesSyntax? = nil, protocolKeyword: TokenSyntax, _ unexpectedBetweenProtocolKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause: UnexpectedNodesSyntax? = nil, primaryAssociatedTypeClause: PrimaryAssociatedTypeClauseSyntax?, _ unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax) -> ProtocolDeclSyntax {
+  public static func makeProtocolDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndProtocolKeyword: UnexpectedNodesSyntax? = nil, protocolKeyword: TokenSyntax, _ unexpectedBetweenProtocolKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndPrimaryAssociatedTypeClause: UnexpectedNodesSyntax? = nil, primaryAssociatedTypeClause: PrimaryAssociatedTypeClauseSyntax?, _ unexpectedBetweenPrimaryAssociatedTypeClauseAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax, _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil) -> ProtocolDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -3089,6 +3277,7 @@ public enum SyntaxFactory {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndMembers?.raw,
       members.raw,
+      unexpectedAfterMembers?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.protocolDecl,
       from: layout, arena: .default)
@@ -3116,11 +3305,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default),
+      nil,
     ], arena: .default))
     return ProtocolDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ExtensionDeclSyntax")
-  public static func makeExtensionDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndExtensionKeyword: UnexpectedNodesSyntax? = nil, extensionKeyword: TokenSyntax, _ unexpectedBetweenExtensionKeywordAndExtendedType: UnexpectedNodesSyntax? = nil, extendedType: TypeSyntax, _ unexpectedBetweenExtendedTypeAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax) -> ExtensionDeclSyntax {
+  public static func makeExtensionDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndExtensionKeyword: UnexpectedNodesSyntax? = nil, extensionKeyword: TokenSyntax, _ unexpectedBetweenExtensionKeywordAndExtendedType: UnexpectedNodesSyntax? = nil, extendedType: TypeSyntax, _ unexpectedBetweenExtendedTypeAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax, _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil) -> ExtensionDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -3136,6 +3326,7 @@ public enum SyntaxFactory {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndMembers?.raw,
       members.raw,
+      unexpectedAfterMembers?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.extensionDecl,
       from: layout, arena: .default)
@@ -3161,11 +3352,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default),
+      nil,
     ], arena: .default))
     return ExtensionDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on MemberDeclBlockSyntax")
-  public static func makeMemberDeclBlock(_ unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclListSyntax, _ unexpectedBetweenMembersAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax) -> MemberDeclBlockSyntax {
+  public static func makeMemberDeclBlock(_ unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclListSyntax, _ unexpectedBetweenMembersAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax, _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil) -> MemberDeclBlockSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftBrace?.raw,
       leftBrace.raw,
@@ -3173,6 +3365,7 @@ public enum SyntaxFactory {
       members.raw,
       unexpectedBetweenMembersAndRightBrace?.raw,
       rightBrace.raw,
+      unexpectedAfterRightBrace?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclBlock,
       from: layout, arena: .default)
@@ -3190,6 +3383,7 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default),
+      nil,
     ], arena: .default))
     return MemberDeclBlockSyntax(data)
   }
@@ -3210,12 +3404,13 @@ public enum SyntaxFactory {
     return MemberDeclListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on MemberDeclListItemSyntax")
-  public static func makeMemberDeclListItem(_ unexpectedBeforeDecl: UnexpectedNodesSyntax? = nil, decl: DeclSyntax, _ unexpectedBetweenDeclAndSemicolon: UnexpectedNodesSyntax? = nil, semicolon: TokenSyntax?) -> MemberDeclListItemSyntax {
+  public static func makeMemberDeclListItem(_ unexpectedBeforeDecl: UnexpectedNodesSyntax? = nil, decl: DeclSyntax, _ unexpectedBetweenDeclAndSemicolon: UnexpectedNodesSyntax? = nil, semicolon: TokenSyntax?, _ unexpectedAfterSemicolon: UnexpectedNodesSyntax? = nil) -> MemberDeclListItemSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDecl?.raw,
       decl.raw,
       unexpectedBetweenDeclAndSemicolon?.raw,
       semicolon?.raw,
+      unexpectedAfterSemicolon?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclListItem,
       from: layout, arena: .default)
@@ -3231,16 +3426,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingDecl, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return MemberDeclListItemSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on SourceFileSyntax")
-  public static func makeSourceFile(_ unexpectedBeforeStatements: UnexpectedNodesSyntax? = nil, statements: CodeBlockItemListSyntax, _ unexpectedBetweenStatementsAndEOFToken: UnexpectedNodesSyntax? = nil, eofToken: TokenSyntax) -> SourceFileSyntax {
+  public static func makeSourceFile(_ unexpectedBeforeStatements: UnexpectedNodesSyntax? = nil, statements: CodeBlockItemListSyntax, _ unexpectedBetweenStatementsAndEOFToken: UnexpectedNodesSyntax? = nil, eofToken: TokenSyntax, _ unexpectedAfterEOFToken: UnexpectedNodesSyntax? = nil) -> SourceFileSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeStatements?.raw,
       statements.raw,
       unexpectedBetweenStatementsAndEOFToken?.raw,
       eofToken.raw,
+      unexpectedAfterEOFToken?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.sourceFile,
       from: layout, arena: .default)
@@ -3256,16 +3453,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
+      nil,
     ], arena: .default))
     return SourceFileSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on InitializerClauseSyntax")
-  public static func makeInitializerClause(_ unexpectedBeforeEqual: UnexpectedNodesSyntax? = nil, equal: TokenSyntax, _ unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? = nil, value: ExprSyntax) -> InitializerClauseSyntax {
+  public static func makeInitializerClause(_ unexpectedBeforeEqual: UnexpectedNodesSyntax? = nil, equal: TokenSyntax, _ unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? = nil, value: ExprSyntax, _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil) -> InitializerClauseSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeEqual?.raw,
       equal.raw,
       unexpectedBetweenEqualAndValue?.raw,
       value.raw,
+      unexpectedAfterValue?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.initializerClause,
       from: layout, arena: .default)
@@ -3281,11 +3480,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.equal, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
     ], arena: .default))
     return InitializerClauseSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on FunctionParameterSyntax")
-  public static func makeFunctionParameter(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndFirstName: UnexpectedNodesSyntax? = nil, firstName: TokenSyntax?, _ unexpectedBetweenFirstNameAndSecondName: UnexpectedNodesSyntax? = nil, secondName: TokenSyntax?, _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax?, _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil, ellipsis: TokenSyntax?, _ unexpectedBetweenEllipsisAndDefaultArgument: UnexpectedNodesSyntax? = nil, defaultArgument: InitializerClauseSyntax?, _ unexpectedBetweenDefaultArgumentAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> FunctionParameterSyntax {
+  public static func makeFunctionParameter(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndFirstName: UnexpectedNodesSyntax? = nil, firstName: TokenSyntax?, _ unexpectedBetweenFirstNameAndSecondName: UnexpectedNodesSyntax? = nil, secondName: TokenSyntax?, _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax?, _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil, ellipsis: TokenSyntax?, _ unexpectedBetweenEllipsisAndDefaultArgument: UnexpectedNodesSyntax? = nil, defaultArgument: InitializerClauseSyntax?, _ unexpectedBetweenDefaultArgumentAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> FunctionParameterSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -3305,6 +3505,7 @@ public enum SyntaxFactory {
       defaultArgument?.raw,
       unexpectedBetweenDefaultArgumentAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionParameter,
       from: layout, arena: .default)
@@ -3316,6 +3517,7 @@ public enum SyntaxFactory {
   public static func makeBlankFunctionParameter(presence: SourcePresence = .present) -> FunctionParameterSyntax {
     let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .functionParameter,
       from: [
+      nil,
       nil,
       nil,
       nil,
@@ -3354,7 +3556,7 @@ public enum SyntaxFactory {
     return ModifierListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on FunctionDeclSyntax")
-  public static func makeFunctionDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndFuncKeyword: UnexpectedNodesSyntax? = nil, funcKeyword: TokenSyntax, _ unexpectedBetweenFuncKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? = nil, signature: FunctionSignatureSyntax, _ unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax?) -> FunctionDeclSyntax {
+  public static func makeFunctionDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndFuncKeyword: UnexpectedNodesSyntax? = nil, funcKeyword: TokenSyntax, _ unexpectedBetweenFuncKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? = nil, signature: FunctionSignatureSyntax, _ unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax?, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> FunctionDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -3372,6 +3574,7 @@ public enum SyntaxFactory {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndBody?.raw,
       body?.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionDecl,
       from: layout, arena: .default)
@@ -3399,11 +3602,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return FunctionDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on InitializerDeclSyntax")
-  public static func makeInitializerDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndInitKeyword: UnexpectedNodesSyntax? = nil, initKeyword: TokenSyntax, _ unexpectedBetweenInitKeywordAndOptionalMark: UnexpectedNodesSyntax? = nil, optionalMark: TokenSyntax?, _ unexpectedBetweenOptionalMarkAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? = nil, signature: FunctionSignatureSyntax, _ unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax?) -> InitializerDeclSyntax {
+  public static func makeInitializerDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndInitKeyword: UnexpectedNodesSyntax? = nil, initKeyword: TokenSyntax, _ unexpectedBetweenInitKeywordAndOptionalMark: UnexpectedNodesSyntax? = nil, optionalMark: TokenSyntax?, _ unexpectedBetweenOptionalMarkAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndSignature: UnexpectedNodesSyntax? = nil, signature: FunctionSignatureSyntax, _ unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax?, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> InitializerDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -3421,6 +3625,7 @@ public enum SyntaxFactory {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndBody?.raw,
       body?.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.initializerDecl,
       from: layout, arena: .default)
@@ -3448,11 +3653,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return InitializerDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DeinitializerDeclSyntax")
-  public static func makeDeinitializerDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndDeinitKeyword: UnexpectedNodesSyntax? = nil, deinitKeyword: TokenSyntax, _ unexpectedBetweenDeinitKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax?) -> DeinitializerDeclSyntax {
+  public static func makeDeinitializerDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndDeinitKeyword: UnexpectedNodesSyntax? = nil, deinitKeyword: TokenSyntax, _ unexpectedBetweenDeinitKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax?, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> DeinitializerDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -3462,6 +3668,7 @@ public enum SyntaxFactory {
       deinitKeyword.raw,
       unexpectedBetweenDeinitKeywordAndBody?.raw,
       body?.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.deinitializerDecl,
       from: layout, arena: .default)
@@ -3481,11 +3688,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.deinitKeyword, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return DeinitializerDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on SubscriptDeclSyntax")
-  public static func makeSubscriptDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndSubscriptKeyword: UnexpectedNodesSyntax? = nil, subscriptKeyword: TokenSyntax, _ unexpectedBetweenSubscriptKeywordAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndIndices: UnexpectedNodesSyntax? = nil, indices: ParameterClauseSyntax, _ unexpectedBetweenIndicesAndResult: UnexpectedNodesSyntax? = nil, result: ReturnClauseSyntax, _ unexpectedBetweenResultAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndAccessor: UnexpectedNodesSyntax? = nil, accessor: Syntax?) -> SubscriptDeclSyntax {
+  public static func makeSubscriptDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndSubscriptKeyword: UnexpectedNodesSyntax? = nil, subscriptKeyword: TokenSyntax, _ unexpectedBetweenSubscriptKeywordAndGenericParameterClause: UnexpectedNodesSyntax? = nil, genericParameterClause: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParameterClauseAndIndices: UnexpectedNodesSyntax? = nil, indices: ParameterClauseSyntax, _ unexpectedBetweenIndicesAndResult: UnexpectedNodesSyntax? = nil, result: ReturnClauseSyntax, _ unexpectedBetweenResultAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndAccessor: UnexpectedNodesSyntax? = nil, accessor: Syntax?, _ unexpectedAfterAccessor: UnexpectedNodesSyntax? = nil) -> SubscriptDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -3503,6 +3711,7 @@ public enum SyntaxFactory {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndAccessor?.raw,
       accessor?.raw,
+      unexpectedAfterAccessor?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.subscriptDecl,
       from: layout, arena: .default)
@@ -3530,16 +3739,18 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return SubscriptDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AccessLevelModifierSyntax")
-  public static func makeAccessLevelModifier(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndModifier: UnexpectedNodesSyntax? = nil, modifier: DeclModifierDetailSyntax?) -> AccessLevelModifierSyntax {
+  public static func makeAccessLevelModifier(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndModifier: UnexpectedNodesSyntax? = nil, modifier: DeclModifierDetailSyntax?, _ unexpectedAfterModifier: UnexpectedNodesSyntax? = nil) -> AccessLevelModifierSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndModifier?.raw,
       modifier?.raw,
+      unexpectedAfterModifier?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessLevelModifier,
       from: layout, arena: .default)
@@ -3555,16 +3766,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return AccessLevelModifierSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AccessPathComponentSyntax")
-  public static func makeAccessPathComponent(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndTrailingDot: UnexpectedNodesSyntax? = nil, trailingDot: TokenSyntax?) -> AccessPathComponentSyntax {
+  public static func makeAccessPathComponent(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndTrailingDot: UnexpectedNodesSyntax? = nil, trailingDot: TokenSyntax?, _ unexpectedAfterTrailingDot: UnexpectedNodesSyntax? = nil) -> AccessPathComponentSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndTrailingDot?.raw,
       trailingDot?.raw,
+      unexpectedAfterTrailingDot?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessPathComponent,
       from: layout, arena: .default)
@@ -3578,6 +3791,7 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+      nil,
       nil,
       nil,
     ], arena: .default))
@@ -3600,7 +3814,7 @@ public enum SyntaxFactory {
     return AccessPathSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ImportDeclSyntax")
-  public static func makeImportDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndImportTok: UnexpectedNodesSyntax? = nil, importTok: TokenSyntax, _ unexpectedBetweenImportTokAndImportKind: UnexpectedNodesSyntax? = nil, importKind: TokenSyntax?, _ unexpectedBetweenImportKindAndPath: UnexpectedNodesSyntax? = nil, path: AccessPathSyntax) -> ImportDeclSyntax {
+  public static func makeImportDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndImportTok: UnexpectedNodesSyntax? = nil, importTok: TokenSyntax, _ unexpectedBetweenImportTokAndImportKind: UnexpectedNodesSyntax? = nil, importKind: TokenSyntax?, _ unexpectedBetweenImportKindAndPath: UnexpectedNodesSyntax? = nil, path: AccessPathSyntax, _ unexpectedAfterPath: UnexpectedNodesSyntax? = nil) -> ImportDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -3612,6 +3826,7 @@ public enum SyntaxFactory {
       importKind?.raw,
       unexpectedBetweenImportKindAndPath?.raw,
       path.raw,
+      unexpectedAfterPath?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.importDecl,
       from: layout, arena: .default)
@@ -3633,11 +3848,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.accessPath, arena: .default),
+      nil,
     ], arena: .default))
     return ImportDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AccessorParameterSyntax")
-  public static func makeAccessorParameter(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> AccessorParameterSyntax {
+  public static func makeAccessorParameter(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> AccessorParameterSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
       leftParen.raw,
@@ -3645,6 +3861,7 @@ public enum SyntaxFactory {
       name.raw,
       unexpectedBetweenNameAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorParameter,
       from: layout, arena: .default)
@@ -3662,11 +3879,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return AccessorParameterSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AccessorDeclSyntax")
-  public static func makeAccessorDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifier: UnexpectedNodesSyntax? = nil, modifier: DeclModifierSyntax?, _ unexpectedBetweenModifierAndAccessorKind: UnexpectedNodesSyntax? = nil, accessorKind: TokenSyntax, _ unexpectedBetweenAccessorKindAndParameter: UnexpectedNodesSyntax? = nil, parameter: AccessorParameterSyntax?, _ unexpectedBetweenParameterAndAsyncKeyword: UnexpectedNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ unexpectedBetweenAsyncKeywordAndThrowsKeyword: UnexpectedNodesSyntax? = nil, throwsKeyword: TokenSyntax?, _ unexpectedBetweenThrowsKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax?) -> AccessorDeclSyntax {
+  public static func makeAccessorDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifier: UnexpectedNodesSyntax? = nil, modifier: DeclModifierSyntax?, _ unexpectedBetweenModifierAndAccessorKind: UnexpectedNodesSyntax? = nil, accessorKind: TokenSyntax, _ unexpectedBetweenAccessorKindAndParameter: UnexpectedNodesSyntax? = nil, parameter: AccessorParameterSyntax?, _ unexpectedBetweenParameterAndAsyncKeyword: UnexpectedNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ unexpectedBetweenAsyncKeywordAndThrowsKeyword: UnexpectedNodesSyntax? = nil, throwsKeyword: TokenSyntax?, _ unexpectedBetweenThrowsKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax?, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> AccessorDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -3682,6 +3900,7 @@ public enum SyntaxFactory {
       throwsKeyword?.raw,
       unexpectedBetweenThrowsKeywordAndBody?.raw,
       body?.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorDecl,
       from: layout, arena: .default)
@@ -3699,6 +3918,7 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
+      nil,
       nil,
       nil,
       nil,
@@ -3727,7 +3947,7 @@ public enum SyntaxFactory {
     return AccessorListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AccessorBlockSyntax")
-  public static func makeAccessorBlock(_ unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndAccessors: UnexpectedNodesSyntax? = nil, accessors: AccessorListSyntax, _ unexpectedBetweenAccessorsAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax) -> AccessorBlockSyntax {
+  public static func makeAccessorBlock(_ unexpectedBeforeLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndAccessors: UnexpectedNodesSyntax? = nil, accessors: AccessorListSyntax, _ unexpectedBetweenAccessorsAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax, _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil) -> AccessorBlockSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftBrace?.raw,
       leftBrace.raw,
@@ -3735,6 +3955,7 @@ public enum SyntaxFactory {
       accessors.raw,
       unexpectedBetweenAccessorsAndRightBrace?.raw,
       rightBrace.raw,
+      unexpectedAfterRightBrace?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorBlock,
       from: layout, arena: .default)
@@ -3752,11 +3973,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.accessorList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default),
+      nil,
     ], arena: .default))
     return AccessorBlockSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PatternBindingSyntax")
-  public static func makePatternBinding(_ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil, initializer: InitializerClauseSyntax?, _ unexpectedBetweenInitializerAndAccessor: UnexpectedNodesSyntax? = nil, accessor: Syntax?, _ unexpectedBetweenAccessorAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> PatternBindingSyntax {
+  public static func makePatternBinding(_ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil, initializer: InitializerClauseSyntax?, _ unexpectedBetweenInitializerAndAccessor: UnexpectedNodesSyntax? = nil, accessor: Syntax?, _ unexpectedBetweenAccessorAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> PatternBindingSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePattern?.raw,
       pattern.raw,
@@ -3768,6 +3990,7 @@ public enum SyntaxFactory {
       accessor?.raw,
       unexpectedBetweenAccessorAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.patternBinding,
       from: layout, arena: .default)
@@ -3781,6 +4004,7 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default),
+      nil,
       nil,
       nil,
       nil,
@@ -3809,7 +4033,7 @@ public enum SyntaxFactory {
     return PatternBindingListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on VariableDeclSyntax")
-  public static func makeVariableDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndLetOrVarKeyword: UnexpectedNodesSyntax? = nil, letOrVarKeyword: TokenSyntax, _ unexpectedBetweenLetOrVarKeywordAndBindings: UnexpectedNodesSyntax? = nil, bindings: PatternBindingListSyntax) -> VariableDeclSyntax {
+  public static func makeVariableDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndLetOrVarKeyword: UnexpectedNodesSyntax? = nil, letOrVarKeyword: TokenSyntax, _ unexpectedBetweenLetOrVarKeywordAndBindings: UnexpectedNodesSyntax? = nil, bindings: PatternBindingListSyntax, _ unexpectedAfterBindings: UnexpectedNodesSyntax? = nil) -> VariableDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -3819,6 +4043,7 @@ public enum SyntaxFactory {
       letOrVarKeyword.raw,
       unexpectedBetweenLetOrVarKeywordAndBindings?.raw,
       bindings.raw,
+      unexpectedAfterBindings?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.variableDecl,
       from: layout, arena: .default)
@@ -3838,11 +4063,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.patternBindingList, arena: .default),
+      nil,
     ], arena: .default))
     return VariableDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on EnumCaseElementSyntax")
-  public static func makeEnumCaseElement(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndAssociatedValue: UnexpectedNodesSyntax? = nil, associatedValue: ParameterClauseSyntax?, _ unexpectedBetweenAssociatedValueAndRawValue: UnexpectedNodesSyntax? = nil, rawValue: InitializerClauseSyntax?, _ unexpectedBetweenRawValueAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> EnumCaseElementSyntax {
+  public static func makeEnumCaseElement(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndAssociatedValue: UnexpectedNodesSyntax? = nil, associatedValue: ParameterClauseSyntax?, _ unexpectedBetweenAssociatedValueAndRawValue: UnexpectedNodesSyntax? = nil, rawValue: InitializerClauseSyntax?, _ unexpectedBetweenRawValueAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> EnumCaseElementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
       identifier.raw,
@@ -3852,6 +4078,7 @@ public enum SyntaxFactory {
       rawValue?.raw,
       unexpectedBetweenRawValueAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElement,
       from: layout, arena: .default)
@@ -3865,6 +4092,7 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+      nil,
       nil,
       nil,
       nil,
@@ -3891,7 +4119,7 @@ public enum SyntaxFactory {
     return EnumCaseElementListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on EnumCaseDeclSyntax")
-  public static func makeEnumCaseDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndCaseKeyword: UnexpectedNodesSyntax? = nil, caseKeyword: TokenSyntax, _ unexpectedBetweenCaseKeywordAndElements: UnexpectedNodesSyntax? = nil, elements: EnumCaseElementListSyntax) -> EnumCaseDeclSyntax {
+  public static func makeEnumCaseDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndCaseKeyword: UnexpectedNodesSyntax? = nil, caseKeyword: TokenSyntax, _ unexpectedBetweenCaseKeywordAndElements: UnexpectedNodesSyntax? = nil, elements: EnumCaseElementListSyntax, _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil) -> EnumCaseDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -3901,6 +4129,7 @@ public enum SyntaxFactory {
       caseKeyword.raw,
       unexpectedBetweenCaseKeywordAndElements?.raw,
       elements.raw,
+      unexpectedAfterElements?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseDecl,
       from: layout, arena: .default)
@@ -3920,11 +4149,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.caseKeyword, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.enumCaseElementList, arena: .default),
+      nil,
     ], arena: .default))
     return EnumCaseDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on EnumDeclSyntax")
-  public static func makeEnumDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndEnumKeyword: UnexpectedNodesSyntax? = nil, enumKeyword: TokenSyntax, _ unexpectedBetweenEnumKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameters: UnexpectedNodesSyntax? = nil, genericParameters: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParametersAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax) -> EnumDeclSyntax {
+  public static func makeEnumDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndEnumKeyword: UnexpectedNodesSyntax? = nil, enumKeyword: TokenSyntax, _ unexpectedBetweenEnumKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndGenericParameters: UnexpectedNodesSyntax? = nil, genericParameters: GenericParameterClauseSyntax?, _ unexpectedBetweenGenericParametersAndInheritanceClause: UnexpectedNodesSyntax? = nil, inheritanceClause: TypeInheritanceClauseSyntax?, _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil, members: MemberDeclBlockSyntax, _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil) -> EnumDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -3942,6 +4172,7 @@ public enum SyntaxFactory {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndMembers?.raw,
       members.raw,
+      unexpectedAfterMembers?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumDecl,
       from: layout, arena: .default)
@@ -3969,11 +4200,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.memberDeclBlock, arena: .default),
+      nil,
     ], arena: .default))
     return EnumDeclSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on OperatorDeclSyntax")
-  public static func makeOperatorDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndOperatorKeyword: UnexpectedNodesSyntax? = nil, operatorKeyword: TokenSyntax, _ unexpectedBetweenOperatorKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes: UnexpectedNodesSyntax? = nil, operatorPrecedenceAndTypes: OperatorPrecedenceAndTypesSyntax?) -> OperatorDeclSyntax {
+  public static func makeOperatorDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndOperatorKeyword: UnexpectedNodesSyntax? = nil, operatorKeyword: TokenSyntax, _ unexpectedBetweenOperatorKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes: UnexpectedNodesSyntax? = nil, operatorPrecedenceAndTypes: OperatorPrecedenceAndTypesSyntax?, _ unexpectedAfterOperatorPrecedenceAndTypes: UnexpectedNodesSyntax? = nil) -> OperatorDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -3985,6 +4217,7 @@ public enum SyntaxFactory {
       identifier.raw,
       unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes?.raw,
       operatorPrecedenceAndTypes?.raw,
+      unexpectedAfterOperatorPrecedenceAndTypes?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorDecl,
       from: layout, arena: .default)
@@ -4004,6 +4237,7 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.operatorKeyword, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.unspacedBinaryOperator(""), arena: .default),
+      nil,
       nil,
       nil,
     ], arena: .default))
@@ -4026,12 +4260,13 @@ public enum SyntaxFactory {
     return DesignatedTypeListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DesignatedTypeElementSyntax")
-  public static func makeDesignatedTypeElement(_ unexpectedBeforeLeadingComma: UnexpectedNodesSyntax? = nil, leadingComma: TokenSyntax, _ unexpectedBetweenLeadingCommaAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax) -> DesignatedTypeElementSyntax {
+  public static func makeDesignatedTypeElement(_ unexpectedBeforeLeadingComma: UnexpectedNodesSyntax? = nil, leadingComma: TokenSyntax, _ unexpectedBetweenLeadingCommaAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedAfterName: UnexpectedNodesSyntax? = nil) -> DesignatedTypeElementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeadingComma?.raw,
       leadingComma.raw,
       unexpectedBetweenLeadingCommaAndName?.raw,
       name.raw,
+      unexpectedAfterName?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeElement,
       from: layout, arena: .default)
@@ -4047,11 +4282,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+      nil,
     ], arena: .default))
     return DesignatedTypeElementSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on OperatorPrecedenceAndTypesSyntax")
-  public static func makeOperatorPrecedenceAndTypes(_ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndPrecedenceGroup: UnexpectedNodesSyntax? = nil, precedenceGroup: TokenSyntax, _ unexpectedBetweenPrecedenceGroupAndDesignatedTypes: UnexpectedNodesSyntax? = nil, designatedTypes: DesignatedTypeListSyntax) -> OperatorPrecedenceAndTypesSyntax {
+  public static func makeOperatorPrecedenceAndTypes(_ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndPrecedenceGroup: UnexpectedNodesSyntax? = nil, precedenceGroup: TokenSyntax, _ unexpectedBetweenPrecedenceGroupAndDesignatedTypes: UnexpectedNodesSyntax? = nil, designatedTypes: DesignatedTypeListSyntax, _ unexpectedAfterDesignatedTypes: UnexpectedNodesSyntax? = nil) -> OperatorPrecedenceAndTypesSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeColon?.raw,
       colon.raw,
@@ -4059,6 +4295,7 @@ public enum SyntaxFactory {
       precedenceGroup.raw,
       unexpectedBetweenPrecedenceGroupAndDesignatedTypes?.raw,
       designatedTypes.raw,
+      unexpectedAfterDesignatedTypes?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorPrecedenceAndTypes,
       from: layout, arena: .default)
@@ -4076,11 +4313,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.designatedTypeList, arena: .default),
+      nil,
     ], arena: .default))
     return OperatorPrecedenceAndTypesSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupDeclSyntax")
-  public static func makePrecedenceGroupDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndPrecedencegroupKeyword: UnexpectedNodesSyntax? = nil, precedencegroupKeyword: TokenSyntax, _ unexpectedBetweenPrecedencegroupKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndGroupAttributes: UnexpectedNodesSyntax? = nil, groupAttributes: PrecedenceGroupAttributeListSyntax, _ unexpectedBetweenGroupAttributesAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax) -> PrecedenceGroupDeclSyntax {
+  public static func makePrecedenceGroupDecl(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil, modifiers: ModifierListSyntax?, _ unexpectedBetweenModifiersAndPrecedencegroupKeyword: UnexpectedNodesSyntax? = nil, precedencegroupKeyword: TokenSyntax, _ unexpectedBetweenPrecedencegroupKeywordAndIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedBetweenIdentifierAndLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndGroupAttributes: UnexpectedNodesSyntax? = nil, groupAttributes: PrecedenceGroupAttributeListSyntax, _ unexpectedBetweenGroupAttributesAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax, _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil) -> PrecedenceGroupDeclSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -4096,6 +4334,7 @@ public enum SyntaxFactory {
       groupAttributes.raw,
       unexpectedBetweenGroupAttributesAndRightBrace?.raw,
       rightBrace.raw,
+      unexpectedAfterRightBrace?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupDecl,
       from: layout, arena: .default)
@@ -4121,6 +4360,7 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.precedenceGroupAttributeList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default),
+      nil,
     ], arena: .default))
     return PrecedenceGroupDeclSyntax(data)
   }
@@ -4141,7 +4381,7 @@ public enum SyntaxFactory {
     return PrecedenceGroupAttributeListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupRelationSyntax")
-  public static func makePrecedenceGroupRelation(_ unexpectedBeforeHigherThanOrLowerThan: UnexpectedNodesSyntax? = nil, higherThanOrLowerThan: TokenSyntax, _ unexpectedBetweenHigherThanOrLowerThanAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndOtherNames: UnexpectedNodesSyntax? = nil, otherNames: PrecedenceGroupNameListSyntax) -> PrecedenceGroupRelationSyntax {
+  public static func makePrecedenceGroupRelation(_ unexpectedBeforeHigherThanOrLowerThan: UnexpectedNodesSyntax? = nil, higherThanOrLowerThan: TokenSyntax, _ unexpectedBetweenHigherThanOrLowerThanAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndOtherNames: UnexpectedNodesSyntax? = nil, otherNames: PrecedenceGroupNameListSyntax, _ unexpectedAfterOtherNames: UnexpectedNodesSyntax? = nil) -> PrecedenceGroupRelationSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeHigherThanOrLowerThan?.raw,
       higherThanOrLowerThan.raw,
@@ -4149,6 +4389,7 @@ public enum SyntaxFactory {
       colon.raw,
       unexpectedBetweenColonAndOtherNames?.raw,
       otherNames.raw,
+      unexpectedAfterOtherNames?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupRelation,
       from: layout, arena: .default)
@@ -4166,6 +4407,7 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.precedenceGroupNameList, arena: .default),
+      nil,
     ], arena: .default))
     return PrecedenceGroupRelationSyntax(data)
   }
@@ -4186,12 +4428,13 @@ public enum SyntaxFactory {
     return PrecedenceGroupNameListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupNameElementSyntax")
-  public static func makePrecedenceGroupNameElement(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> PrecedenceGroupNameElementSyntax {
+  public static func makePrecedenceGroupNameElement(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> PrecedenceGroupNameElementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameElement,
       from: layout, arena: .default)
@@ -4207,11 +4450,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return PrecedenceGroupNameElementSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupAssignmentSyntax")
-  public static func makePrecedenceGroupAssignment(_ unexpectedBeforeAssignmentKeyword: UnexpectedNodesSyntax? = nil, assignmentKeyword: TokenSyntax, _ unexpectedBetweenAssignmentKeywordAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndFlag: UnexpectedNodesSyntax? = nil, flag: TokenSyntax) -> PrecedenceGroupAssignmentSyntax {
+  public static func makePrecedenceGroupAssignment(_ unexpectedBeforeAssignmentKeyword: UnexpectedNodesSyntax? = nil, assignmentKeyword: TokenSyntax, _ unexpectedBetweenAssignmentKeywordAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndFlag: UnexpectedNodesSyntax? = nil, flag: TokenSyntax, _ unexpectedAfterFlag: UnexpectedNodesSyntax? = nil) -> PrecedenceGroupAssignmentSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAssignmentKeyword?.raw,
       assignmentKeyword.raw,
@@ -4219,6 +4463,7 @@ public enum SyntaxFactory {
       colon.raw,
       unexpectedBetweenColonAndFlag?.raw,
       flag.raw,
+      unexpectedAfterFlag?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAssignment,
       from: layout, arena: .default)
@@ -4236,11 +4481,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.trueKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return PrecedenceGroupAssignmentSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PrecedenceGroupAssociativitySyntax")
-  public static func makePrecedenceGroupAssociativity(_ unexpectedBeforeAssociativityKeyword: UnexpectedNodesSyntax? = nil, associativityKeyword: TokenSyntax, _ unexpectedBetweenAssociativityKeywordAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil, value: TokenSyntax) -> PrecedenceGroupAssociativitySyntax {
+  public static func makePrecedenceGroupAssociativity(_ unexpectedBeforeAssociativityKeyword: UnexpectedNodesSyntax? = nil, associativityKeyword: TokenSyntax, _ unexpectedBetweenAssociativityKeywordAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil, value: TokenSyntax, _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil) -> PrecedenceGroupAssociativitySyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAssociativityKeyword?.raw,
       associativityKeyword.raw,
@@ -4248,6 +4494,7 @@ public enum SyntaxFactory {
       colon.raw,
       unexpectedBetweenColonAndValue?.raw,
       value.raw,
+      unexpectedAfterValue?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAssociativity,
       from: layout, arena: .default)
@@ -4265,6 +4512,7 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+      nil,
     ], arena: .default))
     return PrecedenceGroupAssociativitySyntax(data)
   }
@@ -4301,7 +4549,7 @@ public enum SyntaxFactory {
     return NonEmptyTokenListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on CustomAttributeSyntax")
-  public static func makeCustomAttribute(_ unexpectedBeforeAtSignToken: UnexpectedNodesSyntax? = nil, atSignToken: TokenSyntax, _ unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodesSyntax? = nil, attributeName: TypeSyntax, _ unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax?, _ unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? = nil, argumentList: TupleExprElementListSyntax?, _ unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax?) -> CustomAttributeSyntax {
+  public static func makeCustomAttribute(_ unexpectedBeforeAtSignToken: UnexpectedNodesSyntax? = nil, atSignToken: TokenSyntax, _ unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodesSyntax? = nil, attributeName: TypeSyntax, _ unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax?, _ unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? = nil, argumentList: TupleExprElementListSyntax?, _ unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax?, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> CustomAttributeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAtSignToken?.raw,
       atSignToken.raw,
@@ -4313,6 +4561,7 @@ public enum SyntaxFactory {
       argumentList?.raw,
       unexpectedBetweenArgumentListAndRightParen?.raw,
       rightParen?.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.customAttribute,
       from: layout, arena: .default)
@@ -4334,11 +4583,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return CustomAttributeSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AttributeSyntax")
-  public static func makeAttribute(_ unexpectedBeforeAtSignToken: UnexpectedNodesSyntax? = nil, atSignToken: TokenSyntax, _ unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodesSyntax? = nil, attributeName: TokenSyntax, _ unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax?, _ unexpectedBetweenLeftParenAndArgument: UnexpectedNodesSyntax? = nil, argument: Syntax?, _ unexpectedBetweenArgumentAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax?, _ unexpectedBetweenRightParenAndTokenList: UnexpectedNodesSyntax? = nil, tokenList: TokenListSyntax?) -> AttributeSyntax {
+  public static func makeAttribute(_ unexpectedBeforeAtSignToken: UnexpectedNodesSyntax? = nil, atSignToken: TokenSyntax, _ unexpectedBetweenAtSignTokenAndAttributeName: UnexpectedNodesSyntax? = nil, attributeName: TokenSyntax, _ unexpectedBetweenAttributeNameAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax?, _ unexpectedBetweenLeftParenAndArgument: UnexpectedNodesSyntax? = nil, argument: Syntax?, _ unexpectedBetweenArgumentAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax?, _ unexpectedBetweenRightParenAndTokenList: UnexpectedNodesSyntax? = nil, tokenList: TokenListSyntax?, _ unexpectedAfterTokenList: UnexpectedNodesSyntax? = nil) -> AttributeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAtSignToken?.raw,
       atSignToken.raw,
@@ -4352,6 +4602,7 @@ public enum SyntaxFactory {
       rightParen?.raw,
       unexpectedBetweenRightParenAndTokenList?.raw,
       tokenList?.raw,
+      unexpectedAfterTokenList?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.attribute,
       from: layout, arena: .default)
@@ -4367,6 +4618,7 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.atSign, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
+      nil,
       nil,
       nil,
       nil,
@@ -4411,7 +4663,7 @@ public enum SyntaxFactory {
     return SpecializeAttributeSpecListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AvailabilityEntrySyntax")
-  public static func makeAvailabilityEntry(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndAvailabilityList: UnexpectedNodesSyntax? = nil, availabilityList: AvailabilitySpecListSyntax, _ unexpectedBetweenAvailabilityListAndSemicolon: UnexpectedNodesSyntax? = nil, semicolon: TokenSyntax) -> AvailabilityEntrySyntax {
+  public static func makeAvailabilityEntry(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndAvailabilityList: UnexpectedNodesSyntax? = nil, availabilityList: AvailabilitySpecListSyntax, _ unexpectedBetweenAvailabilityListAndSemicolon: UnexpectedNodesSyntax? = nil, semicolon: TokenSyntax, _ unexpectedAfterSemicolon: UnexpectedNodesSyntax? = nil) -> AvailabilityEntrySyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabel?.raw,
       label.raw,
@@ -4421,6 +4673,7 @@ public enum SyntaxFactory {
       availabilityList.raw,
       unexpectedBetweenAvailabilityListAndSemicolon?.raw,
       semicolon.raw,
+      unexpectedAfterSemicolon?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityEntry,
       from: layout, arena: .default)
@@ -4440,11 +4693,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.semicolon, arena: .default),
+      nil,
     ], arena: .default))
     return AvailabilityEntrySyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on LabeledSpecializeEntrySyntax")
-  public static func makeLabeledSpecializeEntry(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil, value: TokenSyntax, _ unexpectedBetweenValueAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> LabeledSpecializeEntrySyntax {
+  public static func makeLabeledSpecializeEntry(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil, value: TokenSyntax, _ unexpectedBetweenValueAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> LabeledSpecializeEntrySyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabel?.raw,
       label.raw,
@@ -4454,6 +4708,7 @@ public enum SyntaxFactory {
       value.raw,
       unexpectedBetweenValueAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.labeledSpecializeEntry,
       from: layout, arena: .default)
@@ -4473,11 +4728,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return LabeledSpecializeEntrySyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on TargetFunctionEntrySyntax")
-  public static func makeTargetFunctionEntry(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndDeclname: UnexpectedNodesSyntax? = nil, declname: DeclNameSyntax, _ unexpectedBetweenDeclnameAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> TargetFunctionEntrySyntax {
+  public static func makeTargetFunctionEntry(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndDeclname: UnexpectedNodesSyntax? = nil, declname: DeclNameSyntax, _ unexpectedBetweenDeclnameAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> TargetFunctionEntrySyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabel?.raw,
       label.raw,
@@ -4487,6 +4743,7 @@ public enum SyntaxFactory {
       declname.raw,
       unexpectedBetweenDeclnameAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.targetFunctionEntry,
       from: layout, arena: .default)
@@ -4506,11 +4763,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.declName, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return TargetFunctionEntrySyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on NamedAttributeStringArgumentSyntax")
-  public static func makeNamedAttributeStringArgument(_ unexpectedBeforeNameTok: UnexpectedNodesSyntax? = nil, nameTok: TokenSyntax, _ unexpectedBetweenNameTokAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndStringOrDeclname: UnexpectedNodesSyntax? = nil, stringOrDeclname: Syntax) -> NamedAttributeStringArgumentSyntax {
+  public static func makeNamedAttributeStringArgument(_ unexpectedBeforeNameTok: UnexpectedNodesSyntax? = nil, nameTok: TokenSyntax, _ unexpectedBetweenNameTokAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndStringOrDeclname: UnexpectedNodesSyntax? = nil, stringOrDeclname: Syntax, _ unexpectedAfterStringOrDeclname: UnexpectedNodesSyntax? = nil) -> NamedAttributeStringArgumentSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeNameTok?.raw,
       nameTok.raw,
@@ -4518,6 +4776,7 @@ public enum SyntaxFactory {
       colon.raw,
       unexpectedBetweenColonAndStringOrDeclname?.raw,
       stringOrDeclname.raw,
+      unexpectedAfterStringOrDeclname?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.namedAttributeStringArgument,
       from: layout, arena: .default)
@@ -4535,16 +4794,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
+      nil,
     ], arena: .default))
     return NamedAttributeStringArgumentSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DeclNameSyntax")
-  public static func makeDeclName(_ unexpectedBeforeDeclBaseName: UnexpectedNodesSyntax? = nil, declBaseName: Syntax, _ unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?) -> DeclNameSyntax {
+  public static func makeDeclName(_ unexpectedBeforeDeclBaseName: UnexpectedNodesSyntax? = nil, declBaseName: Syntax, _ unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?, _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil) -> DeclNameSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDeclBaseName?.raw,
       declBaseName.raw,
       unexpectedBetweenDeclBaseNameAndDeclNameArguments?.raw,
       declNameArguments?.raw,
+      unexpectedAfterDeclNameArguments?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.declName,
       from: layout, arena: .default)
@@ -4560,11 +4821,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return DeclNameSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ImplementsAttributeArgumentsSyntax")
-  public static func makeImplementsAttributeArguments(_ unexpectedBeforeType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedBetweenTypeAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndDeclBaseName: UnexpectedNodesSyntax? = nil, declBaseName: TokenSyntax, _ unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?) -> ImplementsAttributeArgumentsSyntax {
+  public static func makeImplementsAttributeArguments(_ unexpectedBeforeType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedBetweenTypeAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndDeclBaseName: UnexpectedNodesSyntax? = nil, declBaseName: TokenSyntax, _ unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil, declNameArguments: DeclNameArgumentsSyntax?, _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil) -> ImplementsAttributeArgumentsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeType?.raw,
       type.raw,
@@ -4574,6 +4836,7 @@ public enum SyntaxFactory {
       declBaseName.raw,
       unexpectedBetweenDeclBaseNameAndDeclNameArguments?.raw,
       declNameArguments?.raw,
+      unexpectedAfterDeclNameArguments?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.implementsAttributeArguments,
       from: layout, arena: .default)
@@ -4593,16 +4856,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.unknown(""), arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return ImplementsAttributeArgumentsSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ObjCSelectorPieceSyntax")
-  public static func makeObjCSelectorPiece(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax?, _ unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?) -> ObjCSelectorPieceSyntax {
+  public static func makeObjCSelectorPiece(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax?, _ unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil) -> ObjCSelectorPieceSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name?.raw,
       unexpectedBetweenNameAndColon?.raw,
       colon?.raw,
+      unexpectedAfterColon?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.objCSelectorPiece,
       from: layout, arena: .default)
@@ -4614,6 +4879,7 @@ public enum SyntaxFactory {
   public static func makeBlankObjCSelectorPiece(presence: SourcePresence = .present) -> ObjCSelectorPieceSyntax {
     let data = SyntaxData.forRoot(RawSyntax.makeLayout(kind: .objCSelectorPiece,
       from: [
+      nil,
       nil,
       nil,
       nil,
@@ -4638,7 +4904,7 @@ public enum SyntaxFactory {
     return ObjCSelectorSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DifferentiableAttributeArgumentsSyntax")
-  public static func makeDifferentiableAttributeArguments(_ unexpectedBeforeDiffKind: UnexpectedNodesSyntax? = nil, diffKind: TokenSyntax?, _ unexpectedBetweenDiffKindAndDiffKindComma: UnexpectedNodesSyntax? = nil, diffKindComma: TokenSyntax?, _ unexpectedBetweenDiffKindCommaAndDiffParams: UnexpectedNodesSyntax? = nil, diffParams: DifferentiabilityParamsClauseSyntax?, _ unexpectedBetweenDiffParamsAndDiffParamsComma: UnexpectedNodesSyntax? = nil, diffParamsComma: TokenSyntax?, _ unexpectedBetweenDiffParamsCommaAndWhereClause: UnexpectedNodesSyntax? = nil, whereClause: GenericWhereClauseSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+  public static func makeDifferentiableAttributeArguments(_ unexpectedBeforeDiffKind: UnexpectedNodesSyntax? = nil, diffKind: TokenSyntax?, _ unexpectedBetweenDiffKindAndDiffKindComma: UnexpectedNodesSyntax? = nil, diffKindComma: TokenSyntax?, _ unexpectedBetweenDiffKindCommaAndDiffParams: UnexpectedNodesSyntax? = nil, diffParams: DifferentiabilityParamsClauseSyntax?, _ unexpectedBetweenDiffParamsAndDiffParamsComma: UnexpectedNodesSyntax? = nil, diffParamsComma: TokenSyntax?, _ unexpectedBetweenDiffParamsCommaAndWhereClause: UnexpectedNodesSyntax? = nil, whereClause: GenericWhereClauseSyntax?, _ unexpectedAfterWhereClause: UnexpectedNodesSyntax? = nil) -> DifferentiableAttributeArgumentsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDiffKind?.raw,
       diffKind?.raw,
@@ -4650,6 +4916,7 @@ public enum SyntaxFactory {
       diffParamsComma?.raw,
       unexpectedBetweenDiffParamsCommaAndWhereClause?.raw,
       whereClause?.raw,
+      unexpectedAfterWhereClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiableAttributeArguments,
       from: layout, arena: .default)
@@ -4671,11 +4938,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return DifferentiableAttributeArgumentsSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DifferentiabilityParamsClauseSyntax")
-  public static func makeDifferentiabilityParamsClause(_ unexpectedBeforeWrtLabel: UnexpectedNodesSyntax? = nil, wrtLabel: TokenSyntax, _ unexpectedBetweenWrtLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndParameters: UnexpectedNodesSyntax? = nil, parameters: Syntax) -> DifferentiabilityParamsClauseSyntax {
+  public static func makeDifferentiabilityParamsClause(_ unexpectedBeforeWrtLabel: UnexpectedNodesSyntax? = nil, wrtLabel: TokenSyntax, _ unexpectedBetweenWrtLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndParameters: UnexpectedNodesSyntax? = nil, parameters: Syntax, _ unexpectedAfterParameters: UnexpectedNodesSyntax? = nil) -> DifferentiabilityParamsClauseSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWrtLabel?.raw,
       wrtLabel.raw,
@@ -4683,6 +4951,7 @@ public enum SyntaxFactory {
       colon.raw,
       unexpectedBetweenColonAndParameters?.raw,
       parameters.raw,
+      unexpectedAfterParameters?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamsClause,
       from: layout, arena: .default)
@@ -4700,11 +4969,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
+      nil,
     ], arena: .default))
     return DifferentiabilityParamsClauseSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DifferentiabilityParamsSyntax")
-  public static func makeDifferentiabilityParams(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndDiffParams: UnexpectedNodesSyntax? = nil, diffParams: DifferentiabilityParamListSyntax, _ unexpectedBetweenDiffParamsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> DifferentiabilityParamsSyntax {
+  public static func makeDifferentiabilityParams(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndDiffParams: UnexpectedNodesSyntax? = nil, diffParams: DifferentiabilityParamListSyntax, _ unexpectedBetweenDiffParamsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> DifferentiabilityParamsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
       leftParen.raw,
@@ -4712,6 +4982,7 @@ public enum SyntaxFactory {
       diffParams.raw,
       unexpectedBetweenDiffParamsAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParams,
       from: layout, arena: .default)
@@ -4729,6 +5000,7 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.differentiabilityParamList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return DifferentiabilityParamsSyntax(data)
   }
@@ -4749,12 +5021,13 @@ public enum SyntaxFactory {
     return DifferentiabilityParamListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DifferentiabilityParamSyntax")
-  public static func makeDifferentiabilityParam(_ unexpectedBeforeParameter: UnexpectedNodesSyntax? = nil, parameter: Syntax, _ unexpectedBetweenParameterAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> DifferentiabilityParamSyntax {
+  public static func makeDifferentiabilityParam(_ unexpectedBeforeParameter: UnexpectedNodesSyntax? = nil, parameter: Syntax, _ unexpectedBetweenParameterAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> DifferentiabilityParamSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeParameter?.raw,
       parameter.raw,
       unexpectedBetweenParameterAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParam,
       from: layout, arena: .default)
@@ -4770,11 +5043,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return DifferentiabilityParamSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DerivativeRegistrationAttributeArgumentsSyntax")
-  public static func makeDerivativeRegistrationAttributeArguments(_ unexpectedBeforeOfLabel: UnexpectedNodesSyntax? = nil, ofLabel: TokenSyntax, _ unexpectedBetweenOfLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndOriginalDeclName: UnexpectedNodesSyntax? = nil, originalDeclName: QualifiedDeclNameSyntax, _ unexpectedBetweenOriginalDeclNameAndPeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax?, _ unexpectedBetweenPeriodAndAccessorKind: UnexpectedNodesSyntax? = nil, accessorKind: TokenSyntax?, _ unexpectedBetweenAccessorKindAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndDiffParams: UnexpectedNodesSyntax? = nil, diffParams: DifferentiabilityParamsClauseSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+  public static func makeDerivativeRegistrationAttributeArguments(_ unexpectedBeforeOfLabel: UnexpectedNodesSyntax? = nil, ofLabel: TokenSyntax, _ unexpectedBetweenOfLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndOriginalDeclName: UnexpectedNodesSyntax? = nil, originalDeclName: QualifiedDeclNameSyntax, _ unexpectedBetweenOriginalDeclNameAndPeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax?, _ unexpectedBetweenPeriodAndAccessorKind: UnexpectedNodesSyntax? = nil, accessorKind: TokenSyntax?, _ unexpectedBetweenAccessorKindAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndDiffParams: UnexpectedNodesSyntax? = nil, diffParams: DifferentiabilityParamsClauseSyntax?, _ unexpectedAfterDiffParams: UnexpectedNodesSyntax? = nil) -> DerivativeRegistrationAttributeArgumentsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeOfLabel?.raw,
       ofLabel.raw,
@@ -4790,6 +5064,7 @@ public enum SyntaxFactory {
       comma?.raw,
       unexpectedBetweenCommaAndDiffParams?.raw,
       diffParams?.raw,
+      unexpectedAfterDiffParams?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.derivativeRegistrationAttributeArguments,
       from: layout, arena: .default)
@@ -4815,11 +5090,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return DerivativeRegistrationAttributeArgumentsSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on QualifiedDeclNameSyntax")
-  public static func makeQualifiedDeclName(_ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax?, _ unexpectedBetweenBaseTypeAndDot: UnexpectedNodesSyntax? = nil, dot: TokenSyntax?, _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? = nil, arguments: DeclNameArgumentsSyntax?) -> QualifiedDeclNameSyntax {
+  public static func makeQualifiedDeclName(_ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax?, _ unexpectedBetweenBaseTypeAndDot: UnexpectedNodesSyntax? = nil, dot: TokenSyntax?, _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? = nil, arguments: DeclNameArgumentsSyntax?, _ unexpectedAfterArguments: UnexpectedNodesSyntax? = nil) -> QualifiedDeclNameSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBaseType?.raw,
       baseType?.raw,
@@ -4829,6 +5105,7 @@ public enum SyntaxFactory {
       name.raw,
       unexpectedBetweenNameAndArguments?.raw,
       arguments?.raw,
+      unexpectedAfterArguments?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.qualifiedDeclName,
       from: layout, arena: .default)
@@ -4848,16 +5125,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return QualifiedDeclNameSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on FunctionDeclNameSyntax")
-  public static func makeFunctionDeclName(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: Syntax, _ unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? = nil, arguments: DeclNameArgumentsSyntax?) -> FunctionDeclNameSyntax {
+  public static func makeFunctionDeclName(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: Syntax, _ unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? = nil, arguments: DeclNameArgumentsSyntax?, _ unexpectedAfterArguments: UnexpectedNodesSyntax? = nil) -> FunctionDeclNameSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndArguments?.raw,
       arguments?.raw,
+      unexpectedAfterArguments?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionDeclName,
       from: layout, arena: .default)
@@ -4873,11 +5152,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return FunctionDeclNameSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on BackDeployAttributeSpecListSyntax")
-  public static func makeBackDeployAttributeSpecList(_ unexpectedBeforeBeforeLabel: UnexpectedNodesSyntax? = nil, beforeLabel: TokenSyntax, _ unexpectedBetweenBeforeLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndVersionList: UnexpectedNodesSyntax? = nil, versionList: BackDeployVersionListSyntax) -> BackDeployAttributeSpecListSyntax {
+  public static func makeBackDeployAttributeSpecList(_ unexpectedBeforeBeforeLabel: UnexpectedNodesSyntax? = nil, beforeLabel: TokenSyntax, _ unexpectedBetweenBeforeLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndVersionList: UnexpectedNodesSyntax? = nil, versionList: BackDeployVersionListSyntax, _ unexpectedAfterVersionList: UnexpectedNodesSyntax? = nil) -> BackDeployAttributeSpecListSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBeforeLabel?.raw,
       beforeLabel.raw,
@@ -4885,6 +5165,7 @@ public enum SyntaxFactory {
       colon.raw,
       unexpectedBetweenColonAndVersionList?.raw,
       versionList.raw,
+      unexpectedAfterVersionList?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployAttributeSpecList,
       from: layout, arena: .default)
@@ -4902,6 +5183,7 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.backDeployVersionList, arena: .default),
+      nil,
     ], arena: .default))
     return BackDeployAttributeSpecListSyntax(data)
   }
@@ -4922,12 +5204,13 @@ public enum SyntaxFactory {
     return BackDeployVersionListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on BackDeployVersionArgumentSyntax")
-  public static func makeBackDeployVersionArgument(_ unexpectedBeforeAvailabilityVersionRestriction: UnexpectedNodesSyntax? = nil, availabilityVersionRestriction: AvailabilityVersionRestrictionSyntax, _ unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> BackDeployVersionArgumentSyntax {
+  public static func makeBackDeployVersionArgument(_ unexpectedBeforeAvailabilityVersionRestriction: UnexpectedNodesSyntax? = nil, availabilityVersionRestriction: AvailabilityVersionRestrictionSyntax, _ unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> BackDeployVersionArgumentSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAvailabilityVersionRestriction?.raw,
       availabilityVersionRestriction.raw,
       unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployVersionArgument,
       from: layout, arena: .default)
@@ -4943,11 +5226,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilityVersionRestriction, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return BackDeployVersionArgumentSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on OpaqueReturnTypeOfAttributeArgumentsSyntax")
-  public static func makeOpaqueReturnTypeOfAttributeArguments(_ unexpectedBeforeMangledName: UnexpectedNodesSyntax? = nil, mangledName: TokenSyntax, _ unexpectedBetweenMangledNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndOrdinal: UnexpectedNodesSyntax? = nil, ordinal: TokenSyntax) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+  public static func makeOpaqueReturnTypeOfAttributeArguments(_ unexpectedBeforeMangledName: UnexpectedNodesSyntax? = nil, mangledName: TokenSyntax, _ unexpectedBetweenMangledNameAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax, _ unexpectedBetweenCommaAndOrdinal: UnexpectedNodesSyntax? = nil, ordinal: TokenSyntax, _ unexpectedAfterOrdinal: UnexpectedNodesSyntax? = nil) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeMangledName?.raw,
       mangledName.raw,
@@ -4955,6 +5239,7 @@ public enum SyntaxFactory {
       comma.raw,
       unexpectedBetweenCommaAndOrdinal?.raw,
       ordinal.raw,
+      unexpectedAfterOrdinal?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.opaqueReturnTypeOfAttributeArguments,
       from: layout, arena: .default)
@@ -4972,11 +5257,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.comma, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.integerLiteral(""), arena: .default),
+      nil,
     ], arena: .default))
     return OpaqueReturnTypeOfAttributeArgumentsSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ConventionAttributeArgumentsSyntax")
-  public static func makeConventionAttributeArguments(_ unexpectedBeforeConventionLabel: UnexpectedNodesSyntax? = nil, conventionLabel: TokenSyntax, _ unexpectedBetweenConventionLabelAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndCTypeLabel: UnexpectedNodesSyntax? = nil, cTypeLabel: TokenSyntax?, _ unexpectedBetweenCTypeLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndCTypeString: UnexpectedNodesSyntax? = nil, cTypeString: TokenSyntax?) -> ConventionAttributeArgumentsSyntax {
+  public static func makeConventionAttributeArguments(_ unexpectedBeforeConventionLabel: UnexpectedNodesSyntax? = nil, conventionLabel: TokenSyntax, _ unexpectedBetweenConventionLabelAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndCTypeLabel: UnexpectedNodesSyntax? = nil, cTypeLabel: TokenSyntax?, _ unexpectedBetweenCTypeLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndCTypeString: UnexpectedNodesSyntax? = nil, cTypeString: TokenSyntax?, _ unexpectedAfterCTypeString: UnexpectedNodesSyntax? = nil) -> ConventionAttributeArgumentsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeConventionLabel?.raw,
       conventionLabel.raw,
@@ -4988,6 +5274,7 @@ public enum SyntaxFactory {
       colon?.raw,
       unexpectedBetweenColonAndCTypeString?.raw,
       cTypeString?.raw,
+      unexpectedAfterCTypeString?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionAttributeArguments,
       from: layout, arena: .default)
@@ -5009,11 +5296,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return ConventionAttributeArgumentsSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ConventionWitnessMethodAttributeArgumentsSyntax")
-  public static func makeConventionWitnessMethodAttributeArguments(_ unexpectedBeforeWitnessMethodLabel: UnexpectedNodesSyntax? = nil, witnessMethodLabel: TokenSyntax, _ unexpectedBetweenWitnessMethodLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndProtocolName: UnexpectedNodesSyntax? = nil, protocolName: TokenSyntax) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+  public static func makeConventionWitnessMethodAttributeArguments(_ unexpectedBeforeWitnessMethodLabel: UnexpectedNodesSyntax? = nil, witnessMethodLabel: TokenSyntax, _ unexpectedBetweenWitnessMethodLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndProtocolName: UnexpectedNodesSyntax? = nil, protocolName: TokenSyntax, _ unexpectedAfterProtocolName: UnexpectedNodesSyntax? = nil) -> ConventionWitnessMethodAttributeArgumentsSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWitnessMethodLabel?.raw,
       witnessMethodLabel.raw,
@@ -5021,6 +5309,7 @@ public enum SyntaxFactory {
       colon.raw,
       unexpectedBetweenColonAndProtocolName?.raw,
       protocolName.raw,
+      unexpectedAfterProtocolName?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionWitnessMethodAttributeArguments,
       from: layout, arena: .default)
@@ -5038,11 +5327,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+      nil,
     ], arena: .default))
     return ConventionWitnessMethodAttributeArgumentsSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on LabeledStmtSyntax")
-  public static func makeLabeledStmt(_ unexpectedBeforeLabelName: UnexpectedNodesSyntax? = nil, labelName: TokenSyntax, _ unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? = nil, labelColon: TokenSyntax, _ unexpectedBetweenLabelColonAndStatement: UnexpectedNodesSyntax? = nil, statement: StmtSyntax) -> LabeledStmtSyntax {
+  public static func makeLabeledStmt(_ unexpectedBeforeLabelName: UnexpectedNodesSyntax? = nil, labelName: TokenSyntax, _ unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? = nil, labelColon: TokenSyntax, _ unexpectedBetweenLabelColonAndStatement: UnexpectedNodesSyntax? = nil, statement: StmtSyntax, _ unexpectedAfterStatement: UnexpectedNodesSyntax? = nil) -> LabeledStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabelName?.raw,
       labelName.raw,
@@ -5050,6 +5340,7 @@ public enum SyntaxFactory {
       labelColon.raw,
       unexpectedBetweenLabelColonAndStatement?.raw,
       statement.raw,
+      unexpectedAfterStatement?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.labeledStmt,
       from: layout, arena: .default)
@@ -5067,16 +5358,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingStmt, arena: .default),
+      nil,
     ], arena: .default))
     return LabeledStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ContinueStmtSyntax")
-  public static func makeContinueStmt(_ unexpectedBeforeContinueKeyword: UnexpectedNodesSyntax? = nil, continueKeyword: TokenSyntax, _ unexpectedBetweenContinueKeywordAndLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax?) -> ContinueStmtSyntax {
+  public static func makeContinueStmt(_ unexpectedBeforeContinueKeyword: UnexpectedNodesSyntax? = nil, continueKeyword: TokenSyntax, _ unexpectedBetweenContinueKeywordAndLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax?, _ unexpectedAfterLabel: UnexpectedNodesSyntax? = nil) -> ContinueStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeContinueKeyword?.raw,
       continueKeyword.raw,
       unexpectedBetweenContinueKeywordAndLabel?.raw,
       label?.raw,
+      unexpectedAfterLabel?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.continueStmt,
       from: layout, arena: .default)
@@ -5092,11 +5385,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.continueKeyword, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return ContinueStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on WhileStmtSyntax")
-  public static func makeWhileStmt(_ unexpectedBeforeWhileKeyword: UnexpectedNodesSyntax? = nil, whileKeyword: TokenSyntax, _ unexpectedBetweenWhileKeywordAndConditions: UnexpectedNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ unexpectedBetweenConditionsAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax) -> WhileStmtSyntax {
+  public static func makeWhileStmt(_ unexpectedBeforeWhileKeyword: UnexpectedNodesSyntax? = nil, whileKeyword: TokenSyntax, _ unexpectedBetweenWhileKeywordAndConditions: UnexpectedNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ unexpectedBetweenConditionsAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> WhileStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWhileKeyword?.raw,
       whileKeyword.raw,
@@ -5104,6 +5398,7 @@ public enum SyntaxFactory {
       conditions.raw,
       unexpectedBetweenConditionsAndBody?.raw,
       body.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.whileStmt,
       from: layout, arena: .default)
@@ -5121,16 +5416,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.conditionElementList, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default),
+      nil,
     ], arena: .default))
     return WhileStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DeferStmtSyntax")
-  public static func makeDeferStmt(_ unexpectedBeforeDeferKeyword: UnexpectedNodesSyntax? = nil, deferKeyword: TokenSyntax, _ unexpectedBetweenDeferKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax) -> DeferStmtSyntax {
+  public static func makeDeferStmt(_ unexpectedBeforeDeferKeyword: UnexpectedNodesSyntax? = nil, deferKeyword: TokenSyntax, _ unexpectedBetweenDeferKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> DeferStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDeferKeyword?.raw,
       deferKeyword.raw,
       unexpectedBetweenDeferKeywordAndBody?.raw,
       body.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.deferStmt,
       from: layout, arena: .default)
@@ -5146,14 +5443,16 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.deferKeyword, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default),
+      nil,
     ], arena: .default))
     return DeferStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ExpressionStmtSyntax")
-  public static func makeExpressionStmt(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax) -> ExpressionStmtSyntax {
+  public static func makeExpressionStmt(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> ExpressionStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionStmt,
       from: layout, arena: .default)
@@ -5167,6 +5466,7 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
     ], arena: .default))
     return ExpressionStmtSyntax(data)
   }
@@ -5187,7 +5487,7 @@ public enum SyntaxFactory {
     return SwitchCaseListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on RepeatWhileStmtSyntax")
-  public static func makeRepeatWhileStmt(_ unexpectedBeforeRepeatKeyword: UnexpectedNodesSyntax? = nil, repeatKeyword: TokenSyntax, _ unexpectedBetweenRepeatKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedBetweenBodyAndWhileKeyword: UnexpectedNodesSyntax? = nil, whileKeyword: TokenSyntax, _ unexpectedBetweenWhileKeywordAndCondition: UnexpectedNodesSyntax? = nil, condition: ExprSyntax) -> RepeatWhileStmtSyntax {
+  public static func makeRepeatWhileStmt(_ unexpectedBeforeRepeatKeyword: UnexpectedNodesSyntax? = nil, repeatKeyword: TokenSyntax, _ unexpectedBetweenRepeatKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedBetweenBodyAndWhileKeyword: UnexpectedNodesSyntax? = nil, whileKeyword: TokenSyntax, _ unexpectedBetweenWhileKeywordAndCondition: UnexpectedNodesSyntax? = nil, condition: ExprSyntax, _ unexpectedAfterCondition: UnexpectedNodesSyntax? = nil) -> RepeatWhileStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeRepeatKeyword?.raw,
       repeatKeyword.raw,
@@ -5197,6 +5497,7 @@ public enum SyntaxFactory {
       whileKeyword.raw,
       unexpectedBetweenWhileKeywordAndCondition?.raw,
       condition.raw,
+      unexpectedAfterCondition?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.repeatWhileStmt,
       from: layout, arena: .default)
@@ -5216,11 +5517,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.whileKeyword, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
     ], arena: .default))
     return RepeatWhileStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on GuardStmtSyntax")
-  public static func makeGuardStmt(_ unexpectedBeforeGuardKeyword: UnexpectedNodesSyntax? = nil, guardKeyword: TokenSyntax, _ unexpectedBetweenGuardKeywordAndConditions: UnexpectedNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ unexpectedBetweenConditionsAndElseKeyword: UnexpectedNodesSyntax? = nil, elseKeyword: TokenSyntax, _ unexpectedBetweenElseKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax) -> GuardStmtSyntax {
+  public static func makeGuardStmt(_ unexpectedBeforeGuardKeyword: UnexpectedNodesSyntax? = nil, guardKeyword: TokenSyntax, _ unexpectedBetweenGuardKeywordAndConditions: UnexpectedNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ unexpectedBetweenConditionsAndElseKeyword: UnexpectedNodesSyntax? = nil, elseKeyword: TokenSyntax, _ unexpectedBetweenElseKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> GuardStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeGuardKeyword?.raw,
       guardKeyword.raw,
@@ -5230,6 +5532,7 @@ public enum SyntaxFactory {
       elseKeyword.raw,
       unexpectedBetweenElseKeywordAndBody?.raw,
       body.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.guardStmt,
       from: layout, arena: .default)
@@ -5249,16 +5552,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.elseKeyword, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default),
+      nil,
     ], arena: .default))
     return GuardStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on WhereClauseSyntax")
-  public static func makeWhereClause(_ unexpectedBeforeWhereKeyword: UnexpectedNodesSyntax? = nil, whereKeyword: TokenSyntax, _ unexpectedBetweenWhereKeywordAndGuardResult: UnexpectedNodesSyntax? = nil, guardResult: ExprSyntax) -> WhereClauseSyntax {
+  public static func makeWhereClause(_ unexpectedBeforeWhereKeyword: UnexpectedNodesSyntax? = nil, whereKeyword: TokenSyntax, _ unexpectedBetweenWhereKeywordAndGuardResult: UnexpectedNodesSyntax? = nil, guardResult: ExprSyntax, _ unexpectedAfterGuardResult: UnexpectedNodesSyntax? = nil) -> WhereClauseSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWhereKeyword?.raw,
       whereKeyword.raw,
       unexpectedBetweenWhereKeywordAndGuardResult?.raw,
       guardResult.raw,
+      unexpectedAfterGuardResult?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.whereClause,
       from: layout, arena: .default)
@@ -5274,11 +5579,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.whereKeyword, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
     ], arena: .default))
     return WhereClauseSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ForInStmtSyntax")
-  public static func makeForInStmt(_ unexpectedBeforeForKeyword: UnexpectedNodesSyntax? = nil, forKeyword: TokenSyntax, _ unexpectedBetweenForKeywordAndTryKeyword: UnexpectedNodesSyntax? = nil, tryKeyword: TokenSyntax?, _ unexpectedBetweenTryKeywordAndAwaitKeyword: UnexpectedNodesSyntax? = nil, awaitKeyword: TokenSyntax?, _ unexpectedBetweenAwaitKeywordAndCaseKeyword: UnexpectedNodesSyntax? = nil, caseKeyword: TokenSyntax?, _ unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ unexpectedBetweenTypeAnnotationAndInKeyword: UnexpectedNodesSyntax? = nil, inKeyword: TokenSyntax, _ unexpectedBetweenInKeywordAndSequenceExpr: UnexpectedNodesSyntax? = nil, sequenceExpr: ExprSyntax, _ unexpectedBetweenSequenceExprAndWhereClause: UnexpectedNodesSyntax? = nil, whereClause: WhereClauseSyntax?, _ unexpectedBetweenWhereClauseAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax) -> ForInStmtSyntax {
+  public static func makeForInStmt(_ unexpectedBeforeForKeyword: UnexpectedNodesSyntax? = nil, forKeyword: TokenSyntax, _ unexpectedBetweenForKeywordAndTryKeyword: UnexpectedNodesSyntax? = nil, tryKeyword: TokenSyntax?, _ unexpectedBetweenTryKeywordAndAwaitKeyword: UnexpectedNodesSyntax? = nil, awaitKeyword: TokenSyntax?, _ unexpectedBetweenAwaitKeywordAndCaseKeyword: UnexpectedNodesSyntax? = nil, caseKeyword: TokenSyntax?, _ unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ unexpectedBetweenTypeAnnotationAndInKeyword: UnexpectedNodesSyntax? = nil, inKeyword: TokenSyntax, _ unexpectedBetweenInKeywordAndSequenceExpr: UnexpectedNodesSyntax? = nil, sequenceExpr: ExprSyntax, _ unexpectedBetweenSequenceExprAndWhereClause: UnexpectedNodesSyntax? = nil, whereClause: WhereClauseSyntax?, _ unexpectedBetweenWhereClauseAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> ForInStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeForKeyword?.raw,
       forKeyword.raw,
@@ -5300,6 +5606,7 @@ public enum SyntaxFactory {
       whereClause?.raw,
       unexpectedBetweenWhereClauseAndBody?.raw,
       body.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.forInStmt,
       from: layout, arena: .default)
@@ -5331,11 +5638,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default),
+      nil,
     ], arena: .default))
     return ForInStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on SwitchStmtSyntax")
-  public static func makeSwitchStmt(_ unexpectedBeforeSwitchKeyword: UnexpectedNodesSyntax? = nil, switchKeyword: TokenSyntax, _ unexpectedBetweenSwitchKeywordAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndCases: UnexpectedNodesSyntax? = nil, cases: SwitchCaseListSyntax, _ unexpectedBetweenCasesAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax) -> SwitchStmtSyntax {
+  public static func makeSwitchStmt(_ unexpectedBeforeSwitchKeyword: UnexpectedNodesSyntax? = nil, switchKeyword: TokenSyntax, _ unexpectedBetweenSwitchKeywordAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndLeftBrace: UnexpectedNodesSyntax? = nil, leftBrace: TokenSyntax, _ unexpectedBetweenLeftBraceAndCases: UnexpectedNodesSyntax? = nil, cases: SwitchCaseListSyntax, _ unexpectedBetweenCasesAndRightBrace: UnexpectedNodesSyntax? = nil, rightBrace: TokenSyntax, _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil) -> SwitchStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSwitchKeyword?.raw,
       switchKeyword.raw,
@@ -5347,6 +5655,7 @@ public enum SyntaxFactory {
       cases.raw,
       unexpectedBetweenCasesAndRightBrace?.raw,
       rightBrace.raw,
+      unexpectedAfterRightBrace?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchStmt,
       from: layout, arena: .default)
@@ -5368,6 +5677,7 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.switchCaseList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightBrace, arena: .default),
+      nil,
     ], arena: .default))
     return SwitchStmtSyntax(data)
   }
@@ -5388,7 +5698,7 @@ public enum SyntaxFactory {
     return CatchClauseListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DoStmtSyntax")
-  public static func makeDoStmt(_ unexpectedBeforeDoKeyword: UnexpectedNodesSyntax? = nil, doKeyword: TokenSyntax, _ unexpectedBetweenDoKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedBetweenBodyAndCatchClauses: UnexpectedNodesSyntax? = nil, catchClauses: CatchClauseListSyntax?) -> DoStmtSyntax {
+  public static func makeDoStmt(_ unexpectedBeforeDoKeyword: UnexpectedNodesSyntax? = nil, doKeyword: TokenSyntax, _ unexpectedBetweenDoKeywordAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedBetweenBodyAndCatchClauses: UnexpectedNodesSyntax? = nil, catchClauses: CatchClauseListSyntax?, _ unexpectedAfterCatchClauses: UnexpectedNodesSyntax? = nil) -> DoStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDoKeyword?.raw,
       doKeyword.raw,
@@ -5396,6 +5706,7 @@ public enum SyntaxFactory {
       body.raw,
       unexpectedBetweenBodyAndCatchClauses?.raw,
       catchClauses?.raw,
+      unexpectedAfterCatchClauses?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.doStmt,
       from: layout, arena: .default)
@@ -5413,16 +5724,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return DoStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ReturnStmtSyntax")
-  public static func makeReturnStmt(_ unexpectedBeforeReturnKeyword: UnexpectedNodesSyntax? = nil, returnKeyword: TokenSyntax, _ unexpectedBetweenReturnKeywordAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax?) -> ReturnStmtSyntax {
+  public static func makeReturnStmt(_ unexpectedBeforeReturnKeyword: UnexpectedNodesSyntax? = nil, returnKeyword: TokenSyntax, _ unexpectedBetweenReturnKeywordAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax?, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> ReturnStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeReturnKeyword?.raw,
       returnKeyword.raw,
       unexpectedBetweenReturnKeywordAndExpression?.raw,
       expression?.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.returnStmt,
       from: layout, arena: .default)
@@ -5438,16 +5751,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.returnKeyword, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return ReturnStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on YieldStmtSyntax")
-  public static func makeYieldStmt(_ unexpectedBeforeYieldKeyword: UnexpectedNodesSyntax? = nil, yieldKeyword: TokenSyntax, _ unexpectedBetweenYieldKeywordAndYields: UnexpectedNodesSyntax? = nil, yields: Syntax) -> YieldStmtSyntax {
+  public static func makeYieldStmt(_ unexpectedBeforeYieldKeyword: UnexpectedNodesSyntax? = nil, yieldKeyword: TokenSyntax, _ unexpectedBetweenYieldKeywordAndYields: UnexpectedNodesSyntax? = nil, yields: Syntax, _ unexpectedAfterYields: UnexpectedNodesSyntax? = nil) -> YieldStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeYieldKeyword?.raw,
       yieldKeyword.raw,
       unexpectedBetweenYieldKeywordAndYields?.raw,
       yields.raw,
+      unexpectedAfterYields?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldStmt,
       from: layout, arena: .default)
@@ -5463,11 +5778,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.yield, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
+      nil,
     ], arena: .default))
     return YieldStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on YieldListSyntax")
-  public static func makeYieldList(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil, elementList: YieldExprListSyntax, _ unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> YieldListSyntax {
+  public static func makeYieldList(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil, elementList: YieldExprListSyntax, _ unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> YieldListSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
       leftParen.raw,
@@ -5475,6 +5791,7 @@ public enum SyntaxFactory {
       elementList.raw,
       unexpectedBetweenElementListAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldList,
       from: layout, arena: .default)
@@ -5492,14 +5809,16 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.yieldExprList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return YieldListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on FallthroughStmtSyntax")
-  public static func makeFallthroughStmt(_ unexpectedBeforeFallthroughKeyword: UnexpectedNodesSyntax? = nil, fallthroughKeyword: TokenSyntax) -> FallthroughStmtSyntax {
+  public static func makeFallthroughStmt(_ unexpectedBeforeFallthroughKeyword: UnexpectedNodesSyntax? = nil, fallthroughKeyword: TokenSyntax, _ unexpectedAfterFallthroughKeyword: UnexpectedNodesSyntax? = nil) -> FallthroughStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeFallthroughKeyword?.raw,
       fallthroughKeyword.raw,
+      unexpectedAfterFallthroughKeyword?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.fallthroughStmt,
       from: layout, arena: .default)
@@ -5513,16 +5832,18 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.fallthroughKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return FallthroughStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on BreakStmtSyntax")
-  public static func makeBreakStmt(_ unexpectedBeforeBreakKeyword: UnexpectedNodesSyntax? = nil, breakKeyword: TokenSyntax, _ unexpectedBetweenBreakKeywordAndLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax?) -> BreakStmtSyntax {
+  public static func makeBreakStmt(_ unexpectedBeforeBreakKeyword: UnexpectedNodesSyntax? = nil, breakKeyword: TokenSyntax, _ unexpectedBetweenBreakKeywordAndLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax?, _ unexpectedAfterLabel: UnexpectedNodesSyntax? = nil) -> BreakStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBreakKeyword?.raw,
       breakKeyword.raw,
       unexpectedBetweenBreakKeywordAndLabel?.raw,
       label?.raw,
+      unexpectedAfterLabel?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.breakStmt,
       from: layout, arena: .default)
@@ -5536,6 +5857,7 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.breakKeyword, arena: .default),
+      nil,
       nil,
       nil,
     ], arena: .default))
@@ -5574,12 +5896,13 @@ public enum SyntaxFactory {
     return CatchItemListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ConditionElementSyntax")
-  public static func makeConditionElement(_ unexpectedBeforeCondition: UnexpectedNodesSyntax? = nil, condition: Syntax, _ unexpectedBetweenConditionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> ConditionElementSyntax {
+  public static func makeConditionElement(_ unexpectedBeforeCondition: UnexpectedNodesSyntax? = nil, condition: Syntax, _ unexpectedBetweenConditionAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> ConditionElementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeCondition?.raw,
       condition.raw,
       unexpectedBetweenConditionAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.conditionElement,
       from: layout, arena: .default)
@@ -5595,11 +5918,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return ConditionElementSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AvailabilityConditionSyntax")
-  public static func makeAvailabilityCondition(_ unexpectedBeforePoundAvailableKeyword: UnexpectedNodesSyntax? = nil, poundAvailableKeyword: TokenSyntax, _ unexpectedBetweenPoundAvailableKeywordAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? = nil, availabilitySpec: AvailabilitySpecListSyntax, _ unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> AvailabilityConditionSyntax {
+  public static func makeAvailabilityCondition(_ unexpectedBeforePoundAvailableKeyword: UnexpectedNodesSyntax? = nil, poundAvailableKeyword: TokenSyntax, _ unexpectedBetweenPoundAvailableKeywordAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? = nil, availabilitySpec: AvailabilitySpecListSyntax, _ unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> AvailabilityConditionSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundAvailableKeyword?.raw,
       poundAvailableKeyword.raw,
@@ -5609,6 +5933,7 @@ public enum SyntaxFactory {
       availabilitySpec.raw,
       unexpectedBetweenAvailabilitySpecAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityCondition,
       from: layout, arena: .default)
@@ -5628,11 +5953,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return AvailabilityConditionSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on MatchingPatternConditionSyntax")
-  public static func makeMatchingPatternCondition(_ unexpectedBeforeCaseKeyword: UnexpectedNodesSyntax? = nil, caseKeyword: TokenSyntax, _ unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil, initializer: InitializerClauseSyntax) -> MatchingPatternConditionSyntax {
+  public static func makeMatchingPatternCondition(_ unexpectedBeforeCaseKeyword: UnexpectedNodesSyntax? = nil, caseKeyword: TokenSyntax, _ unexpectedBetweenCaseKeywordAndPattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil, initializer: InitializerClauseSyntax, _ unexpectedAfterInitializer: UnexpectedNodesSyntax? = nil) -> MatchingPatternConditionSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeCaseKeyword?.raw,
       caseKeyword.raw,
@@ -5642,6 +5968,7 @@ public enum SyntaxFactory {
       typeAnnotation?.raw,
       unexpectedBetweenTypeAnnotationAndInitializer?.raw,
       initializer.raw,
+      unexpectedAfterInitializer?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.matchingPatternCondition,
       from: layout, arena: .default)
@@ -5661,11 +5988,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.initializerClause, arena: .default),
+      nil,
     ], arena: .default))
     return MatchingPatternConditionSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on OptionalBindingConditionSyntax")
-  public static func makeOptionalBindingCondition(_ unexpectedBeforeLetOrVarKeyword: UnexpectedNodesSyntax? = nil, letOrVarKeyword: TokenSyntax, _ unexpectedBetweenLetOrVarKeywordAndPattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil, initializer: InitializerClauseSyntax?) -> OptionalBindingConditionSyntax {
+  public static func makeOptionalBindingCondition(_ unexpectedBeforeLetOrVarKeyword: UnexpectedNodesSyntax? = nil, letOrVarKeyword: TokenSyntax, _ unexpectedBetweenLetOrVarKeywordAndPattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil, initializer: InitializerClauseSyntax?, _ unexpectedAfterInitializer: UnexpectedNodesSyntax? = nil) -> OptionalBindingConditionSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLetOrVarKeyword?.raw,
       letOrVarKeyword.raw,
@@ -5675,6 +6003,7 @@ public enum SyntaxFactory {
       typeAnnotation?.raw,
       unexpectedBetweenTypeAnnotationAndInitializer?.raw,
       initializer?.raw,
+      unexpectedAfterInitializer?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalBindingCondition,
       from: layout, arena: .default)
@@ -5694,11 +6023,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return OptionalBindingConditionSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on UnavailabilityConditionSyntax")
-  public static func makeUnavailabilityCondition(_ unexpectedBeforePoundUnavailableKeyword: UnexpectedNodesSyntax? = nil, poundUnavailableKeyword: TokenSyntax, _ unexpectedBetweenPoundUnavailableKeywordAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? = nil, availabilitySpec: AvailabilitySpecListSyntax, _ unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> UnavailabilityConditionSyntax {
+  public static func makeUnavailabilityCondition(_ unexpectedBeforePoundUnavailableKeyword: UnexpectedNodesSyntax? = nil, poundUnavailableKeyword: TokenSyntax, _ unexpectedBetweenPoundUnavailableKeywordAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? = nil, availabilitySpec: AvailabilitySpecListSyntax, _ unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> UnavailabilityConditionSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundUnavailableKeyword?.raw,
       poundUnavailableKeyword.raw,
@@ -5708,6 +6038,7 @@ public enum SyntaxFactory {
       availabilitySpec.raw,
       unexpectedBetweenAvailabilitySpecAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.unavailabilityCondition,
       from: layout, arena: .default)
@@ -5727,11 +6058,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.availabilitySpecList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return UnavailabilityConditionSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on HasSymbolConditionSyntax")
-  public static func makeHasSymbolCondition(_ unexpectedBeforeHasSymbolKeyword: UnexpectedNodesSyntax? = nil, hasSymbolKeyword: TokenSyntax, _ unexpectedBetweenHasSymbolKeywordAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> HasSymbolConditionSyntax {
+  public static func makeHasSymbolCondition(_ unexpectedBeforeHasSymbolKeyword: UnexpectedNodesSyntax? = nil, hasSymbolKeyword: TokenSyntax, _ unexpectedBetweenHasSymbolKeywordAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedBetweenExpressionAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> HasSymbolConditionSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeHasSymbolKeyword?.raw,
       hasSymbolKeyword.raw,
@@ -5741,6 +6073,7 @@ public enum SyntaxFactory {
       expression.raw,
       unexpectedBetweenExpressionAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.hasSymbolCondition,
       from: layout, arena: .default)
@@ -5760,6 +6093,7 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return HasSymbolConditionSyntax(data)
   }
@@ -5780,10 +6114,11 @@ public enum SyntaxFactory {
     return ConditionElementListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DeclarationStmtSyntax")
-  public static func makeDeclarationStmt(_ unexpectedBeforeDeclaration: UnexpectedNodesSyntax? = nil, declaration: DeclSyntax) -> DeclarationStmtSyntax {
+  public static func makeDeclarationStmt(_ unexpectedBeforeDeclaration: UnexpectedNodesSyntax? = nil, declaration: DeclSyntax, _ unexpectedAfterDeclaration: UnexpectedNodesSyntax? = nil) -> DeclarationStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDeclaration?.raw,
       declaration.raw,
+      unexpectedAfterDeclaration?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.declarationStmt,
       from: layout, arena: .default)
@@ -5797,16 +6132,18 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingDecl, arena: .default),
+      nil,
     ], arena: .default))
     return DeclarationStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ThrowStmtSyntax")
-  public static func makeThrowStmt(_ unexpectedBeforeThrowKeyword: UnexpectedNodesSyntax? = nil, throwKeyword: TokenSyntax, _ unexpectedBetweenThrowKeywordAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax) -> ThrowStmtSyntax {
+  public static func makeThrowStmt(_ unexpectedBeforeThrowKeyword: UnexpectedNodesSyntax? = nil, throwKeyword: TokenSyntax, _ unexpectedBetweenThrowKeywordAndExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> ThrowStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeThrowKeyword?.raw,
       throwKeyword.raw,
       unexpectedBetweenThrowKeywordAndExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.throwStmt,
       from: layout, arena: .default)
@@ -5822,11 +6159,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.throwKeyword, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
     ], arena: .default))
     return ThrowStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on IfStmtSyntax")
-  public static func makeIfStmt(_ unexpectedBeforeIfKeyword: UnexpectedNodesSyntax? = nil, ifKeyword: TokenSyntax, _ unexpectedBetweenIfKeywordAndConditions: UnexpectedNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ unexpectedBetweenConditionsAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedBetweenBodyAndElseKeyword: UnexpectedNodesSyntax? = nil, elseKeyword: TokenSyntax?, _ unexpectedBetweenElseKeywordAndElseBody: UnexpectedNodesSyntax? = nil, elseBody: Syntax?) -> IfStmtSyntax {
+  public static func makeIfStmt(_ unexpectedBeforeIfKeyword: UnexpectedNodesSyntax? = nil, ifKeyword: TokenSyntax, _ unexpectedBetweenIfKeywordAndConditions: UnexpectedNodesSyntax? = nil, conditions: ConditionElementListSyntax, _ unexpectedBetweenConditionsAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedBetweenBodyAndElseKeyword: UnexpectedNodesSyntax? = nil, elseKeyword: TokenSyntax?, _ unexpectedBetweenElseKeywordAndElseBody: UnexpectedNodesSyntax? = nil, elseBody: Syntax?, _ unexpectedAfterElseBody: UnexpectedNodesSyntax? = nil) -> IfStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIfKeyword?.raw,
       ifKeyword.raw,
@@ -5838,6 +6176,7 @@ public enum SyntaxFactory {
       elseKeyword?.raw,
       unexpectedBetweenElseKeywordAndElseBody?.raw,
       elseBody?.raw,
+      unexpectedAfterElseBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifStmt,
       from: layout, arena: .default)
@@ -5859,11 +6198,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return IfStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on SwitchCaseSyntax")
-  public static func makeSwitchCase(_ unexpectedBeforeUnknownAttr: UnexpectedNodesSyntax? = nil, unknownAttr: AttributeSyntax?, _ unexpectedBetweenUnknownAttrAndLabel: UnexpectedNodesSyntax? = nil, label: Syntax, _ unexpectedBetweenLabelAndStatements: UnexpectedNodesSyntax? = nil, statements: CodeBlockItemListSyntax) -> SwitchCaseSyntax {
+  public static func makeSwitchCase(_ unexpectedBeforeUnknownAttr: UnexpectedNodesSyntax? = nil, unknownAttr: AttributeSyntax?, _ unexpectedBetweenUnknownAttrAndLabel: UnexpectedNodesSyntax? = nil, label: Syntax, _ unexpectedBetweenLabelAndStatements: UnexpectedNodesSyntax? = nil, statements: CodeBlockItemListSyntax, _ unexpectedAfterStatements: UnexpectedNodesSyntax? = nil) -> SwitchCaseSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeUnknownAttr?.raw,
       unknownAttr?.raw,
@@ -5871,6 +6211,7 @@ public enum SyntaxFactory {
       label.raw,
       unexpectedBetweenLabelAndStatements?.raw,
       statements.raw,
+      unexpectedAfterStatements?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCase,
       from: layout, arena: .default)
@@ -5888,16 +6229,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlockItemList, arena: .default),
+      nil,
     ], arena: .default))
     return SwitchCaseSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on SwitchDefaultLabelSyntax")
-  public static func makeSwitchDefaultLabel(_ unexpectedBeforeDefaultKeyword: UnexpectedNodesSyntax? = nil, defaultKeyword: TokenSyntax, _ unexpectedBetweenDefaultKeywordAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax) -> SwitchDefaultLabelSyntax {
+  public static func makeSwitchDefaultLabel(_ unexpectedBeforeDefaultKeyword: UnexpectedNodesSyntax? = nil, defaultKeyword: TokenSyntax, _ unexpectedBetweenDefaultKeywordAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil) -> SwitchDefaultLabelSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDefaultKeyword?.raw,
       defaultKeyword.raw,
       unexpectedBetweenDefaultKeywordAndColon?.raw,
       colon.raw,
+      unexpectedAfterColon?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchDefaultLabel,
       from: layout, arena: .default)
@@ -5913,11 +6256,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.defaultKeyword, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
+      nil,
     ], arena: .default))
     return SwitchDefaultLabelSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on CaseItemSyntax")
-  public static func makeCaseItem(_ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? = nil, whereClause: WhereClauseSyntax?, _ unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> CaseItemSyntax {
+  public static func makeCaseItem(_ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? = nil, whereClause: WhereClauseSyntax?, _ unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> CaseItemSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePattern?.raw,
       pattern.raw,
@@ -5925,6 +6269,7 @@ public enum SyntaxFactory {
       whereClause?.raw,
       unexpectedBetweenWhereClauseAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.caseItem,
       from: layout, arena: .default)
@@ -5942,11 +6287,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return CaseItemSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on CatchItemSyntax")
-  public static func makeCatchItem(_ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax?, _ unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? = nil, whereClause: WhereClauseSyntax?, _ unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> CatchItemSyntax {
+  public static func makeCatchItem(_ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax?, _ unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? = nil, whereClause: WhereClauseSyntax?, _ unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> CatchItemSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePattern?.raw,
       pattern?.raw,
@@ -5954,6 +6300,7 @@ public enum SyntaxFactory {
       whereClause?.raw,
       unexpectedBetweenWhereClauseAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchItem,
       from: layout, arena: .default)
@@ -5971,11 +6318,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return CatchItemSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on SwitchCaseLabelSyntax")
-  public static func makeSwitchCaseLabel(_ unexpectedBeforeCaseKeyword: UnexpectedNodesSyntax? = nil, caseKeyword: TokenSyntax, _ unexpectedBetweenCaseKeywordAndCaseItems: UnexpectedNodesSyntax? = nil, caseItems: CaseItemListSyntax, _ unexpectedBetweenCaseItemsAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax) -> SwitchCaseLabelSyntax {
+  public static func makeSwitchCaseLabel(_ unexpectedBeforeCaseKeyword: UnexpectedNodesSyntax? = nil, caseKeyword: TokenSyntax, _ unexpectedBetweenCaseKeywordAndCaseItems: UnexpectedNodesSyntax? = nil, caseItems: CaseItemListSyntax, _ unexpectedBetweenCaseItemsAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil) -> SwitchCaseLabelSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeCaseKeyword?.raw,
       caseKeyword.raw,
@@ -5983,6 +6331,7 @@ public enum SyntaxFactory {
       caseItems.raw,
       unexpectedBetweenCaseItemsAndColon?.raw,
       colon.raw,
+      unexpectedAfterColon?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseLabel,
       from: layout, arena: .default)
@@ -6000,11 +6349,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.caseItemList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
+      nil,
     ], arena: .default))
     return SwitchCaseLabelSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on CatchClauseSyntax")
-  public static func makeCatchClause(_ unexpectedBeforeCatchKeyword: UnexpectedNodesSyntax? = nil, catchKeyword: TokenSyntax, _ unexpectedBetweenCatchKeywordAndCatchItems: UnexpectedNodesSyntax? = nil, catchItems: CatchItemListSyntax?, _ unexpectedBetweenCatchItemsAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax) -> CatchClauseSyntax {
+  public static func makeCatchClause(_ unexpectedBeforeCatchKeyword: UnexpectedNodesSyntax? = nil, catchKeyword: TokenSyntax, _ unexpectedBetweenCatchKeywordAndCatchItems: UnexpectedNodesSyntax? = nil, catchItems: CatchItemListSyntax?, _ unexpectedBetweenCatchItemsAndBody: UnexpectedNodesSyntax? = nil, body: CodeBlockSyntax, _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil) -> CatchClauseSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeCatchKeyword?.raw,
       catchKeyword.raw,
@@ -6012,6 +6362,7 @@ public enum SyntaxFactory {
       catchItems?.raw,
       unexpectedBetweenCatchItemsAndBody?.raw,
       body.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchClause,
       from: layout, arena: .default)
@@ -6029,11 +6380,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.codeBlock, arena: .default),
+      nil,
     ], arena: .default))
     return CatchClauseSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PoundAssertStmtSyntax")
-  public static func makePoundAssertStmt(_ unexpectedBeforePoundAssert: UnexpectedNodesSyntax? = nil, poundAssert: TokenSyntax, _ unexpectedBetweenPoundAssertAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndCondition: UnexpectedNodesSyntax? = nil, condition: ExprSyntax, _ unexpectedBetweenConditionAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndMessage: UnexpectedNodesSyntax? = nil, message: TokenSyntax?, _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> PoundAssertStmtSyntax {
+  public static func makePoundAssertStmt(_ unexpectedBeforePoundAssert: UnexpectedNodesSyntax? = nil, poundAssert: TokenSyntax, _ unexpectedBetweenPoundAssertAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndCondition: UnexpectedNodesSyntax? = nil, condition: ExprSyntax, _ unexpectedBetweenConditionAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndMessage: UnexpectedNodesSyntax? = nil, message: TokenSyntax?, _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> PoundAssertStmtSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundAssert?.raw,
       poundAssert.raw,
@@ -6047,6 +6399,7 @@ public enum SyntaxFactory {
       message?.raw,
       unexpectedBetweenMessageAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundAssertStmt,
       from: layout, arena: .default)
@@ -6070,16 +6423,18 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return PoundAssertStmtSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on GenericWhereClauseSyntax")
-  public static func makeGenericWhereClause(_ unexpectedBeforeWhereKeyword: UnexpectedNodesSyntax? = nil, whereKeyword: TokenSyntax, _ unexpectedBetweenWhereKeywordAndRequirementList: UnexpectedNodesSyntax? = nil, requirementList: GenericRequirementListSyntax) -> GenericWhereClauseSyntax {
+  public static func makeGenericWhereClause(_ unexpectedBeforeWhereKeyword: UnexpectedNodesSyntax? = nil, whereKeyword: TokenSyntax, _ unexpectedBetweenWhereKeywordAndRequirementList: UnexpectedNodesSyntax? = nil, requirementList: GenericRequirementListSyntax, _ unexpectedAfterRequirementList: UnexpectedNodesSyntax? = nil) -> GenericWhereClauseSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWhereKeyword?.raw,
       whereKeyword.raw,
       unexpectedBetweenWhereKeywordAndRequirementList?.raw,
       requirementList.raw,
+      unexpectedAfterRequirementList?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericWhereClause,
       from: layout, arena: .default)
@@ -6095,6 +6450,7 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.whereKeyword, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericRequirementList, arena: .default),
+      nil,
     ], arena: .default))
     return GenericWhereClauseSyntax(data)
   }
@@ -6115,12 +6471,13 @@ public enum SyntaxFactory {
     return GenericRequirementListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on GenericRequirementSyntax")
-  public static func makeGenericRequirement(_ unexpectedBeforeBody: UnexpectedNodesSyntax? = nil, body: Syntax, _ unexpectedBetweenBodyAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> GenericRequirementSyntax {
+  public static func makeGenericRequirement(_ unexpectedBeforeBody: UnexpectedNodesSyntax? = nil, body: Syntax, _ unexpectedBetweenBodyAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> GenericRequirementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBody?.raw,
       body.raw,
       unexpectedBetweenBodyAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirement,
       from: layout, arena: .default)
@@ -6136,11 +6493,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return GenericRequirementSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on SameTypeRequirementSyntax")
-  public static func makeSameTypeRequirement(_ unexpectedBeforeLeftTypeIdentifier: UnexpectedNodesSyntax? = nil, leftTypeIdentifier: TypeSyntax, _ unexpectedBetweenLeftTypeIdentifierAndEqualityToken: UnexpectedNodesSyntax? = nil, equalityToken: TokenSyntax, _ unexpectedBetweenEqualityTokenAndRightTypeIdentifier: UnexpectedNodesSyntax? = nil, rightTypeIdentifier: TypeSyntax) -> SameTypeRequirementSyntax {
+  public static func makeSameTypeRequirement(_ unexpectedBeforeLeftTypeIdentifier: UnexpectedNodesSyntax? = nil, leftTypeIdentifier: TypeSyntax, _ unexpectedBetweenLeftTypeIdentifierAndEqualityToken: UnexpectedNodesSyntax? = nil, equalityToken: TokenSyntax, _ unexpectedBetweenEqualityTokenAndRightTypeIdentifier: UnexpectedNodesSyntax? = nil, rightTypeIdentifier: TypeSyntax, _ unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? = nil) -> SameTypeRequirementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftTypeIdentifier?.raw,
       leftTypeIdentifier.raw,
@@ -6148,6 +6506,7 @@ public enum SyntaxFactory {
       equalityToken.raw,
       unexpectedBetweenEqualityTokenAndRightTypeIdentifier?.raw,
       rightTypeIdentifier.raw,
+      unexpectedAfterRightTypeIdentifier?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.sameTypeRequirement,
       from: layout, arena: .default)
@@ -6165,11 +6524,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.spacedBinaryOperator(""), arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
     ], arena: .default))
     return SameTypeRequirementSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on LayoutRequirementSyntax")
-  public static func makeLayoutRequirement(_ unexpectedBeforeTypeIdentifier: UnexpectedNodesSyntax? = nil, typeIdentifier: TypeSyntax, _ unexpectedBetweenTypeIdentifierAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndLayoutConstraint: UnexpectedNodesSyntax? = nil, layoutConstraint: TokenSyntax, _ unexpectedBetweenLayoutConstraintAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax?, _ unexpectedBetweenLeftParenAndSize: UnexpectedNodesSyntax? = nil, size: TokenSyntax?, _ unexpectedBetweenSizeAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndAlignment: UnexpectedNodesSyntax? = nil, alignment: TokenSyntax?, _ unexpectedBetweenAlignmentAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax?) -> LayoutRequirementSyntax {
+  public static func makeLayoutRequirement(_ unexpectedBeforeTypeIdentifier: UnexpectedNodesSyntax? = nil, typeIdentifier: TypeSyntax, _ unexpectedBetweenTypeIdentifierAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndLayoutConstraint: UnexpectedNodesSyntax? = nil, layoutConstraint: TokenSyntax, _ unexpectedBetweenLayoutConstraintAndLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax?, _ unexpectedBetweenLeftParenAndSize: UnexpectedNodesSyntax? = nil, size: TokenSyntax?, _ unexpectedBetweenSizeAndComma: UnexpectedNodesSyntax? = nil, comma: TokenSyntax?, _ unexpectedBetweenCommaAndAlignment: UnexpectedNodesSyntax? = nil, alignment: TokenSyntax?, _ unexpectedBetweenAlignmentAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax?, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> LayoutRequirementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeTypeIdentifier?.raw,
       typeIdentifier.raw,
@@ -6187,6 +6547,7 @@ public enum SyntaxFactory {
       alignment?.raw,
       unexpectedBetweenAlignmentAndRightParen?.raw,
       rightParen?.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.layoutRequirement,
       from: layout, arena: .default)
@@ -6204,6 +6565,7 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+      nil,
       nil,
       nil,
       nil,
@@ -6234,7 +6596,7 @@ public enum SyntaxFactory {
     return GenericParameterListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on GenericParameterSyntax")
-  public static func makeGenericParameter(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndInheritedType: UnexpectedNodesSyntax? = nil, inheritedType: TypeSyntax?, _ unexpectedBetweenInheritedTypeAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> GenericParameterSyntax {
+  public static func makeGenericParameter(_ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndInheritedType: UnexpectedNodesSyntax? = nil, inheritedType: TypeSyntax?, _ unexpectedBetweenInheritedTypeAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> GenericParameterSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
@@ -6246,6 +6608,7 @@ public enum SyntaxFactory {
       inheritedType?.raw,
       unexpectedBetweenInheritedTypeAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameter,
       from: layout, arena: .default)
@@ -6261,6 +6624,7 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+      nil,
       nil,
       nil,
       nil,
@@ -6287,12 +6651,13 @@ public enum SyntaxFactory {
     return PrimaryAssociatedTypeListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PrimaryAssociatedTypeSyntax")
-  public static func makePrimaryAssociatedType(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> PrimaryAssociatedTypeSyntax {
+  public static func makePrimaryAssociatedType(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> PrimaryAssociatedTypeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedType,
       from: layout, arena: .default)
@@ -6308,11 +6673,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return PrimaryAssociatedTypeSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on GenericParameterClauseSyntax")
-  public static func makeGenericParameterClause(_ unexpectedBeforeLeftAngleBracket: UnexpectedNodesSyntax? = nil, leftAngleBracket: TokenSyntax, _ unexpectedBetweenLeftAngleBracketAndGenericParameterList: UnexpectedNodesSyntax? = nil, genericParameterList: GenericParameterListSyntax, _ unexpectedBetweenGenericParameterListAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndRightAngleBracket: UnexpectedNodesSyntax? = nil, rightAngleBracket: TokenSyntax) -> GenericParameterClauseSyntax {
+  public static func makeGenericParameterClause(_ unexpectedBeforeLeftAngleBracket: UnexpectedNodesSyntax? = nil, leftAngleBracket: TokenSyntax, _ unexpectedBetweenLeftAngleBracketAndGenericParameterList: UnexpectedNodesSyntax? = nil, genericParameterList: GenericParameterListSyntax, _ unexpectedBetweenGenericParameterListAndGenericWhereClause: UnexpectedNodesSyntax? = nil, genericWhereClause: GenericWhereClauseSyntax?, _ unexpectedBetweenGenericWhereClauseAndRightAngleBracket: UnexpectedNodesSyntax? = nil, rightAngleBracket: TokenSyntax, _ unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? = nil) -> GenericParameterClauseSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftAngleBracket?.raw,
       leftAngleBracket.raw,
@@ -6322,6 +6688,7 @@ public enum SyntaxFactory {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndRightAngleBracket?.raw,
       rightAngleBracket.raw,
+      unexpectedAfterRightAngleBracket?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterClause,
       from: layout, arena: .default)
@@ -6341,11 +6708,12 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: .default),
+      nil,
     ], arena: .default))
     return GenericParameterClauseSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ConformanceRequirementSyntax")
-  public static func makeConformanceRequirement(_ unexpectedBeforeLeftTypeIdentifier: UnexpectedNodesSyntax? = nil, leftTypeIdentifier: TypeSyntax, _ unexpectedBetweenLeftTypeIdentifierAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndRightTypeIdentifier: UnexpectedNodesSyntax? = nil, rightTypeIdentifier: TypeSyntax) -> ConformanceRequirementSyntax {
+  public static func makeConformanceRequirement(_ unexpectedBeforeLeftTypeIdentifier: UnexpectedNodesSyntax? = nil, leftTypeIdentifier: TypeSyntax, _ unexpectedBetweenLeftTypeIdentifierAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndRightTypeIdentifier: UnexpectedNodesSyntax? = nil, rightTypeIdentifier: TypeSyntax, _ unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? = nil) -> ConformanceRequirementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftTypeIdentifier?.raw,
       leftTypeIdentifier.raw,
@@ -6353,6 +6721,7 @@ public enum SyntaxFactory {
       colon.raw,
       unexpectedBetweenColonAndRightTypeIdentifier?.raw,
       rightTypeIdentifier.raw,
+      unexpectedAfterRightTypeIdentifier?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.conformanceRequirement,
       from: layout, arena: .default)
@@ -6370,11 +6739,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
     ], arena: .default))
     return ConformanceRequirementSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PrimaryAssociatedTypeClauseSyntax")
-  public static func makePrimaryAssociatedTypeClause(_ unexpectedBeforeLeftAngleBracket: UnexpectedNodesSyntax? = nil, leftAngleBracket: TokenSyntax, _ unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList: UnexpectedNodesSyntax? = nil, primaryAssociatedTypeList: PrimaryAssociatedTypeListSyntax, _ unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket: UnexpectedNodesSyntax? = nil, rightAngleBracket: TokenSyntax) -> PrimaryAssociatedTypeClauseSyntax {
+  public static func makePrimaryAssociatedTypeClause(_ unexpectedBeforeLeftAngleBracket: UnexpectedNodesSyntax? = nil, leftAngleBracket: TokenSyntax, _ unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList: UnexpectedNodesSyntax? = nil, primaryAssociatedTypeList: PrimaryAssociatedTypeListSyntax, _ unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket: UnexpectedNodesSyntax? = nil, rightAngleBracket: TokenSyntax, _ unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? = nil) -> PrimaryAssociatedTypeClauseSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftAngleBracket?.raw,
       leftAngleBracket.raw,
@@ -6382,6 +6752,7 @@ public enum SyntaxFactory {
       primaryAssociatedTypeList.raw,
       unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket?.raw,
       rightAngleBracket.raw,
+      unexpectedAfterRightAngleBracket?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeClause,
       from: layout, arena: .default)
@@ -6399,16 +6770,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.primaryAssociatedTypeList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: .default),
+      nil,
     ], arena: .default))
     return PrimaryAssociatedTypeClauseSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on SimpleTypeIdentifierSyntax")
-  public static func makeSimpleTypeIdentifier(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax?) -> SimpleTypeIdentifierSyntax {
+  public static func makeSimpleTypeIdentifier(_ unexpectedBeforeName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax?, _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil) -> SimpleTypeIdentifierSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndGenericArgumentClause?.raw,
       genericArgumentClause?.raw,
+      unexpectedAfterGenericArgumentClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.simpleTypeIdentifier,
       from: layout, arena: .default)
@@ -6424,11 +6797,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return SimpleTypeIdentifierSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on MemberTypeIdentifierSyntax")
-  public static func makeMemberTypeIdentifier(_ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax, _ unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax, _ unexpectedBetweenPeriodAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax?) -> MemberTypeIdentifierSyntax {
+  public static func makeMemberTypeIdentifier(_ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax, _ unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax, _ unexpectedBetweenPeriodAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax, _ unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodesSyntax? = nil, genericArgumentClause: GenericArgumentClauseSyntax?, _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil) -> MemberTypeIdentifierSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBaseType?.raw,
       baseType.raw,
@@ -6438,6 +6812,7 @@ public enum SyntaxFactory {
       name.raw,
       unexpectedBetweenNameAndGenericArgumentClause?.raw,
       genericArgumentClause?.raw,
+      unexpectedAfterGenericArgumentClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberTypeIdentifier,
       from: layout, arena: .default)
@@ -6457,14 +6832,16 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return MemberTypeIdentifierSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ClassRestrictionTypeSyntax")
-  public static func makeClassRestrictionType(_ unexpectedBeforeClassKeyword: UnexpectedNodesSyntax? = nil, classKeyword: TokenSyntax) -> ClassRestrictionTypeSyntax {
+  public static func makeClassRestrictionType(_ unexpectedBeforeClassKeyword: UnexpectedNodesSyntax? = nil, classKeyword: TokenSyntax, _ unexpectedAfterClassKeyword: UnexpectedNodesSyntax? = nil) -> ClassRestrictionTypeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeClassKeyword?.raw,
       classKeyword.raw,
+      unexpectedAfterClassKeyword?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.classRestrictionType,
       from: layout, arena: .default)
@@ -6478,11 +6855,12 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.classKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return ClassRestrictionTypeSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ArrayTypeSyntax")
-  public static func makeArrayType(_ unexpectedBeforeLeftSquareBracket: UnexpectedNodesSyntax? = nil, leftSquareBracket: TokenSyntax, _ unexpectedBetweenLeftSquareBracketAndElementType: UnexpectedNodesSyntax? = nil, elementType: TypeSyntax, _ unexpectedBetweenElementTypeAndRightSquareBracket: UnexpectedNodesSyntax? = nil, rightSquareBracket: TokenSyntax) -> ArrayTypeSyntax {
+  public static func makeArrayType(_ unexpectedBeforeLeftSquareBracket: UnexpectedNodesSyntax? = nil, leftSquareBracket: TokenSyntax, _ unexpectedBetweenLeftSquareBracketAndElementType: UnexpectedNodesSyntax? = nil, elementType: TypeSyntax, _ unexpectedBetweenElementTypeAndRightSquareBracket: UnexpectedNodesSyntax? = nil, rightSquareBracket: TokenSyntax, _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil) -> ArrayTypeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftSquareBracket?.raw,
       leftSquareBracket.raw,
@@ -6490,6 +6868,7 @@ public enum SyntaxFactory {
       elementType.raw,
       unexpectedBetweenElementTypeAndRightSquareBracket?.raw,
       rightSquareBracket.raw,
+      unexpectedAfterRightSquareBracket?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayType,
       from: layout, arena: .default)
@@ -6507,11 +6886,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default),
+      nil,
     ], arena: .default))
     return ArrayTypeSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on DictionaryTypeSyntax")
-  public static func makeDictionaryType(_ unexpectedBeforeLeftSquareBracket: UnexpectedNodesSyntax? = nil, leftSquareBracket: TokenSyntax, _ unexpectedBetweenLeftSquareBracketAndKeyType: UnexpectedNodesSyntax? = nil, keyType: TypeSyntax, _ unexpectedBetweenKeyTypeAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValueType: UnexpectedNodesSyntax? = nil, valueType: TypeSyntax, _ unexpectedBetweenValueTypeAndRightSquareBracket: UnexpectedNodesSyntax? = nil, rightSquareBracket: TokenSyntax) -> DictionaryTypeSyntax {
+  public static func makeDictionaryType(_ unexpectedBeforeLeftSquareBracket: UnexpectedNodesSyntax? = nil, leftSquareBracket: TokenSyntax, _ unexpectedBetweenLeftSquareBracketAndKeyType: UnexpectedNodesSyntax? = nil, keyType: TypeSyntax, _ unexpectedBetweenKeyTypeAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValueType: UnexpectedNodesSyntax? = nil, valueType: TypeSyntax, _ unexpectedBetweenValueTypeAndRightSquareBracket: UnexpectedNodesSyntax? = nil, rightSquareBracket: TokenSyntax, _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil) -> DictionaryTypeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftSquareBracket?.raw,
       leftSquareBracket.raw,
@@ -6523,6 +6903,7 @@ public enum SyntaxFactory {
       valueType.raw,
       unexpectedBetweenValueTypeAndRightSquareBracket?.raw,
       rightSquareBracket.raw,
+      unexpectedAfterRightSquareBracket?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryType,
       from: layout, arena: .default)
@@ -6544,11 +6925,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightSquareBracket, arena: .default),
+      nil,
     ], arena: .default))
     return DictionaryTypeSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on MetatypeTypeSyntax")
-  public static func makeMetatypeType(_ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax, _ unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax, _ unexpectedBetweenPeriodAndTypeOrProtocol: UnexpectedNodesSyntax? = nil, typeOrProtocol: TokenSyntax) -> MetatypeTypeSyntax {
+  public static func makeMetatypeType(_ unexpectedBeforeBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax, _ unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax, _ unexpectedBetweenPeriodAndTypeOrProtocol: UnexpectedNodesSyntax? = nil, typeOrProtocol: TokenSyntax, _ unexpectedAfterTypeOrProtocol: UnexpectedNodesSyntax? = nil) -> MetatypeTypeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBaseType?.raw,
       baseType.raw,
@@ -6556,6 +6938,7 @@ public enum SyntaxFactory {
       period.raw,
       unexpectedBetweenPeriodAndTypeOrProtocol?.raw,
       typeOrProtocol.raw,
+      unexpectedAfterTypeOrProtocol?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.metatypeType,
       from: layout, arena: .default)
@@ -6573,16 +6956,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.period, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
+      nil,
     ], arena: .default))
     return MetatypeTypeSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on OptionalTypeSyntax")
-  public static func makeOptionalType(_ unexpectedBeforeWrappedType: UnexpectedNodesSyntax? = nil, wrappedType: TypeSyntax, _ unexpectedBetweenWrappedTypeAndQuestionMark: UnexpectedNodesSyntax? = nil, questionMark: TokenSyntax) -> OptionalTypeSyntax {
+  public static func makeOptionalType(_ unexpectedBeforeWrappedType: UnexpectedNodesSyntax? = nil, wrappedType: TypeSyntax, _ unexpectedBetweenWrappedTypeAndQuestionMark: UnexpectedNodesSyntax? = nil, questionMark: TokenSyntax, _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil) -> OptionalTypeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWrappedType?.raw,
       wrappedType.raw,
       unexpectedBetweenWrappedTypeAndQuestionMark?.raw,
       questionMark.raw,
+      unexpectedAfterQuestionMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalType,
       from: layout, arena: .default)
@@ -6598,16 +6983,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: .default),
+      nil,
     ], arena: .default))
     return OptionalTypeSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ConstrainedSugarTypeSyntax")
-  public static func makeConstrainedSugarType(_ unexpectedBeforeSomeOrAnySpecifier: UnexpectedNodesSyntax? = nil, someOrAnySpecifier: TokenSyntax, _ unexpectedBetweenSomeOrAnySpecifierAndBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax) -> ConstrainedSugarTypeSyntax {
+  public static func makeConstrainedSugarType(_ unexpectedBeforeSomeOrAnySpecifier: UnexpectedNodesSyntax? = nil, someOrAnySpecifier: TokenSyntax, _ unexpectedBetweenSomeOrAnySpecifierAndBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax, _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil) -> ConstrainedSugarTypeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSomeOrAnySpecifier?.raw,
       someOrAnySpecifier.raw,
       unexpectedBetweenSomeOrAnySpecifierAndBaseType?.raw,
       baseType.raw,
+      unexpectedAfterBaseType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.constrainedSugarType,
       from: layout, arena: .default)
@@ -6623,16 +7010,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
     ], arena: .default))
     return ConstrainedSugarTypeSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ImplicitlyUnwrappedOptionalTypeSyntax")
-  public static func makeImplicitlyUnwrappedOptionalType(_ unexpectedBeforeWrappedType: UnexpectedNodesSyntax? = nil, wrappedType: TypeSyntax, _ unexpectedBetweenWrappedTypeAndExclamationMark: UnexpectedNodesSyntax? = nil, exclamationMark: TokenSyntax) -> ImplicitlyUnwrappedOptionalTypeSyntax {
+  public static func makeImplicitlyUnwrappedOptionalType(_ unexpectedBeforeWrappedType: UnexpectedNodesSyntax? = nil, wrappedType: TypeSyntax, _ unexpectedBetweenWrappedTypeAndExclamationMark: UnexpectedNodesSyntax? = nil, exclamationMark: TokenSyntax, _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil) -> ImplicitlyUnwrappedOptionalTypeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWrappedType?.raw,
       wrappedType.raw,
       unexpectedBetweenWrappedTypeAndExclamationMark?.raw,
       exclamationMark.raw,
+      unexpectedAfterExclamationMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.implicitlyUnwrappedOptionalType,
       from: layout, arena: .default)
@@ -6648,16 +7037,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.exclamationMark, arena: .default),
+      nil,
     ], arena: .default))
     return ImplicitlyUnwrappedOptionalTypeSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on CompositionTypeElementSyntax")
-  public static func makeCompositionTypeElement(_ unexpectedBeforeType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedBetweenTypeAndAmpersand: UnexpectedNodesSyntax? = nil, ampersand: TokenSyntax?) -> CompositionTypeElementSyntax {
+  public static func makeCompositionTypeElement(_ unexpectedBeforeType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedBetweenTypeAndAmpersand: UnexpectedNodesSyntax? = nil, ampersand: TokenSyntax?, _ unexpectedAfterAmpersand: UnexpectedNodesSyntax? = nil) -> CompositionTypeElementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeType?.raw,
       type.raw,
       unexpectedBetweenTypeAndAmpersand?.raw,
       ampersand?.raw,
+      unexpectedAfterAmpersand?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElement,
       from: layout, arena: .default)
@@ -6671,6 +7062,7 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
       nil,
       nil,
     ], arena: .default))
@@ -6693,10 +7085,11 @@ public enum SyntaxFactory {
     return CompositionTypeElementListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on CompositionTypeSyntax")
-  public static func makeCompositionType(_ unexpectedBeforeElements: UnexpectedNodesSyntax? = nil, elements: CompositionTypeElementListSyntax) -> CompositionTypeSyntax {
+  public static func makeCompositionType(_ unexpectedBeforeElements: UnexpectedNodesSyntax? = nil, elements: CompositionTypeElementListSyntax, _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil) -> CompositionTypeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeElements?.raw,
       elements.raw,
+      unexpectedAfterElements?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionType,
       from: layout, arena: .default)
@@ -6710,16 +7103,18 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.compositionTypeElementList, arena: .default),
+      nil,
     ], arena: .default))
     return CompositionTypeSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on PackExpansionTypeSyntax")
-  public static func makePackExpansionType(_ unexpectedBeforePatternType: UnexpectedNodesSyntax? = nil, patternType: TypeSyntax, _ unexpectedBetweenPatternTypeAndEllipsis: UnexpectedNodesSyntax? = nil, ellipsis: TokenSyntax) -> PackExpansionTypeSyntax {
+  public static func makePackExpansionType(_ unexpectedBeforePatternType: UnexpectedNodesSyntax? = nil, patternType: TypeSyntax, _ unexpectedBetweenPatternTypeAndEllipsis: UnexpectedNodesSyntax? = nil, ellipsis: TokenSyntax, _ unexpectedAfterEllipsis: UnexpectedNodesSyntax? = nil) -> PackExpansionTypeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePatternType?.raw,
       patternType.raw,
       unexpectedBetweenPatternTypeAndEllipsis?.raw,
       ellipsis.raw,
+      unexpectedAfterEllipsis?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.packExpansionType,
       from: layout, arena: .default)
@@ -6735,11 +7130,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.ellipsis, arena: .default),
+      nil,
     ], arena: .default))
     return PackExpansionTypeSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on TupleTypeElementSyntax")
-  public static func makeTupleTypeElement(_ unexpectedBeforeInOut: UnexpectedNodesSyntax? = nil, inOut: TokenSyntax?, _ unexpectedBetweenInOutAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax?, _ unexpectedBetweenNameAndSecondName: UnexpectedNodesSyntax? = nil, secondName: TokenSyntax?, _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil, ellipsis: TokenSyntax?, _ unexpectedBetweenEllipsisAndInitializer: UnexpectedNodesSyntax? = nil, initializer: InitializerClauseSyntax?, _ unexpectedBetweenInitializerAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> TupleTypeElementSyntax {
+  public static func makeTupleTypeElement(_ unexpectedBeforeInOut: UnexpectedNodesSyntax? = nil, inOut: TokenSyntax?, _ unexpectedBetweenInOutAndName: UnexpectedNodesSyntax? = nil, name: TokenSyntax?, _ unexpectedBetweenNameAndSecondName: UnexpectedNodesSyntax? = nil, secondName: TokenSyntax?, _ unexpectedBetweenSecondNameAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax?, _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedBetweenTypeAndEllipsis: UnexpectedNodesSyntax? = nil, ellipsis: TokenSyntax?, _ unexpectedBetweenEllipsisAndInitializer: UnexpectedNodesSyntax? = nil, initializer: InitializerClauseSyntax?, _ unexpectedBetweenInitializerAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> TupleTypeElementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeInOut?.raw,
       inOut?.raw,
@@ -6757,6 +7153,7 @@ public enum SyntaxFactory {
       initializer?.raw,
       unexpectedBetweenInitializerAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElement,
       from: layout, arena: .default)
@@ -6784,6 +7181,7 @@ public enum SyntaxFactory {
       nil,
       nil,
       nil,
+      nil,
     ], arena: .default))
     return TupleTypeElementSyntax(data)
   }
@@ -6804,7 +7202,7 @@ public enum SyntaxFactory {
     return TupleTypeElementListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on TupleTypeSyntax")
-  public static func makeTupleType(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? = nil, elements: TupleTypeElementListSyntax, _ unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> TupleTypeSyntax {
+  public static func makeTupleType(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? = nil, elements: TupleTypeElementListSyntax, _ unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> TupleTypeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
       leftParen.raw,
@@ -6812,6 +7210,7 @@ public enum SyntaxFactory {
       elements.raw,
       unexpectedBetweenElementsAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleType,
       from: layout, arena: .default)
@@ -6829,11 +7228,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.tupleTypeElementList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return TupleTypeSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on FunctionTypeSyntax")
-  public static func makeFunctionType(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil, arguments: TupleTypeElementListSyntax, _ unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedBetweenRightParenAndAsyncKeyword: UnexpectedNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodesSyntax? = nil, throwsOrRethrowsKeyword: TokenSyntax?, _ unexpectedBetweenThrowsOrRethrowsKeywordAndArrow: UnexpectedNodesSyntax? = nil, arrow: TokenSyntax, _ unexpectedBetweenArrowAndReturnType: UnexpectedNodesSyntax? = nil, returnType: TypeSyntax) -> FunctionTypeSyntax {
+  public static func makeFunctionType(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil, arguments: TupleTypeElementListSyntax, _ unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedBetweenRightParenAndAsyncKeyword: UnexpectedNodesSyntax? = nil, asyncKeyword: TokenSyntax?, _ unexpectedBetweenAsyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodesSyntax? = nil, throwsOrRethrowsKeyword: TokenSyntax?, _ unexpectedBetweenThrowsOrRethrowsKeywordAndArrow: UnexpectedNodesSyntax? = nil, arrow: TokenSyntax, _ unexpectedBetweenArrowAndReturnType: UnexpectedNodesSyntax? = nil, returnType: TypeSyntax, _ unexpectedAfterReturnType: UnexpectedNodesSyntax? = nil) -> FunctionTypeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
       leftParen.raw,
@@ -6849,6 +7249,7 @@ public enum SyntaxFactory {
       arrow.raw,
       unexpectedBetweenArrowAndReturnType?.raw,
       returnType.raw,
+      unexpectedAfterReturnType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionType,
       from: layout, arena: .default)
@@ -6874,11 +7275,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.arrow, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
     ], arena: .default))
     return FunctionTypeSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AttributedTypeSyntax")
-  public static func makeAttributedType(_ unexpectedBeforeSpecifier: UnexpectedNodesSyntax? = nil, specifier: TokenSyntax?, _ unexpectedBetweenSpecifierAndAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax) -> AttributedTypeSyntax {
+  public static func makeAttributedType(_ unexpectedBeforeSpecifier: UnexpectedNodesSyntax? = nil, specifier: TokenSyntax?, _ unexpectedBetweenSpecifierAndAttributes: UnexpectedNodesSyntax? = nil, attributes: AttributeListSyntax?, _ unexpectedBetweenAttributesAndBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax, _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil) -> AttributedTypeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSpecifier?.raw,
       specifier?.raw,
@@ -6886,6 +7288,7 @@ public enum SyntaxFactory {
       attributes?.raw,
       unexpectedBetweenAttributesAndBaseType?.raw,
       baseType.raw,
+      unexpectedAfterBaseType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.attributedType,
       from: layout, arena: .default)
@@ -6903,6 +7306,7 @@ public enum SyntaxFactory {
       nil,
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
     ], arena: .default))
     return AttributedTypeSyntax(data)
   }
@@ -6923,12 +7327,13 @@ public enum SyntaxFactory {
     return GenericArgumentListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on GenericArgumentSyntax")
-  public static func makeGenericArgument(_ unexpectedBeforeArgumentType: UnexpectedNodesSyntax? = nil, argumentType: TypeSyntax, _ unexpectedBetweenArgumentTypeAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> GenericArgumentSyntax {
+  public static func makeGenericArgument(_ unexpectedBeforeArgumentType: UnexpectedNodesSyntax? = nil, argumentType: TypeSyntax, _ unexpectedBetweenArgumentTypeAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> GenericArgumentSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeArgumentType?.raw,
       argumentType.raw,
       unexpectedBetweenArgumentTypeAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgument,
       from: layout, arena: .default)
@@ -6944,11 +7349,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return GenericArgumentSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on GenericArgumentClauseSyntax")
-  public static func makeGenericArgumentClause(_ unexpectedBeforeLeftAngleBracket: UnexpectedNodesSyntax? = nil, leftAngleBracket: TokenSyntax, _ unexpectedBetweenLeftAngleBracketAndArguments: UnexpectedNodesSyntax? = nil, arguments: GenericArgumentListSyntax, _ unexpectedBetweenArgumentsAndRightAngleBracket: UnexpectedNodesSyntax? = nil, rightAngleBracket: TokenSyntax) -> GenericArgumentClauseSyntax {
+  public static func makeGenericArgumentClause(_ unexpectedBeforeLeftAngleBracket: UnexpectedNodesSyntax? = nil, leftAngleBracket: TokenSyntax, _ unexpectedBetweenLeftAngleBracketAndArguments: UnexpectedNodesSyntax? = nil, arguments: GenericArgumentListSyntax, _ unexpectedBetweenArgumentsAndRightAngleBracket: UnexpectedNodesSyntax? = nil, rightAngleBracket: TokenSyntax, _ unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? = nil) -> GenericArgumentClauseSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftAngleBracket?.raw,
       leftAngleBracket.raw,
@@ -6956,6 +7362,7 @@ public enum SyntaxFactory {
       arguments.raw,
       unexpectedBetweenArgumentsAndRightAngleBracket?.raw,
       rightAngleBracket.raw,
+      unexpectedAfterRightAngleBracket?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentClause,
       from: layout, arena: .default)
@@ -6973,16 +7380,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericArgumentList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightAngle, arena: .default),
+      nil,
     ], arena: .default))
     return GenericArgumentClauseSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on NamedOpaqueReturnTypeSyntax")
-  public static func makeNamedOpaqueReturnType(_ unexpectedBeforeGenericParameters: UnexpectedNodesSyntax? = nil, genericParameters: GenericParameterClauseSyntax, _ unexpectedBetweenGenericParametersAndBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax) -> NamedOpaqueReturnTypeSyntax {
+  public static func makeNamedOpaqueReturnType(_ unexpectedBeforeGenericParameters: UnexpectedNodesSyntax? = nil, genericParameters: GenericParameterClauseSyntax, _ unexpectedBetweenGenericParametersAndBaseType: UnexpectedNodesSyntax? = nil, baseType: TypeSyntax, _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil) -> NamedOpaqueReturnTypeSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeGenericParameters?.raw,
       genericParameters.raw,
       unexpectedBetweenGenericParametersAndBaseType?.raw,
       baseType.raw,
+      unexpectedAfterBaseType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.namedOpaqueReturnType,
       from: layout, arena: .default)
@@ -6998,16 +7407,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.genericParameterClause, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
     ], arena: .default))
     return NamedOpaqueReturnTypeSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on TypeAnnotationSyntax")
-  public static func makeTypeAnnotation(_ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax) -> TypeAnnotationSyntax {
+  public static func makeTypeAnnotation(_ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedAfterType: UnexpectedNodesSyntax? = nil) -> TypeAnnotationSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeColon?.raw,
       colon.raw,
       unexpectedBetweenColonAndType?.raw,
       type.raw,
+      unexpectedAfterType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeAnnotation,
       from: layout, arena: .default)
@@ -7023,11 +7434,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
     ], arena: .default))
     return TypeAnnotationSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on EnumCasePatternSyntax")
-  public static func makeEnumCasePattern(_ unexpectedBeforeType: UnexpectedNodesSyntax? = nil, type: TypeSyntax?, _ unexpectedBetweenTypeAndPeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax, _ unexpectedBetweenPeriodAndCaseName: UnexpectedNodesSyntax? = nil, caseName: TokenSyntax, _ unexpectedBetweenCaseNameAndAssociatedTuple: UnexpectedNodesSyntax? = nil, associatedTuple: TuplePatternSyntax?) -> EnumCasePatternSyntax {
+  public static func makeEnumCasePattern(_ unexpectedBeforeType: UnexpectedNodesSyntax? = nil, type: TypeSyntax?, _ unexpectedBetweenTypeAndPeriod: UnexpectedNodesSyntax? = nil, period: TokenSyntax, _ unexpectedBetweenPeriodAndCaseName: UnexpectedNodesSyntax? = nil, caseName: TokenSyntax, _ unexpectedBetweenCaseNameAndAssociatedTuple: UnexpectedNodesSyntax? = nil, associatedTuple: TuplePatternSyntax?, _ unexpectedAfterAssociatedTuple: UnexpectedNodesSyntax? = nil) -> EnumCasePatternSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeType?.raw,
       type?.raw,
@@ -7037,6 +7449,7 @@ public enum SyntaxFactory {
       caseName.raw,
       unexpectedBetweenCaseNameAndAssociatedTuple?.raw,
       associatedTuple?.raw,
+      unexpectedAfterAssociatedTuple?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCasePattern,
       from: layout, arena: .default)
@@ -7056,16 +7469,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return EnumCasePatternSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on IsTypePatternSyntax")
-  public static func makeIsTypePattern(_ unexpectedBeforeIsKeyword: UnexpectedNodesSyntax? = nil, isKeyword: TokenSyntax, _ unexpectedBetweenIsKeywordAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax) -> IsTypePatternSyntax {
+  public static func makeIsTypePattern(_ unexpectedBeforeIsKeyword: UnexpectedNodesSyntax? = nil, isKeyword: TokenSyntax, _ unexpectedBetweenIsKeywordAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedAfterType: UnexpectedNodesSyntax? = nil) -> IsTypePatternSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIsKeyword?.raw,
       isKeyword.raw,
       unexpectedBetweenIsKeywordAndType?.raw,
       type.raw,
+      unexpectedAfterType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.isTypePattern,
       from: layout, arena: .default)
@@ -7081,16 +7496,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.isKeyword, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
     ], arena: .default))
     return IsTypePatternSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on OptionalPatternSyntax")
-  public static func makeOptionalPattern(_ unexpectedBeforeSubPattern: UnexpectedNodesSyntax? = nil, subPattern: PatternSyntax, _ unexpectedBetweenSubPatternAndQuestionMark: UnexpectedNodesSyntax? = nil, questionMark: TokenSyntax) -> OptionalPatternSyntax {
+  public static func makeOptionalPattern(_ unexpectedBeforeSubPattern: UnexpectedNodesSyntax? = nil, subPattern: PatternSyntax, _ unexpectedBetweenSubPatternAndQuestionMark: UnexpectedNodesSyntax? = nil, questionMark: TokenSyntax, _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil) -> OptionalPatternSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSubPattern?.raw,
       subPattern.raw,
       unexpectedBetweenSubPatternAndQuestionMark?.raw,
       questionMark.raw,
+      unexpectedAfterQuestionMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalPattern,
       from: layout, arena: .default)
@@ -7106,14 +7523,16 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.postfixQuestionMark, arena: .default),
+      nil,
     ], arena: .default))
     return OptionalPatternSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on IdentifierPatternSyntax")
-  public static func makeIdentifierPattern(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax) -> IdentifierPatternSyntax {
+  public static func makeIdentifierPattern(_ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil, identifier: TokenSyntax, _ unexpectedAfterIdentifier: UnexpectedNodesSyntax? = nil) -> IdentifierPatternSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
       identifier.raw,
+      unexpectedAfterIdentifier?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.identifierPattern,
       from: layout, arena: .default)
@@ -7127,11 +7546,12 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.selfKeyword, arena: .default),
+      nil,
     ], arena: .default))
     return IdentifierPatternSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AsTypePatternSyntax")
-  public static func makeAsTypePattern(_ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndAsKeyword: UnexpectedNodesSyntax? = nil, asKeyword: TokenSyntax, _ unexpectedBetweenAsKeywordAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax) -> AsTypePatternSyntax {
+  public static func makeAsTypePattern(_ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndAsKeyword: UnexpectedNodesSyntax? = nil, asKeyword: TokenSyntax, _ unexpectedBetweenAsKeywordAndType: UnexpectedNodesSyntax? = nil, type: TypeSyntax, _ unexpectedAfterType: UnexpectedNodesSyntax? = nil) -> AsTypePatternSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePattern?.raw,
       pattern.raw,
@@ -7139,6 +7559,7 @@ public enum SyntaxFactory {
       asKeyword.raw,
       unexpectedBetweenAsKeywordAndType?.raw,
       type.raw,
+      unexpectedAfterType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.asTypePattern,
       from: layout, arena: .default)
@@ -7156,11 +7577,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.asKeyword, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingType, arena: .default),
+      nil,
     ], arena: .default))
     return AsTypePatternSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on TuplePatternSyntax")
-  public static func makeTuplePattern(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? = nil, elements: TuplePatternElementListSyntax, _ unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax) -> TuplePatternSyntax {
+  public static func makeTuplePattern(_ unexpectedBeforeLeftParen: UnexpectedNodesSyntax? = nil, leftParen: TokenSyntax, _ unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? = nil, elements: TuplePatternElementListSyntax, _ unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? = nil, rightParen: TokenSyntax, _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil) -> TuplePatternSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
       leftParen.raw,
@@ -7168,6 +7590,7 @@ public enum SyntaxFactory {
       elements.raw,
       unexpectedBetweenElementsAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePattern,
       from: layout, arena: .default)
@@ -7185,16 +7608,18 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.tuplePatternElementList, arena: .default),
       nil,
       RawSyntax.makeMissingToken(kind: TokenKind.rightParen, arena: .default),
+      nil,
     ], arena: .default))
     return TuplePatternSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on WildcardPatternSyntax")
-  public static func makeWildcardPattern(_ unexpectedBeforeWildcard: UnexpectedNodesSyntax? = nil, wildcard: TokenSyntax, _ unexpectedBetweenWildcardAndTypeAnnotation: UnexpectedNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?) -> WildcardPatternSyntax {
+  public static func makeWildcardPattern(_ unexpectedBeforeWildcard: UnexpectedNodesSyntax? = nil, wildcard: TokenSyntax, _ unexpectedBetweenWildcardAndTypeAnnotation: UnexpectedNodesSyntax? = nil, typeAnnotation: TypeAnnotationSyntax?, _ unexpectedAfterTypeAnnotation: UnexpectedNodesSyntax? = nil) -> WildcardPatternSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWildcard?.raw,
       wildcard.raw,
       unexpectedBetweenWildcardAndTypeAnnotation?.raw,
       typeAnnotation?.raw,
+      unexpectedAfterTypeAnnotation?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.wildcardPattern,
       from: layout, arena: .default)
@@ -7210,11 +7635,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.wildcardKeyword, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return WildcardPatternSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on TuplePatternElementSyntax")
-  public static func makeTuplePatternElement(_ unexpectedBeforeLabelName: UnexpectedNodesSyntax? = nil, labelName: TokenSyntax?, _ unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? = nil, labelColon: TokenSyntax?, _ unexpectedBetweenLabelColonAndPattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> TuplePatternElementSyntax {
+  public static func makeTuplePatternElement(_ unexpectedBeforeLabelName: UnexpectedNodesSyntax? = nil, labelName: TokenSyntax?, _ unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? = nil, labelColon: TokenSyntax?, _ unexpectedBetweenLabelColonAndPattern: UnexpectedNodesSyntax? = nil, pattern: PatternSyntax, _ unexpectedBetweenPatternAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> TuplePatternElementSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabelName?.raw,
       labelName?.raw,
@@ -7224,6 +7650,7 @@ public enum SyntaxFactory {
       pattern.raw,
       unexpectedBetweenPatternAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElement,
       from: layout, arena: .default)
@@ -7243,14 +7670,16 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return TuplePatternElementSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ExpressionPatternSyntax")
-  public static func makeExpressionPattern(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax) -> ExpressionPatternSyntax {
+  public static func makeExpressionPattern(_ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil, expression: ExprSyntax, _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil) -> ExpressionPatternSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionPattern,
       from: layout, arena: .default)
@@ -7264,6 +7693,7 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingExpr, arena: .default),
+      nil,
     ], arena: .default))
     return ExpressionPatternSyntax(data)
   }
@@ -7284,12 +7714,13 @@ public enum SyntaxFactory {
     return TuplePatternElementListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on ValueBindingPatternSyntax")
-  public static func makeValueBindingPattern(_ unexpectedBeforeLetOrVarKeyword: UnexpectedNodesSyntax? = nil, letOrVarKeyword: TokenSyntax, _ unexpectedBetweenLetOrVarKeywordAndValuePattern: UnexpectedNodesSyntax? = nil, valuePattern: PatternSyntax) -> ValueBindingPatternSyntax {
+  public static func makeValueBindingPattern(_ unexpectedBeforeLetOrVarKeyword: UnexpectedNodesSyntax? = nil, letOrVarKeyword: TokenSyntax, _ unexpectedBetweenLetOrVarKeywordAndValuePattern: UnexpectedNodesSyntax? = nil, valuePattern: PatternSyntax, _ unexpectedAfterValuePattern: UnexpectedNodesSyntax? = nil) -> ValueBindingPatternSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLetOrVarKeyword?.raw,
       letOrVarKeyword.raw,
       unexpectedBetweenLetOrVarKeywordAndValuePattern?.raw,
       valuePattern.raw,
+      unexpectedAfterValuePattern?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.valueBindingPattern,
       from: layout, arena: .default)
@@ -7305,6 +7736,7 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.letKeyword, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.missingPattern, arena: .default),
+      nil,
     ], arena: .default))
     return ValueBindingPatternSyntax(data)
   }
@@ -7325,12 +7757,13 @@ public enum SyntaxFactory {
     return AvailabilitySpecListSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AvailabilityArgumentSyntax")
-  public static func makeAvailabilityArgument(_ unexpectedBeforeEntry: UnexpectedNodesSyntax? = nil, entry: Syntax, _ unexpectedBetweenEntryAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?) -> AvailabilityArgumentSyntax {
+  public static func makeAvailabilityArgument(_ unexpectedBeforeEntry: UnexpectedNodesSyntax? = nil, entry: Syntax, _ unexpectedBetweenEntryAndTrailingComma: UnexpectedNodesSyntax? = nil, trailingComma: TokenSyntax?, _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil) -> AvailabilityArgumentSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeEntry?.raw,
       entry.raw,
       unexpectedBetweenEntryAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityArgument,
       from: layout, arena: .default)
@@ -7346,11 +7779,12 @@ public enum SyntaxFactory {
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return AvailabilityArgumentSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AvailabilityLabeledArgumentSyntax")
-  public static func makeAvailabilityLabeledArgument(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil, value: Syntax) -> AvailabilityLabeledArgumentSyntax {
+  public static func makeAvailabilityLabeledArgument(_ unexpectedBeforeLabel: UnexpectedNodesSyntax? = nil, label: TokenSyntax, _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil, colon: TokenSyntax, _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil, value: Syntax, _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil) -> AvailabilityLabeledArgumentSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabel?.raw,
       label.raw,
@@ -7358,6 +7792,7 @@ public enum SyntaxFactory {
       colon.raw,
       unexpectedBetweenColonAndValue?.raw,
       value.raw,
+      unexpectedAfterValue?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityLabeledArgument,
       from: layout, arena: .default)
@@ -7375,16 +7810,18 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.colon, arena: .default),
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
+      nil,
     ], arena: .default))
     return AvailabilityLabeledArgumentSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on AvailabilityVersionRestrictionSyntax")
-  public static func makeAvailabilityVersionRestriction(_ unexpectedBeforePlatform: UnexpectedNodesSyntax? = nil, platform: TokenSyntax, _ unexpectedBetweenPlatformAndVersion: UnexpectedNodesSyntax? = nil, version: VersionTupleSyntax?) -> AvailabilityVersionRestrictionSyntax {
+  public static func makeAvailabilityVersionRestriction(_ unexpectedBeforePlatform: UnexpectedNodesSyntax? = nil, platform: TokenSyntax, _ unexpectedBetweenPlatformAndVersion: UnexpectedNodesSyntax? = nil, version: VersionTupleSyntax?, _ unexpectedAfterVersion: UnexpectedNodesSyntax? = nil) -> AvailabilityVersionRestrictionSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforePlatform?.raw,
       platform.raw,
       unexpectedBetweenPlatformAndVersion?.raw,
       version?.raw,
+      unexpectedAfterVersion?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityVersionRestriction,
       from: layout, arena: .default)
@@ -7400,11 +7837,12 @@ public enum SyntaxFactory {
       RawSyntax.makeMissingToken(kind: TokenKind.identifier(""), arena: .default),
       nil,
       nil,
+      nil,
     ], arena: .default))
     return AvailabilityVersionRestrictionSyntax(data)
   }
   @available(*, deprecated, message: "Use initializer on VersionTupleSyntax")
-  public static func makeVersionTuple(_ unexpectedBeforeMajorMinor: UnexpectedNodesSyntax? = nil, majorMinor: Syntax, _ unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodesSyntax? = nil, patchPeriod: TokenSyntax?, _ unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodesSyntax? = nil, patchVersion: TokenSyntax?) -> VersionTupleSyntax {
+  public static func makeVersionTuple(_ unexpectedBeforeMajorMinor: UnexpectedNodesSyntax? = nil, majorMinor: Syntax, _ unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodesSyntax? = nil, patchPeriod: TokenSyntax?, _ unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodesSyntax? = nil, patchVersion: TokenSyntax?, _ unexpectedAfterPatchVersion: UnexpectedNodesSyntax? = nil) -> VersionTupleSyntax {
     let layout: [RawSyntax?] = [
       unexpectedBeforeMajorMinor?.raw,
       majorMinor.raw,
@@ -7412,6 +7850,7 @@ public enum SyntaxFactory {
       patchPeriod?.raw,
       unexpectedBetweenPatchPeriodAndPatchVersion?.raw,
       patchVersion?.raw,
+      unexpectedAfterPatchVersion?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.versionTuple,
       from: layout, arena: .default)
@@ -7425,6 +7864,7 @@ public enum SyntaxFactory {
       from: [
       nil,
       RawSyntax.makeEmptyLayout(kind: SyntaxKind.unknown, arena: .default),
+      nil,
       nil,
       nil,
       nil,

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxDeclNodes.swift
@@ -82,13 +82,15 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeAttributes: UnexpectedNodesSyntax? = nil,
     attributes: AttributeListSyntax?,
     _ unexpectedBetweenAttributesAndModifiers: UnexpectedNodesSyntax? = nil,
-    modifiers: ModifierListSyntax?
+    modifiers: ModifierListSyntax?,
+    _ unexpectedAfterModifiers: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
       attributes?.raw,
       unexpectedBetweenAttributesAndModifiers?.raw,
       modifiers?.raw,
+      unexpectedAfterModifiers?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.missingDecl,
       from: layout, arena: .default)
@@ -216,6 +218,27 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return MissingDeclSyntax(newData)
   }
 
+  public var unexpectedAfterModifiers: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterModifiers(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterModifiers` replaced.
+  /// - param newChild: The new `unexpectedAfterModifiers` to replace the node's
+  ///                   current `unexpectedAfterModifiers`, if present.
+  public func withUnexpectedAfterModifiers(
+    _ newChild: UnexpectedNodesSyntax?) -> MissingDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return MissingDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -225,6 +248,8 @@ public struct MissingDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -239,6 +264,7 @@ extension MissingDeclSyntax: CustomReflectable {
       "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenAttributesAndModifiers": unexpectedBetweenAttributesAndModifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "modifiers": modifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterModifiers": unexpectedAfterModifiers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -277,7 +303,8 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenGenericParameterClauseAndInitializer: UnexpectedNodesSyntax? = nil,
     initializer: TypeInitializerClauseSyntax,
     _ unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
-    genericWhereClause: GenericWhereClauseSyntax?
+    genericWhereClause: GenericWhereClauseSyntax?,
+    _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -294,6 +321,7 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       initializer.raw,
       unexpectedBetweenInitializerAndGenericWhereClause?.raw,
       genericWhereClause?.raw,
+      unexpectedAfterGenericWhereClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.typealiasDecl,
       from: layout, arena: .default)
@@ -628,6 +656,27 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return TypealiasDeclSyntax(newData)
   }
 
+  public var unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 14, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterGenericWhereClause(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterGenericWhereClause` replaced.
+  /// - param newChild: The new `unexpectedAfterGenericWhereClause` to replace the node's
+  ///                   current `unexpectedAfterGenericWhereClause`, if present.
+  public func withUnexpectedAfterGenericWhereClause(
+    _ newChild: UnexpectedNodesSyntax?) -> TypealiasDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 14)
+    return TypealiasDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -658,6 +707,8 @@ public struct TypealiasDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 13:
       return "generic where clause"
+    case 14:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -681,6 +732,7 @@ extension TypealiasDeclSyntax: CustomReflectable {
       "initializer": Syntax(initializer).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenInitializerAndGenericWhereClause": unexpectedBetweenInitializerAndGenericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterGenericWhereClause": unexpectedAfterGenericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -719,7 +771,8 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenInheritanceClauseAndInitializer: UnexpectedNodesSyntax? = nil,
     initializer: TypeInitializerClauseSyntax?,
     _ unexpectedBetweenInitializerAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
-    genericWhereClause: GenericWhereClauseSyntax?
+    genericWhereClause: GenericWhereClauseSyntax?,
+    _ unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -736,6 +789,7 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       initializer?.raw,
       unexpectedBetweenInitializerAndGenericWhereClause?.raw,
       genericWhereClause?.raw,
+      unexpectedAfterGenericWhereClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.associatedtypeDecl,
       from: layout, arena: .default)
@@ -1071,6 +1125,27 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return AssociatedtypeDeclSyntax(newData)
   }
 
+  public var unexpectedAfterGenericWhereClause: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 14, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterGenericWhereClause(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterGenericWhereClause` replaced.
+  /// - param newChild: The new `unexpectedAfterGenericWhereClause` to replace the node's
+  ///                   current `unexpectedAfterGenericWhereClause`, if present.
+  public func withUnexpectedAfterGenericWhereClause(
+    _ newChild: UnexpectedNodesSyntax?) -> AssociatedtypeDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 14)
+    return AssociatedtypeDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1101,6 +1176,8 @@ public struct AssociatedtypeDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 13:
       return "generic where clause"
+    case 14:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -1124,6 +1201,7 @@ extension AssociatedtypeDeclSyntax: CustomReflectable {
       "initializer": initializer.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenInitializerAndGenericWhereClause": unexpectedBetweenInitializerAndGenericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterGenericWhereClause": unexpectedAfterGenericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1152,13 +1230,15 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeClauses: UnexpectedNodesSyntax? = nil,
     clauses: IfConfigClauseListSyntax,
     _ unexpectedBetweenClausesAndPoundEndif: UnexpectedNodesSyntax? = nil,
-    poundEndif: TokenSyntax
+    poundEndif: TokenSyntax,
+    _ unexpectedAfterPoundEndif: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeClauses?.raw,
       clauses.raw,
       unexpectedBetweenClausesAndPoundEndif?.raw,
       poundEndif.raw,
+      unexpectedAfterPoundEndif?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigDecl,
       from: layout, arena: .default)
@@ -1266,6 +1346,27 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return IfConfigDeclSyntax(newData)
   }
 
+  public var unexpectedAfterPoundEndif: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterPoundEndif(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterPoundEndif` replaced.
+  /// - param newChild: The new `unexpectedAfterPoundEndif` to replace the node's
+  ///                   current `unexpectedAfterPoundEndif`, if present.
+  public func withUnexpectedAfterPoundEndif(
+    _ newChild: UnexpectedNodesSyntax?) -> IfConfigDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return IfConfigDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1275,6 +1376,8 @@ public struct IfConfigDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -1289,6 +1392,7 @@ extension IfConfigDeclSyntax: CustomReflectable {
       "clauses": Syntax(clauses).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenClausesAndPoundEndif": unexpectedBetweenClausesAndPoundEndif.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "poundEndif": Syntax(poundEndif).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterPoundEndif": unexpectedAfterPoundEndif.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1321,7 +1425,8 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndMessage: UnexpectedNodesSyntax? = nil,
     message: StringLiteralExprSyntax,
     _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundError?.raw,
@@ -1332,6 +1437,7 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       message.raw,
       unexpectedBetweenMessageAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundErrorDecl,
       from: layout, arena: .default)
@@ -1503,6 +1609,27 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return PoundErrorDeclSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> PoundErrorDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return PoundErrorDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1521,6 +1648,8 @@ public struct PoundErrorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -1538,6 +1667,7 @@ extension PoundErrorDeclSyntax: CustomReflectable {
       "message": Syntax(message).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenMessageAndRightParen": unexpectedBetweenMessageAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1570,7 +1700,8 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndMessage: UnexpectedNodesSyntax? = nil,
     message: StringLiteralExprSyntax,
     _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundWarning?.raw,
@@ -1581,6 +1712,7 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       message.raw,
       unexpectedBetweenMessageAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundWarningDecl,
       from: layout, arena: .default)
@@ -1752,6 +1884,27 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return PoundWarningDeclSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> PoundWarningDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return PoundWarningDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1770,6 +1923,8 @@ public struct PoundWarningDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -1787,6 +1942,7 @@ extension PoundWarningDeclSyntax: CustomReflectable {
       "message": Syntax(message).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenMessageAndRightParen": unexpectedBetweenMessageAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1819,7 +1975,8 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndArgs: UnexpectedNodesSyntax? = nil,
     args: PoundSourceLocationArgsSyntax?,
     _ unexpectedBetweenArgsAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundSourceLocation?.raw,
@@ -1830,6 +1987,7 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
       args?.raw,
       unexpectedBetweenArgsAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundSourceLocation,
       from: layout, arena: .default)
@@ -2002,6 +2160,27 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return PoundSourceLocationSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return PoundSourceLocationSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2020,6 +2199,8 @@ public struct PoundSourceLocationSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -2037,6 +2218,7 @@ extension PoundSourceLocationSyntax: CustomReflectable {
       "args": args.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenArgsAndRightParen": unexpectedBetweenArgsAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2077,7 +2259,8 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil,
-    members: MemberDeclBlockSyntax
+    members: MemberDeclBlockSyntax,
+    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -2096,6 +2279,7 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndMembers?.raw,
       members.raw,
+      unexpectedAfterMembers?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.classDecl,
       from: layout, arena: .default)
@@ -2472,6 +2656,27 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ClassDeclSyntax(newData)
   }
 
+  public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 16, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterMembers(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
+  /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
+  ///                   current `unexpectedAfterMembers`, if present.
+  public func withUnexpectedAfterMembers(
+    _ newChild: UnexpectedNodesSyntax?) -> ClassDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 16)
+    return ClassDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2506,6 +2711,8 @@ public struct ClassDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 15:
       return nil
+    case 16:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -2531,6 +2738,7 @@ extension ClassDeclSyntax: CustomReflectable {
       "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenGenericWhereClauseAndMembers": unexpectedBetweenGenericWhereClauseAndMembers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "members": Syntax(members).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterMembers": unexpectedAfterMembers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2571,7 +2779,8 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil,
-    members: MemberDeclBlockSyntax
+    members: MemberDeclBlockSyntax,
+    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -2590,6 +2799,7 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndMembers?.raw,
       members.raw,
+      unexpectedAfterMembers?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.actorDecl,
       from: layout, arena: .default)
@@ -2966,6 +3176,27 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ActorDeclSyntax(newData)
   }
 
+  public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 16, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterMembers(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
+  /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
+  ///                   current `unexpectedAfterMembers`, if present.
+  public func withUnexpectedAfterMembers(
+    _ newChild: UnexpectedNodesSyntax?) -> ActorDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 16)
+    return ActorDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -3000,6 +3231,8 @@ public struct ActorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 15:
       return nil
+    case 16:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -3025,6 +3258,7 @@ extension ActorDeclSyntax: CustomReflectable {
       "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenGenericWhereClauseAndMembers": unexpectedBetweenGenericWhereClauseAndMembers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "members": Syntax(members).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterMembers": unexpectedAfterMembers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3065,7 +3299,8 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil,
-    members: MemberDeclBlockSyntax
+    members: MemberDeclBlockSyntax,
+    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -3084,6 +3319,7 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndMembers?.raw,
       members.raw,
+      unexpectedAfterMembers?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.structDecl,
       from: layout, arena: .default)
@@ -3460,6 +3696,27 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return StructDeclSyntax(newData)
   }
 
+  public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 16, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterMembers(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
+  /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
+  ///                   current `unexpectedAfterMembers`, if present.
+  public func withUnexpectedAfterMembers(
+    _ newChild: UnexpectedNodesSyntax?) -> StructDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 16)
+    return StructDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -3494,6 +3751,8 @@ public struct StructDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 15:
       return nil
+    case 16:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -3519,6 +3778,7 @@ extension StructDeclSyntax: CustomReflectable {
       "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenGenericWhereClauseAndMembers": unexpectedBetweenGenericWhereClauseAndMembers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "members": Syntax(members).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterMembers": unexpectedAfterMembers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3559,7 +3819,8 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil,
-    members: MemberDeclBlockSyntax
+    members: MemberDeclBlockSyntax,
+    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -3578,6 +3839,7 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndMembers?.raw,
       members.raw,
+      unexpectedAfterMembers?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.protocolDecl,
       from: layout, arena: .default)
@@ -3954,6 +4216,27 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ProtocolDeclSyntax(newData)
   }
 
+  public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 16, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterMembers(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
+  /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
+  ///                   current `unexpectedAfterMembers`, if present.
+  public func withUnexpectedAfterMembers(
+    _ newChild: UnexpectedNodesSyntax?) -> ProtocolDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 16)
+    return ProtocolDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -3988,6 +4271,8 @@ public struct ProtocolDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 15:
       return nil
+    case 16:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -4013,6 +4298,7 @@ extension ProtocolDeclSyntax: CustomReflectable {
       "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenGenericWhereClauseAndMembers": unexpectedBetweenGenericWhereClauseAndMembers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "members": Syntax(members).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterMembers": unexpectedAfterMembers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4051,7 +4337,8 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil,
-    members: MemberDeclBlockSyntax
+    members: MemberDeclBlockSyntax,
+    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -4068,6 +4355,7 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndMembers?.raw,
       members.raw,
+      unexpectedAfterMembers?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.extensionDecl,
       from: layout, arena: .default)
@@ -4402,6 +4690,27 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ExtensionDeclSyntax(newData)
   }
 
+  public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 14, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterMembers(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
+  /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
+  ///                   current `unexpectedAfterMembers`, if present.
+  public func withUnexpectedAfterMembers(
+    _ newChild: UnexpectedNodesSyntax?) -> ExtensionDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 14)
+    return ExtensionDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -4432,6 +4741,8 @@ public struct ExtensionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 13:
       return nil
+    case 14:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -4455,6 +4766,7 @@ extension ExtensionDeclSyntax: CustomReflectable {
       "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenGenericWhereClauseAndMembers": unexpectedBetweenGenericWhereClauseAndMembers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "members": Syntax(members).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterMembers": unexpectedAfterMembers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4495,7 +4807,8 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodesSyntax? = nil,
-    body: CodeBlockSyntax?
+    body: CodeBlockSyntax?,
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -4514,6 +4827,7 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndBody?.raw,
       body?.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionDecl,
       from: layout, arena: .default)
@@ -4890,6 +5204,27 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return FunctionDeclSyntax(newData)
   }
 
+  public var unexpectedAfterBody: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 16, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterBody(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
+  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
+  ///                   current `unexpectedAfterBody`, if present.
+  public func withUnexpectedAfterBody(
+    _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 16)
+    return FunctionDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -4924,6 +5259,8 @@ public struct FunctionDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 15:
       return nil
+    case 16:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -4949,6 +5286,7 @@ extension FunctionDeclSyntax: CustomReflectable {
       "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenGenericWhereClauseAndBody": unexpectedBetweenGenericWhereClauseAndBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "body": body.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterBody": unexpectedAfterBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4989,7 +5327,8 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenSignatureAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndBody: UnexpectedNodesSyntax? = nil,
-    body: CodeBlockSyntax?
+    body: CodeBlockSyntax?,
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -5008,6 +5347,7 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndBody?.raw,
       body?.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.initializerDecl,
       from: layout, arena: .default)
@@ -5385,6 +5725,27 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return InitializerDeclSyntax(newData)
   }
 
+  public var unexpectedAfterBody: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 16, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterBody(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
+  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
+  ///                   current `unexpectedAfterBody`, if present.
+  public func withUnexpectedAfterBody(
+    _ newChild: UnexpectedNodesSyntax?) -> InitializerDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 16)
+    return InitializerDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -5419,6 +5780,8 @@ public struct InitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 15:
       return nil
+    case 16:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -5444,6 +5807,7 @@ extension InitializerDeclSyntax: CustomReflectable {
       "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenGenericWhereClauseAndBody": unexpectedBetweenGenericWhereClauseAndBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "body": body.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterBody": unexpectedAfterBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5476,7 +5840,8 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenModifiersAndDeinitKeyword: UnexpectedNodesSyntax? = nil,
     deinitKeyword: TokenSyntax,
     _ unexpectedBetweenDeinitKeywordAndBody: UnexpectedNodesSyntax? = nil,
-    body: CodeBlockSyntax?
+    body: CodeBlockSyntax?,
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -5487,6 +5852,7 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       deinitKeyword.raw,
       unexpectedBetweenDeinitKeywordAndBody?.raw,
       body?.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.deinitializerDecl,
       from: layout, arena: .default)
@@ -5697,6 +6063,27 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return DeinitializerDeclSyntax(newData)
   }
 
+  public var unexpectedAfterBody: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterBody(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
+  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
+  ///                   current `unexpectedAfterBody`, if present.
+  public func withUnexpectedAfterBody(
+    _ newChild: UnexpectedNodesSyntax?) -> DeinitializerDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return DeinitializerDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -5715,6 +6102,8 @@ public struct DeinitializerDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -5732,6 +6121,7 @@ extension DeinitializerDeclSyntax: CustomReflectable {
       "deinitKeyword": Syntax(deinitKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenDeinitKeywordAndBody": unexpectedBetweenDeinitKeywordAndBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "body": body.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterBody": unexpectedAfterBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5772,7 +6162,8 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenResultAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndAccessor: UnexpectedNodesSyntax? = nil,
-    accessor: Syntax?
+    accessor: Syntax?,
+    _ unexpectedAfterAccessor: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -5791,6 +6182,7 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndAccessor?.raw,
       accessor?.raw,
+      unexpectedAfterAccessor?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.subscriptDecl,
       from: layout, arena: .default)
@@ -6167,6 +6559,27 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return SubscriptDeclSyntax(newData)
   }
 
+  public var unexpectedAfterAccessor: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 16, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterAccessor(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterAccessor` replaced.
+  /// - param newChild: The new `unexpectedAfterAccessor` to replace the node's
+  ///                   current `unexpectedAfterAccessor`, if present.
+  public func withUnexpectedAfterAccessor(
+    _ newChild: UnexpectedNodesSyntax?) -> SubscriptDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 16)
+    return SubscriptDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -6201,6 +6614,8 @@ public struct SubscriptDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 15:
       return nil
+    case 16:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -6226,6 +6641,7 @@ extension SubscriptDeclSyntax: CustomReflectable {
       "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenGenericWhereClauseAndAccessor": unexpectedBetweenGenericWhereClauseAndAccessor.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "accessor": accessor.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterAccessor": unexpectedAfterAccessor.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6260,7 +6676,8 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenImportTokAndImportKind: UnexpectedNodesSyntax? = nil,
     importKind: TokenSyntax?,
     _ unexpectedBetweenImportKindAndPath: UnexpectedNodesSyntax? = nil,
-    path: AccessPathSyntax
+    path: AccessPathSyntax,
+    _ unexpectedAfterPath: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -6273,6 +6690,7 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       importKind?.raw,
       unexpectedBetweenImportKindAndPath?.raw,
       path.raw,
+      unexpectedAfterPath?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.importDecl,
       from: layout, arena: .default)
@@ -6542,6 +6960,27 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return ImportDeclSyntax(newData)
   }
 
+  public var unexpectedAfterPath: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 10, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterPath(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterPath` replaced.
+  /// - param newChild: The new `unexpectedAfterPath` to replace the node's
+  ///                   current `unexpectedAfterPath`, if present.
+  public func withUnexpectedAfterPath(
+    _ newChild: UnexpectedNodesSyntax?) -> ImportDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 10)
+    return ImportDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -6564,6 +7003,8 @@ public struct ImportDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 9:
       return nil
+    case 10:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -6583,6 +7024,7 @@ extension ImportDeclSyntax: CustomReflectable {
       "importKind": importKind.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenImportKindAndPath": unexpectedBetweenImportKindAndPath.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "path": Syntax(path).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterPath": unexpectedAfterPath.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6621,7 +7063,8 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenAsyncKeywordAndThrowsKeyword: UnexpectedNodesSyntax? = nil,
     throwsKeyword: TokenSyntax?,
     _ unexpectedBetweenThrowsKeywordAndBody: UnexpectedNodesSyntax? = nil,
-    body: CodeBlockSyntax?
+    body: CodeBlockSyntax?,
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -6638,6 +7081,7 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       throwsKeyword?.raw,
       unexpectedBetweenThrowsKeywordAndBody?.raw,
       body?.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorDecl,
       from: layout, arena: .default)
@@ -6956,6 +7400,27 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return AccessorDeclSyntax(newData)
   }
 
+  public var unexpectedAfterBody: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 14, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterBody(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
+  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
+  ///                   current `unexpectedAfterBody`, if present.
+  public func withUnexpectedAfterBody(
+    _ newChild: UnexpectedNodesSyntax?) -> AccessorDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 14)
+    return AccessorDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -6986,6 +7451,8 @@ public struct AccessorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 13:
       return nil
+    case 14:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -7009,6 +7476,7 @@ extension AccessorDeclSyntax: CustomReflectable {
       "throwsKeyword": throwsKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenThrowsKeywordAndBody": unexpectedBetweenThrowsKeywordAndBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "body": body.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterBody": unexpectedAfterBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7041,7 +7509,8 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenModifiersAndLetOrVarKeyword: UnexpectedNodesSyntax? = nil,
     letOrVarKeyword: TokenSyntax,
     _ unexpectedBetweenLetOrVarKeywordAndBindings: UnexpectedNodesSyntax? = nil,
-    bindings: PatternBindingListSyntax
+    bindings: PatternBindingListSyntax,
+    _ unexpectedAfterBindings: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -7052,6 +7521,7 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       letOrVarKeyword.raw,
       unexpectedBetweenLetOrVarKeywordAndBindings?.raw,
       bindings.raw,
+      unexpectedAfterBindings?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.variableDecl,
       from: layout, arena: .default)
@@ -7279,6 +7749,27 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return VariableDeclSyntax(newData)
   }
 
+  public var unexpectedAfterBindings: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterBindings(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterBindings` replaced.
+  /// - param newChild: The new `unexpectedAfterBindings` to replace the node's
+  ///                   current `unexpectedAfterBindings`, if present.
+  public func withUnexpectedAfterBindings(
+    _ newChild: UnexpectedNodesSyntax?) -> VariableDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return VariableDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -7297,6 +7788,8 @@ public struct VariableDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -7314,6 +7807,7 @@ extension VariableDeclSyntax: CustomReflectable {
       "letOrVarKeyword": Syntax(letOrVarKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenLetOrVarKeywordAndBindings": unexpectedBetweenLetOrVarKeywordAndBindings.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "bindings": Syntax(bindings).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterBindings": unexpectedAfterBindings.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7351,7 +7845,8 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenModifiersAndCaseKeyword: UnexpectedNodesSyntax? = nil,
     caseKeyword: TokenSyntax,
     _ unexpectedBetweenCaseKeywordAndElements: UnexpectedNodesSyntax? = nil,
-    elements: EnumCaseElementListSyntax
+    elements: EnumCaseElementListSyntax,
+    _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -7362,6 +7857,7 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       caseKeyword.raw,
       unexpectedBetweenCaseKeywordAndElements?.raw,
       elements.raw,
+      unexpectedAfterElements?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseDecl,
       from: layout, arena: .default)
@@ -7597,6 +8093,27 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return EnumCaseDeclSyntax(newData)
   }
 
+  public var unexpectedAfterElements: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterElements(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterElements` replaced.
+  /// - param newChild: The new `unexpectedAfterElements` to replace the node's
+  ///                   current `unexpectedAfterElements`, if present.
+  public func withUnexpectedAfterElements(
+    _ newChild: UnexpectedNodesSyntax?) -> EnumCaseDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return EnumCaseDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -7615,6 +8132,8 @@ public struct EnumCaseDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return "elements"
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -7632,6 +8151,7 @@ extension EnumCaseDeclSyntax: CustomReflectable {
       "caseKeyword": Syntax(caseKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenCaseKeywordAndElements": unexpectedBetweenCaseKeywordAndElements.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "elements": Syntax(elements).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterElements": unexpectedAfterElements.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7673,7 +8193,8 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenInheritanceClauseAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndMembers: UnexpectedNodesSyntax? = nil,
-    members: MemberDeclBlockSyntax
+    members: MemberDeclBlockSyntax,
+    _ unexpectedAfterMembers: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -7692,6 +8213,7 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndMembers?.raw,
       members.raw,
+      unexpectedAfterMembers?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumDecl,
       from: layout, arena: .default)
@@ -8094,6 +8616,27 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return EnumDeclSyntax(newData)
   }
 
+  public var unexpectedAfterMembers: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 16, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterMembers(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterMembers` replaced.
+  /// - param newChild: The new `unexpectedAfterMembers` to replace the node's
+  ///                   current `unexpectedAfterMembers`, if present.
+  public func withUnexpectedAfterMembers(
+    _ newChild: UnexpectedNodesSyntax?) -> EnumDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 16)
+    return EnumDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -8128,6 +8671,8 @@ public struct EnumDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 15:
       return nil
+    case 16:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -8153,6 +8698,7 @@ extension EnumDeclSyntax: CustomReflectable {
       "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenGenericWhereClauseAndMembers": unexpectedBetweenGenericWhereClauseAndMembers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "members": Syntax(members).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterMembers": unexpectedAfterMembers.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -8188,7 +8734,8 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenOperatorKeywordAndIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes: UnexpectedNodesSyntax? = nil,
-    operatorPrecedenceAndTypes: OperatorPrecedenceAndTypesSyntax?
+    operatorPrecedenceAndTypes: OperatorPrecedenceAndTypesSyntax?,
+    _ unexpectedAfterOperatorPrecedenceAndTypes: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -8201,6 +8748,7 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       identifier.raw,
       unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes?.raw,
       operatorPrecedenceAndTypes?.raw,
+      unexpectedAfterOperatorPrecedenceAndTypes?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorDecl,
       from: layout, arena: .default)
@@ -8462,6 +9010,27 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return OperatorDeclSyntax(newData)
   }
 
+  public var unexpectedAfterOperatorPrecedenceAndTypes: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 10, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterOperatorPrecedenceAndTypes(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterOperatorPrecedenceAndTypes` replaced.
+  /// - param newChild: The new `unexpectedAfterOperatorPrecedenceAndTypes` to replace the node's
+  ///                   current `unexpectedAfterOperatorPrecedenceAndTypes`, if present.
+  public func withUnexpectedAfterOperatorPrecedenceAndTypes(
+    _ newChild: UnexpectedNodesSyntax?) -> OperatorDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 10)
+    return OperatorDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -8484,6 +9053,8 @@ public struct OperatorDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 9:
       return nil
+    case 10:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -8503,6 +9074,7 @@ extension OperatorDeclSyntax: CustomReflectable {
       "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes": unexpectedBetweenIdentifierAndOperatorPrecedenceAndTypes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "operatorPrecedenceAndTypes": operatorPrecedenceAndTypes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterOperatorPrecedenceAndTypes": unexpectedAfterOperatorPrecedenceAndTypes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -8542,7 +9114,8 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftBraceAndGroupAttributes: UnexpectedNodesSyntax? = nil,
     groupAttributes: PrecedenceGroupAttributeListSyntax,
     _ unexpectedBetweenGroupAttributesAndRightBrace: UnexpectedNodesSyntax? = nil,
-    rightBrace: TokenSyntax
+    rightBrace: TokenSyntax,
+    _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -8559,6 +9132,7 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       groupAttributes.raw,
       unexpectedBetweenGroupAttributesAndRightBrace?.raw,
       rightBrace.raw,
+      unexpectedAfterRightBrace?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupDecl,
       from: layout, arena: .default)
@@ -8922,6 +9496,27 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
     return PrecedenceGroupDeclSyntax(newData)
   }
 
+  public var unexpectedAfterRightBrace: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 14, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightBrace(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
+  /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
+  ///                   current `unexpectedAfterRightBrace`, if present.
+  public func withUnexpectedAfterRightBrace(
+    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupDeclSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 14)
+    return PrecedenceGroupDeclSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -8952,6 +9547,8 @@ public struct PrecedenceGroupDeclSyntax: DeclSyntaxProtocol, SyntaxHashable {
       return nil
     case 13:
       return nil
+    case 14:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -8975,6 +9572,7 @@ extension PrecedenceGroupDeclSyntax: CustomReflectable {
       "groupAttributes": Syntax(groupAttributes).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenGroupAttributesAndRightBrace": unexpectedBetweenGroupAttributesAndRightBrace.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightBrace": Syntax(rightBrace).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightBrace": unexpectedAfterRightBrace.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxExprNodes.swift
@@ -127,13 +127,15 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeAmpersand: UnexpectedNodesSyntax? = nil,
     ampersand: TokenSyntax,
     _ unexpectedBetweenAmpersandAndExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax
+    expression: ExprSyntax,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAmpersand?.raw,
       ampersand.raw,
       unexpectedBetweenAmpersandAndExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.inOutExpr,
       from: layout, arena: .default)
@@ -223,6 +225,27 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return InOutExprSyntax(newData)
   }
 
+  public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterExpression(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
+  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
+  ///                   current `unexpectedAfterExpression`, if present.
+  public func withUnexpectedAfterExpression(
+    _ newChild: UnexpectedNodesSyntax?) -> InOutExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return InOutExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -232,6 +255,8 @@ public struct InOutExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -246,6 +271,7 @@ extension InOutExprSyntax: CustomReflectable {
       "ampersand": Syntax(ampersand).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenAmpersandAndExpression": unexpectedBetweenAmpersandAndExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterExpression": unexpectedAfterExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -272,11 +298,13 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforePoundColumn: UnexpectedNodesSyntax? = nil,
-    poundColumn: TokenSyntax
+    poundColumn: TokenSyntax,
+    _ unexpectedAfterPoundColumn: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundColumn?.raw,
       poundColumn.raw,
+      unexpectedAfterPoundColumn?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundColumnExpr,
       from: layout, arena: .default)
@@ -325,11 +353,34 @@ public struct PoundColumnExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return PoundColumnExprSyntax(newData)
   }
 
+  public var unexpectedAfterPoundColumn: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterPoundColumn(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterPoundColumn` replaced.
+  /// - param newChild: The new `unexpectedAfterPoundColumn` to replace the node's
+  ///                   current `unexpectedAfterPoundColumn`, if present.
+  public func withUnexpectedAfterPoundColumn(
+    _ newChild: UnexpectedNodesSyntax?) -> PoundColumnExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return PoundColumnExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -342,6 +393,7 @@ extension PoundColumnExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforePoundColumn": unexpectedBeforePoundColumn.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "poundColumn": Syntax(poundColumn).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterPoundColumn": unexpectedAfterPoundColumn.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -372,7 +424,8 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenTryKeywordAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil,
     questionOrExclamationMark: TokenSyntax?,
     _ unexpectedBetweenQuestionOrExclamationMarkAndExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax
+    expression: ExprSyntax,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeTryKeyword?.raw,
@@ -381,6 +434,7 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       questionOrExclamationMark?.raw,
       unexpectedBetweenQuestionOrExclamationMarkAndExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tryExpr,
       from: layout, arena: .default)
@@ -512,6 +566,27 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return TryExprSyntax(newData)
   }
 
+  public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterExpression(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
+  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
+  ///                   current `unexpectedAfterExpression`, if present.
+  public func withUnexpectedAfterExpression(
+    _ newChild: UnexpectedNodesSyntax?) -> TryExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return TryExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -525,6 +600,8 @@ public struct TryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -541,6 +618,7 @@ extension TryExprSyntax: CustomReflectable {
       "questionOrExclamationMark": questionOrExclamationMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenQuestionOrExclamationMarkAndExpression": unexpectedBetweenQuestionOrExclamationMarkAndExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterExpression": unexpectedAfterExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -569,13 +647,15 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeAwaitKeyword: UnexpectedNodesSyntax? = nil,
     awaitKeyword: TokenSyntax,
     _ unexpectedBetweenAwaitKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax
+    expression: ExprSyntax,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAwaitKeyword?.raw,
       awaitKeyword.raw,
       unexpectedBetweenAwaitKeywordAndExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.awaitExpr,
       from: layout, arena: .default)
@@ -665,6 +745,27 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return AwaitExprSyntax(newData)
   }
 
+  public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterExpression(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
+  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
+  ///                   current `unexpectedAfterExpression`, if present.
+  public func withUnexpectedAfterExpression(
+    _ newChild: UnexpectedNodesSyntax?) -> AwaitExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return AwaitExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -674,6 +775,8 @@ public struct AwaitExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -688,6 +791,7 @@ extension AwaitExprSyntax: CustomReflectable {
       "awaitKeyword": Syntax(awaitKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenAwaitKeywordAndExpression": unexpectedBetweenAwaitKeywordAndExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterExpression": unexpectedAfterExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -716,13 +820,15 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeMoveKeyword: UnexpectedNodesSyntax? = nil,
     moveKeyword: TokenSyntax,
     _ unexpectedBetweenMoveKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax
+    expression: ExprSyntax,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeMoveKeyword?.raw,
       moveKeyword.raw,
       unexpectedBetweenMoveKeywordAndExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.moveExpr,
       from: layout, arena: .default)
@@ -812,6 +918,27 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return MoveExprSyntax(newData)
   }
 
+  public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterExpression(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
+  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
+  ///                   current `unexpectedAfterExpression`, if present.
+  public func withUnexpectedAfterExpression(
+    _ newChild: UnexpectedNodesSyntax?) -> MoveExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return MoveExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -821,6 +948,8 @@ public struct MoveExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -835,6 +964,7 @@ extension MoveExprSyntax: CustomReflectable {
       "moveKeyword": Syntax(moveKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenMoveKeywordAndExpression": unexpectedBetweenMoveKeywordAndExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterExpression": unexpectedAfterExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -863,13 +993,15 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
-    declNameArguments: DeclNameArgumentsSyntax?
+    declNameArguments: DeclNameArgumentsSyntax?,
+    _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
       identifier.raw,
       unexpectedBetweenIdentifierAndDeclNameArguments?.raw,
       declNameArguments?.raw,
+      unexpectedAfterDeclNameArguments?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.identifierExpr,
       from: layout, arena: .default)
@@ -960,6 +1092,27 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return IdentifierExprSyntax(newData)
   }
 
+  public var unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterDeclNameArguments(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterDeclNameArguments` replaced.
+  /// - param newChild: The new `unexpectedAfterDeclNameArguments` to replace the node's
+  ///                   current `unexpectedAfterDeclNameArguments`, if present.
+  public func withUnexpectedAfterDeclNameArguments(
+    _ newChild: UnexpectedNodesSyntax?) -> IdentifierExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return IdentifierExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -969,6 +1122,8 @@ public struct IdentifierExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -983,6 +1138,7 @@ extension IdentifierExprSyntax: CustomReflectable {
       "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenIdentifierAndDeclNameArguments": unexpectedBetweenIdentifierAndDeclNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "declNameArguments": declNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterDeclNameArguments": unexpectedAfterDeclNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1009,11 +1165,13 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeSuperKeyword: UnexpectedNodesSyntax? = nil,
-    superKeyword: TokenSyntax
+    superKeyword: TokenSyntax,
+    _ unexpectedAfterSuperKeyword: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSuperKeyword?.raw,
       superKeyword.raw,
+      unexpectedAfterSuperKeyword?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.superRefExpr,
       from: layout, arena: .default)
@@ -1062,11 +1220,34 @@ public struct SuperRefExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return SuperRefExprSyntax(newData)
   }
 
+  public var unexpectedAfterSuperKeyword: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterSuperKeyword(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterSuperKeyword` replaced.
+  /// - param newChild: The new `unexpectedAfterSuperKeyword` to replace the node's
+  ///                   current `unexpectedAfterSuperKeyword`, if present.
+  public func withUnexpectedAfterSuperKeyword(
+    _ newChild: UnexpectedNodesSyntax?) -> SuperRefExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return SuperRefExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -1079,6 +1260,7 @@ extension SuperRefExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeSuperKeyword": unexpectedBeforeSuperKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "superKeyword": Syntax(superKeyword).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterSuperKeyword": unexpectedAfterSuperKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1105,11 +1287,13 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeNilKeyword: UnexpectedNodesSyntax? = nil,
-    nilKeyword: TokenSyntax
+    nilKeyword: TokenSyntax,
+    _ unexpectedAfterNilKeyword: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeNilKeyword?.raw,
       nilKeyword.raw,
+      unexpectedAfterNilKeyword?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.nilLiteralExpr,
       from: layout, arena: .default)
@@ -1158,11 +1342,34 @@ public struct NilLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return NilLiteralExprSyntax(newData)
   }
 
+  public var unexpectedAfterNilKeyword: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterNilKeyword(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterNilKeyword` replaced.
+  /// - param newChild: The new `unexpectedAfterNilKeyword` to replace the node's
+  ///                   current `unexpectedAfterNilKeyword`, if present.
+  public func withUnexpectedAfterNilKeyword(
+    _ newChild: UnexpectedNodesSyntax?) -> NilLiteralExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return NilLiteralExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -1175,6 +1382,7 @@ extension NilLiteralExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeNilKeyword": unexpectedBeforeNilKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "nilKeyword": Syntax(nilKeyword).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterNilKeyword": unexpectedAfterNilKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1201,11 +1409,13 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeWildcard: UnexpectedNodesSyntax? = nil,
-    wildcard: TokenSyntax
+    wildcard: TokenSyntax,
+    _ unexpectedAfterWildcard: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWildcard?.raw,
       wildcard.raw,
+      unexpectedAfterWildcard?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.discardAssignmentExpr,
       from: layout, arena: .default)
@@ -1254,11 +1464,34 @@ public struct DiscardAssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return DiscardAssignmentExprSyntax(newData)
   }
 
+  public var unexpectedAfterWildcard: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterWildcard(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterWildcard` replaced.
+  /// - param newChild: The new `unexpectedAfterWildcard` to replace the node's
+  ///                   current `unexpectedAfterWildcard`, if present.
+  public func withUnexpectedAfterWildcard(
+    _ newChild: UnexpectedNodesSyntax?) -> DiscardAssignmentExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return DiscardAssignmentExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -1271,6 +1504,7 @@ extension DiscardAssignmentExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeWildcard": unexpectedBeforeWildcard.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "wildcard": Syntax(wildcard).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterWildcard": unexpectedAfterWildcard.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1297,11 +1531,13 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeAssignToken: UnexpectedNodesSyntax? = nil,
-    assignToken: TokenSyntax
+    assignToken: TokenSyntax,
+    _ unexpectedAfterAssignToken: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAssignToken?.raw,
       assignToken.raw,
+      unexpectedAfterAssignToken?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.assignmentExpr,
       from: layout, arena: .default)
@@ -1350,11 +1586,34 @@ public struct AssignmentExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return AssignmentExprSyntax(newData)
   }
 
+  public var unexpectedAfterAssignToken: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterAssignToken(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterAssignToken` replaced.
+  /// - param newChild: The new `unexpectedAfterAssignToken` to replace the node's
+  ///                   current `unexpectedAfterAssignToken`, if present.
+  public func withUnexpectedAfterAssignToken(
+    _ newChild: UnexpectedNodesSyntax?) -> AssignmentExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return AssignmentExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -1367,6 +1626,7 @@ extension AssignmentExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeAssignToken": unexpectedBeforeAssignToken.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "assignToken": Syntax(assignToken).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterAssignToken": unexpectedAfterAssignToken.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1393,11 +1653,13 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeElements: UnexpectedNodesSyntax? = nil,
-    elements: ExprListSyntax
+    elements: ExprListSyntax,
+    _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeElements?.raw,
       elements.raw,
+      unexpectedAfterElements?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.sequenceExpr,
       from: layout, arena: .default)
@@ -1464,11 +1726,34 @@ public struct SequenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return SequenceExprSyntax(newData)
   }
 
+  public var unexpectedAfterElements: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterElements(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterElements` replaced.
+  /// - param newChild: The new `unexpectedAfterElements` to replace the node's
+  ///                   current `unexpectedAfterElements`, if present.
+  public func withUnexpectedAfterElements(
+    _ newChild: UnexpectedNodesSyntax?) -> SequenceExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return SequenceExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -1481,6 +1766,7 @@ extension SequenceExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeElements": unexpectedBeforeElements.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "elements": Syntax(elements).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterElements": unexpectedAfterElements.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1507,11 +1793,13 @@ public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforePoundLine: UnexpectedNodesSyntax? = nil,
-    poundLine: TokenSyntax
+    poundLine: TokenSyntax,
+    _ unexpectedAfterPoundLine: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundLine?.raw,
       poundLine.raw,
+      unexpectedAfterPoundLine?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundLineExpr,
       from: layout, arena: .default)
@@ -1560,11 +1848,34 @@ public struct PoundLineExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return PoundLineExprSyntax(newData)
   }
 
+  public var unexpectedAfterPoundLine: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterPoundLine(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterPoundLine` replaced.
+  /// - param newChild: The new `unexpectedAfterPoundLine` to replace the node's
+  ///                   current `unexpectedAfterPoundLine`, if present.
+  public func withUnexpectedAfterPoundLine(
+    _ newChild: UnexpectedNodesSyntax?) -> PoundLineExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return PoundLineExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -1577,6 +1888,7 @@ extension PoundLineExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforePoundLine": unexpectedBeforePoundLine.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "poundLine": Syntax(poundLine).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterPoundLine": unexpectedAfterPoundLine.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1603,11 +1915,13 @@ public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforePoundFile: UnexpectedNodesSyntax? = nil,
-    poundFile: TokenSyntax
+    poundFile: TokenSyntax,
+    _ unexpectedAfterPoundFile: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundFile?.raw,
       poundFile.raw,
+      unexpectedAfterPoundFile?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFileExpr,
       from: layout, arena: .default)
@@ -1656,11 +1970,34 @@ public struct PoundFileExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return PoundFileExprSyntax(newData)
   }
 
+  public var unexpectedAfterPoundFile: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterPoundFile(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterPoundFile` replaced.
+  /// - param newChild: The new `unexpectedAfterPoundFile` to replace the node's
+  ///                   current `unexpectedAfterPoundFile`, if present.
+  public func withUnexpectedAfterPoundFile(
+    _ newChild: UnexpectedNodesSyntax?) -> PoundFileExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return PoundFileExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -1673,6 +2010,7 @@ extension PoundFileExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforePoundFile": unexpectedBeforePoundFile.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "poundFile": Syntax(poundFile).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterPoundFile": unexpectedAfterPoundFile.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1699,11 +2037,13 @@ public struct PoundFileIDExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforePoundFileID: UnexpectedNodesSyntax? = nil,
-    poundFileID: TokenSyntax
+    poundFileID: TokenSyntax,
+    _ unexpectedAfterPoundFileID: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundFileID?.raw,
       poundFileID.raw,
+      unexpectedAfterPoundFileID?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFileIDExpr,
       from: layout, arena: .default)
@@ -1752,11 +2092,34 @@ public struct PoundFileIDExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return PoundFileIDExprSyntax(newData)
   }
 
+  public var unexpectedAfterPoundFileID: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterPoundFileID(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterPoundFileID` replaced.
+  /// - param newChild: The new `unexpectedAfterPoundFileID` to replace the node's
+  ///                   current `unexpectedAfterPoundFileID`, if present.
+  public func withUnexpectedAfterPoundFileID(
+    _ newChild: UnexpectedNodesSyntax?) -> PoundFileIDExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return PoundFileIDExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -1769,6 +2132,7 @@ extension PoundFileIDExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforePoundFileID": unexpectedBeforePoundFileID.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "poundFileID": Syntax(poundFileID).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterPoundFileID": unexpectedAfterPoundFileID.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1795,11 +2159,13 @@ public struct PoundFilePathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforePoundFilePath: UnexpectedNodesSyntax? = nil,
-    poundFilePath: TokenSyntax
+    poundFilePath: TokenSyntax,
+    _ unexpectedAfterPoundFilePath: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundFilePath?.raw,
       poundFilePath.raw,
+      unexpectedAfterPoundFilePath?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFilePathExpr,
       from: layout, arena: .default)
@@ -1848,11 +2214,34 @@ public struct PoundFilePathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return PoundFilePathExprSyntax(newData)
   }
 
+  public var unexpectedAfterPoundFilePath: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterPoundFilePath(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterPoundFilePath` replaced.
+  /// - param newChild: The new `unexpectedAfterPoundFilePath` to replace the node's
+  ///                   current `unexpectedAfterPoundFilePath`, if present.
+  public func withUnexpectedAfterPoundFilePath(
+    _ newChild: UnexpectedNodesSyntax?) -> PoundFilePathExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return PoundFilePathExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -1865,6 +2254,7 @@ extension PoundFilePathExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforePoundFilePath": unexpectedBeforePoundFilePath.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "poundFilePath": Syntax(poundFilePath).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterPoundFilePath": unexpectedAfterPoundFilePath.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1891,11 +2281,13 @@ public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforePoundFunction: UnexpectedNodesSyntax? = nil,
-    poundFunction: TokenSyntax
+    poundFunction: TokenSyntax,
+    _ unexpectedAfterPoundFunction: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundFunction?.raw,
       poundFunction.raw,
+      unexpectedAfterPoundFunction?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundFunctionExpr,
       from: layout, arena: .default)
@@ -1944,11 +2336,34 @@ public struct PoundFunctionExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return PoundFunctionExprSyntax(newData)
   }
 
+  public var unexpectedAfterPoundFunction: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterPoundFunction(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterPoundFunction` replaced.
+  /// - param newChild: The new `unexpectedAfterPoundFunction` to replace the node's
+  ///                   current `unexpectedAfterPoundFunction`, if present.
+  public func withUnexpectedAfterPoundFunction(
+    _ newChild: UnexpectedNodesSyntax?) -> PoundFunctionExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return PoundFunctionExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -1961,6 +2376,7 @@ extension PoundFunctionExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforePoundFunction": unexpectedBeforePoundFunction.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "poundFunction": Syntax(poundFunction).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterPoundFunction": unexpectedAfterPoundFunction.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1987,11 +2403,13 @@ public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforePoundDsohandle: UnexpectedNodesSyntax? = nil,
-    poundDsohandle: TokenSyntax
+    poundDsohandle: TokenSyntax,
+    _ unexpectedAfterPoundDsohandle: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundDsohandle?.raw,
       poundDsohandle.raw,
+      unexpectedAfterPoundDsohandle?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundDsohandleExpr,
       from: layout, arena: .default)
@@ -2040,11 +2458,34 @@ public struct PoundDsohandleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return PoundDsohandleExprSyntax(newData)
   }
 
+  public var unexpectedAfterPoundDsohandle: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterPoundDsohandle(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterPoundDsohandle` replaced.
+  /// - param newChild: The new `unexpectedAfterPoundDsohandle` to replace the node's
+  ///                   current `unexpectedAfterPoundDsohandle`, if present.
+  public func withUnexpectedAfterPoundDsohandle(
+    _ newChild: UnexpectedNodesSyntax?) -> PoundDsohandleExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return PoundDsohandleExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -2057,6 +2498,7 @@ extension PoundDsohandleExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforePoundDsohandle": unexpectedBeforePoundDsohandle.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "poundDsohandle": Syntax(poundDsohandle).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterPoundDsohandle": unexpectedAfterPoundDsohandle.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2085,13 +2527,15 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil,
     identifier: TokenSyntax,
     _ unexpectedBetweenIdentifierAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
-    genericArgumentClause: GenericArgumentClauseSyntax?
+    genericArgumentClause: GenericArgumentClauseSyntax?,
+    _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
       identifier.raw,
       unexpectedBetweenIdentifierAndGenericArgumentClause?.raw,
       genericArgumentClause?.raw,
+      unexpectedAfterGenericArgumentClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.symbolicReferenceExpr,
       from: layout, arena: .default)
@@ -2182,6 +2626,27 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return SymbolicReferenceExprSyntax(newData)
   }
 
+  public var unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterGenericArgumentClause(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterGenericArgumentClause` replaced.
+  /// - param newChild: The new `unexpectedAfterGenericArgumentClause` to replace the node's
+  ///                   current `unexpectedAfterGenericArgumentClause`, if present.
+  public func withUnexpectedAfterGenericArgumentClause(
+    _ newChild: UnexpectedNodesSyntax?) -> SymbolicReferenceExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return SymbolicReferenceExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2191,6 +2656,8 @@ public struct SymbolicReferenceExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -2205,6 +2672,7 @@ extension SymbolicReferenceExprSyntax: CustomReflectable {
       "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenIdentifierAndGenericArgumentClause": unexpectedBetweenIdentifierAndGenericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "genericArgumentClause": genericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterGenericArgumentClause": unexpectedAfterGenericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2233,13 +2701,15 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeOperatorToken: UnexpectedNodesSyntax? = nil,
     operatorToken: TokenSyntax?,
     _ unexpectedBetweenOperatorTokenAndPostfixExpression: UnexpectedNodesSyntax? = nil,
-    postfixExpression: ExprSyntax
+    postfixExpression: ExprSyntax,
+    _ unexpectedAfterPostfixExpression: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeOperatorToken?.raw,
       operatorToken?.raw,
       unexpectedBetweenOperatorTokenAndPostfixExpression?.raw,
       postfixExpression.raw,
+      unexpectedAfterPostfixExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.prefixOperatorExpr,
       from: layout, arena: .default)
@@ -2330,6 +2800,27 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return PrefixOperatorExprSyntax(newData)
   }
 
+  public var unexpectedAfterPostfixExpression: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterPostfixExpression(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterPostfixExpression` replaced.
+  /// - param newChild: The new `unexpectedAfterPostfixExpression` to replace the node's
+  ///                   current `unexpectedAfterPostfixExpression`, if present.
+  public func withUnexpectedAfterPostfixExpression(
+    _ newChild: UnexpectedNodesSyntax?) -> PrefixOperatorExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return PrefixOperatorExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2339,6 +2830,8 @@ public struct PrefixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -2353,6 +2846,7 @@ extension PrefixOperatorExprSyntax: CustomReflectable {
       "operatorToken": operatorToken.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenOperatorTokenAndPostfixExpression": unexpectedBetweenOperatorTokenAndPostfixExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "postfixExpression": Syntax(postfixExpression).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterPostfixExpression": unexpectedAfterPostfixExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2379,11 +2873,13 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeOperatorToken: UnexpectedNodesSyntax? = nil,
-    operatorToken: TokenSyntax
+    operatorToken: TokenSyntax,
+    _ unexpectedAfterOperatorToken: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeOperatorToken?.raw,
       operatorToken.raw,
+      unexpectedAfterOperatorToken?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.binaryOperatorExpr,
       from: layout, arena: .default)
@@ -2432,11 +2928,34 @@ public struct BinaryOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return BinaryOperatorExprSyntax(newData)
   }
 
+  public var unexpectedAfterOperatorToken: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterOperatorToken(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterOperatorToken` replaced.
+  /// - param newChild: The new `unexpectedAfterOperatorToken` to replace the node's
+  ///                   current `unexpectedAfterOperatorToken`, if present.
+  public func withUnexpectedAfterOperatorToken(
+    _ newChild: UnexpectedNodesSyntax?) -> BinaryOperatorExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return BinaryOperatorExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -2449,6 +2968,7 @@ extension BinaryOperatorExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeOperatorToken": unexpectedBeforeOperatorToken.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "operatorToken": Syntax(operatorToken).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterOperatorToken": unexpectedAfterOperatorToken.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2479,7 +2999,8 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenAsyncKeywordAndThrowsToken: UnexpectedNodesSyntax? = nil,
     throwsToken: TokenSyntax?,
     _ unexpectedBetweenThrowsTokenAndArrowToken: UnexpectedNodesSyntax? = nil,
-    arrowToken: TokenSyntax
+    arrowToken: TokenSyntax,
+    _ unexpectedAfterArrowToken: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAsyncKeyword?.raw,
@@ -2488,6 +3009,7 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       throwsToken?.raw,
       unexpectedBetweenThrowsTokenAndArrowToken?.raw,
       arrowToken.raw,
+      unexpectedAfterArrowToken?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrowExpr,
       from: layout, arena: .default)
@@ -2620,6 +3142,27 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return ArrowExprSyntax(newData)
   }
 
+  public var unexpectedAfterArrowToken: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterArrowToken(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterArrowToken` replaced.
+  /// - param newChild: The new `unexpectedAfterArrowToken` to replace the node's
+  ///                   current `unexpectedAfterArrowToken`, if present.
+  public func withUnexpectedAfterArrowToken(
+    _ newChild: UnexpectedNodesSyntax?) -> ArrowExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return ArrowExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2633,6 +3176,8 @@ public struct ArrowExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -2649,6 +3194,7 @@ extension ArrowExprSyntax: CustomReflectable {
       "throwsToken": throwsToken.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenThrowsTokenAndArrowToken": unexpectedBetweenThrowsTokenAndArrowToken.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "arrowToken": Syntax(arrowToken).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterArrowToken": unexpectedAfterArrowToken.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2679,7 +3225,8 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftOperandAndOperatorOperand: UnexpectedNodesSyntax? = nil,
     operatorOperand: ExprSyntax,
     _ unexpectedBetweenOperatorOperandAndRightOperand: UnexpectedNodesSyntax? = nil,
-    rightOperand: ExprSyntax
+    rightOperand: ExprSyntax,
+    _ unexpectedAfterRightOperand: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftOperand?.raw,
@@ -2688,6 +3235,7 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       operatorOperand.raw,
       unexpectedBetweenOperatorOperandAndRightOperand?.raw,
       rightOperand.raw,
+      unexpectedAfterRightOperand?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.infixOperatorExpr,
       from: layout, arena: .default)
@@ -2818,6 +3366,27 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return InfixOperatorExprSyntax(newData)
   }
 
+  public var unexpectedAfterRightOperand: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightOperand(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightOperand` replaced.
+  /// - param newChild: The new `unexpectedAfterRightOperand` to replace the node's
+  ///                   current `unexpectedAfterRightOperand`, if present.
+  public func withUnexpectedAfterRightOperand(
+    _ newChild: UnexpectedNodesSyntax?) -> InfixOperatorExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return InfixOperatorExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2831,6 +3400,8 @@ public struct InfixOperatorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -2847,6 +3418,7 @@ extension InfixOperatorExprSyntax: CustomReflectable {
       "operatorOperand": Syntax(operatorOperand).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenOperatorOperandAndRightOperand": unexpectedBetweenOperatorOperandAndRightOperand.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightOperand": Syntax(rightOperand).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightOperand": unexpectedAfterRightOperand.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2873,11 +3445,13 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeFloatingDigits: UnexpectedNodesSyntax? = nil,
-    floatingDigits: TokenSyntax
+    floatingDigits: TokenSyntax,
+    _ unexpectedAfterFloatingDigits: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeFloatingDigits?.raw,
       floatingDigits.raw,
+      unexpectedAfterFloatingDigits?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.floatLiteralExpr,
       from: layout, arena: .default)
@@ -2926,11 +3500,34 @@ public struct FloatLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return FloatLiteralExprSyntax(newData)
   }
 
+  public var unexpectedAfterFloatingDigits: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterFloatingDigits(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterFloatingDigits` replaced.
+  /// - param newChild: The new `unexpectedAfterFloatingDigits` to replace the node's
+  ///                   current `unexpectedAfterFloatingDigits`, if present.
+  public func withUnexpectedAfterFloatingDigits(
+    _ newChild: UnexpectedNodesSyntax?) -> FloatLiteralExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return FloatLiteralExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -2943,6 +3540,7 @@ extension FloatLiteralExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeFloatingDigits": unexpectedBeforeFloatingDigits.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "floatingDigits": Syntax(floatingDigits).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterFloatingDigits": unexpectedAfterFloatingDigits.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2973,7 +3571,8 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil,
     elementList: TupleExprElementListSyntax,
     _ unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
@@ -2982,6 +3581,7 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       elementList.raw,
       unexpectedBetweenElementListAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExpr,
       from: layout, arena: .default)
@@ -3130,6 +3730,27 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return TupleExprSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> TupleExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return TupleExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -3143,6 +3764,8 @@ public struct TupleExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -3159,6 +3782,7 @@ extension TupleExprSyntax: CustomReflectable {
       "elementList": Syntax(elementList).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenElementListAndRightParen": unexpectedBetweenElementListAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3189,7 +3813,8 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftSquareAndElements: UnexpectedNodesSyntax? = nil,
     elements: ArrayElementListSyntax,
     _ unexpectedBetweenElementsAndRightSquare: UnexpectedNodesSyntax? = nil,
-    rightSquare: TokenSyntax
+    rightSquare: TokenSyntax,
+    _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftSquare?.raw,
@@ -3198,6 +3823,7 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       elements.raw,
       unexpectedBetweenElementsAndRightSquare?.raw,
       rightSquare.raw,
+      unexpectedAfterRightSquare?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayExpr,
       from: layout, arena: .default)
@@ -3346,6 +3972,27 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return ArrayExprSyntax(newData)
   }
 
+  public var unexpectedAfterRightSquare: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightSquare(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightSquare` replaced.
+  /// - param newChild: The new `unexpectedAfterRightSquare` to replace the node's
+  ///                   current `unexpectedAfterRightSquare`, if present.
+  public func withUnexpectedAfterRightSquare(
+    _ newChild: UnexpectedNodesSyntax?) -> ArrayExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return ArrayExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -3359,6 +4006,8 @@ public struct ArrayExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -3375,6 +4024,7 @@ extension ArrayExprSyntax: CustomReflectable {
       "elements": Syntax(elements).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenElementsAndRightSquare": unexpectedBetweenElementsAndRightSquare.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightSquare": Syntax(rightSquare).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightSquare": unexpectedAfterRightSquare.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3405,7 +4055,8 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftSquareAndContent: UnexpectedNodesSyntax? = nil,
     content: Syntax,
     _ unexpectedBetweenContentAndRightSquare: UnexpectedNodesSyntax? = nil,
-    rightSquare: TokenSyntax
+    rightSquare: TokenSyntax,
+    _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftSquare?.raw,
@@ -3414,6 +4065,7 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       content.raw,
       unexpectedBetweenContentAndRightSquare?.raw,
       rightSquare.raw,
+      unexpectedAfterRightSquare?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryExpr,
       from: layout, arena: .default)
@@ -3544,6 +4196,27 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return DictionaryExprSyntax(newData)
   }
 
+  public var unexpectedAfterRightSquare: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightSquare(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightSquare` replaced.
+  /// - param newChild: The new `unexpectedAfterRightSquare` to replace the node's
+  ///                   current `unexpectedAfterRightSquare`, if present.
+  public func withUnexpectedAfterRightSquare(
+    _ newChild: UnexpectedNodesSyntax?) -> DictionaryExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return DictionaryExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -3557,6 +4230,8 @@ public struct DictionaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -3573,6 +4248,7 @@ extension DictionaryExprSyntax: CustomReflectable {
       "content": Syntax(content).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenContentAndRightSquare": unexpectedBetweenContentAndRightSquare.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightSquare": Syntax(rightSquare).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightSquare": unexpectedAfterRightSquare.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3599,11 +4275,13 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeDigits: UnexpectedNodesSyntax? = nil,
-    digits: TokenSyntax
+    digits: TokenSyntax,
+    _ unexpectedAfterDigits: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDigits?.raw,
       digits.raw,
+      unexpectedAfterDigits?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.integerLiteralExpr,
       from: layout, arena: .default)
@@ -3652,11 +4330,34 @@ public struct IntegerLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return IntegerLiteralExprSyntax(newData)
   }
 
+  public var unexpectedAfterDigits: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterDigits(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterDigits` replaced.
+  /// - param newChild: The new `unexpectedAfterDigits` to replace the node's
+  ///                   current `unexpectedAfterDigits`, if present.
+  public func withUnexpectedAfterDigits(
+    _ newChild: UnexpectedNodesSyntax?) -> IntegerLiteralExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return IntegerLiteralExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -3669,6 +4370,7 @@ extension IntegerLiteralExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeDigits": unexpectedBeforeDigits.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "digits": Syntax(digits).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterDigits": unexpectedAfterDigits.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3695,11 +4397,13 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeBooleanLiteral: UnexpectedNodesSyntax? = nil,
-    booleanLiteral: TokenSyntax
+    booleanLiteral: TokenSyntax,
+    _ unexpectedAfterBooleanLiteral: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBooleanLiteral?.raw,
       booleanLiteral.raw,
+      unexpectedAfterBooleanLiteral?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.booleanLiteralExpr,
       from: layout, arena: .default)
@@ -3748,11 +4452,34 @@ public struct BooleanLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return BooleanLiteralExprSyntax(newData)
   }
 
+  public var unexpectedAfterBooleanLiteral: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterBooleanLiteral(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterBooleanLiteral` replaced.
+  /// - param newChild: The new `unexpectedAfterBooleanLiteral` to replace the node's
+  ///                   current `unexpectedAfterBooleanLiteral`, if present.
+  public func withUnexpectedAfterBooleanLiteral(
+    _ newChild: UnexpectedNodesSyntax?) -> BooleanLiteralExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return BooleanLiteralExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -3765,6 +4492,7 @@ extension BooleanLiteralExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeBooleanLiteral": unexpectedBeforeBooleanLiteral.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "booleanLiteral": Syntax(booleanLiteral).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterBooleanLiteral": unexpectedAfterBooleanLiteral.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3795,7 +4523,8 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenQuestionMarkAndFirstChoice: UnexpectedNodesSyntax? = nil,
     firstChoice: ExprSyntax,
     _ unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? = nil,
-    colonMark: TokenSyntax
+    colonMark: TokenSyntax,
+    _ unexpectedAfterColonMark: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeQuestionMark?.raw,
@@ -3804,6 +4533,7 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       firstChoice.raw,
       unexpectedBetweenFirstChoiceAndColonMark?.raw,
       colonMark.raw,
+      unexpectedAfterColonMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedTernaryExpr,
       from: layout, arena: .default)
@@ -3934,6 +4664,27 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return UnresolvedTernaryExprSyntax(newData)
   }
 
+  public var unexpectedAfterColonMark: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterColonMark(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterColonMark` replaced.
+  /// - param newChild: The new `unexpectedAfterColonMark` to replace the node's
+  ///                   current `unexpectedAfterColonMark`, if present.
+  public func withUnexpectedAfterColonMark(
+    _ newChild: UnexpectedNodesSyntax?) -> UnresolvedTernaryExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return UnresolvedTernaryExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -3947,6 +4698,8 @@ public struct UnresolvedTernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -3963,6 +4716,7 @@ extension UnresolvedTernaryExprSyntax: CustomReflectable {
       "firstChoice": Syntax(firstChoice).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenFirstChoiceAndColonMark": unexpectedBetweenFirstChoiceAndColonMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "colonMark": Syntax(colonMark).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterColonMark": unexpectedAfterColonMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3997,7 +4751,8 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenFirstChoiceAndColonMark: UnexpectedNodesSyntax? = nil,
     colonMark: TokenSyntax,
     _ unexpectedBetweenColonMarkAndSecondChoice: UnexpectedNodesSyntax? = nil,
-    secondChoice: ExprSyntax
+    secondChoice: ExprSyntax,
+    _ unexpectedAfterSecondChoice: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeConditionExpression?.raw,
@@ -4010,6 +4765,7 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       colonMark.raw,
       unexpectedBetweenColonMarkAndSecondChoice?.raw,
       secondChoice.raw,
+      unexpectedAfterSecondChoice?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.ternaryExpr,
       from: layout, arena: .default)
@@ -4222,6 +4978,27 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return TernaryExprSyntax(newData)
   }
 
+  public var unexpectedAfterSecondChoice: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 10, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterSecondChoice(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterSecondChoice` replaced.
+  /// - param newChild: The new `unexpectedAfterSecondChoice` to replace the node's
+  ///                   current `unexpectedAfterSecondChoice`, if present.
+  public func withUnexpectedAfterSecondChoice(
+    _ newChild: UnexpectedNodesSyntax?) -> TernaryExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 10)
+    return TernaryExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -4244,6 +5021,8 @@ public struct TernaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return nil
     case 9:
       return "second choice"
+    case 10:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -4263,6 +5042,7 @@ extension TernaryExprSyntax: CustomReflectable {
       "colonMark": Syntax(colonMark).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenColonMarkAndSecondChoice": unexpectedBetweenColonMarkAndSecondChoice.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "secondChoice": Syntax(secondChoice).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterSecondChoice": unexpectedAfterSecondChoice.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4295,7 +5075,8 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
-    declNameArguments: DeclNameArgumentsSyntax?
+    declNameArguments: DeclNameArgumentsSyntax?,
+    _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBase?.raw,
@@ -4306,6 +5087,7 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       name.raw,
       unexpectedBetweenNameAndDeclNameArguments?.raw,
       declNameArguments?.raw,
+      unexpectedAfterDeclNameArguments?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberAccessExpr,
       from: layout, arena: .default)
@@ -4479,6 +5261,27 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return MemberAccessExprSyntax(newData)
   }
 
+  public var unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterDeclNameArguments(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterDeclNameArguments` replaced.
+  /// - param newChild: The new `unexpectedAfterDeclNameArguments` to replace the node's
+  ///                   current `unexpectedAfterDeclNameArguments`, if present.
+  public func withUnexpectedAfterDeclNameArguments(
+    _ newChild: UnexpectedNodesSyntax?) -> MemberAccessExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return MemberAccessExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -4497,6 +5300,8 @@ public struct MemberAccessExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -4514,6 +5319,7 @@ extension MemberAccessExprSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndDeclNameArguments": unexpectedBetweenNameAndDeclNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "declNameArguments": declNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterDeclNameArguments": unexpectedAfterDeclNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4540,11 +5346,13 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeIsTok: UnexpectedNodesSyntax? = nil,
-    isTok: TokenSyntax
+    isTok: TokenSyntax,
+    _ unexpectedAfterIsTok: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIsTok?.raw,
       isTok.raw,
+      unexpectedAfterIsTok?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedIsExpr,
       from: layout, arena: .default)
@@ -4593,11 +5401,34 @@ public struct UnresolvedIsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return UnresolvedIsExprSyntax(newData)
   }
 
+  public var unexpectedAfterIsTok: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterIsTok(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterIsTok` replaced.
+  /// - param newChild: The new `unexpectedAfterIsTok` to replace the node's
+  ///                   current `unexpectedAfterIsTok`, if present.
+  public func withUnexpectedAfterIsTok(
+    _ newChild: UnexpectedNodesSyntax?) -> UnresolvedIsExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return UnresolvedIsExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -4610,6 +5441,7 @@ extension UnresolvedIsExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeIsTok": unexpectedBeforeIsTok.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "isTok": Syntax(isTok).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterIsTok": unexpectedAfterIsTok.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4640,7 +5472,8 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenExpressionAndIsTok: UnexpectedNodesSyntax? = nil,
     isTok: TokenSyntax,
     _ unexpectedBetweenIsTokAndTypeName: UnexpectedNodesSyntax? = nil,
-    typeName: TypeSyntax
+    typeName: TypeSyntax,
+    _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
@@ -4649,6 +5482,7 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       isTok.raw,
       unexpectedBetweenIsTokAndTypeName?.raw,
       typeName.raw,
+      unexpectedAfterTypeName?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.isExpr,
       from: layout, arena: .default)
@@ -4779,6 +5613,27 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return IsExprSyntax(newData)
   }
 
+  public var unexpectedAfterTypeName: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTypeName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTypeName` replaced.
+  /// - param newChild: The new `unexpectedAfterTypeName` to replace the node's
+  ///                   current `unexpectedAfterTypeName`, if present.
+  public func withUnexpectedAfterTypeName(
+    _ newChild: UnexpectedNodesSyntax?) -> IsExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return IsExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -4792,6 +5647,8 @@ public struct IsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -4808,6 +5665,7 @@ extension IsExprSyntax: CustomReflectable {
       "isTok": Syntax(isTok).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenIsTokAndTypeName": unexpectedBetweenIsTokAndTypeName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "typeName": Syntax(typeName).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterTypeName": unexpectedAfterTypeName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4836,13 +5694,15 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeAsTok: UnexpectedNodesSyntax? = nil,
     asTok: TokenSyntax,
     _ unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil,
-    questionOrExclamationMark: TokenSyntax?
+    questionOrExclamationMark: TokenSyntax?,
+    _ unexpectedAfterQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAsTok?.raw,
       asTok.raw,
       unexpectedBetweenAsTokAndQuestionOrExclamationMark?.raw,
       questionOrExclamationMark?.raw,
+      unexpectedAfterQuestionOrExclamationMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedAsExpr,
       from: layout, arena: .default)
@@ -4933,6 +5793,27 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return UnresolvedAsExprSyntax(newData)
   }
 
+  public var unexpectedAfterQuestionOrExclamationMark: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterQuestionOrExclamationMark(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterQuestionOrExclamationMark` replaced.
+  /// - param newChild: The new `unexpectedAfterQuestionOrExclamationMark` to replace the node's
+  ///                   current `unexpectedAfterQuestionOrExclamationMark`, if present.
+  public func withUnexpectedAfterQuestionOrExclamationMark(
+    _ newChild: UnexpectedNodesSyntax?) -> UnresolvedAsExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return UnresolvedAsExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -4942,6 +5823,8 @@ public struct UnresolvedAsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -4956,6 +5839,7 @@ extension UnresolvedAsExprSyntax: CustomReflectable {
       "asTok": Syntax(asTok).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenAsTokAndQuestionOrExclamationMark": unexpectedBetweenAsTokAndQuestionOrExclamationMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "questionOrExclamationMark": questionOrExclamationMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterQuestionOrExclamationMark": unexpectedAfterQuestionOrExclamationMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4988,7 +5872,8 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenAsTokAndQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil,
     questionOrExclamationMark: TokenSyntax?,
     _ unexpectedBetweenQuestionOrExclamationMarkAndTypeName: UnexpectedNodesSyntax? = nil,
-    typeName: TypeSyntax
+    typeName: TypeSyntax,
+    _ unexpectedAfterTypeName: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
@@ -4999,6 +5884,7 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       questionOrExclamationMark?.raw,
       unexpectedBetweenQuestionOrExclamationMarkAndTypeName?.raw,
       typeName.raw,
+      unexpectedAfterTypeName?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.asExpr,
       from: layout, arena: .default)
@@ -5171,6 +6057,27 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return AsExprSyntax(newData)
   }
 
+  public var unexpectedAfterTypeName: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTypeName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTypeName` replaced.
+  /// - param newChild: The new `unexpectedAfterTypeName` to replace the node's
+  ///                   current `unexpectedAfterTypeName`, if present.
+  public func withUnexpectedAfterTypeName(
+    _ newChild: UnexpectedNodesSyntax?) -> AsExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return AsExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -5189,6 +6096,8 @@ public struct AsExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -5206,6 +6115,7 @@ extension AsExprSyntax: CustomReflectable {
       "questionOrExclamationMark": questionOrExclamationMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenQuestionOrExclamationMarkAndTypeName": unexpectedBetweenQuestionOrExclamationMarkAndTypeName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "typeName": Syntax(typeName).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterTypeName": unexpectedAfterTypeName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5232,11 +6142,13 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeType: UnexpectedNodesSyntax? = nil,
-    type: TypeSyntax
+    type: TypeSyntax,
+    _ unexpectedAfterType: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeType?.raw,
       type.raw,
+      unexpectedAfterType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeExpr,
       from: layout, arena: .default)
@@ -5285,11 +6197,34 @@ public struct TypeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return TypeExprSyntax(newData)
   }
 
+  public var unexpectedAfterType: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterType(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterType` replaced.
+  /// - param newChild: The new `unexpectedAfterType` to replace the node's
+  ///                   current `unexpectedAfterType`, if present.
+  public func withUnexpectedAfterType(
+    _ newChild: UnexpectedNodesSyntax?) -> TypeExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return TypeExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -5302,6 +6237,7 @@ extension TypeExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeType": unexpectedBeforeType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "type": Syntax(type).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterType": unexpectedAfterType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5334,7 +6270,8 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenSignatureAndStatements: UnexpectedNodesSyntax? = nil,
     statements: CodeBlockItemListSyntax,
     _ unexpectedBetweenStatementsAndRightBrace: UnexpectedNodesSyntax? = nil,
-    rightBrace: TokenSyntax
+    rightBrace: TokenSyntax,
+    _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftBrace?.raw,
@@ -5345,6 +6282,7 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       statements.raw,
       unexpectedBetweenStatementsAndRightBrace?.raw,
       rightBrace.raw,
+      unexpectedAfterRightBrace?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureExpr,
       from: layout, arena: .default)
@@ -5535,6 +6473,27 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return ClosureExprSyntax(newData)
   }
 
+  public var unexpectedAfterRightBrace: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightBrace(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
+  /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
+  ///                   current `unexpectedAfterRightBrace`, if present.
+  public func withUnexpectedAfterRightBrace(
+    _ newChild: UnexpectedNodesSyntax?) -> ClosureExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return ClosureExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -5553,6 +6512,8 @@ public struct ClosureExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -5570,6 +6531,7 @@ extension ClosureExprSyntax: CustomReflectable {
       "statements": Syntax(statements).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenStatementsAndRightBrace": unexpectedBetweenStatementsAndRightBrace.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightBrace": Syntax(rightBrace).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightBrace": unexpectedAfterRightBrace.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5596,11 +6558,13 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforePattern: UnexpectedNodesSyntax? = nil,
-    pattern: PatternSyntax
+    pattern: PatternSyntax,
+    _ unexpectedAfterPattern: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePattern?.raw,
       pattern.raw,
+      unexpectedAfterPattern?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.unresolvedPatternExpr,
       from: layout, arena: .default)
@@ -5649,11 +6613,34 @@ public struct UnresolvedPatternExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return UnresolvedPatternExprSyntax(newData)
   }
 
+  public var unexpectedAfterPattern: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterPattern(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterPattern` replaced.
+  /// - param newChild: The new `unexpectedAfterPattern` to replace the node's
+  ///                   current `unexpectedAfterPattern`, if present.
+  public func withUnexpectedAfterPattern(
+    _ newChild: UnexpectedNodesSyntax?) -> UnresolvedPatternExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return UnresolvedPatternExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -5666,6 +6653,7 @@ extension UnresolvedPatternExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforePattern": unexpectedBeforePattern.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "pattern": Syntax(pattern).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterPattern": unexpectedAfterPattern.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5702,7 +6690,8 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenRightParenAndTrailingClosure: UnexpectedNodesSyntax? = nil,
     trailingClosure: ClosureExprSyntax?,
     _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil,
-    additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?
+    additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?,
+    _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeCalledExpression?.raw,
@@ -5717,6 +6706,7 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       trailingClosure?.raw,
       unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.raw,
       additionalTrailingClosures?.raw,
+      unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionCallExpr,
       from: layout, arena: .default)
@@ -6010,6 +7000,27 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return FunctionCallExprSyntax(newData)
   }
 
+  public var unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 12, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterAdditionalTrailingClosures(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterAdditionalTrailingClosures` replaced.
+  /// - param newChild: The new `unexpectedAfterAdditionalTrailingClosures` to replace the node's
+  ///                   current `unexpectedAfterAdditionalTrailingClosures`, if present.
+  public func withUnexpectedAfterAdditionalTrailingClosures(
+    _ newChild: UnexpectedNodesSyntax?) -> FunctionCallExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 12)
+    return FunctionCallExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -6036,6 +7047,8 @@ public struct FunctionCallExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return nil
     case 11:
       return "trailing closures"
+    case 12:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -6057,6 +7070,7 @@ extension FunctionCallExprSyntax: CustomReflectable {
       "trailingClosure": trailingClosure.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures": unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "additionalTrailingClosures": additionalTrailingClosures.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterAdditionalTrailingClosures": unexpectedAfterAdditionalTrailingClosures.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6093,7 +7107,8 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenRightBracketAndTrailingClosure: UnexpectedNodesSyntax? = nil,
     trailingClosure: ClosureExprSyntax?,
     _ unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil,
-    additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?
+    additionalTrailingClosures: MultipleTrailingClosureElementListSyntax?,
+    _ unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeCalledExpression?.raw,
@@ -6108,6 +7123,7 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       trailingClosure?.raw,
       unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures?.raw,
       additionalTrailingClosures?.raw,
+      unexpectedAfterAdditionalTrailingClosures?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.subscriptExpr,
       from: layout, arena: .default)
@@ -6399,6 +7415,27 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return SubscriptExprSyntax(newData)
   }
 
+  public var unexpectedAfterAdditionalTrailingClosures: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 12, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterAdditionalTrailingClosures(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterAdditionalTrailingClosures` replaced.
+  /// - param newChild: The new `unexpectedAfterAdditionalTrailingClosures` to replace the node's
+  ///                   current `unexpectedAfterAdditionalTrailingClosures`, if present.
+  public func withUnexpectedAfterAdditionalTrailingClosures(
+    _ newChild: UnexpectedNodesSyntax?) -> SubscriptExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 12)
+    return SubscriptExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -6425,6 +7462,8 @@ public struct SubscriptExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return nil
     case 11:
       return "trailing closures"
+    case 12:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -6446,6 +7485,7 @@ extension SubscriptExprSyntax: CustomReflectable {
       "trailingClosure": trailingClosure.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures": unexpectedBetweenTrailingClosureAndAdditionalTrailingClosures.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "additionalTrailingClosures": additionalTrailingClosures.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterAdditionalTrailingClosures": unexpectedAfterAdditionalTrailingClosures.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6474,13 +7514,15 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
     expression: ExprSyntax,
     _ unexpectedBetweenExpressionAndQuestionMark: UnexpectedNodesSyntax? = nil,
-    questionMark: TokenSyntax
+    questionMark: TokenSyntax,
+    _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
       unexpectedBetweenExpressionAndQuestionMark?.raw,
       questionMark.raw,
+      unexpectedAfterQuestionMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalChainingExpr,
       from: layout, arena: .default)
@@ -6570,6 +7612,27 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return OptionalChainingExprSyntax(newData)
   }
 
+  public var unexpectedAfterQuestionMark: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterQuestionMark(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterQuestionMark` replaced.
+  /// - param newChild: The new `unexpectedAfterQuestionMark` to replace the node's
+  ///                   current `unexpectedAfterQuestionMark`, if present.
+  public func withUnexpectedAfterQuestionMark(
+    _ newChild: UnexpectedNodesSyntax?) -> OptionalChainingExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return OptionalChainingExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -6579,6 +7642,8 @@ public struct OptionalChainingExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -6593,6 +7658,7 @@ extension OptionalChainingExprSyntax: CustomReflectable {
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenExpressionAndQuestionMark": unexpectedBetweenExpressionAndQuestionMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "questionMark": Syntax(questionMark).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterQuestionMark": unexpectedAfterQuestionMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6621,13 +7687,15 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
     expression: ExprSyntax,
     _ unexpectedBetweenExpressionAndExclamationMark: UnexpectedNodesSyntax? = nil,
-    exclamationMark: TokenSyntax
+    exclamationMark: TokenSyntax,
+    _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
       unexpectedBetweenExpressionAndExclamationMark?.raw,
       exclamationMark.raw,
+      unexpectedAfterExclamationMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.forcedValueExpr,
       from: layout, arena: .default)
@@ -6717,6 +7785,27 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return ForcedValueExprSyntax(newData)
   }
 
+  public var unexpectedAfterExclamationMark: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterExclamationMark(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterExclamationMark` replaced.
+  /// - param newChild: The new `unexpectedAfterExclamationMark` to replace the node's
+  ///                   current `unexpectedAfterExclamationMark`, if present.
+  public func withUnexpectedAfterExclamationMark(
+    _ newChild: UnexpectedNodesSyntax?) -> ForcedValueExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return ForcedValueExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -6726,6 +7815,8 @@ public struct ForcedValueExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -6740,6 +7831,7 @@ extension ForcedValueExprSyntax: CustomReflectable {
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenExpressionAndExclamationMark": unexpectedBetweenExpressionAndExclamationMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "exclamationMark": Syntax(exclamationMark).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterExclamationMark": unexpectedAfterExclamationMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6768,13 +7860,15 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
     expression: ExprSyntax,
     _ unexpectedBetweenExpressionAndOperatorToken: UnexpectedNodesSyntax? = nil,
-    operatorToken: TokenSyntax
+    operatorToken: TokenSyntax,
+    _ unexpectedAfterOperatorToken: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
       unexpectedBetweenExpressionAndOperatorToken?.raw,
       operatorToken.raw,
+      unexpectedAfterOperatorToken?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.postfixUnaryExpr,
       from: layout, arena: .default)
@@ -6864,6 +7958,27 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return PostfixUnaryExprSyntax(newData)
   }
 
+  public var unexpectedAfterOperatorToken: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterOperatorToken(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterOperatorToken` replaced.
+  /// - param newChild: The new `unexpectedAfterOperatorToken` to replace the node's
+  ///                   current `unexpectedAfterOperatorToken`, if present.
+  public func withUnexpectedAfterOperatorToken(
+    _ newChild: UnexpectedNodesSyntax?) -> PostfixUnaryExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return PostfixUnaryExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -6873,6 +7988,8 @@ public struct PostfixUnaryExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -6887,6 +8004,7 @@ extension PostfixUnaryExprSyntax: CustomReflectable {
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenExpressionAndOperatorToken": unexpectedBetweenExpressionAndOperatorToken.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "operatorToken": Syntax(operatorToken).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterOperatorToken": unexpectedAfterOperatorToken.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6915,13 +8033,15 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
     expression: ExprSyntax,
     _ unexpectedBetweenExpressionAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
-    genericArgumentClause: GenericArgumentClauseSyntax
+    genericArgumentClause: GenericArgumentClauseSyntax,
+    _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
       unexpectedBetweenExpressionAndGenericArgumentClause?.raw,
       genericArgumentClause.raw,
+      unexpectedAfterGenericArgumentClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.specializeExpr,
       from: layout, arena: .default)
@@ -7011,6 +8131,27 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return SpecializeExprSyntax(newData)
   }
 
+  public var unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterGenericArgumentClause(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterGenericArgumentClause` replaced.
+  /// - param newChild: The new `unexpectedAfterGenericArgumentClause` to replace the node's
+  ///                   current `unexpectedAfterGenericArgumentClause`, if present.
+  public func withUnexpectedAfterGenericArgumentClause(
+    _ newChild: UnexpectedNodesSyntax?) -> SpecializeExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return SpecializeExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -7020,6 +8161,8 @@ public struct SpecializeExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -7034,6 +8177,7 @@ extension SpecializeExprSyntax: CustomReflectable {
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenExpressionAndGenericArgumentClause": unexpectedBetweenExpressionAndGenericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "genericArgumentClause": Syntax(genericArgumentClause).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterGenericArgumentClause": unexpectedAfterGenericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7068,7 +8212,8 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenSegmentsAndCloseQuote: UnexpectedNodesSyntax? = nil,
     closeQuote: TokenSyntax,
     _ unexpectedBetweenCloseQuoteAndCloseDelimiter: UnexpectedNodesSyntax? = nil,
-    closeDelimiter: TokenSyntax?
+    closeDelimiter: TokenSyntax?,
+    _ unexpectedAfterCloseDelimiter: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeOpenDelimiter?.raw,
@@ -7081,6 +8226,7 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       closeQuote.raw,
       unexpectedBetweenCloseQuoteAndCloseDelimiter?.raw,
       closeDelimiter?.raw,
+      unexpectedAfterCloseDelimiter?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringLiteralExpr,
       from: layout, arena: .default)
@@ -7313,6 +8459,27 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return StringLiteralExprSyntax(newData)
   }
 
+  public var unexpectedAfterCloseDelimiter: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 10, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterCloseDelimiter(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterCloseDelimiter` replaced.
+  /// - param newChild: The new `unexpectedAfterCloseDelimiter` to replace the node's
+  ///                   current `unexpectedAfterCloseDelimiter`, if present.
+  public func withUnexpectedAfterCloseDelimiter(
+    _ newChild: UnexpectedNodesSyntax?) -> StringLiteralExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 10)
+    return StringLiteralExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -7335,6 +8502,8 @@ public struct StringLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return nil
     case 9:
       return nil
+    case 10:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -7354,6 +8523,7 @@ extension StringLiteralExprSyntax: CustomReflectable {
       "closeQuote": Syntax(closeQuote).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenCloseQuoteAndCloseDelimiter": unexpectedBetweenCloseQuoteAndCloseDelimiter.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "closeDelimiter": closeDelimiter.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterCloseDelimiter": unexpectedAfterCloseDelimiter.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7380,11 +8550,13 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeRegex: UnexpectedNodesSyntax? = nil,
-    regex: TokenSyntax
+    regex: TokenSyntax,
+    _ unexpectedAfterRegex: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeRegex?.raw,
       regex.raw,
+      unexpectedAfterRegex?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.regexLiteralExpr,
       from: layout, arena: .default)
@@ -7433,11 +8605,34 @@ public struct RegexLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return RegexLiteralExprSyntax(newData)
   }
 
+  public var unexpectedAfterRegex: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRegex(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRegex` replaced.
+  /// - param newChild: The new `unexpectedAfterRegex` to replace the node's
+  ///                   current `unexpectedAfterRegex`, if present.
+  public func withUnexpectedAfterRegex(
+    _ newChild: UnexpectedNodesSyntax?) -> RegexLiteralExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return RegexLiteralExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -7450,6 +8645,7 @@ extension RegexLiteralExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeRegex": unexpectedBeforeRegex.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "regex": Syntax(regex).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRegex": unexpectedAfterRegex.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7480,7 +8676,8 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenBackslashAndRoot: UnexpectedNodesSyntax? = nil,
     root: TypeSyntax?,
     _ unexpectedBetweenRootAndComponents: UnexpectedNodesSyntax? = nil,
-    components: KeyPathComponentListSyntax
+    components: KeyPathComponentListSyntax,
+    _ unexpectedAfterComponents: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBackslash?.raw,
@@ -7489,6 +8686,7 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       root?.raw,
       unexpectedBetweenRootAndComponents?.raw,
       components.raw,
+      unexpectedAfterComponents?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathExpr,
       from: layout, arena: .default)
@@ -7638,6 +8836,27 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return KeyPathExprSyntax(newData)
   }
 
+  public var unexpectedAfterComponents: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterComponents(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterComponents` replaced.
+  /// - param newChild: The new `unexpectedAfterComponents` to replace the node's
+  ///                   current `unexpectedAfterComponents`, if present.
+  public func withUnexpectedAfterComponents(
+    _ newChild: UnexpectedNodesSyntax?) -> KeyPathExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return KeyPathExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -7651,6 +8870,8 @@ public struct KeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -7667,6 +8888,7 @@ extension KeyPathExprSyntax: CustomReflectable {
       "root": root.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenRootAndComponents": unexpectedBetweenRootAndComponents.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "components": Syntax(components).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterComponents": unexpectedAfterComponents.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7697,7 +8919,8 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenBackslashAndRootExpr: UnexpectedNodesSyntax? = nil,
     rootExpr: ExprSyntax?,
     _ unexpectedBetweenRootExprAndExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax
+    expression: ExprSyntax,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBackslash?.raw,
@@ -7706,6 +8929,7 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       rootExpr?.raw,
       unexpectedBetweenRootExprAndExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.oldKeyPathExpr,
       from: layout, arena: .default)
@@ -7837,6 +9061,27 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return OldKeyPathExprSyntax(newData)
   }
 
+  public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterExpression(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
+  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
+  ///                   current `unexpectedAfterExpression`, if present.
+  public func withUnexpectedAfterExpression(
+    _ newChild: UnexpectedNodesSyntax?) -> OldKeyPathExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return OldKeyPathExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -7851,6 +9096,8 @@ public struct OldKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return nil
     case 5:
       return "expression"
+    case 6:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -7866,6 +9113,7 @@ extension OldKeyPathExprSyntax: CustomReflectable {
       "rootExpr": rootExpr.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenRootExprAndExpression": unexpectedBetweenRootExprAndExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterExpression": unexpectedAfterExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7892,11 +9140,13 @@ public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforePeriod: UnexpectedNodesSyntax? = nil,
-    period: TokenSyntax
+    period: TokenSyntax,
+    _ unexpectedAfterPeriod: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePeriod?.raw,
       period.raw,
+      unexpectedAfterPeriod?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathBaseExpr,
       from: layout, arena: .default)
@@ -7945,11 +9195,34 @@ public struct KeyPathBaseExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return KeyPathBaseExprSyntax(newData)
   }
 
+  public var unexpectedAfterPeriod: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterPeriod(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterPeriod` replaced.
+  /// - param newChild: The new `unexpectedAfterPeriod` to replace the node's
+  ///                   current `unexpectedAfterPeriod`, if present.
+  public func withUnexpectedAfterPeriod(
+    _ newChild: UnexpectedNodesSyntax?) -> KeyPathBaseExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return KeyPathBaseExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -7962,6 +9235,7 @@ extension KeyPathBaseExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforePeriod": unexpectedBeforePeriod.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "period": Syntax(period).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterPeriod": unexpectedAfterPeriod.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7994,7 +9268,8 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndName: UnexpectedNodesSyntax? = nil,
     name: ObjcNameSyntax,
     _ unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeKeyPath?.raw,
@@ -8005,6 +9280,7 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       name.raw,
       unexpectedBetweenNameAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcKeyPathExpr,
       from: layout, arena: .default)
@@ -8194,6 +9470,27 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return ObjcKeyPathExprSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> ObjcKeyPathExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return ObjcKeyPathExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -8212,6 +9509,8 @@ public struct ObjcKeyPathExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -8229,6 +9528,7 @@ extension ObjcKeyPathExprSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndRightParen": unexpectedBetweenNameAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -8265,7 +9565,8 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenColonAndName: UnexpectedNodesSyntax? = nil,
     name: ExprSyntax,
     _ unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundSelector?.raw,
@@ -8280,6 +9581,7 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       name.raw,
       unexpectedBetweenNameAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcSelectorExpr,
       from: layout, arena: .default)
@@ -8535,6 +9837,27 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return ObjcSelectorExprSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 12, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> ObjcSelectorExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 12)
+    return ObjcSelectorExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -8561,6 +9884,8 @@ public struct ObjcSelectorExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return nil
     case 11:
       return nil
+    case 12:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -8582,6 +9907,7 @@ extension ObjcSelectorExprSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndRightParen": unexpectedBetweenNameAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -8610,13 +9936,15 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeBase: UnexpectedNodesSyntax? = nil,
     base: ExprSyntax?,
     _ unexpectedBetweenBaseAndConfig: UnexpectedNodesSyntax? = nil,
-    config: IfConfigDeclSyntax
+    config: IfConfigDeclSyntax,
+    _ unexpectedAfterConfig: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBase?.raw,
       base?.raw,
       unexpectedBetweenBaseAndConfig?.raw,
       config.raw,
+      unexpectedAfterConfig?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.postfixIfConfigExpr,
       from: layout, arena: .default)
@@ -8707,6 +10035,27 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return PostfixIfConfigExprSyntax(newData)
   }
 
+  public var unexpectedAfterConfig: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterConfig(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterConfig` replaced.
+  /// - param newChild: The new `unexpectedAfterConfig` to replace the node's
+  ///                   current `unexpectedAfterConfig`, if present.
+  public func withUnexpectedAfterConfig(
+    _ newChild: UnexpectedNodesSyntax?) -> PostfixIfConfigExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return PostfixIfConfigExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -8716,6 +10065,8 @@ public struct PostfixIfConfigExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -8730,6 +10081,7 @@ extension PostfixIfConfigExprSyntax: CustomReflectable {
       "base": base.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenBaseAndConfig": unexpectedBetweenBaseAndConfig.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "config": Syntax(config).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterConfig": unexpectedAfterConfig.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -8756,11 +10108,13 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil,
-    identifier: TokenSyntax
+    identifier: TokenSyntax,
+    _ unexpectedAfterIdentifier: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
       identifier.raw,
+      unexpectedAfterIdentifier?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.editorPlaceholderExpr,
       from: layout, arena: .default)
@@ -8809,11 +10163,34 @@ public struct EditorPlaceholderExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return EditorPlaceholderExprSyntax(newData)
   }
 
+  public var unexpectedAfterIdentifier: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterIdentifier(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterIdentifier` replaced.
+  /// - param newChild: The new `unexpectedAfterIdentifier` to replace the node's
+  ///                   current `unexpectedAfterIdentifier`, if present.
+  public func withUnexpectedAfterIdentifier(
+    _ newChild: UnexpectedNodesSyntax?) -> EditorPlaceholderExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return EditorPlaceholderExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -8826,6 +10203,7 @@ extension EditorPlaceholderExprSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeIdentifier": unexpectedBeforeIdentifier.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterIdentifier": unexpectedAfterIdentifier.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -8858,7 +10236,8 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil,
     arguments: TupleExprElementListSyntax,
     _ unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
@@ -8869,6 +10248,7 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       arguments.raw,
       unexpectedBetweenArgumentsAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.objectLiteralExpr,
       from: layout, arena: .default)
@@ -9058,6 +10438,27 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
     return ObjectLiteralExprSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> ObjectLiteralExprSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return ObjectLiteralExprSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -9076,6 +10477,8 @@ public struct ObjectLiteralExprSyntax: ExprSyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -9093,6 +10496,7 @@ extension ObjectLiteralExprSyntax: CustomReflectable {
       "arguments": Syntax(arguments).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenArgumentsAndRightParen": unexpectedBetweenArgumentsAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -88,7 +88,8 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenItemAndSemicolon: UnexpectedNodesSyntax? = nil,
     semicolon: TokenSyntax?,
     _ unexpectedBetweenSemicolonAndErrorTokens: UnexpectedNodesSyntax? = nil,
-    errorTokens: Syntax?
+    errorTokens: Syntax?,
+    _ unexpectedAfterErrorTokens: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeItem?.raw,
@@ -97,6 +98,7 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
       semicolon?.raw,
       unexpectedBetweenSemicolonAndErrorTokens?.raw,
       errorTokens?.raw,
+      unexpectedAfterErrorTokens?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlockItem,
       from: layout, arena: .default)
@@ -233,6 +235,27 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
     return CodeBlockItemSyntax(newData)
   }
 
+  public var unexpectedAfterErrorTokens: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterErrorTokens(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterErrorTokens` replaced.
+  /// - param newChild: The new `unexpectedAfterErrorTokens` to replace the node's
+  ///                   current `unexpectedAfterErrorTokens`, if present.
+  public func withUnexpectedAfterErrorTokens(
+    _ newChild: UnexpectedNodesSyntax?) -> CodeBlockItemSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return CodeBlockItemSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -246,6 +269,8 @@ public struct CodeBlockItemSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -262,6 +287,7 @@ extension CodeBlockItemSyntax: CustomReflectable {
       "semicolon": semicolon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenSemicolonAndErrorTokens": unexpectedBetweenSemicolonAndErrorTokens.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "errorTokens": errorTokens.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterErrorTokens": unexpectedAfterErrorTokens.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -292,7 +318,8 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftBraceAndStatements: UnexpectedNodesSyntax? = nil,
     statements: CodeBlockItemListSyntax,
     _ unexpectedBetweenStatementsAndRightBrace: UnexpectedNodesSyntax? = nil,
-    rightBrace: TokenSyntax
+    rightBrace: TokenSyntax,
+    _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftBrace?.raw,
@@ -301,6 +328,7 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
       statements.raw,
       unexpectedBetweenStatementsAndRightBrace?.raw,
       rightBrace.raw,
+      unexpectedAfterRightBrace?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.codeBlock,
       from: layout, arena: .default)
@@ -449,6 +477,27 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
     return CodeBlockSyntax(newData)
   }
 
+  public var unexpectedAfterRightBrace: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightBrace(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
+  /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
+  ///                   current `unexpectedAfterRightBrace`, if present.
+  public func withUnexpectedAfterRightBrace(
+    _ newChild: UnexpectedNodesSyntax?) -> CodeBlockSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return CodeBlockSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -462,6 +511,8 @@ public struct CodeBlockSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -478,6 +529,7 @@ extension CodeBlockSyntax: CustomReflectable {
       "statements": Syntax(statements).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenStatementsAndRightBrace": unexpectedBetweenStatementsAndRightBrace.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightBrace": Syntax(rightBrace).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightBrace": unexpectedAfterRightBrace.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -506,13 +558,15 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? = nil,
-    colon: TokenSyntax
+    colon: TokenSyntax,
+    _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndColon?.raw,
       colon.raw,
+      unexpectedAfterColon?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArgument,
       from: layout, arena: .default)
@@ -602,6 +656,27 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     return DeclNameArgumentSyntax(newData)
   }
 
+  public var unexpectedAfterColon: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterColon(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterColon` replaced.
+  /// - param newChild: The new `unexpectedAfterColon` to replace the node's
+  ///                   current `unexpectedAfterColon`, if present.
+  public func withUnexpectedAfterColon(
+    _ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return DeclNameArgumentSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -611,6 +686,8 @@ public struct DeclNameArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -625,6 +702,7 @@ extension DeclNameArgumentSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndColon": unexpectedBetweenNameAndColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterColon": unexpectedAfterColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -655,7 +733,8 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndArguments: UnexpectedNodesSyntax? = nil,
     arguments: DeclNameArgumentListSyntax,
     _ unexpectedBetweenArgumentsAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
@@ -664,6 +743,7 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
       arguments.raw,
       unexpectedBetweenArgumentsAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.declNameArguments,
       from: layout, arena: .default)
@@ -812,6 +892,27 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
     return DeclNameArgumentsSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> DeclNameArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return DeclNameArgumentsSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -825,6 +926,8 @@ public struct DeclNameArgumentsSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -841,6 +944,7 @@ extension DeclNameArgumentsSyntax: CustomReflectable {
       "arguments": Syntax(arguments).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenArgumentsAndRightParen": unexpectedBetweenArgumentsAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -873,7 +977,8 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenColonAndExpression: UnexpectedNodesSyntax? = nil,
     expression: ExprSyntax,
     _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabel?.raw,
@@ -884,6 +989,7 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
       expression.raw,
       unexpectedBetweenExpressionAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleExprElement,
       from: layout, arena: .default)
@@ -1058,6 +1164,27 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
     return TupleExprElementSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> TupleExprElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return TupleExprElementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1076,6 +1203,8 @@ public struct TupleExprElementSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -1093,6 +1222,7 @@ extension TupleExprElementSyntax: CustomReflectable {
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenExpressionAndTrailingComma": unexpectedBetweenExpressionAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1121,13 +1251,15 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
     expression: ExprSyntax,
     _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
       unexpectedBetweenExpressionAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayElement,
       from: layout, arena: .default)
@@ -1218,6 +1350,27 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
     return ArrayElementSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> ArrayElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return ArrayElementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1227,6 +1380,8 @@ public struct ArrayElementSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -1241,6 +1396,7 @@ extension ArrayElementSyntax: CustomReflectable {
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenExpressionAndTrailingComma": unexpectedBetweenExpressionAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1273,7 +1429,8 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenColonAndValueExpression: UnexpectedNodesSyntax? = nil,
     valueExpression: ExprSyntax,
     _ unexpectedBetweenValueExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeKeyExpression?.raw,
@@ -1284,6 +1441,7 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
       valueExpression.raw,
       unexpectedBetweenValueExpressionAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryElement,
       from: layout, arena: .default)
@@ -1456,6 +1614,27 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
     return DictionaryElementSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> DictionaryElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return DictionaryElementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1474,6 +1653,8 @@ public struct DictionaryElementSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -1491,6 +1672,7 @@ extension DictionaryElementSyntax: CustomReflectable {
       "valueExpression": Syntax(valueExpression).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenValueExpressionAndTrailingComma": unexpectedBetweenValueExpressionAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1525,7 +1707,8 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenAssignTokenAndExpression: UnexpectedNodesSyntax? = nil,
     expression: ExprSyntax,
     _ unexpectedBetweenExpressionAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSpecifier?.raw,
@@ -1538,6 +1721,7 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       expression.raw,
       unexpectedBetweenExpressionAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureItem,
       from: layout, arena: .default)
@@ -1772,6 +1956,27 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
     return ClosureCaptureItemSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 10, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureItemSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 10)
+    return ClosureCaptureItemSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1794,6 +1999,8 @@ public struct ClosureCaptureItemSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 9:
       return nil
+    case 10:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -1813,6 +2020,7 @@ extension ClosureCaptureItemSyntax: CustomReflectable {
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenExpressionAndTrailingComma": unexpectedBetweenExpressionAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1843,7 +2051,8 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftSquareAndItems: UnexpectedNodesSyntax? = nil,
     items: ClosureCaptureItemListSyntax?,
     _ unexpectedBetweenItemsAndRightSquare: UnexpectedNodesSyntax? = nil,
-    rightSquare: TokenSyntax
+    rightSquare: TokenSyntax,
+    _ unexpectedAfterRightSquare: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftSquare?.raw,
@@ -1852,6 +2061,7 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       items?.raw,
       unexpectedBetweenItemsAndRightSquare?.raw,
       rightSquare.raw,
+      unexpectedAfterRightSquare?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureCaptureSignature,
       from: layout, arena: .default)
@@ -2001,6 +2211,27 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     return ClosureCaptureSignatureSyntax(newData)
   }
 
+  public var unexpectedAfterRightSquare: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightSquare(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightSquare` replaced.
+  /// - param newChild: The new `unexpectedAfterRightSquare` to replace the node's
+  ///                   current `unexpectedAfterRightSquare`, if present.
+  public func withUnexpectedAfterRightSquare(
+    _ newChild: UnexpectedNodesSyntax?) -> ClosureCaptureSignatureSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return ClosureCaptureSignatureSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2014,6 +2245,8 @@ public struct ClosureCaptureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -2030,6 +2263,7 @@ extension ClosureCaptureSignatureSyntax: CustomReflectable {
       "items": items.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenItemsAndRightSquare": unexpectedBetweenItemsAndRightSquare.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightSquare": Syntax(rightSquare).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightSquare": unexpectedAfterRightSquare.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2058,13 +2292,15 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureParam,
       from: layout, arena: .default)
@@ -2155,6 +2391,27 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
     return ClosureParamSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> ClosureParamSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return ClosureParamSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2164,6 +2421,8 @@ public struct ClosureParamSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -2178,6 +2437,7 @@ extension ClosureParamSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndTrailingComma": unexpectedBetweenNameAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2216,7 +2476,8 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenThrowsTokAndOutput: UnexpectedNodesSyntax? = nil,
     output: ReturnClauseSyntax?,
     _ unexpectedBetweenOutputAndInTok: UnexpectedNodesSyntax? = nil,
-    inTok: TokenSyntax
+    inTok: TokenSyntax,
+    _ unexpectedAfterInTok: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -2233,6 +2494,7 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       output?.raw,
       unexpectedBetweenOutputAndInTok?.raw,
       inTok.raw,
+      unexpectedAfterInTok?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.closureSignature,
       from: layout, arena: .default)
@@ -2551,6 +2813,27 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     return ClosureSignatureSyntax(newData)
   }
 
+  public var unexpectedAfterInTok: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 14, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterInTok(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterInTok` replaced.
+  /// - param newChild: The new `unexpectedAfterInTok` to replace the node's
+  ///                   current `unexpectedAfterInTok`, if present.
+  public func withUnexpectedAfterInTok(
+    _ newChild: UnexpectedNodesSyntax?) -> ClosureSignatureSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 14)
+    return ClosureSignatureSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2581,6 +2864,8 @@ public struct ClosureSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 13:
       return nil
+    case 14:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -2604,6 +2889,7 @@ extension ClosureSignatureSyntax: CustomReflectable {
       "output": output.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenOutputAndInTok": unexpectedBetweenOutputAndInTok.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "inTok": Syntax(inTok).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterInTok": unexpectedAfterInTok.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2634,7 +2920,8 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
     _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndClosure: UnexpectedNodesSyntax? = nil,
-    closure: ClosureExprSyntax
+    closure: ClosureExprSyntax,
+    _ unexpectedAfterClosure: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabel?.raw,
@@ -2643,6 +2930,7 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
       colon.raw,
       unexpectedBetweenColonAndClosure?.raw,
       closure.raw,
+      unexpectedAfterClosure?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.multipleTrailingClosureElement,
       from: layout, arena: .default)
@@ -2773,6 +3061,27 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
     return MultipleTrailingClosureElementSyntax(newData)
   }
 
+  public var unexpectedAfterClosure: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterClosure(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterClosure` replaced.
+  /// - param newChild: The new `unexpectedAfterClosure` to replace the node's
+  ///                   current `unexpectedAfterClosure`, if present.
+  public func withUnexpectedAfterClosure(
+    _ newChild: UnexpectedNodesSyntax?) -> MultipleTrailingClosureElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return MultipleTrailingClosureElementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2786,6 +3095,8 @@ public struct MultipleTrailingClosureElementSyntax: SyntaxProtocol, SyntaxHashab
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -2802,6 +3113,7 @@ extension MultipleTrailingClosureElementSyntax: CustomReflectable {
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenColonAndClosure": unexpectedBetweenColonAndClosure.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "closure": Syntax(closure).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterClosure": unexpectedAfterClosure.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2828,11 +3140,13 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeContent: UnexpectedNodesSyntax? = nil,
-    content: TokenSyntax
+    content: TokenSyntax,
+    _ unexpectedAfterContent: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeContent?.raw,
       content.raw,
+      unexpectedAfterContent?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.stringSegment,
       from: layout, arena: .default)
@@ -2881,11 +3195,34 @@ public struct StringSegmentSyntax: SyntaxProtocol, SyntaxHashable {
     return StringSegmentSyntax(newData)
   }
 
+  public var unexpectedAfterContent: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterContent(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterContent` replaced.
+  /// - param newChild: The new `unexpectedAfterContent` to replace the node's
+  ///                   current `unexpectedAfterContent`, if present.
+  public func withUnexpectedAfterContent(
+    _ newChild: UnexpectedNodesSyntax?) -> StringSegmentSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return StringSegmentSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -2898,6 +3235,7 @@ extension StringSegmentSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeContent": unexpectedBeforeContent.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "content": Syntax(content).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterContent": unexpectedAfterContent.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2932,7 +3270,8 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndExpressions: UnexpectedNodesSyntax? = nil,
     expressions: TupleExprElementListSyntax,
     _ unexpectedBetweenExpressionsAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBackslash?.raw,
@@ -2945,6 +3284,7 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       expressions.raw,
       unexpectedBetweenExpressionsAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionSegment,
       from: layout, arena: .default)
@@ -3176,6 +3516,27 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
     return ExpressionSegmentSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 10, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> ExpressionSegmentSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 10)
+    return ExpressionSegmentSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -3198,6 +3559,8 @@ public struct ExpressionSegmentSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 9:
       return nil
+    case 10:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -3217,6 +3580,7 @@ extension ExpressionSegmentSyntax: CustomReflectable {
       "expressions": Syntax(expressions).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenExpressionsAndRightParen": unexpectedBetweenExpressionsAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3245,13 +3609,15 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforePeriod: UnexpectedNodesSyntax? = nil,
     period: TokenSyntax?,
     _ unexpectedBetweenPeriodAndComponent: UnexpectedNodesSyntax? = nil,
-    component: Syntax
+    component: Syntax,
+    _ unexpectedAfterComponent: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePeriod?.raw,
       period?.raw,
       unexpectedBetweenPeriodAndComponent?.raw,
       component.raw,
+      unexpectedAfterComponent?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathComponent,
       from: layout, arena: .default)
@@ -3342,6 +3708,27 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
     return KeyPathComponentSyntax(newData)
   }
 
+  public var unexpectedAfterComponent: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterComponent(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterComponent` replaced.
+  /// - param newChild: The new `unexpectedAfterComponent` to replace the node's
+  ///                   current `unexpectedAfterComponent`, if present.
+  public func withUnexpectedAfterComponent(
+    _ newChild: UnexpectedNodesSyntax?) -> KeyPathComponentSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return KeyPathComponentSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -3351,6 +3738,8 @@ public struct KeyPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -3365,6 +3754,7 @@ extension KeyPathComponentSyntax: CustomReflectable {
       "period": period.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenPeriodAndComponent": unexpectedBetweenPeriodAndComponent.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "component": Syntax(component).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterComponent": unexpectedAfterComponent.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3395,7 +3785,8 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenIdentifierAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
     declNameArguments: DeclNameArgumentsSyntax?,
     _ unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
-    genericArgumentClause: GenericArgumentClauseSyntax?
+    genericArgumentClause: GenericArgumentClauseSyntax?,
+    _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
@@ -3404,6 +3795,7 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
       declNameArguments?.raw,
       unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause?.raw,
       genericArgumentClause?.raw,
+      unexpectedAfterGenericArgumentClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathPropertyComponent,
       from: layout, arena: .default)
@@ -3536,6 +3928,27 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
     return KeyPathPropertyComponentSyntax(newData)
   }
 
+  public var unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterGenericArgumentClause(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterGenericArgumentClause` replaced.
+  /// - param newChild: The new `unexpectedAfterGenericArgumentClause` to replace the node's
+  ///                   current `unexpectedAfterGenericArgumentClause`, if present.
+  public func withUnexpectedAfterGenericArgumentClause(
+    _ newChild: UnexpectedNodesSyntax?) -> KeyPathPropertyComponentSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return KeyPathPropertyComponentSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -3549,6 +3962,8 @@ public struct KeyPathPropertyComponentSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -3565,6 +3980,7 @@ extension KeyPathPropertyComponentSyntax: CustomReflectable {
       "declNameArguments": declNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause": unexpectedBetweenDeclNameArgumentsAndGenericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "genericArgumentClause": genericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterGenericArgumentClause": unexpectedAfterGenericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3595,7 +4011,8 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftBracketAndArgumentList: UnexpectedNodesSyntax? = nil,
     argumentList: TupleExprElementListSyntax,
     _ unexpectedBetweenArgumentListAndRightBracket: UnexpectedNodesSyntax? = nil,
-    rightBracket: TokenSyntax
+    rightBracket: TokenSyntax,
+    _ unexpectedAfterRightBracket: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftBracket?.raw,
@@ -3604,6 +4021,7 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
       argumentList.raw,
       unexpectedBetweenArgumentListAndRightBracket?.raw,
       rightBracket.raw,
+      unexpectedAfterRightBracket?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathSubscriptComponent,
       from: layout, arena: .default)
@@ -3752,6 +4170,27 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
     return KeyPathSubscriptComponentSyntax(newData)
   }
 
+  public var unexpectedAfterRightBracket: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightBracket(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightBracket` replaced.
+  /// - param newChild: The new `unexpectedAfterRightBracket` to replace the node's
+  ///                   current `unexpectedAfterRightBracket`, if present.
+  public func withUnexpectedAfterRightBracket(
+    _ newChild: UnexpectedNodesSyntax?) -> KeyPathSubscriptComponentSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return KeyPathSubscriptComponentSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -3765,6 +4204,8 @@ public struct KeyPathSubscriptComponentSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -3781,6 +4222,7 @@ extension KeyPathSubscriptComponentSyntax: CustomReflectable {
       "argumentList": Syntax(argumentList).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenArgumentListAndRightBracket": unexpectedBetweenArgumentListAndRightBracket.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightBracket": Syntax(rightBracket).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightBracket": unexpectedAfterRightBracket.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3807,11 +4249,13 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil,
-    questionOrExclamationMark: TokenSyntax
+    questionOrExclamationMark: TokenSyntax,
+    _ unexpectedAfterQuestionOrExclamationMark: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeQuestionOrExclamationMark?.raw,
       questionOrExclamationMark.raw,
+      unexpectedAfterQuestionOrExclamationMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.keyPathOptionalComponent,
       from: layout, arena: .default)
@@ -3860,11 +4304,34 @@ public struct KeyPathOptionalComponentSyntax: SyntaxProtocol, SyntaxHashable {
     return KeyPathOptionalComponentSyntax(newData)
   }
 
+  public var unexpectedAfterQuestionOrExclamationMark: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterQuestionOrExclamationMark(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterQuestionOrExclamationMark` replaced.
+  /// - param newChild: The new `unexpectedAfterQuestionOrExclamationMark` to replace the node's
+  ///                   current `unexpectedAfterQuestionOrExclamationMark`, if present.
+  public func withUnexpectedAfterQuestionOrExclamationMark(
+    _ newChild: UnexpectedNodesSyntax?) -> KeyPathOptionalComponentSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return KeyPathOptionalComponentSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -3877,6 +4344,7 @@ extension KeyPathOptionalComponentSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeQuestionOrExclamationMark": unexpectedBeforeQuestionOrExclamationMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "questionOrExclamationMark": Syntax(questionOrExclamationMark).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterQuestionOrExclamationMark": unexpectedAfterQuestionOrExclamationMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3905,13 +4373,15 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndDot: UnexpectedNodesSyntax? = nil,
-    dot: TokenSyntax?
+    dot: TokenSyntax?,
+    _ unexpectedAfterDot: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndDot?.raw,
       dot?.raw,
+      unexpectedAfterDot?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.objcNamePiece,
       from: layout, arena: .default)
@@ -4002,6 +4472,27 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
     return ObjcNamePieceSyntax(newData)
   }
 
+  public var unexpectedAfterDot: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterDot(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterDot` replaced.
+  /// - param newChild: The new `unexpectedAfterDot` to replace the node's
+  ///                   current `unexpectedAfterDot`, if present.
+  public func withUnexpectedAfterDot(
+    _ newChild: UnexpectedNodesSyntax?) -> ObjcNamePieceSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return ObjcNamePieceSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -4011,6 +4502,8 @@ public struct ObjcNamePieceSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -4025,6 +4518,7 @@ extension ObjcNamePieceSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndDot": unexpectedBetweenNameAndDot.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "dot": dot.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterDot": unexpectedAfterDot.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4053,13 +4547,15 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
     expression: ExprSyntax,
     _ unexpectedBetweenExpressionAndComma: UnexpectedNodesSyntax? = nil,
-    comma: TokenSyntax?
+    comma: TokenSyntax?,
+    _ unexpectedAfterComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
       unexpectedBetweenExpressionAndComma?.raw,
       comma?.raw,
+      unexpectedAfterComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldExprListElement,
       from: layout, arena: .default)
@@ -4150,6 +4646,27 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
     return YieldExprListElementSyntax(newData)
   }
 
+  public var unexpectedAfterComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterComma` replaced.
+  /// - param newChild: The new `unexpectedAfterComma` to replace the node's
+  ///                   current `unexpectedAfterComma`, if present.
+  public func withUnexpectedAfterComma(
+    _ newChild: UnexpectedNodesSyntax?) -> YieldExprListElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return YieldExprListElementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -4159,6 +4676,8 @@ public struct YieldExprListElementSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -4173,6 +4692,7 @@ extension YieldExprListElementSyntax: CustomReflectable {
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenExpressionAndComma": unexpectedBetweenExpressionAndComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "comma": comma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterComma": unexpectedAfterComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4201,13 +4721,15 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeEqual: UnexpectedNodesSyntax? = nil,
     equal: TokenSyntax,
     _ unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? = nil,
-    value: TypeSyntax
+    value: TypeSyntax,
+    _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeEqual?.raw,
       equal.raw,
       unexpectedBetweenEqualAndValue?.raw,
       value.raw,
+      unexpectedAfterValue?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeInitializerClause,
       from: layout, arena: .default)
@@ -4297,6 +4819,27 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return TypeInitializerClauseSyntax(newData)
   }
 
+  public var unexpectedAfterValue: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterValue(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterValue` replaced.
+  /// - param newChild: The new `unexpectedAfterValue` to replace the node's
+  ///                   current `unexpectedAfterValue`, if present.
+  public func withUnexpectedAfterValue(
+    _ newChild: UnexpectedNodesSyntax?) -> TypeInitializerClauseSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return TypeInitializerClauseSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -4307,6 +4850,8 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 3:
       return "value"
+    case 4:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -4320,6 +4865,7 @@ extension TypeInitializerClauseSyntax: CustomReflectable {
       "equal": Syntax(equal).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenEqualAndValue": unexpectedBetweenEqualAndValue.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "value": Syntax(value).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterValue": unexpectedAfterValue.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4350,7 +4896,8 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndParameterList: UnexpectedNodesSyntax? = nil,
     parameterList: FunctionParameterListSyntax,
     _ unexpectedBetweenParameterListAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
@@ -4359,6 +4906,7 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       parameterList.raw,
       unexpectedBetweenParameterListAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.parameterClause,
       from: layout, arena: .default)
@@ -4507,6 +5055,27 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return ParameterClauseSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> ParameterClauseSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return ParameterClauseSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -4520,6 +5089,8 @@ public struct ParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -4536,6 +5107,7 @@ extension ParameterClauseSyntax: CustomReflectable {
       "parameterList": Syntax(parameterList).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenParameterListAndRightParen": unexpectedBetweenParameterListAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4564,13 +5136,15 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeArrow: UnexpectedNodesSyntax? = nil,
     arrow: TokenSyntax,
     _ unexpectedBetweenArrowAndReturnType: UnexpectedNodesSyntax? = nil,
-    returnType: TypeSyntax
+    returnType: TypeSyntax,
+    _ unexpectedAfterReturnType: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeArrow?.raw,
       arrow.raw,
       unexpectedBetweenArrowAndReturnType?.raw,
       returnType.raw,
+      unexpectedAfterReturnType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.returnClause,
       from: layout, arena: .default)
@@ -4660,6 +5234,27 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return ReturnClauseSyntax(newData)
   }
 
+  public var unexpectedAfterReturnType: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterReturnType(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterReturnType` replaced.
+  /// - param newChild: The new `unexpectedAfterReturnType` to replace the node's
+  ///                   current `unexpectedAfterReturnType`, if present.
+  public func withUnexpectedAfterReturnType(
+    _ newChild: UnexpectedNodesSyntax?) -> ReturnClauseSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return ReturnClauseSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -4670,6 +5265,8 @@ public struct ReturnClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 3:
       return "return type"
+    case 4:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -4683,6 +5280,7 @@ extension ReturnClauseSyntax: CustomReflectable {
       "arrow": Syntax(arrow).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenArrowAndReturnType": unexpectedBetweenArrowAndReturnType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "returnType": Syntax(returnType).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterReturnType": unexpectedAfterReturnType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4715,7 +5313,8 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenAsyncOrReasyncKeywordAndThrowsOrRethrowsKeyword: UnexpectedNodesSyntax? = nil,
     throwsOrRethrowsKeyword: TokenSyntax?,
     _ unexpectedBetweenThrowsOrRethrowsKeywordAndOutput: UnexpectedNodesSyntax? = nil,
-    output: ReturnClauseSyntax?
+    output: ReturnClauseSyntax?,
+    _ unexpectedAfterOutput: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeInput?.raw,
@@ -4726,6 +5325,7 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       throwsOrRethrowsKeyword?.raw,
       unexpectedBetweenThrowsOrRethrowsKeywordAndOutput?.raw,
       output?.raw,
+      unexpectedAfterOutput?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionSignature,
       from: layout, arena: .default)
@@ -4900,6 +5500,27 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
     return FunctionSignatureSyntax(newData)
   }
 
+  public var unexpectedAfterOutput: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterOutput(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterOutput` replaced.
+  /// - param newChild: The new `unexpectedAfterOutput` to replace the node's
+  ///                   current `unexpectedAfterOutput`, if present.
+  public func withUnexpectedAfterOutput(
+    _ newChild: UnexpectedNodesSyntax?) -> FunctionSignatureSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return FunctionSignatureSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -4918,6 +5539,8 @@ public struct FunctionSignatureSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -4935,6 +5558,7 @@ extension FunctionSignatureSyntax: CustomReflectable {
       "throwsOrRethrowsKeyword": throwsOrRethrowsKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenThrowsOrRethrowsKeywordAndOutput": unexpectedBetweenThrowsOrRethrowsKeywordAndOutput.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "output": output.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterOutput": unexpectedAfterOutput.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -4965,7 +5589,8 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenPoundKeywordAndCondition: UnexpectedNodesSyntax? = nil,
     condition: ExprSyntax?,
     _ unexpectedBetweenConditionAndElements: UnexpectedNodesSyntax? = nil,
-    elements: Syntax
+    elements: Syntax,
+    _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundKeyword?.raw,
@@ -4974,6 +5599,7 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
       condition?.raw,
       unexpectedBetweenConditionAndElements?.raw,
       elements.raw,
+      unexpectedAfterElements?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifConfigClause,
       from: layout, arena: .default)
@@ -5105,6 +5731,27 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return IfConfigClauseSyntax(newData)
   }
 
+  public var unexpectedAfterElements: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterElements(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterElements` replaced.
+  /// - param newChild: The new `unexpectedAfterElements` to replace the node's
+  ///                   current `unexpectedAfterElements`, if present.
+  public func withUnexpectedAfterElements(
+    _ newChild: UnexpectedNodesSyntax?) -> IfConfigClauseSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return IfConfigClauseSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -5118,6 +5765,8 @@ public struct IfConfigClauseSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -5134,6 +5783,7 @@ extension IfConfigClauseSyntax: CustomReflectable {
       "condition": condition.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenConditionAndElements": unexpectedBetweenConditionAndElements.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "elements": Syntax(elements).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterElements": unexpectedAfterElements.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5172,7 +5822,8 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLineArgLabelAndLineArgColon: UnexpectedNodesSyntax? = nil,
     lineArgColon: TokenSyntax,
     _ unexpectedBetweenLineArgColonAndLineNumber: UnexpectedNodesSyntax? = nil,
-    lineNumber: TokenSyntax
+    lineNumber: TokenSyntax,
+    _ unexpectedAfterLineNumber: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeFileArgLabel?.raw,
@@ -5189,6 +5840,7 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       lineArgColon.raw,
       unexpectedBetweenLineArgColonAndLineNumber?.raw,
       lineNumber.raw,
+      unexpectedAfterLineNumber?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundSourceLocationArgs,
       from: layout, arena: .default)
@@ -5483,6 +6135,27 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
     return PoundSourceLocationArgsSyntax(newData)
   }
 
+  public var unexpectedAfterLineNumber: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 14, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterLineNumber(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterLineNumber` replaced.
+  /// - param newChild: The new `unexpectedAfterLineNumber` to replace the node's
+  ///                   current `unexpectedAfterLineNumber`, if present.
+  public func withUnexpectedAfterLineNumber(
+    _ newChild: UnexpectedNodesSyntax?) -> PoundSourceLocationArgsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 14)
+    return PoundSourceLocationArgsSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -5513,6 +6186,8 @@ public struct PoundSourceLocationArgsSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 13:
       return "line number"
+    case 14:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -5536,6 +6211,7 @@ extension PoundSourceLocationArgsSyntax: CustomReflectable {
       "lineArgColon": Syntax(lineArgColon).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenLineArgColonAndLineNumber": unexpectedBetweenLineArgColonAndLineNumber.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "lineNumber": Syntax(lineNumber).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterLineNumber": unexpectedAfterLineNumber.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5566,7 +6242,8 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndDetail: UnexpectedNodesSyntax? = nil,
     detail: TokenSyntax,
     _ unexpectedBetweenDetailAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
@@ -5575,6 +6252,7 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
       detail.raw,
       unexpectedBetweenDetailAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.declModifierDetail,
       from: layout, arena: .default)
@@ -5705,6 +6383,27 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
     return DeclModifierDetailSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> DeclModifierDetailSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return DeclModifierDetailSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -5718,6 +6417,8 @@ public struct DeclModifierDetailSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -5734,6 +6435,7 @@ extension DeclModifierDetailSyntax: CustomReflectable {
       "detail": Syntax(detail).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenDetailAndRightParen": unexpectedBetweenDetailAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5762,13 +6464,15 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndDetail: UnexpectedNodesSyntax? = nil,
-    detail: DeclModifierDetailSyntax?
+    detail: DeclModifierDetailSyntax?,
+    _ unexpectedAfterDetail: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndDetail?.raw,
       detail?.raw,
+      unexpectedAfterDetail?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.declModifier,
       from: layout, arena: .default)
@@ -5859,6 +6563,27 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
     return DeclModifierSyntax(newData)
   }
 
+  public var unexpectedAfterDetail: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterDetail(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterDetail` replaced.
+  /// - param newChild: The new `unexpectedAfterDetail` to replace the node's
+  ///                   current `unexpectedAfterDetail`, if present.
+  public func withUnexpectedAfterDetail(
+    _ newChild: UnexpectedNodesSyntax?) -> DeclModifierSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return DeclModifierSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -5868,6 +6593,8 @@ public struct DeclModifierSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -5882,6 +6609,7 @@ extension DeclModifierSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndDetail": unexpectedBetweenNameAndDetail.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "detail": detail.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterDetail": unexpectedAfterDetail.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -5910,13 +6638,15 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeTypeName: UnexpectedNodesSyntax? = nil,
     typeName: TypeSyntax,
     _ unexpectedBetweenTypeNameAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeTypeName?.raw,
       typeName.raw,
       unexpectedBetweenTypeNameAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.inheritedType,
       from: layout, arena: .default)
@@ -6007,6 +6737,27 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     return InheritedTypeSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> InheritedTypeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return InheritedTypeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -6016,6 +6767,8 @@ public struct InheritedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -6030,6 +6783,7 @@ extension InheritedTypeSyntax: CustomReflectable {
       "typeName": Syntax(typeName).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenTypeNameAndTrailingComma": unexpectedBetweenTypeNameAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6058,13 +6812,15 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndInheritedTypeCollection: UnexpectedNodesSyntax? = nil,
-    inheritedTypeCollection: InheritedTypeListSyntax
+    inheritedTypeCollection: InheritedTypeListSyntax,
+    _ unexpectedAfterInheritedTypeCollection: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeColon?.raw,
       colon.raw,
       unexpectedBetweenColonAndInheritedTypeCollection?.raw,
       inheritedTypeCollection.raw,
+      unexpectedAfterInheritedTypeCollection?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeInheritanceClause,
       from: layout, arena: .default)
@@ -6172,6 +6928,27 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return TypeInheritanceClauseSyntax(newData)
   }
 
+  public var unexpectedAfterInheritedTypeCollection: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterInheritedTypeCollection(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterInheritedTypeCollection` replaced.
+  /// - param newChild: The new `unexpectedAfterInheritedTypeCollection` to replace the node's
+  ///                   current `unexpectedAfterInheritedTypeCollection`, if present.
+  public func withUnexpectedAfterInheritedTypeCollection(
+    _ newChild: UnexpectedNodesSyntax?) -> TypeInheritanceClauseSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return TypeInheritanceClauseSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -6181,6 +6958,8 @@ public struct TypeInheritanceClauseSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -6195,6 +6974,7 @@ extension TypeInheritanceClauseSyntax: CustomReflectable {
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenColonAndInheritedTypeCollection": unexpectedBetweenColonAndInheritedTypeCollection.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "inheritedTypeCollection": Syntax(inheritedTypeCollection).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterInheritedTypeCollection": unexpectedAfterInheritedTypeCollection.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6225,7 +7005,8 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftBraceAndMembers: UnexpectedNodesSyntax? = nil,
     members: MemberDeclListSyntax,
     _ unexpectedBetweenMembersAndRightBrace: UnexpectedNodesSyntax? = nil,
-    rightBrace: TokenSyntax
+    rightBrace: TokenSyntax,
+    _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftBrace?.raw,
@@ -6234,6 +7015,7 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
       members.raw,
       unexpectedBetweenMembersAndRightBrace?.raw,
       rightBrace.raw,
+      unexpectedAfterRightBrace?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclBlock,
       from: layout, arena: .default)
@@ -6382,6 +7164,27 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
     return MemberDeclBlockSyntax(newData)
   }
 
+  public var unexpectedAfterRightBrace: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightBrace(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
+  /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
+  ///                   current `unexpectedAfterRightBrace`, if present.
+  public func withUnexpectedAfterRightBrace(
+    _ newChild: UnexpectedNodesSyntax?) -> MemberDeclBlockSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return MemberDeclBlockSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -6395,6 +7198,8 @@ public struct MemberDeclBlockSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -6411,6 +7216,7 @@ extension MemberDeclBlockSyntax: CustomReflectable {
       "members": Syntax(members).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenMembersAndRightBrace": unexpectedBetweenMembersAndRightBrace.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightBrace": Syntax(rightBrace).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightBrace": unexpectedAfterRightBrace.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6443,13 +7249,15 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeDecl: UnexpectedNodesSyntax? = nil,
     decl: DeclSyntax,
     _ unexpectedBetweenDeclAndSemicolon: UnexpectedNodesSyntax? = nil,
-    semicolon: TokenSyntax?
+    semicolon: TokenSyntax?,
+    _ unexpectedAfterSemicolon: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDecl?.raw,
       decl.raw,
       unexpectedBetweenDeclAndSemicolon?.raw,
       semicolon?.raw,
+      unexpectedAfterSemicolon?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberDeclListItem,
       from: layout, arena: .default)
@@ -6542,6 +7350,27 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
     return MemberDeclListItemSyntax(newData)
   }
 
+  public var unexpectedAfterSemicolon: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterSemicolon(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterSemicolon` replaced.
+  /// - param newChild: The new `unexpectedAfterSemicolon` to replace the node's
+  ///                   current `unexpectedAfterSemicolon`, if present.
+  public func withUnexpectedAfterSemicolon(
+    _ newChild: UnexpectedNodesSyntax?) -> MemberDeclListItemSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return MemberDeclListItemSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -6551,6 +7380,8 @@ public struct MemberDeclListItemSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -6565,6 +7396,7 @@ extension MemberDeclListItemSyntax: CustomReflectable {
       "decl": Syntax(decl).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenDeclAndSemicolon": unexpectedBetweenDeclAndSemicolon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "semicolon": semicolon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterSemicolon": unexpectedAfterSemicolon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6593,13 +7425,15 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeStatements: UnexpectedNodesSyntax? = nil,
     statements: CodeBlockItemListSyntax,
     _ unexpectedBetweenStatementsAndEOFToken: UnexpectedNodesSyntax? = nil,
-    eofToken: TokenSyntax
+    eofToken: TokenSyntax,
+    _ unexpectedAfterEOFToken: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeStatements?.raw,
       statements.raw,
       unexpectedBetweenStatementsAndEOFToken?.raw,
       eofToken.raw,
+      unexpectedAfterEOFToken?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.sourceFile,
       from: layout, arena: .default)
@@ -6707,6 +7541,27 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
     return SourceFileSyntax(newData)
   }
 
+  public var unexpectedAfterEOFToken: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterEOFToken(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterEOFToken` replaced.
+  /// - param newChild: The new `unexpectedAfterEOFToken` to replace the node's
+  ///                   current `unexpectedAfterEOFToken`, if present.
+  public func withUnexpectedAfterEOFToken(
+    _ newChild: UnexpectedNodesSyntax?) -> SourceFileSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return SourceFileSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -6716,6 +7571,8 @@ public struct SourceFileSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -6730,6 +7587,7 @@ extension SourceFileSyntax: CustomReflectable {
       "statements": Syntax(statements).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenStatementsAndEOFToken": unexpectedBetweenStatementsAndEOFToken.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "eofToken": Syntax(eofToken).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterEOFToken": unexpectedAfterEOFToken.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6758,13 +7616,15 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeEqual: UnexpectedNodesSyntax? = nil,
     equal: TokenSyntax,
     _ unexpectedBetweenEqualAndValue: UnexpectedNodesSyntax? = nil,
-    value: ExprSyntax
+    value: ExprSyntax,
+    _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeEqual?.raw,
       equal.raw,
       unexpectedBetweenEqualAndValue?.raw,
       value.raw,
+      unexpectedAfterValue?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.initializerClause,
       from: layout, arena: .default)
@@ -6854,6 +7714,27 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return InitializerClauseSyntax(newData)
   }
 
+  public var unexpectedAfterValue: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterValue(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterValue` replaced.
+  /// - param newChild: The new `unexpectedAfterValue` to replace the node's
+  ///                   current `unexpectedAfterValue`, if present.
+  public func withUnexpectedAfterValue(
+    _ newChild: UnexpectedNodesSyntax?) -> InitializerClauseSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return InitializerClauseSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -6863,6 +7744,8 @@ public struct InitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -6877,6 +7760,7 @@ extension InitializerClauseSyntax: CustomReflectable {
       "equal": Syntax(equal).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenEqualAndValue": unexpectedBetweenEqualAndValue.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "value": Syntax(value).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterValue": unexpectedAfterValue.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -6919,7 +7803,8 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenEllipsisAndDefaultArgument: UnexpectedNodesSyntax? = nil,
     defaultArgument: InitializerClauseSyntax?,
     _ unexpectedBetweenDefaultArgumentAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -6940,6 +7825,7 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       defaultArgument?.raw,
       unexpectedBetweenDefaultArgumentAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionParameter,
       from: layout, arena: .default)
@@ -7361,6 +8247,27 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
     return FunctionParameterSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 18, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> FunctionParameterSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 18)
+    return FunctionParameterSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -7399,6 +8306,8 @@ public struct FunctionParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 17:
       return nil
+    case 18:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -7426,6 +8335,7 @@ extension FunctionParameterSyntax: CustomReflectable {
       "defaultArgument": defaultArgument.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenDefaultArgumentAndTrailingComma": unexpectedBetweenDefaultArgumentAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7454,13 +8364,15 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndModifier: UnexpectedNodesSyntax? = nil,
-    modifier: DeclModifierDetailSyntax?
+    modifier: DeclModifierDetailSyntax?,
+    _ unexpectedAfterModifier: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndModifier?.raw,
       modifier?.raw,
+      unexpectedAfterModifier?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessLevelModifier,
       from: layout, arena: .default)
@@ -7551,6 +8463,27 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
     return AccessLevelModifierSyntax(newData)
   }
 
+  public var unexpectedAfterModifier: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterModifier(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterModifier` replaced.
+  /// - param newChild: The new `unexpectedAfterModifier` to replace the node's
+  ///                   current `unexpectedAfterModifier`, if present.
+  public func withUnexpectedAfterModifier(
+    _ newChild: UnexpectedNodesSyntax?) -> AccessLevelModifierSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return AccessLevelModifierSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -7560,6 +8493,8 @@ public struct AccessLevelModifierSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -7574,6 +8509,7 @@ extension AccessLevelModifierSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndModifier": unexpectedBetweenNameAndModifier.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "modifier": modifier.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterModifier": unexpectedAfterModifier.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7602,13 +8538,15 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndTrailingDot: UnexpectedNodesSyntax? = nil,
-    trailingDot: TokenSyntax?
+    trailingDot: TokenSyntax?,
+    _ unexpectedAfterTrailingDot: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndTrailingDot?.raw,
       trailingDot?.raw,
+      unexpectedAfterTrailingDot?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessPathComponent,
       from: layout, arena: .default)
@@ -7699,6 +8637,27 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
     return AccessPathComponentSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingDot: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingDot(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingDot` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingDot` to replace the node's
+  ///                   current `unexpectedAfterTrailingDot`, if present.
+  public func withUnexpectedAfterTrailingDot(
+    _ newChild: UnexpectedNodesSyntax?) -> AccessPathComponentSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return AccessPathComponentSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -7708,6 +8667,8 @@ public struct AccessPathComponentSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -7722,6 +8683,7 @@ extension AccessPathComponentSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndTrailingDot": unexpectedBetweenNameAndTrailingDot.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingDot": trailingDot.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingDot": unexpectedAfterTrailingDot.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7752,7 +8714,8 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
@@ -7761,6 +8724,7 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
       name.raw,
       unexpectedBetweenNameAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorParameter,
       from: layout, arena: .default)
@@ -7891,6 +8855,27 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
     return AccessorParameterSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> AccessorParameterSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return AccessorParameterSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -7904,6 +8889,8 @@ public struct AccessorParameterSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -7920,6 +8907,7 @@ extension AccessorParameterSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndRightParen": unexpectedBetweenNameAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -7950,7 +8938,8 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftBraceAndAccessors: UnexpectedNodesSyntax? = nil,
     accessors: AccessorListSyntax,
     _ unexpectedBetweenAccessorsAndRightBrace: UnexpectedNodesSyntax? = nil,
-    rightBrace: TokenSyntax
+    rightBrace: TokenSyntax,
+    _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftBrace?.raw,
@@ -7959,6 +8948,7 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
       accessors.raw,
       unexpectedBetweenAccessorsAndRightBrace?.raw,
       rightBrace.raw,
+      unexpectedAfterRightBrace?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.accessorBlock,
       from: layout, arena: .default)
@@ -8107,6 +9097,27 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
     return AccessorBlockSyntax(newData)
   }
 
+  public var unexpectedAfterRightBrace: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightBrace(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
+  /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
+  ///                   current `unexpectedAfterRightBrace`, if present.
+  public func withUnexpectedAfterRightBrace(
+    _ newChild: UnexpectedNodesSyntax?) -> AccessorBlockSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return AccessorBlockSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -8120,6 +9131,8 @@ public struct AccessorBlockSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -8136,6 +9149,7 @@ extension AccessorBlockSyntax: CustomReflectable {
       "accessors": Syntax(accessors).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenAccessorsAndRightBrace": unexpectedBetweenAccessorsAndRightBrace.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightBrace": Syntax(rightBrace).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightBrace": unexpectedAfterRightBrace.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -8170,7 +9184,8 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenInitializerAndAccessor: UnexpectedNodesSyntax? = nil,
     accessor: Syntax?,
     _ unexpectedBetweenAccessorAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePattern?.raw,
@@ -8183,6 +9198,7 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       accessor?.raw,
       unexpectedBetweenAccessorAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.patternBinding,
       from: layout, arena: .default)
@@ -8399,6 +9415,27 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
     return PatternBindingSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 10, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> PatternBindingSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 10)
+    return PatternBindingSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -8421,6 +9458,8 @@ public struct PatternBindingSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 9:
       return nil
+    case 10:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -8440,6 +9479,7 @@ extension PatternBindingSyntax: CustomReflectable {
       "accessor": accessor.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenAccessorAndTrailingComma": unexpectedBetweenAccessorAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -8476,7 +9516,8 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenAssociatedValueAndRawValue: UnexpectedNodesSyntax? = nil,
     rawValue: InitializerClauseSyntax?,
     _ unexpectedBetweenRawValueAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
@@ -8487,6 +9528,7 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
       rawValue?.raw,
       unexpectedBetweenRawValueAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCaseElement,
       from: layout, arena: .default)
@@ -8670,6 +9712,27 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
     return EnumCaseElementSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> EnumCaseElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return EnumCaseElementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -8688,6 +9751,8 @@ public struct EnumCaseElementSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -8705,6 +9770,7 @@ extension EnumCaseElementSyntax: CustomReflectable {
       "rawValue": rawValue.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenRawValueAndTrailingComma": unexpectedBetweenRawValueAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -8733,13 +9799,15 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeLeadingComma: UnexpectedNodesSyntax? = nil,
     leadingComma: TokenSyntax,
     _ unexpectedBetweenLeadingCommaAndName: UnexpectedNodesSyntax? = nil,
-    name: TokenSyntax
+    name: TokenSyntax,
+    _ unexpectedAfterName: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeadingComma?.raw,
       leadingComma.raw,
       unexpectedBetweenLeadingCommaAndName?.raw,
       name.raw,
+      unexpectedAfterName?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.designatedTypeElement,
       from: layout, arena: .default)
@@ -8829,6 +9897,27 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     return DesignatedTypeElementSyntax(newData)
   }
 
+  public var unexpectedAfterName: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterName` replaced.
+  /// - param newChild: The new `unexpectedAfterName` to replace the node's
+  ///                   current `unexpectedAfterName`, if present.
+  public func withUnexpectedAfterName(
+    _ newChild: UnexpectedNodesSyntax?) -> DesignatedTypeElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return DesignatedTypeElementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -8838,6 +9927,8 @@ public struct DesignatedTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -8852,6 +9943,7 @@ extension DesignatedTypeElementSyntax: CustomReflectable {
       "leadingComma": Syntax(leadingComma).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenLeadingCommaAndName": unexpectedBetweenLeadingCommaAndName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterName": unexpectedAfterName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -8885,7 +9977,8 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenColonAndPrecedenceGroup: UnexpectedNodesSyntax? = nil,
     precedenceGroup: TokenSyntax,
     _ unexpectedBetweenPrecedenceGroupAndDesignatedTypes: UnexpectedNodesSyntax? = nil,
-    designatedTypes: DesignatedTypeListSyntax
+    designatedTypes: DesignatedTypeListSyntax,
+    _ unexpectedAfterDesignatedTypes: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeColon?.raw,
@@ -8894,6 +9987,7 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
       precedenceGroup.raw,
       unexpectedBetweenPrecedenceGroupAndDesignatedTypes?.raw,
       designatedTypes.raw,
+      unexpectedAfterDesignatedTypes?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.operatorPrecedenceAndTypes,
       from: layout, arena: .default)
@@ -9048,6 +10142,27 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
     return OperatorPrecedenceAndTypesSyntax(newData)
   }
 
+  public var unexpectedAfterDesignatedTypes: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterDesignatedTypes(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterDesignatedTypes` replaced.
+  /// - param newChild: The new `unexpectedAfterDesignatedTypes` to replace the node's
+  ///                   current `unexpectedAfterDesignatedTypes`, if present.
+  public func withUnexpectedAfterDesignatedTypes(
+    _ newChild: UnexpectedNodesSyntax?) -> OperatorPrecedenceAndTypesSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return OperatorPrecedenceAndTypesSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -9061,6 +10176,8 @@ public struct OperatorPrecedenceAndTypesSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -9077,6 +10194,7 @@ extension OperatorPrecedenceAndTypesSyntax: CustomReflectable {
       "precedenceGroup": Syntax(precedenceGroup).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenPrecedenceGroupAndDesignatedTypes": unexpectedBetweenPrecedenceGroupAndDesignatedTypes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "designatedTypes": Syntax(designatedTypes).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterDesignatedTypes": unexpectedAfterDesignatedTypes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -9111,7 +10229,8 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenHigherThanOrLowerThanAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndOtherNames: UnexpectedNodesSyntax? = nil,
-    otherNames: PrecedenceGroupNameListSyntax
+    otherNames: PrecedenceGroupNameListSyntax,
+    _ unexpectedAfterOtherNames: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeHigherThanOrLowerThan?.raw,
@@ -9120,6 +10239,7 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
       colon.raw,
       unexpectedBetweenColonAndOtherNames?.raw,
       otherNames.raw,
+      unexpectedAfterOtherNames?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupRelation,
       from: layout, arena: .default)
@@ -9275,6 +10395,27 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
     return PrecedenceGroupRelationSyntax(newData)
   }
 
+  public var unexpectedAfterOtherNames: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterOtherNames(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterOtherNames` replaced.
+  /// - param newChild: The new `unexpectedAfterOtherNames` to replace the node's
+  ///                   current `unexpectedAfterOtherNames`, if present.
+  public func withUnexpectedAfterOtherNames(
+    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupRelationSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return PrecedenceGroupRelationSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -9288,6 +10429,8 @@ public struct PrecedenceGroupRelationSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -9304,6 +10447,7 @@ extension PrecedenceGroupRelationSyntax: CustomReflectable {
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenColonAndOtherNames": unexpectedBetweenColonAndOtherNames.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "otherNames": Syntax(otherNames).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterOtherNames": unexpectedAfterOtherNames.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -9332,13 +10476,15 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupNameElement,
       from: layout, arena: .default)
@@ -9429,6 +10575,27 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
     return PrecedenceGroupNameElementSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupNameElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return PrecedenceGroupNameElementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -9438,6 +10605,8 @@ public struct PrecedenceGroupNameElementSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -9452,6 +10621,7 @@ extension PrecedenceGroupNameElementSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndTrailingComma": unexpectedBetweenNameAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -9486,7 +10656,8 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenAssignmentKeywordAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndFlag: UnexpectedNodesSyntax? = nil,
-    flag: TokenSyntax
+    flag: TokenSyntax,
+    _ unexpectedAfterFlag: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAssignmentKeyword?.raw,
@@ -9495,6 +10666,7 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
       colon.raw,
       unexpectedBetweenColonAndFlag?.raw,
       flag.raw,
+      unexpectedAfterFlag?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAssignment,
       from: layout, arena: .default)
@@ -9632,6 +10804,27 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
     return PrecedenceGroupAssignmentSyntax(newData)
   }
 
+  public var unexpectedAfterFlag: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterFlag(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterFlag` replaced.
+  /// - param newChild: The new `unexpectedAfterFlag` to replace the node's
+  ///                   current `unexpectedAfterFlag`, if present.
+  public func withUnexpectedAfterFlag(
+    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssignmentSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return PrecedenceGroupAssignmentSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -9645,6 +10838,8 @@ public struct PrecedenceGroupAssignmentSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -9661,6 +10856,7 @@ extension PrecedenceGroupAssignmentSyntax: CustomReflectable {
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenColonAndFlag": unexpectedBetweenColonAndFlag.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "flag": Syntax(flag).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterFlag": unexpectedAfterFlag.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -9695,7 +10891,8 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
     _ unexpectedBetweenAssociativityKeywordAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil,
-    value: TokenSyntax
+    value: TokenSyntax,
+    _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAssociativityKeyword?.raw,
@@ -9704,6 +10901,7 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
       colon.raw,
       unexpectedBetweenColonAndValue?.raw,
       value.raw,
+      unexpectedAfterValue?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.precedenceGroupAssociativity,
       from: layout, arena: .default)
@@ -9840,6 +11038,27 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
     return PrecedenceGroupAssociativitySyntax(newData)
   }
 
+  public var unexpectedAfterValue: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterValue(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterValue` replaced.
+  /// - param newChild: The new `unexpectedAfterValue` to replace the node's
+  ///                   current `unexpectedAfterValue`, if present.
+  public func withUnexpectedAfterValue(
+    _ newChild: UnexpectedNodesSyntax?) -> PrecedenceGroupAssociativitySyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return PrecedenceGroupAssociativitySyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -9853,6 +11072,8 @@ public struct PrecedenceGroupAssociativitySyntax: SyntaxProtocol, SyntaxHashable
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -9869,6 +11090,7 @@ extension PrecedenceGroupAssociativitySyntax: CustomReflectable {
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenColonAndValue": unexpectedBetweenColonAndValue.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "value": Syntax(value).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterValue": unexpectedAfterValue.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -9906,7 +11128,8 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndArgumentList: UnexpectedNodesSyntax? = nil,
     argumentList: TupleExprElementListSyntax?,
     _ unexpectedBetweenArgumentListAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax?
+    rightParen: TokenSyntax?,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAtSignToken?.raw,
@@ -9919,6 +11142,7 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
       argumentList?.raw,
       unexpectedBetweenArgumentListAndRightParen?.raw,
       rightParen?.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.customAttribute,
       from: layout, arena: .default)
@@ -10154,6 +11378,27 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
     return CustomAttributeSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 10, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> CustomAttributeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 10)
+    return CustomAttributeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -10176,6 +11421,8 @@ public struct CustomAttributeSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 9:
       return nil
+    case 10:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -10195,6 +11442,7 @@ extension CustomAttributeSyntax: CustomReflectable {
       "argumentList": argumentList.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenArgumentListAndRightParen": unexpectedBetweenArgumentListAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": rightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -10234,7 +11482,8 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenArgumentAndRightParen: UnexpectedNodesSyntax? = nil,
     rightParen: TokenSyntax?,
     _ unexpectedBetweenRightParenAndTokenList: UnexpectedNodesSyntax? = nil,
-    tokenList: TokenListSyntax?
+    tokenList: TokenListSyntax?,
+    _ unexpectedAfterTokenList: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAtSignToken?.raw,
@@ -10249,6 +11498,7 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       rightParen?.raw,
       unexpectedBetweenRightParenAndTokenList?.raw,
       tokenList?.raw,
+      unexpectedAfterTokenList?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.attribute,
       from: layout, arena: .default)
@@ -10537,6 +11787,27 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
     return AttributeSyntax(newData)
   }
 
+  public var unexpectedAfterTokenList: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 12, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTokenList(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTokenList` replaced.
+  /// - param newChild: The new `unexpectedAfterTokenList` to replace the node's
+  ///                   current `unexpectedAfterTokenList`, if present.
+  public func withUnexpectedAfterTokenList(
+    _ newChild: UnexpectedNodesSyntax?) -> AttributeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 12)
+    return AttributeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -10563,6 +11834,8 @@ public struct AttributeSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 11:
       return nil
+    case 12:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -10584,6 +11857,7 @@ extension AttributeSyntax: CustomReflectable {
       "rightParen": rightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenRightParenAndTokenList": unexpectedBetweenRightParenAndTokenList.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "tokenList": tokenList.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTokenList": unexpectedAfterTokenList.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -10619,7 +11893,8 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenColonAndAvailabilityList: UnexpectedNodesSyntax? = nil,
     availabilityList: AvailabilitySpecListSyntax,
     _ unexpectedBetweenAvailabilityListAndSemicolon: UnexpectedNodesSyntax? = nil,
-    semicolon: TokenSyntax
+    semicolon: TokenSyntax,
+    _ unexpectedAfterSemicolon: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabel?.raw,
@@ -10630,6 +11905,7 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
       availabilityList.raw,
       unexpectedBetweenAvailabilityListAndSemicolon?.raw,
       semicolon.raw,
+      unexpectedAfterSemicolon?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityEntry,
       from: layout, arena: .default)
@@ -10821,6 +12097,27 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
     return AvailabilityEntrySyntax(newData)
   }
 
+  public var unexpectedAfterSemicolon: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterSemicolon(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterSemicolon` replaced.
+  /// - param newChild: The new `unexpectedAfterSemicolon` to replace the node's
+  ///                   current `unexpectedAfterSemicolon`, if present.
+  public func withUnexpectedAfterSemicolon(
+    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityEntrySyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return AvailabilityEntrySyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -10839,6 +12136,8 @@ public struct AvailabilityEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -10856,6 +12155,7 @@ extension AvailabilityEntrySyntax: CustomReflectable {
       "availabilityList": Syntax(availabilityList).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenAvailabilityListAndSemicolon": unexpectedBetweenAvailabilityListAndSemicolon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "semicolon": Syntax(semicolon).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterSemicolon": unexpectedAfterSemicolon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -10892,7 +12192,8 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil,
     value: TokenSyntax,
     _ unexpectedBetweenValueAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabel?.raw,
@@ -10903,6 +12204,7 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
       value.raw,
       unexpectedBetweenValueAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.labeledSpecializeEntry,
       from: layout, arena: .default)
@@ -11081,6 +12383,27 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
     return LabeledSpecializeEntrySyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> LabeledSpecializeEntrySyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return LabeledSpecializeEntrySyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -11099,6 +12422,8 @@ public struct LabeledSpecializeEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -11116,6 +12441,7 @@ extension LabeledSpecializeEntrySyntax: CustomReflectable {
       "value": Syntax(value).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenValueAndTrailingComma": unexpectedBetweenValueAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -11153,7 +12479,8 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenColonAndDeclname: UnexpectedNodesSyntax? = nil,
     declname: DeclNameSyntax,
     _ unexpectedBetweenDeclnameAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabel?.raw,
@@ -11164,6 +12491,7 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
       declname.raw,
       unexpectedBetweenDeclnameAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.targetFunctionEntry,
       from: layout, arena: .default)
@@ -11342,6 +12670,27 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
     return TargetFunctionEntrySyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> TargetFunctionEntrySyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return TargetFunctionEntrySyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -11360,6 +12709,8 @@ public struct TargetFunctionEntrySyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -11377,6 +12728,7 @@ extension TargetFunctionEntrySyntax: CustomReflectable {
       "declname": Syntax(declname).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenDeclnameAndTrailingComma": unexpectedBetweenDeclnameAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -11412,7 +12764,8 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
     _ unexpectedBetweenNameTokAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndStringOrDeclname: UnexpectedNodesSyntax? = nil,
-    stringOrDeclname: Syntax
+    stringOrDeclname: Syntax,
+    _ unexpectedAfterStringOrDeclname: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeNameTok?.raw,
@@ -11421,6 +12774,7 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
       colon.raw,
       unexpectedBetweenColonAndStringOrDeclname?.raw,
       stringOrDeclname.raw,
+      unexpectedAfterStringOrDeclname?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.namedAttributeStringArgument,
       from: layout, arena: .default)
@@ -11553,6 +12907,27 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
     return NamedAttributeStringArgumentSyntax(newData)
   }
 
+  public var unexpectedAfterStringOrDeclname: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterStringOrDeclname(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterStringOrDeclname` replaced.
+  /// - param newChild: The new `unexpectedAfterStringOrDeclname` to replace the node's
+  ///                   current `unexpectedAfterStringOrDeclname`, if present.
+  public func withUnexpectedAfterStringOrDeclname(
+    _ newChild: UnexpectedNodesSyntax?) -> NamedAttributeStringArgumentSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return NamedAttributeStringArgumentSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -11567,6 +12942,8 @@ public struct NamedAttributeStringArgumentSyntax: SyntaxProtocol, SyntaxHashable
       return nil
     case 5:
       return "value"
+    case 6:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -11582,6 +12959,7 @@ extension NamedAttributeStringArgumentSyntax: CustomReflectable {
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenColonAndStringOrDeclname": unexpectedBetweenColonAndStringOrDeclname.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "stringOrDeclname": Syntax(stringOrDeclname).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterStringOrDeclname": unexpectedAfterStringOrDeclname.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -11610,13 +12988,15 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeDeclBaseName: UnexpectedNodesSyntax? = nil,
     declBaseName: Syntax,
     _ unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
-    declNameArguments: DeclNameArgumentsSyntax?
+    declNameArguments: DeclNameArgumentsSyntax?,
+    _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDeclBaseName?.raw,
       declBaseName.raw,
       unexpectedBetweenDeclBaseNameAndDeclNameArguments?.raw,
       declNameArguments?.raw,
+      unexpectedAfterDeclNameArguments?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.declName,
       from: layout, arena: .default)
@@ -11714,6 +13094,27 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     return DeclNameSyntax(newData)
   }
 
+  public var unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterDeclNameArguments(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterDeclNameArguments` replaced.
+  /// - param newChild: The new `unexpectedAfterDeclNameArguments` to replace the node's
+  ///                   current `unexpectedAfterDeclNameArguments`, if present.
+  public func withUnexpectedAfterDeclNameArguments(
+    _ newChild: UnexpectedNodesSyntax?) -> DeclNameSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return DeclNameSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -11724,6 +13125,8 @@ public struct DeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 3:
       return "arguments"
+    case 4:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -11737,6 +13140,7 @@ extension DeclNameSyntax: CustomReflectable {
       "declBaseName": Syntax(declBaseName).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenDeclBaseNameAndDeclNameArguments": unexpectedBetweenDeclBaseNameAndDeclNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "declNameArguments": declNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterDeclNameArguments": unexpectedAfterDeclNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -11773,7 +13177,8 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     _ unexpectedBetweenCommaAndDeclBaseName: UnexpectedNodesSyntax? = nil,
     declBaseName: TokenSyntax,
     _ unexpectedBetweenDeclBaseNameAndDeclNameArguments: UnexpectedNodesSyntax? = nil,
-    declNameArguments: DeclNameArgumentsSyntax?
+    declNameArguments: DeclNameArgumentsSyntax?,
+    _ unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeType?.raw,
@@ -11784,6 +13189,7 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       declBaseName.raw,
       unexpectedBetweenDeclBaseNameAndDeclNameArguments?.raw,
       declNameArguments?.raw,
+      unexpectedAfterDeclNameArguments?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.implementsAttributeArguments,
       from: layout, arena: .default)
@@ -11970,6 +13376,27 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     return ImplementsAttributeArgumentsSyntax(newData)
   }
 
+  public var unexpectedAfterDeclNameArguments: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterDeclNameArguments(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterDeclNameArguments` replaced.
+  /// - param newChild: The new `unexpectedAfterDeclNameArguments` to replace the node's
+  ///                   current `unexpectedAfterDeclNameArguments`, if present.
+  public func withUnexpectedAfterDeclNameArguments(
+    _ newChild: UnexpectedNodesSyntax?) -> ImplementsAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return ImplementsAttributeArgumentsSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -11988,6 +13415,8 @@ public struct ImplementsAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return nil
     case 7:
       return "declaration name arguments"
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -12005,6 +13434,7 @@ extension ImplementsAttributeArgumentsSyntax: CustomReflectable {
       "declBaseName": Syntax(declBaseName).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenDeclBaseNameAndDeclNameArguments": unexpectedBetweenDeclBaseNameAndDeclNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "declNameArguments": declNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterDeclNameArguments": unexpectedAfterDeclNameArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -12038,13 +13468,15 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax?,
     _ unexpectedBetweenNameAndColon: UnexpectedNodesSyntax? = nil,
-    colon: TokenSyntax?
+    colon: TokenSyntax?,
+    _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name?.raw,
       unexpectedBetweenNameAndColon?.raw,
       colon?.raw,
+      unexpectedAfterColon?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.objCSelectorPiece,
       from: layout, arena: .default)
@@ -12136,6 +13568,27 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
     return ObjCSelectorPieceSyntax(newData)
   }
 
+  public var unexpectedAfterColon: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterColon(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterColon` replaced.
+  /// - param newChild: The new `unexpectedAfterColon` to replace the node's
+  ///                   current `unexpectedAfterColon`, if present.
+  public func withUnexpectedAfterColon(
+    _ newChild: UnexpectedNodesSyntax?) -> ObjCSelectorPieceSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return ObjCSelectorPieceSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -12145,6 +13598,8 @@ public struct ObjCSelectorPieceSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -12159,6 +13614,7 @@ extension ObjCSelectorPieceSyntax: CustomReflectable {
       "name": name.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenNameAndColon": unexpectedBetweenNameAndColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "colon": colon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterColon": unexpectedAfterColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -12198,7 +13654,8 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
     _ unexpectedBetweenDiffParamsAndDiffParamsComma: UnexpectedNodesSyntax? = nil,
     diffParamsComma: TokenSyntax?,
     _ unexpectedBetweenDiffParamsCommaAndWhereClause: UnexpectedNodesSyntax? = nil,
-    whereClause: GenericWhereClauseSyntax?
+    whereClause: GenericWhereClauseSyntax?,
+    _ unexpectedAfterWhereClause: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDiffKind?.raw,
@@ -12211,6 +13668,7 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
       diffParamsComma?.raw,
       unexpectedBetweenDiffParamsCommaAndWhereClause?.raw,
       whereClause?.raw,
+      unexpectedAfterWhereClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiableAttributeArguments,
       from: layout, arena: .default)
@@ -12435,6 +13893,27 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
     return DifferentiableAttributeArgumentsSyntax(newData)
   }
 
+  public var unexpectedAfterWhereClause: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 10, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterWhereClause(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterWhereClause` replaced.
+  /// - param newChild: The new `unexpectedAfterWhereClause` to replace the node's
+  ///                   current `unexpectedAfterWhereClause`, if present.
+  public func withUnexpectedAfterWhereClause(
+    _ newChild: UnexpectedNodesSyntax?) -> DifferentiableAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 10)
+    return DifferentiableAttributeArgumentsSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -12457,6 +13936,8 @@ public struct DifferentiableAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHash
       return nil
     case 9:
       return nil
+    case 10:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -12476,6 +13957,7 @@ extension DifferentiableAttributeArgumentsSyntax: CustomReflectable {
       "diffParamsComma": diffParamsComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenDiffParamsCommaAndWhereClause": unexpectedBetweenDiffParamsCommaAndWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "whereClause": whereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterWhereClause": unexpectedAfterWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -12507,7 +13989,8 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
     _ unexpectedBetweenWrtLabelAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndParameters: UnexpectedNodesSyntax? = nil,
-    parameters: Syntax
+    parameters: Syntax,
+    _ unexpectedAfterParameters: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWrtLabel?.raw,
@@ -12516,6 +13999,7 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
       colon.raw,
       unexpectedBetweenColonAndParameters?.raw,
       parameters.raw,
+      unexpectedAfterParameters?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParamsClause,
       from: layout, arena: .default)
@@ -12650,6 +14134,27 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
     return DifferentiabilityParamsClauseSyntax(newData)
   }
 
+  public var unexpectedAfterParameters: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterParameters(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterParameters` replaced.
+  /// - param newChild: The new `unexpectedAfterParameters` to replace the node's
+  ///                   current `unexpectedAfterParameters`, if present.
+  public func withUnexpectedAfterParameters(
+    _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsClauseSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return DifferentiabilityParamsClauseSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -12664,6 +14169,8 @@ public struct DifferentiabilityParamsClauseSyntax: SyntaxProtocol, SyntaxHashabl
       return nil
     case 5:
       return "parameters"
+    case 6:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -12679,6 +14186,7 @@ extension DifferentiabilityParamsClauseSyntax: CustomReflectable {
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenColonAndParameters": unexpectedBetweenColonAndParameters.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "parameters": Syntax(parameters).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterParameters": unexpectedAfterParameters.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -12710,7 +14218,8 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndDiffParams: UnexpectedNodesSyntax? = nil,
     diffParams: DifferentiabilityParamListSyntax,
     _ unexpectedBetweenDiffParamsAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
@@ -12719,6 +14228,7 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
       diffParams.raw,
       unexpectedBetweenDiffParamsAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParams,
       from: layout, arena: .default)
@@ -12868,6 +14378,27 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
     return DifferentiabilityParamsSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return DifferentiabilityParamsSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -12881,6 +14412,8 @@ public struct DifferentiabilityParamsSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -12897,6 +14430,7 @@ extension DifferentiabilityParamsSyntax: CustomReflectable {
       "diffParams": Syntax(diffParams).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenDiffParamsAndRightParen": unexpectedBetweenDiffParamsAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -12929,13 +14463,15 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeParameter: UnexpectedNodesSyntax? = nil,
     parameter: Syntax,
     _ unexpectedBetweenParameterAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeParameter?.raw,
       parameter.raw,
       unexpectedBetweenParameterAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.differentiabilityParam,
       from: layout, arena: .default)
@@ -13026,6 +14562,27 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
     return DifferentiabilityParamSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> DifferentiabilityParamSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return DifferentiabilityParamSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -13035,6 +14592,8 @@ public struct DifferentiabilityParamSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -13049,6 +14608,7 @@ extension DifferentiabilityParamSyntax: CustomReflectable {
       "parameter": Syntax(parameter).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenParameterAndTrailingComma": unexpectedBetweenParameterAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -13092,7 +14652,8 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
     _ unexpectedBetweenAccessorKindAndComma: UnexpectedNodesSyntax? = nil,
     comma: TokenSyntax?,
     _ unexpectedBetweenCommaAndDiffParams: UnexpectedNodesSyntax? = nil,
-    diffParams: DifferentiabilityParamsClauseSyntax?
+    diffParams: DifferentiabilityParamsClauseSyntax?,
+    _ unexpectedAfterDiffParams: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeOfLabel?.raw,
@@ -13109,6 +14670,7 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       comma?.raw,
       unexpectedBetweenCommaAndDiffParams?.raw,
       diffParams?.raw,
+      unexpectedAfterDiffParams?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.derivativeRegistrationAttributeArguments,
       from: layout, arena: .default)
@@ -13418,6 +14980,27 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
     return DerivativeRegistrationAttributeArgumentsSyntax(newData)
   }
 
+  public var unexpectedAfterDiffParams: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 14, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterDiffParams(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterDiffParams` replaced.
+  /// - param newChild: The new `unexpectedAfterDiffParams` to replace the node's
+  ///                   current `unexpectedAfterDiffParams`, if present.
+  public func withUnexpectedAfterDiffParams(
+    _ newChild: UnexpectedNodesSyntax?) -> DerivativeRegistrationAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 14)
+    return DerivativeRegistrationAttributeArgumentsSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -13448,6 +15031,8 @@ public struct DerivativeRegistrationAttributeArgumentsSyntax: SyntaxProtocol, Sy
       return nil
     case 13:
       return nil
+    case 14:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -13471,6 +15056,7 @@ extension DerivativeRegistrationAttributeArgumentsSyntax: CustomReflectable {
       "comma": comma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenCommaAndDiffParams": unexpectedBetweenCommaAndDiffParams.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "diffParams": diffParams.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterDiffParams": unexpectedAfterDiffParams.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -13507,7 +15093,8 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenDotAndName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? = nil,
-    arguments: DeclNameArgumentsSyntax?
+    arguments: DeclNameArgumentsSyntax?,
+    _ unexpectedAfterArguments: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBaseType?.raw,
@@ -13518,6 +15105,7 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       name.raw,
       unexpectedBetweenNameAndArguments?.raw,
       arguments?.raw,
+      unexpectedAfterArguments?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.qualifiedDeclName,
       from: layout, arena: .default)
@@ -13702,6 +15290,27 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     return QualifiedDeclNameSyntax(newData)
   }
 
+  public var unexpectedAfterArguments: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterArguments(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterArguments` replaced.
+  /// - param newChild: The new `unexpectedAfterArguments` to replace the node's
+  ///                   current `unexpectedAfterArguments`, if present.
+  public func withUnexpectedAfterArguments(
+    _ newChild: UnexpectedNodesSyntax?) -> QualifiedDeclNameSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return QualifiedDeclNameSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -13720,6 +15329,8 @@ public struct QualifiedDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return "arguments"
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -13737,6 +15348,7 @@ extension QualifiedDeclNameSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndArguments": unexpectedBetweenNameAndArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "arguments": arguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterArguments": unexpectedAfterArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -13766,13 +15378,15 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeName: UnexpectedNodesSyntax? = nil,
     name: Syntax,
     _ unexpectedBetweenNameAndArguments: UnexpectedNodesSyntax? = nil,
-    arguments: DeclNameArgumentsSyntax?
+    arguments: DeclNameArgumentsSyntax?,
+    _ unexpectedAfterArguments: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndArguments?.raw,
       arguments?.raw,
+      unexpectedAfterArguments?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionDeclName,
       from: layout, arena: .default)
@@ -13870,6 +15484,27 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
     return FunctionDeclNameSyntax(newData)
   }
 
+  public var unexpectedAfterArguments: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterArguments(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterArguments` replaced.
+  /// - param newChild: The new `unexpectedAfterArguments` to replace the node's
+  ///                   current `unexpectedAfterArguments`, if present.
+  public func withUnexpectedAfterArguments(
+    _ newChild: UnexpectedNodesSyntax?) -> FunctionDeclNameSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return FunctionDeclNameSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -13880,6 +15515,8 @@ public struct FunctionDeclNameSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 3:
       return "arguments"
+    case 4:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -13893,6 +15530,7 @@ extension FunctionDeclNameSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndArguments": unexpectedBetweenNameAndArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "arguments": arguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterArguments": unexpectedAfterArguments.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -13926,7 +15564,8 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
     _ unexpectedBetweenBeforeLabelAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndVersionList: UnexpectedNodesSyntax? = nil,
-    versionList: BackDeployVersionListSyntax
+    versionList: BackDeployVersionListSyntax,
+    _ unexpectedAfterVersionList: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBeforeLabel?.raw,
@@ -13935,6 +15574,7 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
       colon.raw,
       unexpectedBetweenColonAndVersionList?.raw,
       versionList.raw,
+      unexpectedAfterVersionList?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployAttributeSpecList,
       from: layout, arena: .default)
@@ -14091,6 +15731,27 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
     return BackDeployAttributeSpecListSyntax(newData)
   }
 
+  public var unexpectedAfterVersionList: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterVersionList(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterVersionList` replaced.
+  /// - param newChild: The new `unexpectedAfterVersionList` to replace the node's
+  ///                   current `unexpectedAfterVersionList`, if present.
+  public func withUnexpectedAfterVersionList(
+    _ newChild: UnexpectedNodesSyntax?) -> BackDeployAttributeSpecListSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return BackDeployAttributeSpecListSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -14104,6 +15765,8 @@ public struct BackDeployAttributeSpecListSyntax: SyntaxProtocol, SyntaxHashable 
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -14120,6 +15783,7 @@ extension BackDeployAttributeSpecListSyntax: CustomReflectable {
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenColonAndVersionList": unexpectedBetweenColonAndVersionList.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "versionList": Syntax(versionList).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterVersionList": unexpectedAfterVersionList.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -14152,13 +15816,15 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeAvailabilityVersionRestriction: UnexpectedNodesSyntax? = nil,
     availabilityVersionRestriction: AvailabilityVersionRestrictionSyntax,
     _ unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAvailabilityVersionRestriction?.raw,
       availabilityVersionRestriction.raw,
       unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.backDeployVersionArgument,
       from: layout, arena: .default)
@@ -14253,6 +15919,27 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     return BackDeployVersionArgumentSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> BackDeployVersionArgumentSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return BackDeployVersionArgumentSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -14262,6 +15949,8 @@ public struct BackDeployVersionArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -14276,6 +15965,7 @@ extension BackDeployVersionArgumentSyntax: CustomReflectable {
       "availabilityVersionRestriction": Syntax(availabilityVersionRestriction).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma": unexpectedBetweenAvailabilityVersionRestrictionAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -14309,7 +15999,8 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
     _ unexpectedBetweenMangledNameAndComma: UnexpectedNodesSyntax? = nil,
     comma: TokenSyntax,
     _ unexpectedBetweenCommaAndOrdinal: UnexpectedNodesSyntax? = nil,
-    ordinal: TokenSyntax
+    ordinal: TokenSyntax,
+    _ unexpectedAfterOrdinal: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeMangledName?.raw,
@@ -14318,6 +16009,7 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
       comma.raw,
       unexpectedBetweenCommaAndOrdinal?.raw,
       ordinal.raw,
+      unexpectedAfterOrdinal?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.opaqueReturnTypeOfAttributeArguments,
       from: layout, arena: .default)
@@ -14450,6 +16142,27 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
     return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
   }
 
+  public var unexpectedAfterOrdinal: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterOrdinal(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterOrdinal` replaced.
+  /// - param newChild: The new `unexpectedAfterOrdinal` to replace the node's
+  ///                   current `unexpectedAfterOrdinal`, if present.
+  public func withUnexpectedAfterOrdinal(
+    _ newChild: UnexpectedNodesSyntax?) -> OpaqueReturnTypeOfAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return OpaqueReturnTypeOfAttributeArgumentsSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -14463,6 +16176,8 @@ public struct OpaqueReturnTypeOfAttributeArgumentsSyntax: SyntaxProtocol, Syntax
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -14479,6 +16194,7 @@ extension OpaqueReturnTypeOfAttributeArgumentsSyntax: CustomReflectable {
       "comma": Syntax(comma).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenCommaAndOrdinal": unexpectedBetweenCommaAndOrdinal.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "ordinal": Syntax(ordinal).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterOrdinal": unexpectedAfterOrdinal.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -14516,7 +16232,8 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     _ unexpectedBetweenCTypeLabelAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax?,
     _ unexpectedBetweenColonAndCTypeString: UnexpectedNodesSyntax? = nil,
-    cTypeString: TokenSyntax?
+    cTypeString: TokenSyntax?,
+    _ unexpectedAfterCTypeString: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeConventionLabel?.raw,
@@ -14529,6 +16246,7 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       colon?.raw,
       unexpectedBetweenColonAndCTypeString?.raw,
       cTypeString?.raw,
+      unexpectedAfterCTypeString?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionAttributeArguments,
       from: layout, arena: .default)
@@ -14746,6 +16464,27 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
     return ConventionAttributeArgumentsSyntax(newData)
   }
 
+  public var unexpectedAfterCTypeString: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 10, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterCTypeString(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterCTypeString` replaced.
+  /// - param newChild: The new `unexpectedAfterCTypeString` to replace the node's
+  ///                   current `unexpectedAfterCTypeString`, if present.
+  public func withUnexpectedAfterCTypeString(
+    _ newChild: UnexpectedNodesSyntax?) -> ConventionAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 10)
+    return ConventionAttributeArgumentsSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -14768,6 +16507,8 @@ public struct ConventionAttributeArgumentsSyntax: SyntaxProtocol, SyntaxHashable
       return nil
     case 9:
       return nil
+    case 10:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -14787,6 +16528,7 @@ extension ConventionAttributeArgumentsSyntax: CustomReflectable {
       "colon": colon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenColonAndCTypeString": unexpectedBetweenColonAndCTypeString.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "cTypeString": cTypeString.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterCTypeString": unexpectedAfterCTypeString.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -14820,7 +16562,8 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
     _ unexpectedBetweenWitnessMethodLabelAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndProtocolName: UnexpectedNodesSyntax? = nil,
-    protocolName: TokenSyntax
+    protocolName: TokenSyntax,
+    _ unexpectedAfterProtocolName: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWitnessMethodLabel?.raw,
@@ -14829,6 +16572,7 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
       colon.raw,
       unexpectedBetweenColonAndProtocolName?.raw,
       protocolName.raw,
+      unexpectedAfterProtocolName?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.conventionWitnessMethodAttributeArguments,
       from: layout, arena: .default)
@@ -14959,6 +16703,27 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
     return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
   }
 
+  public var unexpectedAfterProtocolName: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterProtocolName(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterProtocolName` replaced.
+  /// - param newChild: The new `unexpectedAfterProtocolName` to replace the node's
+  ///                   current `unexpectedAfterProtocolName`, if present.
+  public func withUnexpectedAfterProtocolName(
+    _ newChild: UnexpectedNodesSyntax?) -> ConventionWitnessMethodAttributeArgumentsSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return ConventionWitnessMethodAttributeArgumentsSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -14972,6 +16737,8 @@ public struct ConventionWitnessMethodAttributeArgumentsSyntax: SyntaxProtocol, S
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -14988,6 +16755,7 @@ extension ConventionWitnessMethodAttributeArgumentsSyntax: CustomReflectable {
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenColonAndProtocolName": unexpectedBetweenColonAndProtocolName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "protocolName": Syntax(protocolName).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterProtocolName": unexpectedAfterProtocolName.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -15016,13 +16784,15 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeWhereKeyword: UnexpectedNodesSyntax? = nil,
     whereKeyword: TokenSyntax,
     _ unexpectedBetweenWhereKeywordAndGuardResult: UnexpectedNodesSyntax? = nil,
-    guardResult: ExprSyntax
+    guardResult: ExprSyntax,
+    _ unexpectedAfterGuardResult: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWhereKeyword?.raw,
       whereKeyword.raw,
       unexpectedBetweenWhereKeywordAndGuardResult?.raw,
       guardResult.raw,
+      unexpectedAfterGuardResult?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.whereClause,
       from: layout, arena: .default)
@@ -15112,6 +16882,27 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return WhereClauseSyntax(newData)
   }
 
+  public var unexpectedAfterGuardResult: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterGuardResult(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterGuardResult` replaced.
+  /// - param newChild: The new `unexpectedAfterGuardResult` to replace the node's
+  ///                   current `unexpectedAfterGuardResult`, if present.
+  public func withUnexpectedAfterGuardResult(
+    _ newChild: UnexpectedNodesSyntax?) -> WhereClauseSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return WhereClauseSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -15121,6 +16912,8 @@ public struct WhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -15135,6 +16928,7 @@ extension WhereClauseSyntax: CustomReflectable {
       "whereKeyword": Syntax(whereKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenWhereKeywordAndGuardResult": unexpectedBetweenWhereKeywordAndGuardResult.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "guardResult": Syntax(guardResult).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterGuardResult": unexpectedAfterGuardResult.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -15165,7 +16959,8 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndElementList: UnexpectedNodesSyntax? = nil,
     elementList: YieldExprListSyntax,
     _ unexpectedBetweenElementListAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
@@ -15174,6 +16969,7 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
       elementList.raw,
       unexpectedBetweenElementListAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldList,
       from: layout, arena: .default)
@@ -15322,6 +17118,27 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
     return YieldListSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> YieldListSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return YieldListSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -15335,6 +17152,8 @@ public struct YieldListSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -15351,6 +17170,7 @@ extension YieldListSyntax: CustomReflectable {
       "elementList": Syntax(elementList).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenElementListAndRightParen": unexpectedBetweenElementListAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -15379,13 +17199,15 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeCondition: UnexpectedNodesSyntax? = nil,
     condition: Syntax,
     _ unexpectedBetweenConditionAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeCondition?.raw,
       condition.raw,
       unexpectedBetweenConditionAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.conditionElement,
       from: layout, arena: .default)
@@ -15476,6 +17298,27 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
     return ConditionElementSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> ConditionElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return ConditionElementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -15485,6 +17328,8 @@ public struct ConditionElementSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -15499,6 +17344,7 @@ extension ConditionElementSyntax: CustomReflectable {
       "condition": Syntax(condition).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenConditionAndTrailingComma": unexpectedBetweenConditionAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -15531,7 +17377,8 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? = nil,
     availabilitySpec: AvailabilitySpecListSyntax,
     _ unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundAvailableKeyword?.raw,
@@ -15542,6 +17389,7 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
       availabilitySpec.raw,
       unexpectedBetweenAvailabilitySpecAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityCondition,
       from: layout, arena: .default)
@@ -15731,6 +17579,27 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
     return AvailabilityConditionSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityConditionSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return AvailabilityConditionSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -15749,6 +17618,8 @@ public struct AvailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -15766,6 +17637,7 @@ extension AvailabilityConditionSyntax: CustomReflectable {
       "availabilitySpec": Syntax(availabilitySpec).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenAvailabilitySpecAndRightParen": unexpectedBetweenAvailabilitySpecAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -15798,7 +17670,8 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil,
     typeAnnotation: TypeAnnotationSyntax?,
     _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil,
-    initializer: InitializerClauseSyntax
+    initializer: InitializerClauseSyntax,
+    _ unexpectedAfterInitializer: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeCaseKeyword?.raw,
@@ -15809,6 +17682,7 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
       typeAnnotation?.raw,
       unexpectedBetweenTypeAnnotationAndInitializer?.raw,
       initializer.raw,
+      unexpectedAfterInitializer?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.matchingPatternCondition,
       from: layout, arena: .default)
@@ -15981,6 +17855,27 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
     return MatchingPatternConditionSyntax(newData)
   }
 
+  public var unexpectedAfterInitializer: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterInitializer(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterInitializer` replaced.
+  /// - param newChild: The new `unexpectedAfterInitializer` to replace the node's
+  ///                   current `unexpectedAfterInitializer`, if present.
+  public func withUnexpectedAfterInitializer(
+    _ newChild: UnexpectedNodesSyntax?) -> MatchingPatternConditionSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return MatchingPatternConditionSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -15999,6 +17894,8 @@ public struct MatchingPatternConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -16016,6 +17913,7 @@ extension MatchingPatternConditionSyntax: CustomReflectable {
       "typeAnnotation": typeAnnotation.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenTypeAnnotationAndInitializer": unexpectedBetweenTypeAnnotationAndInitializer.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "initializer": Syntax(initializer).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterInitializer": unexpectedAfterInitializer.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -16048,7 +17946,8 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenPatternAndTypeAnnotation: UnexpectedNodesSyntax? = nil,
     typeAnnotation: TypeAnnotationSyntax?,
     _ unexpectedBetweenTypeAnnotationAndInitializer: UnexpectedNodesSyntax? = nil,
-    initializer: InitializerClauseSyntax?
+    initializer: InitializerClauseSyntax?,
+    _ unexpectedAfterInitializer: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLetOrVarKeyword?.raw,
@@ -16059,6 +17958,7 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
       typeAnnotation?.raw,
       unexpectedBetweenTypeAnnotationAndInitializer?.raw,
       initializer?.raw,
+      unexpectedAfterInitializer?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalBindingCondition,
       from: layout, arena: .default)
@@ -16232,6 +18132,27 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
     return OptionalBindingConditionSyntax(newData)
   }
 
+  public var unexpectedAfterInitializer: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterInitializer(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterInitializer` replaced.
+  /// - param newChild: The new `unexpectedAfterInitializer` to replace the node's
+  ///                   current `unexpectedAfterInitializer`, if present.
+  public func withUnexpectedAfterInitializer(
+    _ newChild: UnexpectedNodesSyntax?) -> OptionalBindingConditionSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return OptionalBindingConditionSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -16250,6 +18171,8 @@ public struct OptionalBindingConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -16267,6 +18190,7 @@ extension OptionalBindingConditionSyntax: CustomReflectable {
       "typeAnnotation": typeAnnotation.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenTypeAnnotationAndInitializer": unexpectedBetweenTypeAnnotationAndInitializer.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "initializer": initializer.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterInitializer": unexpectedAfterInitializer.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -16299,7 +18223,8 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndAvailabilitySpec: UnexpectedNodesSyntax? = nil,
     availabilitySpec: AvailabilitySpecListSyntax,
     _ unexpectedBetweenAvailabilitySpecAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundUnavailableKeyword?.raw,
@@ -16310,6 +18235,7 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
       availabilitySpec.raw,
       unexpectedBetweenAvailabilitySpecAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.unavailabilityCondition,
       from: layout, arena: .default)
@@ -16499,6 +18425,27 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
     return UnavailabilityConditionSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> UnavailabilityConditionSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return UnavailabilityConditionSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -16517,6 +18464,8 @@ public struct UnavailabilityConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -16534,6 +18483,7 @@ extension UnavailabilityConditionSyntax: CustomReflectable {
       "availabilitySpec": Syntax(availabilitySpec).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenAvailabilitySpecAndRightParen": unexpectedBetweenAvailabilitySpecAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -16566,7 +18516,8 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndExpression: UnexpectedNodesSyntax? = nil,
     expression: ExprSyntax,
     _ unexpectedBetweenExpressionAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeHasSymbolKeyword?.raw,
@@ -16577,6 +18528,7 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
       expression.raw,
       unexpectedBetweenExpressionAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.hasSymbolCondition,
       from: layout, arena: .default)
@@ -16748,6 +18700,27 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
     return HasSymbolConditionSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> HasSymbolConditionSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return HasSymbolConditionSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -16766,6 +18739,8 @@ public struct HasSymbolConditionSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -16783,6 +18758,7 @@ extension HasSymbolConditionSyntax: CustomReflectable {
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenExpressionAndRightParen": unexpectedBetweenExpressionAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -16813,7 +18789,8 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenUnknownAttrAndLabel: UnexpectedNodesSyntax? = nil,
     label: Syntax,
     _ unexpectedBetweenLabelAndStatements: UnexpectedNodesSyntax? = nil,
-    statements: CodeBlockItemListSyntax
+    statements: CodeBlockItemListSyntax,
+    _ unexpectedAfterStatements: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeUnknownAttr?.raw,
@@ -16822,6 +18799,7 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
       label.raw,
       unexpectedBetweenLabelAndStatements?.raw,
       statements.raw,
+      unexpectedAfterStatements?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCase,
       from: layout, arena: .default)
@@ -16971,6 +18949,27 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
     return SwitchCaseSyntax(newData)
   }
 
+  public var unexpectedAfterStatements: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterStatements(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterStatements` replaced.
+  /// - param newChild: The new `unexpectedAfterStatements` to replace the node's
+  ///                   current `unexpectedAfterStatements`, if present.
+  public func withUnexpectedAfterStatements(
+    _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return SwitchCaseSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -16984,6 +18983,8 @@ public struct SwitchCaseSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -17000,6 +19001,7 @@ extension SwitchCaseSyntax: CustomReflectable {
       "label": Syntax(label).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenLabelAndStatements": unexpectedBetweenLabelAndStatements.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "statements": Syntax(statements).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterStatements": unexpectedAfterStatements.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -17028,13 +19030,15 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeDefaultKeyword: UnexpectedNodesSyntax? = nil,
     defaultKeyword: TokenSyntax,
     _ unexpectedBetweenDefaultKeywordAndColon: UnexpectedNodesSyntax? = nil,
-    colon: TokenSyntax
+    colon: TokenSyntax,
+    _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDefaultKeyword?.raw,
       defaultKeyword.raw,
       unexpectedBetweenDefaultKeywordAndColon?.raw,
       colon.raw,
+      unexpectedAfterColon?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchDefaultLabel,
       from: layout, arena: .default)
@@ -17124,6 +19128,27 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
     return SwitchDefaultLabelSyntax(newData)
   }
 
+  public var unexpectedAfterColon: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterColon(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterColon` replaced.
+  /// - param newChild: The new `unexpectedAfterColon` to replace the node's
+  ///                   current `unexpectedAfterColon`, if present.
+  public func withUnexpectedAfterColon(
+    _ newChild: UnexpectedNodesSyntax?) -> SwitchDefaultLabelSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return SwitchDefaultLabelSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -17133,6 +19158,8 @@ public struct SwitchDefaultLabelSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -17147,6 +19174,7 @@ extension SwitchDefaultLabelSyntax: CustomReflectable {
       "defaultKeyword": Syntax(defaultKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenDefaultKeywordAndColon": unexpectedBetweenDefaultKeywordAndColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterColon": unexpectedAfterColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -17177,7 +19205,8 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? = nil,
     whereClause: WhereClauseSyntax?,
     _ unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePattern?.raw,
@@ -17186,6 +19215,7 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
       whereClause?.raw,
       unexpectedBetweenWhereClauseAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.caseItem,
       from: layout, arena: .default)
@@ -17318,6 +19348,27 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
     return CaseItemSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> CaseItemSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return CaseItemSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -17331,6 +19382,8 @@ public struct CaseItemSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -17347,6 +19400,7 @@ extension CaseItemSyntax: CustomReflectable {
       "whereClause": whereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenWhereClauseAndTrailingComma": unexpectedBetweenWhereClauseAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -17377,7 +19431,8 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenPatternAndWhereClause: UnexpectedNodesSyntax? = nil,
     whereClause: WhereClauseSyntax?,
     _ unexpectedBetweenWhereClauseAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePattern?.raw,
@@ -17386,6 +19441,7 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
       whereClause?.raw,
       unexpectedBetweenWhereClauseAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchItem,
       from: layout, arena: .default)
@@ -17519,6 +19575,27 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
     return CatchItemSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> CatchItemSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return CatchItemSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -17532,6 +19609,8 @@ public struct CatchItemSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -17548,6 +19627,7 @@ extension CatchItemSyntax: CustomReflectable {
       "whereClause": whereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenWhereClauseAndTrailingComma": unexpectedBetweenWhereClauseAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -17578,7 +19658,8 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenCaseKeywordAndCaseItems: UnexpectedNodesSyntax? = nil,
     caseItems: CaseItemListSyntax,
     _ unexpectedBetweenCaseItemsAndColon: UnexpectedNodesSyntax? = nil,
-    colon: TokenSyntax
+    colon: TokenSyntax,
+    _ unexpectedAfterColon: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeCaseKeyword?.raw,
@@ -17587,6 +19668,7 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
       caseItems.raw,
       unexpectedBetweenCaseItemsAndColon?.raw,
       colon.raw,
+      unexpectedAfterColon?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchCaseLabel,
       from: layout, arena: .default)
@@ -17735,6 +19817,27 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
     return SwitchCaseLabelSyntax(newData)
   }
 
+  public var unexpectedAfterColon: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterColon(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterColon` replaced.
+  /// - param newChild: The new `unexpectedAfterColon` to replace the node's
+  ///                   current `unexpectedAfterColon`, if present.
+  public func withUnexpectedAfterColon(
+    _ newChild: UnexpectedNodesSyntax?) -> SwitchCaseLabelSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return SwitchCaseLabelSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -17748,6 +19851,8 @@ public struct SwitchCaseLabelSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -17764,6 +19869,7 @@ extension SwitchCaseLabelSyntax: CustomReflectable {
       "caseItems": Syntax(caseItems).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenCaseItemsAndColon": unexpectedBetweenCaseItemsAndColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterColon": unexpectedAfterColon.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -17794,7 +19900,8 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenCatchKeywordAndCatchItems: UnexpectedNodesSyntax? = nil,
     catchItems: CatchItemListSyntax?,
     _ unexpectedBetweenCatchItemsAndBody: UnexpectedNodesSyntax? = nil,
-    body: CodeBlockSyntax
+    body: CodeBlockSyntax,
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeCatchKeyword?.raw,
@@ -17803,6 +19910,7 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
       catchItems?.raw,
       unexpectedBetweenCatchItemsAndBody?.raw,
       body.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.catchClause,
       from: layout, arena: .default)
@@ -17952,6 +20060,27 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return CatchClauseSyntax(newData)
   }
 
+  public var unexpectedAfterBody: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterBody(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
+  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
+  ///                   current `unexpectedAfterBody`, if present.
+  public func withUnexpectedAfterBody(
+    _ newChild: UnexpectedNodesSyntax?) -> CatchClauseSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return CatchClauseSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -17965,6 +20094,8 @@ public struct CatchClauseSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -17981,6 +20112,7 @@ extension CatchClauseSyntax: CustomReflectable {
       "catchItems": catchItems.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenCatchItemsAndBody": unexpectedBetweenCatchItemsAndBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "body": Syntax(body).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterBody": unexpectedAfterBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -18009,13 +20141,15 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeWhereKeyword: UnexpectedNodesSyntax? = nil,
     whereKeyword: TokenSyntax,
     _ unexpectedBetweenWhereKeywordAndRequirementList: UnexpectedNodesSyntax? = nil,
-    requirementList: GenericRequirementListSyntax
+    requirementList: GenericRequirementListSyntax,
+    _ unexpectedAfterRequirementList: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWhereKeyword?.raw,
       whereKeyword.raw,
       unexpectedBetweenWhereKeywordAndRequirementList?.raw,
       requirementList.raw,
+      unexpectedAfterRequirementList?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericWhereClause,
       from: layout, arena: .default)
@@ -18123,6 +20257,27 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return GenericWhereClauseSyntax(newData)
   }
 
+  public var unexpectedAfterRequirementList: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRequirementList(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRequirementList` replaced.
+  /// - param newChild: The new `unexpectedAfterRequirementList` to replace the node's
+  ///                   current `unexpectedAfterRequirementList`, if present.
+  public func withUnexpectedAfterRequirementList(
+    _ newChild: UnexpectedNodesSyntax?) -> GenericWhereClauseSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return GenericWhereClauseSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -18132,6 +20287,8 @@ public struct GenericWhereClauseSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -18146,6 +20303,7 @@ extension GenericWhereClauseSyntax: CustomReflectable {
       "whereKeyword": Syntax(whereKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenWhereKeywordAndRequirementList": unexpectedBetweenWhereKeywordAndRequirementList.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "requirementList": Syntax(requirementList).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRequirementList": unexpectedAfterRequirementList.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -18174,13 +20332,15 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeBody: UnexpectedNodesSyntax? = nil,
     body: Syntax,
     _ unexpectedBetweenBodyAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBody?.raw,
       body.raw,
       unexpectedBetweenBodyAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericRequirement,
       from: layout, arena: .default)
@@ -18271,6 +20431,27 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     return GenericRequirementSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> GenericRequirementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return GenericRequirementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -18280,6 +20461,8 @@ public struct GenericRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -18294,6 +20477,7 @@ extension GenericRequirementSyntax: CustomReflectable {
       "body": Syntax(body).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenBodyAndTrailingComma": unexpectedBetweenBodyAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -18324,7 +20508,8 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftTypeIdentifierAndEqualityToken: UnexpectedNodesSyntax? = nil,
     equalityToken: TokenSyntax,
     _ unexpectedBetweenEqualityTokenAndRightTypeIdentifier: UnexpectedNodesSyntax? = nil,
-    rightTypeIdentifier: TypeSyntax
+    rightTypeIdentifier: TypeSyntax,
+    _ unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftTypeIdentifier?.raw,
@@ -18333,6 +20518,7 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       equalityToken.raw,
       unexpectedBetweenEqualityTokenAndRightTypeIdentifier?.raw,
       rightTypeIdentifier.raw,
+      unexpectedAfterRightTypeIdentifier?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.sameTypeRequirement,
       from: layout, arena: .default)
@@ -18463,6 +20649,27 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     return SameTypeRequirementSyntax(newData)
   }
 
+  public var unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightTypeIdentifier(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightTypeIdentifier` replaced.
+  /// - param newChild: The new `unexpectedAfterRightTypeIdentifier` to replace the node's
+  ///                   current `unexpectedAfterRightTypeIdentifier`, if present.
+  public func withUnexpectedAfterRightTypeIdentifier(
+    _ newChild: UnexpectedNodesSyntax?) -> SameTypeRequirementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return SameTypeRequirementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -18477,6 +20684,8 @@ public struct SameTypeRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 5:
       return "right-hand type"
+    case 6:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -18492,6 +20701,7 @@ extension SameTypeRequirementSyntax: CustomReflectable {
       "equalityToken": Syntax(equalityToken).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenEqualityTokenAndRightTypeIdentifier": unexpectedBetweenEqualityTokenAndRightTypeIdentifier.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightTypeIdentifier": Syntax(rightTypeIdentifier).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightTypeIdentifier": unexpectedAfterRightTypeIdentifier.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -18532,7 +20742,8 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenCommaAndAlignment: UnexpectedNodesSyntax? = nil,
     alignment: TokenSyntax?,
     _ unexpectedBetweenAlignmentAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax?
+    rightParen: TokenSyntax?,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeTypeIdentifier?.raw,
@@ -18551,6 +20762,7 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       alignment?.raw,
       unexpectedBetweenAlignmentAndRightParen?.raw,
       rightParen?.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.layoutRequirement,
       from: layout, arena: .default)
@@ -18891,6 +21103,27 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     return LayoutRequirementSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 16, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> LayoutRequirementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 16)
+    return LayoutRequirementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -18925,6 +21158,8 @@ public struct LayoutRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 15:
       return nil
+    case 16:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -18950,6 +21185,7 @@ extension LayoutRequirementSyntax: CustomReflectable {
       "alignment": alignment.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenAlignmentAndRightParen": unexpectedBetweenAlignmentAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": rightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -18984,7 +21220,8 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenColonAndInheritedType: UnexpectedNodesSyntax? = nil,
     inheritedType: TypeSyntax?,
     _ unexpectedBetweenInheritedTypeAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeAttributes?.raw,
@@ -18997,6 +21234,7 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       inheritedType?.raw,
       unexpectedBetweenInheritedTypeAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameter,
       from: layout, arena: .default)
@@ -19231,6 +21469,27 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
     return GenericParameterSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 10, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> GenericParameterSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 10)
+    return GenericParameterSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -19253,6 +21512,8 @@ public struct GenericParameterSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 9:
       return nil
+    case 10:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -19272,6 +21533,7 @@ extension GenericParameterSyntax: CustomReflectable {
       "inheritedType": inheritedType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenInheritedTypeAndTrailingComma": unexpectedBetweenInheritedTypeAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -19300,13 +21562,15 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedType,
       from: layout, arena: .default)
@@ -19397,6 +21661,27 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     return PrimaryAssociatedTypeSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return PrimaryAssociatedTypeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -19406,6 +21691,8 @@ public struct PrimaryAssociatedTypeSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -19420,6 +21707,7 @@ extension PrimaryAssociatedTypeSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndTrailingComma": unexpectedBetweenNameAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -19452,7 +21740,8 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenGenericParameterListAndGenericWhereClause: UnexpectedNodesSyntax? = nil,
     genericWhereClause: GenericWhereClauseSyntax?,
     _ unexpectedBetweenGenericWhereClauseAndRightAngleBracket: UnexpectedNodesSyntax? = nil,
-    rightAngleBracket: TokenSyntax
+    rightAngleBracket: TokenSyntax,
+    _ unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftAngleBracket?.raw,
@@ -19463,6 +21752,7 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       genericWhereClause?.raw,
       unexpectedBetweenGenericWhereClauseAndRightAngleBracket?.raw,
       rightAngleBracket.raw,
+      unexpectedAfterRightAngleBracket?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericParameterClause,
       from: layout, arena: .default)
@@ -19653,6 +21943,27 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return GenericParameterClauseSyntax(newData)
   }
 
+  public var unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightAngleBracket(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightAngleBracket` replaced.
+  /// - param newChild: The new `unexpectedAfterRightAngleBracket` to replace the node's
+  ///                   current `unexpectedAfterRightAngleBracket`, if present.
+  public func withUnexpectedAfterRightAngleBracket(
+    _ newChild: UnexpectedNodesSyntax?) -> GenericParameterClauseSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return GenericParameterClauseSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -19671,6 +21982,8 @@ public struct GenericParameterClauseSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -19688,6 +22001,7 @@ extension GenericParameterClauseSyntax: CustomReflectable {
       "genericWhereClause": genericWhereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenGenericWhereClauseAndRightAngleBracket": unexpectedBetweenGenericWhereClauseAndRightAngleBracket.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightAngleBracket": Syntax(rightAngleBracket).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightAngleBracket": unexpectedAfterRightAngleBracket.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -19718,7 +22032,8 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftTypeIdentifierAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndRightTypeIdentifier: UnexpectedNodesSyntax? = nil,
-    rightTypeIdentifier: TypeSyntax
+    rightTypeIdentifier: TypeSyntax,
+    _ unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftTypeIdentifier?.raw,
@@ -19727,6 +22042,7 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
       colon.raw,
       unexpectedBetweenColonAndRightTypeIdentifier?.raw,
       rightTypeIdentifier.raw,
+      unexpectedAfterRightTypeIdentifier?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.conformanceRequirement,
       from: layout, arena: .default)
@@ -19857,6 +22173,27 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     return ConformanceRequirementSyntax(newData)
   }
 
+  public var unexpectedAfterRightTypeIdentifier: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightTypeIdentifier(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightTypeIdentifier` replaced.
+  /// - param newChild: The new `unexpectedAfterRightTypeIdentifier` to replace the node's
+  ///                   current `unexpectedAfterRightTypeIdentifier`, if present.
+  public func withUnexpectedAfterRightTypeIdentifier(
+    _ newChild: UnexpectedNodesSyntax?) -> ConformanceRequirementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return ConformanceRequirementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -19870,6 +22207,8 @@ public struct ConformanceRequirementSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -19886,6 +22225,7 @@ extension ConformanceRequirementSyntax: CustomReflectable {
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenColonAndRightTypeIdentifier": unexpectedBetweenColonAndRightTypeIdentifier.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightTypeIdentifier": Syntax(rightTypeIdentifier).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightTypeIdentifier": unexpectedAfterRightTypeIdentifier.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -19916,7 +22256,8 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
     _ unexpectedBetweenLeftAngleBracketAndPrimaryAssociatedTypeList: UnexpectedNodesSyntax? = nil,
     primaryAssociatedTypeList: PrimaryAssociatedTypeListSyntax,
     _ unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket: UnexpectedNodesSyntax? = nil,
-    rightAngleBracket: TokenSyntax
+    rightAngleBracket: TokenSyntax,
+    _ unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftAngleBracket?.raw,
@@ -19925,6 +22266,7 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
       primaryAssociatedTypeList.raw,
       unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket?.raw,
       rightAngleBracket.raw,
+      unexpectedAfterRightAngleBracket?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.primaryAssociatedTypeClause,
       from: layout, arena: .default)
@@ -20073,6 +22415,27 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
     return PrimaryAssociatedTypeClauseSyntax(newData)
   }
 
+  public var unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightAngleBracket(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightAngleBracket` replaced.
+  /// - param newChild: The new `unexpectedAfterRightAngleBracket` to replace the node's
+  ///                   current `unexpectedAfterRightAngleBracket`, if present.
+  public func withUnexpectedAfterRightAngleBracket(
+    _ newChild: UnexpectedNodesSyntax?) -> PrimaryAssociatedTypeClauseSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return PrimaryAssociatedTypeClauseSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -20086,6 +22449,8 @@ public struct PrimaryAssociatedTypeClauseSyntax: SyntaxProtocol, SyntaxHashable 
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -20102,6 +22467,7 @@ extension PrimaryAssociatedTypeClauseSyntax: CustomReflectable {
       "primaryAssociatedTypeList": Syntax(primaryAssociatedTypeList).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket": unexpectedBetweenPrimaryAssociatedTypeListAndRightAngleBracket.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightAngleBracket": Syntax(rightAngleBracket).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightAngleBracket": unexpectedAfterRightAngleBracket.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -20130,13 +22496,15 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeType: UnexpectedNodesSyntax? = nil,
     type: TypeSyntax,
     _ unexpectedBetweenTypeAndAmpersand: UnexpectedNodesSyntax? = nil,
-    ampersand: TokenSyntax?
+    ampersand: TokenSyntax?,
+    _ unexpectedAfterAmpersand: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeType?.raw,
       type.raw,
       unexpectedBetweenTypeAndAmpersand?.raw,
       ampersand?.raw,
+      unexpectedAfterAmpersand?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionTypeElement,
       from: layout, arena: .default)
@@ -20227,6 +22595,27 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     return CompositionTypeElementSyntax(newData)
   }
 
+  public var unexpectedAfterAmpersand: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterAmpersand(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterAmpersand` replaced.
+  /// - param newChild: The new `unexpectedAfterAmpersand` to replace the node's
+  ///                   current `unexpectedAfterAmpersand`, if present.
+  public func withUnexpectedAfterAmpersand(
+    _ newChild: UnexpectedNodesSyntax?) -> CompositionTypeElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return CompositionTypeElementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -20236,6 +22625,8 @@ public struct CompositionTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -20250,6 +22641,7 @@ extension CompositionTypeElementSyntax: CustomReflectable {
       "type": Syntax(type).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenTypeAndAmpersand": unexpectedBetweenTypeAndAmpersand.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "ampersand": ampersand.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterAmpersand": unexpectedAfterAmpersand.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -20290,7 +22682,8 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenEllipsisAndInitializer: UnexpectedNodesSyntax? = nil,
     initializer: InitializerClauseSyntax?,
     _ unexpectedBetweenInitializerAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeInOut?.raw,
@@ -20309,6 +22702,7 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       initializer?.raw,
       unexpectedBetweenInitializerAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleTypeElement,
       from: layout, arena: .default)
@@ -20651,6 +23045,27 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
     return TupleTypeElementSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 16, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> TupleTypeElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 16)
+    return TupleTypeElementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -20685,6 +23100,8 @@ public struct TupleTypeElementSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 15:
       return nil
+    case 16:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -20710,6 +23127,7 @@ extension TupleTypeElementSyntax: CustomReflectable {
       "initializer": initializer.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenInitializerAndTrailingComma": unexpectedBetweenInitializerAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -20738,13 +23156,15 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeArgumentType: UnexpectedNodesSyntax? = nil,
     argumentType: TypeSyntax,
     _ unexpectedBetweenArgumentTypeAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeArgumentType?.raw,
       argumentType.raw,
       unexpectedBetweenArgumentTypeAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgument,
       from: layout, arena: .default)
@@ -20835,6 +23255,27 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     return GenericArgumentSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> GenericArgumentSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return GenericArgumentSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -20844,6 +23285,8 @@ public struct GenericArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -20858,6 +23301,7 @@ extension GenericArgumentSyntax: CustomReflectable {
       "argumentType": Syntax(argumentType).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenArgumentTypeAndTrailingComma": unexpectedBetweenArgumentTypeAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -20888,7 +23332,8 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftAngleBracketAndArguments: UnexpectedNodesSyntax? = nil,
     arguments: GenericArgumentListSyntax,
     _ unexpectedBetweenArgumentsAndRightAngleBracket: UnexpectedNodesSyntax? = nil,
-    rightAngleBracket: TokenSyntax
+    rightAngleBracket: TokenSyntax,
+    _ unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftAngleBracket?.raw,
@@ -20897,6 +23342,7 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
       arguments.raw,
       unexpectedBetweenArgumentsAndRightAngleBracket?.raw,
       rightAngleBracket.raw,
+      unexpectedAfterRightAngleBracket?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.genericArgumentClause,
       from: layout, arena: .default)
@@ -21045,6 +23491,27 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
     return GenericArgumentClauseSyntax(newData)
   }
 
+  public var unexpectedAfterRightAngleBracket: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightAngleBracket(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightAngleBracket` replaced.
+  /// - param newChild: The new `unexpectedAfterRightAngleBracket` to replace the node's
+  ///                   current `unexpectedAfterRightAngleBracket`, if present.
+  public func withUnexpectedAfterRightAngleBracket(
+    _ newChild: UnexpectedNodesSyntax?) -> GenericArgumentClauseSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return GenericArgumentClauseSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -21058,6 +23525,8 @@ public struct GenericArgumentClauseSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -21074,6 +23543,7 @@ extension GenericArgumentClauseSyntax: CustomReflectable {
       "arguments": Syntax(arguments).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenArgumentsAndRightAngleBracket": unexpectedBetweenArgumentsAndRightAngleBracket.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightAngleBracket": Syntax(rightAngleBracket).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightAngleBracket": unexpectedAfterRightAngleBracket.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -21102,13 +23572,15 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndType: UnexpectedNodesSyntax? = nil,
-    type: TypeSyntax
+    type: TypeSyntax,
+    _ unexpectedAfterType: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeColon?.raw,
       colon.raw,
       unexpectedBetweenColonAndType?.raw,
       type.raw,
+      unexpectedAfterType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.typeAnnotation,
       from: layout, arena: .default)
@@ -21198,6 +23670,27 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
     return TypeAnnotationSyntax(newData)
   }
 
+  public var unexpectedAfterType: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterType(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterType` replaced.
+  /// - param newChild: The new `unexpectedAfterType` to replace the node's
+  ///                   current `unexpectedAfterType`, if present.
+  public func withUnexpectedAfterType(
+    _ newChild: UnexpectedNodesSyntax?) -> TypeAnnotationSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return TypeAnnotationSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -21207,6 +23700,8 @@ public struct TypeAnnotationSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -21221,6 +23716,7 @@ extension TypeAnnotationSyntax: CustomReflectable {
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenColonAndType": unexpectedBetweenColonAndType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "type": Syntax(type).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterType": unexpectedAfterType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -21253,7 +23749,8 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLabelColonAndPattern: UnexpectedNodesSyntax? = nil,
     pattern: PatternSyntax,
     _ unexpectedBetweenPatternAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabelName?.raw,
@@ -21264,6 +23761,7 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
       pattern.raw,
       unexpectedBetweenPatternAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePatternElement,
       from: layout, arena: .default)
@@ -21438,6 +23936,27 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
     return TuplePatternElementSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> TuplePatternElementSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return TuplePatternElementSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -21456,6 +23975,8 @@ public struct TuplePatternElementSyntax: SyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -21473,6 +23994,7 @@ extension TuplePatternElementSyntax: CustomReflectable {
       "pattern": Syntax(pattern).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenPatternAndTrailingComma": unexpectedBetweenPatternAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -21505,13 +24027,15 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeEntry: UnexpectedNodesSyntax? = nil,
     entry: Syntax,
     _ unexpectedBetweenEntryAndTrailingComma: UnexpectedNodesSyntax? = nil,
-    trailingComma: TokenSyntax?
+    trailingComma: TokenSyntax?,
+    _ unexpectedAfterTrailingComma: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeEntry?.raw,
       entry.raw,
       unexpectedBetweenEntryAndTrailingComma?.raw,
       trailingComma?.raw,
+      unexpectedAfterTrailingComma?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityArgument,
       from: layout, arena: .default)
@@ -21607,6 +24131,27 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     return AvailabilityArgumentSyntax(newData)
   }
 
+  public var unexpectedAfterTrailingComma: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTrailingComma(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTrailingComma` replaced.
+  /// - param newChild: The new `unexpectedAfterTrailingComma` to replace the node's
+  ///                   current `unexpectedAfterTrailingComma`, if present.
+  public func withUnexpectedAfterTrailingComma(
+    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityArgumentSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return AvailabilityArgumentSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -21616,6 +24161,8 @@ public struct AvailabilityArgumentSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -21630,6 +24177,7 @@ extension AvailabilityArgumentSyntax: CustomReflectable {
       "entry": Syntax(entry).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenEntryAndTrailingComma": unexpectedBetweenEntryAndTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "trailingComma": trailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTrailingComma": unexpectedAfterTrailingComma.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -21664,7 +24212,8 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
     _ unexpectedBetweenLabelAndColon: UnexpectedNodesSyntax? = nil,
     colon: TokenSyntax,
     _ unexpectedBetweenColonAndValue: UnexpectedNodesSyntax? = nil,
-    value: Syntax
+    value: Syntax,
+    _ unexpectedAfterValue: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabel?.raw,
@@ -21673,6 +24222,7 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
       colon.raw,
       unexpectedBetweenColonAndValue?.raw,
       value.raw,
+      unexpectedAfterValue?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityLabeledArgument,
       from: layout, arena: .default)
@@ -21806,6 +24356,27 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
     return AvailabilityLabeledArgumentSyntax(newData)
   }
 
+  public var unexpectedAfterValue: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterValue(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterValue` replaced.
+  /// - param newChild: The new `unexpectedAfterValue` to replace the node's
+  ///                   current `unexpectedAfterValue`, if present.
+  public func withUnexpectedAfterValue(
+    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityLabeledArgumentSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return AvailabilityLabeledArgumentSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -21820,6 +24391,8 @@ public struct AvailabilityLabeledArgumentSyntax: SyntaxProtocol, SyntaxHashable 
       return nil
     case 5:
       return "value"
+    case 6:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -21835,6 +24408,7 @@ extension AvailabilityLabeledArgumentSyntax: CustomReflectable {
       "colon": Syntax(colon).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenColonAndValue": unexpectedBetweenColonAndValue.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "value": Syntax(value).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterValue": unexpectedAfterValue.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -21867,13 +24441,15 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
     _ unexpectedBeforePlatform: UnexpectedNodesSyntax? = nil,
     platform: TokenSyntax,
     _ unexpectedBetweenPlatformAndVersion: UnexpectedNodesSyntax? = nil,
-    version: VersionTupleSyntax?
+    version: VersionTupleSyntax?,
+    _ unexpectedAfterVersion: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePlatform?.raw,
       platform.raw,
       unexpectedBetweenPlatformAndVersion?.raw,
       version?.raw,
+      unexpectedAfterVersion?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.availabilityVersionRestriction,
       from: layout, arena: .default)
@@ -21969,6 +24545,27 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
     return AvailabilityVersionRestrictionSyntax(newData)
   }
 
+  public var unexpectedAfterVersion: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterVersion(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterVersion` replaced.
+  /// - param newChild: The new `unexpectedAfterVersion` to replace the node's
+  ///                   current `unexpectedAfterVersion`, if present.
+  public func withUnexpectedAfterVersion(
+    _ newChild: UnexpectedNodesSyntax?) -> AvailabilityVersionRestrictionSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return AvailabilityVersionRestrictionSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -21979,6 +24576,8 @@ public struct AvailabilityVersionRestrictionSyntax: SyntaxProtocol, SyntaxHashab
       return nil
     case 3:
       return "version"
+    case 4:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -21992,6 +24591,7 @@ extension AvailabilityVersionRestrictionSyntax: CustomReflectable {
       "platform": Syntax(platform).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenPlatformAndVersion": unexpectedBetweenPlatformAndVersion.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "version": version.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterVersion": unexpectedAfterVersion.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -22026,7 +24626,8 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenMajorMinorAndPatchPeriod: UnexpectedNodesSyntax? = nil,
     patchPeriod: TokenSyntax?,
     _ unexpectedBetweenPatchPeriodAndPatchVersion: UnexpectedNodesSyntax? = nil,
-    patchVersion: TokenSyntax?
+    patchVersion: TokenSyntax?,
+    _ unexpectedAfterPatchVersion: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeMajorMinor?.raw,
@@ -22035,6 +24636,7 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
       patchPeriod?.raw,
       unexpectedBetweenPatchPeriodAndPatchVersion?.raw,
       patchVersion?.raw,
+      unexpectedAfterPatchVersion?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.versionTuple,
       from: layout, arena: .default)
@@ -22181,6 +24783,27 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
     return VersionTupleSyntax(newData)
   }
 
+  public var unexpectedAfterPatchVersion: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterPatchVersion(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterPatchVersion` replaced.
+  /// - param newChild: The new `unexpectedAfterPatchVersion` to replace the node's
+  ///                   current `unexpectedAfterPatchVersion`, if present.
+  public func withUnexpectedAfterPatchVersion(
+    _ newChild: UnexpectedNodesSyntax?) -> VersionTupleSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return VersionTupleSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -22194,6 +24817,8 @@ public struct VersionTupleSyntax: SyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -22210,6 +24835,7 @@ extension VersionTupleSyntax: CustomReflectable {
       "patchPeriod": patchPeriod.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenPatchPeriodAndPatchVersion": unexpectedBetweenPatchPeriodAndPatchVersion.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "patchVersion": patchVersion.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterPatchVersion": unexpectedAfterPatchVersion.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxPatternNodes.swift
@@ -131,7 +131,8 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenPeriodAndCaseName: UnexpectedNodesSyntax? = nil,
     caseName: TokenSyntax,
     _ unexpectedBetweenCaseNameAndAssociatedTuple: UnexpectedNodesSyntax? = nil,
-    associatedTuple: TuplePatternSyntax?
+    associatedTuple: TuplePatternSyntax?,
+    _ unexpectedAfterAssociatedTuple: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeType?.raw,
@@ -142,6 +143,7 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       caseName.raw,
       unexpectedBetweenCaseNameAndAssociatedTuple?.raw,
       associatedTuple?.raw,
+      unexpectedAfterAssociatedTuple?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.enumCasePattern,
       from: layout, arena: .default)
@@ -315,6 +317,27 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     return EnumCasePatternSyntax(newData)
   }
 
+  public var unexpectedAfterAssociatedTuple: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterAssociatedTuple(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterAssociatedTuple` replaced.
+  /// - param newChild: The new `unexpectedAfterAssociatedTuple` to replace the node's
+  ///                   current `unexpectedAfterAssociatedTuple`, if present.
+  public func withUnexpectedAfterAssociatedTuple(
+    _ newChild: UnexpectedNodesSyntax?) -> EnumCasePatternSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return EnumCasePatternSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -333,6 +356,8 @@ public struct EnumCasePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return "associated values"
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -350,6 +375,7 @@ extension EnumCasePatternSyntax: CustomReflectable {
       "caseName": Syntax(caseName).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenCaseNameAndAssociatedTuple": unexpectedBetweenCaseNameAndAssociatedTuple.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "associatedTuple": associatedTuple.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterAssociatedTuple": unexpectedAfterAssociatedTuple.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -378,13 +404,15 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeIsKeyword: UnexpectedNodesSyntax? = nil,
     isKeyword: TokenSyntax,
     _ unexpectedBetweenIsKeywordAndType: UnexpectedNodesSyntax? = nil,
-    type: TypeSyntax
+    type: TypeSyntax,
+    _ unexpectedAfterType: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIsKeyword?.raw,
       isKeyword.raw,
       unexpectedBetweenIsKeywordAndType?.raw,
       type.raw,
+      unexpectedAfterType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.isTypePattern,
       from: layout, arena: .default)
@@ -474,6 +502,27 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     return IsTypePatternSyntax(newData)
   }
 
+  public var unexpectedAfterType: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterType(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterType` replaced.
+  /// - param newChild: The new `unexpectedAfterType` to replace the node's
+  ///                   current `unexpectedAfterType`, if present.
+  public func withUnexpectedAfterType(
+    _ newChild: UnexpectedNodesSyntax?) -> IsTypePatternSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return IsTypePatternSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -483,6 +532,8 @@ public struct IsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -497,6 +548,7 @@ extension IsTypePatternSyntax: CustomReflectable {
       "isKeyword": Syntax(isKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenIsKeywordAndType": unexpectedBetweenIsKeywordAndType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "type": Syntax(type).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterType": unexpectedAfterType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -525,13 +577,15 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeSubPattern: UnexpectedNodesSyntax? = nil,
     subPattern: PatternSyntax,
     _ unexpectedBetweenSubPatternAndQuestionMark: UnexpectedNodesSyntax? = nil,
-    questionMark: TokenSyntax
+    questionMark: TokenSyntax,
+    _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSubPattern?.raw,
       subPattern.raw,
       unexpectedBetweenSubPatternAndQuestionMark?.raw,
       questionMark.raw,
+      unexpectedAfterQuestionMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalPattern,
       from: layout, arena: .default)
@@ -621,6 +675,27 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     return OptionalPatternSyntax(newData)
   }
 
+  public var unexpectedAfterQuestionMark: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterQuestionMark(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterQuestionMark` replaced.
+  /// - param newChild: The new `unexpectedAfterQuestionMark` to replace the node's
+  ///                   current `unexpectedAfterQuestionMark`, if present.
+  public func withUnexpectedAfterQuestionMark(
+    _ newChild: UnexpectedNodesSyntax?) -> OptionalPatternSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return OptionalPatternSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -630,6 +705,8 @@ public struct OptionalPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -644,6 +721,7 @@ extension OptionalPatternSyntax: CustomReflectable {
       "subPattern": Syntax(subPattern).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenSubPatternAndQuestionMark": unexpectedBetweenSubPatternAndQuestionMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "questionMark": Syntax(questionMark).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterQuestionMark": unexpectedAfterQuestionMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -670,11 +748,13 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeIdentifier: UnexpectedNodesSyntax? = nil,
-    identifier: TokenSyntax
+    identifier: TokenSyntax,
+    _ unexpectedAfterIdentifier: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIdentifier?.raw,
       identifier.raw,
+      unexpectedAfterIdentifier?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.identifierPattern,
       from: layout, arena: .default)
@@ -723,11 +803,34 @@ public struct IdentifierPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     return IdentifierPatternSyntax(newData)
   }
 
+  public var unexpectedAfterIdentifier: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterIdentifier(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterIdentifier` replaced.
+  /// - param newChild: The new `unexpectedAfterIdentifier` to replace the node's
+  ///                   current `unexpectedAfterIdentifier`, if present.
+  public func withUnexpectedAfterIdentifier(
+    _ newChild: UnexpectedNodesSyntax?) -> IdentifierPatternSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return IdentifierPatternSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -740,6 +843,7 @@ extension IdentifierPatternSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeIdentifier": unexpectedBeforeIdentifier.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "identifier": Syntax(identifier).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterIdentifier": unexpectedAfterIdentifier.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -770,7 +874,8 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenPatternAndAsKeyword: UnexpectedNodesSyntax? = nil,
     asKeyword: TokenSyntax,
     _ unexpectedBetweenAsKeywordAndType: UnexpectedNodesSyntax? = nil,
-    type: TypeSyntax
+    type: TypeSyntax,
+    _ unexpectedAfterType: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePattern?.raw,
@@ -779,6 +884,7 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       asKeyword.raw,
       unexpectedBetweenAsKeywordAndType?.raw,
       type.raw,
+      unexpectedAfterType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.asTypePattern,
       from: layout, arena: .default)
@@ -909,6 +1015,27 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     return AsTypePatternSyntax(newData)
   }
 
+  public var unexpectedAfterType: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterType(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterType` replaced.
+  /// - param newChild: The new `unexpectedAfterType` to replace the node's
+  ///                   current `unexpectedAfterType`, if present.
+  public func withUnexpectedAfterType(
+    _ newChild: UnexpectedNodesSyntax?) -> AsTypePatternSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return AsTypePatternSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -922,6 +1049,8 @@ public struct AsTypePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -938,6 +1067,7 @@ extension AsTypePatternSyntax: CustomReflectable {
       "asKeyword": Syntax(asKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenAsKeywordAndType": unexpectedBetweenAsKeywordAndType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "type": Syntax(type).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterType": unexpectedAfterType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -968,7 +1098,8 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? = nil,
     elements: TuplePatternElementListSyntax,
     _ unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
@@ -977,6 +1108,7 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
       elements.raw,
       unexpectedBetweenElementsAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tuplePattern,
       from: layout, arena: .default)
@@ -1125,6 +1257,27 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     return TuplePatternSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> TuplePatternSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return TuplePatternSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1138,6 +1291,8 @@ public struct TuplePatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -1154,6 +1309,7 @@ extension TuplePatternSyntax: CustomReflectable {
       "elements": Syntax(elements).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenElementsAndRightParen": unexpectedBetweenElementsAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1182,13 +1338,15 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeWildcard: UnexpectedNodesSyntax? = nil,
     wildcard: TokenSyntax,
     _ unexpectedBetweenWildcardAndTypeAnnotation: UnexpectedNodesSyntax? = nil,
-    typeAnnotation: TypeAnnotationSyntax?
+    typeAnnotation: TypeAnnotationSyntax?,
+    _ unexpectedAfterTypeAnnotation: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWildcard?.raw,
       wildcard.raw,
       unexpectedBetweenWildcardAndTypeAnnotation?.raw,
       typeAnnotation?.raw,
+      unexpectedAfterTypeAnnotation?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.wildcardPattern,
       from: layout, arena: .default)
@@ -1279,6 +1437,27 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     return WildcardPatternSyntax(newData)
   }
 
+  public var unexpectedAfterTypeAnnotation: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTypeAnnotation(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTypeAnnotation` replaced.
+  /// - param newChild: The new `unexpectedAfterTypeAnnotation` to replace the node's
+  ///                   current `unexpectedAfterTypeAnnotation`, if present.
+  public func withUnexpectedAfterTypeAnnotation(
+    _ newChild: UnexpectedNodesSyntax?) -> WildcardPatternSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return WildcardPatternSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1288,6 +1467,8 @@ public struct WildcardPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -1302,6 +1483,7 @@ extension WildcardPatternSyntax: CustomReflectable {
       "wildcard": Syntax(wildcard).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenWildcardAndTypeAnnotation": unexpectedBetweenWildcardAndTypeAnnotation.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "typeAnnotation": typeAnnotation.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterTypeAnnotation": unexpectedAfterTypeAnnotation.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1328,11 +1510,13 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax
+    expression: ExprSyntax,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionPattern,
       from: layout, arena: .default)
@@ -1381,11 +1565,34 @@ public struct ExpressionPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     return ExpressionPatternSyntax(newData)
   }
 
+  public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterExpression(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
+  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
+  ///                   current `unexpectedAfterExpression`, if present.
+  public func withUnexpectedAfterExpression(
+    _ newChild: UnexpectedNodesSyntax?) -> ExpressionPatternSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return ExpressionPatternSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -1398,6 +1605,7 @@ extension ExpressionPatternSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeExpression": unexpectedBeforeExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterExpression": unexpectedAfterExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1426,13 +1634,15 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeLetOrVarKeyword: UnexpectedNodesSyntax? = nil,
     letOrVarKeyword: TokenSyntax,
     _ unexpectedBetweenLetOrVarKeywordAndValuePattern: UnexpectedNodesSyntax? = nil,
-    valuePattern: PatternSyntax
+    valuePattern: PatternSyntax,
+    _ unexpectedAfterValuePattern: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLetOrVarKeyword?.raw,
       letOrVarKeyword.raw,
       unexpectedBetweenLetOrVarKeywordAndValuePattern?.raw,
       valuePattern.raw,
+      unexpectedAfterValuePattern?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.valueBindingPattern,
       from: layout, arena: .default)
@@ -1522,6 +1732,27 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     return ValueBindingPatternSyntax(newData)
   }
 
+  public var unexpectedAfterValuePattern: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterValuePattern(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterValuePattern` replaced.
+  /// - param newChild: The new `unexpectedAfterValuePattern` to replace the node's
+  ///                   current `unexpectedAfterValuePattern`, if present.
+  public func withUnexpectedAfterValuePattern(
+    _ newChild: UnexpectedNodesSyntax?) -> ValueBindingPatternSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return ValueBindingPatternSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1531,6 +1762,8 @@ public struct ValueBindingPatternSyntax: PatternSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -1545,6 +1778,7 @@ extension ValueBindingPatternSyntax: CustomReflectable {
       "letOrVarKeyword": Syntax(letOrVarKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenLetOrVarKeywordAndValuePattern": unexpectedBetweenLetOrVarKeywordAndValuePattern.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "valuePattern": Syntax(valuePattern).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterValuePattern": unexpectedAfterValuePattern.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxStmtNodes.swift
@@ -129,7 +129,8 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLabelNameAndLabelColon: UnexpectedNodesSyntax? = nil,
     labelColon: TokenSyntax,
     _ unexpectedBetweenLabelColonAndStatement: UnexpectedNodesSyntax? = nil,
-    statement: StmtSyntax
+    statement: StmtSyntax,
+    _ unexpectedAfterStatement: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLabelName?.raw,
@@ -138,6 +139,7 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       labelColon.raw,
       unexpectedBetweenLabelColonAndStatement?.raw,
       statement.raw,
+      unexpectedAfterStatement?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.labeledStmt,
       from: layout, arena: .default)
@@ -268,6 +270,27 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return LabeledStmtSyntax(newData)
   }
 
+  public var unexpectedAfterStatement: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterStatement(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterStatement` replaced.
+  /// - param newChild: The new `unexpectedAfterStatement` to replace the node's
+  ///                   current `unexpectedAfterStatement`, if present.
+  public func withUnexpectedAfterStatement(
+    _ newChild: UnexpectedNodesSyntax?) -> LabeledStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return LabeledStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -281,6 +304,8 @@ public struct LabeledStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -297,6 +322,7 @@ extension LabeledStmtSyntax: CustomReflectable {
       "labelColon": Syntax(labelColon).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenLabelColonAndStatement": unexpectedBetweenLabelColonAndStatement.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "statement": Syntax(statement).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterStatement": unexpectedAfterStatement.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -325,13 +351,15 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeContinueKeyword: UnexpectedNodesSyntax? = nil,
     continueKeyword: TokenSyntax,
     _ unexpectedBetweenContinueKeywordAndLabel: UnexpectedNodesSyntax? = nil,
-    label: TokenSyntax?
+    label: TokenSyntax?,
+    _ unexpectedAfterLabel: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeContinueKeyword?.raw,
       continueKeyword.raw,
       unexpectedBetweenContinueKeywordAndLabel?.raw,
       label?.raw,
+      unexpectedAfterLabel?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.continueStmt,
       from: layout, arena: .default)
@@ -422,6 +450,27 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return ContinueStmtSyntax(newData)
   }
 
+  public var unexpectedAfterLabel: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterLabel(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterLabel` replaced.
+  /// - param newChild: The new `unexpectedAfterLabel` to replace the node's
+  ///                   current `unexpectedAfterLabel`, if present.
+  public func withUnexpectedAfterLabel(
+    _ newChild: UnexpectedNodesSyntax?) -> ContinueStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return ContinueStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -432,6 +481,8 @@ public struct ContinueStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return nil
     case 3:
       return "label"
+    case 4:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -445,6 +496,7 @@ extension ContinueStmtSyntax: CustomReflectable {
       "continueKeyword": Syntax(continueKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenContinueKeywordAndLabel": unexpectedBetweenContinueKeywordAndLabel.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "label": label.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterLabel": unexpectedAfterLabel.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -475,7 +527,8 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenWhileKeywordAndConditions: UnexpectedNodesSyntax? = nil,
     conditions: ConditionElementListSyntax,
     _ unexpectedBetweenConditionsAndBody: UnexpectedNodesSyntax? = nil,
-    body: CodeBlockSyntax
+    body: CodeBlockSyntax,
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWhileKeyword?.raw,
@@ -484,6 +537,7 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       conditions.raw,
       unexpectedBetweenConditionsAndBody?.raw,
       body.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.whileStmt,
       from: layout, arena: .default)
@@ -632,6 +686,27 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return WhileStmtSyntax(newData)
   }
 
+  public var unexpectedAfterBody: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterBody(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
+  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
+  ///                   current `unexpectedAfterBody`, if present.
+  public func withUnexpectedAfterBody(
+    _ newChild: UnexpectedNodesSyntax?) -> WhileStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return WhileStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -645,6 +720,8 @@ public struct WhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -661,6 +738,7 @@ extension WhileStmtSyntax: CustomReflectable {
       "conditions": Syntax(conditions).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenConditionsAndBody": unexpectedBetweenConditionsAndBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "body": Syntax(body).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterBody": unexpectedAfterBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -689,13 +767,15 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeDeferKeyword: UnexpectedNodesSyntax? = nil,
     deferKeyword: TokenSyntax,
     _ unexpectedBetweenDeferKeywordAndBody: UnexpectedNodesSyntax? = nil,
-    body: CodeBlockSyntax
+    body: CodeBlockSyntax,
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDeferKeyword?.raw,
       deferKeyword.raw,
       unexpectedBetweenDeferKeywordAndBody?.raw,
       body.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.deferStmt,
       from: layout, arena: .default)
@@ -785,6 +865,27 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return DeferStmtSyntax(newData)
   }
 
+  public var unexpectedAfterBody: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterBody(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
+  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
+  ///                   current `unexpectedAfterBody`, if present.
+  public func withUnexpectedAfterBody(
+    _ newChild: UnexpectedNodesSyntax?) -> DeferStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return DeferStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -794,6 +895,8 @@ public struct DeferStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -808,6 +911,7 @@ extension DeferStmtSyntax: CustomReflectable {
       "deferKeyword": Syntax(deferKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenDeferKeywordAndBody": unexpectedBetweenDeferKeywordAndBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "body": Syntax(body).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterBody": unexpectedAfterBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -834,11 +938,13 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax
+    expression: ExprSyntax,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.expressionStmt,
       from: layout, arena: .default)
@@ -887,11 +993,34 @@ public struct ExpressionStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return ExpressionStmtSyntax(newData)
   }
 
+  public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterExpression(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
+  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
+  ///                   current `unexpectedAfterExpression`, if present.
+  public func withUnexpectedAfterExpression(
+    _ newChild: UnexpectedNodesSyntax?) -> ExpressionStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return ExpressionStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -904,6 +1033,7 @@ extension ExpressionStmtSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeExpression": unexpectedBeforeExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterExpression": unexpectedAfterExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -936,7 +1066,8 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenBodyAndWhileKeyword: UnexpectedNodesSyntax? = nil,
     whileKeyword: TokenSyntax,
     _ unexpectedBetweenWhileKeywordAndCondition: UnexpectedNodesSyntax? = nil,
-    condition: ExprSyntax
+    condition: ExprSyntax,
+    _ unexpectedAfterCondition: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeRepeatKeyword?.raw,
@@ -947,6 +1078,7 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       whileKeyword.raw,
       unexpectedBetweenWhileKeywordAndCondition?.raw,
       condition.raw,
+      unexpectedAfterCondition?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.repeatWhileStmt,
       from: layout, arena: .default)
@@ -1118,6 +1250,27 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return RepeatWhileStmtSyntax(newData)
   }
 
+  public var unexpectedAfterCondition: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterCondition(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterCondition` replaced.
+  /// - param newChild: The new `unexpectedAfterCondition` to replace the node's
+  ///                   current `unexpectedAfterCondition`, if present.
+  public func withUnexpectedAfterCondition(
+    _ newChild: UnexpectedNodesSyntax?) -> RepeatWhileStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return RepeatWhileStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1136,6 +1289,8 @@ public struct RepeatWhileStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return "condition"
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -1153,6 +1308,7 @@ extension RepeatWhileStmtSyntax: CustomReflectable {
       "whileKeyword": Syntax(whileKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenWhileKeywordAndCondition": unexpectedBetweenWhileKeywordAndCondition.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "condition": Syntax(condition).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterCondition": unexpectedAfterCondition.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1185,7 +1341,8 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenConditionsAndElseKeyword: UnexpectedNodesSyntax? = nil,
     elseKeyword: TokenSyntax,
     _ unexpectedBetweenElseKeywordAndBody: UnexpectedNodesSyntax? = nil,
-    body: CodeBlockSyntax
+    body: CodeBlockSyntax,
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeGuardKeyword?.raw,
@@ -1196,6 +1353,7 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       elseKeyword.raw,
       unexpectedBetweenElseKeywordAndBody?.raw,
       body.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.guardStmt,
       from: layout, arena: .default)
@@ -1385,6 +1543,27 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return GuardStmtSyntax(newData)
   }
 
+  public var unexpectedAfterBody: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterBody(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
+  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
+  ///                   current `unexpectedAfterBody`, if present.
+  public func withUnexpectedAfterBody(
+    _ newChild: UnexpectedNodesSyntax?) -> GuardStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return GuardStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1403,6 +1582,8 @@ public struct GuardStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return "body"
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -1420,6 +1601,7 @@ extension GuardStmtSyntax: CustomReflectable {
       "elseKeyword": Syntax(elseKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenElseKeywordAndBody": unexpectedBetweenElseKeywordAndBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "body": Syntax(body).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterBody": unexpectedAfterBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1464,7 +1646,8 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenSequenceExprAndWhereClause: UnexpectedNodesSyntax? = nil,
     whereClause: WhereClauseSyntax?,
     _ unexpectedBetweenWhereClauseAndBody: UnexpectedNodesSyntax? = nil,
-    body: CodeBlockSyntax
+    body: CodeBlockSyntax,
+    _ unexpectedAfterBody: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeForKeyword?.raw,
@@ -1487,6 +1670,7 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       whereClause?.raw,
       unexpectedBetweenWhereClauseAndBody?.raw,
       body.raw,
+      unexpectedAfterBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.forInStmt,
       from: layout, arena: .default)
@@ -1909,6 +2093,27 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return ForInStmtSyntax(newData)
   }
 
+  public var unexpectedAfterBody: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 20, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterBody(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterBody` replaced.
+  /// - param newChild: The new `unexpectedAfterBody` to replace the node's
+  ///                   current `unexpectedAfterBody`, if present.
+  public func withUnexpectedAfterBody(
+    _ newChild: UnexpectedNodesSyntax?) -> ForInStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 20)
+    return ForInStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1951,6 +2156,8 @@ public struct ForInStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return nil
     case 19:
       return "body"
+    case 20:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -1980,6 +2187,7 @@ extension ForInStmtSyntax: CustomReflectable {
       "whereClause": whereClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenWhereClauseAndBody": unexpectedBetweenWhereClauseAndBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "body": Syntax(body).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterBody": unexpectedAfterBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2014,7 +2222,8 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftBraceAndCases: UnexpectedNodesSyntax? = nil,
     cases: SwitchCaseListSyntax,
     _ unexpectedBetweenCasesAndRightBrace: UnexpectedNodesSyntax? = nil,
-    rightBrace: TokenSyntax
+    rightBrace: TokenSyntax,
+    _ unexpectedAfterRightBrace: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSwitchKeyword?.raw,
@@ -2027,6 +2236,7 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       cases.raw,
       unexpectedBetweenCasesAndRightBrace?.raw,
       rightBrace.raw,
+      unexpectedAfterRightBrace?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.switchStmt,
       from: layout, arena: .default)
@@ -2257,6 +2467,27 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return SwitchStmtSyntax(newData)
   }
 
+  public var unexpectedAfterRightBrace: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 10, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightBrace(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightBrace` replaced.
+  /// - param newChild: The new `unexpectedAfterRightBrace` to replace the node's
+  ///                   current `unexpectedAfterRightBrace`, if present.
+  public func withUnexpectedAfterRightBrace(
+    _ newChild: UnexpectedNodesSyntax?) -> SwitchStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 10)
+    return SwitchStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2279,6 +2510,8 @@ public struct SwitchStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return nil
     case 9:
       return nil
+    case 10:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -2298,6 +2531,7 @@ extension SwitchStmtSyntax: CustomReflectable {
       "cases": Syntax(cases).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenCasesAndRightBrace": unexpectedBetweenCasesAndRightBrace.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightBrace": Syntax(rightBrace).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightBrace": unexpectedAfterRightBrace.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2328,7 +2562,8 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenDoKeywordAndBody: UnexpectedNodesSyntax? = nil,
     body: CodeBlockSyntax,
     _ unexpectedBetweenBodyAndCatchClauses: UnexpectedNodesSyntax? = nil,
-    catchClauses: CatchClauseListSyntax?
+    catchClauses: CatchClauseListSyntax?,
+    _ unexpectedAfterCatchClauses: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDoKeyword?.raw,
@@ -2337,6 +2572,7 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       body.raw,
       unexpectedBetweenBodyAndCatchClauses?.raw,
       catchClauses?.raw,
+      unexpectedAfterCatchClauses?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.doStmt,
       from: layout, arena: .default)
@@ -2486,6 +2722,27 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return DoStmtSyntax(newData)
   }
 
+  public var unexpectedAfterCatchClauses: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterCatchClauses(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterCatchClauses` replaced.
+  /// - param newChild: The new `unexpectedAfterCatchClauses` to replace the node's
+  ///                   current `unexpectedAfterCatchClauses`, if present.
+  public func withUnexpectedAfterCatchClauses(
+    _ newChild: UnexpectedNodesSyntax?) -> DoStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return DoStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2499,6 +2756,8 @@ public struct DoStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -2515,6 +2774,7 @@ extension DoStmtSyntax: CustomReflectable {
       "body": Syntax(body).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenBodyAndCatchClauses": unexpectedBetweenBodyAndCatchClauses.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "catchClauses": catchClauses.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterCatchClauses": unexpectedAfterCatchClauses.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2543,13 +2803,15 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeReturnKeyword: UnexpectedNodesSyntax? = nil,
     returnKeyword: TokenSyntax,
     _ unexpectedBetweenReturnKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax?
+    expression: ExprSyntax?,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeReturnKeyword?.raw,
       returnKeyword.raw,
       unexpectedBetweenReturnKeywordAndExpression?.raw,
       expression?.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.returnStmt,
       from: layout, arena: .default)
@@ -2640,6 +2902,27 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return ReturnStmtSyntax(newData)
   }
 
+  public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterExpression(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
+  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
+  ///                   current `unexpectedAfterExpression`, if present.
+  public func withUnexpectedAfterExpression(
+    _ newChild: UnexpectedNodesSyntax?) -> ReturnStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return ReturnStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2649,6 +2932,8 @@ public struct ReturnStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -2663,6 +2948,7 @@ extension ReturnStmtSyntax: CustomReflectable {
       "returnKeyword": Syntax(returnKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenReturnKeywordAndExpression": unexpectedBetweenReturnKeywordAndExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "expression": expression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterExpression": unexpectedAfterExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2691,13 +2977,15 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeYieldKeyword: UnexpectedNodesSyntax? = nil,
     yieldKeyword: TokenSyntax,
     _ unexpectedBetweenYieldKeywordAndYields: UnexpectedNodesSyntax? = nil,
-    yields: Syntax
+    yields: Syntax,
+    _ unexpectedAfterYields: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeYieldKeyword?.raw,
       yieldKeyword.raw,
       unexpectedBetweenYieldKeywordAndYields?.raw,
       yields.raw,
+      unexpectedAfterYields?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.yieldStmt,
       from: layout, arena: .default)
@@ -2787,6 +3075,27 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return YieldStmtSyntax(newData)
   }
 
+  public var unexpectedAfterYields: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterYields(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterYields` replaced.
+  /// - param newChild: The new `unexpectedAfterYields` to replace the node's
+  ///                   current `unexpectedAfterYields`, if present.
+  public func withUnexpectedAfterYields(
+    _ newChild: UnexpectedNodesSyntax?) -> YieldStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return YieldStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2796,6 +3105,8 @@ public struct YieldStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -2810,6 +3121,7 @@ extension YieldStmtSyntax: CustomReflectable {
       "yieldKeyword": Syntax(yieldKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenYieldKeywordAndYields": unexpectedBetweenYieldKeywordAndYields.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "yields": Syntax(yields).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterYields": unexpectedAfterYields.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2836,11 +3148,13 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeFallthroughKeyword: UnexpectedNodesSyntax? = nil,
-    fallthroughKeyword: TokenSyntax
+    fallthroughKeyword: TokenSyntax,
+    _ unexpectedAfterFallthroughKeyword: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeFallthroughKeyword?.raw,
       fallthroughKeyword.raw,
+      unexpectedAfterFallthroughKeyword?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.fallthroughStmt,
       from: layout, arena: .default)
@@ -2889,11 +3203,34 @@ public struct FallthroughStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return FallthroughStmtSyntax(newData)
   }
 
+  public var unexpectedAfterFallthroughKeyword: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterFallthroughKeyword(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterFallthroughKeyword` replaced.
+  /// - param newChild: The new `unexpectedAfterFallthroughKeyword` to replace the node's
+  ///                   current `unexpectedAfterFallthroughKeyword`, if present.
+  public func withUnexpectedAfterFallthroughKeyword(
+    _ newChild: UnexpectedNodesSyntax?) -> FallthroughStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return FallthroughStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -2906,6 +3243,7 @@ extension FallthroughStmtSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeFallthroughKeyword": unexpectedBeforeFallthroughKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "fallthroughKeyword": Syntax(fallthroughKeyword).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterFallthroughKeyword": unexpectedAfterFallthroughKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2934,13 +3272,15 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeBreakKeyword: UnexpectedNodesSyntax? = nil,
     breakKeyword: TokenSyntax,
     _ unexpectedBetweenBreakKeywordAndLabel: UnexpectedNodesSyntax? = nil,
-    label: TokenSyntax?
+    label: TokenSyntax?,
+    _ unexpectedAfterLabel: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBreakKeyword?.raw,
       breakKeyword.raw,
       unexpectedBetweenBreakKeywordAndLabel?.raw,
       label?.raw,
+      unexpectedAfterLabel?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.breakStmt,
       from: layout, arena: .default)
@@ -3031,6 +3371,27 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return BreakStmtSyntax(newData)
   }
 
+  public var unexpectedAfterLabel: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterLabel(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterLabel` replaced.
+  /// - param newChild: The new `unexpectedAfterLabel` to replace the node's
+  ///                   current `unexpectedAfterLabel`, if present.
+  public func withUnexpectedAfterLabel(
+    _ newChild: UnexpectedNodesSyntax?) -> BreakStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return BreakStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -3041,6 +3402,8 @@ public struct BreakStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return nil
     case 3:
       return "label"
+    case 4:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -3054,6 +3417,7 @@ extension BreakStmtSyntax: CustomReflectable {
       "breakKeyword": Syntax(breakKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenBreakKeywordAndLabel": unexpectedBetweenBreakKeywordAndLabel.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "label": label.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterLabel": unexpectedAfterLabel.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3080,11 +3444,13 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeDeclaration: UnexpectedNodesSyntax? = nil,
-    declaration: DeclSyntax
+    declaration: DeclSyntax,
+    _ unexpectedAfterDeclaration: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeDeclaration?.raw,
       declaration.raw,
+      unexpectedAfterDeclaration?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.declarationStmt,
       from: layout, arena: .default)
@@ -3133,11 +3499,34 @@ public struct DeclarationStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return DeclarationStmtSyntax(newData)
   }
 
+  public var unexpectedAfterDeclaration: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterDeclaration(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterDeclaration` replaced.
+  /// - param newChild: The new `unexpectedAfterDeclaration` to replace the node's
+  ///                   current `unexpectedAfterDeclaration`, if present.
+  public func withUnexpectedAfterDeclaration(
+    _ newChild: UnexpectedNodesSyntax?) -> DeclarationStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return DeclarationStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -3150,6 +3539,7 @@ extension DeclarationStmtSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeDeclaration": unexpectedBeforeDeclaration.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "declaration": Syntax(declaration).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterDeclaration": unexpectedAfterDeclaration.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3178,13 +3568,15 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeThrowKeyword: UnexpectedNodesSyntax? = nil,
     throwKeyword: TokenSyntax,
     _ unexpectedBetweenThrowKeywordAndExpression: UnexpectedNodesSyntax? = nil,
-    expression: ExprSyntax
+    expression: ExprSyntax,
+    _ unexpectedAfterExpression: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeThrowKeyword?.raw,
       throwKeyword.raw,
       unexpectedBetweenThrowKeywordAndExpression?.raw,
       expression.raw,
+      unexpectedAfterExpression?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.throwStmt,
       from: layout, arena: .default)
@@ -3274,6 +3666,27 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return ThrowStmtSyntax(newData)
   }
 
+  public var unexpectedAfterExpression: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterExpression(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterExpression` replaced.
+  /// - param newChild: The new `unexpectedAfterExpression` to replace the node's
+  ///                   current `unexpectedAfterExpression`, if present.
+  public func withUnexpectedAfterExpression(
+    _ newChild: UnexpectedNodesSyntax?) -> ThrowStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return ThrowStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -3283,6 +3696,8 @@ public struct ThrowStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -3297,6 +3712,7 @@ extension ThrowStmtSyntax: CustomReflectable {
       "throwKeyword": Syntax(throwKeyword).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenThrowKeywordAndExpression": unexpectedBetweenThrowKeywordAndExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "expression": Syntax(expression).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterExpression": unexpectedAfterExpression.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3331,7 +3747,8 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenBodyAndElseKeyword: UnexpectedNodesSyntax? = nil,
     elseKeyword: TokenSyntax?,
     _ unexpectedBetweenElseKeywordAndElseBody: UnexpectedNodesSyntax? = nil,
-    elseBody: Syntax?
+    elseBody: Syntax?,
+    _ unexpectedAfterElseBody: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeIfKeyword?.raw,
@@ -3344,6 +3761,7 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       elseKeyword?.raw,
       unexpectedBetweenElseKeywordAndElseBody?.raw,
       elseBody?.raw,
+      unexpectedAfterElseBody?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.ifStmt,
       from: layout, arena: .default)
@@ -3576,6 +3994,27 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return IfStmtSyntax(newData)
   }
 
+  public var unexpectedAfterElseBody: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 10, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterElseBody(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterElseBody` replaced.
+  /// - param newChild: The new `unexpectedAfterElseBody` to replace the node's
+  ///                   current `unexpectedAfterElseBody`, if present.
+  public func withUnexpectedAfterElseBody(
+    _ newChild: UnexpectedNodesSyntax?) -> IfStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 10)
+    return IfStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -3598,6 +4037,8 @@ public struct IfStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return nil
     case 9:
       return "else body"
+    case 10:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -3617,6 +4058,7 @@ extension IfStmtSyntax: CustomReflectable {
       "elseKeyword": elseKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenElseKeywordAndElseBody": unexpectedBetweenElseKeywordAndElseBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "elseBody": elseBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterElseBody": unexpectedAfterElseBody.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -3653,7 +4095,8 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenCommaAndMessage: UnexpectedNodesSyntax? = nil,
     message: TokenSyntax?,
     _ unexpectedBetweenMessageAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePoundAssert?.raw,
@@ -3668,6 +4111,7 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       message?.raw,
       unexpectedBetweenMessageAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.poundAssertStmt,
       from: layout, arena: .default)
@@ -3926,6 +4370,27 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
     return PoundAssertStmtSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 12, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> PoundAssertStmtSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 12)
+    return PoundAssertStmtSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -3952,6 +4417,8 @@ public struct PoundAssertStmtSyntax: StmtSyntaxProtocol, SyntaxHashable {
       return nil
     case 11:
       return nil
+    case 12:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -3973,6 +4440,7 @@ extension PoundAssertStmtSyntax: CustomReflectable {
       "message": message.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenMessageAndRightParen": unexpectedBetweenMessageAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }

--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxTypeNodes.swift
@@ -127,13 +127,15 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
-    genericArgumentClause: GenericArgumentClauseSyntax?
+    genericArgumentClause: GenericArgumentClauseSyntax?,
+    _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeName?.raw,
       name.raw,
       unexpectedBetweenNameAndGenericArgumentClause?.raw,
       genericArgumentClause?.raw,
+      unexpectedAfterGenericArgumentClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.simpleTypeIdentifier,
       from: layout, arena: .default)
@@ -224,6 +226,27 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return SimpleTypeIdentifierSyntax(newData)
   }
 
+  public var unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterGenericArgumentClause(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterGenericArgumentClause` replaced.
+  /// - param newChild: The new `unexpectedAfterGenericArgumentClause` to replace the node's
+  ///                   current `unexpectedAfterGenericArgumentClause`, if present.
+  public func withUnexpectedAfterGenericArgumentClause(
+    _ newChild: UnexpectedNodesSyntax?) -> SimpleTypeIdentifierSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return SimpleTypeIdentifierSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -233,6 +256,8 @@ public struct SimpleTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -247,6 +272,7 @@ extension SimpleTypeIdentifierSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndGenericArgumentClause": unexpectedBetweenNameAndGenericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "genericArgumentClause": genericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterGenericArgumentClause": unexpectedAfterGenericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -279,7 +305,8 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenPeriodAndName: UnexpectedNodesSyntax? = nil,
     name: TokenSyntax,
     _ unexpectedBetweenNameAndGenericArgumentClause: UnexpectedNodesSyntax? = nil,
-    genericArgumentClause: GenericArgumentClauseSyntax?
+    genericArgumentClause: GenericArgumentClauseSyntax?,
+    _ unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBaseType?.raw,
@@ -290,6 +317,7 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       name.raw,
       unexpectedBetweenNameAndGenericArgumentClause?.raw,
       genericArgumentClause?.raw,
+      unexpectedAfterGenericArgumentClause?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.memberTypeIdentifier,
       from: layout, arena: .default)
@@ -462,6 +490,27 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return MemberTypeIdentifierSyntax(newData)
   }
 
+  public var unexpectedAfterGenericArgumentClause: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 8, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterGenericArgumentClause(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterGenericArgumentClause` replaced.
+  /// - param newChild: The new `unexpectedAfterGenericArgumentClause` to replace the node's
+  ///                   current `unexpectedAfterGenericArgumentClause`, if present.
+  public func withUnexpectedAfterGenericArgumentClause(
+    _ newChild: UnexpectedNodesSyntax?) -> MemberTypeIdentifierSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 8)
+    return MemberTypeIdentifierSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -480,6 +529,8 @@ public struct MemberTypeIdentifierSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return nil
     case 7:
       return nil
+    case 8:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -497,6 +548,7 @@ extension MemberTypeIdentifierSyntax: CustomReflectable {
       "name": Syntax(name).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenNameAndGenericArgumentClause": unexpectedBetweenNameAndGenericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "genericArgumentClause": genericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
+      "unexpectedAfterGenericArgumentClause": unexpectedAfterGenericArgumentClause.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -523,11 +575,13 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeClassKeyword: UnexpectedNodesSyntax? = nil,
-    classKeyword: TokenSyntax
+    classKeyword: TokenSyntax,
+    _ unexpectedAfterClassKeyword: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeClassKeyword?.raw,
       classKeyword.raw,
+      unexpectedAfterClassKeyword?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.classRestrictionType,
       from: layout, arena: .default)
@@ -576,11 +630,34 @@ public struct ClassRestrictionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return ClassRestrictionTypeSyntax(newData)
   }
 
+  public var unexpectedAfterClassKeyword: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterClassKeyword(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterClassKeyword` replaced.
+  /// - param newChild: The new `unexpectedAfterClassKeyword` to replace the node's
+  ///                   current `unexpectedAfterClassKeyword`, if present.
+  public func withUnexpectedAfterClassKeyword(
+    _ newChild: UnexpectedNodesSyntax?) -> ClassRestrictionTypeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return ClassRestrictionTypeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -593,6 +670,7 @@ extension ClassRestrictionTypeSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeClassKeyword": unexpectedBeforeClassKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "classKeyword": Syntax(classKeyword).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterClassKeyword": unexpectedAfterClassKeyword.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -623,7 +701,8 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftSquareBracketAndElementType: UnexpectedNodesSyntax? = nil,
     elementType: TypeSyntax,
     _ unexpectedBetweenElementTypeAndRightSquareBracket: UnexpectedNodesSyntax? = nil,
-    rightSquareBracket: TokenSyntax
+    rightSquareBracket: TokenSyntax,
+    _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftSquareBracket?.raw,
@@ -632,6 +711,7 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       elementType.raw,
       unexpectedBetweenElementTypeAndRightSquareBracket?.raw,
       rightSquareBracket.raw,
+      unexpectedAfterRightSquareBracket?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.arrayType,
       from: layout, arena: .default)
@@ -762,6 +842,27 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return ArrayTypeSyntax(newData)
   }
 
+  public var unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightSquareBracket(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightSquareBracket` replaced.
+  /// - param newChild: The new `unexpectedAfterRightSquareBracket` to replace the node's
+  ///                   current `unexpectedAfterRightSquareBracket`, if present.
+  public func withUnexpectedAfterRightSquareBracket(
+    _ newChild: UnexpectedNodesSyntax?) -> ArrayTypeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return ArrayTypeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -775,6 +876,8 @@ public struct ArrayTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -791,6 +894,7 @@ extension ArrayTypeSyntax: CustomReflectable {
       "elementType": Syntax(elementType).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenElementTypeAndRightSquareBracket": unexpectedBetweenElementTypeAndRightSquareBracket.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightSquareBracket": Syntax(rightSquareBracket).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightSquareBracket": unexpectedAfterRightSquareBracket.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -825,7 +929,8 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenColonAndValueType: UnexpectedNodesSyntax? = nil,
     valueType: TypeSyntax,
     _ unexpectedBetweenValueTypeAndRightSquareBracket: UnexpectedNodesSyntax? = nil,
-    rightSquareBracket: TokenSyntax
+    rightSquareBracket: TokenSyntax,
+    _ unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftSquareBracket?.raw,
@@ -838,6 +943,7 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       valueType.raw,
       unexpectedBetweenValueTypeAndRightSquareBracket?.raw,
       rightSquareBracket.raw,
+      unexpectedAfterRightSquareBracket?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.dictionaryType,
       from: layout, arena: .default)
@@ -1050,6 +1156,27 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return DictionaryTypeSyntax(newData)
   }
 
+  public var unexpectedAfterRightSquareBracket: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 10, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightSquareBracket(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightSquareBracket` replaced.
+  /// - param newChild: The new `unexpectedAfterRightSquareBracket` to replace the node's
+  ///                   current `unexpectedAfterRightSquareBracket`, if present.
+  public func withUnexpectedAfterRightSquareBracket(
+    _ newChild: UnexpectedNodesSyntax?) -> DictionaryTypeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 10)
+    return DictionaryTypeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1072,6 +1199,8 @@ public struct DictionaryTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return nil
     case 9:
       return nil
+    case 10:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -1091,6 +1220,7 @@ extension DictionaryTypeSyntax: CustomReflectable {
       "valueType": Syntax(valueType).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenValueTypeAndRightSquareBracket": unexpectedBetweenValueTypeAndRightSquareBracket.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightSquareBracket": Syntax(rightSquareBracket).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightSquareBracket": unexpectedAfterRightSquareBracket.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1121,7 +1251,8 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenBaseTypeAndPeriod: UnexpectedNodesSyntax? = nil,
     period: TokenSyntax,
     _ unexpectedBetweenPeriodAndTypeOrProtocol: UnexpectedNodesSyntax? = nil,
-    typeOrProtocol: TokenSyntax
+    typeOrProtocol: TokenSyntax,
+    _ unexpectedAfterTypeOrProtocol: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeBaseType?.raw,
@@ -1130,6 +1261,7 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       period.raw,
       unexpectedBetweenPeriodAndTypeOrProtocol?.raw,
       typeOrProtocol.raw,
+      unexpectedAfterTypeOrProtocol?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.metatypeType,
       from: layout, arena: .default)
@@ -1260,6 +1392,27 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return MetatypeTypeSyntax(newData)
   }
 
+  public var unexpectedAfterTypeOrProtocol: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterTypeOrProtocol(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterTypeOrProtocol` replaced.
+  /// - param newChild: The new `unexpectedAfterTypeOrProtocol` to replace the node's
+  ///                   current `unexpectedAfterTypeOrProtocol`, if present.
+  public func withUnexpectedAfterTypeOrProtocol(
+    _ newChild: UnexpectedNodesSyntax?) -> MetatypeTypeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return MetatypeTypeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1273,6 +1426,8 @@ public struct MetatypeTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -1289,6 +1444,7 @@ extension MetatypeTypeSyntax: CustomReflectable {
       "period": Syntax(period).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenPeriodAndTypeOrProtocol": unexpectedBetweenPeriodAndTypeOrProtocol.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "typeOrProtocol": Syntax(typeOrProtocol).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterTypeOrProtocol": unexpectedAfterTypeOrProtocol.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1317,13 +1473,15 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeWrappedType: UnexpectedNodesSyntax? = nil,
     wrappedType: TypeSyntax,
     _ unexpectedBetweenWrappedTypeAndQuestionMark: UnexpectedNodesSyntax? = nil,
-    questionMark: TokenSyntax
+    questionMark: TokenSyntax,
+    _ unexpectedAfterQuestionMark: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWrappedType?.raw,
       wrappedType.raw,
       unexpectedBetweenWrappedTypeAndQuestionMark?.raw,
       questionMark.raw,
+      unexpectedAfterQuestionMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.optionalType,
       from: layout, arena: .default)
@@ -1413,6 +1571,27 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return OptionalTypeSyntax(newData)
   }
 
+  public var unexpectedAfterQuestionMark: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterQuestionMark(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterQuestionMark` replaced.
+  /// - param newChild: The new `unexpectedAfterQuestionMark` to replace the node's
+  ///                   current `unexpectedAfterQuestionMark`, if present.
+  public func withUnexpectedAfterQuestionMark(
+    _ newChild: UnexpectedNodesSyntax?) -> OptionalTypeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return OptionalTypeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1422,6 +1601,8 @@ public struct OptionalTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -1436,6 +1617,7 @@ extension OptionalTypeSyntax: CustomReflectable {
       "wrappedType": Syntax(wrappedType).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenWrappedTypeAndQuestionMark": unexpectedBetweenWrappedTypeAndQuestionMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "questionMark": Syntax(questionMark).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterQuestionMark": unexpectedAfterQuestionMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1464,13 +1646,15 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeSomeOrAnySpecifier: UnexpectedNodesSyntax? = nil,
     someOrAnySpecifier: TokenSyntax,
     _ unexpectedBetweenSomeOrAnySpecifierAndBaseType: UnexpectedNodesSyntax? = nil,
-    baseType: TypeSyntax
+    baseType: TypeSyntax,
+    _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSomeOrAnySpecifier?.raw,
       someOrAnySpecifier.raw,
       unexpectedBetweenSomeOrAnySpecifierAndBaseType?.raw,
       baseType.raw,
+      unexpectedAfterBaseType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.constrainedSugarType,
       from: layout, arena: .default)
@@ -1560,6 +1744,27 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return ConstrainedSugarTypeSyntax(newData)
   }
 
+  public var unexpectedAfterBaseType: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterBaseType(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterBaseType` replaced.
+  /// - param newChild: The new `unexpectedAfterBaseType` to replace the node's
+  ///                   current `unexpectedAfterBaseType`, if present.
+  public func withUnexpectedAfterBaseType(
+    _ newChild: UnexpectedNodesSyntax?) -> ConstrainedSugarTypeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return ConstrainedSugarTypeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1569,6 +1774,8 @@ public struct ConstrainedSugarTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -1583,6 +1790,7 @@ extension ConstrainedSugarTypeSyntax: CustomReflectable {
       "someOrAnySpecifier": Syntax(someOrAnySpecifier).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenSomeOrAnySpecifierAndBaseType": unexpectedBetweenSomeOrAnySpecifierAndBaseType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "baseType": Syntax(baseType).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterBaseType": unexpectedAfterBaseType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1611,13 +1819,15 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
     _ unexpectedBeforeWrappedType: UnexpectedNodesSyntax? = nil,
     wrappedType: TypeSyntax,
     _ unexpectedBetweenWrappedTypeAndExclamationMark: UnexpectedNodesSyntax? = nil,
-    exclamationMark: TokenSyntax
+    exclamationMark: TokenSyntax,
+    _ unexpectedAfterExclamationMark: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeWrappedType?.raw,
       wrappedType.raw,
       unexpectedBetweenWrappedTypeAndExclamationMark?.raw,
       exclamationMark.raw,
+      unexpectedAfterExclamationMark?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.implicitlyUnwrappedOptionalType,
       from: layout, arena: .default)
@@ -1707,6 +1917,27 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
     return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
   }
 
+  public var unexpectedAfterExclamationMark: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterExclamationMark(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterExclamationMark` replaced.
+  /// - param newChild: The new `unexpectedAfterExclamationMark` to replace the node's
+  ///                   current `unexpectedAfterExclamationMark`, if present.
+  public func withUnexpectedAfterExclamationMark(
+    _ newChild: UnexpectedNodesSyntax?) -> ImplicitlyUnwrappedOptionalTypeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return ImplicitlyUnwrappedOptionalTypeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1716,6 +1947,8 @@ public struct ImplicitlyUnwrappedOptionalTypeSyntax: TypeSyntaxProtocol, SyntaxH
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -1730,6 +1963,7 @@ extension ImplicitlyUnwrappedOptionalTypeSyntax: CustomReflectable {
       "wrappedType": Syntax(wrappedType).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenWrappedTypeAndExclamationMark": unexpectedBetweenWrappedTypeAndExclamationMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "exclamationMark": Syntax(exclamationMark).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterExclamationMark": unexpectedAfterExclamationMark.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1756,11 +1990,13 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
 
   public init(
     _ unexpectedBeforeElements: UnexpectedNodesSyntax? = nil,
-    elements: CompositionTypeElementListSyntax
+    elements: CompositionTypeElementListSyntax,
+    _ unexpectedAfterElements: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeElements?.raw,
       elements.raw,
+      unexpectedAfterElements?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.compositionType,
       from: layout, arena: .default)
@@ -1827,11 +2063,34 @@ public struct CompositionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return CompositionTypeSyntax(newData)
   }
 
+  public var unexpectedAfterElements: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 2, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterElements(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterElements` replaced.
+  /// - param newChild: The new `unexpectedAfterElements` to replace the node's
+  ///                   current `unexpectedAfterElements`, if present.
+  public func withUnexpectedAfterElements(
+    _ newChild: UnexpectedNodesSyntax?) -> CompositionTypeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 2)
+    return CompositionTypeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
       return nil
     case 1:
+      return nil
+    case 2:
       return nil
     default:
       fatalError("Invalid index")
@@ -1844,6 +2103,7 @@ extension CompositionTypeSyntax: CustomReflectable {
     return Mirror(self, children: [
       "unexpectedBeforeElements": unexpectedBeforeElements.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "elements": Syntax(elements).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterElements": unexpectedAfterElements.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -1872,13 +2132,15 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforePatternType: UnexpectedNodesSyntax? = nil,
     patternType: TypeSyntax,
     _ unexpectedBetweenPatternTypeAndEllipsis: UnexpectedNodesSyntax? = nil,
-    ellipsis: TokenSyntax
+    ellipsis: TokenSyntax,
+    _ unexpectedAfterEllipsis: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforePatternType?.raw,
       patternType.raw,
       unexpectedBetweenPatternTypeAndEllipsis?.raw,
       ellipsis.raw,
+      unexpectedAfterEllipsis?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.packExpansionType,
       from: layout, arena: .default)
@@ -1968,6 +2230,27 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return PackExpansionTypeSyntax(newData)
   }
 
+  public var unexpectedAfterEllipsis: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterEllipsis(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterEllipsis` replaced.
+  /// - param newChild: The new `unexpectedAfterEllipsis` to replace the node's
+  ///                   current `unexpectedAfterEllipsis`, if present.
+  public func withUnexpectedAfterEllipsis(
+    _ newChild: UnexpectedNodesSyntax?) -> PackExpansionTypeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return PackExpansionTypeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -1977,6 +2260,8 @@ public struct PackExpansionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -1991,6 +2276,7 @@ extension PackExpansionTypeSyntax: CustomReflectable {
       "patternType": Syntax(patternType).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenPatternTypeAndEllipsis": unexpectedBetweenPatternTypeAndEllipsis.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "ellipsis": Syntax(ellipsis).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterEllipsis": unexpectedAfterEllipsis.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2021,7 +2307,8 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenLeftParenAndElements: UnexpectedNodesSyntax? = nil,
     elements: TupleTypeElementListSyntax,
     _ unexpectedBetweenElementsAndRightParen: UnexpectedNodesSyntax? = nil,
-    rightParen: TokenSyntax
+    rightParen: TokenSyntax,
+    _ unexpectedAfterRightParen: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
@@ -2030,6 +2317,7 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       elements.raw,
       unexpectedBetweenElementsAndRightParen?.raw,
       rightParen.raw,
+      unexpectedAfterRightParen?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.tupleType,
       from: layout, arena: .default)
@@ -2178,6 +2466,27 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return TupleTypeSyntax(newData)
   }
 
+  public var unexpectedAfterRightParen: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterRightParen(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterRightParen` replaced.
+  /// - param newChild: The new `unexpectedAfterRightParen` to replace the node's
+  ///                   current `unexpectedAfterRightParen`, if present.
+  public func withUnexpectedAfterRightParen(
+    _ newChild: UnexpectedNodesSyntax?) -> TupleTypeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return TupleTypeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2191,6 +2500,8 @@ public struct TupleTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -2207,6 +2518,7 @@ extension TupleTypeSyntax: CustomReflectable {
       "elements": Syntax(elements).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenElementsAndRightParen": unexpectedBetweenElementsAndRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "rightParen": Syntax(rightParen).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterRightParen": unexpectedAfterRightParen.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2245,7 +2557,8 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenThrowsOrRethrowsKeywordAndArrow: UnexpectedNodesSyntax? = nil,
     arrow: TokenSyntax,
     _ unexpectedBetweenArrowAndReturnType: UnexpectedNodesSyntax? = nil,
-    returnType: TypeSyntax
+    returnType: TypeSyntax,
+    _ unexpectedAfterReturnType: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeLeftParen?.raw,
@@ -2262,6 +2575,7 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       arrow.raw,
       unexpectedBetweenArrowAndReturnType?.raw,
       returnType.raw,
+      unexpectedAfterReturnType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.functionType,
       from: layout, arena: .default)
@@ -2576,6 +2890,27 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return FunctionTypeSyntax(newData)
   }
 
+  public var unexpectedAfterReturnType: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 14, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterReturnType(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterReturnType` replaced.
+  /// - param newChild: The new `unexpectedAfterReturnType` to replace the node's
+  ///                   current `unexpectedAfterReturnType`, if present.
+  public func withUnexpectedAfterReturnType(
+    _ newChild: UnexpectedNodesSyntax?) -> FunctionTypeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 14)
+    return FunctionTypeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2606,6 +2941,8 @@ public struct FunctionTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       return nil
     case 13:
       return nil
+    case 14:
+      return nil
     default:
       fatalError("Invalid index")
     }
@@ -2629,6 +2966,7 @@ extension FunctionTypeSyntax: CustomReflectable {
       "arrow": Syntax(arrow).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenArrowAndReturnType": unexpectedBetweenArrowAndReturnType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "returnType": Syntax(returnType).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterReturnType": unexpectedAfterReturnType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2659,7 +2997,8 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedBetweenSpecifierAndAttributes: UnexpectedNodesSyntax? = nil,
     attributes: AttributeListSyntax?,
     _ unexpectedBetweenAttributesAndBaseType: UnexpectedNodesSyntax? = nil,
-    baseType: TypeSyntax
+    baseType: TypeSyntax,
+    _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeSpecifier?.raw,
@@ -2668,6 +3007,7 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
       attributes?.raw,
       unexpectedBetweenAttributesAndBaseType?.raw,
       baseType.raw,
+      unexpectedAfterBaseType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.attributedType,
       from: layout, arena: .default)
@@ -2818,6 +3158,27 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return AttributedTypeSyntax(newData)
   }
 
+  public var unexpectedAfterBaseType: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 6, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterBaseType(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterBaseType` replaced.
+  /// - param newChild: The new `unexpectedAfterBaseType` to replace the node's
+  ///                   current `unexpectedAfterBaseType`, if present.
+  public func withUnexpectedAfterBaseType(
+    _ newChild: UnexpectedNodesSyntax?) -> AttributedTypeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 6)
+    return AttributedTypeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2831,6 +3192,8 @@ public struct AttributedTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     case 4:
       return nil
     case 5:
+      return nil
+    case 6:
       return nil
     default:
       fatalError("Invalid index")
@@ -2847,6 +3210,7 @@ extension AttributedTypeSyntax: CustomReflectable {
       "attributes": attributes.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "unexpectedBetweenAttributesAndBaseType": unexpectedBetweenAttributesAndBaseType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "baseType": Syntax(baseType).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterBaseType": unexpectedAfterBaseType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }
@@ -2875,13 +3239,15 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     _ unexpectedBeforeGenericParameters: UnexpectedNodesSyntax? = nil,
     genericParameters: GenericParameterClauseSyntax,
     _ unexpectedBetweenGenericParametersAndBaseType: UnexpectedNodesSyntax? = nil,
-    baseType: TypeSyntax
+    baseType: TypeSyntax,
+    _ unexpectedAfterBaseType: UnexpectedNodesSyntax? = nil
   ) {
     let layout: [RawSyntax?] = [
       unexpectedBeforeGenericParameters?.raw,
       genericParameters.raw,
       unexpectedBetweenGenericParametersAndBaseType?.raw,
       baseType.raw,
+      unexpectedAfterBaseType?.raw,
     ]
     let raw = RawSyntax.makeLayout(kind: SyntaxKind.namedOpaqueReturnType,
       from: layout, arena: .default)
@@ -2971,6 +3337,27 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     return NamedOpaqueReturnTypeSyntax(newData)
   }
 
+  public var unexpectedAfterBaseType: UnexpectedNodesSyntax? {
+    get {
+      let childData = data.child(at: 4, parent: Syntax(self))
+      if childData == nil { return nil }
+      return UnexpectedNodesSyntax(childData!)
+    }
+    set(value) {
+      self = withUnexpectedAfterBaseType(value)
+    }
+  }
+
+  /// Returns a copy of the receiver with its `unexpectedAfterBaseType` replaced.
+  /// - param newChild: The new `unexpectedAfterBaseType` to replace the node's
+  ///                   current `unexpectedAfterBaseType`, if present.
+  public func withUnexpectedAfterBaseType(
+    _ newChild: UnexpectedNodesSyntax?) -> NamedOpaqueReturnTypeSyntax {
+    let raw = newChild?.raw
+    let newData = data.replacingChild(raw, at: 4)
+    return NamedOpaqueReturnTypeSyntax(newData)
+  }
+
   public func childNameForDiagnostics(_ index: SyntaxChildrenIndex) -> String? {
     switch index.data?.indexInParent {
     case 0:
@@ -2980,6 +3367,8 @@ public struct NamedOpaqueReturnTypeSyntax: TypeSyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
+      return nil
+    case 4:
       return nil
     default:
       fatalError("Invalid index")
@@ -2994,6 +3383,7 @@ extension NamedOpaqueReturnTypeSyntax: CustomReflectable {
       "genericParameters": Syntax(genericParameters).asProtocol(SyntaxProtocol.self),
       "unexpectedBetweenGenericParametersAndBaseType": unexpectedBetweenGenericParametersAndBaseType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
       "baseType": Syntax(baseType).asProtocol(SyntaxProtocol.self),
+      "unexpectedAfterBaseType": unexpectedAfterBaseType.map(Syntax.init)?.asProtocol(SyntaxProtocol.self) as Any,
     ])
   }
 }

--- a/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
+++ b/Sources/SwiftSyntaxParser/gyb_generated/NodeDeclarationHash.swift
@@ -17,6 +17,6 @@
 extension SyntaxParser {
   static func verifyNodeDeclarationHash() -> Bool {
     return String(cString: swiftparse_syntax_structure_versioning_identifier()!) ==
-      "1af49f8e78efc75c6798cf6750b842dac14b8f5a"
+      "c0b7ce08b8daaed9bd51788168a18e1cec63a5a9"
   }
 }

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -648,7 +648,7 @@ final class DeclarationTests: XCTestCase {
       "() -> #^DIAG^#throws Int",
       { $0.parseFunctionSignature() },
       diagnostics: [
-        DiagnosticSpec(message: "'throws' may only occur before '->'", fixIts: ["move 'throws' before '->'"])
+        DiagnosticSpec(message: "'throws' may only occur before '->'", fixIts: ["move 'throws' in front of '->'"])
       ],
       fixedSource: "() throws -> Int"
     )

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -581,10 +581,17 @@ final class ExpressionTests: XCTestCase {
     AssertParse(
       "[(Int) -> #^DIAG^#throws Int]()",
       diagnostics: [
-        // FIXME: We should suggest to move 'throws' in front of '->'
-        DiagnosticSpec(message: "expected expression in array element"),
-        DiagnosticSpec(message: "unexpected text 'throws Int' in array"),
-      ]
+        DiagnosticSpec(message: "'throws' may only occur before '->'", fixIts: ["move 'throws' in front of '->'"]),
+      ],
+      fixedSource: "[(Int) throws -> Int]()"
+    )
+
+    AssertParse(
+      "[(Int) -> #^DIAG^#async throws Int]()",
+      diagnostics: [
+        DiagnosticSpec(message: "'async throws' may only occur before '->'", fixIts: ["move 'async throws' in front of '->'"]),
+      ],
+      fixedSource: "[(Int) async throws -> Int]()"
     )
 
     AssertParse(

--- a/Tests/SwiftParserTest/translated/TypeExprTests.swift
+++ b/Tests/SwiftParserTest/translated/TypeExprTests.swift
@@ -2,24 +2,9 @@
 
 import XCTest
 
+// Types in expression contexts must be followed by a member access or
+// constructor call.
 final class TypeExprTests: XCTestCase {
-  func testTypeExpr1() {
-    AssertParse(
-      """
-      // not ready: dont_run: %target-typecheck-verify-swift -enable-astscope-lookup -swift-version 4
-      """
-    )
-  }
-
-  func testTypeExpr2() {
-    AssertParse(
-      """
-      // Types in expression contexts must be followed by a member access or
-      // constructor call.
-      """
-    )
-  }
-
   func testTypeExpr3() {
     AssertParse(
       """
@@ -49,11 +34,7 @@ final class TypeExprTests: XCTestCase {
         static func meth() {} 
         func instMeth() {} 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 5: protocol methods must not have bodies
-        // TODO: Old parser expected error on line 6: protocol methods must not have bodies
-      ]
+      """
     )
   }
 
@@ -63,10 +44,7 @@ final class TypeExprTests: XCTestCase {
       protocol Bad {
         init() {} 
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 2: protocol initializers must not have bodies
-      ]
+      """
     )
   }
 
@@ -349,54 +327,213 @@ final class TypeExprTests: XCTestCase {
     )
   }
 
-  func testTypeExpr25() {
+  func testTypeExpr25a() {
     AssertParse(
       """
-      // https://github.com/apple/swift/issues/43119
-      func testFunctionCollectionTypes() {
-        _ = [(Int) -> Int]()
-        _ = [(Int, Int) -> Int]()
-        _ = [(x: Int, y: Int) -> Int]()
-        // Make sure associativity is correct
-        let a = [(Int) -> (Int) -> Int]()
-        let b: Int = a[0](5)(4)
-        _ = [String: (Int) -> Int]()
-        _ = [String: (Int, Int) -> Int]()
-        _ = [1 -> Int]() 
-        _ = [Int -> 1]() 
-        // Should parse () as void type when before or after arrow
-        _ = [() -> Int]()
-        _ = [(Int) -> ()]()
-        _ = 2 + () -> Int 
-        _ = () -> (Int, Int).2 
-        _ = (Int) -> Int 
-        _ = @convention(c) () -> Int 
-        _ = 1 + (@convention(c) () -> Int).self 
-        _ = (@autoclosure () -> Int) -> (Int, Int).2 
-        _ = ((@autoclosure () -> Int) -> (Int, Int)).1 
-        _ = ((inout Int) -> Void).self
-        _ = [(Int) throws -> Int]()
-        _ = [@convention(swift) (Int) throws -> Int]().count
-        _ = [(inout Int) throws -> (inout () -> Void) -> Void]().count
-        _ = [String: (@autoclosure (Int) -> Int32) -> Void]().keys 
-        let _ = [(Int) -> #^DIAG_1^#throws Int]() 
-        let _ = [Int throws #^DIAG_2^#Int](); 
-      }
+      _ = [(Int) -> Int]()
+      """
+    )
+  }
+
+  func testTypeExpr25b() {
+    AssertParse(
+      """
+      _ = [(Int, Int) -> Int]()
+      """
+    )
+  }
+
+  func testTypeExpr25c() {
+    AssertParse(
+      """
+      _ = [(x: Int, y: Int) -> Int]()
+      """
+    )
+  }
+
+  func testTypeExpr25d() {
+    AssertParse(
+      """
+      // Make sure associativity is correct
+      let a = [(Int) -> (Int) -> Int]()
+      """
+    )
+  }
+
+  func testTypeExpr25e() {
+    AssertParse(
+      """
+      let b: Int = a[0](5)(4)
+      """
+    )
+  }
+
+  func testTypeExpr25f() {
+    AssertParse(
+      """
+      _ = [String: (Int) -> Int]()
+      """
+    )
+  }
+
+  func testTypeExpr25g() {
+    AssertParse(
+      """
+      _ = [String: (Int, Int) -> Int]()
+      """
+    )
+  }
+
+  func testTypeExpr25h() {
+    AssertParse(
+      """
+      _ = [1 -> Int]()
+      """
+    )
+  }
+
+  func testTypeExpr25i() {
+    AssertParse(
+      """
+      _ = [Int -> 1]()
+      """
+    )
+  }
+
+  func testTypeExpr25j() {
+    AssertParse(
+      """
+      // Should parse () as void type when before or after arrow
+      _ = [() -> Int]()
+      """
+    )
+  }
+
+  func testTypeExpr25k() {
+    AssertParse(
+      """
+      _ = [(Int) -> ()]()
+      """
+    )
+  }
+
+  func testTypeExpr25l() {
+    AssertParse(
+      """
+      _ = 2 + () -> Int
+      """
+    )
+  }
+
+  func testTypeExpr25m() {
+    AssertParse(
+      """
+      _ = () -> (Int, Int).2
+      """
+    )
+  }
+
+  func testTypeExpr25n() {
+    AssertParse(
+      """
+      _ = (Int) -> Int
+      """
+    )
+  }
+
+  func testTypeExpr25o() {
+    AssertParse(
+      """
+      _ = @convention(c) () -> Int
+      """
+    )
+  }
+
+  func testTypeExpr25p() {
+    AssertParse(
+      """
+      _ = 1 + (@convention(c) () -> Int).self
+      """
+    )
+  }
+
+  func testTypeExpr25q() {
+    AssertParse(
+      """
+      _ = (@autoclosure () -> Int) -> (Int, Int).2
+      """
+    )
+  }
+
+  func testTypeExpr25r() {
+    AssertParse(
+      """
+      _ = ((@autoclosure () -> Int) -> (Int, Int)).1
+      """
+    )
+  }
+
+  func testTypeExpr25s() {
+    AssertParse(
+      """
+      _ = ((inout Int) -> Void).self
+      """
+    )
+  }
+
+  func testTypeExpr25t() {
+    AssertParse(
+      """
+      _ = [(Int) throws -> Int]()
+      """
+    )
+  }
+
+  func testTypeExpr25u() {
+    AssertParse(
+      """
+      _ = [@convention(swift) (Int) throws -> Int]().count
+      """
+    )
+  }
+
+  func testTypeExpr25v() {
+    AssertParse(
+      """
+      _ = [(inout Int) throws -> (inout () -> Void) -> Void]().count
+      """
+    )
+  }
+
+  func testTypeExpr25w() {
+    AssertParse(
+      """
+      _ = [String: (@autoclosure (Int) -> Int32) -> Void]().keys
+      """
+    )
+  }
+
+  func testTypeExpr25x() {
+    AssertParse(
+      """
+      let _ = [(Int) -> #^DIAG^#throws Int]()
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 11: expected type before '->'
-        // TODO: Old parser expected error on line 12: expected type after '->'
-        // TODO: Old parser expected error on line 12: single argument function types require parentheses
-        // TODO: Old parser expected error on line 16: expected type before '->'
-        // TODO: Old parser expected error on line 17: expected type after '->'
-        // TODO: Old parser expected error on line 21: expected type after '->'
-        // TODO: Old parser expected error on line 27: argument type of @autoclosure parameter must be '()'
-        // TODO: Old parser expected error on line 28: 'throws' may only occur before '->'
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "expected expression in array element"),
-        DiagnosticSpec(locationMarker: "DIAG_1", message: "unexpected text 'throws Int' in array"),
-        // TODO: Old parser expected error on line 29: 'throws' may only occur before '->'
-        // TODO: Old parser expected error on line 29: consecutive statements on a line must be separated by ';'
-        DiagnosticSpec(locationMarker: "DIAG_2", message: "expected '->' in array element"),
+        DiagnosticSpec(message: "'throws' may only occur before '->'"),
+      ],
+      fixedSource: """
+      let _ = [(Int) throws -> Int]()
+      """
+    )
+  }
+
+  func testTypeExpr25y() {
+    AssertParse(
+      """
+      let _ = [Int throws #^DIAG^#Int]();
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected '->' in array element")
       ]
     )
   }
@@ -422,13 +559,7 @@ final class TypeExprTests: XCTestCase {
         _ = (P1 & P2 -> P3 & P2).self 
         _ = ((P1 & P2) -> (P3 & P2) -> P1 & Any).self // Ok
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 13: single argument function types require parentheses, Fix-It replacements: 7 - 7 = '(', 14 - 14 = ')'
-        // TODO: Old parser expected error on line 14: single argument function types require parentheses, Fix-It replacements: 18 - 18 = '(', 25 - 25 = ')'
-        // TODO: Old parser expected error on line 14: single argument function types require parentheses, Fix-It replacements: 7 - 7 = '(', 14 - 14 = ')'
-        // TODO: Old parser expected error on line 16: single argument function types require parentheses, Fix-It replacements: 8 - 8 = '(', 15 - 15 = ')'
-      ]
+      """
     )
   }
 
@@ -442,10 +573,7 @@ final class TypeExprTests: XCTestCase {
         //     (type_expr typerepr='P1 & P2 throws -> P3 & P1')))
         _ = try P1 & P2 throws -> P3 & P1
       }
-      """,
-      diagnostics: [
-        // TODO: Old parser expected error on line 6: single argument function types require parentheses, Fix-It replacements: 11 - 11 = '(', 18 - 18 = ')'
-      ]
+      """
     )
   }
 
@@ -455,7 +583,6 @@ final class TypeExprTests: XCTestCase {
       func takesVoid(f: #^DIAG_1^#Void #^DIAG_2^#-> ()) {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: single argument function types require parentheses, Fix-It replacements: 19 - 23 = '()'
         DiagnosticSpec(locationMarker: "DIAG_1", message: "expected '(' to start function type"),
         DiagnosticSpec(locationMarker: "DIAG_2", message: "expected ')' in function type"),
       ]

--- a/Tests/SwiftSyntaxTest/CustomReflectableTests.swift
+++ b/Tests/SwiftSyntaxTest/CustomReflectableTests.swift
@@ -127,8 +127,10 @@ public class CustomReflectableTests: XCTestCase {
                                                - pieces: 0 elements
                                              ▿ tokenKind: SwiftSyntax.TokenKind.integerLiteral
                                                - integerLiteral: "1"
+                                           - unexpectedAfterDigits: nil
                                          - unexpectedBetweenExpressionAndTrailingComma: nil
                                          - trailingComma: nil
+                                         - unexpectedAfterTrailingComma: nil
                                        ▿ TupleExprElementSyntax
                                          - unexpectedBeforeLabel: nil
                                          - label: nil
@@ -145,8 +147,10 @@ public class CustomReflectableTests: XCTestCase {
                                                - pieces: 0 elements
                                              ▿ tokenKind: SwiftSyntax.TokenKind.integerLiteral
                                                - integerLiteral: "2"
+                                           - unexpectedAfterDigits: nil
                                          - unexpectedBetweenExpressionAndTrailingComma: nil
                                          - trailingComma: nil
+                                         - unexpectedAfterTrailingComma: nil
 
                                      """)
       }(),
@@ -184,8 +188,10 @@ public class CustomReflectableTests: XCTestCase {
                                                  - pieces: 0 elements
                                                ▿ tokenKind: SwiftSyntax.TokenKind.integerLiteral
                                                  - integerLiteral: "1"
+                                             - unexpectedAfterDigits: nil
                                            - unexpectedBetweenExpressionAndTrailingComma: nil
                                            - trailingComma: nil
+                                           - unexpectedAfterTrailingComma: nil
                                          ▿ TupleExprElementSyntax
                                            - unexpectedBeforeLabel: nil
                                            - label: nil
@@ -202,8 +208,10 @@ public class CustomReflectableTests: XCTestCase {
                                                  - pieces: 0 elements
                                                ▿ tokenKind: SwiftSyntax.TokenKind.integerLiteral
                                                  - integerLiteral: "2"
+                                             - unexpectedAfterDigits: nil
                                            - unexpectedBetweenExpressionAndTrailingComma: nil
                                            - trailingComma: nil
+                                           - unexpectedAfterTrailingComma: nil
 
                                      """)
       }(),

--- a/gyb_syntax_support/Node.py
+++ b/gyb_syntax_support/Node.py
@@ -28,11 +28,13 @@ class Node(object):
         self.children = []
         # Add implicitly generated UnexpectedNodes children in between any two
         # defined children
-        if kind != 'SyntaxCollection':
-            for i in range(2 * len(children)):
+        if kind != 'SyntaxCollection' and len(children) > 0:
+            for i in range(2 * len(children) + 1):
                 if i % 2 == 0:
                     if i == 0:
                         name = 'UnexpectedBefore' + children[0].name
+                    elif i == 2 * len(children):
+                        name = 'UnexpectedAfter' + children[-1].name
                     else:
                         name = 'UnexpectedBetween%sAnd%s' % \
                             (children[int(i / 2) - 1].name, children[int(i / 2)].name)


### PR DESCRIPTION
After parsing the `->` for an `ArrowExpr`, eat trailing `throws` or `async` and include them as unexpected nodes after the `->`. This is safe because the expression after `->` cannot start with `throws` or `async`.

This changes the syntax nodes to allow unexpected tokens after the last expected token. Previously @rintaro had concerns about unexpected nodes at the end of a node because this make it even more ambiguous where the unexpected tokens should be placed, but it’s super convenient for this diagnostic, so allowed it again. 