### PR TITLE
Simplify the signatures for Parser.parse()

### DIFF
--- a/Sources/SwiftOperators/SwiftOperators.docc/SwiftOperators.md
+++ b/Sources/SwiftOperators/SwiftOperators.docc/SwiftOperators.md
@@ -45,7 +45,7 @@ import SwiftParser
 import SwiftOperators
 
 var opPrecedence = OperatorTable.standardOperators // Use the Swift standard library operators
-let parsed = try Parser.parse(source: "x + y * z")
+let parsed = Parser.parse(source: "x + y * z")
 dump(parsed) // contains SequenceExprSyntax(x, +, y, *, z)
 let folded = try opPrecedence.foldAll(parsed)
 dump(folded) // contains InfixOperatorExpr(x, +, InfixOperatorExpr(y, *, z))
@@ -65,12 +65,12 @@ let moreOperators =
 
   infix operator **: ExponentiationPrecedence
   """
-let parsedOperators = try Parser.parse(source: moreOperators)
+let parsedOperators = Parser.parse(source: moreOperators)
 
 // Adds **, ExponentiationPrecedence to the set of known operators and precedence groups.
 try opPrecedence.addSourceFile(parsedOperators) 
 
-let parsed2 = try Parser.parse(source: "b ** c ** d")
+let parsed2 = Parser.parse(source: "b ** c ** d")
 dump(parsed2) // contains SequenceExprSyntax(b, **, c, **, d)
 let folded2 = try opPrecedence.foldAll(parsed2)
 dump(folded2) // contains InfixOperatorExpr(b, **, InfixOperatorExpr(c, **, d))

--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -13,31 +13,23 @@
 @_spi(RawSyntax) import SwiftSyntax
 
 extension Parser {
+  /// Parse the source code in the given string as Swift source file.
   public static func parse(
     source: String,
-    parseTransition: IncrementalParseTransition? = nil,
-    filenameForDiagnostics: String = "",
-    languageVersion: String? = nil,
-    enableBareSlashRegexLiteral: Bool? = nil
-  ) throws -> SourceFileSyntax {
+    parseTransition: IncrementalParseTransition? = nil
+  ) -> SourceFileSyntax {
     var source = source
     source.makeContiguousUTF8()
-    return try source.withUTF8 { buffer in
-      return try parse(source: buffer,
-                       parseTransition: parseTransition,
-                       filenameForDiagnostics: filenameForDiagnostics,
-                       languageVersion: languageVersion,
-                       enableBareSlashRegexLiteral: enableBareSlashRegexLiteral)
+    return source.withUTF8 { buffer in
+      return parse(source: buffer, parseTransition: parseTransition)
     }
   }
 
+  /// Parse the source code in the given string as Swift source file.
   public static func parse(
     source: UnsafeBufferPointer<UInt8>,
-    parseTransition: IncrementalParseTransition? = nil,
-    filenameForDiagnostics: String = "",
-    languageVersion: String? = nil,
-    enableBareSlashRegexLiteral: Bool? = nil
-  ) throws -> SourceFileSyntax {
+    parseTransition: IncrementalParseTransition? = nil
+  ) -> SourceFileSyntax {
     var parser = Parser(source)
     // Extended lifetime is required because `SyntaxArena` in the parser must
     // be alive until `Syntax(raw:)` retains the arena.

--- a/Sources/swift-parser-cli/swift-parser-cli.swift
+++ b/Sources/swift-parser-cli/swift-parser-cli.swift
@@ -83,20 +83,12 @@ class VerifyRoundTrip: ParsableCommand {
     abstract: "Verify that printing the parsed syntax tree produces the original source"
   )
 
-  init(sourceFile: String?, swiftVersion: String?, enableBareSlashRegex: Bool?) {
+  init(sourceFile: String?) {
     self.sourceFile = sourceFile
-    self.swiftVersion = swiftVersion
-    self.enableBareSlashRegex = enableBareSlashRegex
   }
 
   @Argument(help: "The source file that should be parsed; if omitted, use stdin")
   var sourceFile: String?
-
-  @Option(name: .long, help: "Interpret input according to a specific Swift language version number")
-  var swiftVersion: String?
-
-  @Option(name: .long, help: "Enable or disable the use of forward slash regular-expression literal syntax")
-  var enableBareSlashRegex: Bool?
 
   @Flag(name: .long, help: "Perform sequence folding with the standard operators")
   var foldSequences: Bool = false
@@ -117,22 +109,15 @@ class VerifyRoundTrip: ParsableCommand {
 
     try source.withUnsafeBufferPointer { sourceBuffer in
       try Self.run(
-        source: sourceBuffer, swiftVersion: swiftVersion,
-        enableBareSlashRegex: enableBareSlashRegex,
-        foldSequences: foldSequences
+        source: sourceBuffer, foldSequences: foldSequences
       )
     }
   }
 
   static func run(
-    source: UnsafeBufferPointer<UInt8>, swiftVersion: String?,
-    enableBareSlashRegex: Bool?, foldSequences: Bool
+    source: UnsafeBufferPointer<UInt8>, foldSequences: Bool
   ) throws {
-    let tree = try Parser.parse(
-      source: source,
-      languageVersion: swiftVersion,
-      enableBareSlashRegexLiteral: enableBareSlashRegex
-    )
+    let tree = Parser.parse(source: source)
 
     let resultTree: Syntax
     if foldSequences {
@@ -158,24 +143,14 @@ class PrintDiags: ParsableCommand {
   @Argument(help: "The source file that should be parsed; if omitted, use stdin")
   var sourceFile: String?
 
-  @Option(name: .long, help: "Interpret input according to a specific Swift language version number")
-  var swiftVersion: String?
-
-  @Option(name: .long, help: "Enable or disable the use of forward slash regular-expression literal syntax")
-  var enableBareSlashRegex: Bool?
-
   @Flag(name: .long, help: "Perform sequence folding with the standard operators")
   var foldSequences: Bool = false
 
   func run() throws {
     let source = try getContentsOfSourceFile(at: sourceFile)
 
-    try source.withUnsafeBufferPointer { sourceBuffer in
-      let tree = try Parser.parse(
-        source: sourceBuffer,
-        languageVersion: swiftVersion,
-        enableBareSlashRegexLiteral: enableBareSlashRegex
-      )
+    source.withUnsafeBufferPointer { sourceBuffer in
+      let tree = Parser.parse(source: sourceBuffer)
       
       var diags = ParseDiagnosticsGenerator.diagnostics(for: tree)
       print(DiagnosticsFormatter.annotatedSource(tree: tree, diags: diags))
@@ -202,24 +177,14 @@ class PrintInitCall: ParsableCommand {
   @Argument(help: "The source file that should be parsed; if omitted, use stdin")
   var sourceFile: String?
 
-  @Option(name: .long, help: "Interpret input according to a specific Swift language version number")
-  var swiftVersion: String?
-
-  @Option(name: .long, help: "Enable or disable the use of forward slash regular-expression literal syntax")
-  var enableBareSlashRegex: Bool?
-
   @Flag(name: .long, help: "Perform sequence folding with the standard operators")
   var foldSequences: Bool = false
 
   func run() throws {
     let source = try getContentsOfSourceFile(at: sourceFile)
 
-    try source.withUnsafeBufferPointer { sourceBuffer in
-      var tree = try Parser.parse(
-        source: sourceBuffer,
-        languageVersion: swiftVersion,
-        enableBareSlashRegexLiteral: enableBareSlashRegex
-      )
+    source.withUnsafeBufferPointer { sourceBuffer in
+      var tree = Parser.parse(source: sourceBuffer)
 
       if foldSequences {
         tree = foldAllSequences(tree).0.as(SourceFileSyntax.self)!
@@ -241,24 +206,14 @@ class PrintTree: ParsableCommand {
   @Argument(help: "The source file that should be parsed; if omitted, use stdin")
   var sourceFile: String?
 
-  @Option(name: .long, help: "Interpret input according to a specific Swift language version number")
-  var swiftVersion: String?
-
-  @Option(name: .long, help: "Enable or disable the use of forward slash regular-expression literal syntax")
-  var enableBareSlashRegex: Bool?
-
   @Flag(name: .long, help: "Perform sequence folding with the standard operators")
   var foldSequences: Bool = false
 
   func run() throws {
     let source = try getContentsOfSourceFile(at: sourceFile)
 
-    try source.withUnsafeBufferPointer { sourceBuffer in
-      let tree = try Parser.parse(
-        source: sourceBuffer,
-        languageVersion: swiftVersion,
-        enableBareSlashRegexLiteral: enableBareSlashRegex
-      )
+    source.withUnsafeBufferPointer { sourceBuffer in
+      let tree = Parser.parse(source: sourceBuffer)
 
       let resultTree: Syntax
       if foldSequences {
@@ -282,12 +237,6 @@ class Reduce: ParsableCommand {
 
   @Argument(help: "The test case that should be reduced; if omitted, use stdin")
   var sourceFile: String?
-
-  @Option(name: .long, help: "Interpret input according to a specific Swift language version number")
-  var swiftVersion: String?
-
-  @Option(name: .long, help: "Enable or disable the use of forward slash regular-expression literal syntax")
-  var enableBareSlashRegex: Bool?
 
   @Flag(name: .long, help: "Perform sequence folding with the standard operators")
   var foldSequences: Bool = false
@@ -326,16 +275,6 @@ class Reduce: ParsableCommand {
       process.arguments = [
         "verify-round-trip", tempFileURL.path,
       ]
-      if let enableBareSlashRegex = enableBareSlashRegex {
-        process.arguments! += [
-          "--enable-bare-slash-regex", enableBareSlashRegex ? "true" : "false"
-        ]
-      }
-      if let swiftVersion = swiftVersion {
-        process.arguments! += [
-          "--swift-version", swiftVersion
-        ]
-      }
       if foldSequences {
         process.arguments! += [ "--fold-sequences" ]
       }
@@ -372,8 +311,8 @@ class Reduce: ParsableCommand {
   private func runVerifyRoundTripInCurrentProcess(source: [UInt8]) throws -> Bool {
     do {
       try source.withUnsafeBufferPointer { sourceBuffer in
-        try VerifyRoundTrip.run(source: sourceBuffer, swiftVersion: self.swiftVersion, enableBareSlashRegex: self.enableBareSlashRegex,
-            foldSequences: foldSequences)
+        try VerifyRoundTrip.run(
+          source: sourceBuffer, foldSequences: foldSequences)
       }
     } catch {
       return false

--- a/Tests/PerformanceTest/ParsingPerformanceTests.swift
+++ b/Tests/PerformanceTest/ParsingPerformanceTests.swift
@@ -26,7 +26,7 @@ public class ParsingPerformanceTests: XCTestCase {
     measure {
       do {
         let source = try String(contentsOf: inputFile)
-        _ = try SwiftParser.Parser.parse(source: source)
+        _ = SwiftParser.Parser.parse(source: source)
       } catch {
         XCTFail(error.localizedDescription)
       }

--- a/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
+++ b/Tests/SwiftDiagnosticsTest/DiagnosticsFormatterTests.swift
@@ -16,7 +16,7 @@ import SwiftParser
 final class DiagnosticsFormatterTests: XCTestCase {
   
   func annotate(source: String) throws -> String {
-    let tree = try Parser.parse(source: source)
+    let tree = Parser.parse(source: source)
     let diags = ParseDiagnosticsGenerator.diagnostics(for: tree)
     return DiagnosticsFormatter.annotatedSource(tree: tree, diags: diags)
   }

--- a/Tests/SwiftOperatorsTest/OperatorTableTests.swift
+++ b/Tests/SwiftOperatorsTest/OperatorTableTests.swift
@@ -80,12 +80,12 @@ extension OperatorTable {
     _ fullyParenthesizedSource: String
   ) throws {
     // Parse and fold the source we're testing.
-    let parsed = try Parser.parse(source: source)
+    let parsed = Parser.parse(source: source)
     let foldedSyntax = try foldAll(parsed)
     XCTAssertFalse(foldedSyntax.containsExprSequence)
 
     // Parse and "fold" the parenthesized version.
-    let parenthesizedParsed = try Parser.parse(source: fullyParenthesizedSource)
+    let parenthesizedParsed = Parser.parse(source: fullyParenthesizedSource)
     let parenthesizedSyntax = ExplicitParenFolder().visit(parenthesizedParsed)
     XCTAssertFalse(parenthesizedSyntax.containsExprSequence)
 
@@ -102,7 +102,7 @@ extension OperatorTable {
 public class OperatorPrecedenceTests: XCTestCase {
   func testLogicalExprsSingle() throws {
     let opPrecedence = OperatorTable.logicalOperators
-    let parsed = try Parser.parse(source: "x && y || w && v || z")
+    let parsed = Parser.parse(source: "x && y || w && v || z")
     let sequenceExpr =
       parsed.statements.first!.item.as(SequenceExprSyntax.self)!
     let foldedExpr = try opPrecedence.foldSingle(sequenceExpr)
@@ -118,7 +118,7 @@ public class OperatorPrecedenceTests: XCTestCase {
 
   func testSwiftExprs() throws {
     let opPrecedence = OperatorTable.standardOperators
-    let parsed = try Parser.parse(source: "(x + y > 17) && x && y || w && v || z")
+    let parsed = Parser.parse(source: "(x + y > 17) && x && y || w && v || z")
     let sequenceExpr =
         parsed.statements.first!.item.as(SequenceExprSyntax.self)!
     let foldedExpr = try opPrecedence.foldSingle(sequenceExpr)
@@ -128,7 +128,7 @@ public class OperatorPrecedenceTests: XCTestCase {
 
   func testNestedSwiftExprs() throws {
     let opPrecedence = OperatorTable.standardOperators
-    let parsed = try Parser.parse(source: "(x + y > 17) && x && y || w && v || z")
+    let parsed = Parser.parse(source: "(x + y > 17) && x && y || w && v || z")
     let foldedAll = try opPrecedence.foldAll(parsed)
     XCTAssertEqual("\(foldedAll)", "(x + y > 17) && x && y || w && v || z")
     XCTAssertFalse(foldedAll.containsExprSequence)
@@ -175,11 +175,11 @@ public class OperatorPrecedenceTests: XCTestCase {
     infix operator ||: LogicalDisjunctionPrecedence
     """
 
