### PR TITLE
Only diagnose missing semicolons if the terminated node contains no errors

### DIFF
--- a/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
+++ b/Sources/SwiftParser/Diagnostics/ParseDiagnosticsGenerator.swift
@@ -221,10 +221,16 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
       return .skipChildren
     }
     if let semicolon = node.semicolon, semicolon.presence == .missing {
-      let position = semicolon.previousToken(viewMode: .sourceAccurate)?.endPositionBeforeTrailingTrivia
-      addDiagnostic(semicolon, position: position, .consecutiveStatementsOnSameLine, fixIts: [
-        FixIt(message: .insertSemicolon, changes: .makePresentBeforeTrivia(token: semicolon))
-      ], handledNodes: [semicolon.id])
+      if !node.item.hasError {
+        // Only diagnose the missing semicolon if the item doesn't contain any errors.
+        // If the item contains errors, the root cause is most likely something different and not the missing semicolon.
+        let position = semicolon.previousToken(viewMode: .sourceAccurate)?.endPositionBeforeTrailingTrivia
+        addDiagnostic(semicolon, position: position, .consecutiveStatementsOnSameLine, fixIts: [
+          FixIt(message: .insertSemicolon, changes: .makePresentBeforeTrivia(token: semicolon))
+        ], handledNodes: [semicolon.id])
+      } else {
+        handledNodes.append(semicolon.id)
+      }
     }
     return .visitChildren
   }
