### PR TITLE
Detect and recover from missing type colon

### DIFF
--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -135,6 +135,8 @@ extension Parser {
         arena: self.arena
       )
     } else if lookahead.canParseType() && !self.currentToken.isAtStartOfLine {
+      // TODO: If we are in a for loop, dont do this. normally there an "in" is expected. Siehe failing tests
+        
       // Recovery if the user forgot to add ':'
       let result = self.parseResultType()
       type = RawTypeAnnotationSyntax(

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -120,7 +120,7 @@ extension Parser {
   /// =======
   ///
   ///     typed-pattern → pattern ':' attributes? inout? type
-  mutating func parseTypedPattern(allowRecover: Bool = true) -> (RawPatternSyntax, RawTypeAnnotationSyntax?) {
+  mutating func parseTypedPattern(allowRecoveryFromMissingColon: Bool = true) -> (RawPatternSyntax, RawTypeAnnotationSyntax?) {
     let pattern = self.parsePattern()
 
     // Now parse an optional type annotation.
@@ -134,7 +134,9 @@ extension Parser {
         type: result,
         arena: self.arena
       )
-    } else if allowRecover && lookahead.canParseType() && !self.currentToken.isAtStartOfLine {
+    } else if allowRecoveryFromMissingColon
+                && !self.currentToken.isAtStartOfLine
+                && lookahead.canParseType() {
       // Recovery if the user forgot to add ':'
       let result = self.parseResultType()
       type = RawTypeAnnotationSyntax(

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -120,7 +120,7 @@ extension Parser {
   /// =======
   ///
   ///     typed-pattern → pattern ':' attributes? inout? type
-  mutating func parseTypedPattern() -> (RawPatternSyntax, RawTypeAnnotationSyntax?) {
+  mutating func parseTypedPattern(allowRecover: Bool = true) -> (RawPatternSyntax, RawTypeAnnotationSyntax?) {
     let pattern = self.parsePattern()
 
     // Now parse an optional type annotation.
@@ -134,9 +134,7 @@ extension Parser {
         type: result,
         arena: self.arena
       )
-    } else if lookahead.canParseType() && !self.currentToken.isAtStartOfLine {
-      // TODO: If we are in a for loop, dont do this. normally there an "in" is expected. Siehe failing tests
-        
+    } else if allowRecover && lookahead.canParseType() && !self.currentToken.isAtStartOfLine {
       // Recovery if the user forgot to add ':'
       let result = self.parseResultType()
       type = RawTypeAnnotationSyntax(

--- a/Sources/SwiftParser/Patterns.swift
+++ b/Sources/SwiftParser/Patterns.swift
@@ -125,7 +125,19 @@ extension Parser {
 
     // Now parse an optional type annotation.
     guard let colon = self.consume(if: .colon) else {
-      return (pattern, nil)
+      
+      let result = self.parseResultType()
+      if result.syntax.isMissingAllTokens {
+        return (pattern, nil)
+      }
+      
+      let type = RawTypeAnnotationSyntax(
+        colon: .init(missing: .colon, arena: self.arena),
+        type: result,
+        arena: self.arena
+      )
+       
+      return (pattern, type)
     }
 
     let result = self.parseResultType()

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -572,7 +572,7 @@ extension Parser {
         type = nil
       }
     } else {
-      (pattern, type) = self.parseTypedPattern(allowRecover: false)
+      (pattern, type) = self.parseTypedPattern(allowRecoveryFromMissingColon: false)
     }
 
     let (unexpectedBeforeInKeyword, inKeyword) = self.expect(.inKeyword)

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -572,7 +572,7 @@ extension Parser {
         type = nil
       }
     } else {
-      (pattern, type) = self.parseTypedPattern()
+      (pattern, type) = self.parseTypedPattern(allowRecover: false)
     }
 
     let (unexpectedBeforeInKeyword, inKeyword) = self.expect(.inKeyword)

--- a/Tests/SwiftParserTest/Types.swift
+++ b/Tests/SwiftParserTest/Types.swift
@@ -7,7 +7,7 @@ final class TypeTests: XCTestCase {
   func testMissingColonInType() {
     AssertParse(
       """
-      var foo #^DIAG^#Bar = 1
+      var foo 1️⃣Bar = 1
       """, diagnostics: [
         DiagnosticSpec(message: "expected ':' in type annotation")
       ])

--- a/Tests/SwiftParserTest/Types.swift
+++ b/Tests/SwiftParserTest/Types.swift
@@ -3,6 +3,16 @@
 import XCTest
 
 final class TypeTests: XCTestCase {
+  
+  func testMissingColonInType() {
+    AssertParse(
+      """
+      var foo #^DIAG^#Bar = 1
+      """, diagnostics: [
+        DiagnosticSpec(message: "expected ':' in type annotation")
+      ])
+  }
+    
   func testClosureParsing() throws {
     AssertParse(
       "(a, b) -> c",


### PR DESCRIPTION
This PR will make the Parser capable of detect and recover from a missing colon in a type declaration. The motivating example was the following:

```
protocol Foo {
    var i Int { get }
}

protocol Bar {
    
}

  --- Diagnostics Before 

 1 │ protocol Foo {
 2 │     var i Int { get }
   ∣           ╰─ unexpected text before protocol
 3 │ }
 4 │
 5 │ protocol Bar {
 6 │
 7 │ }
   ∣  ╰─ expected '}' to end protocol


  --- Diagnostics After
 
 1 │ protocol Foo {
 2 │     var i Int { get }
   ∣          ╰─ expected ':' in type annotation
 3 │ }
 4 │
```

