### PR TITLE
Detect and recover from missing comma in tupel

### DIFF
--- a/Sources/SwiftParser/Parser.swift
+++ b/Sources/SwiftParser/Parser.swift
@@ -149,7 +149,7 @@ public struct Parser: TokenConsumer {
   }
 
   @_spi(RawSyntax)
-  public mutating func missingToken(_ kind: RawTokenKind, text: SyntaxText?) -> RawTokenSyntax {
+  public mutating func missingToken(_ kind: RawTokenKind, text: SyntaxText? = nil) -> RawTokenSyntax {
     return RawTokenSyntax(missing: kind, text: text, arena: self.arena)
   }
 
@@ -327,7 +327,7 @@ extension Parser {
         if let remapping = remapping {
           return $0.missingToken(remapping, text: kind.defaultText)
         } else {
-          return $0.missingToken(kind, text: nil)
+          return $0.missingToken(kind)
         }
       }
     )
@@ -366,7 +366,7 @@ extension Parser {
     return expectImpl(
       consume: { $0.consume(ifAny: kinds, contextualKeywords: contextualKeywords) },
       canRecoverTo: { $0.canRecoverTo(kinds, contextualKeywords: contextualKeywords) },
-      makeMissing: { $0.missingToken(defaultKind, text: nil) }
+      makeMissing: { $0.missingToken(defaultKind) }
     )
   }
 
@@ -390,7 +390,7 @@ extension Parser {
     if let unknown = self.consume(if: .unknown) {
       return (
         RawUnexpectedNodesSyntax(elements: [RawSyntax(unknown)], arena: self.arena),
-        self.missingToken(.identifier, text: nil)
+        self.missingToken(.identifier)
       )
     }
     if let number = self.consume(ifAny: [.integerLiteral, .floatingLiteral]) {
@@ -407,7 +407,7 @@ extension Parser {
     }
     return (
       nil,
-      self.missingToken(.identifier, text: nil)
+      self.missingToken(.identifier)
     )
   }
 
@@ -419,12 +419,12 @@ extension Parser {
     if let unknown = self.consume(if: .unknown) {
       return (
         RawUnexpectedNodesSyntax(elements: [RawSyntax(unknown)], arena: self.arena),
-        self.missingToken(.identifier, text: nil)
+        self.missingToken(.identifier)
       )
     }
     return (
       nil,
-      self.missingToken(.identifier, text: nil)
+      self.missingToken(.identifier)
     )
   }
 

--- a/Tests/SwiftParserTest/Types.swift
+++ b/Tests/SwiftParserTest/Types.swift
@@ -358,9 +358,86 @@ final class TypeParameterPackTests: XCTestCase {
     // We allow whitespace between the generic parameter and the '...', this is
     // consistent with regular variadic parameters.
     AssertParse(
+    """
+    func f1<T ...>(_ x: T ...) -> (T ...) {}
+    """)
+  }
+  
+  func testMissingCommaInType() throws {
+    AssertParse(
       """
-      func f1<T ...>(_ x: T ...) -> (T ...) {}
+      var foo: (Int)
       """)
+    
+    AssertParse(
+      """
+      var foo: (Int, Int)
+      """)
+    
+    AssertParse(
+      """
+      var foo: (bar: Int 1️⃣bar2: Int)
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected ',' in tuple type")
+      ])
+    
+    AssertParse(
+      """
+      var foo: (bar: Int 1️⃣Int)
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected ',' in tuple type")
+      ])
+    
+    AssertParse(
+      """
+      var foo: (a 1️⃣Int)
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected ':' in tuple type")
+      ])
+    
+    AssertParse(
+      """
+      var foo: (A 1️⃣Int)
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected ',' in tuple type")
+      ])
+    
+    AssertParse(
+      """
+      var foo: (_ 1️⃣a 2️⃣Int)
+      """,
+      diagnostics: [
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in tuple type"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ',' in tuple type")
+      ])
+    
+    AssertParse(
+      """
+      var foo: (Array<Foo> 1️⃣Array<Bar>)
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected ',' in tuple type"),
+      ])
+    
+    AssertParse(
+      """
+      var foo: (a 1️⃣Array<Bar>)
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected ':' in tuple type"),
+      ])
+    
+    AssertParse(
+      """
+      var foo: (Array<Foo> 1️⃣a)
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected ',' in tuple type"),
+      ])
   }
 }
 


### PR DESCRIPTION
This PR will make the Parser capable of detect and recover from a missing comma in tuples. The motivating example was the following:

```
var a: (foo: Foo bar: Bar)

 --- Before Diagnostics
 
 1 │ var a: (foo: Foo bar: Bar)
   ∣                  ╰─ unexpected text 'bar: Bar' in tuple type

 
 --- After Diagnostics
 
 1 │ var a: (foo: Foo bar: Bar)
   ∣                  ╰─ expected ',' in tuple type

```

The recover logic includes some interesting logic for the case `var x: (foo bar)`. In this case we could either recover to a missing comma or a missing colon. I checked if the first part of the tuple is uppercase to decide which one is missing.