### PR TITLE
Add diagnostic for try let and try var

### DIFF
--- a/Sources/SwiftParser/CMakeLists.txt
+++ b/Sources/SwiftParser/CMakeLists.txt
@@ -23,6 +23,7 @@ add_library(SwiftParser STATIC
   RawTokenKindSubset.swift
   Recovery.swift
   Statements.swift
+  SyntaxUtils.swift
   TokenConsumer.swift
   TokenPrecedence.swift
   TopLevel.swift

--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -1623,7 +1623,7 @@ extension Parser {
         let initializer: RawInitializerClauseSyntax?
         if let equal = self.consume(if: .equal) {
           var value = self.parseExpression()
-          if hasTryBeforeIntroducer {
+          if hasTryBeforeIntroducer && !value.is(RawTryExprSyntax.self) {
             value = RawExprSyntax(RawTryExprSyntax(
               tryKeyword: missingToken(.tryKeyword, text: nil),
               questionOrExclamationMark: nil,

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -87,7 +87,7 @@ public struct EffectsSpecifierAfterArrow: ParserError {
   public let effectsSpecifiersAfterArrow: [TokenSyntax]
 
   public var message: String {
-    "\(missingNodesDescription(missingNodes: effectsSpecifiersAfterArrow.map(Syntax.init), commonParent: nil)) may only occur before '->'"
+    "\(missingNodesDescription(effectsSpecifiersAfterArrow)) may only occur before '->'"
   }
 }
 
@@ -165,7 +165,7 @@ public struct MoveTokensInFrontOfFixIt: ParserFixIt {
   public let inFrontOf: RawTokenKind
 
   public var message: String {
-    "move \(missingNodesDescription(missingNodes: movedTokens.map(Syntax.init), commonParent: nil)) in front of '\(inFrontOf.nameForDiagnostics)'"
+    "move \(missingNodesDescription(movedTokens)) in front of '\(inFrontOf.nameForDiagnostics)'"
   }
 }
 
@@ -175,6 +175,6 @@ public struct ReplaceTokensFixIt: ParserFixIt {
   public let replacement: TokenSyntax
 
   public var message: String {
-    "replace \(missingNodesDescription(missingNodes: replaceTokens.map(Syntax.init), commonParent: nil)) by '\(replacement.text)'"
+    "replace \(missingNodesDescription(replaceTokens)) by '\(replacement.text)'"
   }
 }

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -71,6 +71,9 @@ public enum StaticParserError: String, DiagnosticMessage {
   case missingColonInTernaryExprDiagnostic = "expected ':' after '? ...' in ternary expression"
   case missingFunctionParameterClause = "expected argument list in function declaration"
   case throwsInReturnPosition = "'throws' may only occur before '->'"
+  case tryMustBePlacedOnReturnedExpr = "'try' must be placed on the returned expression"
+  case tryMustBePlacedOnThrownExpr = "'try' must be placed on the thrown expression"
+  case tryOnInitialValueExpression = "'try' must be placed on the initial value expression"
 
   public var message: String { self.rawValue }
 
@@ -125,6 +128,14 @@ public struct MissingAttributeArgument: ParserError {
   }
 }
 
+public struct TryCannotBeUsed: ParserError {
+  public let nextToken: TokenSyntax
+
+  public var message: String {
+    return "'try' cannot be used with '\(nextToken.text)'"
+  }
+}
+
 public struct UnexpectedNodesError: ParserError {
   public let unexpectedNodes: UnexpectedNodesSyntax
 
@@ -154,6 +165,18 @@ public enum StaticParserFixIt: String, FixItMessage {
 
   public var fixItID: MessageID {
     MessageID(domain: diagnosticDomain, id: "\(type(of: self)).\(self)")
+  }
+}
+
+public struct MoveTokensAfterFixIt: ParserFixIt {
+  /// The token that should be moved
+  public let movedTokens: [TokenSyntax]
+
+  /// The token after which `movedTokens` should be moved
+  public let after: RawTokenKind
+
+  public var message: String {
+    "move \(missingNodesDescription(movedTokens)) after '\(after.nameForDiagnostics)'"
   }
 }
 

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -192,6 +192,15 @@ public struct MoveTokensInFrontOfFixIt: ParserFixIt {
   }
 }
 
+
+public struct RemoveRedundantFixIt: ParserFixIt {
+  public let removeTokens: [TokenSyntax]
+
+  public var message: String {
+    "remove redundant \(missingNodesDescription(removeTokens))"
+  }
+}
+
 public struct ReplaceTokensFixIt: ParserFixIt {
   public let replaceTokens: [TokenSyntax]
 

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -14,8 +14,15 @@
 
 extension TokenConsumer {
   func atStartOfExpression() -> Bool {
-    if self.at(anyIn: ExpressionStart.self) != nil {
+    switch self.at(anyIn: ExpressionStart.self) {
+    case (.awaitTryMove, let handle)?:
+      var backtrack = self.lookahead()
+      backtrack.eat(handle)
+      return !backtrack.atStartOfDeclaration() && !backtrack.atStartOfStatement()
+    case (_, _)?:
       return true
+    case nil:
+      break
     }
     if self.at(.atSign) || self.at(.inoutKeyword) {
       var backtrack = self.lookahead()

--- a/Sources/SwiftParser/RawTokenKindSubset.swift
+++ b/Sources/SwiftParser/RawTokenKindSubset.swift
@@ -261,6 +261,13 @@ enum CanBeStatementStart: RawTokenKindSubset {
     default: return nil
     }
   }
+
+  var precedence: TokenPrecedence? {
+    switch self {
+    case .yieldAsIdentifier: return .stmtKeyword
+    default: return nil
+    }
+  }
 }
 
 enum ContextualDeclKeyword: SyntaxText, ContextualKeywords {

--- a/Sources/SwiftParser/SyntaxUtils.swift
+++ b/Sources/SwiftParser/SyntaxUtils.swift
@@ -1,0 +1,26 @@
+//===--- SyntaxUtils.swift ------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2022 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+@_spi(RawSyntax) import SwiftSyntax
+
+extension RawUnexpectedNodesSyntax {
+  /// Returns `true` if this contains a token that satisfies `condition`.
+  func containsToken(where condition: (RawTokenSyntax) -> Bool) -> Bool {
+    return self.elements.contains(where: { node in
+      if let token = node.as(RawTokenSyntax.self) {
+        return condition(token)
+      } else {
+        return false
+      }
+    })
+  }
+}

--- a/Sources/SwiftParser/TokenPrecedence.swift
+++ b/Sources/SwiftParser/TokenPrecedence.swift
@@ -111,7 +111,7 @@ public enum TokenPrecedence: Comparable {
       // Legacy literals
         .__column__Keyword, .__dso_handle__Keyword, .__file__Keyword, .__function__Keyword, .__line__Keyword,
       // Pound literals
-        .poundAssertKeyword, .poundAvailableKeyword, .poundColorLiteralKeyword, .poundColumnKeyword, .poundDsohandleKeyword, .poundFileIDKeyword, .poundFileKeyword, .poundFileLiteralKeyword, .poundFilePathKeyword, .poundFunctionKeyword, .poundImageLiteralKeyword, .poundKeyPathKeyword, .poundLineKeyword, .poundSelectorKeyword, .poundSourceLocationKeyword, .poundUnavailableKeyword, .poundHasSymbolKeyword,
+        .poundAvailableKeyword, .poundColorLiteralKeyword, .poundColumnKeyword, .poundDsohandleKeyword, .poundFileIDKeyword, .poundFileKeyword, .poundFileLiteralKeyword, .poundFilePathKeyword, .poundFunctionKeyword, .poundImageLiteralKeyword, .poundKeyPathKeyword, .poundLineKeyword, .poundSelectorKeyword, .poundSourceLocationKeyword, .poundUnavailableKeyword, .poundHasSymbolKeyword,
       // Identifiers
         .dollarIdentifier, .identifier,
       // '_' can occur in types to replace a type identifier
@@ -168,8 +168,8 @@ public enum TokenPrecedence: Comparable {
         .caseKeyword, .catchKeyword, .defaultKeyword, .elseKeyword,
       // Return-like statements
         .breakKeyword, .continueKeyword, .fallthroughKeyword, .returnKeyword, .throwKeyword, .yield,
-      // #error and #warning are statement-like
-        .poundErrorKeyword, .poundWarningKeyword:
+      // #error, #warning and #assert are statement-like
+        .poundErrorKeyword, .poundWarningKeyword, .poundAssertKeyword:
       self = .stmtKeyword
 
       // MARK: Strong bracketet

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -158,6 +158,8 @@ extension Parser {
       return RawSyntax(self.parseExpression())
     } else if self.atStartOfDeclaration(isAtTopLevel: isAtTopLevel, allowRecovery: true) {
       return RawSyntax(self.parseDeclaration())
+    } else if self.atStartOfStatement(allowRecovery: true) {
+      return RawSyntax(self.parseStatement())
     } else {
       return RawSyntax(RawMissingExprSyntax(arena: self.arena))
     }

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -743,14 +743,14 @@ final class DeclarationTests: XCTestCase {
   func testTextRecovery() {
     AssertParse(
       """
-      Lorem1️⃣ ipsum2️⃣ dolor3️⃣ sit4️⃣ amet5️⃣, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
+      Lorem1️⃣ ipsum2️⃣ dolor3️⃣ sit4️⃣ amet5️⃣, consectetur adipiscing elit
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "4️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "5️⃣", message: "extraneous code at top level"),
+        DiagnosticSpec(locationMarker: "5️⃣", message: "extraneous ', consectetur adipiscing elit' at top level"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -92,7 +92,7 @@ final class StatementTests: XCTestCase {
   }
 
   func testReturn() {
-    AssertParse("return actor", { $0.parseReturnStatement() })
+    AssertParse("return actor", { $0.parseReturnStatement(returnHandle: .constant(.returnKeyword)) })
 
     AssertParse(
       "{ 1️⃣return 0 }",

--- a/Tests/SwiftParserTest/translated/SwitchTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchTests.swift
@@ -1369,8 +1369,7 @@ final class SwitchTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: switch must be exhaustive
-        // TODO: Old parser expected note on line 5: remove '@unknown' to handle remaining values
+        DiagnosticSpec(message: "expected expression in 'return' statement")
       ]
     )
   }
@@ -1387,9 +1386,7 @@ final class SwitchTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: switch must be exhaustive
-        // TODO: Old parser expected error on line 5: expected ':' after 'default'
-        // TODO: Old parser expected note on line 5: remove '@unknown' to handle remaining values
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected expression in 'return' statement"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected ':' in switch case"),
       ]
     )

--- a/Tests/SwiftParserTest/translated/TryTests.swift
+++ b/Tests/SwiftParserTest/translated/TryTests.swift
@@ -122,6 +122,17 @@ final class TryTests: XCTestCase {
     )
   }
 
+  func testTry11() {
+    AssertParse(
+      """
+      1️⃣try let singleLet = try foo()
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "'try' must be placed on the initial value expression", fixIts: ["remove redundant 'try'"]),
+      ], fixedSource: "let singleLet = try foo()"
+    )
+  }
+
   func testTry11a() {
     AssertParse(
       """

--- a/Tests/SwiftParserTest/translated/TryTests.swift
+++ b/Tests/SwiftParserTest/translated/TryTests.swift
@@ -125,38 +125,32 @@ final class TryTests: XCTestCase {
   func testTry11a() {
     AssertParse(
       """
-      try1️⃣ 2️⃣let singleLet = foo()
+      1️⃣try let singleLet = foo()
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 21 - 21 = 'try '
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in 'try' expression"),
-      ]
+        DiagnosticSpec(message: "'try' must be placed on the initial value expression", fixIts: ["move 'try' after '='"]),
+      ], fixedSource: "let singleLet = try foo()"
     )
   }
 
   func testTry11b() {
     AssertParse(
       """
-      try1️⃣ 2️⃣var singleVar = foo()
+      1️⃣try var singleVar = foo()
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 21 - 21 = 'try '
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in 'try' expression"),
-      ]
+        DiagnosticSpec(message: "'try' must be placed on the initial value expression", fixIts: ["move 'try' after '='"]),
+      ], fixedSource: "var singleVar = try foo()"
     )
   }
 
   func testTry11c() {
     AssertParse(
       """
-      try1️⃣ 2️⃣let uninit: Int
+      1️⃣try let uninit: Int
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in 'try' expression"),
+        DiagnosticSpec(message: "'try' must be placed on the initial value expression", fixIts: []),
       ]
     )
   }
@@ -164,32 +158,22 @@ final class TryTests: XCTestCase {
   func testTry11d() {
     AssertParse(
       """
-      try1️⃣ 2️⃣let (destructure1, destructure2) = (foo(), bar())
+      1️⃣try let (destructure1, destructure2) = (foo(), bar())
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression, Fix-It replacements: 1 - 5 = '', 40 - 40 = 'try '
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in 'try' expression"),
-      ]
+        DiagnosticSpec(message: "'try' must be placed on the initial value expression", fixIts: ["move 'try' after '='"]),
+      ], fixedSource: "let (destructure1, destructure2) = try (foo(), bar())"
     )
   }
 
   func testTry11e() {
     AssertParse(
       """
-      try1️⃣ 2️⃣let multi1 = foo(), multi2 = bar() //  expected-error 2 {{call can throw but is not marked with 'try'}}
+      1️⃣try let multi1 = foo(), multi2 = bar()
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 1: 'try' must be placed on the initial value expression
-        // TODO: Old parser expected note on line 1: did you mean to use 'try'?, Fix-It replacements: 18 - 18 = 'try '
-        // TODO: Old parser expected note on line 1: did you mean to use 'try'?, Fix-It replacements: 34 - 34 = 'try '
-        // TODO: Old parser expected note on line 1: did you mean to handle error as optional value?, Fix-It replacements: 18 - 18 = 'try? '
-        // TODO: Old parser expected note on line 1: did you mean to handle error as optional value?, Fix-It replacements: 34 - 34 = 'try? '
-        // TODO: Old parser expected note on line 1: did you mean to disable error propagation?, Fix-It replacements: 18 - 18 = 'try! '
-        // TODO: Old parser expected note on line 1: did you mean to disable error propagation?, Fix-It replacements: 34 - 34 = 'try! '
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in 'try' expression"),
-      ]
+        DiagnosticSpec(message: "'try' must be placed on the initial value expression", fixIts: ["move 'try' after '='"]),
+      ], fixedSource: "let multi1 = try foo(), multi2 = try bar()"
     )
   }
 
@@ -204,35 +188,30 @@ final class TryTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected note on line 1: in declaration of 'TryDecl'
-        // TODO: Old parser expected error on line 2: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
-        // TODO: Old parser expected error on line 2: call can throw, but errors cannot be thrown out of a property initializer
-        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text 'try' before variable"),
-        // TODO: Old parser expected error on line 3: 'try' must be placed on the initial value expression, Fix-It replacements: 3 - 7 = '', 23 - 23 = 'try '
-        // TODO: Old parser expected error on line 3: call can throw, but errors cannot be thrown out of a property initializer
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text 'try' before variable"),
-        // TODO: Old parser expected error on line 4: expected declaration
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text 'try' before function"),
-      ]
+        DiagnosticSpec(locationMarker: "1️⃣", message: "'try' must be placed on the initial value expression", fixIts: ["move 'try' after '='"]),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "'try' must be placed on the initial value expression", fixIts: ["move 'try' after '='"]),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "'try' cannot be used with 'func'"),
+      ], fixedSource: """
+      class TryDecl {
+        let singleLet = try foo()
+        var singleVar = try foo()
+        try
+        func method() {}
+      }
+      """
     )
   }
 
   func testTry12a() {
     AssertParse(
       """
-      func test() throws -> Int {
-        try1️⃣ 2️⃣while true {
-          try3️⃣ 4️⃣break
-        }
+      1️⃣try while true {
+        2️⃣try break
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: 'try' cannot be used with 'while'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in 'try' expression"),
-        // TODO: Old parser expected error on line 3: 'try' cannot be used with 'break'
-        DiagnosticSpec(locationMarker: "3️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected expression in 'try' expression"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "'try' cannot be used with 'while'"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "'try' cannot be used with 'break'"),
       ]
     )
   }
@@ -240,31 +219,22 @@ final class TryTests: XCTestCase {
   func testTry12b() {
     AssertParse(
       """
-      func test() throws -> Int {
-        try1️⃣ 2️⃣throw 3️⃣
-      }
+      1️⃣try throw 2️⃣
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 5: 'try' must be placed on the thrown expression, Fix-It replacements: 3 - 7 = '', 3 - 3 = 'try '
-        // TODO: Old parser expected error on line 5: expected expression in 'throw' statement
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "'try' must be placed on the thrown expression", fixIts: ["move 'try' after 'throw'"]),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in 'try' expression"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected expression in 'throw' statement"),
-      ]
+      ], fixedSource: "throw try <#expression#>"
     )
   }
 
   func testTry12c() {
     AssertParse(
       """
-      func test() throws -> Int {
-        try1️⃣ 2️⃣return
-      }
+      1️⃣try return
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 7: 'try' cannot be used with 'return'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in 'try' expression"),
+        DiagnosticSpec(message: "'try' cannot be used with 'return'"),
       ]
     )
   }
@@ -272,30 +242,22 @@ final class TryTests: XCTestCase {
   func testTry12d() {
     AssertParse(
       """
-      func test() throws -> Int {
-        try1️⃣ 2️⃣throw foo()
-      }
+      1️⃣try throw foo()
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 9: 'try' must be placed on the thrown expression, Fix-It replacements: 3 - 7 = '', 13 - 13 = 'try '
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in 'try' expression"),
-      ]
+        DiagnosticSpec(message: "'try' must be placed on the thrown expression", fixIts: ["move 'try' after 'throw'"]),
+      ], fixedSource: "throw try foo()"
     )
   }
 
   func testTry12e() {
     AssertParse(
       """
-      func test() throws -> Int {
-        try1️⃣ 2️⃣return foo()
-      }
+      1️⃣try return foo()
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 10: 'try' must be placed on the returned expression, Fix-It replacements: 3 - 7 = '', 14 - 14 = 'try '
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in 'try' expression"),
-      ]
+        DiagnosticSpec(message: "'try' must be placed on the returned expression", fixIts: ["move 'try' after 'return'"]),
+      ], fixedSource: "return try foo()"
     )
   }
 
@@ -613,5 +575,4 @@ final class TryTests: XCTestCase {
       """
     )
   }
-
 }


### PR DESCRIPTION
Add a diagnostic if the user wrote `try let foo = bar()`. 

Also support recovery at of statements (essentially adding `allowRecovery` to `atStartOfStatement`). This required a rewrite of `atStartOfStatement`.