-    let parsedOperatorPrecedence = try Parser.parse(source: logicalOperatorSources)
+    let parsedOperatorPrecedence = Parser.parse(source: logicalOperatorSources)
     var opPrecedence = OperatorTable()
     try opPrecedence.addSourceFile(parsedOperatorPrecedence)
 
-    let parsed = try Parser.parse(source: "x && y || w && v || z")
+    let parsed = Parser.parse(source: "x && y || w && v || z")
     let sequenceExpr =
       parsed.statements.first!.item.as(SequenceExprSyntax.self)!
     let foldedExpr = try opPrecedence.foldSingle(sequenceExpr)
@@ -204,7 +204,7 @@ public class OperatorPrecedenceTests: XCTestCase {
     }
     """
 
-    let parsedOperatorPrecedence = try Parser.parse(source: sources)
+    let parsedOperatorPrecedence = Parser.parse(source: sources)
 
     var opPrecedence = OperatorTable()
     var errors: [OperatorError] = []
@@ -244,7 +244,7 @@ public class OperatorPrecedenceTests: XCTestCase {
       postfix operator*
       """
 
-    let parsedOperatorPrecedence = try Parser.parse(source: sources)
+    let parsedOperatorPrecedence = Parser.parse(source: sources)
 
     var opPrecedence = OperatorTable()
     var errors: [OperatorError] = []
