### PR TITLE
Improve diagnostic if an editor placeholder is used to represent a closure

### DIFF
--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -200,6 +200,18 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
 
   // MARK: - Specialized diagnostic generation
 
+  public override func visit(_ node: ClosureExprSyntax) -> SyntaxVisitorContinueKind {
+    if shouldSkip(node) {
+      return .skipChildren
+    }
+    if node.statements.only?.item.is(EditorPlaceholderExprSyntax.self) == true {
+      // Only emit a single diagnostic about the editor placeholder and none for the missing '{' and '}'.
+      addDiagnostic(node, .editorPlaceholderInSourceFile, handledNodes: [node.id])
+      return .skipChildren
+    }
+    return .visitChildren
+  }
+
   public override func visit(_ node: CodeBlockItemSyntax) -> SyntaxVisitorContinueKind {
     if let semicolon = node.semicolon, semicolon.presence == .missing {
       let position = semicolon.previousToken(viewMode: .sourceAccurate)?.endPositionBeforeTrailingTrivia

--- a/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
+++ b/Sources/SwiftParser/Diagnostics/ParserDiagnosticMessages.swift
@@ -68,6 +68,7 @@ public extension ParserFixIt {
 public enum StaticParserError: String, DiagnosticMessage {
   case consecutiveStatementsOnSameLine = "consecutive statements on a line must be separated by ';'"
   case cStyleForLoop = "C-style for statement has been removed in Swift 3"
+  case editorPlaceholderInSourceFile = "editor placeholder in source file"
   case missingColonInTernaryExprDiagnostic = "expected ':' after '? ...' in ternary expression"
   case missingFunctionParameterClause = "expected argument list in function declaration"
   case throwsInReturnPosition = "'throws' may only occur before '->'"

--- a/Sources/SwiftParser/Diagnostics/Utils.swift
+++ b/Sources/SwiftParser/Diagnostics/Utils.swift
@@ -22,3 +22,14 @@ extension String {
     return String(result)
   }
 }
+
+extension Collection {
+  /// If the collection contains a single element, return it, otherwise `nil`.
+  var only: Element? {
+    if self.count == 1 {
+      return self.first!
+    } else {
+      return nil
+    }
+  }
+}

--- a/Sources/SwiftParser/Expressions.swift
+++ b/Sources/SwiftParser/Expressions.swift
@@ -2290,6 +2290,10 @@ extension Parser.Lookahead {
     if backtrack.peek().tokenKind == .leftBrace {
       return true
     }
+    if backtrack.peek().isEditorPlaceholder {
+      // Editor placeholder can represent entire closures
+      return true
+    }
 
     return false
   }

--- a/Sources/SwiftParser/Lexer.swift
+++ b/Sources/SwiftParser/Lexer.swift
@@ -51,6 +51,12 @@ public struct Lexer {
       return self.flags.contains(.isMultilineStringLiteral)
     }
 
+    var isEditorPlaceholder: Bool {
+      return self.tokenKind == .identifier &&
+      self.tokenText.starts(with: SyntaxText("<#")) &&
+      self.tokenText.hasSuffix(SyntaxText("#>"))
+    }
+
     @_spi(RawSyntax)
     public init(
       tokenKind: RawTokenKind,

--- a/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
+++ b/Tests/SwiftParserTest/translated/TrailingClosuresTests.swift
@@ -1,5 +1,6 @@
 // This test file has been translated from swift/test/Parse/trailing_closures.swift
 
+import SwiftSyntax
 import XCTest
 
 final class TrailingClosuresTests: XCTestCase {
@@ -145,30 +146,44 @@ final class TrailingClosuresTests: XCTestCase {
     )
   }
 
-  func testTrailingClosures13() {
+  func testTrailingClosures13a() {
     AssertParse(
       """
-      func test_multiple_trailing_syntax_without_labels() {
-        func fn(f: () -> Void, g: () -> Void) {}
-        fn {} g: {} // Ok
-        fn {} _: {} //  {{none}}
-        fn {}1️⃣ g2️⃣: <#T##() -> Void#>
-        func multiple(_: () -> Void, _: () -> Void) {}
-        multiple {} _: { }
-        func mixed_args_1(a: () -> Void, _: () -> Void) {}
-        func mixed_args_2(_: () -> Void, a: () -> Void, _: () -> Void) {} 
-        mixed_args_1 {} _: {}
-        mixed_args_1 {} a: {}  //  {{none}}
-        mixed_args_2 {} a: {} _: {}
-        mixed_args_2 {} _: {} //  {{none}}
-        mixed_args_2 {} _: {} _: {} //  {{none}}
-      }
+      fn {} g: {}
+      fn {} _: {}
+      multiple {} _: { }
+      mixed_args_1 {} _: {}
+      mixed_args_1 {} a: {}  //  {{none}}
+      mixed_args_2 {} a: {} _: {}
+      mixed_args_2 {} _: {} //  {{none}}
+      mixed_args_2 {} _: {} _: {} //  {{none}}
+      """
+    )
+  }
+
+  func testTrailingClosures13b() {
+    AssertParse(
+      """
+      fn {} g: 1️⃣<#T##() -> Void#>
       """,
+      substructure: Syntax(MultipleTrailingClosureElementSyntax(
+        label: .identifier("g"),
+        colon: .colonToken(trailingTrivia: .space),
+        closure: ClosureExprSyntax(
+          leftBrace: .leftBraceToken(presence: .missing),
+          signature: nil,
+          statements: CodeBlockItemListSyntax([
+            CodeBlockItemSyntax(
+              item: Syntax(EditorPlaceholderExprSyntax(identifier: .identifier("<#T##() -> Void#>"))),
+              semicolon: nil,
+              errorTokens: nil
+            )
+          ]),
+          rightBrace: .rightBraceToken(presence: .missing)
+        )
+      )),
       diagnostics: [
-        // TODO: Old parser expected error on line 5: editor placeholder in source file
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text ': <#T##() -> Void#>' before function"),
+        DiagnosticSpec(message: "editor placeholder in source file"),
       ]
     )
   }


### PR DESCRIPTION
If an editor placeholder is used where a closure is expected, parse it as a closure with missing braces and the editor placeholder as its only statement. Detect that pattern in the diagnostics generator and emit a corresponding diagnostic.