### PR TITLE
Replace 'value' by 'type' as name for diagnostics in TypeInitializerClause

### DIFF
--- a/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
+++ b/Sources/SwiftSyntax/gyb_generated/syntax_nodes/SyntaxNodes.swift
@@ -4849,7 +4849,7 @@ public struct TypeInitializerClauseSyntax: SyntaxProtocol, SyntaxHashable {
     case 2:
       return nil
     case 3:
-      return "value"
+      return "type"
     case 4:
       return nil
     default:

--- a/Tests/SwiftParserTest/translated/TypealiasTests.swift
+++ b/Tests/SwiftParserTest/translated/TypealiasTests.swift
@@ -86,7 +86,7 @@ final class TypealiasTests: XCTestCase {
       typealias Recovery11️⃣
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected '=' and value in typealias declaration"),
+        DiagnosticSpec(message: "expected '=' and type in typealias declaration"),
       ]
     )
   }
@@ -98,7 +98,7 @@ final class TypealiasTests: XCTestCase {
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected '=' in typealias declaration", fixIts: ["replace ':' by '='"]),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected value in typealias declaration"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in typealias declaration"),
       ]
     )
   }
@@ -109,7 +109,7 @@ final class TypealiasTests: XCTestCase {
       typealias Recovery3 =1️⃣
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected value in typealias declaration"),
+        DiagnosticSpec(message: "expected type in typealias declaration"),
       ]
     )
   }
@@ -143,7 +143,7 @@ final class TypealiasTests: XCTestCase {
       typealias Recovery6 = 1️⃣=
       """,
       diagnostics: [
-        DiagnosticSpec(message: "expected value in typealias declaration"),
+        DiagnosticSpec(message: "expected type in typealias declaration"),
         DiagnosticSpec(message: "extraneous '=' at top level"),
       ]
     )
@@ -159,7 +159,7 @@ final class TypealiasTests: XCTestCase {
         // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 11 - 17 = '`switch`'
         DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in typealias declaration"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected '=' and value in typealias declaration"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected '=' and type in typealias declaration"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected expression and '{}' to end 'switch' statement"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous '= Int' at top level"),
       ]

--- a/gyb_syntax_support/DeclNodes.py
+++ b/gyb_syntax_support/DeclNodes.py
@@ -8,7 +8,7 @@ DECL_NODES = [
     Node('TypeInitializerClause', name_for_diagnostics=None, kind='Syntax',
          children=[
              Child('Equal', kind='EqualToken'),
-             Child('Value', kind='Type', name_for_diagnostics='value'),
+             Child('Value', kind='Type', name_for_diagnostics='type'),
          ]),
 
     # typealias-declaration -> attributes? access-level-modifier? 'typealias'


### PR DESCRIPTION
As suggested in https://github.com/apple/swift-syntax/pull/892#discussion_r990358572.