@@ -266,7 +266,7 @@ public class OperatorPrecedenceTests: XCTestCase {
   }
 
   func testFoldErrors() throws {
-    let parsedOperatorPrecedence = try Parser.parse(source:
+    let parsedOperatorPrecedence = Parser.parse(source:
       """
       precedencegroup A {
         associativity: none
@@ -294,7 +294,7 @@ public class OperatorPrecedenceTests: XCTestCase {
 
     do {
       var errors: [OperatorError] = []
-      let parsed = try Parser.parse(source: "a + b * c")
+      let parsed = Parser.parse(source: "a + b * c")
       let sequenceExpr =
         parsed.statements.first!.item.as(SequenceExprSyntax.self)!
       _ = opPrecedence.foldSingle(sequenceExpr) { error in
@@ -313,7 +313,7 @@ public class OperatorPrecedenceTests: XCTestCase {
 
     do {
       var errors: [OperatorError] = []
-      let parsed = try Parser.parse(source: "a / c")
+      let parsed = Parser.parse(source: "a / c")
       let sequenceExpr =
         parsed.statements.first!.item.as(SequenceExprSyntax.self)!
       _ = opPrecedence.foldSingle(sequenceExpr) { error in
@@ -332,7 +332,7 @@ public class OperatorPrecedenceTests: XCTestCase {
 
     do {
       var errors: [OperatorError] = []
-      let parsed = try Parser.parse(source: "a + b - c")
+      let parsed = Parser.parse(source: "a + b - c")
       let sequenceExpr =
         parsed.statements.first!.item.as(SequenceExprSyntax.self)!
       _ = opPrecedence.foldSingle(sequenceExpr) { error in
@@ -354,7 +354,7 @@ public class OperatorPrecedenceTests: XCTestCase {
 
     do {
       var errors: [OperatorError] = []
-      let parsed = try Parser.parse(source: "a ++ b - d")
+      let parsed = Parser.parse(source: "a ++ b - d")
       let sequenceExpr =
         parsed.statements.first!.item.as(SequenceExprSyntax.self)!
       _ = opPrecedence.foldSingle(sequenceExpr) { error in

--- a/Tests/SwiftParserTest/ParserTests.swift
+++ b/Tests/SwiftParserTest/ParserTests.swift
@@ -8,8 +8,8 @@ public class ParserTests: XCTestCase {
   /// Run a single parse test.
   func runParseTest(fileURL: URL, checkDiagnostics: Bool) throws {
     let fileContents = try Data(contentsOf: fileURL)
-    let parsed = try fileContents.withUnsafeBytes({ buffer in
-      try Parser.parse(source: buffer.bindMemory(to: UInt8.self))
+    let parsed = fileContents.withUnsafeBytes({ buffer in
+      Parser.parse(source: buffer.bindMemory(to: UInt8.self))
     })
     AssertDataEqualWithDiff(Data(parsed.syntaxTextBytes), fileContents,
                             additionalInfo: "Failed in file \(fileURL)")

--- a/Tests/SwiftParserTest/SyntaxTransformVisitor.swift
+++ b/Tests/SwiftParserTest/SyntaxTransformVisitor.swift
@@ -20,8 +20,8 @@ final class SyntaxTransformVisitorTest: XCTestCase {
         visitChildren(node).reduce(1, +)
       }
     }
-    _ = try {
-      let parsed = try Parser.parse(source: """
+    _ = {
+      let parsed = Parser.parse(source: """
           func foo() {
             public func foo() {
               func foo() {
@@ -75,24 +75,24 @@ final class SyntaxTransformVisitorTest: XCTestCase {
           "[" + visit(node.elementType) + "]"
       }
     }
-    _ = try {
-      let parsed = try Parser.parse(source: """
+    _ = {
+      let parsed = Parser.parse(source: """
           func foo(a: Int, b: Foo, c: [Int]) -> Result {
           }
           """)
       let stringified = PrintFunctionType().visit(parsed)
       XCTAssertEqual(stringified, "(Int, Foo, [Int]) -> Result")
     }()
-    _ = try {
-      let parsed = try Parser.parse(source: """
+    _ = {
+      let parsed = Parser.parse(source: """
           func foo() {
           }
           """)
       let stringified = PrintFunctionType().visit(parsed)
       XCTAssertEqual(stringified, "() -> Void")
     }()
-    _ = try {
-      let parsed = try Parser.parse(source: """
+    _ = {
+      let parsed = Parser.parse(source: """
           func foo(a: Int) -> [Result] {
           }
           """)

--- a/Tests/SwiftParserTest/TriviaParserTests.swift
+++ b/Tests/SwiftParserTest/TriviaParserTests.swift
@@ -158,7 +158,7 @@ final class TriviaParserTests: XCTestCase {
       /* comment only */
 
       """
-    let sourceFileSyntax = try Parser.parse(source: source)
+    let sourceFileSyntax = Parser.parse(source: source)
     XCTAssertEqual(sourceFileSyntax.leadingTrivia, [
       .blockComment("/* comment only */"),
       .newlines(1)

--- a/Tests/SwiftSyntaxBuilderTest/StringInterpolation.swift
+++ b/Tests/SwiftSyntaxBuilderTest/StringInterpolation.swift
@@ -83,7 +83,7 @@ final class StringInterpolationTests: XCTestCase {
 
 
   func testRewriter() throws {
-    let sourceFile = try Parser.parse(source: """
+    let sourceFile = Parser.parse(source: """
       class Foo {
         func method() {}
       }


### PR DESCRIPTION
The new parser doesn't throw, and doesn't use several of the parameters that the old one used. Drop the extraneous parameters and `throws`.