### PR TITLE
Use indentation to judge whether a closing `}` should be considered part of a code block if `{` is missing

### DIFF
--- a/Sources/SwiftParser/Declarations.swift
+++ b/Sources/SwiftParser/Declarations.swift
@@ -298,7 +298,7 @@ extension Parser {
     } else {
       whereClause = nil
     }
-    let members = self.parseMemberDeclList()
+    let members = self.parseMemberDeclList(introducer: extensionKeyword)
     return RawExtensionDeclSyntax(
       attributes: attrs.attributes,
       modifiers: attrs.modifiers,
@@ -577,8 +577,11 @@ extension Parser {
     )
   }
 
+  /// `introducer` is the `struct`, `class`, ... keyword that is the cause that the member decl block is being parsed.
+  /// If the left brace is missing, its indentation will be used to judge whether a following `}` was
+  /// indented to close this code block or a surrounding context. See `expectRightBrace`.
   @_spi(RawSyntax)
-  public mutating func parseMemberDeclList() -> RawMemberDeclBlockSyntax {
+  public mutating func parseMemberDeclList(introducer: RawTokenSyntax? = nil) -> RawMemberDeclBlockSyntax {
     var elements = [RawMemberDeclListItemSyntax]()
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
     do {
@@ -594,7 +597,7 @@ extension Parser {
         elements.append(newElement)
       }
     }
-    let (unexpectedBeforeRBrace, rbrace) = self.expect(.rightBrace)
+    let (unexpectedBeforeRBrace, rbrace) = self.expectRightBrace(leftBrace: lbrace, introducer: introducer)
     let members: RawMemberDeclListSyntax
     if elements.isEmpty && (lbrace.isMissing || rbrace.isMissing) {
       members = RawMemberDeclListSyntax(elements: [], arena: self.arena)
@@ -676,7 +679,7 @@ extension Parser {
       whereClause = nil
     }
 
-    let members = self.parseMemberDeclList()
+    let members = self.parseMemberDeclList(introducer: classKeyword)
     return RawClassDeclSyntax(
       attributes: attrs.attributes,
       modifiers: attrs.modifiers,
@@ -798,7 +801,7 @@ extension Parser {
       whereClause = nil
     }
 
-    let members = self.parseMemberDeclList()
+    let members = self.parseMemberDeclList(introducer: enumKeyword)
     return RawEnumDeclSyntax(
       attributes: attrs.attributes, modifiers: attrs.modifiers,
       unexpectedBeforeEnumKeyword,
@@ -943,7 +946,7 @@ extension Parser {
       whereClause = nil
     }
 
-    let members = self.parseMemberDeclList()
+    let members = self.parseMemberDeclList(introducer: structKeyword)
     return RawStructDeclSyntax(
       attributes: attrs.attributes, modifiers: attrs.modifiers,
       unexpectedBeforeStructKeyword,
@@ -1055,7 +1058,7 @@ extension Parser {
       whereClause = nil
     }
 
-    let members = self.parseMemberDeclList()
+    let members = self.parseMemberDeclList(introducer: protocolKeyword)
 
     return RawProtocolDeclSyntax(
       attributes: attrs.attributes, modifiers: attrs.modifiers,
@@ -1183,7 +1186,7 @@ extension Parser {
       whereClause = nil
     }
 
-    let members = self.parseMemberDeclList()
+    let members = self.parseMemberDeclList(introducer: actorKeyword)
     return RawActorDeclSyntax(
       attributes: attrs.attributes,
       modifiers: attrs.modifiers,

--- a/Sources/SwiftParser/TopLevel.swift
+++ b/Sources/SwiftParser/TopLevel.swift
@@ -81,10 +81,14 @@ extension Parser {
   /// =======
   ///
   ///     code-block → '{' statements? '}'
-  mutating func parseCodeBlock() -> RawCodeBlockSyntax {
+  ///
+  /// `introducer` is the `while`, `if`, ... keyword that is the cause that the code block is being parsed.
+  /// If the left brace is missing, its indentation will be used to judge whether a following `}` was
+  /// indented to close this code block or a surrounding context. See `expectRightBrace`.
+  mutating func parseCodeBlock(introducer: RawTokenSyntax? = nil) -> RawCodeBlockSyntax {
     let (unexpectedBeforeLBrace, lbrace) = self.expect(.leftBrace)
     let itemList = parseCodeBlockItemList(isAtTopLevel: false, stopCondition: { $0.at(.rightBrace) })
-    let (unexpectedBeforeRBrace, rbrace) = self.expect(.rightBrace)
+    let (unexpectedBeforeRBrace, rbrace) = self.expectRightBrace(leftBrace: lbrace, introducer: introducer)
 
     return .init(
       unexpectedBeforeLBrace,

--- a/Tests/SwiftParserTest/Declarations.swift
+++ b/Tests/SwiftParserTest/Declarations.swift
@@ -1109,6 +1109,19 @@ final class DeclarationTests: XCTestCase {
       ]
     )
   }
+
+  func testMatchBracesBasedOnSpaces() {
+    AssertParse(
+      """
+      struct Foo {
+        struct Bar 1️⃣
+      }
+      """,
+      diagnostics: [
+        DiagnosticSpec(message: "expected member block in struct")
+      ]
+    )
+  }
 }
 
 extension Parser.DeclAttributes {

--- a/Tests/SwiftParserTest/translated/ForeachAsyncTests.swift
+++ b/Tests/SwiftParserTest/translated/ForeachAsyncTests.swift
@@ -64,8 +64,8 @@ final class ForeachAsyncTests: XCTestCase {
         // FIXME: Bad diagnostics; should be just 'expected 'in' after for-each patter'.
         for await i 1️⃣r { 
         }         
-        for await i in r 2️⃣sum = sum + i; 
-      }3️⃣
+        for await i in r 2️⃣sum = sum + i;3️⃣
+      }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 21: found an unexpected second identifier in constant declaration
@@ -76,7 +76,7 @@ final class ForeachAsyncTests: XCTestCase {
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected 'in' in 'for' statement"),
         // TODO: Old parser expected error on line 23: expected '{' to start the body of for-each loop
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected '{' in 'for' statement"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected '}' to end function"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "expected '}' to end 'for' statement"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/ForeachTests.swift
+++ b/Tests/SwiftParserTest/translated/ForeachTests.swift
@@ -41,8 +41,8 @@ final class ForeachTests: XCTestCase {
         // FIXME: Bad diagnostics; should be just 'expected 'in' after for-each patter'.
         for i 1️⃣r { 
         }         
-        for i in r 2️⃣sum = sum + i; 
-      }3️⃣
+        for i in r 2️⃣sum = sum + i;3️⃣
+      }
       """,
       diagnostics: [
         // TODO: Old parser expected error on line 21: found an unexpected second identifier in constant declaration
@@ -53,7 +53,7 @@ final class ForeachTests: XCTestCase {
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected 'in' in 'for' statement"),
         // TODO: Old parser expected error on line 23: expected '{' to start the body of for-each loop
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected '{' in 'for' statement"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected '}' to end function"),
+        DiagnosticSpec(locationMarker: "3️⃣", message: "expected '}' to end 'for' statement"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/GuardTests.swift
+++ b/Tests/SwiftParserTest/translated/GuardTests.swift
@@ -17,10 +17,9 @@ final class GuardTests: XCTestCase {
         // TODO: Old parser expected error on line 2: missing condition in 'guard' statement
         // TODO: Old parser expected error on line 2: expected 'else' after 'guard' condition
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected 'else' in 'guard' statement"),
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected '{' in 'guard' statement"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected code block in 'guard' statement"),
         // TODO: Old parser expected error on line 5: missing condition in 'guard' statement
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected expression in 'guard' statement"),
-        DiagnosticSpec(locationMarker: "3️⃣", message: "expected '}' to end function"),
       ]
     )
   }

--- a/Tests/SwiftParserTest/translated/SwitchTests.swift
+++ b/Tests/SwiftParserTest/translated/SwitchTests.swift
@@ -23,8 +23,6 @@ final class SwitchTests: XCTestCase {
       }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: expected expression in 'switch' statement
-        // TODO: Old parser expected error on line 2: expected identifier in function declaration
         DiagnosticSpec(locationMarker: "1️⃣", message: "expected expression and '{}' to end 'switch' statement"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected identifier in function"),
         DiagnosticSpec(locationMarker: "2️⃣", message: "expected argument list in function declaration")
@@ -37,12 +35,10 @@ final class SwitchTests: XCTestCase {
       """
       func parseError2(x: Int) {
         switch x 1️⃣
-      }2️⃣
+      }
       """,
       diagnostics: [
-        // TODO: Old parser expected error on line 2: expected '{' after 'switch' subject expression
-        DiagnosticSpec(locationMarker: "1️⃣", message: "expected '{' in 'switch' statement"),
-        DiagnosticSpec(locationMarker: "2️⃣", message: "expected '}' to end function"),
+        DiagnosticSpec(locationMarker: "1️⃣", message: "expected '{}' in 'switch' statement"),
       ]
     )
   }


### PR DESCRIPTION
## Motivating example: 

```swift
struct Foo {
  func foo() 
}
```
  
We need to decide whether we should use the `}` to close the opening `{` of the `struct` or `func`.

## Solution

Do what a human would do: Use to decide how to match the braces. If the opening `{` of the `func` is missing and the `}` has an indentation that’s less than that of the `func` keyword, assume that it was indented to match an outer and don’t eat it for the `func`.