@@ -234,10 +240,16 @@ public class ParseDiagnosticsGenerator: SyntaxAnyVisitor {
       return .skipChildren
     }
     if let semicolon = node.semicolon, semicolon.presence == .missing {
-      let position = semicolon.previousToken(viewMode: .sourceAccurate)?.endPositionBeforeTrailingTrivia
-      addDiagnostic(semicolon, position: position, .consecutiveDeclarationsOnSameLine, fixIts: [
-        FixIt(message: .insertSemicolon, changes: .makePresentBeforeTrivia(token: semicolon))
-      ], handledNodes: [semicolon.id])
+      if !node.decl.hasError {
+        // Only diagnose the missing semicolon if the decl doesn't contain any errors.
+        // If the decl contains errors, the root cause is most likely something different and not the missing semicolon.
+        let position = semicolon.previousToken(viewMode: .sourceAccurate)?.endPositionBeforeTrailingTrivia
+        addDiagnostic(semicolon, position: position, .consecutiveDeclarationsOnSameLine, fixIts: [
+          FixIt(message: .insertSemicolon, changes: .makePresentBeforeTrivia(token: semicolon))
+        ], handledNodes: [semicolon.id])
+      } else {
+        handledNodes.append(semicolon.id)
+      }
     }
     return .visitChildren
   }

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -801,7 +801,7 @@ final class DeclarationTests: XCTestCase {
 
   func testDontRecoverFromDeclKeyword() {
     AssertParse(
-      "func foo(first second 1️⃣third2️⃣ 3️⃣struct4️⃣: Int) {}",
+      "func foo(first second 1️⃣third 3️⃣struct4️⃣: Int) {}",
       substructure: Syntax(FunctionParameterSyntax(
         attributes: nil,
         modifiers: nil,
@@ -815,7 +815,6 @@ final class DeclarationTests: XCTestCase {
       )),
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected ':' in function parameter"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected ')' to end parameter clause"),
         DiagnosticSpec(locationMarker: "4️⃣", message: "expected identifier in struct"),
         DiagnosticSpec(locationMarker: "4️⃣", message: "expected member block in struct"),

--- a/Tests/SwiftParserTest/Expressions.swift
+++ b/Tests/SwiftParserTest/Expressions.swift
@@ -505,7 +505,6 @@ final class ExpressionTests: XCTestCase {
       """##,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected root in key path"),
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end tuple type"),
       ]
     )
@@ -613,13 +612,12 @@ final class ExpressionTests: XCTestCase {
     AssertParse(
       """
       do {
-        true ? () :1️⃣ 2️⃣throw opaque_error()
+        true ? () : 1️⃣throw opaque_error()
       } catch _ {
       }
       """,
       diagnostics: [
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in 'do' statement"),
+        DiagnosticSpec(message: "expected expression in 'do' statement"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/AsyncTests.swift
+++ b/Tests/SwiftParserTest/translated/AsyncTests.swift
@@ -91,19 +91,18 @@ final class AsyncTests: XCTestCase {
   func testAsync8() {
     AssertParse(
       """
-      func asyncGlobal8() async throws1️⃣ async -> 2️⃣async Int3️⃣ async {}
+      func asyncGlobal8() async throws1️⃣ async -> 2️⃣async Int async {}
       """,
       diagnostics: [
         DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "'async' may only occur before '->'"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "consecutive statements on a line must be separated by ';'"),
         // TODO: Old parser expected error on line 1: 'async' has already been specified, Fix-It replacements: 34 - 40 = ''
         // TODO: Old parser expected error on line 1: 'async' has already been specified, Fix-It replacements: 43 - 49 = ''
         // TODO: Old parser expected error on line 1: 'async' has already been specified, Fix-It replacements: 53 - 59 = ''
       ],
       // TODO: This should not insert another 'async'
       fixedSource: """
-      func asyncGlobal8() async throws; async async -> Int; async {}
+      func asyncGlobal8() async throws; async async -> Int async {}
       """
     )
   }
@@ -115,7 +114,7 @@ final class AsyncTests: XCTestCase {
         init() async { }
         deinit1️⃣ async 2️⃣{ }
         func f() async { }
-        subscript(x: Int)3️⃣ 4️⃣async 5️⃣-> Int {
+        subscript(x: Int) 4️⃣async 5️⃣-> Int {
           get {
             return 0
           }
@@ -132,7 +131,6 @@ final class AsyncTests: XCTestCase {
         // TODO: Old parser expected error on line 5: single argument function types require parentheses
         // TODO: Old parser expected error on line 5: cannot find type 'async' in scope
         // TODO: Old parser expected note on line 5: cannot use module 'async' as a type
-        DiagnosticSpec(locationMarker: "3️⃣", message: "consecutive declarations on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "4️⃣", message: "expected '->' and return type in subscript"),
         DiagnosticSpec(locationMarker: "5️⃣", message: "expected declaration after 'async' modifier in class"),
         DiagnosticSpec(locationMarker: "5️⃣", message: "unexpected text in class"),

--- a/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
+++ b/Tests/SwiftParserTest/translated/AvailabilityQueryUnavailabilityTests.swift
@@ -20,11 +20,11 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
       if #unavailable(OSX 10.51, *) {} 
       // Disallow use as an expression.
       if (1️⃣#unavailable(OSX 10.51)) {}  
-      let x =2️⃣ 3️⃣#unavailable(OSX 10.51)
+      let x = 3️⃣#unavailable(OSX 10.51)
       (#unavailable(OSX 10.51) ? 1 : 0) 
       if !#unavailable(OSX 10.52) { 
       }
-      if let _ = Optional(5),4️⃣ 5️⃣!6️⃣#unavailable(OSX 10.52) {
+      if let _ = Optional(5), 5️⃣!6️⃣#unavailable(OSX 10.52) {
       }
       """,
       diagnostics: [
@@ -33,13 +33,11 @@ final class AvailabilityQueryUnavailabilityTests: XCTestCase {
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected value in tuple"),
         DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '#unavailable(OSX 10.51)' in tuple"),
         // TODO: Old parser expected error on line 5: #unavailable may only be used as condition of
-        DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "expected expression in variable"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text before variable"),
         // TODO: Old parser expected error on line 6: #unavailable may only be used as condition of an
         // TODO: Old parser expected error on line 7: #unavailable may only be used as condition of an
         // TODO: Old parser expected error on line 9: #unavailable may only be used as condition
-        DiagnosticSpec(locationMarker: "4️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "5️⃣", message: "expected pattern in variable"),
         DiagnosticSpec(locationMarker: "6️⃣", message: "expected expression in prefix operator expression"),
         DiagnosticSpec(locationMarker: "6️⃣", message: "extraneous code at top level"),

--- a/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
+++ b/Tests/SwiftParserTest/translated/DeprecatedWhereTests.swift
@@ -174,12 +174,11 @@ final class DeprecatedWhereTests: XCTestCase {
   func testDeprecatedWhere12() {
     AssertParse(
       """
-      func testCombinedConstraintsOld<T:1️⃣ 2️⃣protocol3️⃣<ProtoA, ProtoB> where T: ProtoC>(x: T) {}
+      func testCombinedConstraintsOld<T: 2️⃣protocol3️⃣<ProtoA, ProtoB> where T: ProtoC>(x: T) {}
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 60 - 76 = '', 83 - 83 = ' where T: ProtoC'
         // TODO: Old parser expected error on line 1: 'protocol<...>' composition syntax has been removed
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected inherited type in generic parameter"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected '>' to end generic parameter clause"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected argument list in function declaration"),
@@ -193,12 +192,11 @@ final class DeprecatedWhereTests: XCTestCase {
   func testDeprecatedWhere13() {
     AssertParse(
       """
-      func testCombinedConstraintsOld<T:1️⃣ 2️⃣protocol3️⃣<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {}
+      func testCombinedConstraintsOld<T: 2️⃣protocol3️⃣<ProtoA, ProtoB> where T: ProtoC>(x: T) where T: ProtoD {}
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: 'where' clause next to generic parameters is obsolete, Fix-It replacements: 60 - 76 = '', 84 - 89 = 'where T: ProtoC,'
         // TODO: Old parser expected error on line 1: 'protocol<...>' composition syntax has been removed
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected inherited type in generic parameter"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected '>' to end generic parameter clause"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected argument list in function declaration"),

--- a/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
+++ b/Tests/SwiftParserTest/translated/DollarIdentifierTests.swift
@@ -17,14 +17,13 @@ final class DollarIdentifierTests: XCTestCase {
     AssertParse(
       """
       func dollarVar() {
-        var1️⃣ 2️⃣$ 3️⃣: Int = 42
+        var 2️⃣$ 3️⃣: Int = 42
         $ += 1
         print($)
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 7 - 8 = '`$`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected pattern in variable"),
         DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text in function"),
         // TODO: Old parser expected error on line 3: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 3 - 4 = '`$`'
@@ -37,14 +36,13 @@ final class DollarIdentifierTests: XCTestCase {
     AssertParse(
       """
       func dollarLet() {
-        let1️⃣ 2️⃣$ = 42
+        let 1️⃣$ = 42
         print($)
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 7 - 8 = '`$`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected pattern in variable"),
+        DiagnosticSpec(message: "expected pattern in variable"),
         // TODO: Old parser expected error on line 3: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 9 - 10 = '`$`'
       ]
     )
@@ -54,14 +52,13 @@ final class DollarIdentifierTests: XCTestCase {
     AssertParse(
       """
       func dollarClass() {
-        class1️⃣ 2️⃣$ {}
+        class 1️⃣$ {}
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 9 - 10 = '`$`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in class"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in class"),
+        DiagnosticSpec(message: "expected identifier in class"),
+        DiagnosticSpec(message: "expected member block in class"),
       ]
     )
   }
@@ -70,14 +67,13 @@ final class DollarIdentifierTests: XCTestCase {
     AssertParse(
       """
       func dollarEnum() {
-        enum1️⃣ 2️⃣$ {}
+        enum 1️⃣$ {}
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 8 - 9 = '`$`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in enum"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in enum"),
+        DiagnosticSpec(message: "expected identifier in enum"),
+        DiagnosticSpec(message: "expected member block in enum"),
       ]
     )
   }
@@ -86,14 +82,13 @@ final class DollarIdentifierTests: XCTestCase {
     AssertParse(
       """
       func dollarStruct() {
-        struct1️⃣ 2️⃣$ {}
+        struct 1️⃣$ {}
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: '$' is not an identifier; use backticks to escape it, Fix-It replacements: 10 - 11 = '`$`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in struct"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in struct"),
+        DiagnosticSpec(message: "expected identifier in struct"),
+        DiagnosticSpec(message: "expected member block in struct"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/EnumTests.swift
+++ b/Tests/SwiftParserTest/translated/EnumTests.swift
@@ -420,19 +420,18 @@ final class EnumTests: XCTestCase {
     AssertParse(
       """
       enum Recovery5 {
-        case1️⃣ 2️⃣.UE3
-        case 3️⃣.UE4, .UE5
+        case 1️⃣.UE3
+        case 2️⃣.UE4, .UE5
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: extraneous '.' in enum 'case' declaration, Fix-It replacements: 8 - 9 = ''
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive declarations on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in enum case"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '.UE3' before enum case"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "unexpected text '.UE3' before enum case"),
         // TODO: Old parser expected error on line 3: extraneous '.' in enum 'case' declaration, Fix-It replacements: 8 - 9 = ''
         // TODO: Old parser expected error on line 3: extraneous '.' in enum 'case' declaration, Fix-It replacements: 14 - 15 = ''
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in enum case"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text '.UE4, .UE5' in enum"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in enum case"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '.UE4, .UE5' in enum"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/ErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/ErrorsTests.swift
@@ -29,7 +29,7 @@ final class ErrorsTests: XCTestCase {
       """
       func one() {
         do {
-          true ? () :1️⃣ 2️⃣throw opaque_error()
+          true ? () : 1️⃣throw opaque_error()
         } catch _ {
         }
         do {
@@ -37,7 +37,7 @@ final class ErrorsTests: XCTestCase {
           let error2 = error
         }
         do {
-        } catch 3️⃣where true {
+        } catch 2️⃣where true {
           let error2 = error
         } catch {
         }
@@ -73,9 +73,8 @@ final class ErrorsTests: XCTestCase {
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 3: expected expression after '? ... :' in ternary expression
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in 'do' statement"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected expression in pattern"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected expression in 'do' statement"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in pattern"),
       ]
     )
   }
@@ -274,7 +273,7 @@ final class ErrorsTests: XCTestCase {
       """
       // rdar://21328447
       func fixitThrow0()1️⃣ throw {}
-      func fixitThrow1()2️⃣ throw3️⃣ 4️⃣-> Int {}
+      func fixitThrow1()2️⃣ throw 3️⃣-> Int {}
       func fixitThrow2() throws {
         var _: (Int)
         throw MSV.Foo
@@ -286,9 +285,8 @@ final class ErrorsTests: XCTestCase {
         DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
         // TODO: Old parser expected error on line 3: expected throwing specifier; did you mean 'throws'?, Fix-It replacements: 20 - 25 = 'throws'
         DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected expression in 'throw' statement"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "unexpected text '-> Int {}' before function"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "expected expression in 'throw' statement"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text '-> Int {}' before function"),
         // TODO: Old parser expected error on line 7: expected throwing specifier; did you mean 'throws'?, Fix-It replacements: 16 - 21 = 'throws'
       ]
     )

--- a/Tests/SwiftParserTest/translated/InvalidTests.swift
+++ b/Tests/SwiftParserTest/translated/InvalidTests.swift
@@ -7,15 +7,14 @@ final class InvalidTests: XCTestCase {
     AssertParse(
       """
       // rdar://15946844
-      func test1(inout1️⃣ 2️⃣var x : Int3️⃣) {}
+      func test1(inout 1️⃣var x : Int2️⃣) {}
       """,
       diagnostics: [
         // TODO: Old parser expected warning on line 2: 'var' in this position is interpreted as an argument label, Fix-It replacements: 18 - 21 = '`var`'
         // TODO: Old parser expected error on line 2: 'inout' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 12 - 17 = '', 26 - 26 = 'inout '
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in type"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous ') {}' at top level"),
       ]
     )
   }
@@ -23,15 +22,14 @@ final class InvalidTests: XCTestCase {
   func testInvalid1b() {
     AssertParse(
       """
-      func test2(inout1️⃣ 2️⃣let x : Int3️⃣) {}
+      func test2(inout 1️⃣let x : Int2️⃣) {}
       """,
       diagnostics: [
         // TODO: Old parser expected warning on line 1: 'let' in this position is interpreted as an argument label, Fix-It replacements: 18 - 21 = '`let`'
         // TODO: Old parser expected error on line 1: 'inout' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 12 - 17 = '', 26 - 26 = 'inout '
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in type"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous ') {}' at top level"),
       ]
     )
   }
@@ -51,15 +49,14 @@ final class InvalidTests: XCTestCase {
   func testInvalid2a() {
     AssertParse(
       """
-      func test1s(__shared1️⃣ 2️⃣var x : Int3️⃣) {}
+      func test1s(__shared 1️⃣var x : Int2️⃣) {}
       """,
       diagnostics: [
         // TODO: Old parser expected warning on line 1: 'var' in this position is interpreted as an argument label, Fix-It replacements: 22 - 25 = '`var`'
         // TODO: Old parser expected error on line 1: '__shared' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 21 = '', 30 - 30 = '__shared '
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in type"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous ') {}' at top level"),
       ]
     )
   }
@@ -67,15 +64,14 @@ final class InvalidTests: XCTestCase {
   func testInvalid2b() {
     AssertParse(
       """
-      func test2s(__shared1️⃣ 2️⃣let x : Int3️⃣) {}
+      func test2s(__shared 1️⃣let x : Int2️⃣) {}
       """,
       diagnostics: [
         // TODO: Old parser expected warning on line 1: 'let' in this position is interpreted as an argument label, Fix-It replacements: 22 - 25 = '`let`'
         // TODO: Old parser expected error on line 1: '__shared' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 21 = '', 30 - 30 = '__shared '
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in type"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous ') {}' at top level"),
       ]
     )
   }
@@ -83,15 +79,14 @@ final class InvalidTests: XCTestCase {
   func testInvalid3a() {
     AssertParse(
       """
-      func test1o(__owned1️⃣ 2️⃣var x : Int3️⃣) {}
+      func test1o(__owned 1️⃣var x : Int2️⃣) {}
       """,
       diagnostics: [
         // TODO: Old parser expected warning on line 1: 'var' in this position is interpreted as an argument label, Fix-It replacements: 21 - 24 = '`var`'
         // TODO: Old parser expected error on line 1: '__owned' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 20 = ''
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in type"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous ') {}' at top level"),
       ]
     )
   }
@@ -99,15 +94,14 @@ final class InvalidTests: XCTestCase {
   func testInvalid3b() {
     AssertParse(
       """
-      func test2o(__owned1️⃣ 2️⃣let x : Int3️⃣) {}
+      func test2o(__owned 1️⃣let x : Int2️⃣) {}
       """,
       diagnostics: [
         // TODO: Old parser expected warning on line 2: 'let' in this position is interpreted as an argument label, Fix-It replacements: 21 - 24 = '`let`'
         // TODO: Old parser expected error on line 2: '__owned' before a parameter name is not allowed, place it before the parameter type instead, Fix-It replacements: 13 - 20 = ''
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected type in type"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected type in type"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous ') {}' at top level"),
       ]
     )
   }
@@ -226,16 +220,15 @@ final class InvalidTests: XCTestCase {
     AssertParse(
       """
       // rdar://problem/18507467
-      func d(_ b: 1️⃣String 2️⃣->3️⃣ 4️⃣<T>() -> T5️⃣) {}
+      func d(_ b: 1️⃣String 2️⃣-> 3️⃣<T>() -> T4️⃣) {}
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: expected type for function result
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected '(' to start function type"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' in function type"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected type in function type"),
-        DiagnosticSpec(locationMarker: "4️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "5️⃣", message: "extraneous ') {}' at top level"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "expected type in function type"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "expected ')' to end parameter clause"),
+        DiagnosticSpec(locationMarker: "4️⃣", message: "extraneous ') {}' at top level"),
       ]
     )
   }
@@ -341,16 +334,15 @@ final class InvalidTests: XCTestCase {
   func testInvalid18() {
     AssertParse(
       """
-      let1️⃣ 2️⃣for 3️⃣= 2
+      let 1️⃣for 2️⃣= 2
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: keyword 'for' cannot be used as an identifier here
         // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 5 - 8 = '`for`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected pattern in variable"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected pattern, 'in' and expression in 'for' statement"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected code block in 'for' statement"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous '= 2' at top level"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected pattern in variable"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected pattern, 'in' and expression in 'for' statement"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected code block in 'for' statement"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous '= 2' at top level"),
       ]
     )
   }
@@ -393,16 +385,15 @@ final class InvalidTests: XCTestCase {
   func testInvalid22() {
     AssertParse(
       """
-      let1️⃣ 2️⃣for 3️⃣= 2
+      let 1️⃣for 2️⃣= 2
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: keyword 'for' cannot be used as an identifier here
         // TODO: Old parser expected note on line 1: if this name is unavoidable, use backticks to escape it, Fix-It replacements: 5 - 8 = '`for`'
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected pattern in variable"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected pattern, 'in' and expression in 'for' statement"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected code block in 'for' statement"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "extraneous '= 2' at top level"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected pattern in variable"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected pattern, 'in' and expression in 'for' statement"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected code block in 'for' statement"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "extraneous '= 2' at top level"),
       ]
     )
   }
@@ -460,7 +451,6 @@ final class InvalidTests: XCTestCase {
         // TODO: Old parser expected note on line 2: join the identifiers together, Fix-It replacements: 6 - 5 = 'werewolf'
         // TODO: Old parser expected note on line 2: join the identifiers together with camel-case, Fix-It replacements: 6 - 5 = 'wereWolf'
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
       ]
     )
   }
@@ -477,7 +467,6 @@ final class InvalidTests: XCTestCase {
         // TODO: Old parser expected note on line 2: join the identifiers together, Fix-It replacements: 6 - 9 = 'hammerleavings'
         // TODO: Old parser expected note on line 2: join the identifiers together with camel-case, Fix-It replacements: 6 - 9 = 'hammerLeavings'
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected ')' to end parameter clause"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "consecutive statements on a line must be separated by ';'"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/NumberIdentifierErrorsTests.swift
+++ b/Tests/SwiftParserTest/translated/NumberIdentifierErrorsTests.swift
@@ -37,17 +37,16 @@ final class NumberIdentifierErrorsTests: XCTestCase {
   func testNumberIdentifierErrors3a() {
     AssertParse(
       """
-      protocol1️⃣ 2️⃣4 {
-        associatedtype 3️⃣5
+      protocol 1️⃣4 {
+        associatedtype 2️⃣5
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: protocol name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in protocol"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in protocol"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in protocol"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected member block in protocol"),
         // TODO: Old parser expected error on line 2: associatedtype name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in associatedtype declaration"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in associatedtype declaration"),
       ]
     )
   }
@@ -55,17 +54,16 @@ final class NumberIdentifierErrorsTests: XCTestCase {
   func testNumberIdentifierErrors3b() {
     AssertParse(
       """
-      protocol1️⃣ 2️⃣6.0 {
-        associatedtype 3️⃣7.0
+      protocol 1️⃣6.0 {
+        associatedtype 2️⃣7.0
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: protocol name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in protocol"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in protocol"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in protocol"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected member block in protocol"),
         // TODO: Old parser expected error on line 2: associatedtype name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in associatedtype declaration"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in associatedtype declaration"),
       ]
     )
   }
@@ -113,13 +111,12 @@ final class NumberIdentifierErrorsTests: XCTestCase {
   func testNumberIdentifierErrors5a() {
     AssertParse(
       """
-      struct1️⃣ 2️⃣13 {}
+      struct 1️⃣13 {}
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: struct name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in struct"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in struct"),
+        DiagnosticSpec(message: "expected identifier in struct"),
+        DiagnosticSpec(message: "expected member block in struct"),
       ]
     )
   }
@@ -127,13 +124,12 @@ final class NumberIdentifierErrorsTests: XCTestCase {
   func testNumberIdentifierErrors5b() {
     AssertParse(
       """
-      struct1️⃣ 2️⃣14.0 {}
+      struct 1️⃣14.0 {}
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: struct name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in struct"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in struct"),
+        DiagnosticSpec(message: "expected identifier in struct"),
+        DiagnosticSpec(message: "expected member block in struct"),
       ]
     )
   }
@@ -154,13 +150,12 @@ final class NumberIdentifierErrorsTests: XCTestCase {
   func testNumberIdentifierErrors6a() {
     AssertParse(
       """
-      enum1️⃣ 2️⃣16 {}
+      enum 1️⃣16 {}
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: enum name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in enum"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in enum"),
+        DiagnosticSpec(message: "expected identifier in enum"),
+        DiagnosticSpec(message: "expected member block in enum"),
       ]
     )
   }
@@ -168,13 +163,12 @@ final class NumberIdentifierErrorsTests: XCTestCase {
   func testNumberIdentifierErrors6b() {
     AssertParse(
       """
-      enum1️⃣ 2️⃣17.0 {}
+      enum 1️⃣17.0 {}
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: enum name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in enum"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in enum"),
+        DiagnosticSpec(message: "expected identifier in enum"),
+        DiagnosticSpec(message: "expected member block in enum"),
       ]
     )
   }
@@ -195,18 +189,17 @@ final class NumberIdentifierErrorsTests: XCTestCase {
   func testNumberIdentifierErrors7a() {
     AssertParse(
       """
-      class1️⃣ 2️⃣19 {
-        func 3️⃣20() {}
+      class 1️⃣19 {
+        func 2️⃣20() {}
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: class name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in class"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in class"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in class"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected member block in class"),
         // TODO: Old parser expected error on line 2: function name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text '20' before parameter clause"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '20' before parameter clause"),
       ]
     )
   }
@@ -214,18 +207,17 @@ final class NumberIdentifierErrorsTests: XCTestCase {
   func testNumberIdentifierErrors7b() {
     AssertParse(
       """
-      class1️⃣ 2️⃣21.0 {
-        func 3️⃣22.0() {}
+      class 1️⃣21.0 {
+        func 2️⃣22.0() {}
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 1: class name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in class"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected member block in class"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected identifier in class"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected member block in class"),
         // TODO: Old parser expected error on line 2: function name can only start with a letter or underscore, not a number
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "unexpected text '22.0' before parameter clause"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "unexpected text '22.0' before parameter clause"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/SelfRebindingTests.swift
+++ b/Tests/SwiftParserTest/translated/SelfRebindingTests.swift
@@ -46,15 +46,14 @@ final class SelfRebindingTests: XCTestCase {
       struct T {
           var mutable: Int = 0
           func f() {
-              let1️⃣ 2️⃣self = self
+              let 1️⃣self = self
           }
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 4: keyword 'self' cannot be used as an identifier here
         // TODO: Old parser expected note on line 4: if this name is unavoidable, use backticks to escape it
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected pattern in variable"),
+        DiagnosticSpec(message: "expected pattern in variable"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/SuperTests.swift
+++ b/Tests/SwiftParserTest/translated/SuperTests.swift
@@ -65,7 +65,6 @@ final class SuperTests: XCTestCase {
       """#,
       diagnostics: [
         DiagnosticSpec(message: "expected identifier in member access"),
-        DiagnosticSpec(message: "consecutive statements on a line must be separated by ';'")
         // TODO: Old parser expected error on line 33: expected '.' or '[' after 'super'
         // TODO: Old parser expected error on line 36: expected '.' or '[' after 'super'
       ]

--- a/Tests/SwiftParserTest/translated/SwitchTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchTests.swift
@@ -19,16 +19,15 @@ final class SwitchTests: XCTestCase {
     AssertParse(
       """
       func parseError1(x: Int) {
-        switch1️⃣ 2️⃣func 3️⃣{} 
+        switch 1️⃣func 2️⃣{}
       }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 2: expected expression in 'switch' statement
         // TODO: Old parser expected error on line 2: expected identifier in function declaration
-        DiagnosticSpec(locationMarker: "1️⃣", message: "consecutive statements on a line must be separated by ';'"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression and '{}' to end 'switch' statement"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected identifier in function"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected argument list in function declaration")
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected expression and '{}' to end 'switch' statement"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in function"),
+        DiagnosticSpec(locationMarker: "2️⃣", message: "expected argument list in function declaration")
       ]
     )
   }


### PR DESCRIPTION
If the item contains errors, the root cause is most likely something different and not the missing semicolon.