### PR TITLE
Decontextualize multi-'yield' Parsing

### DIFF
--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -18,8 +18,8 @@ extension TokenConsumer {
   ///
   /// - Note: This function must be kept in sync with `parseStatement()`.
   /// - Seealso: ``Parser/parseStatement()``
-  func atStartOfStatement(context: Parser.ItemContext? = nil) -> Bool {
-    return self.lookahead().isStartOfStatement(context: context)
+  func atStartOfStatement() -> Bool {
+    return self.lookahead().isStartOfStatement()
   }
 }
 
@@ -1074,7 +1074,7 @@ extension Parser.Lookahead {
   ///
   /// - Note: This function must be kept in sync with `parseStatement()`.
   /// - Seealso: ``Parser/parseStatement()``
-  public func isStartOfStatement(context: Parser.ItemContext?) -> Bool {
+  public func isStartOfStatement() -> Bool {
     switch self.currentToken.tokenKind {
     case .returnKeyword,
         .throwKeyword,
@@ -1106,10 +1106,23 @@ extension Parser.Lookahead {
     case .identifier:
       // "identifier ':' for/while/do/switch" is a label on a loop/switch.
       guard self.peek().tokenKind == .colon else {
-        // "yield" in the right context begins a yield statement.
-        if context == .coroutineAccessor, self.atContextualKeyword("yield") {
-          return true
+        if self.atContextualKeyword("yield") {
+          switch self.peek().tokenKind {
+          case .prefixAmpersand:
+            // "yield &" always denotes a yield statement.
+            return true
+          case .leftParen:
+            // "yield (", by contrast, must be disambiguated with additional
+            // context. We always consider it an apply expression of a function
+            // called `yield` for the purposes of the parse.
+            return false
+          default:
+            // "yield" followed by any other token is likely a yield statement
+            // of some singular expression.
+            return true
+          }
         }
+
         return false
       }
 
@@ -1127,7 +1140,7 @@ extension Parser.Lookahead {
       }
       // For better recovery, we just accept a label on any statement.  We reject
       // putting a label on something inappropriate in `parseStatement()`.
-      return backtrack.isStartOfStatement(context: context)
+      return backtrack.isStartOfStatement()
 
     case .atSign:
       // Might be a statement or case attribute. The only one of these we have
@@ -1139,7 +1152,7 @@ extension Parser.Lookahead {
       var backtrack = self.lookahead()
       backtrack.eat(.atSign)
       backtrack.expectIdentifierWithoutRecovery()
-      return backtrack.isStartOfStatement(context: context)
+      return backtrack.isStartOfStatement()
     default:
       return false
     }

--- a/Sources/SwiftParser/Statements.swift
+++ b/Sources/SwiftParser/Statements.swift
@@ -1117,9 +1117,9 @@ extension Parser.Lookahead {
             // called `yield` for the purposes of the parse.
             return false
           default:
-            // "yield" followed by any other token is likely a yield statement
-            // of some singular expression.
-            return true
+            // "yield" followed immediately by any other token is likely a
+            // yield statement of some singular expression.
+            return !self.peek().isAtStartOfLine
           }
         }
 

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -76,11 +76,11 @@ extension Parser {
   ///
   /// This function is used when parsing places where function bodies are
   /// optional - like the function requirements in protocol declarations.
-  mutating func parseOptionalCodeBlock(context: ItemContext? = nil) -> RawCodeBlockSyntax? {
+  mutating func parseOptionalCodeBlock() -> RawCodeBlockSyntax? {
     guard self.at(.leftBrace) else {
       return nil
     }
-    return self.parseCodeBlock(context: context)
+    return self.parseCodeBlock()
   }
 
   /// Parse a code block.
@@ -89,7 +89,7 @@ extension Parser {
   /// =======
   ///
   ///     code-block → '{' statements? '}'
-  mutating func parseCodeBlock(context: ItemContext? = nil) -> RawCodeBlockSyntax {
+  mutating func parseCodeBlock() -> RawCodeBlockSyntax {
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
     let itemList = parseCodeBlockItemList(context: context, stopCondition: { $0.at(.rightBrace) })
     let (unexpectedBeforeRBrace, rbrace) = self.expect(.rightBrace)
@@ -101,14 +101,6 @@ extension Parser {
       unexpectedBeforeRBrace,
       rightBrace: rbrace,
       arena: self.arena)
-  }
-}
-
-extension Parser {
-  public enum ItemContext {
-    case topLevel
-    // Enables the 'yield' contextual keyword in statement position.
-    case coroutineAccessor
   }
 
   /// Parse an individual item - either in a code block or at the top level.
@@ -130,10 +122,10 @@ extension Parser {
   ///     statement → compiler-control-statement
   ///     statements → statement statements?
   @_spi(RawSyntax)
-  public mutating func parseCodeBlockItem(context: ItemContext? = nil) -> RawCodeBlockItemSyntax? {
+  public mutating func parseCodeBlockItem(isAtTopLevel: Bool = false) -> RawCodeBlockItemSyntax? {
     // FIXME: It is unfortunate that the Swift book refers to these as
     // "statements" and not "items".
-    let item = self.parseItem(context: context)
+    let item = self.parseItem(isAtTopLevel: isAtTopLevel)
     let semi = self.consume(if: .semicolon)
 
     if item.isEmpty && semi == nil {
@@ -147,7 +139,7 @@ extension Parser {
   /// closing braces while trying to recover to the next item.
   /// If we are not at the top level, such a closing brace should close the
   /// wrapping declaration instead of being consumed by lookeahead.
-  private mutating func parseItem(context: ItemContext? = nil) -> RawSyntax {
+  private mutating func parseItem(isAtTopLevel: Bool = false) -> RawSyntax {
     if self.at(.poundIfKeyword) {
       return RawSyntax(self.parsePoundIfDirective {
         $0.parseCodeBlockItem()
@@ -160,11 +152,11 @@ extension Parser {
       return RawSyntax(self.parsePoundSourceLocationDirective())
     } else if self.atStartOfDeclaration() {
       return RawSyntax(self.parseDeclaration())
-    } else if self.atStartOfStatement(context: context) {
+    } else if self.atStartOfStatement() {
       return RawSyntax(self.parseStatement())
     } else if self.atStartOfExpression() {
       return RawSyntax(self.parseExpression())
-    } else if self.atStartOfDeclaration(context: context, allowRecovery: true) {
+    } else if self.atStartOfDeclaration(isAtTopLevel: isAtTopLevel, allowRecovery: true) {
       return RawSyntax(self.parseDeclaration())
     } else {
       return RawSyntax(RawMissingExprSyntax(arena: self.arena))

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -37,12 +37,12 @@ extension Parser {
 }
 
 extension Parser {
-  mutating func parseCodeBlockItemList(context: ItemContext?, stopCondition: (inout Parser) -> Bool) -> RawCodeBlockItemListSyntax {
+  mutating func parseCodeBlockItemList(stopCondition: (inout Parser) -> Bool) -> RawCodeBlockItemListSyntax {
     var elements = [RawCodeBlockItemSyntax]()
     var loopProgress = LoopProgressCondition()
     while !stopCondition(&self), loopProgress.evaluate(currentToken) {
       let newItemAtStartOfLine = self.currentToken.isAtStartOfLine
-      guard let newElement = self.parseCodeBlockItem(context: context) else {
+      guard let newElement = self.parseCodeBlockItem() else {
         break
       }
       if let lastItem = elements.last, lastItem.semicolon == nil && !newItemAtStartOfLine {
@@ -68,7 +68,7 @@ extension Parser {
   ///
   ///     top-level-declaration → statements?
   mutating func parseTopLevelCodeBlockItems() -> RawCodeBlockItemListSyntax {
-    return parseCodeBlockItemList(context: .topLevel, stopCondition: { _ in false })
+    return parseCodeBlockItemList(stopCondition: { _ in false })
   }
 
   /// The optional form of `parseCodeBlock` that checks to see if the parser has
@@ -91,7 +91,7 @@ extension Parser {
   ///     code-block → '{' statements? '}'
   mutating func parseCodeBlock() -> RawCodeBlockSyntax {
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
-    let itemList = parseCodeBlockItemList(context: context, stopCondition: { $0.at(.rightBrace) })
+    let itemList = parseCodeBlockItemList(stopCondition: { $0.at(.rightBrace) })
     let (unexpectedBeforeRBrace, rbrace) = self.expect(.rightBrace)
 
     return .init(

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -332,10 +332,71 @@ final class StatementTests: XCTestCase {
       ]), rightAngleBracket: .rightAngleToken()))),
       substructureAfterMarker: "1️⃣")
   }
-<<<<<<< HEAD
 
   func testYield() {
     // Make sure these are always considered a yield statement
+    AssertParse(
+      """
+      var x: Int {
+        _read {
+          1️⃣yield &x
+        }
+      }
+      """,
+      substructure: Syntax(YieldStmtSyntax(
+        yieldKeyword: .contextualKeyword("yield"),
+        yields: Syntax(InOutExprSyntax(
+          ampersand: .prefixAmpersandToken(),
+          expression: ExprSyntax(IdentifierExprSyntax(
+            identifier: .identifier("x"),
+            declNameArguments: nil)))))),
+      substructureAfterMarker: "1️⃣")
+
+    AssertParse(
+      """
+      @inlinable internal subscript(key: Key) -> Value? {
+        @inline(__always) get {
+          return lookup(key)
+        }
+        @inline(__always) _modify {
+          guard isNative else {
+            let cocoa = asCocoa
+            var native = _NativeDictionary<Key, Value>(
+              cocoa, capacity: cocoa.count + 1)
+            self = .init(native: native)
+            1️⃣yield &native[key, isUnique: true]
+            return
+          }
+          let isUnique = isUniquelyReferenced()
+          yield &asNative[key, isUnique: isUnique]
+        }
+      }
+      """,
+      substructure: Syntax(YieldStmtSyntax(
+        yieldKeyword: .contextualKeyword("yield"),
+        yields: Syntax(InOutExprSyntax(
+          ampersand: .prefixAmpersandToken(),
+          expression: ExprSyntax(SubscriptExprSyntax(
+            calledExpression: ExprSyntax(IdentifierExprSyntax(identifier: .identifier("native"), declNameArguments: nil)),
+            leftBracket: .leftSquareBracketToken(),
+            argumentList: TupleExprElementListSyntax([
+              TupleExprElementSyntax(
+                label: nil,
+                colon: nil,
+                expression: ExprSyntax(IdentifierExprSyntax(identifier: .identifier("key"), declNameArguments: nil)),
+                trailingComma: .commaToken()),
+              TupleExprElementSyntax(
+                label: .identifier("isUnique"),
+                colon: .colonToken(),
+                expression: ExprSyntax(BooleanLiteralExprSyntax(booleanLiteral: .trueKeyword())),
+                trailingComma: nil),
+            ]),
+            rightBracket: .rightSquareBracketToken(),
+            trailingClosure: nil,
+            additionalTrailingClosures: nil)))))),
+      substructureAfterMarker: "1️⃣")
+
+    // Make sure these are not.
     AssertParse(
       """
       var x: Int {
@@ -344,17 +405,17 @@ final class StatementTests: XCTestCase {
         }
       }
       """,
-      substructure: Syntax(YieldStmtSyntax(
-        yieldKeyword: .contextualKeyword("yield"),
-        yields: Syntax(YieldListSyntax(
-          leftParen: .leftParenToken(),
-          elementList: YieldExprListSyntax([]),
-          rightParen: .rightParenToken())
-        ))
-      ),
-      substructureAfterMarker: "1️⃣")
+      substructure: Syntax(FunctionCallExprSyntax(
+        calledExpression: ExprSyntax(IdentifierExprSyntax(
+          identifier: .identifier("yield"),
+          declNameArguments: nil)),
+        leftParen: .leftParenToken(),
+        argumentList: TupleExprElementListSyntax([]),
+        rightParen: .rightParenToken(),
+        trailingClosure: nil,
+        additionalTrailingClosures: nil)),
+    substructureAfterMarker: "1️⃣")
 
-    // Make sure these are not.
     AssertParse(
       """
       var x: Int {
@@ -397,6 +458,4 @@ final class StatementTests: XCTestCase {
         trailingClosure: nil,
         additionalTrailingClosures: nil)))
   }
-=======
->>>>>>> parent of a76e907 (Plumb Coroutine Accessor Context Through Item Parsing)
 }

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -333,6 +333,16 @@ final class StatementTests: XCTestCase {
       substructureAfterMarker: "1️⃣")
   }
 
+  func testHangingYieldArgument() {
+    AssertParse(
+      """
+      1️⃣yield
+      print("huh")
+      """,
+      substructure: Syntax(IdentifierExprSyntax(identifier: .identifier("yield"), declNameArguments: nil)),
+    substructureAfterMarker: "1️⃣")
+  }
+
   func testYield() {
     // Make sure these are always considered a yield statement
     AssertParse(

--- a/Tests/SwiftParserTest/Statements.swift
+++ b/Tests/SwiftParserTest/Statements.swift
@@ -332,6 +332,7 @@ final class StatementTests: XCTestCase {
       ]), rightAngleBracket: .rightAngleToken()))),
       substructureAfterMarker: "1️⃣")
   }
+<<<<<<< HEAD
 
   func testYield() {
     // Make sure these are always considered a yield statement
@@ -396,4 +397,6 @@ final class StatementTests: XCTestCase {
         trailingClosure: nil,
         additionalTrailingClosures: nil)))
   }
+=======
+>>>>>>> parent of a76e907 (Plumb Coroutine Accessor Context Through Item Parsing)
 }


### PR DESCRIPTION
Yield statements support the ability to yield multiple values out of the coroutine context. These are modeled like an argument list in the grammar and parse sort of like one (minus labels). But this means there's a pretty serious grammatical ambiguity with applies

func yield() {}

yield ()

Rather than contextualize the parse, we're going to ignore the contextuality of multi-yields. The swift parser will always unambiguously parse 'yield &' as a yield statement, regardless of context. It will similarly unambiguously parse 'yield (' as an apply of a function called 'yield' regardless of context. We will then rewrite this AST on the way out to ASTGen where we actually have the ability to make context-sensitive decisions about the parse.

Fixes a regression introduced by #864 in the parsing of the macOS 11.3 copy of the standard library's swift interface.