### PR TITLE
[Keypath parsing] Handle space after `\` and operators ending in `.`.

### DIFF
--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -797,11 +797,6 @@ extension Parser {
       return nil
     }
 
-    // Make sure the end isn't a ".".
-    if lastWasDot {
-      return nil
-    }
-
     return numComponents
   }
 
@@ -908,7 +903,10 @@ extension Parser {
 
       // Check for a postfix operator starting with '.' that contains only
       // periods, '?'s, and '!'s. Expand that into key path components.
-      if self.at(any: [.postfixOperator,.postfixQuestionMark,.exclamationMark]),
+      if self.at(any: [
+            .postfixOperator, .postfixQuestionMark,
+            .exclamationMark, .prefixOperator]
+         ),
          let numComponents = getNumOptionalKeyPathPostfixComponents(
           self.currentToken.tokenText) {
         components.append(

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -413,7 +413,7 @@ extension Parser {
   }
 }
 
-// MARK: Spliting Tokens
+// MARK: Splitting Tokens
 
 extension Parser {
   /// Consumes a given token, or splits the current token into a leading token

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -179,6 +179,13 @@ final class ExpressionTests: XCTestCase {
       \Optional.?!?!?!?.??!
       """#
     )
+
+    AssertParse(
+      #"""
+      _ = distinctUntilChanged(\ .?.status)
+      _ = distinctUntilChanged(\.?.status)
+      """#
+    )
   }
 
   func testBasicLiterals() {


### PR DESCRIPTION
Fixes #888 and rdar://100871146.