### PR TITLE
Recovery if keyword is used where an identifier is expected

### DIFF
--- a/Sources/SwiftParser/Attributes.swift
+++ b/Sources/SwiftParser/Attributes.swift
@@ -261,7 +261,7 @@ extension Parser {
   }
 
   mutating func parseDifferentiabilityParameters() -> RawDifferentiabilityParamsClauseSyntax {
-    let (unexpectedBeforeWrt, wrt) = self.expectIdentifier()
+    let (unexpectedBeforeWrt, wrt) = self.expectIdentifier(keywordRecovery: true)
     let (unexpectedBeforeColon, colon) = self.expect(.colon)
 
     guard let leftParen = self.consume(if: .leftParen) else {
@@ -654,7 +654,7 @@ extension Parser {
     let (unexpectedBeforeAtSign, atSign) = self.expect(.atSign)
     let (unexpectedBeforePrivateToken, privateToken) = self.expectContextualKeyword("_private")
     let (unexpectedBeforeLeftParen, leftParen) = self.expect(.leftParen)
-    let (unexpectedBeforeLabel, label) = self.expectIdentifier()
+    let (unexpectedBeforeLabel, label) = self.expectIdentifier(keywordRecovery: true)
     let (unexpectedBeforeColon, colon) = self.expect(.colon)
     let filename = self.consumeAnyToken()
     let (unexpectedBeforeRightParen, rightParen) = self.expect(.rightParen)

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -605,7 +605,7 @@ extension Parser {
     _ handle: RecoveryConsumptionHandle
   ) -> RawClassDeclSyntax {
     let (unexpectedBeforeClassKeyword, classKeyword) = self.eat(handle)
-    let (unexpectedBeforeName, name) = self.expectIdentifier()
+    let (unexpectedBeforeName, name) = self.expectIdentifier(keywordRecovery: true)
     if unexpectedBeforeName == nil && name.isMissing {
       return RawClassDeclSyntax(
         attributes: attrs.attributes,
@@ -727,7 +727,7 @@ extension Parser {
     _ handle: RecoveryConsumptionHandle
   ) -> RawEnumDeclSyntax {
     let (unexpectedBeforeEnumKeyword, enumKeyword) = self.eat(handle)
-    let (unexpectedBeforeName, name) = self.expectIdentifier()
+    let (unexpectedBeforeName, name) = self.expectIdentifier(keywordRecovery: true)
     if unexpectedBeforeName == nil, name.isMissing {
       return RawEnumDeclSyntax(
         attributes: attrs.attributes,
@@ -809,7 +809,7 @@ extension Parser {
       var keepGoing: RawTokenSyntax? = nil
       var loopProgress = LoopProgressCondition()
       repeat {
-        let (unexpectedBeforeName, name) = self.expectIdentifier()
+        let (unexpectedBeforeName, name) = self.expectIdentifier(keywordRecovery: true)
 
         let associatedValue: RawParameterClauseSyntax?
         if self.at(.leftParen, where: { !$0.isAtStartOfLine }) {
@@ -872,7 +872,7 @@ extension Parser {
     _ handle: RecoveryConsumptionHandle
   ) -> RawStructDeclSyntax {
     let (unexpectedBeforeStructKeyword, structKeyword) = self.eat(handle)
-    let (unexpectedBeforeName, name) = self.expectIdentifier()
+    let (unexpectedBeforeName, name) = self.expectIdentifier(keywordRecovery: true)
     if unexpectedBeforeName == nil && name.isMissing {
       return RawStructDeclSyntax(
         attributes: attrs.attributes,
@@ -982,7 +982,7 @@ extension Parser {
     _ handle: RecoveryConsumptionHandle
   ) -> RawProtocolDeclSyntax {
     let (unexpectedBeforeProtocolKeyword, protocolKeyword) = self.eat(handle)
-    let (unexpectedBeforeName, name) = self.expectIdentifier()
+    let (unexpectedBeforeName, name) = self.expectIdentifier(keywordRecovery: true)
     if unexpectedBeforeName == nil && name.isMissing {
       return RawProtocolDeclSyntax(
         attributes: attrs.attributes,
@@ -1056,7 +1056,7 @@ extension Parser {
     _ handle: RecoveryConsumptionHandle
   ) -> RawAssociatedtypeDeclSyntax {
     let (unexpectedBeforeAssocKeyword, assocKeyword) = self.eat(handle)
-    let (unexpectedBeforeName, name) = self.expectIdentifier()
+    let (unexpectedBeforeName, name) = self.expectIdentifier(keywordRecovery: true)
     if unexpectedBeforeName == nil && name.isMissing {
       return RawAssociatedtypeDeclSyntax(
         attributes: attrs.attributes,
@@ -1130,7 +1130,7 @@ extension Parser {
     _ handle: RecoveryConsumptionHandle
   ) -> RawActorDeclSyntax {
     let (unexpectedBeforeActorKeyword, actorKeyword) = self.eat(handle)
-    let (unexpectedBeforeName, name) = self.expectIdentifier()
+    let (unexpectedBeforeName, name) = self.expectIdentifier(keywordRecovery: true)
 
     let generics: RawGenericParameterClauseSyntax?
     if self.currentToken.starts(with: "<") {
@@ -1475,7 +1475,7 @@ extension Parser {
       unexpectedBeforeIdentifier = nil
       identifier = self.consumePrefix(name, as: .spacedBinaryOperator)
     } else {
-      (unexpectedBeforeIdentifier, identifier) = self.expectIdentifier()
+      (unexpectedBeforeIdentifier, identifier) = self.expectIdentifier(keywordRecovery: true)
     }
 
     let genericParams: RawGenericParameterClauseSyntax?
@@ -1903,7 +1903,7 @@ extension Parser {
     _ handle: RecoveryConsumptionHandle
   ) -> RawTypealiasDeclSyntax {
     let (unexpectedBeforeTypealiasKeyword, typealiasKeyword) = self.eat(handle)
-    let (unexpectedBeforeName, name) = self.expectIdentifier()
+    let (unexpectedBeforeName, name) = self.expectIdentifier(keywordRecovery: true)
 
     // Parse a generic parameter list if it is present.
     let generics: RawGenericParameterClauseSyntax?
@@ -1977,7 +1977,7 @@ extension Parser {
     // checking.
     let precedenceAndTypes: RawOperatorPrecedenceAndTypesSyntax?
     if let colon = self.consume(if: .colon) {
-      let (unexpectedBeforeIdentifier, identifier) = self.expectIdentifier()
+      let (unexpectedBeforeIdentifier, identifier) = self.expectIdentifier(keywordRecovery: true)
       var types = [RawDesignatedTypeElementSyntax]()
       while let comma = self.consume(if: .comma) {
         // FIXME: The compiler accepts... anything here. This is a bug.
@@ -2038,7 +2038,7 @@ extension Parser {
     _ handle: RecoveryConsumptionHandle
   ) -> RawPrecedenceGroupDeclSyntax {
     let (unexpectedBeforeGroup, group) = self.eat(handle)
-    let (unexpectedBeforeIdentifier, identifier) = self.expectIdentifier()
+    let (unexpectedBeforeIdentifier, identifier) = self.expectIdentifier(keywordRecovery: true)
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
     var elements = [RawSyntax]()
 

--- a/Sources/SwiftParser/Diagnostics/MissingNodesError.swift
+++ b/Sources/SwiftParser/Diagnostics/MissingNodesError.swift
@@ -222,7 +222,7 @@ public struct InsertTokenFixIt: ParserFixIt {
     assert(missingNodes.allSatisfy({ $0.parent == self.commonParent }))
   }
 
-  public var message: String { "Insert \(missingNodesDescription(missingNodes, commonParent: commonParent))" }
+  public var message: String { "insert \(missingNodesDescription(missingNodes, commonParent: commonParent))" }
 }
 
 // MARK: - Generate Error

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -113,6 +113,10 @@ public struct InvalidIdentifierError: ParserError {
     switch invalidIdentifier.tokenKind {
     case .unknown(let text) where text.first?.isNumber == true:
       return "identifier can only start with a letter or underscore, not a number"
+    case .wildcardKeyword:
+      return "'\(invalidIdentifier.text)' cannot be used as an identifier here"
+    case let tokenKind where tokenKind.isKeyword:
+      return "keyword '\(invalidIdentifier.text)' cannot be used as an identifier here"
     default:
       return "'\(invalidIdentifier.text)' is not a valid identifier"
     }
@@ -160,6 +164,7 @@ public struct UnexpectedNodesError: ParserError {
 public enum StaticParserFixIt: String, FixItMessage {
   case insertSemicolon = "insert ';'"
   case insertAttributeArguments = "insert attribute argument"
+  case wrapKeywordInBackticks = "if this name is unavoidable, use backticks to escape it"
 
   public var message: String { self.rawValue }
 

--- a/Sources/_SwiftSyntaxTestSupport/AssertEqualWithDiff.swift
+++ b/Sources/_SwiftSyntaxTestSupport/AssertEqualWithDiff.swift
@@ -62,7 +62,7 @@ public func AssertDataEqualWithDiff(
 }
 
 /// `XCTFail` with `diff`-style output.
-private func FailStringsEqualWithDiff(
+public func FailStringsEqualWithDiff(
   _ actual: String,
   _ expected: String,
   _ message: String = "",

--- a/Tests/SwiftParserTest/Assertions.swift
+++ b/Tests/SwiftParserTest/Assertions.swift
@@ -254,11 +254,13 @@ func AssertDiagnostic<T: SyntaxProtocol>(
     }
   }
   if let fixIts = spec.fixIts {
-    XCTAssertEqual(
-      fixIts, diag.fixIts.map(\.message.message),
-      "Fix-Its for diagnostic did not match expected Fix-Its",
-      file: file, line: line
-    )
+    if fixIts != diag.fixIts.map(\.message.message) {
+      FailStringsEqualWithDiff(
+        diag.fixIts.map(\.message.message).joined(separator: "\n"),
+        fixIts.joined(separator: "\n"),
+        file: file, line: line
+      )
+    }
   }
 }
 

--- a/Tests/SwiftParserTest/Attributes.swift
+++ b/Tests/SwiftParserTest/Attributes.swift
@@ -12,7 +12,7 @@ final class AttributeTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected argument for '@_dynamicReplacement' attribute", fixIts: ["insert attribute argument"]),
-        DiagnosticSpec(message: "expected ')' to end attribute", fixIts: ["Insert ')'"]),
+        DiagnosticSpec(message: "expected ')' to end attribute", fixIts: ["insert ')'"]),
       ],
       fixedSource: """
         @_dynamicReplacement(for: <#identifier#>)
@@ -30,9 +30,9 @@ final class AttributeTests: XCTestCase {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' and parameters in '@differentiable' argument", fixIts: ["Insert ':' and parameters"]),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected '=' and right-hand type in same type requirement", fixIts: ["Insert '=' and right-hand type"]),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end attribute", fixIts: ["Insert ')'"]),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' and parameters in '@differentiable' argument", fixIts: ["insert ':' and parameters"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected '=' and right-hand type in same type requirement", fixIts: ["insert '=' and right-hand type"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end attribute", fixIts: ["insert ')'"]),
       ],
       fixedSource: """
         @differentiable(reverse wrt: <#syntax#>,where T = <#type#>)

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -35,15 +35,20 @@ final class DeclarationTests: XCTestCase {
       """
     )
 
-    AssertParse("""
-                func 1️⃣where
-                r2️⃣
-                """,
-                diagnostics: [
-                  DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in function"),
-                  DiagnosticSpec(locationMarker: "1️⃣", message: "expected argument list in function declaration"),
-                  DiagnosticSpec(locationMarker: "2️⃣", message: "expected '=' and right-hand type in same type requirement"),
-                ])
+    AssertParse(
+      """
+      func 1️⃣where2️⃣
+      r3️⃣
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "keyword 'where' cannot be used as an identifier here", fixIts: ["if this name is unavoidable, use backticks to escape it"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected '(' to start parameter clause", fixIts: ["insert '('"]),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "expected ')' to end parameter clause", fixIts: ["insert ')'"]),
+      ], fixedSource: """
+      func `where`(
+      r)
+      """
+    )
 
     AssertParse("func /^/ (lhs: Int, rhs: Int) -> Int { 1 / 2 }")
 

--- a/Tests/SwiftParserTest/translated/EnumTests.swift
+++ b/Tests/SwiftParserTest/translated/EnumTests.swift
@@ -281,14 +281,13 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum SwitchEnvy {
-        case 1️⃣_:
+        case 1️⃣_2️⃣:
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
-        DiagnosticSpec(message: "expected identifier in enum case"),
-        DiagnosticSpec(message: "expected declaration in enum"),
-        DiagnosticSpec(message: "unexpected text '_:' in enum"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "'_' cannot be used as an identifier here"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected declaration in enum"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text ':' in enum"),
       ]
     )
   }
@@ -461,16 +460,8 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 18: keyword '_' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 18: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 15 - 16 = '`_`'
-        // TODO: Old parser expected note on line 18: '_' previously declared here
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in enum case"),
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '_;' before enum case"),
-        // TODO: Old parser expected error on line 19: keyword '_' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 19: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 9 = '`_`'
-        // TODO: Old parser expected error on line 19: invalid redeclaration of '_'
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in enum case"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '_;' before enum case"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "'_' cannot be used as an identifier here"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "'_' cannot be used as an identifier here"),
         // TODO: Old parser expected error on line 20: expected identifier after comma in enum 'case' declaration
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in enum case"),
       ]
@@ -1251,15 +1242,10 @@ final class EnumTests: XCTestCase {
   func testEnum82() {
     AssertParse(
       """
-      enum1️⃣ 2️⃣switch {}3️⃣
+      enum 1️⃣switch {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: keyword 'switch' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 6 - 12 = '`switch`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in enum"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in enum"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected '{}' in 'switch' statement"),
+        DiagnosticSpec(message: "keyword 'switch' cannot be used as an identifier here"),
       ]
     )
   }
@@ -1293,15 +1279,11 @@ final class EnumTests: XCTestCase {
       enum E_53662 {
         case identifier
         case 1️⃣operator 
-        case 2️⃣identifier2
+        case identifier2
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: keyword 'operator' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 3: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 16 = '`operator`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in enum case"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected declaration in enum"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text 'identifier2' in enum"),
+        DiagnosticSpec(message: "keyword 'operator' cannot be used as an identifier here"),
       ]
     )
   }
@@ -1311,15 +1293,12 @@ final class EnumTests: XCTestCase {
       """
       enum E_53662_var {
         case identifier
-        case 1️⃣var 2️⃣
+        case 1️⃣var
         case identifier2
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: keyword 'var' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 3: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 11 = '`var`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in enum case"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected pattern in variable"),
+        DiagnosticSpec(message: "keyword 'var' cannot be used as an identifier here"),
       ]
     )
   }
@@ -1334,10 +1313,7 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 3: keyword '_' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 3: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 9 = '`_`'
-        DiagnosticSpec(message: "expected identifier in enum case"),
-        DiagnosticSpec(message: "unexpected text '_' before enum case"),
+        DiagnosticSpec(message: "'_' cannot be used as an identifier here"),
       ]
     )
   }
@@ -1346,17 +1322,13 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum E_53662_Comma {
-        case a, b, c, 1️⃣func2️⃣, d 
+        case a, b, c, 1️⃣func, d
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: keyword 'func' cannot be used as an identifier here
         // TODO: Old parser expected note on line 2: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 17 - 21 = '`func`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in enum case"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected argument list in function declaration"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected declaration in enum"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text ', d' in enum"),
+        DiagnosticSpec(message: "keyword 'func' cannot be used as an identifier here"),
       ]
     )
   }
@@ -1389,8 +1361,6 @@ final class EnumTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(message: "expected identifier in enum case"),
-        // TODO: Old parser expected error on line 3: keyword 'func' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 3: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 3 - 7 = '`func`'
       ]
     )
   }
@@ -1403,9 +1373,7 @@ final class EnumTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: 'case' label can only appear inside a 'switch' statement
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in enum case"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected pattern in variable"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "keyword 'let' cannot be used as an identifier here"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected declaration in enum"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '.foo(x, y):' in enum"),
       ]

--- a/Tests/SwiftParserTest/translated/IdentifiersTests.swift
+++ b/Tests/SwiftParserTest/translated/IdentifiersTests.swift
@@ -83,16 +83,14 @@ final class IdentifiersTests: XCTestCase {
     AssertParse(
       """
       // Keywords as identifiers
-      class1️⃣ 2️⃣switch {} 3️⃣
+      class 1️⃣switch {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: keyword 'switch' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 2: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 7 - 13 = '`switch`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in class"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in class"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected '{}' in 'switch' statement"),
-      ]
+        DiagnosticSpec(message: "keyword 'switch' cannot be used as an identifier here", fixIts: ["if this name is unavoidable, use backticks to escape it"]),
+      ], fixedSource: """
+      // Keywords as identifiers
+      class `switch` {}
+      """
     )
   }
 
@@ -102,8 +100,8 @@ final class IdentifiersTests: XCTestCase {
       struct Self {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: keyword 'Self' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 12 = '`Self`'
+        // TODO: Old parser expected error on line 3: keyword 'Self' cannot be used as an identifier here
+        // TODO: Old parser expected note on line 3: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 8 - 12 = '`Self`'
       ]
     )
   }
@@ -111,17 +109,10 @@ final class IdentifiersTests: XCTestCase {
   func testIdentifiers8c() {
     AssertParse(
       """
-      protocol1️⃣ 2️⃣enum3️⃣ 4️⃣{}
+      protocol 1️⃣enum {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: keyword 'enum' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 10 - 14 = '`enum`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in protocol"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in protocol"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected identifier in enum"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected member block in enum"),
+        DiagnosticSpec(message: "keyword 'enum' cannot be used as an identifier here"),
       ]
     )
   }
@@ -131,19 +122,12 @@ final class IdentifiersTests: XCTestCase {
       """
       protocol test {
         associatedtype 1️⃣public
-      2️⃣}
-      func 3️⃣_(_ x: Int) {}4️⃣
+      }
+      func 2️⃣_(_ x: Int) {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: keyword 'public' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 2: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 18 - 24 = '`public`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in associatedtype declaration"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '}' in function"),
-        // TODO: Old parser expected note on line 8: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 6 - 7 = '`_`'
-        // TODO: Old parser expected error on line 8: keyword '_' cannot be used as an identifier here
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text '_' before parameter clause"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected '}' to end protocol"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "keyword 'public' cannot be used as an identifier here"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "'_' cannot be used as an identifier here"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/InvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidTests.swift
@@ -330,16 +330,10 @@ final class InvalidTests: XCTestCase {
   func testInvalid17() {
     AssertParse(
       """
-      func1️⃣ 2️⃣repeat3️⃣() {}4️⃣
+      func 1️⃣repeat() {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: keyword 'repeat' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 6 - 12 = '`repeat`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected argument list in function declaration"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text '()' in 'repeat' statement"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected 'while' and condition in 'repeat' statement"),
+        DiagnosticSpec(message: "keyword 'repeat' cannot be used as an identifier here"),
       ]
     )
   }
@@ -388,16 +382,10 @@ final class InvalidTests: XCTestCase {
   func testInvalid21() {
     AssertParse(
       """
-      func1️⃣ 2️⃣repeat3️⃣() {}4️⃣
+      func 1️⃣repeat() {}
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: keyword 'repeat' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 6 - 12 = '`repeat`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected argument list in function declaration"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text '()' in 'repeat' statement"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected 'while' and condition in 'repeat' statement"),
+        DiagnosticSpec(message: "keyword 'repeat' cannot be used as an identifier here"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/TypealiasTests.swift
+++ b/Tests/SwiftParserTest/translated/TypealiasTests.swift
@@ -152,17 +152,12 @@ final class TypealiasTests: XCTestCase {
   func testTypealias11() {
     AssertParse(
       """
-      typealias1️⃣ 2️⃣switch 3️⃣= Int
+      typealias 1️⃣switch = Int
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: keyword 'switch' cannot be used as an identifier here
-        // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 11 - 17 = '`switch`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in typealias declaration"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected '=' and type in typealias declaration"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected expression and '{}' to end 'switch' statement"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous '= Int' at top level"),
-      ]
+        DiagnosticSpec(message: "keyword 'switch' cannot be used as an identifier here", fixIts: ["if this name is unavoidable, use backticks to escape it"])
+      ],
+      fixedSource: "typealias `switch` = Int"
     )
   }
 


### PR DESCRIPTION
In places where the only acceptable token after an identifier is not a keyword, we can consume a keyword in place of an identifier and diagnose this as usage of a keyword where an identifier was expected.